### PR TITLE
feat: generation tracker + model settings + Desktop app kill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ dist/
 *.tsbuildinfo
 .claude/
 model-settings.user.jsonc
+generations.db
+generations.db-wal
+generations.db-shm
 workflows/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ dist/
 .env
 *.tsbuildinfo
 .claude/
-model-settings.user.json
+model-settings.user.jsonc
 workflows/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI installation and port.
 
-**30 MCP tools** | **10 slash commands** | **4 knowledge skills** | **3 autonomous agents** | **2 hooks**
+**32 MCP tools** | **10 slash commands** | **4 knowledge skills** | **3 autonomous agents** | **2 hooks**
 
 ---
 
@@ -97,7 +97,7 @@ claude plugin install comfyui-mcp
 
 ## MCP Tools
 
-30 tools organized into 12 categories:
+32 tools organized into 13 categories:
 
 ### Workflow Execution
 
@@ -183,6 +183,24 @@ claude plugin install comfyui-mcp
 | `stop_comfyui` | Stop the running ComfyUI process (saves PID and launch args for restart) |
 | `start_comfyui` | Start ComfyUI using info saved from a previous stop |
 | `restart_comfyui` | Stop and restart ComfyUI, preserving all launch arguments |
+
+### Generation Tracker
+
+| Tool | Description |
+|------|-------------|
+| `suggest_settings` | Suggest proven sampler/scheduler/steps/CFG settings from local generation history — query by model family, LoRA hash, or text search |
+| `generation_stats` | Show local generation tracking statistics — total runs, unique combos, breakdown by model family |
+
+Every successful `run_workflow` call automatically logs settings to a local SQLite database (`generations.db`). Same settings combos get a `reuse_count` bump instead of duplicates, creating a natural popularity signal. Models and LoRAs are identified by content hash (AutoV2 / SHA256), not filenames — so renamed files still group together.
+
+```bash
+# View local stats from the CLI
+npm run generations:stats
+```
+
+### Model Settings
+
+Community-maintained preset library (`model-settings.json`) with research-backed sampler, scheduler, steps, and CFG values for 10+ model families. User overrides in `model-settings.user.jsonc` (auto-created from template on install, gitignored).
 
 ---
 
@@ -418,6 +436,7 @@ npm install
 | `npm test` | Run unit tests (vitest) |
 | `npm run test:integration` | Run integration tests (requires running ComfyUI) |
 | `npm run lint` | Type-check without emitting |
+| `npm run generations:stats` | Show local generation tracking statistics |
 
 ### Local testing with Claude Code
 
@@ -444,6 +463,11 @@ claude --plugin-dir ./plugin
 ### Project structure
 
 ```
+model-settings.json            # Community-maintained model presets (shipped)
+model-settings.user.jsonc.example  # User override template (copied on install)
+scripts/
+  postinstall.mjs              # Auto-creates user config from template
+  generation-stats.mjs         # CLI: npm run generations:stats
 src/
   index.ts                 # MCP server entry point (stdio transport)
   config.ts                # Auto-detection & environment config
@@ -458,6 +482,10 @@ src/
     mermaid-converter.ts   # Workflow → Mermaid diagram
     mermaid-parser.ts      # Mermaid diagram → Workflow
     model-resolver.ts      # HuggingFace search, local models, downloads
+    generation-tracker.ts  # SQLite generation log, settings dedup, stats
+    file-hasher.ts         # SHA256 hashing of .safetensors with cache
+    civitai-lookup.ts      # CivitAI API lookup by content hash
+    workflow-settings-extractor.ts  # Extract settings from workflow JSON
     process-control.ts     # Stop, start, restart ComfyUI process
     registry-client.ts     # ComfyUI Registry API
     skill-generator.ts     # Generate node pack skill docs
@@ -472,6 +500,7 @@ src/
     memory-management.ts   # clear_vram, get_embeddings
     registry-search.ts     # search_custom_nodes, get_node_pack_details
     skill-generator.ts     # generate_node_skill
+    generation-tracker.ts  # suggest_settings, generation_stats
     diagnostics.ts         # get_logs, get_history
     process-control.ts     # stop_comfyui, start_comfyui, restart_comfyui
     index.ts               # Registers all tool groups

--- a/docs/design/generation-tracker.md
+++ b/docs/design/generation-tracker.md
@@ -1,0 +1,457 @@
+# Generation Tracker & Community Settings
+
+## Overview
+
+A local SQLite database that tracks every generation's settings, counts reuse,
+and optionally shares anonymized public-LoRA settings to a Cloudflare backend.
+The MCP server queries the local DB to suggest "what worked before" when building
+new workflows, and can also fetch community-aggregated settings.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ComfyUI MCP Server                                        │
+│                                                             │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐  │
+│  │ Workflow      │───▶│ Generation   │───▶│ Settings     │  │
+│  │ Executor      │    │ Tracker      │    │ Advisor      │  │
+│  │ (existing)    │    │ (new)        │    │ (new)        │  │
+│  └──────────────┘    └──────┬───────┘    └──────┬───────┘  │
+│                             │                    │          │
+│                      ┌──────▼───────┐     ┌─────▼────────┐ │
+│                      │ SQLite DB    │     │ Community    │  │
+│                      │ (local)      │     │ API Client   │  │
+│                      │ better-      │     │ (optional)   │  │
+│                      │ sqlite3      │     └─────┬────────┘ │
+│                      └──────────────┘           │          │
+└─────────────────────────────────────────────────┼──────────┘
+                                                  │
+                                          ┌───────▼─────────┐
+                                          │ Cloudflare      │
+                                          │ Workers + D1    │
+                                          │ (community API) │
+                                          └─────────────────┘
+```
+
+---
+
+## Local Database: `generations.db`
+
+Location: `<comfyui_path>/comfyui-mcp/generations.db`
+(Lives alongside the user's ComfyUI data, gitignored.)
+
+### Schema
+
+```sql
+-- Core generation log
+CREATE TABLE generations (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+
+  -- Settings fingerprint (SHA256 of canonical JSON of tracked fields)
+  settings_hash TEXT    NOT NULL,
+
+  -- Model identification (by content hash, not filename)
+  model_family  TEXT    NOT NULL,  -- 'qwen_image', 'sdxl', 'flux', etc.
+  model_hash    TEXT    NOT NULL,  -- AutoV2 (first 10 chars of SHA256) of checkpoint/unet
+  model_name    TEXT,              -- checkpoint/unet filename (for full-text search, not part of hash)
+  preset_name   TEXT,              -- from model-settings.json, or 'custom'
+
+  -- Sampler settings
+  sampler       TEXT    NOT NULL,
+  scheduler     TEXT    NOT NULL,
+  steps         INTEGER NOT NULL,
+  cfg           REAL    NOT NULL,
+  denoise       REAL    DEFAULT 1.0,
+  shift         REAL,              -- auraflow_shift for Qwen
+
+  -- Resolution (tracked per-generation, NOT part of settings_hash)
+  width         INTEGER NOT NULL,
+  height        INTEGER NOT NULL,
+
+  -- LoRA (nullable — not all gens use LoRAs)
+  lora_hash     TEXT,              -- AutoV2 of LoRA file (content-addressed)
+  lora_name     TEXT,              -- LoRA filename (for full-text search, not part of hash)
+  lora_strength REAL,
+  lora_civitai_id    INTEGER,      -- NULL = private/unknown, populated after hash lookup
+
+  -- Satisfaction signal
+  -- Implicit: if the user runs the same settings_hash again, we increment reuse_count
+  -- Explicit: user can thumbs-up/down via MCP tool (future)
+  reuse_count   INTEGER NOT NULL DEFAULT 1,
+
+  -- Negative prompt hash (for dedup, not stored in full)
+  neg_prompt_hash TEXT
+);
+
+-- Fast lookups
+CREATE INDEX idx_gen_settings_hash ON generations(settings_hash);
+CREATE INDEX idx_gen_model_family  ON generations(model_family);
+CREATE INDEX idx_gen_model_hash    ON generations(model_hash);
+CREATE INDEX idx_gen_lora_hash     ON generations(lora_hash);
+CREATE INDEX idx_gen_lora_civitai  ON generations(lora_civitai_id);
+CREATE INDEX idx_gen_created       ON generations(created_at);
+
+-- File hash cache (avoid re-hashing large .safetensors files)
+-- Covers both models (checkpoints, unets) and LoRAs.
+-- Keyed on filename + size + mtime — if any change, re-hash.
+CREATE TABLE file_hashes (
+  filename      TEXT    PRIMARY KEY,  -- basename of the file
+  file_path     TEXT    NOT NULL,     -- full path (local only, never shared)
+  file_size     INTEGER NOT NULL,
+  file_mtime    TEXT    NOT NULL,
+  sha256        TEXT    NOT NULL,
+  autov2        TEXT    NOT NULL,     -- sha256[:10].toUpperCase()
+  file_type     TEXT    NOT NULL,     -- 'checkpoint' | 'unet' | 'lora' | 'vae'
+  civitai_id    INTEGER,              -- NULL = not found / not checked
+  civitai_name  TEXT,
+  civitai_model_id INTEGER,           -- parent model ID on CivitAI
+  checked_at    TEXT                  -- last time we queried CivitAI
+);
+```
+
+### Settings Hash
+
+The `settings_hash` is a SHA256 of a canonical JSON string containing only
+the **settings identity fields**, sorted alphabetically. This is what defines
+"the same combo" — resolution is intentionally excluded because the same
+sampler/steps/CFG combo works across resolutions and we want those to count
+together.
+
+Models and LoRAs are identified by their **AutoV2 content hash** (first 10 chars
+of SHA256), not filenames. This means renamed files, different quantizations of
+the same weights, or the same model downloaded from different sources all map to
+the same identity.
+
+```json
+{
+  "cfg": 4.0,
+  "denoise": 1.0,
+  "lora_hash": "A1B2C3D4E5",
+  "lora_strength": 1.0,
+  "model_family": "qwen_image",
+  "model_hash": "F6G7H8I9J0",
+  "sampler": "euler",
+  "scheduler": "simple",
+  "shift": 3.1,
+  "steps": 4
+}
+```
+
+**Excluded from hash** (tracked per-row but not part of the fingerprint):
+- `width`, `height` — resolution is a per-generation choice
+- `model_name`, `lora_name` — display names, not identity
+- `preset_name` — informational only
+- `neg_prompt_hash` — prompt content is never part of settings identity
+
+When a generation runs with an already-seen `settings_hash`, we UPDATE
+`reuse_count += 1` and `created_at` to the latest timestamp instead of inserting
+a duplicate row. This keeps the DB compact and gives us a natural popularity signal.
+
+---
+
+## File Identification Flow
+
+All models (checkpoints, UNETs) and LoRAs go through the same hashing pipeline.
+The `file_hashes` table caches results so we only compute SHA256 once per file version.
+
+```
+1. Workflow references a file → extract filename + resolve full path
+2. stat() the file → get size + mtime
+3. Check file_hashes table (by filename + size + mtime)
+   ├─ Cache hit  → use cached autov2 / civitai_id
+   └─ Cache miss →
+       a. Compute SHA256 of the .safetensors file
+       b. Derive AutoV2 = sha256[:10].toUpperCase()
+       c. Query CivitAI: GET /api/v1/model-versions/by-hash/{autov2}
+          ├─ Found  → store civitai_id, civitai_name, civitai_model_id
+          └─ Not found → civitai_id = NULL (private/unknown)
+       d. INSERT into file_hashes cache
+4. Use autov2 as model_hash / lora_hash in the generations row
+5. Use civitai_id for LoRA privacy filtering
+```
+
+**Privacy rule**: Only generations where `lora_civitai_id IS NOT NULL` (or no LoRA)
+are eligible for community sharing. Private LoRAs never leave the machine.
+
+**Hashing note**: SHA256 of large safetensors files (2-12GB) takes 5-20 seconds.
+We run this in a worker thread and cache aggressively. The cache invalidates only
+when file size or mtime changes (renamed files keep their hash).
+
+---
+
+## Settings Advisor (MCP Hook)
+
+When building a new workflow, the MCP server queries the local DB:
+
+```sql
+-- "What worked well for this model?"
+-- Groups by settings_hash (resolution-agnostic), shows most popular combos
+SELECT sampler, scheduler, steps, cfg, shift, denoise,
+       lora_hash, lora_name, lora_strength,
+       model_hash, model_name,
+       reuse_count, preset_name
+FROM generations
+WHERE model_family = ?
+ORDER BY reuse_count DESC, created_at DESC
+LIMIT 10;
+
+-- "What worked well for this specific LoRA?"
+SELECT sampler, scheduler, steps, cfg, shift, denoise,
+       model_hash, model_name, reuse_count
+FROM generations
+WHERE lora_hash = ?
+ORDER BY reuse_count DESC
+LIMIT 10;
+```
+
+The advisor returns the top settings to the LLM as context, letting it
+suggest proven combos to the user. Combined with model-settings.json presets,
+this creates a feedback loop: defaults → user experiments → local tracking →
+better suggestions.
+
+---
+
+## NPM Scripts
+
+### `npm run generations:review`
+
+Interactive CLI that shows what would be shared:
+
+```
+$ npm run generations:review
+
+=== Generation Settings Ready to Share ===
+
+  Model Family     Sampler/Sched      Steps  CFG   LoRA                          Uses
+  ─────────────    ────────────────   ─────  ────  ────────────────────────────   ────
+  qwen_image       euler/simple       4      1.0   Lightning-4steps (CivitAI)    47
+  qwen_image       euler_a/beta       50     4.0   (none)                        12
+  sdxl             dpmpp_2m/karras    25     6.5   (none)                        8
+  illustrious      euler_a/simple     22     4.5   (none)                        5
+
+  4 entries (private LoRAs excluded)
+
+  Share these with the community? [y/N]
+```
+
+### `npm run generations:stats`
+
+Local-only stats view:
+
+```
+$ npm run generations:stats
+
+  Total generations tracked: 234
+  Unique setting combos: 18
+  Most used: qwen_image / euler/simple / 4 steps (47 uses)
+  Models: qwen_image (142), sdxl (52), illustrious (28), flux (12)
+```
+
+---
+
+## Community Backend (Cloudflare)
+
+### Stack
+
+- **Cloudflare Workers** — API endpoints (free tier: 100k req/day)
+- **Cloudflare D1** — SQLite-compatible edge database (free tier: 5M reads/day, 100k writes/day)
+- **Rate limiting** — Cloudflare's built-in rate limiting rules
+
+### Endpoints
+
+#### `POST /api/v1/settings/submit`
+
+Submit anonymized generation settings.
+
+```json
+// Request
+{
+  "client_version": "0.2.0",
+  "entries": [
+    {
+      "settings_hash": "abc123...",
+      "model_family": "qwen_image",
+      "model_hash": "F6G7H8I9J0",
+      "model_name": "qwen_image_2512_fp8_e4m3fn.safetensors",
+      "model_civitai_id": 789012,
+      "sampler": "euler",
+      "scheduler": "simple",
+      "steps": 4,
+      "cfg": 1.0,
+      "denoise": 1.0,
+      "shift": 3.1,
+      "lora_hash": "A1B2C3D4E5",
+      "lora_name": "Qwen-Image-Lightning-4steps-V1.0.safetensors",
+      "lora_civitai_id": 123456,
+      "lora_strength": 1.0,
+      "reuse_count": 47
+    }
+  ]
+}
+
+// Response
+{ "accepted": 1, "thank_you": true }
+```
+
+**What is sent**: content hashes (AutoV2), CivitAI IDs, sampler params, reuse counts.
+
+**What is NOT sent**: prompts, negative prompts, image data, filenames, file paths,
+resolutions, private LoRA/model hashes (no CivitAI match), usernames, IP-derived
+location, timestamps.
+
+#### `GET /api/v1/settings/search`
+
+Query community-aggregated settings.
+
+```
+GET /api/v1/settings/search?model_family=qwen_image&lora_civitai_id=123456
+
+// Response
+{
+  "results": [
+    {
+      "model_family": "qwen_image",
+      "model_hash": "F6G7H8I9J0",
+      "model_name": "qwen_image_2512_fp8_e4m3fn.safetensors",
+      "model_civitai_id": 789012,
+      "sampler": "euler",
+      "scheduler": "simple",
+      "steps": 4,
+      "cfg": 1.0,
+      "denoise": 1.0,
+      "shift": 3.1,
+      "lora_hash": "A1B2C3D4E5",
+      "lora_name": "Qwen-Image-Lightning-4steps-V1.0.safetensors",
+      "lora_civitai_id": 123456,
+      "lora_strength": 1.0,
+      "total_uses": 1247,
+      "unique_users": 89,
+      "avg_reuse": 14.0
+    }
+  ],
+  "total": 1,
+  "cache_ttl": 3600
+}
+```
+
+Searchable by: `model_family`, `model_hash`, `model_civitai_id`, `model_name`,
+`lora_hash`, `lora_civitai_id`, `lora_name`, `sampler`, `scheduler`.
+All filters are AND-combined. Name fields support `LIKE` / substring matching
+(e.g. `?model_name=copax` matches "CopaxTimelessV11.safetensors").
+
+Rate limit: 60 req/min per IP.
+
+#### `GET /api/v1/settings/popular`
+
+Top settings across all users, filterable.
+
+```
+GET /api/v1/settings/popular?model_family=sdxl&limit=10
+
+// Response — same shape as search, ordered by total_uses DESC
+```
+
+### D1 Schema (Cloudflare)
+
+```sql
+CREATE TABLE community_settings (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  settings_hash    TEXT    NOT NULL UNIQUE,
+
+  -- Identity (hashes for dedup, names for full-text search)
+  model_family     TEXT    NOT NULL,
+  model_hash       TEXT    NOT NULL,     -- AutoV2 of checkpoint/unet
+  model_name       TEXT,                 -- e.g. "qwen_image_2512_fp8_e4m3fn.safetensors"
+  model_civitai_id INTEGER,              -- CivitAI model version ID
+  lora_hash        TEXT,                 -- AutoV2 of LoRA (NULL if none)
+  lora_name        TEXT,                 -- e.g. "Qwen-Image-Lightning-4steps-V1.0.safetensors"
+  lora_civitai_id  INTEGER,              -- CivitAI model version ID
+  lora_strength    REAL,
+
+  -- Settings
+  sampler          TEXT    NOT NULL,
+  scheduler        TEXT    NOT NULL,
+  steps            INTEGER NOT NULL,
+  cfg              REAL    NOT NULL,
+  denoise          REAL,
+  shift            REAL,
+
+  -- Aggregates
+  total_uses       INTEGER NOT NULL DEFAULT 0,
+  unique_users     INTEGER NOT NULL DEFAULT 0,
+  first_seen       TEXT    NOT NULL DEFAULT (datetime('now')),
+  last_seen        TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_cs_model      ON community_settings(model_family);
+CREATE INDEX idx_cs_model_hash ON community_settings(model_hash);
+CREATE INDEX idx_cs_lora_hash  ON community_settings(lora_hash);
+CREATE INDEX idx_cs_lora_civ   ON community_settings(lora_civitai_id);
+CREATE INDEX idx_cs_popular    ON community_settings(total_uses DESC);
+```
+
+On submit, the worker does an UPSERT keyed on `settings_hash`:
+- If new: INSERT with `total_uses = reuse_count`, `unique_users = 1`
+- If exists: `total_uses += reuse_count`, `unique_users += 1`
+
+---
+
+## MCP Tools (New)
+
+### `generation_log`
+Called automatically after `run_workflow` completes successfully.
+Extracts settings from the executed workflow and logs to SQLite.
+Not exposed to the user — internal hook.
+
+### `suggest_settings`
+```
+Input:  { model_family: "qwen_image", use_case?: "portrait" | "landscape" | ... }
+Output: Top local + community settings for the given model, ranked by reuse.
+```
+
+### `generation_stats`
+```
+Input:  { model_family?: string }
+Output: Local generation statistics summary.
+```
+
+---
+
+## Implementation Order
+
+### Phase 1: Local tracking (no network)
+1. Add `better-sqlite3` dependency
+2. Create `src/services/generation-tracker.ts` — DB init, log, query
+3. Create `src/services/lora-identifier.ts` — SHA256 hashing + cache
+4. Hook into workflow executor — log after successful run
+5. Add `suggest_settings` MCP tool
+6. Add `npm run generations:stats` script
+
+### Phase 2: CivitAI identification
+7. Add CivitAI hash lookup in lora-identifier
+8. Cache results in `lora_hashes` table
+9. Filter shareable vs private in generation log
+
+### Phase 3: Community sharing
+10. Stand up Cloudflare Worker + D1
+11. Add `npm run generations:review` script (preview + confirm)
+12. Add submit endpoint client in MCP server
+13. Add `search_community_settings` MCP tool
+14. Rate limiting + privacy review
+
+---
+
+## Privacy Guarantees
+
+1. **Opt-in only** — Nothing is shared without explicit `npm run generations:review` confirmation
+2. **No prompts** — Text prompts and negative prompts are never stored in shareable form
+3. **No images** — No generated images or thumbnails
+4. **No private LoRAs** — Only LoRAs with a verified CivitAI hash are included
+5. **No PII** — No usernames, paths, IPs stored server-side (Cloudflare Workers don't log by default)
+6. **Local-first** — The local DB works fully offline; community features are additive
+7. **Reviewable** — Users see exactly what will be sent before confirming
+8. **No tracking** — No analytics cookies, no device fingerprinting, no session tracking

--- a/model-settings.json
+++ b/model-settings.json
@@ -1,0 +1,509 @@
+{
+  "$schema": "model-settings.schema.json",
+  "_version": "0.2.0",
+  "_description": "Community-maintained best settings for ComfyUI models. Merge order: defaults (this file) → user overrides (model-settings.user.json). PRs welcome!",
+  "_updated": "2026-02-16",
+  "_merge_strategy": "deep_merge_user_wins",
+
+  "model_families": {
+
+    "qwen_image": {
+      "display_name": "Qwen Image (Base Architecture)",
+      "architecture": "qwen_image",
+      "clip_type": "qwen_image",
+      "vae": "qwen_image_vae.safetensors",
+      "prompt_style": "natural_language",
+      "prompt_notes": "Use natural language, 1-3 sentences. Put text to render in quotes. 'photograph' > 'photorealistic'. Negative prompts: use NLP-style descriptions, not keyword spam.",
+      "resolutions": {
+        "_note": "Qwen Image operates at ~1.6 megapixels natively",
+        "square": [1328, 1328],
+        "portrait_3_4": [1104, 1472],
+        "portrait_9_16": [928, 1664],
+        "portrait_2_3": [1056, 1584],
+        "landscape_4_3": [1472, 1104],
+        "landscape_16_9": [1664, 928],
+        "landscape_3_2": [1584, 1056],
+        "ultrawide_portrait": [1536, 2048]
+      },
+
+      "presets": {
+        "lightning_4step": {
+          "description": "Fast 4-step with LightX2V lightning LoRA. Good general-purpose.",
+          "steps": 4,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "lora": {
+            "name": "Qwen-Image-Lightning-4steps-V1.0.safetensors",
+            "strength": 1.0
+          },
+          "notes": "For 2511 edit models, use 2511-specific lightning LoRA."
+        },
+        "lightning_4step_2511_edit": {
+          "description": "Fast 4-step specifically for 2511 edit model.",
+          "steps": 4,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "lora": {
+            "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+            "strength": 1.0
+          },
+          "notes": "Cannot combine with distilled model variant."
+        },
+        "lightning_8step": {
+          "description": "Higher quality 8-step lightning. Better detail than 4-step.",
+          "steps": 8,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "lora": {
+            "name": "Qwen-Image-Lightning-8steps-V1.0.safetensors",
+            "strength": 1.0
+          }
+        },
+        "lightning_8step_character": {
+          "description": "8-step lightning tuned for detailed character/portrait work.",
+          "steps": 8,
+          "cfg": 2.5,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "lora": {
+            "name": "Qwen-Image-Lightning-8steps-V1.0.safetensors",
+            "strength": 1.0
+          },
+          "notes": "CFG 2.5 gives better prompt adherence for character details (Imageized author examples)."
+        },
+        "standard": {
+          "description": "Official full-quality settings from ComfyUI template.",
+          "steps": 50,
+          "cfg": 4.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "notes": "Official ComfyUI workflow template values. 30-50 steps work well."
+        },
+        "standard_golden": {
+          "description": "Community-tested 'golden configuration' for best quality.",
+          "steps": 50,
+          "cfg": 4.5,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "notes": "Community consensus: CFG 4.5 + 50 steps for peak quality."
+        },
+        "standard_character_composition": {
+          "description": "Optimized for multi-character scenes and complex compositions.",
+          "steps": 30,
+          "cfg": 4.0,
+          "sampler": "euler_ancestral",
+          "scheduler": "beta",
+          "denoise": 1.0,
+          "auraflow_shift": 3.1,
+          "notes": "euler_ancestral + beta helps with character variety and scene coherence."
+        }
+      }
+    },
+
+    "qwen_image_2512": {
+      "display_name": "Qwen Image 2512 (December 2025)",
+      "inherits": "qwen_image",
+      "unet": "qwen_image_2512_fp8_e4m3fn.safetensors",
+      "clip": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "vae": "qwen_image_vae.safetensors",
+      "notes": "Latest official Qwen Image model. fp8 for 24GB VRAM. Inherits all qwen_image presets."
+    },
+
+    "qwen_image_2511_edit": {
+      "display_name": "Qwen Image Edit 2511 (November 2025)",
+      "inherits": "qwen_image",
+      "unet": "qwen_image_edit_2511_bf16.safetensors",
+      "clip": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "vae": "qwen_image_vae.safetensors",
+      "notes": "Optimized for image editing. bf16 precision. Use 2511-specific lightning LoRA.",
+
+      "presets": {
+        "edit_standard": {
+          "description": "Full quality img2img editing.",
+          "steps": 40,
+          "cfg": 4.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "denoise": 0.75,
+          "notes": "Denoise 0.5-0.8: lower = closer to input. Negative conditioning should be zeroed."
+        }
+      }
+    },
+
+    "qwen_finetuned": {
+      "display_name": "Qwen Image Fine-tuned Models",
+      "architecture": "qwen_image",
+
+      "models": {
+        "qwenUltimateRealism_v11": {
+          "display_name": "Qwen Ultimate Realism v1.1",
+          "author": "Imageized",
+          "source": "https://civitai.com/models/2027494",
+          "unet_path": "Qwen/imageized/qwenUltimateRealism_v11.safetensors",
+          "clip": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+          "vae": "qwen_image_vae.safetensors",
+          "focus": "Product photography, hyper-realistic, e-commerce",
+          "presets": {
+            "author_quality": {
+              "description": "Author's best quality settings.",
+              "steps": 30,
+              "cfg": 7.5,
+              "sampler": "euler",
+              "scheduler": "simple",
+              "denoise": 1.0,
+              "notes": "Steps 20-40, CFG 5-10 (sweet spot 7-8)."
+            },
+            "author_fast": {
+              "steps": 4,
+              "cfg": 1.0,
+              "sampler": "euler",
+              "scheduler": "simple",
+              "lora": {
+                "name": "Qwen-Image-Lightning-4steps-V1.0.safetensors",
+                "strength": 1.01
+              },
+              "notes": "Author uses strength 1.01 specifically."
+            }
+          }
+        },
+
+        "copaxTimeless_qwenUltraRealistic": {
+          "display_name": "CopaxTimeless Qwen Ultra Realistic",
+          "author": "Copax",
+          "source": "https://civitai.com/models/copaxTimeless",
+          "unet_path": "Qwen/realistic/copaxTimeless_qwenUltraRealistic.safetensors",
+          "clip": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+          "vae": "qwen_image_vae.safetensors",
+          "focus": "Ultra-realistic portraits and scenes",
+          "presets": {
+            "author_recommended": {
+              "steps": 30,
+              "cfg": 4.0,
+              "sampler": "res_multistep",
+              "scheduler": "sgm_uniform",
+              "denoise": 1.0,
+              "auraflow_shift": 3.1,
+              "notes": "Consistently uses res_multistep + sgm_uniform. Steps 20/30/50 all work."
+            }
+          },
+          "resolutions": [
+            [1152, 1536], [992, 1776], [928, 1984], [1536, 2048]
+          ]
+        },
+
+        "redcraftRedzimage_DX1": {
+          "display_name": "RedCraft Redzimage DX1",
+          "source": "https://civitai.com/models/958009",
+          "unet_path": "redcraftRedzimageUpdatedJAN30_redzibDX1.safetensors",
+          "loader": "CheckpointLoaderSimple",
+          "focus": "Realistic generation (combined checkpoint)",
+          "presets": {
+            "distilled_fast": {
+              "steps": 10,
+              "cfg": 1.0,
+              "sampler": "euler",
+              "scheduler": "simple"
+            },
+            "standard": {
+              "steps": 30,
+              "cfg": 4.0,
+              "sampler": "euler",
+              "scheduler": "simple"
+            }
+          },
+          "notes": "Combined checkpoint (UNET+CLIP+VAE). Use CheckpointLoaderSimple, not separate loaders."
+        }
+      }
+    },
+
+    "z_image": {
+      "display_name": "Z-Image Family",
+      "architecture": "z_image",
+      "notes": "Must use Qwen tokenizer, not standard CLIP nodes.",
+
+      "models": {
+        "z_image_turbo": {
+          "display_name": "Z-Image Turbo",
+          "unet": "z_image_turbo_bf16.safetensors",
+          "clip": "qwen_3_4b.safetensors",
+          "vae": "flux2-vae.safetensors",
+          "clip_type": "qwen_image",
+          "presets": {
+            "author_recommended": {
+              "steps": 14,
+              "cfg": 1.0,
+              "sampler": "res_2s",
+              "scheduler": "simple",
+              "notes": "From CopaxTimeless author. Distilled CFG 1."
+            },
+            "beauty_fashion": {
+              "steps": 10,
+              "cfg": 1.0,
+              "sampler": "euler_ancestral",
+              "scheduler": "beta",
+              "notes": "Smooth skin, ideal for beauty/fashion (560-image test)."
+            },
+            "sharpest": {
+              "steps": 10,
+              "cfg": 1.0,
+              "sampler": "dpmpp_sde",
+              "scheduler": "beta",
+              "notes": "Sharpest, most natural results from community testing."
+            }
+          },
+          "negative_prompt_template": "over-smooth skin, plastic skin, doll face, anime, CGI, waxy texture, blurry face, fake pores, exaggerated makeup, over-sharpening, unrealistic symmetry, flat lighting, low detail skin, extra fingers, distorted anatomy"
+        }
+      }
+    },
+
+    "sdxl": {
+      "display_name": "SDXL 1.0",
+      "architecture": "sdxl",
+      "clip_type": "sdxl",
+      "prompt_style": "tags_and_natural",
+
+      "presets": {
+        "realistic_photo": {
+          "description": "Gold standard for SDXL photorealism.",
+          "steps": 25,
+          "cfg": 5.0,
+          "sampler": "dpmpp_2m",
+          "scheduler": "karras",
+          "notes": "DPM++ 2M Karras. CFG 5-7. AVOID Euler for SDXL (causes washed-out images)."
+        },
+        "realistic_creative": {
+          "description": "More diverse realistic results.",
+          "steps": 30,
+          "cfg": 6.0,
+          "sampler": "dpmpp_2m_sde",
+          "scheduler": "karras",
+          "notes": "DPM++ 2M SDE Karras for more creative variation."
+        },
+        "realistic_best": {
+          "description": "Highest quality realistic (slow).",
+          "steps": 35,
+          "cfg": 6.0,
+          "sampler": "heun",
+          "scheduler": "normal",
+          "notes": "Heun is 2x compute per step but highest quality. Use for final renders."
+        },
+        "anime_pony": {
+          "description": "Pony Diffusion V6 XL author settings.",
+          "steps": 25,
+          "cfg": 7.0,
+          "sampler": "euler_ancestral",
+          "scheduler": "normal",
+          "clip_skip": 2,
+          "notes": "CLIP SKIP 2 IS CRITICAL for Pony — model outputs blobs without it. No neg prompt needed. Use score_9, score_8_up tags."
+        },
+        "anime_sharp": {
+          "description": "Sharp anime with SDE sampler.",
+          "steps": 25,
+          "cfg": 7.5,
+          "sampler": "dpmpp_sde",
+          "scheduler": "karras",
+          "notes": "DPM++ SDE Karras for sharper anime. Slower than 2M."
+        }
+      },
+      "resolutions": {
+        "square": [1024, 1024],
+        "portrait_3_4": [896, 1152],
+        "portrait_9_16": [768, 1344],
+        "landscape_4_3": [1152, 896],
+        "landscape_16_9": [1344, 768]
+      }
+    },
+
+    "illustrious": {
+      "display_name": "Illustrious XL",
+      "architecture": "sdxl",
+      "clip_type": "sdxl",
+      "prompt_style": "booru_tags",
+      "prompt_notes": "Use danbooru tags: 1girl, solo, long_hair, blue_eyes. Quality: masterpiece, best quality, absurdres. CFG > 7.5 causes oversaturation, < 3 loses color.",
+
+      "presets": {
+        "default": {
+          "description": "Community standard Illustrious settings.",
+          "steps": 25,
+          "cfg": 4.5,
+          "sampler": "euler_ancestral",
+          "scheduler": "simple",
+          "notes": "CFG 4.5-5.0 is the sweet spot. euler_ancestral is community favorite."
+        },
+        "detailed": {
+          "steps": 30,
+          "cfg": 5.0,
+          "sampler": "dpmpp_2m",
+          "scheduler": "karras",
+          "notes": "More consistent/detailed. For complex compositions, increase steps to 40."
+        },
+        "sharp_shading": {
+          "steps": 15,
+          "cfg": 5.0,
+          "sampler": "dpmpp_2s_ancestral",
+          "scheduler": "karras",
+          "notes": "Enhanced shading detail. Watch for noise in flat color areas."
+        }
+      },
+      "resolutions": {
+        "optimal_range": "1024-1536px per side"
+      }
+    },
+
+    "flux": {
+      "display_name": "Flux.1",
+      "architecture": "flux",
+      "clip_type": "flux",
+      "prompt_style": "natural_language",
+      "prompt_notes": "Natural language descriptions. No quality tags needed. Detailed, descriptive prompts work best.",
+      "notes": "Flux uses FluxGuidance node (guidance=3.5), NOT KSampler CFG. Set KSampler CFG=1.0 always.",
+
+      "presets": {
+        "dev": {
+          "description": "Flux.1-dev standard.",
+          "steps": 20,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "guidance": 3.5,
+          "notes": "Guidance 3.5 via FluxGuidance node. Steps 20-28. Short prompts: guidance 3.5-4.0, long prompts: 1.0-1.5."
+        },
+        "schnell": {
+          "description": "Flux.1-schnell (1-4 steps, no LoRA needed).",
+          "steps": 4,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple"
+        },
+        "flux2_turbo": {
+          "description": "Flux 2 with turbo LoRA.",
+          "steps": 4,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "simple",
+          "lora": {
+            "name": "flux2-turbo-lora.safetensors",
+            "strength": 1.0
+          }
+        }
+      },
+      "resolutions": {
+        "square": [1024, 1024],
+        "portrait_3_4": [896, 1152],
+        "landscape_4_3": [1152, 896]
+      }
+    },
+
+    "sd35": {
+      "display_name": "Stable Diffusion 3.5",
+      "architecture": "sd3",
+
+      "presets": {
+        "large": {
+          "steps": 25,
+          "cfg": 4.5,
+          "sampler": "dpmpp_2m",
+          "scheduler": "normal"
+        },
+        "large_turbo": {
+          "steps": 5,
+          "cfg": 1.0,
+          "sampler": "euler",
+          "scheduler": "normal"
+        },
+        "medium": {
+          "steps": 28,
+          "cfg": 4.5,
+          "sampler": "euler",
+          "scheduler": "normal"
+        }
+      }
+    }
+  },
+
+  "lightning_loras": {
+    "_description": "Index of available lightning/turbo LoRAs.",
+
+    "qwen_image_4step": {
+      "file": "Qwen-Image-Lightning-4steps-V1.0.safetensors",
+      "source": "https://huggingface.co/lightx2v/Qwen-Image-2512-Lightning",
+      "steps": 4,
+      "compatible_with": ["qwen_image", "qwen_image_2512", "qwen_finetuned"],
+      "strength": 1.0,
+      "cfg": 1.0,
+      "speedup": "12-25x"
+    },
+    "qwen_image_8step": {
+      "file": "Qwen-Image-Lightning-8steps-V1.0.safetensors",
+      "source": "https://huggingface.co/lightx2v/Qwen-Image-2512-Lightning",
+      "steps": 8,
+      "compatible_with": ["qwen_image", "qwen_image_2512", "qwen_finetuned"],
+      "strength": 1.0,
+      "cfg": 1.0,
+      "notes": "Better quality than 4-step. Use CFG 2.5 for character detail."
+    },
+    "qwen_edit_2511_4step": {
+      "file": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "source": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning",
+      "steps": 4,
+      "compatible_with": ["qwen_image_2511_edit"],
+      "strength": 1.0,
+      "cfg": 1.0,
+      "speedup": "~10x",
+      "notes": "Cannot combine with distilled model."
+    },
+    "wuli_turbo_v3": {
+      "file": "NOT_INSTALLED",
+      "source": "https://huggingface.co/Wuli-art/Qwen-Image-2512-Turbo-LoRA",
+      "steps": 4,
+      "compatible_with": ["qwen_image_2512"],
+      "strength": 1.0,
+      "cfg": 1.0,
+      "speedup": "20x",
+      "notes": "Wuli-art V3.0 (Jan 2026). CFG-distilled. Also has 2-step and 8-step variants. May need download."
+    },
+    "flux2_turbo": {
+      "file": "flux2-turbo-lora.safetensors",
+      "steps": 4,
+      "compatible_with": ["flux"],
+      "strength": 1.0,
+      "cfg": 1.0
+    }
+  },
+
+  "sampler_guide": {
+    "_description": "Quick reference for sampler/scheduler by use case.",
+    "general_fast":         { "sampler": "euler",           "scheduler": "simple",      "notes": "Works everywhere. Default." },
+    "sdxl_realistic":       { "sampler": "dpmpp_2m",        "scheduler": "karras",      "notes": "SDXL gold standard. AVOID Euler on SDXL." },
+    "sdxl_anime":           { "sampler": "euler_ancestral",  "scheduler": "normal",      "notes": "Pony/anime SDXL. Clip skip 2 for Pony." },
+    "illustrious":          { "sampler": "euler_ancestral",  "scheduler": "simple",      "notes": "CFG 4.5-5.0 sweet spot." },
+    "character_composition":{ "sampler": "euler_ancestral",  "scheduler": "beta",        "notes": "Multi-character scenes, varied compositions." },
+    "qwen_realistic_hq":    { "sampler": "res_multistep",   "scheduler": "sgm_uniform", "notes": "CopaxTimeless pick for Qwen." },
+    "z_image_sharp":        { "sampler": "dpmpp_sde",       "scheduler": "beta",        "notes": "Sharpest Z-Image results (560-image test)." },
+    "z_image_beauty":       { "sampler": "euler_ancestral",  "scheduler": "beta",        "notes": "Smooth skin, fashion/beauty." },
+    "z_image_turbo":        { "sampler": "res_2s",          "scheduler": "simple",      "notes": "Z-Image Turbo distilled." }
+  },
+
+  "_contributing": {
+    "how_to_contribute": "Fork the repo, add your model/preset, submit a PR.",
+    "required_fields": ["Model name + author", "Source URL", "At least one preset (steps/cfg/sampler/scheduler)", "Resolution if non-standard"],
+    "optional_fields": ["Lightning LoRA compatibility", "Prompt style tips", "Known quirks", "img2img denoise range"],
+    "contributors": [
+      { "name": "artokun", "role": "maintainer", "date": "2026-02-16" }
+    ]
+  }
+}

--- a/model-settings.user.jsonc.example
+++ b/model-settings.user.jsonc.example
@@ -1,0 +1,97 @@
+// =============================================================================
+// ComfyUI MCP — User Model Settings
+// =============================================================================
+//
+// Your personal overrides. Deep-merged ON TOP of model-settings.json defaults.
+// User settings always win. This file is gitignored.
+//
+// Merge rules:
+//   - Keys here override matching keys in defaults
+//   - New keys are added alongside defaults
+//   - To "disable" a default, override it with your preferred value
+//
+// Tip: Copy any preset from model-settings.json, paste here, tweak values.
+// Only include what you want to change — everything else inherits from defaults.
+// =============================================================================
+{
+  // ---------------------------------------------------------------------------
+  // Override existing presets
+  // ---------------------------------------------------------------------------
+  // "model_families": {
+  //
+  //   // Example: Make Qwen 2512 standard faster by default
+  //   "qwen_image": {
+  //     "presets": {
+  //       "standard": {
+  //         "steps": 30,
+  //         "notes": "I prefer 30 steps — good enough quality, 40% faster"
+  //       }
+  //     }
+  //   },
+  //
+  //   // Example: Add a personal preset to an existing family
+  //   "sdxl": {
+  //     "presets": {
+  //       "my_portrait_style": {
+  //         "description": "My go-to for portrait photography",
+  //         "steps": 28,
+  //         "cfg": 6.5,
+  //         "sampler": "dpmpp_2m_sde",
+  //         "scheduler": "karras",
+  //         "denoise": 1.0
+  //       }
+  //     }
+  //   }
+  // },
+
+  // ---------------------------------------------------------------------------
+  // Add models not in the official config
+  // ---------------------------------------------------------------------------
+  // "custom_models": {
+  //
+  //   // Example: A custom SDXL merge you downloaded
+  //   "my_sdxl_merge_v3": {
+  //     "display_name": "My Custom SDXL Merge v3",
+  //     "architecture": "sdxl",
+  //     "loader": "CheckpointLoaderSimple",
+  //     "checkpoint": "my_merge_v3.safetensors",
+  //     "presets": {
+  //       "default": {
+  //         "steps": 22,
+  //         "cfg": 6.5,
+  //         "sampler": "dpmpp_2m",
+  //         "scheduler": "karras"
+  //       }
+  //     }
+  //   },
+  //
+  //   // Example: A Qwen fine-tune from CivitAI
+  //   "my_qwen_finetune": {
+  //     "display_name": "SomeAuthor's Qwen Realistic v2",
+  //     "architecture": "qwen_image",
+  //     "unet_path": "Qwen/custom/someModel_v2.safetensors",
+  //     "clip": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+  //     "vae": "qwen_image_vae.safetensors",
+  //     "source": "https://civitai.com/models/XXXXX",
+  //     "presets": {
+  //       "author_recommended": {
+  //         "steps": 25,
+  //         "cfg": 5.0,
+  //         "sampler": "euler",
+  //         "scheduler": "simple",
+  //         "auraflow_shift": 3.1
+  //       }
+  //     }
+  //   }
+  // },
+
+  // ---------------------------------------------------------------------------
+  // Pin your favorite presets for quick access
+  // ---------------------------------------------------------------------------
+  // "favorite_presets": {
+  //   "txt2img_default": "qwen_image.lightning_4step",
+  //   "portrait_default": "qwen_image.lightning_8step_character",
+  //   "anime_default": "illustrious.default",
+  //   "fast_realistic": "qwen_image_2512.lightning_4step"
+  // }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,12 @@
     "": {
       "name": "comfyui-mcp",
       "version": "0.2.0",
+      "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@stable-canvas/comfyui-client": "^1.5.9",
+        "better-sqlite3": "^12.6.2",
         "dotenv": "^16.4.7",
         "zod": "^3.24.2"
       },
@@ -17,6 +20,7 @@
         "comfyui-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.13.4",
         "cross-env": "^10.1.0",
         "tsx": "^4.19.2",
@@ -891,6 +895,16 @@
       "integrity": "sha512-20SaRj8CfBms5ucfUHPwX5uhSuWaSjNCNSVFgTQ/cBq0A8myZiyFmP3k9IF1uisshVwOwdFEsdNLIbr3DnszUA==",
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1097,6 +1111,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1119,6 +1187,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1195,6 +1287,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1302,6 +1400,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1312,6 +1425,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1319,6 +1441,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -1360,6 +1491,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1487,6 +1627,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1598,6 +1747,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1636,6 +1791,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1710,6 +1871,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1792,10 +1959,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -1928,6 +2121,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1953,6 +2173,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1960,6 +2186,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -2107,6 +2345,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2118,6 +2382,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2157,6 +2431,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-from-string": {
@@ -2239,11 +2542,43 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2396,6 +2731,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2429,6 +2809,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -2440,6 +2838,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -2532,6 +2958,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2575,6 +3013,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "test:integration": "cross-env COMFYUI_INTEGRATION=true vitest run",
     "lint": "tsc --noEmit",
+    "postinstall": "node scripts/postinstall.mjs",
     "release": "npm version patch && git push --follow-tags",
     "release:minor": "npm version minor && git push --follow-tags",
     "release:major": "npm version major && git push --follow-tags"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:integration": "cross-env COMFYUI_INTEGRATION=true vitest run",
     "lint": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs",
+    "generations:stats": "node scripts/generation-stats.mjs",
     "release": "npm version patch && git push --follow-tags",
     "release:minor": "npm version minor && git push --follow-tags",
     "release:major": "npm version major && git push --follow-tags"
@@ -23,10 +24,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@stable-canvas/comfyui-client": "^1.5.9",
+    "better-sqlite3": "^12.6.2",
     "dotenv": "^16.4.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.4",
     "cross-env": "^10.1.0",
     "tsx": "^4.19.2",

--- a/scripts/generation-stats.mjs
+++ b/scripts/generation-stats.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * CLI script: npm run generations:stats
+ *
+ * Shows local generation tracking statistics.
+ */
+
+import Database from "better-sqlite3";
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Find the generations.db — same logic as generation-tracker.ts
+function findDb() {
+  const home = homedir();
+
+  // Check common ComfyUI data paths
+  const candidates = [
+    join(home, "Documents", "ComfyUI", "comfyui-mcp", "generations.db"),
+    join(home, "My Documents", "ComfyUI", "comfyui-mcp", "generations.db"),
+    join(home, "AppData", "Local", "Programs", "ComfyUI", "resources", "ComfyUI", "comfyui-mcp", "generations.db"),
+    join(home, "ComfyUI", "comfyui-mcp", "generations.db"),
+    // Fallback: next to the package
+    join(__dirname, "..", "generations.db"),
+  ];
+
+  // COMFYUI_PATH env override
+  if (process.env.COMFYUI_PATH) {
+    candidates.unshift(
+      join(process.env.COMFYUI_PATH, "comfyui-mcp", "generations.db"),
+    );
+  }
+
+  for (const path of candidates) {
+    if (existsSync(path)) return path;
+  }
+
+  return null;
+}
+
+function main() {
+  const dbPath = findDb();
+
+  if (!dbPath) {
+    console.log("\n  No generations.db found. Run some workflows first!\n");
+    process.exit(0);
+  }
+
+  const db = new Database(dbPath, { readonly: true });
+
+  const totalRow = db
+    .prepare("SELECT COALESCE(SUM(reuse_count), 0) AS total FROM generations")
+    .get();
+  const uniqueRow = db
+    .prepare("SELECT COUNT(*) AS cnt FROM generations")
+    .get();
+
+  console.log("\n  === Generation Stats ===\n");
+  console.log(`  Database: ${dbPath}`);
+  console.log(`  Total generations: ${totalRow.total}`);
+  console.log(`  Unique setting combos: ${uniqueRow.cnt}`);
+
+  // Breakdown by model family
+  const breakdown = db
+    .prepare(
+      `SELECT model_family, SUM(reuse_count) AS total, COUNT(*) AS combos
+       FROM generations
+       GROUP BY model_family
+       ORDER BY total DESC`,
+    )
+    .all();
+
+  if (breakdown.length > 0) {
+    console.log("\n  Model Family          Generations  Combos");
+    console.log("  " + "─".repeat(50));
+    for (const row of breakdown) {
+      const family = row.model_family.padEnd(22);
+      const total = String(row.total).padStart(11);
+      const combos = String(row.combos).padStart(7);
+      console.log(`  ${family}${total}${combos}`);
+    }
+  }
+
+  // Top 10 settings
+  const top = db
+    .prepare(
+      `SELECT model_family, model_name, sampler, scheduler, steps, cfg, shift,
+              lora_name, lora_strength, reuse_count
+       FROM generations
+       ORDER BY reuse_count DESC, created_at DESC
+       LIMIT 10`,
+    )
+    .all();
+
+  if (top.length > 0) {
+    console.log("\n  Top Settings:\n");
+    for (const [i, row] of top.entries()) {
+      const lora = row.lora_name
+        ? ` + ${row.lora_name} (${row.lora_strength})`
+        : "";
+      const shiftStr = row.shift != null ? `, shift ${row.shift}` : "";
+      console.log(
+        `  ${i + 1}. ${row.model_family} / ${row.sampler}/${row.scheduler} / ` +
+          `${row.steps} steps / CFG ${row.cfg}${shiftStr}${lora}` +
+          ` — ${row.reuse_count}x`,
+      );
+      if (row.model_name) {
+        console.log(`     Model: ${row.model_name}`);
+      }
+    }
+  }
+
+  // File hash cache stats
+  try {
+    const hashCount = db
+      .prepare("SELECT COUNT(*) AS cnt FROM file_hashes")
+      .get();
+    const civitaiCount = db
+      .prepare("SELECT COUNT(*) AS cnt FROM file_hashes WHERE civitai_id IS NOT NULL")
+      .get();
+    console.log(
+      `\n  File hashes cached: ${hashCount.cnt} (${civitaiCount.cnt} matched on CivitAI)`,
+    );
+  } catch {
+    // file_hashes table may not exist yet
+  }
+
+  console.log("");
+  db.close();
+}
+
+main();

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+/**
+ * Post-install script for comfyui-mcp.
+ *
+ * Copies model-settings.user.jsonc from the example template if the user
+ * doesn't already have one — same pattern as .env.example → .env.
+ */
+
+import { existsSync, copyFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const example = resolve(root, "model-settings.user.jsonc.example");
+const target = resolve(root, "model-settings.user.jsonc");
+
+if (!existsSync(target)) {
+  if (existsSync(example)) {
+    copyFileSync(example, target);
+    console.log(
+      "✔ Created model-settings.user.jsonc from example template. Edit it to add your personal presets."
+    );
+  }
+} else {
+  // User file already exists — don't touch it
+}

--- a/src/services/civitai-lookup.ts
+++ b/src/services/civitai-lookup.ts
@@ -1,0 +1,102 @@
+import { config } from "../config.js";
+import { logger } from "../utils/logger.js";
+import type { FileHasher } from "./file-hasher.js";
+
+export interface CivitaiModelVersion {
+  id: number;
+  modelId: number;
+  name: string;
+  model?: {
+    name: string;
+    type: string;
+  };
+}
+
+/**
+ * Look up a model/LoRA on CivitAI by its AutoV2 hash.
+ * Updates the file_hashes cache with the result.
+ */
+export async function lookupByHash(
+  hasher: FileHasher,
+  filename: string,
+  autov2: string,
+): Promise<CivitaiModelVersion | null> {
+  const url = `https://civitai.com/api/v1/model-versions/by-hash/${autov2}`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (config.civitaiApiToken) {
+    headers["Authorization"] = `Bearer ${config.civitaiApiToken}`;
+  }
+
+  try {
+    logger.debug(`CivitAI lookup: ${autov2} (${filename})`);
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
+
+    if (res.status === 404) {
+      // Not found on CivitAI — private or unlisted model
+      hasher.updateCivitaiInfo(filename, null, null, null);
+      logger.debug(`CivitAI: ${filename} not found (private/unlisted)`);
+      return null;
+    }
+
+    if (!res.ok) {
+      logger.warn(`CivitAI API error: ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    const data = (await res.json()) as CivitaiModelVersion;
+
+    hasher.updateCivitaiInfo(
+      filename,
+      data.id,
+      data.model?.name ?? data.name,
+      data.modelId,
+    );
+
+    logger.info(
+      `CivitAI match: ${filename} → ${data.model?.name ?? data.name} (version ${data.id})`,
+    );
+    return data;
+  } catch (err) {
+    logger.warn(`CivitAI lookup failed for ${filename}`, {
+      error: err instanceof Error ? err.message : err,
+    });
+    return null;
+  }
+}
+
+/**
+ * Batch-check multiple files against CivitAI.
+ * Only checks files that haven't been looked up yet.
+ */
+export async function batchLookup(
+  hasher: FileHasher,
+  files: Array<{ filename: string; autov2: string }>,
+): Promise<Map<string, CivitaiModelVersion | null>> {
+  const results = new Map<string, CivitaiModelVersion | null>();
+
+  for (const file of files) {
+    if (!hasher.needsCivitaiCheck(file.filename)) {
+      const cached = hasher.getCached(file.filename);
+      if (cached?.civitaiId) {
+        results.set(file.filename, {
+          id: cached.civitaiId,
+          modelId: cached.civitaiModelId ?? 0,
+          name: cached.civitaiName ?? file.filename,
+        });
+      } else {
+        results.set(file.filename, null);
+      }
+      continue;
+    }
+
+    // Rate-limit: 1 request per 500ms to be polite
+    const result = await lookupByHash(hasher, file.filename, file.autov2);
+    results.set(file.filename, result);
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  return results;
+}

--- a/src/services/file-hasher.ts
+++ b/src/services/file-hasher.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { basename } from "node:path";
+import type Database from "better-sqlite3";
+import { logger } from "../utils/logger.js";
+
+export interface FileHashResult {
+  filename: string;
+  filePath: string;
+  sha256: string;
+  autov2: string;
+  fileType: string;
+  civitaiId: number | null;
+  civitaiName: string | null;
+  civitaiModelId: number | null;
+}
+
+const INIT_SQL = `
+CREATE TABLE IF NOT EXISTS file_hashes (
+  filename         TEXT    PRIMARY KEY,
+  file_path        TEXT    NOT NULL,
+  file_size        INTEGER NOT NULL,
+  file_mtime       TEXT    NOT NULL,
+  sha256           TEXT    NOT NULL,
+  autov2           TEXT    NOT NULL,
+  file_type        TEXT    NOT NULL,
+  civitai_id       INTEGER,
+  civitai_name     TEXT,
+  civitai_model_id INTEGER,
+  checked_at       TEXT
+);
+`;
+
+export class FileHasher {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+    this.db.exec(INIT_SQL);
+  }
+
+  /**
+   * Get or compute the hash for a file. Uses cache if file hasn't changed.
+   */
+  async getHash(filePath: string, fileType: string): Promise<FileHashResult> {
+    const filename = basename(filePath);
+    const info = await stat(filePath);
+    const fileSize = info.size;
+    const fileMtime = info.mtime.toISOString();
+
+    // Check cache
+    const cached = this.db
+      .prepare(
+        `SELECT * FROM file_hashes WHERE filename = ? AND file_size = ? AND file_mtime = ?`,
+      )
+      .get(filename, fileSize, fileMtime) as Record<string, unknown> | undefined;
+
+    if (cached) {
+      return {
+        filename,
+        filePath,
+        sha256: cached.sha256 as string,
+        autov2: cached.autov2 as string,
+        fileType: cached.file_type as string,
+        civitaiId: cached.civitai_id as number | null,
+        civitaiName: cached.civitai_name as string | null,
+        civitaiModelId: cached.civitai_model_id as number | null,
+      };
+    }
+
+    // Compute SHA256
+    logger.info(`Hashing ${filename} (${(fileSize / 1024 / 1024).toFixed(0)} MB)...`);
+    const sha256 = await computeSHA256(filePath);
+    const autov2 = sha256.slice(0, 10).toUpperCase();
+    logger.info(`Hash complete: ${filename} → ${autov2}`);
+
+    // Upsert into cache
+    this.db
+      .prepare(
+        `INSERT INTO file_hashes (filename, file_path, file_size, file_mtime, sha256, autov2, file_type)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(filename) DO UPDATE SET
+           file_path = excluded.file_path,
+           file_size = excluded.file_size,
+           file_mtime = excluded.file_mtime,
+           sha256 = excluded.sha256,
+           autov2 = excluded.autov2,
+           file_type = excluded.file_type`,
+      )
+      .run(filename, filePath, fileSize, fileMtime, sha256, autov2, fileType);
+
+    return {
+      filename,
+      filePath,
+      sha256,
+      autov2,
+      fileType,
+      civitaiId: null,
+      civitaiName: null,
+      civitaiModelId: null,
+    };
+  }
+
+  /**
+   * Update CivitAI metadata for a cached file hash.
+   */
+  updateCivitaiInfo(
+    filename: string,
+    civitaiId: number | null,
+    civitaiName: string | null,
+    civitaiModelId: number | null,
+  ): void {
+    this.db
+      .prepare(
+        `UPDATE file_hashes
+         SET civitai_id = ?, civitai_name = ?, civitai_model_id = ?, checked_at = datetime('now')
+         WHERE filename = ?`,
+      )
+      .run(civitaiId, civitaiName, civitaiModelId, filename);
+  }
+
+  /**
+   * Look up a cached hash by filename (no recomputation).
+   */
+  getCached(filename: string): FileHashResult | null {
+    const row = this.db
+      .prepare(`SELECT * FROM file_hashes WHERE filename = ?`)
+      .get(filename) as Record<string, unknown> | undefined;
+
+    if (!row) return null;
+
+    return {
+      filename: row.filename as string,
+      filePath: row.file_path as string,
+      sha256: row.sha256 as string,
+      autov2: row.autov2 as string,
+      fileType: row.file_type as string,
+      civitaiId: row.civitai_id as number | null,
+      civitaiName: row.civitai_name as string | null,
+      civitaiModelId: row.civitai_model_id as number | null,
+    };
+  }
+
+  /**
+   * Check if a file needs CivitAI lookup (no civitai check recorded).
+   */
+  needsCivitaiCheck(filename: string): boolean {
+    const row = this.db
+      .prepare(`SELECT checked_at FROM file_hashes WHERE filename = ?`)
+      .get(filename) as { checked_at: string | null } | undefined;
+    return !row || row.checked_at === null;
+  }
+}
+
+/**
+ * Stream-based SHA256 for large files. Doesn't load the whole file into memory.
+ */
+function computeSHA256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
+}

--- a/src/services/generation-tracker.ts
+++ b/src/services/generation-tracker.ts
@@ -1,0 +1,404 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+import BetterSqlite3 from "better-sqlite3";
+import type Database from "better-sqlite3";
+import { config } from "../config.js";
+import { logger } from "../utils/logger.js";
+import { FileHasher, type FileHashResult } from "./file-hasher.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GenerationEntry {
+  modelFamily: string;
+  modelHash: string;
+  modelName: string | null;
+  presetName: string | null;
+  sampler: string;
+  scheduler: string;
+  steps: number;
+  cfg: number;
+  denoise: number;
+  shift: number | null;
+  width: number;
+  height: number;
+  loraHash: string | null;
+  loraName: string | null;
+  loraStrength: number | null;
+  loraCivitaiId: number | null;
+  negPromptHash: string | null;
+}
+
+export interface TopSetting {
+  settingsHash: string;
+  modelFamily: string;
+  modelHash: string;
+  modelName: string | null;
+  presetName: string | null;
+  sampler: string;
+  scheduler: string;
+  steps: number;
+  cfg: number;
+  denoise: number;
+  shift: number | null;
+  loraHash: string | null;
+  loraName: string | null;
+  loraStrength: number | null;
+  reuseCount: number;
+  createdAt: string;
+}
+
+export interface GenerationStats {
+  totalGenerations: number;
+  uniqueCombos: number;
+  modelBreakdown: Array<{ modelFamily: string; count: number }>;
+  topSettings: TopSetting[];
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const INIT_SQL = `
+CREATE TABLE IF NOT EXISTS generations (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+  settings_hash   TEXT    NOT NULL,
+  model_family    TEXT    NOT NULL,
+  model_hash      TEXT    NOT NULL,
+  model_name      TEXT,
+  preset_name     TEXT,
+  sampler         TEXT    NOT NULL,
+  scheduler       TEXT    NOT NULL,
+  steps           INTEGER NOT NULL,
+  cfg             REAL    NOT NULL,
+  denoise         REAL    DEFAULT 1.0,
+  shift           REAL,
+  width           INTEGER NOT NULL,
+  height          INTEGER NOT NULL,
+  lora_hash       TEXT,
+  lora_name       TEXT,
+  lora_strength   REAL,
+  lora_civitai_id INTEGER,
+  reuse_count     INTEGER NOT NULL DEFAULT 1,
+  neg_prompt_hash TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_gen_settings_hash ON generations(settings_hash);
+CREATE INDEX IF NOT EXISTS idx_gen_model_family  ON generations(model_family);
+CREATE INDEX IF NOT EXISTS idx_gen_model_hash    ON generations(model_hash);
+CREATE INDEX IF NOT EXISTS idx_gen_lora_hash     ON generations(lora_hash);
+CREATE INDEX IF NOT EXISTS idx_gen_lora_civitai  ON generations(lora_civitai_id);
+CREATE INDEX IF NOT EXISTS idx_gen_created       ON generations(created_at);
+`;
+
+// ---------------------------------------------------------------------------
+// Settings hash computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the settings fingerprint. This determines what counts as "the same combo".
+ * Resolution, display names, and preset names are intentionally excluded.
+ */
+function computeSettingsHash(entry: GenerationEntry): string {
+  const canonical: Record<string, unknown> = {
+    cfg: entry.cfg,
+    denoise: entry.denoise,
+    model_family: entry.modelFamily,
+    model_hash: entry.modelHash,
+    sampler: entry.sampler,
+    scheduler: entry.scheduler,
+    steps: entry.steps,
+  };
+
+  // Only include optional fields if they have values
+  if (entry.shift != null) canonical.shift = entry.shift;
+  if (entry.loraHash) canonical.lora_hash = entry.loraHash;
+  if (entry.loraStrength != null && entry.loraHash) canonical.lora_strength = entry.loraStrength;
+
+  // Sort keys for deterministic output
+  const sorted = Object.keys(canonical)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = canonical[key];
+      return acc;
+    }, {});
+
+  return createHash("sha256").update(JSON.stringify(sorted)).digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// GenerationTracker class
+// ---------------------------------------------------------------------------
+
+export class GenerationTracker {
+  private db: Database.Database;
+  public readonly fileHasher: FileHasher;
+
+  constructor(dbPath?: string) {
+    const resolvedPath = dbPath ?? this.defaultDbPath();
+
+    // Ensure parent directory exists
+    const dir = join(resolvedPath, "..");
+    mkdirSync(dir, { recursive: true });
+
+    this.db = new BetterSqlite3(resolvedPath);
+    this.db.pragma("journal_mode = WAL");
+    this.db.pragma("foreign_keys = ON");
+    this.db.exec(INIT_SQL);
+
+    this.fileHasher = new FileHasher(this.db);
+
+    logger.info(`Generation tracker DB: ${resolvedPath}`);
+  }
+
+  private defaultDbPath(): string {
+    if (config.comfyuiPath) {
+      return join(config.comfyuiPath, "comfyui-mcp", "generations.db");
+    }
+    // Fallback: next to the MCP server package
+    return join(process.cwd(), "generations.db");
+  }
+
+  /**
+   * Log a generation. If the same settings_hash already exists,
+   * increments reuse_count and updates timestamp instead of inserting.
+   */
+  logGeneration(entry: GenerationEntry): { settingsHash: string; reuseCount: number } {
+    const settingsHash = computeSettingsHash(entry);
+
+    const existing = this.db
+      .prepare(`SELECT id, reuse_count FROM generations WHERE settings_hash = ?`)
+      .get(settingsHash) as { id: number; reuse_count: number } | undefined;
+
+    if (existing) {
+      this.db
+        .prepare(
+          `UPDATE generations
+           SET reuse_count = reuse_count + 1,
+               created_at = datetime('now'),
+               width = ?,
+               height = ?
+           WHERE id = ?`,
+        )
+        .run(entry.width, entry.height, existing.id);
+
+      const newCount = existing.reuse_count + 1;
+      logger.info(
+        `Generation logged (reuse #${newCount}): ${entry.modelFamily} / ${entry.sampler}/${entry.scheduler} / ${entry.steps} steps`,
+      );
+      return { settingsHash, reuseCount: newCount };
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO generations (
+           settings_hash, model_family, model_hash, model_name, preset_name,
+           sampler, scheduler, steps, cfg, denoise, shift,
+           width, height,
+           lora_hash, lora_name, lora_strength, lora_civitai_id,
+           neg_prompt_hash
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        settingsHash,
+        entry.modelFamily,
+        entry.modelHash,
+        entry.modelName,
+        entry.presetName,
+        entry.sampler,
+        entry.scheduler,
+        entry.steps,
+        entry.cfg,
+        entry.denoise,
+        entry.shift,
+        entry.width,
+        entry.height,
+        entry.loraHash,
+        entry.loraName,
+        entry.loraStrength,
+        entry.loraCivitaiId,
+        entry.negPromptHash,
+      );
+
+    logger.info(
+      `Generation logged (new): ${entry.modelFamily} / ${entry.sampler}/${entry.scheduler} / ${entry.steps} steps`,
+    );
+    return { settingsHash, reuseCount: 1 };
+  }
+
+  /**
+   * Get top settings for a model family, ordered by reuse count.
+   */
+  suggestSettings(
+    modelFamily: string,
+    limit = 10,
+  ): TopSetting[] {
+    const rows = this.db
+      .prepare(
+        `SELECT settings_hash, model_family, model_hash, model_name, preset_name,
+                sampler, scheduler, steps, cfg, denoise, shift,
+                lora_hash, lora_name, lora_strength, reuse_count, created_at
+         FROM generations
+         WHERE model_family = ?
+         ORDER BY reuse_count DESC, created_at DESC
+         LIMIT ?`,
+      )
+      .all(modelFamily, limit) as Array<Record<string, unknown>>;
+
+    return rows.map(mapRowToTopSetting);
+  }
+
+  /**
+   * Get top settings for a specific LoRA hash.
+   */
+  suggestSettingsForLora(
+    loraHash: string,
+    limit = 10,
+  ): TopSetting[] {
+    const rows = this.db
+      .prepare(
+        `SELECT settings_hash, model_family, model_hash, model_name, preset_name,
+                sampler, scheduler, steps, cfg, denoise, shift,
+                lora_hash, lora_name, lora_strength, reuse_count, created_at
+         FROM generations
+         WHERE lora_hash = ?
+         ORDER BY reuse_count DESC, created_at DESC
+         LIMIT ?`,
+      )
+      .all(loraHash, limit) as Array<Record<string, unknown>>;
+
+    return rows.map(mapRowToTopSetting);
+  }
+
+  /**
+   * Search generations by model or LoRA name (substring match).
+   */
+  searchByName(
+    query: string,
+    limit = 20,
+  ): TopSetting[] {
+    const pattern = `%${query}%`;
+    const rows = this.db
+      .prepare(
+        `SELECT settings_hash, model_family, model_hash, model_name, preset_name,
+                sampler, scheduler, steps, cfg, denoise, shift,
+                lora_hash, lora_name, lora_strength, reuse_count, created_at
+         FROM generations
+         WHERE model_name LIKE ? OR lora_name LIKE ?
+         ORDER BY reuse_count DESC, created_at DESC
+         LIMIT ?`,
+      )
+      .all(pattern, pattern, limit) as Array<Record<string, unknown>>;
+
+    return rows.map(mapRowToTopSetting);
+  }
+
+  /**
+   * Get overall generation statistics.
+   */
+  getStats(modelFamily?: string): GenerationStats {
+    const whereClause = modelFamily ? `WHERE model_family = ?` : "";
+    const params = modelFamily ? [modelFamily] : [];
+
+    const totalRow = this.db
+      .prepare(`SELECT COALESCE(SUM(reuse_count), 0) AS total FROM generations ${whereClause}`)
+      .get(...params) as { total: number };
+
+    const uniqueRow = this.db
+      .prepare(`SELECT COUNT(*) AS cnt FROM generations ${whereClause}`)
+      .get(...params) as { cnt: number };
+
+    const breakdownRows = this.db
+      .prepare(
+        `SELECT model_family, COALESCE(SUM(reuse_count), 0) AS total
+         FROM generations
+         GROUP BY model_family
+         ORDER BY total DESC`,
+      )
+      .all() as Array<{ model_family: string; total: number }>;
+
+    const topRows = this.db
+      .prepare(
+        `SELECT settings_hash, model_family, model_hash, model_name, preset_name,
+                sampler, scheduler, steps, cfg, denoise, shift,
+                lora_hash, lora_name, lora_strength, reuse_count, created_at
+         FROM generations ${whereClause}
+         ORDER BY reuse_count DESC, created_at DESC
+         LIMIT 5`,
+      )
+      .all(...params) as Array<Record<string, unknown>>;
+
+    return {
+      totalGenerations: totalRow.total,
+      uniqueCombos: uniqueRow.cnt,
+      modelBreakdown: breakdownRows.map((r) => ({
+        modelFamily: r.model_family,
+        count: r.total,
+      })),
+      topSettings: topRows.map(mapRowToTopSetting),
+    };
+  }
+
+  /**
+   * Get shareable entries (only those with public LoRAs or no LoRA).
+   */
+  getShareableEntries(): TopSetting[] {
+    const rows = this.db
+      .prepare(
+        `SELECT settings_hash, model_family, model_hash, model_name, preset_name,
+                sampler, scheduler, steps, cfg, denoise, shift,
+                lora_hash, lora_name, lora_strength, reuse_count, created_at
+         FROM generations
+         WHERE lora_hash IS NULL OR lora_civitai_id IS NOT NULL
+         ORDER BY reuse_count DESC`,
+      )
+      .all() as Array<Record<string, unknown>>;
+
+    return rows.map(mapRowToTopSetting);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mapRowToTopSetting(row: Record<string, unknown>): TopSetting {
+  return {
+    settingsHash: row.settings_hash as string,
+    modelFamily: row.model_family as string,
+    modelHash: row.model_hash as string,
+    modelName: row.model_name as string | null,
+    presetName: row.preset_name as string | null,
+    sampler: row.sampler as string,
+    scheduler: row.scheduler as string,
+    steps: row.steps as number,
+    cfg: row.cfg as number,
+    denoise: row.denoise as number,
+    shift: row.shift as number | null,
+    loraHash: row.lora_hash as string | null,
+    loraName: row.lora_name as string | null,
+    loraStrength: row.lora_strength as number | null,
+    reuseCount: row.reuse_count as number,
+    createdAt: row.created_at as string,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _tracker: GenerationTracker | null = null;
+
+export function getTracker(): GenerationTracker {
+  if (!_tracker) {
+    _tracker = new GenerationTracker();
+  }
+  return _tracker;
+}

--- a/src/services/workflow-settings-extractor.ts
+++ b/src/services/workflow-settings-extractor.ts
@@ -187,8 +187,9 @@ export async function extractSettings(
   let loaderClassType = "CheckpointLoaderSimple";
 
   if (isIntegrated) {
-    // QwenImageIntegratedKSampler has unet, clip, vae inputs directly
-    const unetRef = resolveRef(workflow, inputs.unet);
+    // QwenImageIntegratedKSampler: v1 uses "unet" input, v2 uses "model" input
+    const modelInput = inputs.model ?? inputs.unet;
+    const unetRef = resolveRef(workflow, modelInput);
     if (unetRef && MODEL_LOADER_NODES.has(unetRef.class_type)) {
       loaderClassType = unetRef.class_type;
       modelName =

--- a/src/services/workflow-settings-extractor.ts
+++ b/src/services/workflow-settings-extractor.ts
@@ -1,0 +1,274 @@
+import { join } from "node:path";
+import { config } from "../config.js";
+import { logger } from "../utils/logger.js";
+import type { GenerationEntry } from "./generation-tracker.js";
+import type { FileHasher } from "./file-hasher.js";
+
+/**
+ * Node class types we recognize for extracting generation settings.
+ */
+const SAMPLER_NODES = new Set([
+  "KSampler",
+  "KSamplerAdvanced",
+  "SamplerCustom",
+  "QwenImageIntegratedKSampler",
+]);
+
+const MODEL_LOADER_NODES = new Set([
+  "CheckpointLoaderSimple",
+  "CheckpointLoader",
+  "UNETLoader",
+  "unCLIPCheckpointLoader",
+]);
+
+const LORA_NODES = new Set([
+  "LoraLoader",
+  "LoraLoaderModelOnly",
+]);
+
+const VAE_DECODE_NODES = new Set([
+  "VAEDecode",
+  "VAEDecodeTiled",
+]);
+
+interface WorkflowNode {
+  class_type: string;
+  inputs: Record<string, unknown>;
+}
+
+type WorkflowJSON = Record<string, WorkflowNode>;
+
+/**
+ * Resolve a node input reference. ComfyUI links are [nodeId, outputIndex].
+ */
+function resolveRef(
+  workflow: WorkflowJSON,
+  value: unknown,
+): WorkflowNode | null {
+  if (Array.isArray(value) && value.length === 2 && typeof value[0] === "string") {
+    return workflow[value[0]] ?? null;
+  }
+  return null;
+}
+
+/**
+ * Walk upward from a sampler node to find the model loader.
+ */
+function findModelLoader(
+  workflow: WorkflowJSON,
+  samplerNode: WorkflowNode,
+): WorkflowNode | null {
+  // KSampler.model input
+  const modelRef = samplerNode.inputs.model;
+  if (!modelRef) return null;
+
+  const modelNode = resolveRef(workflow, modelRef);
+  if (!modelNode) return null;
+
+  // Direct loader
+  if (MODEL_LOADER_NODES.has(modelNode.class_type)) return modelNode;
+
+  // LoRA in between — follow through
+  if (LORA_NODES.has(modelNode.class_type)) {
+    const upstream = resolveRef(workflow, modelNode.inputs.model);
+    if (upstream && MODEL_LOADER_NODES.has(upstream.class_type)) return upstream;
+  }
+
+  return null;
+}
+
+/**
+ * Walk upward from a sampler node to find a LoRA loader.
+ */
+function findLoraLoader(
+  workflow: WorkflowJSON,
+  samplerNode: WorkflowNode,
+): WorkflowNode | null {
+  const modelRef = samplerNode.inputs.model;
+  if (!modelRef) return null;
+
+  const modelNode = resolveRef(workflow, modelRef);
+  if (!modelNode) return null;
+
+  if (LORA_NODES.has(modelNode.class_type)) return modelNode;
+
+  return null;
+}
+
+/**
+ * Determine model family from checkpoint name and node types.
+ */
+function inferModelFamily(
+  checkpointName: string,
+  loaderClassType: string,
+  samplerInputs: Record<string, unknown>,
+): string {
+  const lower = checkpointName.toLowerCase();
+
+  if (lower.includes("qwen") && lower.includes("edit")) return "qwen_image_edit";
+  if (lower.includes("qwen")) return "qwen_image";
+  if (lower.includes("flux")) return "flux";
+  if (lower.includes("sdxl") || lower.includes("sd_xl")) return "sdxl";
+  if (lower.includes("illustrious")) return "illustrious";
+  if (lower.includes("pony")) return "pony";
+  if (lower.includes("sd3") || lower.includes("sd_3")) return "sd35";
+  if (lower.includes("z-image") || lower.includes("zimage")) return "z_image";
+  if (lower.includes("copax")) return "qwen_finetuned";
+  if (lower.includes("redcraft")) return "qwen_finetuned";
+
+  // Check by loader type
+  if (loaderClassType === "UNETLoader") {
+    if (samplerInputs.auraflow_shift != null) return "qwen_image";
+  }
+
+  return "unknown";
+}
+
+/**
+ * Extract generation settings from a ComfyUI API-format workflow.
+ * Returns null if no sampler node is found.
+ */
+export async function extractSettings(
+  workflow: WorkflowJSON,
+  hasher: FileHasher,
+): Promise<GenerationEntry | null> {
+  // Find the primary sampler node
+  let samplerNode: WorkflowNode | null = null;
+  let samplerNodeId = "";
+
+  for (const [id, node] of Object.entries(workflow)) {
+    if (SAMPLER_NODES.has(node.class_type)) {
+      samplerNode = node;
+      samplerNodeId = id;
+      break;
+    }
+  }
+
+  if (!samplerNode) {
+    logger.debug("No sampler node found in workflow — skipping tracking");
+    return null;
+  }
+
+  const inputs = samplerNode.inputs;
+
+  // Extract sampler params
+  const sampler = String(inputs.sampler_name ?? inputs.sampler ?? "unknown");
+  const scheduler = String(inputs.scheduler ?? "unknown");
+  const steps = Number(inputs.steps ?? 0);
+  const cfg = Number(inputs.cfg ?? inputs.cfg_scale ?? 0);
+  const denoise = Number(inputs.denoise ?? 1.0);
+  const shift = inputs.auraflow_shift != null ? Number(inputs.auraflow_shift) : null;
+
+  // Extract resolution from latent_image input or direct width/height
+  let width = Number(inputs.width ?? 0);
+  let height = Number(inputs.height ?? 0);
+
+  if (width === 0 || height === 0) {
+    // Try to find EmptyLatentImage node connected to latent_image input
+    const latentRef = inputs.latent_image;
+    const latentNode = resolveRef(workflow, latentRef);
+    if (latentNode) {
+      width = Number(latentNode.inputs.width ?? 0);
+      height = Number(latentNode.inputs.height ?? 0);
+    }
+  }
+
+  // Find model loader
+  let modelName: string | null = null;
+  let modelHash = "UNKNOWN";
+  let modelFamily = "unknown";
+
+  const isIntegrated = samplerNode.class_type === "QwenImageIntegratedKSampler";
+
+  if (isIntegrated) {
+    // QwenImageIntegratedKSampler has unet, clip, vae inputs directly
+    const unetRef = resolveRef(workflow, inputs.unet);
+    if (unetRef && MODEL_LOADER_NODES.has(unetRef.class_type)) {
+      modelName =
+        String(unetRef.inputs.unet_name ?? unetRef.inputs.ckpt_name ?? "");
+    }
+  } else {
+    const loader = findModelLoader(workflow, samplerNode);
+    if (loader) {
+      modelName =
+        String(loader.inputs.ckpt_name ?? loader.inputs.unet_name ?? "");
+    }
+  }
+
+  if (modelName) {
+    modelFamily = inferModelFamily(
+      modelName,
+      isIntegrated ? "UNETLoader" : "CheckpointLoaderSimple",
+      inputs,
+    );
+
+    // Hash the model file
+    try {
+      const modelDir = modelName.includes("/")
+        ? "unet"
+        : "checkpoints";
+      const modelsRoot = config.comfyuiPath
+        ? join(config.comfyuiPath, "models", modelDir)
+        : "";
+      if (modelsRoot) {
+        const hashResult = await hasher.getHash(
+          join(modelsRoot, modelName),
+          modelDir === "unet" ? "unet" : "checkpoint",
+        );
+        modelHash = hashResult.autov2;
+      }
+    } catch (err) {
+      logger.warn(`Could not hash model file: ${modelName}`, {
+        error: err instanceof Error ? err.message : err,
+      });
+    }
+  }
+
+  // Find LoRA
+  let loraName: string | null = null;
+  let loraHash: string | null = null;
+  let loraStrength: number | null = null;
+  let loraCivitaiId: number | null = null;
+
+  const loraLoader = isIntegrated ? null : findLoraLoader(workflow, samplerNode);
+  if (loraLoader) {
+    loraName = String(loraLoader.inputs.lora_name ?? "");
+    loraStrength = Number(loraLoader.inputs.strength_model ?? 1.0);
+
+    // Hash the LoRA file
+    try {
+      const loraPath = config.comfyuiPath
+        ? join(config.comfyuiPath, "models", "loras", loraName)
+        : "";
+      if (loraPath) {
+        const hashResult = await hasher.getHash(loraPath, "lora");
+        loraHash = hashResult.autov2;
+        loraCivitaiId = hashResult.civitaiId;
+      }
+    } catch (err) {
+      logger.warn(`Could not hash LoRA file: ${loraName}`, {
+        error: err instanceof Error ? err.message : err,
+      });
+    }
+  }
+
+  return {
+    modelFamily,
+    modelHash,
+    modelName,
+    presetName: null, // Could be inferred from model-settings.json match in the future
+    sampler,
+    scheduler,
+    steps,
+    cfg,
+    denoise,
+    shift,
+    width,
+    height,
+    loraHash,
+    loraName,
+    loraStrength,
+    loraCivitaiId,
+    negPromptHash: null, // Could hash negative prompt text in the future
+  };
+}

--- a/src/tools/generation-tracker.ts
+++ b/src/tools/generation-tracker.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getTracker } from "../services/generation-tracker.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerGenerationTrackerTools(server: McpServer): void {
+  server.tool(
+    "suggest_settings",
+    "Suggest proven sampler/scheduler/steps/CFG settings based on local generation history. " +
+      "Query by model family, LoRA hash, or text search on model/LoRA names.",
+    {
+      model_family: z
+        .string()
+        .optional()
+        .describe(
+          "Model family to query (e.g. 'qwen_image', 'sdxl', 'flux', 'illustrious')",
+        ),
+      lora_hash: z
+        .string()
+        .optional()
+        .describe("AutoV2 hash (10 chars) of a specific LoRA to find settings for"),
+      search: z
+        .string()
+        .optional()
+        .describe(
+          "Full-text search on model/LoRA filenames (e.g. 'copax', 'lightning')",
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Max results (default 10)"),
+    },
+    async (args) => {
+      try {
+        const tracker = getTracker();
+        const limit = args.limit ?? 10;
+
+        let results;
+        let heading: string;
+
+        if (args.lora_hash) {
+          results = tracker.suggestSettingsForLora(args.lora_hash, limit);
+          heading = `Top settings for LoRA ${args.lora_hash}`;
+        } else if (args.search) {
+          results = tracker.searchByName(args.search, limit);
+          heading = `Settings matching "${args.search}"`;
+        } else if (args.model_family) {
+          results = tracker.suggestSettings(args.model_family, limit);
+          heading = `Top settings for ${args.model_family}`;
+        } else {
+          // No filter — show overall top settings
+          const stats = tracker.getStats();
+          results = stats.topSettings;
+          heading = "Top settings across all models";
+        }
+
+        if (results.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No generation history found. Run some workflows first to build up settings data.",
+              },
+            ],
+          };
+        }
+
+        const lines = [`## ${heading}\n`];
+        for (const [i, s] of results.entries()) {
+          const lora = s.loraName
+            ? `LoRA: ${s.loraName} (${s.loraStrength})`
+            : "no LoRA";
+          lines.push(
+            `${i + 1}. **${s.sampler}/${s.scheduler}** — ${s.steps} steps, CFG ${s.cfg}` +
+              (s.shift != null ? `, shift ${s.shift}` : "") +
+              `, denoise ${s.denoise}` +
+              `\n   Model: ${s.modelName ?? s.modelHash} (${s.modelFamily})` +
+              `\n   ${lora}` +
+              `\n   Used ${s.reuseCount}x` +
+              (s.presetName ? ` | Preset: ${s.presetName}` : ""),
+          );
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "generation_stats",
+    "Show local generation tracking statistics — total runs, unique combos, breakdown by model family.",
+    {
+      model_family: z
+        .string()
+        .optional()
+        .describe("Filter stats to a specific model family"),
+    },
+    async (args) => {
+      try {
+        const tracker = getTracker();
+        const stats = tracker.getStats(args.model_family);
+
+        const lines: string[] = [];
+
+        if (args.model_family) {
+          lines.push(`## Generation Stats: ${args.model_family}\n`);
+        } else {
+          lines.push("## Generation Stats\n");
+        }
+
+        lines.push(`- **Total generations**: ${stats.totalGenerations}`);
+        lines.push(`- **Unique setting combos**: ${stats.uniqueCombos}`);
+
+        if (stats.modelBreakdown.length > 0) {
+          lines.push("\n### By model family\n");
+          for (const b of stats.modelBreakdown) {
+            lines.push(`- ${b.modelFamily}: ${b.count} generations`);
+          }
+        }
+
+        if (stats.topSettings.length > 0) {
+          lines.push("\n### Most-used settings\n");
+          for (const [i, s] of stats.topSettings.entries()) {
+            const lora = s.loraName ? ` + ${s.loraName}` : "";
+            lines.push(
+              `${i + 1}. ${s.modelFamily} / ${s.sampler}/${s.scheduler} / ` +
+                `${s.steps} steps / CFG ${s.cfg}${lora} — ${s.reuseCount}x`,
+            );
+          }
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerWorkflowLibraryTools } from "./workflow-library.js";
 import { registerProcessControlTools } from "./process-control.js";
 import { registerImageManagementTools } from "./image-management.js";
 import { registerMemoryManagementTools } from "./memory-management.js";
+import { registerGenerationTrackerTools } from "./generation-tracker.js";
 
 export function registerAllTools(server: McpServer): void {
   registerWorkflowExecuteTools(server);
@@ -25,4 +26,5 @@ export function registerAllTools(server: McpServer): void {
   registerProcessControlTools(server);
   registerImageManagementTools(server);
   registerMemoryManagementTools(server);
+  registerGenerationTrackerTools(server);
 }


### PR DESCRIPTION
## Summary
- **Generation Tracker**: Local SQLite database that logs workflow settings on every `run_workflow` call. Deduplicates by settings hash (model hash + sampler/scheduler/steps/CFG + LoRA hash), bumping `reuse_count` for repeated combos. Two new MCP tools: `suggest_settings` and `generation_stats`.
- **File Hashing**: SHA256 streaming hash for `.safetensors` files with SQLite cache (keyed on filename+size+mtime). AutoV2 format (first 10 chars of SHA256, uppercased) for CivitAI compatibility.
- **CivitAI Lookup**: Hash-based model identification via `GET /api/v1/model-versions/by-hash/{autov2}` with rate-limited batch processing.
- **Model Family Detection**: Regex-based version extraction for Qwen Image models (2509/2511/2512), with confirmed base versions for finetuned models (copaxTimeless → 2512, qwenImageEditRemix → 2511 edit, qwenUltimateRealism → original). Z-Image check moved before Qwen to fix redcraftRedzimage miscategorization.
- **Model Settings**: Community-maintained preset library (`model-settings.json`) with JSONC user overrides and postinstall auto-copy.
- **Desktop App Kill**: `stopComfyUI` now finds and kills the Electron shell (ComfyUI.exe) parent process, not just the Python backend.
- **CLI Stats**: `npm run generations:stats` for reviewing local generation history.

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] Run a workflow with a Qwen model — verify generation logged to SQLite
- [ ] Run same settings again — verify `reuse_count` increments instead of creating duplicate
- [ ] `suggest_settings` returns relevant results
- [ ] `generation_stats` shows correct totals and breakdown
- [ ] `npm run generations:stats` CLI works
- [ ] Model family correctly identified for: copaxTimeless (2512), qwenImageEditRemix (2511 edit), redcraftRedzimage (z_image)
- [ ] Stop ComfyUI Desktop app — verify Electron shell is killed, not just Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)