### PR TITLE
feat: add get_image tool with HTTP-based image access for remote ComfyUI

### DIFF
--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -205,3 +205,51 @@ export async function getHistory(
   const res = await client.fetchApi(path);
   return res.json() as Promise<Record<string, HistoryEntry>>;
 }
+
+/**
+ * Fetch an image from ComfyUI's /view endpoint as a base64 string.
+ * Works over HTTP — no local filesystem access needed.
+ */
+export async function fetchImage(
+  filename: string,
+  type: "output" | "input" | "temp" = "output",
+  subfolder = "",
+): Promise<{ base64: string; mimeType: string }> {
+  const client = getClient();
+  const params = new URLSearchParams({ filename, type, subfolder });
+  const res = await client.fetchApi(`/view?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`ComfyUI /view returned ${res.status} for "${filename}"`);
+  }
+  const contentType = res.headers.get("content-type") ?? "image/png";
+  const mimeType = contentType.split(";")[0].trim();
+  const arrayBuffer = await res.arrayBuffer();
+  const base64 = Buffer.from(arrayBuffer).toString("base64");
+  return { base64, mimeType };
+}
+
+/**
+ * Upload an image to ComfyUI's input/ directory via HTTP multipart POST.
+ * Works over HTTP — no local filesystem access needed.
+ */
+export async function uploadImageHttp(
+  filename: string,
+  data: Buffer,
+  mimeType = "image/png",
+): Promise<{ name: string; subfolder: string; type: string }> {
+  const client = getClient();
+  const formData = new FormData();
+  const blob = new Blob([data], { type: mimeType });
+  formData.append("image", blob, filename);
+  formData.append("type", "input");
+  formData.append("overwrite", "true");
+  const res = await client.fetchApi("/upload/image", {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`ComfyUI /upload/image returned ${res.status}: ${text}`);
+  }
+  return res.json() as Promise<{ name: string; subfolder: string; type: string }>;
+}

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -228,3 +228,47 @@ export async function listOutputImages(options?: {
 
   return images.slice(0, limit);
 }
+
+import { fetchImage, uploadImageHttp } from "../comfyui/client.js";
+import { readFile as nodeReadFile } from "node:fs/promises";
+
+/**
+ * Fetch a generated image from ComfyUI via HTTP /view endpoint.
+ * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
+ */
+export async function getOutputImage(
+  filename: string,
+  type: "output" | "input" | "temp" = "output",
+  subfolder = "",
+): Promise<{ base64: string; mimeType: string; filename: string }> {
+  const result = await fetchImage(filename, type, subfolder);
+  return { ...result, filename };
+}
+
+/**
+ * Upload a local image to ComfyUI via HTTP multipart POST.
+ * Falls back to HTTP when COMFYUI_PATH is not available (remote ComfyUI).
+ */
+export async function uploadImageAuto(
+  sourcePath: string,
+  filename?: string,
+): Promise<{ filename: string }> {
+  const resolvedFilename = filename ?? basename(sourcePath);
+  const ext = extname(resolvedFilename).toLowerCase();
+  const allowed = [".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif", ".tiff", ".tif"];
+  if (!allowed.includes(ext)) {
+    throw new ValidationError(
+      `Unsupported image format "${ext}". Supported: ${allowed.join(", ")}`,
+    );
+  }
+  const data = await nodeReadFile(sourcePath);
+  const mimeMap: Record<string, string> = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".webp": "image/webp", ".bmp": "image/bmp", ".gif": "image/gif",
+    ".tiff": "image/tiff", ".tif": "image/tiff",
+  };
+  const mimeType = mimeMap[ext] ?? "application/octet-stream";
+  logger.info("Uploading image to ComfyUI via HTTP", { sourcePath, resolvedFilename });
+  const result = await uploadImageHttp(resolvedFilename, data, mimeType);
+  return { filename: result.name };
+}

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -71,15 +71,31 @@ function formatHistoryEntry(
     lines.push("**Execution was interrupted/cancelled**");
   }
 
-  // Output nodes
   const outputKeys = Object.keys(entry.outputs || {});
   if (outputKeys.length > 0) {
     lines.push("");
     lines.push(`### Outputs (${outputKeys.length} nodes)`);
     for (const nodeId of outputKeys) {
       const output = entry.outputs[nodeId] as Record<string, unknown>;
-      const outputTypes = Object.keys(output);
-      lines.push(`- Node ${nodeId}: ${outputTypes.join(", ")}`);
+      // Expand image filenames so callers can use get_image directly
+      if (Array.isArray(output.images)) {
+        const imgs = output.images as Array<{
+          filename: string;
+          subfolder?: string;
+          type?: string;
+        }>;
+        const fileList = imgs
+          .map((img) =>
+            img.subfolder
+              ? `${img.subfolder}/${img.filename}`
+              : img.filename,
+          )
+          .join(", ");
+        lines.push(`- Node ${nodeId}: images → **${fileList}**`);
+      } else {
+        const outputTypes = Object.keys(output);
+        lines.push(`- Node ${nodeId}: ${outputTypes.join(", ")}`);
+      }
     }
   }
 

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -1,35 +1,71 @@
 import { z } from "zod";
+import { writeFile, mkdir } from "node:fs/promises";
+import { join, basename } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   uploadImage,
   extractWorkflowFromImage,
   listOutputImages,
+  getOutputImage,
+  uploadImageAuto,
 } from "../services/image-management.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 export function registerImageManagementTools(server: McpServer): void {
+  // ── get_image ────────────────────────────────────────────────────────────
+  // Fetches a generated image from ComfyUI via HTTP /view.
+  // Works with remote ComfyUI — no COMFYUI_PATH required.
   server.tool(
-    "upload_image",
-    "Copy a local image file into ComfyUI's input/ directory so it can be used in img2img, inpaint, or ControlNet workflows. Returns the filename to use in LoadImage nodes.",
+    "get_image",
+    "Fetch a generated image from ComfyUI and return it as an inline image. " +
+      "Works with remote ComfyUI instances — does not require COMFYUI_PATH. " +
+      "Use get_history first to obtain the filename.",
     {
-      source_path: z
-        .string()
-        .describe("Absolute path to the local image file to upload"),
       filename: z
+        .string()
+        .describe("Output image filename, e.g. PulID_Klein_00001_.png"),
+      type: z
+        .enum(["output", "input", "temp"])
+        .optional()
+        .default("output")
+        .describe("Image directory: output (default), input, or temp"),
+      subfolder: z
+        .string()
+        .optional()
+        .default("")
+        .describe("Subfolder within the directory, if any"),
+      save_dir: z
         .string()
         .optional()
         .describe(
-          "Override the filename in ComfyUI's input/ directory. Auto-detected from source path if omitted.",
+          "Local directory to save the image file. Defaults to /tmp/comfyui-images/.",
         ),
     },
     async (args) => {
       try {
-        const result = await uploadImage(args.source_path, args.filename);
+        const { base64, mimeType } = await getOutputImage(
+          args.filename,
+          args.type ?? "output",
+          args.subfolder ?? "",
+        );
+
+        // Save to local file
+        const saveDir = args.save_dir ?? process.cwd();
+        await mkdir(saveDir, { recursive: true });
+        const localFilename = basename(args.filename);
+        const savePath = join(saveDir, localFilename);
+        await writeFile(savePath, Buffer.from(base64, "base64"));
+
         return {
           content: [
             {
               type: "text" as const,
-              text: `Image uploaded successfully.\n\nFilename: ${result.filename}\nPath: ${result.path}\n\nUse "${result.filename}" as the \`image\` input in LoadImage nodes.`,
+              text: `Saved to: ${savePath}`,
+            },
+            {
+              type: "image" as const,
+              data: base64,
+              mimeType,
             },
           ],
         };
@@ -39,9 +75,74 @@ export function registerImageManagementTools(server: McpServer): void {
     },
   );
 
+  // ── upload_image ─────────────────────────────────────────────────────────
+  // Tries HTTP upload first (works remote), falls back to filesystem copy.
+  server.tool(
+    "upload_image",
+    "Upload a local image file to ComfyUI's input/ directory so it can be " +
+      "referenced in LoadImage nodes. Tries HTTP upload first (works with " +
+      "remote ComfyUI), falls back to filesystem copy when COMFYUI_PATH is set.",
+    {
+      source_path: z
+        .string()
+        .describe("Absolute path to the local image file to upload"),
+      filename: z
+        .string()
+        .optional()
+        .describe(
+          "Override the filename in ComfyUI's input/ directory. " +
+            "Auto-detected from source path if omitted.",
+        ),
+    },
+    async (args) => {
+      try {
+        // Try HTTP upload first (works for remote ComfyUI)
+        const result = await uploadImageAuto(args.source_path, args.filename);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Image uploaded successfully via HTTP.\n\n` +
+                `Filename: ${result.filename}\n\n` +
+                `Use "${result.filename}" as the \`image\` input in LoadImage nodes.`,
+            },
+          ],
+        };
+      } catch (httpErr) {
+        // Fall back to filesystem copy if HTTP fails and COMFYUI_PATH is set
+        try {
+          const result = await uploadImage(args.source_path, args.filename);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `Image uploaded successfully via filesystem.\n\n` +
+                  `Filename: ${result.filename}\nPath: ${result.path}\n\n` +
+                  `Use "${result.filename}" as the \`image\` input in LoadImage nodes.`,
+              },
+            ],
+          };
+        } catch (fsErr) {
+          // Both failed — report both errors
+          return errorToToolResult(
+            new Error(
+              `HTTP upload failed: ${httpErr instanceof Error ? httpErr.message : httpErr}\n` +
+                `Filesystem fallback also failed: ${fsErr instanceof Error ? fsErr.message : fsErr}`,
+            ),
+          );
+        }
+      }
+    },
+  );
+
+  // ── workflow_from_image ───────────────────────────────────────────────────
   server.tool(
     "workflow_from_image",
-    "Extract embedded ComfyUI workflow metadata from a PNG file. ComfyUI stores the full workflow (API format) and prompt data in PNG tEXt chunks. Use this to reverse-engineer how any ComfyUI image was generated.",
+    "Extract embedded ComfyUI workflow metadata from a PNG file. " +
+      "ComfyUI stores the full workflow (API format) and prompt data in PNG tEXt chunks. " +
+      "Use this to reverse-engineer how any ComfyUI image was generated.",
     {
       image_path: z
         .string()
@@ -50,17 +151,21 @@ export function registerImageManagementTools(server: McpServer): void {
     async (args) => {
       try {
         const result = await extractWorkflowFromImage(args.image_path);
-
         const sections: string[] = [];
-
         if (result.prompt) {
-          sections.push("## API Format (prompt)\n\nThis is the executable workflow format:\n```json\n" + JSON.stringify(result.prompt, null, 2) + "\n```");
+          sections.push(
+            "## API Format (prompt)\n\nThis is the executable workflow format:\n```json\n" +
+              JSON.stringify(result.prompt, null, 2) +
+              "\n```",
+          );
         }
-
         if (result.workflow) {
-          sections.push("## UI Format (workflow)\n\nThis is the ComfyUI web UI format with layout data:\n```json\n" + JSON.stringify(result.workflow, null, 2) + "\n```");
+          sections.push(
+            "## UI Format (workflow)\n\nThis is the ComfyUI web UI format with layout data:\n```json\n" +
+              JSON.stringify(result.workflow, null, 2) +
+              "\n```",
+          );
         }
-
         return {
           content: [
             {
@@ -75,9 +180,12 @@ export function registerImageManagementTools(server: McpServer): void {
     },
   );
 
+  // ── list_output_images ────────────────────────────────────────────────────
   server.tool(
     "list_output_images",
-    "List recently generated images from ComfyUI's output directory. Returns filenames, sizes, and timestamps sorted newest-first.",
+    "List recently generated images from ComfyUI's output directory. " +
+      "Returns filenames sorted newest-first. Requires COMFYUI_PATH. " +
+      "For remote ComfyUI, use get_history to find filenames, then get_image to fetch them.",
     {
       limit: z
         .number()
@@ -97,7 +205,6 @@ export function registerImageManagementTools(server: McpServer): void {
           limit: args.limit,
           pattern: args.pattern,
         });
-
         if (images.length === 0) {
           return {
             content: [
@@ -110,13 +217,11 @@ export function registerImageManagementTools(server: McpServer): void {
             ],
           };
         }
-
         const lines = images.map((img, i) => {
           const sizeMB = (img.size / 1024 / 1024).toFixed(1);
           const date = new Date(img.modified).toLocaleString();
           return `${i + 1}. **${img.filename}** (${sizeMB} MB) — ${date}`;
         });
-
         return {
           content: [
             {


### PR DESCRIPTION
* Add fetchImage/uploadImageHttp to client layer for pure HTTP image transfer.
* New get_image tool fetches via /view API and saves to current workspace.
* Rewrite upload_image to try HTTP first with filesystem fallback.
* Expand image filenames in get_history output for easy get_image chaining.