### PR TITLE
feat: support component/subgraph node expansion in workflow converter

### DIFF
--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -75,6 +75,55 @@ export interface JobProgress {
   prompt_id?: string;
 }
 
+// Subgraph / component types (used in workflow definitions)
+
+export interface SubgraphLink {
+  id: number;
+  origin_id: number;
+  origin_slot: number;
+  target_id: number;
+  target_slot: number;
+  type: string;
+}
+
+export interface SubgraphInput {
+  id: string;
+  name: string;
+  type: string;
+  linkIds: number[];
+  localized_name?: string;
+  label?: string;
+  pos?: [number, number];
+}
+
+export interface SubgraphOutput {
+  id: string;
+  name: string;
+  type: string;
+  linkIds: number[];
+  localized_name?: string;
+  label?: string;
+  pos?: [number, number];
+}
+
+export interface SubgraphDefinition {
+  id: string;
+  version?: number;
+  name: string;
+  inputNode: { id: number; bounding?: number[] };
+  outputNode: { id: number; bounding?: number[] };
+  inputs: SubgraphInput[];
+  outputs: SubgraphOutput[];
+  widgets?: unknown[];
+  nodes: UiNode[];
+  links: SubgraphLink[];
+  groups?: unknown[];
+  state?: Record<string, unknown>;
+  revision?: number;
+  config?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+}
+
 // UI format types (what ComfyUI web UI saves)
 
 export interface UiNodeInput {
@@ -118,4 +167,7 @@ export interface UiWorkflow {
   extra?: Record<string, unknown>;
   config?: Record<string, unknown>;
   groups?: unknown[];
+  definitions?: {
+    subgraphs?: SubgraphDefinition[];
+  };
 }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -5,6 +5,8 @@ import type {
   UiWorkflow,
   UiNode,
   UiLink,
+  SubgraphDefinition,
+  SubgraphLink,
 } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
 
@@ -90,6 +92,396 @@ function getOrderedInputNames(def: ComfyUINodeDef): string[] {
   return names;
 }
 
+// ── Component / subgraph expansion ──────────────────────────────────────────
+
+interface ExpandResult {
+  expanded: UiWorkflow;
+  warnings: string[];
+}
+
+/**
+ * Expand component/subgraph nodes by flattening their inner graphs into the
+ * outer workflow.  Component nodes have a UUID `type` that matches a definition
+ * in `workflow.definitions.subgraphs`.  Each inner node gets a unique ID to
+ * avoid collisions with outer nodes or other component instances.
+ *
+ * Handles nested components (component inside component) iteratively up to a
+ * maximum depth of 10.
+ */
+export function expandComponents(ui: UiWorkflow): ExpandResult {
+  const subgraphs = ui.definitions?.subgraphs;
+  if (!subgraphs || subgraphs.length === 0) {
+    return { expanded: ui, warnings: [] };
+  }
+
+  // Build subgraph lookup: UUID → definition
+  const sgMap = new Map<string, SubgraphDefinition>();
+  for (const sg of subgraphs) {
+    sgMap.set(sg.id, sg);
+  }
+
+  // Deep-clone so we don't mutate the caller's data
+  let nodes: UiNode[] = JSON.parse(JSON.stringify(ui.nodes));
+  let links: UiLink[] = JSON.parse(JSON.stringify(ui.links));
+  const warnings: string[] = [];
+
+  // Find max IDs for safe remapping
+  let nextNodeId = 1;
+  let nextLinkId = 1;
+  for (const n of nodes) nextNodeId = Math.max(nextNodeId, n.id + 1);
+  for (const l of links) nextLinkId = Math.max(nextLinkId, l[0] + 1);
+  for (const sg of subgraphs) {
+    for (const n of sg.nodes) nextNodeId = Math.max(nextNodeId, n.id + 1);
+    for (const l of sg.links) nextLinkId = Math.max(nextLinkId, l.id + 1);
+  }
+
+  const MAX_DEPTH = 10;
+  for (let depth = 0; depth < MAX_DEPTH; depth++) {
+    const componentNodes = nodes.filter((n) => sgMap.has(n.type));
+    if (componentNodes.length === 0) break;
+
+    for (const compNode of componentNodes) {
+      const sg = sgMap.get(compNode.type)!;
+
+      // Skip muted / bypassed component nodes
+      if (compNode.mode === 2 || compNode.mode === 4) {
+        warnings.push(
+          `Component node ${compNode.id} ("${sg.name}") is muted/bypassed — skipping expansion.`,
+        );
+        // Remove it so the main converter doesn't warn about unknown type
+        nodes = nodes.filter((n) => n.id !== compNode.id);
+        continue;
+      }
+
+      const result = expandSingleComponent(
+        compNode,
+        sg,
+        nodes,
+        links,
+        nextNodeId,
+        nextLinkId,
+      );
+      nodes = result.nodes;
+      links = result.links;
+      nextNodeId = result.nextNodeId;
+      nextLinkId = result.nextLinkId;
+      warnings.push(...result.warnings);
+    }
+  }
+
+  const expanded: UiWorkflow = {
+    ...ui,
+    nodes,
+    links,
+  };
+  return { expanded, warnings };
+}
+
+/**
+ * Expand a single component node, returning the modified nodes & links arrays.
+ */
+function expandSingleComponent(
+  compNode: UiNode,
+  sg: SubgraphDefinition,
+  outerNodes: UiNode[],
+  outerLinks: UiLink[],
+  nextNodeId: number,
+  nextLinkId: number,
+): {
+  nodes: UiNode[];
+  links: UiLink[];
+  nextNodeId: number;
+  nextLinkId: number;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  const inputNodeId = sg.inputNode.id; // typically -10
+  const outputNodeId = sg.outputNode.id; // typically -20
+
+  // ── 1. Remap inner node IDs ──────────────────────────────────────────────
+  const nodeRemap = new Map<number, number>(); // oldInner → newOuter
+  for (const inner of sg.nodes) {
+    nodeRemap.set(inner.id, nextNodeId++);
+  }
+
+  // ── 2. Remap inner link IDs ──────────────────────────────────────────────
+  const linkRemap = new Map<number, number>();
+  for (const inner of sg.links) {
+    linkRemap.set(inner.id, nextLinkId++);
+  }
+
+  // ── 3. Build inner link lookup ───────────────────────────────────────────
+  const innerLinkById = new Map<number, SubgraphLink>();
+  for (const l of sg.links) innerLinkById.set(l.id, l);
+
+  // ── 4. Clone inner nodes with remapped IDs ──────────────────────────────
+  const newNodes: UiNode[] = [];
+  for (const inner of sg.nodes) {
+    const cloned: UiNode = JSON.parse(JSON.stringify(inner));
+    cloned.id = nodeRemap.get(inner.id)!;
+
+    // Remap link references in inputs
+    if (cloned.inputs) {
+      for (const inp of cloned.inputs) {
+        if (inp.link != null) {
+          inp.link = linkRemap.get(inp.link) ?? inp.link;
+        }
+      }
+    }
+    // Remap link references in outputs
+    if (cloned.outputs) {
+      for (const out of cloned.outputs) {
+        if (out.links) {
+          out.links = out.links.map((lid) => linkRemap.get(lid) ?? lid);
+        }
+      }
+    }
+
+    newNodes.push(cloned);
+  }
+
+  // ── 5. Convert inner links to outer array format ────────────────────────
+  // Skip links involving virtual input/output nodes — those get rewired.
+  const newLinks: UiLink[] = [];
+  for (const il of sg.links) {
+    if (il.origin_id === inputNodeId || il.target_id === outputNodeId) continue;
+    const newId = linkRemap.get(il.id)!;
+    const newSrc = nodeRemap.get(il.origin_id);
+    const newTgt = nodeRemap.get(il.target_id);
+    if (newSrc == null || newTgt == null) {
+      warnings.push(
+        `Component "${sg.name}": inner link ${il.id} references unknown node — skipping.`,
+      );
+      continue;
+    }
+    newLinks.push([newId, newSrc, il.origin_slot, newTgt, il.target_slot, il.type]);
+  }
+
+  // ── 6. Rewire external inputs (outer → component → inner) ──────────────
+  // Build outer link map for quick lookup
+  const outerLinkMap = new Map<number, UiLink>();
+  for (const ol of outerLinks) outerLinkMap.set(ol[0], ol);
+
+  const linksToRemove = new Set<number>(); // outer link IDs to remove
+  const linksToAdd: UiLink[] = [];
+
+  if (compNode.inputs) {
+    for (let slotIdx = 0; slotIdx < compNode.inputs.length; slotIdx++) {
+      const compInput = compNode.inputs[slotIdx];
+      if (compInput.link == null) continue;
+
+      const outerLink = outerLinkMap.get(compInput.link);
+      if (!outerLink) continue;
+
+      const srcNodeId = outerLink[1];
+      const srcSlot = outerLink[2];
+
+      // Find the matching subgraph input by name
+      const sgInput = sg.inputs.find((inp) => inp.name === compInput.name);
+      if (!sgInput) {
+        warnings.push(
+          `Component "${sg.name}": could not match input "${compInput.name}" — skipping rewire.`,
+        );
+        continue;
+      }
+
+      // For each inner link from the virtual input node, create a new outer link
+      for (const innerLinkId of sgInput.linkIds) {
+        const il = innerLinkById.get(innerLinkId);
+        if (!il || il.origin_id !== inputNodeId) continue;
+        const remappedTarget = nodeRemap.get(il.target_id);
+        if (remappedTarget == null) continue;
+
+        const newId = nextLinkId++;
+        linksToAdd.push([newId, srcNodeId, srcSlot, remappedTarget, il.target_slot, il.type]);
+
+        // Update the cloned inner node's input to point to the new link
+        const targetNode = newNodes.find((n) => n.id === remappedTarget);
+        if (targetNode?.inputs) {
+          for (const inp of targetNode.inputs) {
+            if (inp.link === linkRemap.get(innerLinkId)) {
+              inp.link = newId;
+            }
+          }
+        }
+      }
+
+      linksToRemove.add(compInput.link);
+    }
+  }
+
+  // ── 7. Rewire external outputs (inner → component → outer) ─────────────
+  if (compNode.outputs) {
+    for (let slotIdx = 0; slotIdx < compNode.outputs.length; slotIdx++) {
+      const compOutput = compNode.outputs[slotIdx];
+      if (!compOutput.links || compOutput.links.length === 0) continue;
+
+      // Find the matching subgraph output by name
+      const sgOutput = sg.outputs.find((out) => out.name === compOutput.name);
+      if (!sgOutput) {
+        warnings.push(
+          `Component "${sg.name}": could not match output "${compOutput.name}" — skipping rewire.`,
+        );
+        continue;
+      }
+
+      // Find the inner node that produces this output
+      let innerSrcId: number | null = null;
+      let innerSrcSlot = 0;
+      for (const innerLinkId of sgOutput.linkIds) {
+        const il = innerLinkById.get(innerLinkId);
+        if (il && il.target_id === outputNodeId) {
+          innerSrcId = il.origin_id;
+          innerSrcSlot = il.origin_slot;
+          break;
+        }
+      }
+      if (innerSrcId == null) continue;
+      const remappedSrc = nodeRemap.get(innerSrcId);
+      if (remappedSrc == null) continue;
+
+      // Rewire each outer link that consumes this component output
+      for (const outerLinkId of compOutput.links) {
+        const outerLink = outerLinkMap.get(outerLinkId);
+        if (!outerLink) continue;
+
+        const tgtNodeId = outerLink[3];
+        const tgtSlot = outerLink[4];
+        const linkType = outerLink[5];
+
+        const newId = nextLinkId++;
+        linksToAdd.push([newId, remappedSrc, innerSrcSlot, tgtNodeId, tgtSlot, linkType]);
+
+        // Update the outer target node's input to reference the new link
+        const tgtNode = outerNodes.find((n) => n.id === tgtNodeId);
+        if (tgtNode?.inputs) {
+          for (const inp of tgtNode.inputs) {
+            if (inp.link === outerLinkId) {
+              inp.link = newId;
+            }
+          }
+        }
+
+        linksToRemove.add(outerLinkId);
+      }
+    }
+  }
+
+  // ── 8. Apply proxy widget values ────────────────────────────────────────
+  const proxyWidgets: [string, string][] =
+    (compNode.properties?.proxyWidgets as [string, string][]) ?? [];
+  const widgetValues = compNode.widgets_values ?? [];
+
+  for (let i = 0; i < proxyWidgets.length; i++) {
+    const [innerNodeIdStr, widgetName] = proxyWidgets[i];
+    const value = i < widgetValues.length ? widgetValues[i] : undefined;
+    if (value === undefined || value === null) continue;
+
+    const innerNodeIdNum = Number(innerNodeIdStr);
+    const remapped = nodeRemap.get(innerNodeIdNum);
+    if (remapped == null) continue;
+
+    const targetNode = newNodes.find((n) => n.id === remapped);
+    if (!targetNode) continue;
+
+    // Find the widget position in widgets_values by counting widget-type inputs
+    const widgetIdx = findWidgetIndex(targetNode, widgetName);
+    if (widgetIdx != null) {
+      if (!targetNode.widgets_values) targetNode.widgets_values = [];
+      targetNode.widgets_values[widgetIdx] = value;
+    }
+  }
+
+  // ── 9. Resolve PrimitiveNode-type nodes inside the subgraph ─────────────
+  // PrimitiveNode/PrimitiveInt/PrimitiveFloat/PrimitiveBoolean/PrimitiveStringMultiline
+  // produce widget values but get skipped by the main converter. Resolve them
+  // by pushing their value onto the target node's widgets_values.
+  const PRIMITIVE_TYPES = new Set([
+    "PrimitiveNode", "PrimitiveInt", "PrimitiveFloat",
+    "PrimitiveBoolean", "PrimitiveStringMultiline", "CustomCombo",
+  ]);
+  const primitiveNodeIds = new Set(
+    newNodes.filter((n) => PRIMITIVE_TYPES.has(n.type)).map((n) => n.id),
+  );
+  if (primitiveNodeIds.size > 0) {
+    // For each new link FROM a primitive node, set the value on the target
+    for (const link of newLinks) {
+      const [, srcId, , tgtId, tgtSlot] = link;
+      if (!primitiveNodeIds.has(srcId)) continue;
+
+      const primNode = newNodes.find((n) => n.id === srcId);
+      const tgtNode = newNodes.find((n) => n.id === tgtId);
+      if (!primNode || !tgtNode) continue;
+
+      const primValue =
+        primNode.widgets_values && primNode.widgets_values.length > 0
+          ? primNode.widgets_values[0]
+          : undefined;
+      if (primValue === undefined) continue;
+
+      // Find the target input at tgtSlot that has a widget
+      if (tgtNode.inputs) {
+        const tgtInput = tgtNode.inputs.find(
+          (inp) => inp.link === link[0] && inp.widget,
+        );
+        if (tgtInput) {
+          const idx = findWidgetIndex(tgtNode, tgtInput.widget!.name);
+          if (idx != null) {
+            if (!tgtNode.widgets_values) tgtNode.widgets_values = [];
+            tgtNode.widgets_values[idx] = primValue;
+          }
+          // Clear the link so the main converter treats this as a widget value
+          tgtInput.link = null;
+        }
+      }
+    }
+  }
+
+  // ── 10. Assemble result ─────────────────────────────────────────────────
+  const resultNodes = [
+    ...outerNodes.filter((n) => n.id !== compNode.id),
+    ...newNodes,
+  ];
+  const resultLinks = [
+    ...outerLinks.filter((l) => !linksToRemove.has(l[0])),
+    ...newLinks,
+    ...linksToAdd,
+  ];
+
+  return {
+    nodes: resultNodes,
+    links: resultLinks,
+    nextNodeId,
+    nextLinkId,
+    warnings,
+  };
+}
+
+/**
+ * Find the widgets_values index for a named widget on a UI node.
+ * Counts widget-type inputs (those with a `widget` property) in order.
+ */
+function findWidgetIndex(node: UiNode, widgetName: string): number | null {
+  if (!node.inputs) return null;
+
+  // Widget inputs on a UiNode are entries in `inputs[]` that have a `widget` property.
+  // However, not all widgets appear in `inputs[]` — some are only in `widgets_values`.
+  // We count only the widget-inputs that appear in the node's inputs array,
+  // matching by the `widget.name` field.
+  let idx = 0;
+  for (const inp of node.inputs) {
+    if (inp.widget) {
+      if (inp.widget.name === widgetName) return idx;
+      idx++;
+    }
+  }
+
+  // Fallback: if widget is not in inputs[] (pure widget, no link slot),
+  // it may be at a fixed position. Search widgets_values if we can match by name.
+  // For now, return null — the widget is likely at its default value.
+  return null;
+}
+
 /**
  * Convert a ComfyUI UI-format workflow to API format.
  * Requires objectInfo from /object_info to map widgets_values to named inputs.
@@ -98,12 +490,15 @@ export function convertUiToApi(
   ui: UiWorkflow,
   objectInfo: ObjectInfo,
 ): ConversionResult {
+  // Expand component/subgraph nodes before conversion
+  const { expanded, warnings: expandWarnings } = expandComponents(ui);
+
   const workflow: WorkflowJSON = {};
-  const warnings: string[] = [];
+  const warnings: string[] = [...expandWarnings];
 
   // Build link lookup: linkId → LinkInfo
   const linkMap = new Map<number, LinkInfo>();
-  for (const link of ui.links) {
+  for (const link of expanded.links) {
     if (!Array.isArray(link) || link.length < 6) continue;
     const [linkId, sourceNodeId, sourceSlot, targetNodeId, targetSlot, typeName] =
       link as UiLink;
@@ -117,7 +512,7 @@ export function convertUiToApi(
   }
 
   // Build a set of node IDs for validating link targets
-  const nodeIdSet = new Set(ui.nodes.map((n) => n.id));
+  const nodeIdSet = new Set(expanded.nodes.map((n) => n.id));
 
   // Node types that are purely visual/internal and have no API equivalent
   const SKIP_TYPES = new Set(["Reroute", "Note", "PrimitiveNode", "MarkdownNote"]);
@@ -128,7 +523,7 @@ export function convertUiToApi(
     "SetNode_GetNode", "SetNode_SetNode",
   ]);
 
-  for (const node of ui.nodes) {
+  for (const node of expanded.nodes) {
     const nodeId = String(node.id);
     const classType = node.type;
 
@@ -237,7 +632,7 @@ export function convertUiToApi(
   }
 
   const nodeCount = Object.keys(workflow).length;
-  const skipped = ui.nodes.length - nodeCount;
+  const skipped = expanded.nodes.length - nodeCount;
   logger.info(
     `Converted UI workflow: ${nodeCount} nodes (${skipped} skipped)`,
   );


### PR DESCRIPTION
## Summary

- Adds support for ComfyUI's component/subgraph system in the workflow converter
- Component nodes (UUID `type` matching `definitions.subgraphs`) are now expanded into their inner node graphs before API conversion
- Previously these nodes were silently skipped with "not found in object_info", dropping the entire component pipeline

## What changed

**`src/comfyui/types.ts`**
- Added `SubgraphDefinition`, `SubgraphLink`, `SubgraphInput`, `SubgraphOutput` interfaces
- Extended `UiWorkflow` with optional `definitions.subgraphs`

**`src/services/workflow-converter.ts`**
- Added `expandComponents()` preprocessing step called at the start of `convertUiToApi()`
- Flattens component inner graphs: remaps node/link IDs, rewires external I/O through subgraph boundaries, applies proxy widget values, resolves PrimitiveNode types
- Handles nested components iteratively (up to depth 10)
- Gracefully skips muted/bypassed components

## Before / After

A workflow with an LTX-2.3 video generation component (47 inner nodes):
- **Before**: `get_workflow` / `analyze_workflow` returned 2 nodes, skipping the entire component
- **After**: Returns all 48 nodes with correct connections and widget values

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Tested against a real LTX-2.3 t2v workflow with a 47-node component subgraph
- [x] Verified expanded workflow converts to valid API format using live ComfyUI `/object_info`
- [x] Verified correct wiring: outer LoadImage → inner ResizeImageMaskNode, inner CreateVideo → outer SaveVideo
- [x] Verified checkpoint/model names preserved through proxy widget mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>