### PR TITLE
feat: add COMFYUI_SSL env var for HTTPS/WSS support

### DIFF
--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -10,6 +10,7 @@ export function getClient(): Client {
   if (!clientInstance) {
     clientInstance = new Client({
       api_host: getComfyUIApiHost(),
+      ssl: config.comfyuiSsl,
       clientId: "comfyui-mcp",
       // Node 22+ provides global WebSocket
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,7 +113,8 @@ async function detectComfyUIPort(host: string): Promise<number> {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 1000);
-      const res = await fetch(`http://${host}:${port}/system_stats`, {
+      const protocol = parsedConfig.comfyuiSsl ? "https" : "http";
+      const res = await fetch(`${protocol}://${host}:${port}/system_stats`, {
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -135,6 +136,7 @@ async function detectComfyUIPort(host: string): Promise<number> {
 const configSchema = z.object({
   comfyuiHost: z.string().default("127.0.0.1"),
   comfyuiPort: z.coerce.number().int().positive().optional(),
+  comfyuiSsl: z.coerce.boolean().default(false),
   comfyuiPath: z.string().optional(),
   huggingfaceToken: z.string().optional(),
   githubToken: z.string().optional(),
@@ -146,6 +148,7 @@ export type Config = z.infer<typeof configSchema> & { resolvedPort: number };
 const parsedConfig = configSchema.parse({
   comfyuiHost: process.env.COMFYUI_HOST,
   comfyuiPort: process.env.COMFYUI_PORT || undefined,
+  comfyuiSsl: process.env.COMFYUI_SSL,
   comfyuiPath: resolveComfyUIPath(process.env.COMFYUI_PATH),
   huggingfaceToken: process.env.HUGGINGFACE_TOKEN,
   githubToken: process.env.GITHUB_TOKEN,


### PR DESCRIPTION
## Summary

- Add `COMFYUI_SSL` environment variable to enable HTTPS/WSS connections
- The `@stable-canvas/comfyui-client` lib already supports `ssl: true` in its constructor — this PR simply exposes it as an env var
- Also updates `detectComfyUIPort()` to use HTTPS when `COMFYUI_SSL=true`

## Use case

Connecting to a remote ComfyUI instance served over HTTPS (e.g. via [Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve)):

```json
{
  "mcpServers": {
    "comfyui": {
      "command": "npx",
      "args": ["-y", "comfyui-mcp"],
      "env": {
        "COMFYUI_HOST": "my-server.tail12345.ts.net",
        "COMFYUI_PORT": "443",
        "COMFYUI_SSL": "true"
      }
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Add `comfyuiSsl` to Zod schema, read `COMFYUI_SSL` env var, use dynamic protocol in port detection |
| `src/comfyui/client.ts` | Pass `ssl: config.comfyuiSsl` to `@stable-canvas/comfyui-client` constructor |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Default behavior unchanged (`COMFYUI_SSL` unset → HTTP as before)
- [ ] Setting `COMFYUI_SSL=true` uses HTTPS for API calls and WSS for WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)