### PR TITLE
fix: honor COMFYUI_SSL env var for HTTPS/WSS connections

### DIFF
--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -10,6 +10,7 @@ export function getClient(): Client {
   if (!clientInstance) {
     clientInstance = new Client({
       api_host: getComfyUIApiHost(),
+      ssl: config.comfyuiSsl,
       // Node 22+ provides global WebSocket
     });
     logger.info("ComfyUI client created", {

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,14 +89,15 @@ function resolveComfyUIPath(envPath?: string): string | undefined {
  * Tries common ports: 8000 (Desktop app default), 8188 (repo/CLI default).
  * Returns the first port that responds, or the default if none found.
  */
-async function detectComfyUIPort(host: string): Promise<number> {
+async function detectComfyUIPort(host: string, ssl: boolean): Promise<number> {
   const ports = [8188, 8000];
+  const protocol = ssl ? "https" : "http";
 
   for (const port of ports) {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 1000);
-      const res = await fetch(`http://${host}:${port}/system_stats`, {
+      const res = await fetch(`${protocol}://${host}:${port}/system_stats`, {
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -119,6 +120,7 @@ const configSchema = z.object({
   comfyuiHost: z.string().default("127.0.0.1"),
   comfyuiPort: z.coerce.number().int().positive().optional(),
   comfyuiPath: z.string().optional(),
+  comfyuiSsl: z.coerce.boolean().default(false),
   huggingfaceToken: z.string().optional(),
   githubToken: z.string().optional(),
   civitaiApiToken: z.string().optional(),
@@ -130,6 +132,7 @@ const parsedConfig = configSchema.parse({
   comfyuiHost: process.env.COMFYUI_HOST,
   comfyuiPort: process.env.COMFYUI_PORT || undefined,
   comfyuiPath: resolveComfyUIPath(process.env.COMFYUI_PATH),
+  comfyuiSsl: process.env.COMFYUI_SSL || false,
   huggingfaceToken: process.env.HUGGINGFACE_TOKEN,
   githubToken: process.env.GITHUB_TOKEN,
   civitaiApiToken: process.env.CIVITAI_API_TOKEN,
@@ -137,10 +140,14 @@ const parsedConfig = configSchema.parse({
 
 // Resolve port: explicit env var wins, otherwise auto-detect
 const resolvedPort = parsedConfig.comfyuiPort
-  ?? await detectComfyUIPort(parsedConfig.comfyuiHost);
+  ?? await detectComfyUIPort(parsedConfig.comfyuiHost, parsedConfig.comfyuiSsl);
 
 export const config: Config = { ...parsedConfig, resolvedPort };
 
 export function getComfyUIApiHost(): string {
   return `${config.comfyuiHost}:${config.resolvedPort}`;
+}
+
+export function getComfyUIProtocol(): "http" | "https" {
+  return config.comfyuiSsl ? "https" : "http";
 }


### PR DESCRIPTION
## Summary
- Parse `COMFYUI_SSL` into `config.comfyuiSsl` (zod-coerced boolean, defaults to `false`)
- Pass `ssl` to the `@stable-canvas/comfyui-client` `Client` constructor — the library handles both HTTPS and WSS upgrades
- Apply the SSL setting to the auto port-detection probe in `detectComfyUIPort`
- Export a `getComfyUIProtocol()` helper for any future call sites

Closes #5.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] With `COMFYUI_SSL=true`, `getClient().apiURL('/foo')` returns `https://...`
- [x] With `COMFYUI_SSL` unset, behavior is unchanged (`http://`)
- [ ] Verified end-to-end against a real TLS-fronted ComfyUI (not run locally — no TLS proxy available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)