### PR TITLE
fix: honor COMFYUI_SSL in process-control and job-watcher

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -164,3 +164,7 @@ export const config: Config = { ...parsedConfig, resolvedPort };
 export function getComfyUIApiHost(): string {
   return `${config.comfyuiHost}:${config.resolvedPort}`;
 }
+
+export function getComfyUIProtocol(): "http" | "https" {
+  return config.comfyuiSsl ? "https" : "http";
+}

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -7,7 +7,7 @@ import {
   getHistory,
   type HistoryEntry,
 } from "../comfyui/client.js";
-import { getComfyUIApiHost } from "../config.js";
+import { getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
 import { attachExecutionListeners } from "../comfyui/events.js";
 import { logger } from "../utils/logger.js";
 
@@ -74,7 +74,7 @@ function buildImageUrl(
 ): string {
   const host = getComfyUIApiHost();
   const params = new URLSearchParams({ filename, subfolder, type });
-  return `http://${host}/view?${params.toString()}`;
+  return `${getComfyUIProtocol()}://${host}/view?${params.toString()}`;
 }
 
 function buildNotification(

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,7 +1,7 @@
 import { execSync, spawn } from "node:child_process";
 import { platform } from "node:os";
 import { getSystemStats, resetClient } from "../comfyui/client.js";
-import { config, getComfyUIApiHost } from "../config.js";
+import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -245,7 +245,7 @@ async function waitForApiReady(timeoutMs = 60000): Promise<void> {
     try {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 2000);
-      const res = await fetch(`http://${host}/system_stats`, {
+      const res = await fetch(`${getComfyUIProtocol()}://${host}/system_stats`, {
         signal: controller.signal,
       });
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
Follow-up to #4, which only addressed `src/config.ts` and `src/comfyui/client.ts`. Two other call sites still hardcoded `http://`:

- `waitForApiReady()` in `src/services/process-control.ts` — readiness check after launching ComfyUI
- `buildImageUrl()` in `src/services/job-watcher.ts` — image URLs in completion notifications

Adds a `getComfyUIProtocol()` helper to `src/config.ts` and uses it in both locations.

Closes #5.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Verified `getComfyUIProtocol()` returns `"https"` when `COMFYUI_SSL=true`, `"http"` otherwise
- [x] No remaining hardcoded `http://` in `src/`
- [ ] End-to-end against a real TLS-fronted ComfyUI (no TLS proxy available locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)