### PR TITLE
fix: honor COMFYUI_PORT/COMFYUI_HOST in plugin hook and monitor

### DIFF
--- a/plugin/hooks/vram-check.mjs
+++ b/plugin/hooks/vram-check.mjs
@@ -8,7 +8,7 @@
  * JSON stdout with hookSpecificOutput = structured control.
  */
 
-const COMFY_PORT = Number(process.env.COMFY_PORT) || 8000;
+const COMFY_PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
 const VRAM_WARNING_MB = 1024; // Warn if less than 1GB free
 
 async function check() {

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -9,11 +9,11 @@
  * Detects stalls (no progress for too long) and unreachable servers.
  * Exits when all tracked jobs complete.
  *
- * Env: COMFY_PORT (default 8000), COMFY_HOST (default 127.0.0.1)
+ * Env: COMFYUI_PORT (or COMFY_PORT, default 8000), COMFYUI_HOST (or COMFY_HOST, default 127.0.0.1)
  */
 
-const HOST = process.env.COMFY_HOST || "127.0.0.1";
-const PORT = Number(process.env.COMFY_PORT) || 8000;
+const HOST = process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
+const PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
 const TIMEOUT_MS = 10 * 60 * 1000;
 const THROTTLE_MS = 2000;
 const THROTTLE_PCT = 10;


### PR DESCRIPTION
## Summary

`plugin/hooks/vram-check.mjs` and `plugin/scripts/monitor-progress.mjs` read `COMFY_PORT` / `COMFY_HOST`, but the rest of the plugin (README, `src/config.ts`) uses `COMFYUI_PORT` / `COMFYUI_HOST`. Users who set the documented names — and don't also set the short ones — hit a confusing failure mode whenever ComfyUI runs on a non-default port:

- The MCP server's TypeScript code reads `COMFYUI_PORT` and successfully reaches ComfyUI.
- The PreToolUse hook reads `COMFY_PORT`, falls back to `8000`, fails to reach ComfyUI, and denies `enqueue_workflow` with `"ComfyUI is not running. Use start_comfyui to start it first."` — even though ComfyUI is in fact running and `start_comfyui` was just called successfully.

The Desktop app pins port `8889` for some installs, which surfaces this immediately.

This PR makes the two plugin scripts read the documented `COMFYUI_*` names first and fall back to the legacy `COMFY_*` names, so existing setups keep working.

## Changes

- `plugin/hooks/vram-check.mjs`: `process.env.COMFYUI_PORT ?? process.env.COMFY_PORT ?? 8000`
- `plugin/scripts/monitor-progress.mjs`: same pattern for both `COMFYUI_HOST` and `COMFYUI_PORT`; updated the docstring to match.

Diff is 4 lines of behavior change. No defaults moved, no public contract changed.

## Test plan

- [x] With only `COMFYUI_PORT=8889` set, `enqueue_workflow` no longer trips the PreToolUse hook and reaches ComfyUI.
- [x] With only `COMFY_PORT=8889` set (legacy), behavior unchanged.
- [x] With neither set, both scripts fall back to `8000` as before.
- [x] `monitor-progress.mjs` connects via WebSocket to the configured host/port and reports step progress.