### PR TITLE
fix: honor COMFYUI_HOST/COMFYUI_SSL in plugin scripts

### DIFF
--- a/plugin/hooks/vram-check.mjs
+++ b/plugin/hooks/vram-check.mjs
@@ -8,14 +8,16 @@
  * JSON stdout with hookSpecificOutput = structured control.
  */
 
+const COMFY_HOST = process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
 const COMFY_PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
+const COMFY_PROTOCOL = process.env.COMFYUI_SSL === "true" ? "https" : "http";
 const VRAM_WARNING_MB = 1024; // Warn if less than 1GB free
 
 async function check() {
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(`http://127.0.0.1:${COMFY_PORT}/system_stats`, {
+    const res = await fetch(`${COMFY_PROTOCOL}://${COMFY_HOST}:${COMFY_PORT}/system_stats`, {
       signal: controller.signal,
     });
     clearTimeout(timeout);

--- a/plugin/scripts/monitor-progress.mjs
+++ b/plugin/scripts/monitor-progress.mjs
@@ -9,11 +9,15 @@
  * Detects stalls (no progress for too long) and unreachable servers.
  * Exits when all tracked jobs complete.
  *
- * Env: COMFYUI_PORT (or COMFY_PORT, default 8000), COMFYUI_HOST (or COMFY_HOST, default 127.0.0.1)
+ * Env: COMFYUI_PORT (or COMFY_PORT, default 8000), COMFYUI_HOST (or COMFY_HOST, default 127.0.0.1),
+ *      COMFYUI_SSL (default false — set "true" to use https:// + wss://)
  */
 
 const HOST = process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
 const PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
+const SSL = process.env.COMFYUI_SSL === "true";
+const HTTP_PROTOCOL = SSL ? "https" : "http";
+const WS_PROTOCOL = SSL ? "wss" : "ws";
 const TIMEOUT_MS = 10 * 60 * 1000;
 const THROTTLE_MS = 2000;
 const THROTTLE_PCT = 10;
@@ -63,7 +67,7 @@ async function fetchJSON(path, timeoutMs = 5000) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(`http://${HOST}:${PORT}${path}`, {
+    const res = await fetch(`${HTTP_PROTOCOL}://${HOST}:${PORT}${path}`, {
       signal: controller.signal,
     });
     clearTimeout(timer);
@@ -278,7 +282,7 @@ function connectWebSocket() {
     // ComfyUI routes progress/executing events only to the WS client whose clientId
     // matches the client_id in the POST /prompt body.
     const ws = new WebSocket(
-      `ws://${HOST}:${PORT}/ws?clientId=comfyui-mcp`,
+      `${WS_PROTOCOL}://${HOST}:${PORT}/ws?clientId=comfyui-mcp`,
     );
 
     ws.onopen = () => {


### PR DESCRIPTION
## Summary
Follow-up to #10. Two adjacent gaps were left after that PR landed:

- `plugin/hooks/vram-check.mjs` hardcoded `127.0.0.1` and `http://`, so a TLS-fronted or non-loopback ComfyUI fails the PreToolUse check and `enqueue_workflow` is denied with the misleading "ComfyUI is not running" message.
- `plugin/scripts/monitor-progress.mjs` hardcoded `http://` (fetch path) and `ws://` (WebSocket), so the background progress monitor can't reach ComfyUI behind TLS.

Both scripts now derive the protocol from `COMFYUI_SSL` (mirroring `getComfyUIProtocol()` in `src/config.ts`), and `vram-check.mjs` now respects `COMFYUI_HOST` / `COMFY_HOST`.

## Test plan
- [x] `node --check` passes on both files
- [x] URL construction verified for `COMFYUI_SSL=true` (`https://` + `wss://`) and unset (`http://` + `ws://`)
- [x] `COMFYUI_HOST` overrides default `127.0.0.1` in `vram-check.mjs`
- [x] Legacy `COMFY_HOST` / `COMFY_PORT` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)