### PR TITLE
feat: node snapshot tools (save/restore/list) — port comfy-cli node snapshots

### DIFF
--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -137,7 +137,7 @@ describe("saveNodeSnapshot (named — file path)", () => {
 
     const result = await saveNodeSnapshot("prod-baseline");
     expect(result.method).toBe("file");
-    expect(result.name).toBe("prod-baseline");
+    expect(result.name).toBe("prod-baseline.json");
 
     // get_current was fetched.
     expect(fetchMock.mock.calls[0][0]).toBe(
@@ -169,6 +169,34 @@ describe("saveNodeSnapshot (named — file path)", () => {
     );
     // Dir existed, so no mkdir.
     expect(fsMocks.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it("writes a custom_nodes-wrapped YAML file for a .yaml name", async () => {
+    const state = {
+      comfyui: "abc",
+      cnr_custom_nodes: { "comfyui-impact-pack": "1.0.0" },
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(state));
+
+    const result = await saveNodeSnapshot("prod.yaml");
+    expect(result.name).toBe("prod.yaml");
+
+    const [writtenPath, contents] = fsMocks.writeFileSync.mock.calls[0];
+    expect(writtenPath).toBe(
+      "/fake/comfyui/user/__manager/snapshots/prod.yaml",
+    );
+    // comfy-cli/cm-cli YAML contract: body wrapped under `custom_nodes:`.
+    expect(contents).toMatch(/^custom_nodes:/);
+    expect(contents).toContain('"comfyui-impact-pack": "1.0.0"');
+  });
+
+  it("does not double-append .json when the name already ends in .json", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ comfyui: "x" }));
+    await saveNodeSnapshot("prod.json");
+    const [writtenPath] = fsMocks.writeFileSync.mock.calls[0];
+    expect(writtenPath).toBe(
+      "/fake/comfyui/user/__manager/snapshots/prod.json",
+    );
   });
 
   it("errors clearly when comfyuiPath is undefined (remote mode)", async () => {

--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks. config and node:fs are mocked so the file-write path has no real
+// side effects; global.fetch is stubbed per-test for the Manager HTTP API.
+// ---------------------------------------------------------------------------
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/fake/comfyui" as string | undefined },
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIProtocol: () => "http",
+}));
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => fsMocks);
+
+import {
+  saveNodeSnapshot,
+  restoreNodeSnapshot,
+  listNodeSnapshots,
+} from "../../services/node-snapshots.js";
+import { NodeSnapshotError } from "../../utils/errors.js";
+import { config } from "../../config.js";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fsMocks.existsSync.mockReset().mockReturnValue(false);
+  fsMocks.mkdirSync.mockReset();
+  fsMocks.writeFileSync.mockReset();
+  (config as { comfyuiPath?: string }).comfyuiPath = "/fake/comfyui";
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("listNodeSnapshots", () => {
+  it("returns the items array from /snapshot/getlist", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ items: ["2024-01-02_03-04-05_snapshot", "prod"] }),
+    );
+    const result = await listNodeSnapshots();
+    expect(result.snapshots).toEqual([
+      "2024-01-02_03-04-05_snapshot",
+      "prod",
+    ]);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8188/snapshot/getlist");
+  });
+
+  it("returns empty array when items is missing", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    const result = await listNodeSnapshots();
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it("filters non-string items", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: ["a", 5, null, "b"] }));
+    const result = await listNodeSnapshots();
+    expect(result.snapshots).toEqual(["a", "b"]);
+  });
+
+  it("throws NodeSnapshotError on non-2xx", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 500));
+    await expect(listNodeSnapshots()).rejects.toBeInstanceOf(NodeSnapshotError);
+  });
+
+  it("wraps network failures in NodeSnapshotError", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    await expect(listNodeSnapshots()).rejects.toBeInstanceOf(NodeSnapshotError);
+  });
+});
+
+describe("saveNodeSnapshot (no name — HTTP path)", () => {
+  it("POSTs /snapshot/save and reports the newly created name via list diff", async () => {
+    // before getlist
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: ["old"] }));
+    // save POST
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, true, 200));
+    // after getlist
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ items: ["2024-05-25_10-00-00_snapshot", "old"] }),
+    );
+
+    const result = await saveNodeSnapshot();
+    expect(result.method).toBe("http");
+    expect(result.name).toBe("2024-05-25_10-00-00_snapshot");
+
+    // Verify the save call was a POST to the right endpoint.
+    const saveCall = fetchMock.mock.calls[1];
+    expect(saveCall[0]).toBe("http://127.0.0.1:8188/snapshot/save");
+    expect(saveCall[1]).toMatchObject({ method: "POST" });
+
+    // No files written on the HTTP path.
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to newest list entry when diff finds nothing new", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: ["only"] }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, true, 200));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: ["only"] }));
+    const result = await saveNodeSnapshot();
+    expect(result.name).toBe("only");
+  });
+
+  it("treats whitespace-only name as no name (HTTP path)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: [] }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, true, 200));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: ["x_snapshot"] }));
+    const result = await saveNodeSnapshot("   ");
+    expect(result.method).toBe("http");
+  });
+});
+
+describe("saveNodeSnapshot (named — file path)", () => {
+  it("fetches get_current and writes <name>.json to the snapshots dir", async () => {
+    const state = { comfyui: "abc123", git_custom_nodes: {} };
+    fetchMock.mockResolvedValueOnce(jsonResponse(state));
+
+    const result = await saveNodeSnapshot("prod-baseline");
+    expect(result.method).toBe("file");
+    expect(result.name).toBe("prod-baseline");
+
+    // get_current was fetched.
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:8188/snapshot/get_current",
+    );
+
+    // Wrote to the newest-layout dir (none existed, so candidate[0]).
+    expect(fsMocks.writeFileSync).toHaveBeenCalledTimes(1);
+    const [writtenPath, contents] = fsMocks.writeFileSync.mock.calls[0];
+    expect(writtenPath).toBe(
+      "/fake/comfyui/user/__manager/snapshots/prod-baseline.json",
+    );
+    expect(JSON.parse(contents as string)).toEqual(state);
+    // Dir was created since existsSync returned false.
+    expect(fsMocks.mkdirSync).toHaveBeenCalled();
+  });
+
+  it("writes into an existing Manager snapshots dir when one is present", async () => {
+    // Make the legacy default-layout dir "exist".
+    fsMocks.existsSync.mockImplementation((p: unknown) =>
+      String(p).includes("user/default/ComfyUI-Manager/snapshots"),
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse({ comfyui: "x" }));
+
+    await saveNodeSnapshot("named");
+    const [writtenPath] = fsMocks.writeFileSync.mock.calls[0];
+    expect(writtenPath).toBe(
+      "/fake/comfyui/user/default/ComfyUI-Manager/snapshots/named.json",
+    );
+    // Dir existed, so no mkdir.
+    expect(fsMocks.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it("errors clearly when comfyuiPath is undefined (remote mode)", async () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    await expect(saveNodeSnapshot("name")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+    // Must not have made any HTTP call or written files.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("rejects path-traversal names before any IO", async () => {
+    await expect(saveNodeSnapshot("../evil")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+    await expect(saveNodeSnapshot("a/b")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+    await expect(saveNodeSnapshot("a\\b")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("restoreNodeSnapshot", () => {
+  it("POSTs /snapshot/restore with the target in the JSON body", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, true, 200));
+    const result = await restoreNodeSnapshot("prod");
+    expect(result.name).toBe("prod");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:8188/snapshot/restore");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ target: "prod" });
+    expect(init.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("strips a trailing .json from the target", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, true, 200));
+    const result = await restoreNodeSnapshot("prod.json");
+    expect(result.name).toBe("prod");
+    const init = fetchMock.mock.calls[0][1];
+    expect(JSON.parse(init.body)).toEqual({ target: "prod" });
+  });
+
+  it("throws on empty name without calling fetch", async () => {
+    await expect(restoreNodeSnapshot("  ")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws NodeSnapshotError on non-2xx restore", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 400));
+    await expect(restoreNodeSnapshot("prod")).rejects.toBeInstanceOf(
+      NodeSnapshotError,
+    );
+  });
+});

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -95,6 +95,55 @@ function resolveSnapshotWriteDir(comfyuiPath: string): string {
   return candidates[0];
 }
 
+/**
+ * Serialize a JSON-ish value to YAML. Scalars are always double-quoted (valid,
+ * if verbose, YAML), which sidesteps any need to decide when keys/values like
+ * git URLs require quoting.
+ */
+function toYaml(value: unknown, indent: number): string {
+  const pad = "  ".repeat(indent);
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    return (
+      "\n" +
+      value
+        .map((item) => {
+          const rendered = toYaml(item, indent + 1);
+          // A nested block (object/array) renders on following indented lines.
+          return rendered.startsWith("\n")
+            ? `${pad}-${rendered}`
+            : `${pad}- ${rendered}`;
+        })
+        .join("\n")
+    );
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return "{}";
+  return (
+    "\n" +
+    entries
+      .map(([k, v]) => {
+        const rendered = toYaml(v, indent + 1);
+        return rendered.startsWith("\n")
+          ? `${pad}${JSON.stringify(k)}:${rendered}`
+          : `${pad}${JSON.stringify(k)}: ${rendered}`;
+      })
+      .join("\n")
+  );
+}
+
+/**
+ * Render a snapshot as a comfy-cli/cm-cli-compatible YAML document. The CLI
+ * wraps the snapshot body under a top-level `custom_nodes:` key (restore reads
+ * `info['custom_nodes']` for .yaml files), so we must match that contract.
+ */
+function snapshotToYaml(snapshot: unknown): string {
+  return `custom_nodes:${toYaml(snapshot, 1)}\n`;
+}
+
 /** GET /snapshot/getlist */
 export async function listNodeSnapshots(): Promise<ListSnapshotsResult> {
   const res = await managerFetch("/snapshot/getlist");
@@ -148,18 +197,30 @@ export async function saveNodeSnapshot(
   const res = await managerFetch("/snapshot/get_current");
   const snapshot = await res.json();
 
+  // Honor the comfy-cli contract: the file FORMAT is chosen by extension.
+  // `.json` → bare object (4-space indent, as save_snapshot_with_postfix does);
+  // `.yaml`/`.yml` → the snapshot wrapped under a `custom_nodes:` key. A name
+  // without a recognized extension defaults to `.json` (never double-appended).
+  const lower = trimmed.toLowerCase();
+  const isYaml = lower.endsWith(".yaml") || lower.endsWith(".yml");
+  const isJson = lower.endsWith(".json");
+  const fileName = isYaml || isJson ? trimmed : `${trimmed}.json`;
+
   const dir = resolveSnapshotWriteDir(config.comfyuiPath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const filePath = join(dir, `${trimmed}.json`);
-  writeFileSync(filePath, JSON.stringify(snapshot, null, 4), "utf-8");
+  const filePath = join(dir, fileName);
+  const contents = isYaml
+    ? snapshotToYaml(snapshot)
+    : JSON.stringify(snapshot, null, 4);
+  writeFileSync(filePath, contents, "utf-8");
   logger.info(`Wrote named node snapshot to ${filePath}`);
 
   return {
-    name: trimmed,
+    name: fileName,
     method: "file",
-    message: `Saved snapshot "${trimmed}" to ${filePath}.`,
+    message: `Saved snapshot "${fileName}" to ${filePath}.`,
   };
 }
 

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -1,0 +1,208 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { NodeSnapshotError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// ComfyUI-Manager snapshot HTTP API
+//
+// Confirmed endpoints (Comfy-Org/ComfyUI-Manager, glob/manager_server.py):
+//   GET  /snapshot/getlist      -> { items: string[] }   (names without .json)
+//   POST /snapshot/save         -> 200 (filename {date}_snapshot.json, no name arg)
+//   POST /snapshot/restore      -> 200, body { target: <name> }
+//   GET  /snapshot/get_current  -> snapshot state JSON
+//
+// The HTTP API works against remote instances (--comfyui-url). Naming a
+// snapshot is only possible via the file fallback (writes get_current output
+// to the Manager snapshots dir), which requires a local config.comfyuiPath.
+// ---------------------------------------------------------------------------
+
+export interface SaveSnapshotResult {
+  name: string;
+  method: "http" | "file";
+  message: string;
+}
+
+export interface RestoreSnapshotResult {
+  name: string;
+  message: string;
+}
+
+export interface ListSnapshotsResult {
+  snapshots: string[];
+}
+
+function managerBaseUrl(): string {
+  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+}
+
+/**
+ * Fetch a ComfyUI-Manager endpoint. Throws NodeSnapshotError on non-2xx or
+ * network failure so callers can route through errorToToolResult.
+ */
+async function managerFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const url = `${managerBaseUrl()}${path}`;
+  logger.debug("Manager API request", { url, method: init?.method ?? "GET" });
+
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new NodeSnapshotError(
+      `Failed to reach ComfyUI-Manager at ${url}: ${msg}. ` +
+        `Is ComfyUI running with ComfyUI-Manager installed?`,
+      { url },
+    );
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new NodeSnapshotError(
+      `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`,
+      { url, status: res.status, body },
+    );
+  }
+  return res;
+}
+
+/**
+ * Candidate ComfyUI-Manager snapshot directories under a local install,
+ * newest layout first. Mirrors manager_migration.get_manager_path().
+ */
+function snapshotDirCandidates(comfyuiPath: string): string[] {
+  return [
+    join(comfyuiPath, "user", "__manager", "snapshots"),
+    join(comfyuiPath, "user", "default", "ComfyUI-Manager", "snapshots"),
+    join(comfyuiPath, "custom_nodes", "ComfyUI-Manager", "snapshots"),
+  ];
+}
+
+/**
+ * Resolve the directory to write a named snapshot into. Prefers an existing
+ * Manager snapshots dir; otherwise falls back to the newest-layout path
+ * (created on write).
+ */
+function resolveSnapshotWriteDir(comfyuiPath: string): string {
+  const candidates = snapshotDirCandidates(comfyuiPath);
+  for (const dir of candidates) {
+    if (existsSync(dir)) return dir;
+  }
+  return candidates[0];
+}
+
+/** GET /snapshot/getlist */
+export async function listNodeSnapshots(): Promise<ListSnapshotsResult> {
+  const res = await managerFetch("/snapshot/getlist");
+  const data = (await res.json()) as { items?: unknown };
+  const items = Array.isArray(data.items)
+    ? data.items.filter((x): x is string => typeof x === "string")
+    : [];
+  logger.info(`Listed ${items.length} node snapshot(s)`);
+  return { snapshots: items };
+}
+
+/**
+ * Save a snapshot of the current custom-node + version state.
+ *
+ * - No name: POST /snapshot/save (Manager names it {date}_snapshot). Works
+ *   remotely. We diff getlist before/after to report the created name.
+ * - Named: fetch GET /snapshot/get_current and write <name>.json into the
+ *   local Manager snapshots dir. Requires config.comfyuiPath (errors clearly
+ *   in remote --comfyui-url mode).
+ */
+export async function saveNodeSnapshot(
+  name?: string,
+): Promise<SaveSnapshotResult> {
+  const trimmed = name?.trim();
+
+  if (!trimmed) {
+    // HTTP-only path — Manager assigns a timestamped name.
+    const before = new Set((await listNodeSnapshots()).snapshots);
+    await managerFetch("/snapshot/save", { method: "POST" });
+    const after = (await listNodeSnapshots()).snapshots;
+    const created = after.find((n) => !before.has(n));
+    const resolved = created ?? after[0] ?? "(unknown)";
+    return {
+      name: resolved,
+      method: "http",
+      message: `Saved snapshot "${resolved}" via ComfyUI-Manager.`,
+    };
+  }
+
+  // Named snapshot — requires a local install to write the file.
+  validateSnapshotName(trimmed);
+  if (!config.comfyuiPath) {
+    throw new NodeSnapshotError(
+      "Saving a named snapshot requires a local ComfyUI install path, which " +
+        "is unavailable in remote (--comfyui-url) mode. Omit the name to let " +
+        "ComfyUI-Manager assign a timestamped snapshot instead.",
+    );
+  }
+
+  // Capture current state from the running instance via the Manager API.
+  const res = await managerFetch("/snapshot/get_current");
+  const snapshot = await res.json();
+
+  const dir = resolveSnapshotWriteDir(config.comfyuiPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const filePath = join(dir, `${trimmed}.json`);
+  writeFileSync(filePath, JSON.stringify(snapshot, null, 4), "utf-8");
+  logger.info(`Wrote named node snapshot to ${filePath}`);
+
+  return {
+    name: trimmed,
+    method: "file",
+    message: `Saved snapshot "${trimmed}" to ${filePath}.`,
+  };
+}
+
+/** POST /snapshot/restore with { target } */
+export async function restoreNodeSnapshot(
+  name: string,
+): Promise<RestoreSnapshotResult> {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    throw new NodeSnapshotError("Snapshot name is required to restore.");
+  }
+
+  // The Manager stores names without the .json suffix; tolerate either.
+  const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
+
+  await managerFetch("/snapshot/restore", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ target }),
+  });
+
+  logger.info(`Requested restore of node snapshot "${target}"`);
+  return {
+    name: target,
+    message:
+      `Restore of snapshot "${target}" requested. ComfyUI-Manager applies ` +
+      `custom-node changes on the next ComfyUI restart.`,
+  };
+}
+
+/**
+ * Reject names that would escape the snapshots directory or produce an
+ * invalid filename.
+ */
+function validateSnapshotName(name: string): void {
+  if (
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.includes("..") ||
+    name.includes("\0")
+  ) {
+    throw new NodeSnapshotError(
+      `Invalid snapshot name "${name}": must not contain path separators or "..".`,
+    );
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerDefaultsTools } from "./defaults.js";
 import { registerGenerateImageTool } from "./generate-image.js";
 import { registerConditionedGenerationTools } from "./generate-conditioned.js";
 import { registerWorkflowDslTools } from "./workflow-dsl.js";
+import { registerNodeSnapshotsTools } from "./node-snapshots.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -44,5 +45,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerGenerateImageTool(server);
   registerConditionedGenerationTools(server);
   registerWorkflowDslTools(server);
+  registerNodeSnapshotsTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/node-snapshots.ts
+++ b/src/tools/node-snapshots.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  saveNodeSnapshot,
+  restoreNodeSnapshot,
+  listNodeSnapshots,
+} from "../services/node-snapshots.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerNodeSnapshotsTools(server: McpServer): void {
+  server.tool(
+    "save_node_snapshot",
+    "Save a snapshot of the current ComfyUI custom-node and version state via " +
+      "ComfyUI-Manager (mirrors `comfy node save-snapshot`). With no name, " +
+      "Manager assigns a timestamped snapshot (works against remote instances). " +
+      "Provide a name to write a custom-named snapshot file — this requires a " +
+      "local ComfyUI install and is unavailable in remote (--comfyui-url) mode.",
+    {
+      name: z
+        .string()
+        .optional()
+        .describe(
+          "Optional custom snapshot name (no extension, no path separators). " +
+            "Omit to let ComfyUI-Manager assign a timestamped name.",
+        ),
+    },
+    async (args) => {
+      try {
+        const result = await saveNodeSnapshot(args.name);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "restore_node_snapshot",
+    "Restore a previously saved custom-node snapshot via ComfyUI-Manager " +
+      "(mirrors `comfy node restore-snapshot`). ComfyUI-Manager applies the " +
+      "custom-node changes on the next ComfyUI restart. Use list_node_snapshots " +
+      "to find available snapshot names.",
+    {
+      name: z
+        .string()
+        .describe("Name of the snapshot to restore (as shown by list_node_snapshots)."),
+    },
+    async (args) => {
+      try {
+        const result = await restoreNodeSnapshot(args.name);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "list_node_snapshots",
+    "List available custom-node snapshots known to ComfyUI-Manager " +
+      "(mirrors `comfy node` snapshot listing).",
+    {},
+    async () => {
+      try {
+        const result = await listNodeSnapshots();
+        const text =
+          result.snapshots.length === 0
+            ? "No node snapshots found."
+            : `Available node snapshots (${result.snapshots.length}):\n` +
+              result.snapshots.map((s) => `- ${s}`).join("\n");
+        return { content: [{ type: "text" as const, text }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -69,6 +69,13 @@ export class ProcessControlError extends ComfyUIError {
   }
 }
 
+export class NodeSnapshotError extends ComfyUIError {
+  constructor(message: string, details?: unknown) {
+    super(message, "NODE_SNAPSHOT_ERROR", details);
+    this.name = "NodeSnapshotError";
+  }
+}
+
 export function errorToToolResult(err: unknown): CallToolResult {
   if (err instanceof ComfyUIError) return err.toToolResult();
   const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Ports `comfy node save-snapshot|restore-snapshot` from [comfy-cli](https://github.com/Comfy-Org/comfy-cli) into the ComfyUI MCP server as three new tools, backed by the ComfyUI-Manager HTTP snapshot API (with a local-file fallback for custom names).

New tools:
- **`save_node_snapshot`** — with no name, `POST /snapshot/save` lets Manager assign a timestamped snapshot (`{date}_snapshot`); this works against remote instances. With a custom `name`, captures `GET /snapshot/get_current` and writes `<name>.json` into the local Manager snapshots directory.
- **`restore_node_snapshot`** — `POST /snapshot/restore` with `{ target }`. Manager applies custom-node changes on the next ComfyUI restart.
- **`list_node_snapshots`** — `GET /snapshot/getlist`.

## Mechanism (hybrid)

Endpoints were confirmed against `Comfy-Org/ComfyUI-Manager` `glob/manager_server.py` (not invented):
- `GET /snapshot/getlist` → `{ items: string[] }` (names without `.json`)
- `POST /snapshot/save` → 200 (postfix hardcoded to `snapshot`, no name arg)
- `POST /snapshot/restore` → body `{ target }` read from JSON
- `GET /snapshot/get_current` → snapshot state JSON

The HTTP API works against remote instances. Custom-named snapshots require writing a file into the Manager snapshots dir, so the named-save path needs a local `config.comfyuiPath`; in remote `--comfyui-url` mode it returns a clear error directing the user to omit the name. Snapshot-dir candidates mirror `manager_migration.get_manager_path()` (`user/__manager/snapshots`, `user/default/ComfyUI-Manager/snapshots`, legacy `custom_nodes/ComfyUI-Manager/snapshots`).

A local `managerFetch()` helper lives inside the service file (no shared client). Snapshot names are validated against path traversal (`/`, `\`, `..`, NUL).

## Conventions

- Business logic in `src/services/node-snapshots.ts`; thin tool wrappers in `src/tools/node-snapshots.ts`.
- Added `NodeSnapshotError` to `src/utils/errors.ts`; all handlers route through `errorToToolResult`.
- Wired into `src/tools/index.ts` (one import + one `registerNodeSnapshotsTools(server)` call before `registerAutoloadedWorkflows`).

## Testing

- 16 new unit tests (`src/__tests__/services/node-snapshots.test.ts`) mock `global.fetch` for the Manager HTTP API and `node:fs` for the file-write path — no real side effects.
- `npm run build` clean (typecheck gate); full suite passes (117 tests).
- Code-review skill (high effort) surfaced no correctness findings.
- **Live e2e deferred**: this worktree has no running ComfyUI/ComfyUI-Manager instance. Tools should be smoke-tested against a real instance before relying on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)