### PR TITLE
feat: custom-node management tools (comfy-cli node parity)

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -153,14 +153,17 @@ describe("node-management service", () => {
       );
     });
 
-    it("auto-detects a git URL and sends it in the files array", async () => {
+    it("auto-detects a git URL and sends version:'unknown' with the repo in files", async () => {
       const { calls } = stubFetch();
       await installCustomNode({ id: "https://github.com/foo/bar" });
 
       const installCall = calls.find((c) =>
         c.url.includes("/manager/queue/install"),
       );
+      // version:"unknown" is required — it routes the Manager handler into the
+      // git branch (and avoids the bracket-access KeyError on json_data['version']).
       expect(installCall!.body).toMatchObject({
+        version: "unknown",
         files: ["https://github.com/foo/bar"],
         pip: [],
       });

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1,0 +1,404 @@
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+
+// Mock config so importing node-management doesn't trigger the real port
+// auto-detection (a live fetch) and lets us flip comfyuiPath per-test.
+vi.mock("../../config.js", () => {
+  const config: {
+    comfyuiPath: string | undefined;
+    resolvedPort: number;
+    comfyuiHost: string;
+    comfyuiSsl: boolean;
+    githubToken: string | undefined;
+  } = {
+    comfyuiPath: "/fake/comfy",
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined,
+  };
+  return {
+    config,
+    getComfyUIApiHost: () => `${config.comfyuiHost}:${config.resolvedPort}`,
+    getComfyUIProtocol: () => (config.comfyuiSsl ? "https" : "http"),
+  };
+});
+
+// Mock child_process for the cm-cli subprocess paths.
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+// Mock fs so resolveCmCliPath's existsSync check is controllable.
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => true),
+}));
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { config } from "../../config.js";
+import {
+  installCustomNode,
+  updateCustomNode,
+  reinstallCustomNode,
+  fixCustomNode,
+  listInstalledNodes,
+  syncNodeDependencies,
+  setQueueTimingForTests,
+  NodeManagementError,
+} from "../../services/node-management.js";
+import { ProcessControlError } from "../../utils/errors.js";
+
+const mockedExec = vi.mocked(execFileSync);
+const mockedExists = vi.mocked(existsSync);
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+/**
+ * Install a fetch stub that records every call and returns canned responses.
+ * The queue status returns "done" on the first poll so runManagerQueue resolves.
+ */
+function stubFetch(opts: {
+  installedBody?: unknown;
+  statusSequence?: unknown[];
+} = {}) {
+  const calls: Call[] = [];
+  let statusIdx = 0;
+  const statusSeq = opts.statusSequence ?? [
+    { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false },
+  ];
+
+  const fetchMock = vi.fn(
+    async (url: string, init?: RequestInit): Promise<Response> => {
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(init.body as string) : undefined;
+      calls.push({ url, method, body });
+
+      const path = new URL(url).pathname + (new URL(url).search || "");
+
+      if (path.startsWith("/customnode/installed")) {
+        return jsonResponse(opts.installedBody ?? {});
+      }
+      if (path === "/manager/queue/status") {
+        const s = statusSeq[Math.min(statusIdx, statusSeq.length - 1)];
+        statusIdx++;
+        return jsonResponse(s);
+      }
+      // queue ops + start return empty bodies
+      return new Response("", { status: 200 });
+    },
+  );
+
+  vi.stubGlobal("fetch", fetchMock);
+  return { calls, fetchMock };
+}
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("node-management service", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    mockedExists.mockReset();
+    mockedExists.mockReturnValue(true);
+    config.comfyuiPath = "/fake/comfy";
+    config.githubToken = undefined;
+    // Shrink polling timings so the suite stays fast.
+    setQueueTimingForTests({
+      pollIntervalMs: 1,
+      startupGraceMs: 0,
+      timeoutMs: 5000,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ---- install -----------------------------------------------------------
+
+  describe("installCustomNode", () => {
+    it("installs a registry id via the Manager queue API with latest version", async () => {
+      const { calls } = stubFetch();
+      const res = await installCustomNode({ id: "comfyui-impact-pack" });
+
+      expect(res.mechanism).toBe("manager-http");
+      const installCall = calls.find((c) =>
+        c.url.includes("/manager/queue/install"),
+      );
+      expect(installCall).toBeDefined();
+      expect(installCall!.method).toBe("POST");
+      expect(installCall!.body).toMatchObject({
+        id: "comfyui-impact-pack",
+        version: "latest",
+        selected_version: "latest",
+      });
+      // Must kick the queue worker.
+      expect(calls.some((c) => c.url.endsWith("/manager/queue/start"))).toBe(
+        true,
+      );
+    });
+
+    it("auto-detects a git URL and sends it in the files array", async () => {
+      const { calls } = stubFetch();
+      await installCustomNode({ id: "https://github.com/foo/bar" });
+
+      const installCall = calls.find((c) =>
+        c.url.includes("/manager/queue/install"),
+      );
+      expect(installCall!.body).toMatchObject({
+        files: ["https://github.com/foo/bar"],
+        pip: [],
+      });
+    });
+
+    it("honors an explicit version", async () => {
+      const { calls } = stubFetch();
+      await installCustomNode({ id: "some-pack", version: "1.2.3" });
+      const installCall = calls.find((c) =>
+        c.url.includes("/manager/queue/install"),
+      );
+      expect(installCall!.body).toMatchObject({
+        version: "1.2.3",
+        selected_version: "1.2.3",
+      });
+    });
+
+    it("does not return early when the worker has not yet started (pending queue)", async () => {
+      // First poll: worker thread not yet spun up — idle-looking but a queued
+      // item is pending (total=1 > done=0). Must NOT be treated as done.
+      // Second poll: worker is running. Third: drained.
+      const { calls } = stubFetch({
+        statusSequence: [
+          { total_count: 1, done_count: 0, in_progress_count: 0, is_processing: false },
+          { total_count: 1, done_count: 0, in_progress_count: 1, is_processing: true },
+          { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false },
+        ],
+      });
+
+      const res = await installCustomNode({ id: "pack" });
+      expect(res.mechanism).toBe("manager-http");
+      // It should have polled status at least 3 times before returning.
+      const statusPolls = calls.filter((c) =>
+        c.url.endsWith("/manager/queue/status"),
+      );
+      expect(statusPolls.length).toBeGreaterThanOrEqual(3);
+      expect((res.details as { done_count: number }).done_count).toBe(1);
+    });
+
+    it("uses cm-cli subprocess when forced", async () => {
+      mockedExec.mockReturnValue("installed ok" as never);
+      const res = await installCustomNode({ id: "some-pack", useCmCli: true });
+
+      expect(res.mechanism).toBe("cm-cli");
+      const [bin, args] = mockedExec.mock.calls[0];
+      expect(bin).toBe("python");
+      expect(args).toEqual([
+        "/fake/comfy/custom_nodes/ComfyUI-Manager/cm-cli.py",
+        "install",
+        "some-pack",
+        "--mode",
+        "remote",
+        "--channel",
+        "default",
+      ]);
+    });
+  });
+
+  // ---- update ------------------------------------------------------------
+
+  describe("updateCustomNode", () => {
+    it("updates a single pack via /manager/queue/update", async () => {
+      const { calls } = stubFetch();
+      await updateCustomNode({ id: "my-pack" });
+      const c = calls.find((x) => x.url.includes("/manager/queue/update"));
+      expect(c!.url).toContain("/manager/queue/update");
+      expect(c!.body).toMatchObject({ id: "my-pack", version: "latest" });
+    });
+
+    it("routes 'all' to /manager/queue/update_all", async () => {
+      const { calls } = stubFetch();
+      await updateCustomNode({ id: "all", mode: "local" });
+      const c = calls.find((x) => x.url.includes("/manager/queue/update_all"));
+      expect(c).toBeDefined();
+      expect(c!.body).toMatchObject({ mode: "local" });
+    });
+  });
+
+  // ---- reinstall ---------------------------------------------------------
+
+  describe("reinstallCustomNode", () => {
+    it("posts to /manager/queue/reinstall", async () => {
+      const { calls } = stubFetch();
+      await reinstallCustomNode({ id: "my-pack" });
+      const c = calls.find((x) => x.url.includes("/manager/queue/reinstall"));
+      expect(c!.body).toMatchObject({ id: "my-pack", version: "latest" });
+    });
+  });
+
+  // ---- fix ---------------------------------------------------------------
+
+  describe("fixCustomNode", () => {
+    it("posts a single pack to /manager/queue/fix over HTTP", async () => {
+      const { calls } = stubFetch();
+      const res = await fixCustomNode({ id: "my-pack" });
+      expect(res.mechanism).toBe("manager-http");
+      const c = calls.find((x) => x.url.includes("/manager/queue/fix"));
+      expect(c!.body).toMatchObject({ id: "my-pack" });
+    });
+
+    it("routes 'all' to the cm-cli subprocess", async () => {
+      mockedExec.mockReturnValue("fixed all" as never);
+      const res = await fixCustomNode({ id: "all" });
+      expect(res.mechanism).toBe("cm-cli");
+      const [, args] = mockedExec.mock.calls[0];
+      expect(args).toContain("fix");
+      expect(args).toContain("all");
+    });
+  });
+
+  // ---- list --------------------------------------------------------------
+
+  describe("listInstalledNodes", () => {
+    it("parses an object-keyed installed response", async () => {
+      stubFetch({
+        installedBody: {
+          "ComfyUI-Impact-Pack": {
+            ver: "8.0.0",
+            cnr_id: "comfyui-impact-pack",
+            aux_id: "",
+            enabled: true,
+          },
+          "some-git-node": {
+            ver: "abc1234",
+            cnr_id: "",
+            aux_id: "user/some-git-node",
+            enabled: false,
+          },
+        },
+      });
+
+      const nodes = await listInstalledNodes();
+      expect(nodes).toHaveLength(2);
+
+      const impact = nodes.find((n) => n.module === "ComfyUI-Impact-Pack")!;
+      expect(impact.cnrId).toBe("comfyui-impact-pack");
+      expect(impact.auxId).toBeUndefined();
+      expect(impact.version).toBe("8.0.0");
+      expect(impact.enabled).toBe(true);
+
+      const git = nodes.find((n) => n.module === "some-git-node")!;
+      expect(git.auxId).toBe("user/some-git-node");
+      expect(git.cnrId).toBeUndefined();
+      expect(git.enabled).toBe(false);
+    });
+
+    it("handles an array-shaped installed response", async () => {
+      stubFetch({
+        installedBody: [
+          { title: "PackA", ver: "1.0.0", cnr_id: "packa", enabled: true },
+        ],
+      });
+      const nodes = await listInstalledNodes();
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0].module).toBe("PackA");
+    });
+
+    it("treats missing enabled as enabled unless is_disabled is set", async () => {
+      stubFetch({
+        installedBody: {
+          A: { ver: "1" },
+          B: { ver: "1", is_disabled: true },
+        },
+      });
+      const nodes = await listInstalledNodes();
+      expect(nodes.find((n) => n.module === "A")!.enabled).toBe(true);
+      expect(nodes.find((n) => n.module === "B")!.enabled).toBe(false);
+    });
+  });
+
+  // ---- sync deps ---------------------------------------------------------
+
+  describe("syncNodeDependencies", () => {
+    it("runs cm-cli restore-dependencies", async () => {
+      mockedExec.mockReturnValue("deps restored" as never);
+      const res = await syncNodeDependencies();
+      expect(res.mechanism).toBe("cm-cli");
+      const [, args] = mockedExec.mock.calls[0];
+      expect(args).toEqual([
+        "/fake/comfy/custom_nodes/ComfyUI-Manager/cm-cli.py",
+        "restore-dependencies",
+      ]);
+    });
+  });
+
+  // ---- error handling ----------------------------------------------------
+
+  describe("subprocess error handling", () => {
+    it("throws ProcessControlError when comfyuiPath is undefined (remote mode)", async () => {
+      config.comfyuiPath = undefined;
+      await expect(syncNodeDependencies()).rejects.toBeInstanceOf(
+        ProcessControlError,
+      );
+      expect(mockedExec).not.toHaveBeenCalled();
+    });
+
+    it("throws NodeManagementError when cm-cli.py is missing", async () => {
+      mockedExists.mockReturnValue(false);
+      await expect(syncNodeDependencies()).rejects.toBeInstanceOf(
+        NodeManagementError,
+      );
+    });
+
+    it("wraps cm-cli failures with stdout/stderr details", async () => {
+      const err = Object.assign(new Error("boom"), {
+        stdout: Buffer.from("some out"),
+        stderr: Buffer.from("trace"),
+      });
+      mockedExec.mockImplementation(() => {
+        throw err;
+      });
+      await expect(syncNodeDependencies()).rejects.toMatchObject({
+        code: "NODE_MANAGEMENT_ERROR",
+      });
+    });
+
+    it("surfaces a clear error when ENOENT (python missing)", async () => {
+      const err = Object.assign(new Error("spawn python ENOENT"), {
+        code: "ENOENT",
+      });
+      mockedExec.mockImplementation(() => {
+        throw err;
+      });
+      await expect(syncNodeDependencies()).rejects.toBeInstanceOf(
+        ProcessControlError,
+      );
+    });
+  });
+
+  describe("HTTP error handling", () => {
+    it("throws NodeManagementError when the Manager API is unreachable", async () => {
+      const fetchMock = vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await expect(
+        installCustomNode({ id: "x" }),
+      ).rejects.toBeInstanceOf(NodeManagementError);
+    });
+  });
+});

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -347,8 +347,12 @@ export async function installCustomNode(
 
   let body: Record<string, unknown>;
   if (source === "git") {
-    // Unknown-type git install: pass the repo URL in `files`.
-    body = { files: [id], pip: [], channel, mode };
+    // Plain (non-registry) git install. ComfyUI-Manager's /manager/queue/install
+    // handler reads json_data['version'] with bracket access and routes
+    // version === "unknown" into the git branch, where it derives the pack name
+    // from basename(files[0]) and clones `files` as the git URL. Omitting
+    // `version` makes the server raise KeyError (500), so it MUST be "unknown".
+    body = { version: "unknown", files: [id], pip: [], channel, mode };
   } else {
     body = {
       id,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1,0 +1,564 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { ComfyUIError, ProcessControlError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// Custom-node management — ports `comfy-cli node install|update|reinstall|fix|
+// show|uv-sync` to MCP tools.
+//
+// Strategy (hybrid, confirmed with maintainer):
+//   1. Prefer the ComfyUI-Manager HTTP API (works against remote instances).
+//      Manager uses a queue model: POST an operation to /manager/queue/<op>,
+//      then POST /manager/queue/start to begin processing, then poll
+//      /manager/queue/status until the queue drains.
+//   2. Fall back to the cm-cli.py subprocess (against config.comfyuiPath) for
+//      anything the HTTP API can't do, or when the user forces it.
+//
+// Endpoint paths verified against Comfy-Org/ComfyUI-Manager (glob/
+// manager_server.py): /customnode/installed, /manager/queue/install,
+// /manager/queue/update, /manager/queue/update_all, /manager/queue/reinstall,
+// /manager/queue/fix, /manager/queue/start, /manager/queue/status.
+// cm-cli subcommands verified from cm-cli.py: install, reinstall, update, fix,
+// show, restore-dependencies (there is NO `uv-sync` subcommand — comfy-cli's
+// `node uv-sync` maps to dependency reconciliation, handled here via
+// restore-dependencies).
+// ---------------------------------------------------------------------------
+
+export class NodeManagementError extends ComfyUIError {
+  constructor(message: string, details?: unknown) {
+    super(message, "NODE_MANAGEMENT_ERROR", details);
+    this.name = "NodeManagementError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type InstallSource = "registry" | "git" | "auto";
+export type ManagerMode = "remote" | "local" | "cache";
+
+export interface InstalledNode {
+  /** Custom-node module/folder name (the key Manager uses internally). */
+  module: string;
+  /** ComfyUI Node Registry id, if the pack is CNR-registered. */
+  cnrId?: string;
+  /** GitHub/aux id for git-based packs. */
+  auxId?: string;
+  /** Installed version (semver, commit hash, "nightly", or "unknown"). */
+  version?: string;
+  /** Whether the pack is currently enabled. */
+  enabled: boolean;
+}
+
+export interface NodeOpResult {
+  /** Which mechanism handled the request. */
+  mechanism: "manager-http" | "cm-cli";
+  /** Human-readable summary. */
+  message: string;
+  /** Raw queue status (HTTP path) or subprocess output (cm-cli path). */
+  details?: unknown;
+}
+
+interface QueueStatus {
+  total_count: number;
+  done_count: number;
+  in_progress_count: number;
+  is_processing: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Manager HTTP helper (local to this unit — do NOT extract to a shared client)
+// ---------------------------------------------------------------------------
+
+function managerBaseUrl(): string {
+  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+}
+
+interface ManagerFetchOptions {
+  method?: "GET" | "POST";
+  body?: unknown;
+  /** Treat a non-2xx response as a soft failure (return undefined) instead of throwing. */
+  soft?: boolean;
+}
+
+async function managerFetch<T>(
+  path: string,
+  options: ManagerFetchOptions = {},
+): Promise<T | undefined> {
+  const { method = "GET", body, soft = false } = options;
+  const url = `${managerBaseUrl()}${path}`;
+  logger.debug("Manager API request", { url, method });
+
+  const headers: Record<string, string> = {};
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    if (soft) return undefined;
+    throw new NodeManagementError(
+      `ComfyUI-Manager API unreachable at ${url}. Is ComfyUI running with ComfyUI-Manager installed? (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+    );
+  }
+
+  if (!res.ok) {
+    if (soft) return undefined;
+    const text = await res.text().catch(() => "");
+    throw new NodeManagementError(
+      `ComfyUI-Manager API ${res.status} ${res.statusText} for ${path}`,
+      { url, status: res.status, body: text },
+    );
+  }
+
+  // Some endpoints return empty bodies (e.g. queue ops). Parse defensively.
+  const raw = await res.text();
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return raw as unknown as T;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Tunable timing for queue polling. Defaults are production values; tests
+ * shrink these via setQueueTimingForTests to keep the suite fast.
+ */
+const queueTiming = {
+  pollIntervalMs: 1500,
+  // The worker thread is spawned asynchronously by /manager/queue/start, so a
+  // poll taken immediately afterward can read is_processing=false /
+  // in_progress_count=0 while the queued item is still pending (total_count
+  // counts queued items). Give the worker a grace window to spin up before
+  // treating an idle-looking status as "done".
+  startupGraceMs: 8000,
+  timeoutMs: 600_000,
+};
+
+/** @internal — test hook to shrink polling timings; not part of the tool API. */
+export function setQueueTimingForTests(
+  overrides: Partial<typeof queueTiming>,
+): void {
+  Object.assign(queueTiming, overrides);
+}
+
+/**
+ * Kick off the Manager queue worker and poll until it drains.
+ * Returns the final queue status.
+ */
+async function runManagerQueue(): Promise<QueueStatus> {
+  await managerFetch("/manager/queue/start", { method: "POST" });
+
+  const start = Date.now();
+  let lastStatus: QueueStatus | undefined;
+  while (Date.now() - start < queueTiming.timeoutMs) {
+    await sleep(queueTiming.pollIntervalMs);
+    const status = await managerFetch<QueueStatus>("/manager/queue/status", {
+      soft: true,
+    });
+    if (status) {
+      lastStatus = status;
+      // Manager defines total_count = done + in_progress + queued. The queue
+      // is fully drained only once nothing is processing AND every item that
+      // was ever queued has completed (done_count >= total_count, which also
+      // implies in_progress_count === 0 and no queued items remain).
+      const drained =
+        !status.is_processing && status.done_count >= status.total_count;
+      if (drained && Date.now() - start >= queueTiming.startupGraceMs) {
+        return status;
+      }
+    }
+  }
+  throw new NodeManagementError(
+    `ComfyUI-Manager queue did not finish within ${queueTiming.timeoutMs / 1000}s`,
+    lastStatus,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// cm-cli subprocess helper
+// ---------------------------------------------------------------------------
+
+const CM_CLI_TIMEOUT = 600_000;
+
+function resolveCmCliPath(): string {
+  if (!config.comfyuiPath) {
+    throw new ProcessControlError(
+      "This operation requires a local ComfyUI install, but config.comfyuiPath " +
+        "is not set (running in remote --comfyui-url mode). Set COMFYUI_PATH or " +
+        "use the ComfyUI-Manager HTTP API instead.",
+    );
+  }
+  const cmCli = join(
+    config.comfyuiPath,
+    "custom_nodes",
+    "ComfyUI-Manager",
+    "cm-cli.py",
+  );
+  if (!existsSync(cmCli)) {
+    throw new NodeManagementError(
+      `cm-cli.py not found at ${cmCli}. ComfyUI-Manager must be installed under ` +
+        `custom_nodes/ to use the subprocess fallback.`,
+    );
+  }
+  return cmCli;
+}
+
+/**
+ * Run a cm-cli.py subcommand. Returns combined stdout.
+ * Throws ProcessControlError if comfyuiPath is undefined (remote mode).
+ */
+function runCmCli(args: string[]): string {
+  const cmCli = resolveCmCliPath();
+  const pythonExe = process.env.COMFYUI_PYTHON || "python";
+  logger.info("Running cm-cli", { args: [cmCli, ...args].join(" ") });
+
+  try {
+    const out = execFileSync(pythonExe, [cmCli, ...args], {
+      cwd: config.comfyuiPath,
+      encoding: "utf-8",
+      timeout: CM_CLI_TIMEOUT,
+      env: {
+        ...process.env,
+        ...(config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}),
+      },
+    });
+    return out;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
+    const stdout = e.stdout ? e.stdout.toString() : "";
+    const stderr = e.stderr ? e.stderr.toString() : "";
+    if (e.code === "ENOENT") {
+      throw new ProcessControlError(
+        `Python executable "${pythonExe}" not found. Set COMFYUI_PYTHON to the ` +
+          `python interpreter for your ComfyUI install.`,
+      );
+    }
+    throw new NodeManagementError(
+      `cm-cli ${args[0]} failed: ${e.message}`,
+      { stdout, stderr },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize the /customnode/installed response into InstalledNode[].
+ * Manager returns an object keyed by module name (see manager_core
+ * get_installed_node_packs), each value carrying { ver, cnr_id, aux_id, enabled }.
+ * Older/variant builds may return an array; handle both.
+ */
+function parseInstalled(raw: unknown): InstalledNode[] {
+  if (!raw || typeof raw !== "object") return [];
+
+  const toNode = (module: string, v: Record<string, unknown>): InstalledNode => ({
+    module,
+    cnrId:
+      typeof v.cnr_id === "string" && v.cnr_id.length > 0 ? v.cnr_id : undefined,
+    auxId:
+      typeof v.aux_id === "string" && v.aux_id.length > 0 ? v.aux_id : undefined,
+    version: typeof v.ver === "string" ? v.ver : undefined,
+    // `enabled` may be absent on some builds; treat missing as enabled,
+    // but honor an explicit is_disabled flag if present.
+    enabled:
+      typeof v.enabled === "boolean"
+        ? v.enabled
+        : v.is_disabled === true
+          ? false
+          : true,
+  });
+
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((entry): entry is Record<string, unknown> =>
+        Boolean(entry && typeof entry === "object"),
+      )
+      .map((entry) => {
+        const module =
+          (typeof entry.title === "string" && entry.title) ||
+          (typeof entry.module === "string" && entry.module) ||
+          (typeof entry.cnr_id === "string" && entry.cnr_id) ||
+          "unknown";
+        return toNode(module, entry);
+      });
+  }
+
+  return Object.entries(raw as Record<string, unknown>)
+    .filter(([, v]) => Boolean(v && typeof v === "object"))
+    .map(([module, v]) => toNode(module, v as Record<string, unknown>));
+}
+
+function looksLikeGitUrl(id: string): boolean {
+  return /^(https?:\/\/|git@|git\+)/i.test(id) || id.endsWith(".git");
+}
+
+// ---------------------------------------------------------------------------
+// Public API — install
+// ---------------------------------------------------------------------------
+
+export interface InstallOptions {
+  id: string;
+  source?: InstallSource;
+  version?: string;
+  mode?: ManagerMode;
+  channel?: string;
+  /** Force the cm-cli subprocess instead of the HTTP API. */
+  useCmCli?: boolean;
+}
+
+export async function installCustomNode(
+  opts: InstallOptions,
+): Promise<NodeOpResult> {
+  const { id, version, mode = "remote", channel = "default" } = opts;
+  const source =
+    opts.source && opts.source !== "auto"
+      ? opts.source
+      : looksLikeGitUrl(id)
+        ? "git"
+        : "registry";
+
+  if (opts.useCmCli) {
+    // cm-cli install accepts registry ids and git urls alike.
+    const out = runCmCli(["install", id, "--mode", mode, "--channel", channel]);
+    return {
+      mechanism: "cm-cli",
+      message: `Installed "${id}" via cm-cli.`,
+      details: out.trim(),
+    };
+  }
+
+  let body: Record<string, unknown>;
+  if (source === "git") {
+    // Unknown-type git install: pass the repo URL in `files`.
+    body = { files: [id], pip: [], channel, mode };
+  } else {
+    body = {
+      id,
+      version: version ?? "latest",
+      selected_version: version ?? "latest",
+      channel,
+      mode,
+    };
+  }
+
+  await managerFetch("/manager/queue/install", { method: "POST", body });
+  const status = await runManagerQueue();
+  return {
+    mechanism: "manager-http",
+    message: `Queued + installed "${id}" (${source}) via ComfyUI-Manager. A restart may be required to load new nodes.`,
+    details: status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+export interface UpdateOptions {
+  /** Registry id / module name, or "all" to update every installed pack. */
+  id: string;
+  mode?: ManagerMode;
+  channel?: string;
+  useCmCli?: boolean;
+}
+
+export async function updateCustomNode(
+  opts: UpdateOptions,
+): Promise<NodeOpResult> {
+  const { id, mode = "remote", channel = "default" } = opts;
+  const all = id.trim().toLowerCase() === "all";
+
+  if (opts.useCmCli) {
+    const out = runCmCli(["update", id, "--mode", mode, "--channel", channel]);
+    return {
+      mechanism: "cm-cli",
+      message: all
+        ? "Updated all installed node packs via cm-cli."
+        : `Updated "${id}" via cm-cli.`,
+      details: out.trim(),
+    };
+  }
+
+  if (all) {
+    await managerFetch("/manager/queue/update_all", {
+      method: "POST",
+      body: { mode },
+    });
+  } else {
+    await managerFetch("/manager/queue/update", {
+      method: "POST",
+      body: { id, version: "latest" },
+    });
+  }
+  const status = await runManagerQueue();
+  return {
+    mechanism: "manager-http",
+    message: all
+      ? "Queued + updated all installed node packs via ComfyUI-Manager."
+      : `Queued + updated "${id}" via ComfyUI-Manager.`,
+    details: status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// reinstall
+// ---------------------------------------------------------------------------
+
+export interface ReinstallOptions {
+  id: string;
+  version?: string;
+  mode?: ManagerMode;
+  channel?: string;
+  useCmCli?: boolean;
+}
+
+export async function reinstallCustomNode(
+  opts: ReinstallOptions,
+): Promise<NodeOpResult> {
+  const { id, version, mode = "remote", channel = "default" } = opts;
+
+  if (opts.useCmCli) {
+    const out = runCmCli(["reinstall", id, "--mode", mode, "--channel", channel]);
+    return {
+      mechanism: "cm-cli",
+      message: `Reinstalled "${id}" via cm-cli.`,
+      details: out.trim(),
+    };
+  }
+
+  await managerFetch("/manager/queue/reinstall", {
+    method: "POST",
+    body: {
+      id,
+      version: version ?? "latest",
+      selected_version: version ?? "latest",
+      channel,
+      mode,
+    },
+  });
+  const status = await runManagerQueue();
+  return {
+    mechanism: "manager-http",
+    message: `Queued + reinstalled "${id}" via ComfyUI-Manager. A restart may be required.`,
+    details: status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fix
+// ---------------------------------------------------------------------------
+
+export interface FixOptions {
+  /** Registry id / module name, or "all". */
+  id: string;
+  mode?: ManagerMode;
+  channel?: string;
+  useCmCli?: boolean;
+}
+
+export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
+  const { id, mode = "remote", channel = "default" } = opts;
+  const all = id.trim().toLowerCase() === "all";
+
+  // The HTTP API has no "fix all"; cm-cli supports it. Route accordingly.
+  if (opts.useCmCli || all) {
+    const out = runCmCli(["fix", id, "--mode", mode, "--channel", channel]);
+    return {
+      mechanism: "cm-cli",
+      message: all
+        ? "Repaired all installed node packs via cm-cli."
+        : `Repaired "${id}" via cm-cli.`,
+      details: out.trim(),
+    };
+  }
+
+  await managerFetch("/manager/queue/fix", {
+    method: "POST",
+    body: { id, version: "latest" },
+  });
+  const status = await runManagerQueue();
+  return {
+    mechanism: "manager-http",
+    message: `Queued + repaired "${id}" via ComfyUI-Manager.`,
+    details: status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list installed
+// ---------------------------------------------------------------------------
+
+export interface ListInstalledOptions {
+  mode?: "default" | "imported";
+  useCmCli?: boolean;
+}
+
+export async function listInstalledNodes(
+  opts: ListInstalledOptions = {},
+): Promise<InstalledNode[]> {
+  const { mode = "default" } = opts;
+
+  if (opts.useCmCli) {
+    // cm-cli `show installed` prints a formatted table — return raw lines as
+    // pseudo-nodes since structured data is HTTP-only.
+    const out = runCmCli(["show", "installed"]);
+    const lines = out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !l.startsWith("#"));
+    return lines.map((line) => ({
+      module: line,
+      enabled: true,
+      version: undefined,
+    }));
+  }
+
+  const raw = await managerFetch<unknown>(
+    `/customnode/installed?mode=${encodeURIComponent(mode)}`,
+  );
+  return parseInstalled(raw);
+}
+
+// ---------------------------------------------------------------------------
+// sync dependencies (comfy-cli `node uv-sync` analogue)
+// ---------------------------------------------------------------------------
+
+export interface SyncDepsResult {
+  mechanism: "cm-cli";
+  message: string;
+  details?: unknown;
+}
+
+/**
+ * Reconcile installed-node Python dependencies. comfy-cli exposes this as
+ * `node uv-sync`, but ComfyUI-Manager has no `uv-sync` subcommand or HTTP
+ * endpoint; the equivalent reconciliation is cm-cli `restore-dependencies`,
+ * which reinstalls each installed pack's requirements. Subprocess-only.
+ */
+export async function syncNodeDependencies(): Promise<SyncDepsResult> {
+  const out = runCmCli(["restore-dependencies"]);
+  return {
+    mechanism: "cm-cli",
+    message:
+      "Reconciled installed-node Python dependencies via cm-cli restore-dependencies.",
+    details: out.trim(),
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerDefaultsTools } from "./defaults.js";
 import { registerGenerateImageTool } from "./generate-image.js";
 import { registerConditionedGenerationTools } from "./generate-conditioned.js";
 import { registerWorkflowDslTools } from "./workflow-dsl.js";
+import { registerNodeManagementTools } from "./node-management.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -44,5 +45,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerGenerateImageTool(server);
   registerConditionedGenerationTools(server);
   registerWorkflowDslTools(server);
+  registerNodeManagementTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  installCustomNode,
+  updateCustomNode,
+  reinstallCustomNode,
+  fixCustomNode,
+  listInstalledNodes,
+  syncNodeDependencies,
+  type InstalledNode,
+} from "../services/node-management.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+const modeSchema = z
+  .enum(["remote", "local", "cache"])
+  .optional()
+  .describe(
+    "ComfyUI-Manager data source mode (default 'remote'): 'remote' fetches the live node list, 'local'/'cache' use bundled/cached data.",
+  );
+
+const useCmCliSchema = z
+  .boolean()
+  .optional()
+  .describe(
+    "Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.",
+  );
+
+const channelSchema = z
+  .string()
+  .optional()
+  .describe("ComfyUI-Manager channel name (default 'default').");
+
+function formatInstalledNodes(nodes: InstalledNode[]): string {
+  if (nodes.length === 0) return "No custom nodes installed.";
+  return nodes
+    .map((n, i) => {
+      const idParts = [
+        n.cnrId ? `cnr:${n.cnrId}` : null,
+        n.auxId ? `git:${n.auxId}` : null,
+      ].filter(Boolean);
+      const idStr = idParts.length ? ` [${idParts.join(", ")}]` : "";
+      return (
+        `${i + 1}. ${n.module}${idStr}\n` +
+        `   version: ${n.version ?? "unknown"} | ${n.enabled ? "enabled" : "disabled"}`
+      );
+    })
+    .join("\n");
+}
+
+export function registerNodeManagementTools(server: McpServer): void {
+  server.tool(
+    "install_custom_node",
+    "Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), git URL, or name. Uses the ComfyUI-Manager HTTP API (works against remote instances) and falls back to the cm-cli subprocess when forced. A ComfyUI restart may be required to load newly installed nodes.",
+    {
+      id: z
+        .string()
+        .describe("Registry id, git URL, or node-pack name to install."),
+      source: z
+        .enum(["registry", "git", "auto"])
+        .optional()
+        .describe(
+          "How to interpret `id` (default 'auto', which detects git URLs vs registry ids).",
+        ),
+      version: z
+        .string()
+        .optional()
+        .describe(
+          "Version to install (e.g. 'latest', 'nightly', or a semver). Registry installs only; defaults to 'latest'.",
+        ),
+      mode: modeSchema,
+      channel: channelSchema,
+      useCmCli: useCmCliSchema,
+    },
+    async (args) => {
+      try {
+        const result = await installCustomNode(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "update_custom_node",
+    "Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback.",
+    {
+      id: z
+        .string()
+        .describe("Registry id / module name to update, or 'all' for every pack."),
+      mode: modeSchema,
+      channel: channelSchema,
+      useCmCli: useCmCliSchema,
+    },
+    async (args) => {
+      try {
+        const result = await updateCustomNode(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "reinstall_custom_node",
+    "Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback. A ComfyUI restart may be required.",
+    {
+      id: z.string().describe("Registry id / module name to reinstall."),
+      version: z
+        .string()
+        .optional()
+        .describe("Version to reinstall (default 'latest')."),
+      mode: modeSchema,
+      channel: channelSchema,
+      useCmCli: useCmCliSchema,
+    },
+    async (args) => {
+      try {
+        const result = await reinstallCustomNode(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "fix_custom_node",
+    "Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Single-pack repair uses the ComfyUI-Manager HTTP API; 'all' and forced runs use the cm-cli subprocess (requires a local ComfyUI install).",
+    {
+      id: z
+        .string()
+        .describe("Registry id / module name to repair, or 'all' for every pack."),
+      mode: modeSchema,
+      channel: channelSchema,
+      useCmCli: useCmCliSchema,
+    },
+    async (args) => {
+      try {
+        const result = await fixCustomNode(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "list_installed_nodes",
+    "List installed ComfyUI custom node packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); the cm-cli fallback returns names only.",
+    {
+      mode: z
+        .enum(["default", "imported"])
+        .optional()
+        .describe(
+          "'default' lists all installed packs; 'imported' lists only those successfully imported this session.",
+        ),
+      useCmCli: useCmCliSchema,
+    },
+    async (args) => {
+      try {
+        const nodes = await listInstalledNodes(args);
+        return {
+          content: [{ type: "text" as const, text: formatInstalledNodes(nodes) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "sync_node_dependencies",
+    "Reconcile the Python dependencies of all installed custom node packs (comfy-cli `node uv-sync` analogue). Runs cm-cli restore-dependencies as a subprocess and requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.",
+    {},
+    async () => {
+      try {
+        const result = await syncNodeDependencies();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Ports `comfy-cli node install|update|reinstall|fix|show|uv-sync` into the MCP server as new tools. This is **unit: Custom-node management** of the 10-unit comfy-cli port effort.

**Hybrid mechanism (confirmed by maintainer):** prefer the ComfyUI-Manager HTTP queue API (works against remote `--comfyui-url` instances); fall back to the `cm-cli.py` subprocess (run against `config.comfyuiPath`) for ops the API can't do. Subprocess-only paths return a clear `ProcessControlError` when `config.comfyuiPath` is undefined (remote mode).

## New MCP tools
- `install_custom_node` — by registry id, git URL, or name (auto-detects git URLs)
- `update_custom_node` — single pack or `all`
- `reinstall_custom_node`
- `fix_custom_node` — single pack via HTTP; `all` via cm-cli
- `list_installed_nodes` — module, cnr/aux id, version, enabled state
- `sync_node_dependencies` — cm-cli `restore-dependencies` (the `node uv-sync` analogue; ComfyUI-Manager has no `uv-sync` subcommand)

## Files
- `src/services/node-management.ts` — business logic + local `managerFetch` helper (not shared, to avoid collisions with parallel units)
- `src/tools/node-management.ts` — thin tool wrappers
- `src/tools/index.ts` — one import + one `registerNodeManagementTools(server)` call (minimal/additive)
- `src/__tests__/services/node-management.test.ts` — 19 cases

## Endpoint verification
Manager endpoints were confirmed against `Comfy-Org/ComfyUI-Manager` (`glob/manager_server.py`, `cm-cli.py`) via WebFetch — not invented:
`/manager/queue/{install,update,update_all,reinstall,fix,start,status}` and `/customnode/installed`. The queue is asynchronous: POST the op, POST `/manager/queue/start`, then poll `/manager/queue/status` until drained.

## Correctness note (found in self-review)
`/manager/queue/start` spawns the worker thread asynchronously, so an immediate status poll can read `is_processing=false` / `in_progress_count=0` while the queued item is still pending. `runManagerQueue` now relies on Manager's own invariant `total_count = done + in_progress + queued` (drain = `!is_processing && done_count >= total_count`) plus a startup grace window, so it never reports success before the operation actually runs. Covered by a dedicated test.

## Testing
- `npm run build` — zero errors (typecheck gate)
- `npm test` — full suite green (120 tests; 19 new)
- Tests mock `global.fetch` (Manager HTTP) and `node:child_process` (`execFileSync`) — no real network/disk/process side effects.
- **Live-ComfyUI verification deferred to the maintainer** (worktree has no running ComfyUI / no ComfyUI-Manager install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)