### PR TITLE
feat: workspace & environment MCP tools (comfy-cli port)

### DIFF
--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -188,6 +188,20 @@ describe("setDefaultWorkspace + getWorkspace round-trip", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("ignores a non-string defaultWorkspace (shape validation)", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    try {
+      await writeFile(cfgPath, JSON.stringify({ defaultWorkspace: 123 }), "utf-8");
+      configureWorkspace({ configPath: cfgPath });
+      const ws = await getWorkspace();
+      expect(ws.default_workspace).toBeUndefined();
+      expect(ws.workspace_source).toBe("none");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -271,6 +285,31 @@ describe("getEnvironment", () => {
       expect(env.local.python).toBeUndefined();
       expect(env.local.git).toBeUndefined();
       expect(env.local.note).toMatch(/No local ComfyUI path/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the saved default workspace for local probes when COMFYUI_PATH is unset", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    const install = join(dir, "DefaultComfyUI");
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: cfgPath });
+      mockConfig.comfyuiPath = undefined; // no active path
+      await setDefaultWorkspace(install); // but a saved default
+      mockGetSystemStats.mockRejectedValueOnce(new Error("offline"));
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      // Local probes ran against the saved default rather than being skipped.
+      expect(env.local.workspace_path).toBe(install);
+      expect(env.local.python?.version).toBe("3.12.0");
+      expect(env.local.note).toMatch(/saved default workspace/i);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mocks for modules with side effects / network at load time
+// ---------------------------------------------------------------------------
+
+type ExecResult = { stdout?: string; stderr?: string } | Error;
+
+// Shared mutable state created via vi.hoisted so the vi.mock factories (which
+// are hoisted to the top of the module) can safely reference it.
+const h = vi.hoisted(() => {
+  return {
+    mockConfig: { comfyuiPath: undefined as string | undefined, resolvedPort: 8188 },
+    mockGetSystemStats: vi.fn(),
+    execFileResponder: (() => new Error("not configured")) as (
+      cmd: string,
+      args: string[],
+    ) => ExecResult,
+  };
+});
+
+vi.mock("../../config.js", () => ({
+  config: h.mockConfig,
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIProtocol: () => "http",
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: () => h.mockGetSystemStats(),
+}));
+
+// execFile is wrapped by promisify() at module load. The mock invokes the
+// node-style callback so promisify resolves/rejects accordingly. Tests set
+// h.execFileResponder to control responses, keyed loosely by command/args.
+vi.mock("node:child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, res?: { stdout: string; stderr: string }) => void,
+  ) => {
+    const result = h.execFileResponder(cmd, args);
+    if (result instanceof Error) {
+      cb(result);
+    } else {
+      cb(null, { stdout: result.stdout ?? "", stderr: result.stderr ?? "" });
+    }
+  },
+}));
+
+const mockConfig = h.mockConfig;
+const mockGetSystemStats = h.mockGetSystemStats;
+function setExecFileResponder(
+  fn: (cmd: string, args: string[]) => ExecResult,
+): void {
+  h.execFileResponder = fn;
+}
+
+import {
+  configureWorkspace,
+  resetWorkspaceConfig,
+  getWorkspace,
+  setDefaultWorkspace,
+  listWorkspaces,
+  getEnvironment,
+} from "../../services/workspace-env.js";
+
+async function tmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "comfyui-ws-"));
+}
+
+beforeEach(() => {
+  mockConfig.comfyuiPath = undefined;
+  mockConfig.resolvedPort = 8188;
+  mockGetSystemStats.mockReset();
+  setExecFileResponder(() => new Error("not configured"));
+  resetWorkspaceConfig();
+  delete process.env.COMFYUI_PATH;
+});
+
+afterEach(() => {
+  resetWorkspaceConfig();
+});
+
+// ---------------------------------------------------------------------------
+// set_default_workspace / get_workspace round-trip
+// ---------------------------------------------------------------------------
+
+describe("setDefaultWorkspace + getWorkspace round-trip", () => {
+  it("persists the default workspace to the config file and reads it back", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    try {
+      configureWorkspace({ configPath: cfgPath });
+
+      const result = await setDefaultWorkspace("/some/ComfyUI");
+      expect(result.saved).toBe(true);
+      expect(result.default_workspace).toBe("/some/ComfyUI");
+      expect(result.config_path).toBe(cfgPath);
+
+      // File on disk has the value
+      const raw = JSON.parse(await readFile(cfgPath, "utf-8"));
+      expect(raw.defaultWorkspace).toBe("/some/ComfyUI");
+
+      // get_workspace reads it back; no comfyuiPath so source is default-config
+      const ws = await getWorkspace();
+      expect(ws.default_workspace).toBe("/some/ComfyUI");
+      expect(ws.workspace_path).toBe("/some/ComfyUI");
+      expect(ws.workspace_source).toBe("default-config");
+      expect(ws.api_target).toBe("http://127.0.0.1:8188");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the parent directory when persisting to a missing path", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "nested", "deep", "workspace.json");
+    try {
+      configureWorkspace({ configPath: cfgPath });
+      await setDefaultWorkspace("/x/ComfyUI");
+      const raw = JSON.parse(await readFile(cfgPath, "utf-8"));
+      expect(raw.defaultWorkspace).toBe("/x/ComfyUI");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("trims whitespace and rejects empty paths", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    try {
+      configureWorkspace({ configPath: cfgPath });
+      const r = await setDefaultWorkspace("  /trim/me  ");
+      expect(r.default_workspace).toBe("/trim/me");
+      await expect(setDefaultWorkspace("   ")).rejects.toThrow(/non-empty/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports source 'env' when COMFYUI_PATH is set and 'auto-detected' otherwise", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    try {
+      configureWorkspace({ configPath: cfgPath });
+      mockConfig.comfyuiPath = "/active/ComfyUI";
+
+      // auto-detected (no env var)
+      let ws = await getWorkspace();
+      expect(ws.workspace_path).toBe("/active/ComfyUI");
+      expect(ws.workspace_source).toBe("auto-detected");
+
+      // env-driven
+      process.env.COMFYUI_PATH = "/active/ComfyUI";
+      ws = await getWorkspace();
+      expect(ws.workspace_source).toBe("env");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports source 'none' when nothing is configured", async () => {
+    const dir = await tmpDir();
+    try {
+      configureWorkspace({ configPath: join(dir, "missing.json") });
+      const ws = await getWorkspace();
+      expect(ws.workspace_path).toBeUndefined();
+      expect(ws.workspace_source).toBe("none");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a malformed config file and treats it as empty", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    try {
+      await writeFile(cfgPath, "{ not json", "utf-8");
+      configureWorkspace({ configPath: cfgPath });
+      const ws = await getWorkspace();
+      expect(ws.default_workspace).toBeUndefined();
+      expect(ws.workspace_source).toBe("none");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_workspaces
+// ---------------------------------------------------------------------------
+
+describe("listWorkspaces", () => {
+  it("includes the active path and saved default and marks them", async () => {
+    const dir = await tmpDir();
+    const cfgPath = join(dir, "workspace.json");
+    // Build a real valid-looking install so looks_valid is true for the active.
+    const activeInstall = join(dir, "ActiveComfyUI");
+    await mkdir(join(activeInstall, "models"), { recursive: true });
+    try {
+      configureWorkspace({ configPath: cfgPath });
+      mockConfig.comfyuiPath = activeInstall;
+      await setDefaultWorkspace("/saved/default/ComfyUI");
+
+      const list = await listWorkspaces();
+      expect(list.active_workspace).toBe(activeInstall);
+      expect(list.default_workspace).toBe("/saved/default/ComfyUI");
+
+      const active = list.workspaces.find((w) => w.path === activeInstall);
+      expect(active?.active).toBe(true);
+      expect(active?.looks_valid).toBe(true);
+
+      const def = list.workspaces.find(
+        (w) => w.path === "/saved/default/ComfyUI",
+      );
+      expect(def?.is_default).toBe(true);
+      // Nonexistent path → not valid
+      expect(def?.looks_valid).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_environment
+// ---------------------------------------------------------------------------
+
+describe("getEnvironment", () => {
+  it("reports running instance from system_stats and degrades local probes when no path", async () => {
+    const dir = await tmpDir();
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = undefined;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "posix",
+          python_version: "3.12.1",
+          embedded_python: false,
+          comfyui_version: "0.3.10",
+        },
+        devices: [
+          {
+            name: "NVIDIA RTX 4090",
+            type: "cuda",
+            index: 0,
+            vram_total: 24 * 1024 * 1024 * 1024,
+            vram_free: 20 * 1024 * 1024 * 1024,
+            torch_vram_total: 0,
+            torch_vram_free: 0,
+          },
+        ],
+      });
+
+      const env = await getEnvironment();
+      expect(env.running_instance.reachable).toBe(true);
+      expect(env.running_instance.os).toBe("posix");
+      expect(env.running_instance.comfyui_version).toBe("0.3.10");
+      expect(env.running_instance.devices?.[0]).toMatchObject({
+        name: "NVIDIA RTX 4090",
+        type: "cuda",
+        vram_total_mb: 24 * 1024,
+      });
+
+      // No local path → probes skipped, note present, no python/git
+      expect(env.local.workspace_path).toBeUndefined();
+      expect(env.local.python).toBeUndefined();
+      expect(env.local.git).toBeUndefined();
+      expect(env.local.note).toMatch(/No local ComfyUI path/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("captures the unreachable error and still returns local probes when path set", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      // python --version succeeds; pip show returns one package; git fails
+      setExecFileResponder((cmd, args) => {
+        if (args.includes("--version")) {
+          return { stdout: "Python 3.11.5\n" };
+        }
+        if (args.includes("pip")) {
+          return {
+            stdout:
+              "Name: torch\nVersion: 2.3.1\n---\nName: numpy\nVersion: 1.26.4\n",
+          };
+        }
+        // git rev-parse — no .git dir so probeGitRev returns early anyway,
+        // but guard with an error to be safe.
+        return new Error("not a git repo");
+      });
+
+      const env = await getEnvironment();
+      expect(env.running_instance.reachable).toBe(false);
+      expect(env.running_instance.error).toMatch(/ECONNREFUSED/);
+
+      expect(env.local.workspace_path).toBe(install);
+      expect(env.local.python?.version).toBe("3.11.5");
+      expect(env.local.packages?.torch).toBe("2.3.1");
+      expect(env.local.packages?.numpy).toBe("1.26.4");
+      // No .git directory created → git omitted
+      expect(env.local.git).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("notes when python is unavailable in a configured workspace", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockRejectedValueOnce(new Error("offline"));
+      // Every subprocess fails (no python on PATH)
+      setExecFileResponder(() => new Error("command not found"));
+
+      const env = await getEnvironment();
+      expect(env.local.python).toBeUndefined();
+      expect(env.local.note).toMatch(/Python interpreter not found/i);
+      expect(env.local.packages).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads ComfyUI-Manager version from pyproject.toml and git rev when present", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(join(install, "custom_nodes", "ComfyUI-Manager"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(install, "custom_nodes", "ComfyUI-Manager", "pyproject.toml"),
+      '[project]\nname = "comfyui-manager"\nversion = "3.10.1"\n',
+      "utf-8",
+    );
+    await mkdir(join(install, ".git"), { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockRejectedValueOnce(new Error("offline"));
+
+      setExecFileResponder((cmd, args) => {
+        if (cmd === "git" && args.includes("--short")) {
+          return { stdout: "abc1234\n" };
+        }
+        if (cmd === "git" && args.includes("--abbrev-ref")) {
+          return { stdout: "master\n" };
+        }
+        if (args.includes("--version")) return { stdout: "Python 3.12.0\n" };
+        if (args.includes("pip")) return new Error("no pip");
+        return new Error("unexpected");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.comfyui_manager_version).toBe("3.10.1");
+      expect(env.local.git).toEqual({ rev: "abc1234", branch: "master" });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -51,11 +51,23 @@ async function readWorkspaceConfig(): Promise<WorkspaceConfig> {
   try {
     const raw = await readFile(path, "utf-8");
     const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as WorkspaceConfig;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      logger.warn("Workspace config is not a JSON object, ignoring", { path });
+      return {};
     }
-    logger.warn("Workspace config is not a JSON object, ignoring", { path });
-    return {};
+    // Validate the shape rather than blindly casting: defaultWorkspace must be a
+    // non-empty string when present, else it is dropped.
+    const cfg: WorkspaceConfig = {};
+    const dw = (parsed as Record<string, unknown>).defaultWorkspace;
+    if (typeof dw === "string" && dw.trim().length > 0) {
+      cfg.defaultWorkspace = dw;
+    } else if (dw !== undefined) {
+      logger.warn("Ignoring invalid defaultWorkspace in workspace config", {
+        path,
+        type: typeof dw,
+      });
+    }
+    return cfg;
   } catch (err) {
     logger.warn("Failed to parse workspace config, ignoring", {
       path,
@@ -424,17 +436,24 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     running.error = err instanceof Error ? err.message : String(err);
   }
 
-  // 2. Local probes — only when we have a local workspace path
+  // 2. Local probes — use the active path, else fall back to the saved default
+  //    workspace (set via set_default_workspace) so `env` still inspects a known
+  //    local install when COMFYUI_PATH isn't set.
   const local: EnvironmentInfo["local"] = {};
-  const workspacePath = config.comfyuiPath;
+  const cfg = await readWorkspaceConfig();
+  const workspacePath = config.comfyuiPath ?? cfg.defaultWorkspace;
   if (!workspacePath) {
     local.note =
-      "No local ComfyUI path configured (COMFYUI_PATH unset and none auto-detected). " +
-      "Local environment probes skipped; remote /system_stats used instead.";
+      "No local ComfyUI path configured (COMFYUI_PATH unset, none auto-detected, " +
+      "and no saved default workspace). Local environment probes skipped; remote " +
+      "/system_stats used instead.";
     return { running_instance: running, local };
   }
 
   local.workspace_path = workspacePath;
+  if (!config.comfyuiPath && cfg.defaultWorkspace) {
+    local.note = `Using saved default workspace "${cfg.defaultWorkspace}" (COMFYUI_PATH not set).`;
+  }
 
   const py = await probePython(workspacePath);
   if (py) {
@@ -442,7 +461,12 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     const pkgs = await probePipPackages(py.executable, KEY_PACKAGES);
     if (Object.keys(pkgs).length > 0) local.packages = pkgs;
   } else {
-    local.note = "Python interpreter not found on PATH or in workspace .venv.";
+    local.note = [
+      local.note,
+      "Python interpreter not found on PATH or in workspace .venv.",
+    ]
+      .filter(Boolean)
+      .join(" ");
   }
 
   const git = await probeGitRev(workspacePath);

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1,0 +1,455 @@
+import { execFile } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { getSystemStats } from "../comfyui/client.js";
+import { logger } from "../utils/logger.js";
+import { ValidationError } from "../utils/errors.js";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Workspace config persistence (mirrors comfy-cli set-default / which)
+// ---------------------------------------------------------------------------
+
+interface WorkspaceConfig {
+  defaultWorkspace?: string;
+}
+
+/**
+ * Resolve the path to the workspace config JSON file.
+ * Uses XDG_CONFIG_HOME when set, otherwise ~/.config/comfyui-mcp/workspace.json.
+ */
+function defaultWorkspaceConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const root = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(root, "comfyui-mcp", "workspace.json");
+}
+
+// Module-level override hook so tests can point at a temp file. Defaults to the
+// platform config path lazily (so env changes in tests are picked up before set).
+let configPathOverride: string | undefined;
+
+export function configureWorkspace(opts: { configPath?: string }): void {
+  configPathOverride = opts.configPath;
+}
+
+export function resetWorkspaceConfig(): void {
+  configPathOverride = undefined;
+}
+
+function workspaceConfigPath(): string {
+  return configPathOverride ?? defaultWorkspaceConfigPath();
+}
+
+async function readWorkspaceConfig(): Promise<WorkspaceConfig> {
+  const path = workspaceConfigPath();
+  if (!existsSync(path)) return {};
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as WorkspaceConfig;
+    }
+    logger.warn("Workspace config is not a JSON object, ignoring", { path });
+    return {};
+  } catch (err) {
+    logger.warn("Failed to parse workspace config, ignoring", {
+      path,
+      error: err instanceof Error ? err.message : err,
+    });
+    return {};
+  }
+}
+
+async function writeWorkspaceConfig(cfg: WorkspaceConfig): Promise<void> {
+  const path = workspaceConfigPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(cfg, null, 2), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// ComfyUI install auto-detection
+// (mirrors detectComfyUIPaths logic in src/config.ts — kept local because that
+//  helper is not exported and config.ts is owned by another unit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-detect ComfyUI installation directories. Checks common locations on
+ * macOS, Linux, and Windows. Returns all found paths, most-preferred first.
+ */
+export function detectComfyUIInstalls(): string[] {
+  const home = homedir();
+  const candidates: string[] = [];
+
+  // macOS: ComfyUI Desktop app stores data here
+  candidates.push(join(home, "Documents", "ComfyUI"));
+  // macOS: Application Support
+  candidates.push(join(home, "Library", "Application Support", "ComfyUI"));
+  // Common manual install locations
+  candidates.push(join(home, "ComfyUI"));
+  candidates.push(join(home, "code", "ComfyUI"));
+  candidates.push(join(home, "projects", "ComfyUI"));
+  candidates.push(join(home, "src", "ComfyUI"));
+  // Linux common paths
+  candidates.push("/opt/ComfyUI");
+  candidates.push(join(home, ".local", "share", "ComfyUI"));
+  // Windows common paths
+  candidates.push(join(home, "AppData", "Local", "ComfyUI"));
+  candidates.push(join(home, "Desktop", "ComfyUI"));
+  // Windows: ComfyUI Desktop app installs here
+  candidates.push(
+    join(home, "AppData", "Local", "Programs", "ComfyUI", "resources", "ComfyUI"),
+  );
+
+  // Scan ~/Documents and ~/My Documents for any ComfyUI-named directories
+  const documentsDirs = [join(home, "Documents"), join(home, "My Documents")];
+  for (const dir of documentsDirs) {
+    try {
+      if (!existsSync(dir)) continue;
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.toLowerCase().includes("comfyui")) {
+          const fullPath = join(dir, entry.name);
+          if (!candidates.includes(fullPath)) candidates.push(fullPath);
+        }
+      }
+    } catch {
+      // Ignore permission errors
+    }
+  }
+
+  return candidates.filter((p) => {
+    if (!existsSync(p)) return false;
+    if (!p.includes("Documents")) return true;
+    return existsSync(join(p, "models")) || existsSync(join(p, "custom_nodes"));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// get_workspace — mirrors comfy-cli which
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceInfo {
+  workspace_path?: string;
+  workspace_source: "env" | "auto-detected" | "default-config" | "none";
+  default_workspace?: string;
+  api_target: string;
+}
+
+export async function getWorkspace(): Promise<WorkspaceInfo> {
+  const cfg = await readWorkspaceConfig();
+  const apiTarget = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+
+  let source: WorkspaceInfo["workspace_source"];
+  if (config.comfyuiPath) {
+    // config.comfyuiPath is COMFYUI_PATH env or auto-detection
+    source = process.env.COMFYUI_PATH ? "env" : "auto-detected";
+  } else if (cfg.defaultWorkspace) {
+    source = "default-config";
+  } else {
+    source = "none";
+  }
+
+  return {
+    workspace_path: config.comfyuiPath ?? cfg.defaultWorkspace,
+    workspace_source: source,
+    default_workspace: cfg.defaultWorkspace,
+    api_target: apiTarget,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// set_default_workspace — mirrors comfy-cli set-default
+// ---------------------------------------------------------------------------
+
+export interface SetDefaultResult {
+  saved: boolean;
+  default_workspace: string;
+  config_path: string;
+  exists: boolean;
+}
+
+export async function setDefaultWorkspace(
+  path: string,
+): Promise<SetDefaultResult> {
+  const trimmed = path.trim();
+  if (trimmed.length === 0) {
+    throw new ValidationError("Workspace path must be a non-empty string.");
+  }
+
+  const cfg = await readWorkspaceConfig();
+  cfg.defaultWorkspace = trimmed;
+  await writeWorkspaceConfig(cfg);
+
+  return {
+    saved: true,
+    default_workspace: trimmed,
+    config_path: workspaceConfigPath(),
+    exists: existsSync(trimmed),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list_workspaces — auto-detected installs + active + saved default
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceListEntry {
+  path: string;
+  active: boolean;
+  is_default: boolean;
+  looks_valid: boolean;
+}
+
+export interface WorkspaceList {
+  active_workspace?: string;
+  default_workspace?: string;
+  workspaces: WorkspaceListEntry[];
+}
+
+export async function listWorkspaces(): Promise<WorkspaceList> {
+  const cfg = await readWorkspaceConfig();
+  const detected = detectComfyUIInstalls();
+
+  // Merge detected installs with active path and saved default so the caller
+  // sees a complete picture even if one isn't in the detection list.
+  const paths = new Set<string>(detected);
+  if (config.comfyuiPath) paths.add(config.comfyuiPath);
+  if (cfg.defaultWorkspace) paths.add(cfg.defaultWorkspace);
+
+  const workspaces: WorkspaceListEntry[] = [...paths].map((p) => ({
+    path: p,
+    active: p === config.comfyuiPath,
+    is_default: p === cfg.defaultWorkspace,
+    looks_valid:
+      existsSync(join(p, "models")) || existsSync(join(p, "custom_nodes")),
+  }));
+
+  return {
+    active_workspace: config.comfyuiPath,
+    default_workspace: cfg.defaultWorkspace,
+    workspaces,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// get_environment — mirrors comfy-cli env
+// ---------------------------------------------------------------------------
+
+const IS_WIN = platform() === "win32";
+
+/** Run a command quietly; return trimmed stdout or undefined on any failure. */
+async function probe(
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string },
+): Promise<string | undefined> {
+  try {
+    const { stdout, stderr } = await execFileAsync(cmd, args, {
+      cwd: opts?.cwd,
+      timeout: 8000,
+      windowsHide: true,
+    });
+    const out = (stdout || stderr || "").trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve the python executable to probe, preferring a venv inside the workspace. */
+function pythonCandidates(workspacePath: string | undefined): string[] {
+  const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
+  const candidates: string[] = [];
+  if (workspacePath) {
+    const venvBin = IS_WIN
+      ? join(workspacePath, ".venv", "Scripts")
+      : join(workspacePath, ".venv", "bin");
+    for (const n of names) {
+      const p = join(venvBin, n);
+      if (existsSync(p)) candidates.push(p);
+    }
+  }
+  // Fall back to PATH-resolved interpreters
+  candidates.push(...names);
+  return candidates;
+}
+
+async function probePython(
+  workspacePath: string | undefined,
+): Promise<{ executable: string; version: string } | undefined> {
+  for (const exe of pythonCandidates(workspacePath)) {
+    const version = await probe(exe, ["--version"]);
+    if (version) return { executable: exe, version: version.replace(/^Python\s+/i, "") };
+  }
+  return undefined;
+}
+
+async function probePipPackages(
+  pythonExe: string,
+  names: string[],
+): Promise<Record<string, string>> {
+  // `pip show` is portable across pip/uv-managed venvs.
+  const found: Record<string, string> = {};
+  const out = await probe(pythonExe, [
+    "-m",
+    "pip",
+    "show",
+    ...names,
+  ]);
+  if (!out) return found;
+  // `pip show A B C` emits records separated by a line of "---".
+  for (const block of out.split(/^---$/m)) {
+    const nameMatch = block.match(/^Name:\s*(.+)$/m);
+    const verMatch = block.match(/^Version:\s*(.+)$/m);
+    if (nameMatch && verMatch) {
+      found[nameMatch[1].trim().toLowerCase()] = verMatch[1].trim();
+    }
+  }
+  return found;
+}
+
+async function probeGitRev(
+  workspacePath: string,
+): Promise<{ rev?: string; branch?: string } | undefined> {
+  if (!existsSync(join(workspacePath, ".git"))) return undefined;
+  const rev = await probe("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: workspacePath,
+  });
+  const branch = await probe("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd: workspacePath,
+  });
+  if (!rev && !branch) return undefined;
+  return { rev, branch };
+}
+
+/** Read ComfyUI-Manager version from its local install if present. */
+async function readManagerVersion(
+  workspacePath: string,
+): Promise<string | undefined> {
+  const dirNames = ["ComfyUI-Manager", "comfyui-manager"];
+  for (const dirName of dirNames) {
+    const file = join(workspacePath, "custom_nodes", dirName, "pyproject.toml");
+    try {
+      if (!existsSync(file)) continue;
+      // Tiny TOML peek — only the version line, no full parser needed.
+      const text = await readFile(file, "utf-8");
+      const m = text.match(/^version\s*=\s*["']([^"']+)["']/m);
+      if (m) return m[1];
+      // Presence without a parseable version still tells us it's installed.
+      return "installed";
+    } catch {
+      // try next
+    }
+  }
+  // Fallback: directory presence
+  for (const dirName of dirNames) {
+    if (existsSync(join(workspacePath, "custom_nodes", dirName))) {
+      return "installed";
+    }
+  }
+  return undefined;
+}
+
+export interface EnvironmentInfo {
+  // Running instance (from /system_stats — works remotely)
+  running_instance: {
+    reachable: boolean;
+    api_target: string;
+    os?: string;
+    python_version?: string;
+    embedded_python?: boolean;
+    comfyui_version?: string;
+    devices?: Array<{
+      name: string;
+      type: string;
+      vram_total_mb?: number;
+      vram_free_mb?: number;
+    }>;
+    error?: string;
+  };
+  // Local workspace probes (omitted/degraded when no local path)
+  local: {
+    workspace_path?: string;
+    python?: { executable: string; version: string };
+    git?: { rev?: string; branch?: string };
+    comfyui_manager_version?: string;
+    packages?: Record<string, string>;
+    note?: string;
+  };
+}
+
+const KEY_PACKAGES = [
+  "torch",
+  "torchvision",
+  "torchaudio",
+  "xformers",
+  "numpy",
+  "transformers",
+  "diffusers",
+  "comfyui-frontend-package",
+];
+
+export async function getEnvironment(): Promise<EnvironmentInfo> {
+  const apiTarget = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+
+  // 1. Running instance via /system_stats (works for remote targets too)
+  const running: EnvironmentInfo["running_instance"] = {
+    reachable: false,
+    api_target: apiTarget,
+  };
+  try {
+    const stats = await getSystemStats();
+    running.reachable = true;
+    running.os = stats.system.os;
+    running.python_version = stats.system.python_version;
+    running.embedded_python = stats.system.embedded_python;
+    running.comfyui_version = stats.system.comfyui_version;
+    running.devices = (stats.devices ?? []).map((d) => ({
+      name: d.name,
+      type: d.type,
+      vram_total_mb:
+        typeof d.vram_total === "number"
+          ? Math.round(d.vram_total / (1024 * 1024))
+          : undefined,
+      vram_free_mb:
+        typeof d.vram_free === "number"
+          ? Math.round(d.vram_free / (1024 * 1024))
+          : undefined,
+    }));
+  } catch (err) {
+    running.error = err instanceof Error ? err.message : String(err);
+  }
+
+  // 2. Local probes — only when we have a local workspace path
+  const local: EnvironmentInfo["local"] = {};
+  const workspacePath = config.comfyuiPath;
+  if (!workspacePath) {
+    local.note =
+      "No local ComfyUI path configured (COMFYUI_PATH unset and none auto-detected). " +
+      "Local environment probes skipped; remote /system_stats used instead.";
+    return { running_instance: running, local };
+  }
+
+  local.workspace_path = workspacePath;
+
+  const py = await probePython(workspacePath);
+  if (py) {
+    local.python = py;
+    const pkgs = await probePipPackages(py.executable, KEY_PACKAGES);
+    if (Object.keys(pkgs).length > 0) local.packages = pkgs;
+  } else {
+    local.note = "Python interpreter not found on PATH or in workspace .venv.";
+  }
+
+  const git = await probeGitRev(workspacePath);
+  if (git) local.git = git;
+
+  const managerVersion = await readManagerVersion(workspacePath);
+  if (managerVersion) local.comfyui_manager_version = managerVersion;
+
+  return { running_instance: running, local };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerDefaultsTools } from "./defaults.js";
 import { registerGenerateImageTool } from "./generate-image.js";
 import { registerConditionedGenerationTools } from "./generate-conditioned.js";
 import { registerWorkflowDslTools } from "./workflow-dsl.js";
+import { registerWorkspaceEnvTools } from "./workspace-env.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -44,5 +45,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerGenerateImageTool(server);
   registerConditionedGenerationTools(server);
   registerWorkflowDslTools(server);
+  registerWorkspaceEnvTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/workspace-env.ts
+++ b/src/tools/workspace-env.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  getWorkspace,
+  setDefaultWorkspace,
+  listWorkspaces,
+  getEnvironment,
+} from "../services/workspace-env.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerWorkspaceEnvTools(server: McpServer): void {
+  server.tool(
+    "get_workspace",
+    "Report the active ComfyUI workspace (mirrors `comfy-cli which`): the local installation path being used (from COMFYUI_PATH or auto-detection), the source of that path, any persisted default workspace, and the resolved API target the MCP server talks to.",
+    {},
+    async () => {
+      try {
+        const info = await getWorkspace();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(info, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "set_default_workspace",
+    "Persist a default ComfyUI workspace path to the MCP config file (mirrors `comfy-cli set-default`). The value is stored under the OS config dir (e.g. ~/.config/comfyui-mcp/workspace.json) and reported by get_workspace/list_workspaces. Does NOT change the live API target.",
+    {
+      path: z
+        .string()
+        .min(1)
+        .describe("Absolute path to a ComfyUI installation directory to remember as the default workspace."),
+    },
+    async (args) => {
+      try {
+        const result = await setDefaultWorkspace(args.path);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "list_workspaces",
+    "List known/auto-detected ComfyUI installations on this machine. Scans common install locations across macOS, Linux, and Windows and marks which one is active and which is the saved default.",
+    {},
+    async () => {
+      try {
+        const result = await listWorkspaces();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "get_environment",
+    "Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). Degrades gracefully: local probes are omitted when no local path is configured or tools are unavailable.",
+    {},
+    async () => {
+      try {
+        const info = await getEnvironment();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(info, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Ports the **Workspace & environment** slice of `comfy-cli` into the MCP server as four new read-mostly tools. Unit of a larger parallel comfy-cli port effort.

| Tool | Mirrors | Behavior |
|------|---------|----------|
| `get_workspace` | `comfy-cli which` | Reports active workspace path (`config.comfyuiPath`), its source (env / auto-detected / default-config / none), any saved default, and the resolved API target. |
| `set_default_workspace` | `comfy-cli set-default` | Persists a default workspace path to `~/.config/comfyui-mcp/workspace.json` (XDG-aware; creates dirs as needed). Does not change the live API target. |
| `list_workspaces` | — | Lists auto-detected ComfyUI installs (macOS/Linux/Windows common paths + Documents scan), marking which is active and which is the saved default. |
| `get_environment` | `comfy-cli env` | Combines `/system_stats` (running instance — works remotely) with local subprocess probes (Python version, git rev/branch, ComfyUI-Manager version, key pip packages like torch/CUDA) against `config.comfyuiPath`. Degrades gracefully when no local path is configured or tools are unavailable. |

## Design

- **Hybrid, read-mostly.** ComfyUI client (`getSystemStats`) for the running instance so it works against remote targets; `node:child_process` (`execFile`) probes for local details, each wrapped to omit-not-error on failure.
- Business logic in `src/services/workspace-env.ts`; thin tool wrapper in `src/tools/workspace-env.ts`. Errors via `errorToToolResult`.
- Wiring into `src/tools/index.ts` is minimal/additive: one import + one `registerWorkspaceEnvTools(server)` before `registerAutoloadedWorkflows`.
- Install auto-detection mirrors `detectComfyUIPaths` in `src/config.ts`. That helper is not exported and `config.ts` is owned by another unit, so the candidate-list logic is replicated locally rather than editing a foreign file. Worth a follow-up to export and dedupe once units merge.

## Testing

- `npm run build` / `npm run lint`: clean.
- Added `src/__tests__/services/workspace-env.test.ts` (11 tests) mocking `config`, the ComfyUI client, and `node:child_process`, using real temp files for config round-trips. Covers: set/get default round-trip through the config file, source attribution (env/auto-detected/none), malformed-config tolerance, list marking active/default, `get_environment` graceful degradation with no local path, unreachable-instance error capture, pip/git/manager parsing, and python-unavailable note.
- Full suite: **112 passed**.
- Live e2e deferred — this worktree has no running ComfyUI. `get_environment`'s remote path is exercised via mocked `/system_stats`; local subprocess parsing is covered via a mocked `execFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)