### PR TITLE
feat: add configure_manager tool for ComfyUI-Manager settings

### DIFF
--- a/src/__tests__/services/manager-config.test.ts
+++ b/src/__tests__/services/manager-config.test.ts
@@ -77,9 +77,9 @@ describe("configureManager (HTTP API actions)", () => {
   });
 
   it("set_component_policy hits /manager/policy/component", async () => {
-    const f = fetchSequence([{ ok: true }, { ok: true, __text: "always" }]);
+    const f = fetchSequence([{ ok: true }, { ok: true, __text: "higher" }]);
     vi.stubGlobal("fetch", f);
-    await configureManager("set_component_policy", "always");
+    await configureManager("set_component_policy", "higher");
     expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/policy/component");
   });
 

--- a/src/__tests__/services/manager-config.test.ts
+++ b/src/__tests__/services/manager-config.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+// Mock node:fs so config.ini fallback has no real side effects.
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+// Mock config so we control comfyuiPath and the API host/protocol.
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/fake/ComfyUI" as string | undefined },
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIProtocol: () => "http" as const,
+}));
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { config } from "../../config.js";
+import {
+  configureManager,
+  MANAGER_CONFIG_ACTIONS,
+} from "../../services/manager-config.js";
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+
+/** Build a fetch mock that returns scripted responses per call. */
+function fetchSequence(responses: Array<Partial<Response> & { __text?: string; __json?: unknown }>) {
+  let i = 0;
+  return vi.fn(async () => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      statusText: r.statusText ?? "OK",
+      text: async () => r.__text ?? "",
+      json: async () => r.__json ?? {},
+    } as unknown as Response;
+  });
+}
+
+describe("configureManager (HTTP API actions)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    config.comfyuiPath = "/fake/ComfyUI";
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("set_preview_method POSTs {value} then reads back state", async () => {
+    const f = fetchSequence([
+      { ok: true }, // POST
+      { ok: true, __text: "taesd\n" }, // GET state
+    ]);
+    vi.stubGlobal("fetch", f);
+
+    const res = await configureManager("set_preview_method", "taesd");
+
+    expect(res.via).toBe("api");
+    expect(res.state).toBe("taesd");
+    const [postUrl, postInit] = f.mock.calls[0];
+    expect(postUrl).toBe("http://127.0.0.1:8188/manager/preview_method");
+    expect(postInit.method).toBe("POST");
+    expect(JSON.parse(postInit.body)).toEqual({ value: "taesd" });
+    expect(f.mock.calls[1][0]).toBe("http://127.0.0.1:8188/manager/preview_method");
+  });
+
+  it("set_db_mode hits /manager/db_mode", async () => {
+    const f = fetchSequence([{ ok: true }, { ok: true, __text: "remote" }]);
+    vi.stubGlobal("fetch", f);
+    const res = await configureManager("set_db_mode", "remote");
+    expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/db_mode");
+    expect(res.state).toBe("remote");
+  });
+
+  it("set_component_policy hits /manager/policy/component", async () => {
+    const f = fetchSequence([{ ok: true }, { ok: true, __text: "always" }]);
+    vi.stubGlobal("fetch", f);
+    await configureManager("set_component_policy", "always");
+    expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/policy/component");
+  });
+
+  it("set_update_policy hits /manager/policy/update", async () => {
+    const f = fetchSequence([{ ok: true }, { ok: true, __text: "nightly-comfyui" }]);
+    vi.stubGlobal("fetch", f);
+    await configureManager("set_update_policy", "nightly-comfyui");
+    expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/policy/update");
+  });
+
+  it("set_channel POSTs the name and verifies the selection echoes back", async () => {
+    const f = fetchSequence([
+      { ok: true }, // POST
+      { ok: true, __json: { selected: "default", list: [] } }, // GET
+    ]);
+    vi.stubGlobal("fetch", f);
+    const res = await configureManager("set_channel", "default");
+    expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/channel_url_list");
+    expect(JSON.parse(f.mock.calls[0][1].body)).toEqual({ value: "default" });
+    expect(res.state).toBe("default");
+  });
+
+  it("set_channel throws when Manager ignores an unknown channel name", async () => {
+    const f = fetchSequence([
+      { ok: true },
+      { ok: true, __json: { selected: "custom", list: [] } },
+    ]);
+    vi.stubGlobal("fetch", f);
+    await expect(configureManager("set_channel", "bogus")).rejects.toThrow(/did not switch/i);
+  });
+
+  it("reset_queue POSTs /manager/queue/reset and needs no value", async () => {
+    const f = fetchSequence([{ ok: true }]);
+    vi.stubGlobal("fetch", f);
+    const res = await configureManager("reset_queue");
+    expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/queue/reset");
+    expect(f.mock.calls[0][1].method).toBe("POST");
+    expect(res.via).toBe("api");
+  });
+
+  it("surfaces a clear error when Manager API returns non-OK", async () => {
+    const f = fetchSequence([{ ok: false, status: 403, statusText: "Forbidden", __text: "nope" }]);
+    vi.stubGlobal("fetch", f);
+    await expect(configureManager("set_db_mode", "cache")).rejects.toThrow(/403/);
+  });
+
+  it("surfaces a clear error when ComfyUI is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    await expect(configureManager("reset_queue")).rejects.toThrow(/Could not reach/i);
+  });
+});
+
+describe("configureManager (config.ini fallback actions)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    config.comfyuiPath = "/fake/ComfyUI";
+    // No HTTP fetch should be needed for these.
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("fetch should not be called for config-file actions");
+    }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("set_network_mode updates an existing key in [default]", () => {
+    // First candidate path exists.
+    mockedExistsSync.mockImplementation((p) =>
+      String(p).endsWith("user/__manager/config.ini"),
+    );
+    mockedReadFileSync.mockReturnValue("[default]\nnetwork_mode = public\ndb_mode = cache\n");
+
+    const res = configureManager("set_network_mode", "offline");
+    return res.then((r) => {
+      expect(r.via).toBe("config-file");
+      expect(r.state).toBe("offline");
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      expect(written).toContain("network_mode = offline");
+      expect(written).toContain("db_mode = cache");
+      expect(written).not.toContain("network_mode = public");
+    });
+  });
+
+  it("set_security_level appends the key when missing", async () => {
+    mockedExistsSync.mockImplementation((p) =>
+      String(p).endsWith("user/__manager/config.ini"),
+    );
+    mockedReadFileSync.mockReturnValue("[default]\npreview_method = auto\n");
+
+    const r = await configureManager("set_security_level", "weak");
+    expect(r.state).toBe("weak");
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    expect(written).toContain("security_level = weak");
+    expect(written).toContain("preview_method = auto");
+  });
+
+  it("falls back to the legacy config.ini location", async () => {
+    mockedExistsSync.mockImplementation((p) =>
+      String(p).endsWith("user/default/ComfyUI-Manager/config.ini"),
+    );
+    mockedReadFileSync.mockReturnValue("[default]\n");
+    await configureManager("set_network_mode", "private");
+    expect(mockedWriteFileSync.mock.calls[0][0]).toContain(
+      "user/default/ComfyUI-Manager/config.ini",
+    );
+  });
+
+  it("sanitizes CRLF/NUL out of written values", async () => {
+    mockedExistsSync.mockImplementation((p) =>
+      String(p).endsWith("user/__manager/config.ini"),
+    );
+    mockedReadFileSync.mockReturnValue("[default]\nsecurity_level = normal\n");
+    // network_mode is enum-validated, so test sanitization via the ini writer
+    // path using a valid value (no injection possible through the enum) — assert
+    // the written file has no stray CR.
+    await configureManager("set_network_mode", "public");
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    expect(written).not.toContain("\r");
+  });
+
+  it("errors clearly when comfyuiPath is undefined and no HTTP setter exists", async () => {
+    config.comfyuiPath = undefined;
+    await expect(configureManager("set_network_mode", "public")).rejects.toThrow(
+      /no ComfyUI install path is known/i,
+    );
+  });
+
+  it("errors clearly when config.ini cannot be found", async () => {
+    mockedExistsSync.mockReturnValue(false);
+    await expect(configureManager("set_security_level", "normal")).rejects.toThrow(
+      /Could not find ComfyUI-Manager config\.ini/i,
+    );
+  });
+});
+
+describe("configureManager validation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    config.comfyuiPath = "/fake/ComfyUI";
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, text: async () => "" }) as unknown as Response));
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("rejects invalid enum values per action", async () => {
+    await expect(configureManager("set_preview_method", "bogus")).rejects.toThrow(/Invalid preview method/i);
+    await expect(configureManager("set_db_mode", "bogus")).rejects.toThrow(/Invalid db mode/i);
+    await expect(configureManager("set_network_mode", "bogus")).rejects.toThrow(/Invalid network mode/i);
+    await expect(configureManager("set_security_level", "bogus")).rejects.toThrow(/Invalid security level/i);
+  });
+
+  it("requires a value for value-taking actions", async () => {
+    await expect(configureManager("set_db_mode")).rejects.toThrow(/requires a "value"/i);
+    await expect(configureManager("set_channel", "")).rejects.toThrow(/requires a "value"/i);
+  });
+
+  it("exposes the expected action set", () => {
+    expect([...MANAGER_CONFIG_ACTIONS]).toEqual([
+      "set_preview_method",
+      "set_db_mode",
+      "set_component_policy",
+      "set_update_policy",
+      "set_channel",
+      "reset_queue",
+      "set_network_mode",
+      "set_security_level",
+    ]);
+  });
+});

--- a/src/services/manager-config.ts
+++ b/src/services/manager-config.ts
@@ -60,13 +60,13 @@ const VALID_SECURITY_LEVELS = ["strong", "normal", "normal-", "weak"] as const;
 // HTTP-settable values (manager_server.py set_* handlers).
 const VALID_PREVIEW_METHODS = ["auto", "latent2rgb", "taesd", "none"] as const;
 const VALID_DB_MODES = ["local", "cache", "remote"] as const;
-const VALID_COMPONENT_POLICIES = ["workflow", "always"] as const;
-const VALID_UPDATE_POLICIES = [
-  "stable-comfyui",
-  "nightly-comfyui",
-  "stable",
-  "nightly",
-] as const;
+// Component sharing policy dropdown (js/comfyui-manager.js) → switch in
+// js/components-manager.js handles 'higher'/'mine'; anything else == 'workflow'.
+const VALID_COMPONENT_POLICIES = ["workflow", "higher", "mine"] as const;
+// Update policy dropdown (js/comfyui-manager.js); only 'nightly-comfyui' is
+// compared server-side (manager_server.py update_comfyui). The bare
+// 'stable'/'nightly' values are not valid update_policy settings.
+const VALID_UPDATE_POLICIES = ["stable-comfyui", "nightly-comfyui"] as const;
 
 export type NetworkMode = (typeof VALID_NETWORK_MODES)[number];
 export type SecurityLevel = (typeof VALID_SECURITY_LEVELS)[number];

--- a/src/services/manager-config.ts
+++ b/src/services/manager-config.ts
@@ -1,0 +1,389 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { ComfyUIError, ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+/**
+ * ComfyUI-Manager configuration, mirroring `comfy-cli manager` capabilities.
+ *
+ * Mechanism (hybrid):
+ *  - Prefer the ComfyUI-Manager HTTP API (works against remote ComfyUI too).
+ *  - Fall back to editing Manager's `config.ini` (under config.comfyuiPath) only
+ *    for settings the HTTP API cannot change (network_mode, security_level).
+ *
+ * Endpoints / config keys are taken verbatim from Comfy-Org/ComfyUI-Manager:
+ *  - glob/manager_server.py  (HTTP routes: preview_method, db_mode,
+ *    policy/component, policy/update, channel_url_list, queue/reset)
+ *  - glob/manager_core.py    (config.ini `[default]` section keys + valid values)
+ */
+
+export class ManagerConfigError extends ComfyUIError {
+  constructor(message: string, details?: unknown) {
+    super(message, "MANAGER_CONFIG_ERROR", details);
+    this.name = "ManagerConfigError";
+  }
+}
+
+/** Small Manager-specific fetch helper (no shared client per unit conventions). */
+async function managerFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const url = `${getComfyUIProtocol()}://${getComfyUIApiHost()}${path}`;
+  logger.debug("ComfyUI-Manager API request", { url, method: init?.method ?? "GET" });
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (err) {
+    throw new ManagerConfigError(
+      `Could not reach ComfyUI-Manager at ${url}. Is ComfyUI running with ComfyUI-Manager installed?`,
+      { url, cause: err instanceof Error ? err.message : String(err) },
+    );
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ManagerConfigError(
+      `ComfyUI-Manager API ${res.status}: ${res.statusText || "request failed"}`,
+      { url, status: res.status, body },
+    );
+  }
+  return res;
+}
+
+// --- Valid values, taken from manager_core.py read_config() defaults ---
+
+// config.ini `[default]` section keys (manager_core.py write_config()).
+const VALID_NETWORK_MODES = ["public", "private", "offline"] as const;
+const VALID_SECURITY_LEVELS = ["strong", "normal", "normal-", "weak"] as const;
+
+// HTTP-settable values (manager_server.py set_* handlers).
+const VALID_PREVIEW_METHODS = ["auto", "latent2rgb", "taesd", "none"] as const;
+const VALID_DB_MODES = ["local", "cache", "remote"] as const;
+const VALID_COMPONENT_POLICIES = ["workflow", "always"] as const;
+const VALID_UPDATE_POLICIES = [
+  "stable-comfyui",
+  "nightly-comfyui",
+  "stable",
+  "nightly",
+] as const;
+
+export type NetworkMode = (typeof VALID_NETWORK_MODES)[number];
+export type SecurityLevel = (typeof VALID_SECURITY_LEVELS)[number];
+export type PreviewMethod = (typeof VALID_PREVIEW_METHODS)[number];
+export type DbMode = (typeof VALID_DB_MODES)[number];
+export type ComponentPolicy = (typeof VALID_COMPONENT_POLICIES)[number];
+export type UpdatePolicy = (typeof VALID_UPDATE_POLICIES)[number];
+
+export interface ManagerConfigResult {
+  /** Human-readable description of what was applied. */
+  message: string;
+  /** Whether the change was applied via the HTTP API ("api") or config.ini ("config-file"). */
+  via: "api" | "config-file";
+  /** Resulting state value, when known. */
+  state?: string;
+}
+
+function assertOneOf<T extends string>(
+  value: string,
+  allowed: readonly T[],
+  label: string,
+): T {
+  if (!allowed.includes(value as T)) {
+    throw new ValidationError(
+      `Invalid ${label} "${value}". Expected one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value as T;
+}
+
+// --- HTTP-API backed settings ---
+
+/** POST {value} to a Manager endpoint and read the resulting GET state. */
+async function setViaApi(
+  postPath: string,
+  value: string,
+  getPath: string = postPath,
+): Promise<string> {
+  await managerFetch(postPath, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value }),
+  });
+  // Read back the resulting state (these GET endpoints return text/plain).
+  const res = await managerFetch(getPath, { method: "GET" });
+  return (await res.text()).trim();
+}
+
+export async function setPreviewMethod(
+  value: string,
+): Promise<ManagerConfigResult> {
+  const v = assertOneOf(value, VALID_PREVIEW_METHODS, "preview method");
+  const state = await setViaApi("/manager/preview_method", v);
+  return {
+    message: `Set ComfyUI-Manager preview method to "${v}".`,
+    via: "api",
+    state,
+  };
+}
+
+export async function setDbMode(value: string): Promise<ManagerConfigResult> {
+  const v = assertOneOf(value, VALID_DB_MODES, "db mode");
+  const state = await setViaApi("/manager/db_mode", v);
+  return {
+    message: `Set ComfyUI-Manager database mode to "${v}".`,
+    via: "api",
+    state,
+  };
+}
+
+export async function setComponentPolicy(
+  value: string,
+): Promise<ManagerConfigResult> {
+  const v = assertOneOf(value, VALID_COMPONENT_POLICIES, "component policy");
+  const state = await setViaApi("/manager/policy/component", v);
+  return {
+    message: `Set ComfyUI-Manager component policy to "${v}".`,
+    via: "api",
+    state,
+  };
+}
+
+export async function setUpdatePolicy(
+  value: string,
+): Promise<ManagerConfigResult> {
+  const v = assertOneOf(value, VALID_UPDATE_POLICIES, "update policy");
+  const state = await setViaApi("/manager/policy/update", v);
+  return {
+    message: `Set ComfyUI-Manager update policy to "${v}".`,
+    via: "api",
+    state,
+  };
+}
+
+/**
+ * Set the active channel by name. The Manager POST expects a channel *name*
+ * (e.g. "default", "dev"); it resolves it to a URL internally and ignores
+ * unknown names, so we verify against the returned selection.
+ */
+export async function setChannel(value: string): Promise<ManagerConfigResult> {
+  if (!value || !value.trim()) {
+    throw new ValidationError("Channel name must be a non-empty string.");
+  }
+  const name = value.trim();
+  await managerFetch("/manager/channel_url_list", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ value: name }),
+  });
+  const res = await managerFetch("/manager/channel_url_list", { method: "GET" });
+  const data = (await res.json()) as { selected?: string };
+  const selected = data.selected ?? "custom";
+  // Manager silently ignores unknown channel names, leaving selection unchanged.
+  if (selected !== name) {
+    throw new ManagerConfigError(
+      `ComfyUI-Manager did not switch to channel "${name}" (still "${selected}"). The channel name may be unknown.`,
+      { requested: name, selected },
+    );
+  }
+  return {
+    message: `Set ComfyUI-Manager channel to "${name}".`,
+    via: "api",
+    state: selected,
+  };
+}
+
+/**
+ * Reset the Manager task queue. This is the runtime, HTTP-reachable analog of
+ * `comfy-cli manager clear` (which clears reserved startup actions locally).
+ */
+export async function resetQueue(): Promise<ManagerConfigResult> {
+  await managerFetch("/manager/queue/reset", { method: "POST" });
+  return {
+    message: "Reset the ComfyUI-Manager task queue (cleared pending actions).",
+    via: "api",
+  };
+}
+
+// --- config.ini fallback for settings with no HTTP setter ---
+
+/**
+ * Candidate locations of ComfyUI-Manager's config.ini relative to the ComfyUI
+ * install root, newest layout first (see manager_core.update_user_directory /
+ * manager_migration.get_manager_path). All live under `<comfyui>/user/`.
+ */
+function managerConfigCandidates(comfyuiPath: string): string[] {
+  return [
+    join(comfyuiPath, "user", "__manager", "config.ini"),
+    join(comfyuiPath, "user", "default", "ComfyUI-Manager", "config.ini"),
+    // Legacy git-clone install location.
+    join(comfyuiPath, "custom_nodes", "ComfyUI-Manager", "config.ini"),
+  ];
+}
+
+function resolveManagerConfigPath(): string {
+  if (!config.comfyuiPath) {
+    throw new ManagerConfigError(
+      "This setting has no ComfyUI-Manager HTTP endpoint and must be written to config.ini, " +
+        "but no ComfyUI install path is known. Set COMFYUI_PATH (or run against a local install).",
+    );
+  }
+  const candidates = managerConfigCandidates(config.comfyuiPath);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new ManagerConfigError(
+    `Could not find ComfyUI-Manager config.ini under "${config.comfyuiPath}". Looked in: ${candidates.join(", ")}. Is ComfyUI-Manager installed?`,
+    { candidates },
+  );
+}
+
+/**
+ * Minimal in-place editor for the `[default]` section of Manager's config.ini.
+ * Updates an existing `key = value` line or appends one to the section. Avoids
+ * a full INI rewrite so unrelated keys/comments are preserved.
+ */
+function setIniDefaultKey(contents: string, key: string, value: string): string {
+  // Strip any CR/NUL to mirror Manager's own CRLF-injection sanitization.
+  const safeValue = value.replace(/[\r\n\x00]/g, "");
+  const lines = contents.split("\n");
+
+  let inDefault = false;
+  let defaultHeaderIdx = -1;
+  let lastDefaultLineIdx = -1;
+  const keyRe = new RegExp(`^\\s*${key}\\s*=`, "i");
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    const sectionMatch = /^\[(.+)\]\s*$/.exec(trimmed);
+    if (sectionMatch) {
+      const section = sectionMatch[1].trim().toLowerCase();
+      inDefault = section === "default";
+      if (inDefault) defaultHeaderIdx = i;
+      continue;
+    }
+    if (inDefault) {
+      if (trimmed !== "") lastDefaultLineIdx = i;
+      if (keyRe.test(lines[i])) {
+        lines[i] = `${key} = ${safeValue}`;
+        return lines.join("\n");
+      }
+    }
+  }
+
+  if (defaultHeaderIdx === -1) {
+    // No [default] section: append a fresh one.
+    const sep = contents.endsWith("\n") || contents === "" ? "" : "\n";
+    return `${contents}${sep}[default]\n${key} = ${safeValue}\n`;
+  }
+
+  // Insert after the last non-empty line within [default].
+  const insertAt = (lastDefaultLineIdx === -1 ? defaultHeaderIdx : lastDefaultLineIdx) + 1;
+  lines.splice(insertAt, 0, `${key} = ${safeValue}`);
+  return lines.join("\n");
+}
+
+function setManagerConfigKeyOnDisk(key: string, value: string): string {
+  const path = resolveManagerConfigPath();
+  let contents: string;
+  try {
+    contents = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new ManagerConfigError(`Could not read ${path}.`, {
+      path,
+      cause: err instanceof Error ? err.message : String(err),
+    });
+  }
+  const updated = setIniDefaultKey(contents, key, value);
+  try {
+    writeFileSync(path, updated, "utf-8");
+  } catch (err) {
+    throw new ManagerConfigError(`Could not write ${path}.`, {
+      path,
+      cause: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return path;
+}
+
+export function setNetworkMode(value: string): ManagerConfigResult {
+  const v = assertOneOf(value, VALID_NETWORK_MODES, "network mode");
+  const path = setManagerConfigKeyOnDisk("network_mode", v);
+  return {
+    message:
+      `Set ComfyUI-Manager network_mode to "${v}" in ${path}. ` +
+      "Restart ComfyUI for the change to take effect.",
+    via: "config-file",
+    state: v,
+  };
+}
+
+export function setSecurityLevel(value: string): ManagerConfigResult {
+  const v = assertOneOf(value, VALID_SECURITY_LEVELS, "security level");
+  const path = setManagerConfigKeyOnDisk("security_level", v);
+  return {
+    message:
+      `Set ComfyUI-Manager security_level to "${v}" in ${path}. ` +
+      "Restart ComfyUI for the change to take effect.",
+    via: "config-file",
+    state: v,
+  };
+}
+
+// --- Action dispatch ---
+
+export const MANAGER_CONFIG_ACTIONS = [
+  "set_preview_method",
+  "set_db_mode",
+  "set_component_policy",
+  "set_update_policy",
+  "set_channel",
+  "reset_queue",
+  "set_network_mode",
+  "set_security_level",
+] as const;
+
+export type ManagerConfigAction = (typeof MANAGER_CONFIG_ACTIONS)[number];
+
+const ACTIONS_REQUIRING_VALUE: ReadonlySet<ManagerConfigAction> = new Set([
+  "set_preview_method",
+  "set_db_mode",
+  "set_component_policy",
+  "set_update_policy",
+  "set_channel",
+  "set_network_mode",
+  "set_security_level",
+]);
+
+export async function configureManager(
+  action: ManagerConfigAction,
+  value?: string,
+): Promise<ManagerConfigResult> {
+  if (ACTIONS_REQUIRING_VALUE.has(action) && (value === undefined || value === "")) {
+    throw new ValidationError(`Action "${action}" requires a "value".`);
+  }
+
+  switch (action) {
+    case "set_preview_method":
+      return setPreviewMethod(value as string);
+    case "set_db_mode":
+      return setDbMode(value as string);
+    case "set_component_policy":
+      return setComponentPolicy(value as string);
+    case "set_update_policy":
+      return setUpdatePolicy(value as string);
+    case "set_channel":
+      return setChannel(value as string);
+    case "reset_queue":
+      return resetQueue();
+    case "set_network_mode":
+      return setNetworkMode(value as string);
+    case "set_security_level":
+      return setSecurityLevel(value as string);
+    default: {
+      // Exhaustiveness guard.
+      const _never: never = action;
+      throw new ValidationError(`Unknown action "${_never as string}".`);
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,6 +19,7 @@ import { registerDefaultsTools } from "./defaults.js";
 import { registerGenerateImageTool } from "./generate-image.js";
 import { registerConditionedGenerationTools } from "./generate-conditioned.js";
 import { registerWorkflowDslTools } from "./workflow-dsl.js";
+import { registerManagerConfigTools } from "./manager-config.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -44,5 +45,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerGenerateImageTool(server);
   registerConditionedGenerationTools(server);
   registerWorkflowDslTools(server);
+  registerManagerConfigTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/manager-config.ts
+++ b/src/tools/manager-config.ts
@@ -25,14 +25,16 @@ export function registerManagerConfigTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Value for the chosen action (required for all except reset_queue). " +
-            "set_preview_method: auto|latent2rgb|taesd|none. " +
-            "set_db_mode: local|cache|remote. " +
-            "set_component_policy: workflow|always. " +
-            "set_update_policy: stable-comfyui|nightly-comfyui|stable|nightly. " +
-            "set_channel: a channel name (e.g. default). " +
-            "set_network_mode: public|private|offline. " +
-            "set_security_level: strong|normal|normal-|weak.",
+          "Value for the chosen action (omit only for reset_queue). Allowed values per action — " +
+            "set_preview_method: auto | latent2rgb | taesd | none; " +
+            "set_db_mode: local | cache | remote; " +
+            "set_component_policy: workflow | higher | mine; " +
+            "set_update_policy: stable-comfyui | nightly-comfyui; " +
+            "set_channel: a channel name (e.g. default); " +
+            "set_network_mode: public | private | offline; " +
+            "set_security_level: strong | normal | normal- | weak. " +
+            "HTTP-API actions take effect live; the config.ini actions " +
+            "(set_network_mode, set_security_level) apply only after a ComfyUI restart.",
         ),
     },
     async (args) => {

--- a/src/tools/manager-config.ts
+++ b/src/tools/manager-config.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  configureManager,
+  MANAGER_CONFIG_ACTIONS,
+} from "../services/manager-config.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerManagerConfigTools(server: McpServer): void {
+  server.tool(
+    "configure_manager",
+    "Configure ComfyUI-Manager settings, mirroring `comfy-cli manager` subcommands. " +
+      "Most actions use the ComfyUI-Manager HTTP API (works against remote ComfyUI); " +
+      "set_network_mode and set_security_level have no HTTP setter and are written to " +
+      "Manager's config.ini (requires a known local ComfyUI path; restart ComfyUI to apply).",
+    {
+      action: z
+        .enum(MANAGER_CONFIG_ACTIONS)
+        .describe(
+          "Which setting to change. HTTP API: set_preview_method, set_db_mode, " +
+            "set_component_policy, set_update_policy, set_channel, reset_queue. " +
+            "config.ini fallback: set_network_mode, set_security_level.",
+        ),
+      value: z
+        .string()
+        .optional()
+        .describe(
+          "Value for the chosen action (required for all except reset_queue). " +
+            "set_preview_method: auto|latent2rgb|taesd|none. " +
+            "set_db_mode: local|cache|remote. " +
+            "set_component_policy: workflow|always. " +
+            "set_update_policy: stable-comfyui|nightly-comfyui|stable|nightly. " +
+            "set_channel: a channel name (e.g. default). " +
+            "set_network_mode: public|private|offline. " +
+            "set_security_level: strong|normal|normal-|weak.",
+        ),
+    },
+    async (args) => {
+      try {
+        const result = await configureManager(args.action, args.value);
+        const stateLine =
+          result.state !== undefined ? `\nResulting state: ${result.state}` : "";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `${result.message} (via ${result.via})${stateLine}`,
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Ports the `comfy-cli manager` configuration capabilities into this MCP server as a new `configure_manager` tool (one unit of the larger comfy-cli port effort).

**Hybrid mechanism (confirmed against ComfyUI-Manager source):**
- Prefer the ComfyUI-Manager HTTP API — works against remote ComfyUI too.
- Fall back to editing Manager's `config.ini` (`[default]` section under `config.comfyuiPath`) only for settings that have **no** HTTP setter. Returns a clear error if `comfyuiPath` is undefined and no API path exists.

## Actions

| Action | Mechanism | Endpoint / key |
|---|---|---|
| `set_preview_method` | HTTP API | `POST /manager/preview_method` |
| `set_db_mode` | HTTP API | `POST /manager/db_mode` |
| `set_component_policy` | HTTP API | `POST /manager/policy/component` |
| `set_update_policy` | HTTP API | `POST /manager/policy/update` |
| `set_channel` | HTTP API | `POST /manager/channel_url_list` |
| `reset_queue` | HTTP API | `POST /manager/queue/reset` |
| `set_network_mode` | config.ini | `[default] network_mode` |
| `set_security_level` | config.ini | `[default] security_level` |

`set_network_mode` and `set_security_level` are deliberately not settable over HTTP in ComfyUI-Manager (security), so they use the config.ini fallback and require a known local ComfyUI path; a restart is needed to apply.

## Endpoint / key provenance

Verified via the Comfy-Org/ComfyUI-Manager repo (not invented):
- `glob/manager_server.py` — HTTP routes and `set_*` handlers (each POST takes `{"value": ...}`).
- `glob/manager_core.py` — `read_config`/`write_config`: `[default]` section, exact keys and valid value enums (network_mode: public|private|offline; security_level: strong|normal|normal-|weak; db_mode: local|cache|remote; etc.).
- config.ini candidate paths from `manager_core.update_user_directory` / `manager_migration.get_manager_path` (`user/__manager/`, legacy `user/default/ComfyUI-Manager/`, and the legacy git-clone `custom_nodes/ComfyUI-Manager/`).

## Conventions

- `src/services/manager-config.ts` — business logic + local `managerFetch()` helper + minimal in-place `config.ini` editor (preserves unrelated keys/comments; sanitizes CR/NUL like Manager does). Adds a `ManagerConfigError` subclass of `ComfyUIError`.
- `src/tools/manager-config.ts` — thin `registerManagerConfigTools(server)` wrapper using `server.tool(...)`, zod enum input, `errorToToolResult` on failure.
- `src/tools/index.ts` — one import + one registration call before `registerAutoloadedWorkflows`.

## Testing

- 18 new vitest cases mocking `global.fetch` and `node:fs` (no real side effects): each action maps to the correct Manager request, invalid enum values are rejected, config.ini fallback updates/appends keys correctly and errors clearly when the path/file is missing, and the unreachable-server / non-OK paths surface clear errors.
- `npm run build` — zero errors. `npm test` — full suite green (119 passed).
- Live e2e deferred: this worktree has no running ComfyUI instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)