### PR TITLE
docs: TDQS description improvements for core tools

### DIFF
--- a/src/services/workflow-autoload.ts
+++ b/src/services/workflow-autoload.ts
@@ -72,7 +72,9 @@ export function buildToolSchema(placeholders: Placeholder[]): Record<string, Zod
   const shape: Record<string, ZodTypeAny> = {};
   for (const p of placeholders) {
     if (!(p.name in shape)) {
-      shape[p.name] = zodForType(p.type);
+      shape[p.name] = zodForType(p.type).describe(
+        `Value for "${p.name}" (${p.type}); fills a PARAM_* placeholder in the workflow.`,
+      );
     }
   }
   return shape;

--- a/src/tools/generate-conditioned.ts
+++ b/src/tools/generate-conditioned.ts
@@ -25,14 +25,14 @@ const deps: ConditionedDeps = {
 };
 
 const commonShape = {
-  negative_prompt: z.string().optional(),
-  width: z.number().int().positive().optional(),
-  height: z.number().int().positive().optional(),
-  steps: z.number().int().positive().optional(),
-  cfg: z.number().positive().optional(),
-  sampler: z.string().optional(),
-  scheduler: z.string().optional(),
-  seed: z.number().int().optional(),
+  negative_prompt: z.string().optional().describe("Negative prompt (default: empty / from defaults)"),
+  width: z.number().int().positive().optional().describe("Image width in pixels"),
+  height: z.number().int().positive().optional().describe("Image height in pixels"),
+  steps: z.number().int().positive().optional().describe("Sampling steps"),
+  cfg: z.number().positive().optional().describe("CFG scale"),
+  sampler: z.string().optional().describe("Sampler name (e.g. euler, dpmpp_2m)"),
+  scheduler: z.string().optional().describe("Scheduler (e.g. normal, karras)"),
+  seed: z.number().int().optional().describe("Seed (omit to randomize)"),
   checkpoint: z.string().optional().describe("Checkpoint filename; auto-selected if omitted"),
 };
 
@@ -61,12 +61,12 @@ function enqueuedResult(result: { prompt_id: string; queue_remaining?: number; c
 export function registerConditionedGenerationTools(server: McpServer): void {
   server.tool(
     "generate_with_controlnet",
-    "Generate an image conditioned by a ControlNet preprocessed image (pose skeleton, depth, canny, normal, etc.) plus a text prompt. Upload the control image first with upload_image, then pass its filename as control_image. Unspecified params fall back to your defaults; checkpoint and controlnet_model auto-resolve from local models. Returns prompt_id immediately; asset_id arrives in the completion notification.",
+    "Generate an image conditioned by a ControlNet preprocessed image (pose skeleton, depth, canny, normal, etc.) plus a text prompt. Upload the control image first with upload_image, then pass its filename as control_image. Unspecified params fall back to your defaults; checkpoint and controlnet_model auto-resolve from local models. Returns prompt_id immediately; asset_id arrives in the completion notification. control_image must already be a preprocessed map (this tool does not run the preprocessor); requires a running ComfyUI with a matching controlnet model in models/controlnet/.",
     {
       prompt: z.string().describe("Positive text prompt"),
       control_image: z.string().describe("Filename of the (already-uploaded) control image in ComfyUI's input dir"),
       controlnet_model: z.string().optional().describe("ControlNet model file (in models/controlnet/); auto-selected if omitted"),
-      strength: z.number().positive().optional().describe("ControlNet conditioning strength (default 1.0)"),
+      strength: z.number().positive().optional().describe("ControlNet conditioning strength, typically 0.0-2.0 (default 1.0); higher = stronger adherence to the control image"),
       ...commonShape,
     },
     async (args) => {
@@ -80,11 +80,11 @@ export function registerConditionedGenerationTools(server: McpServer): void {
 
   server.tool(
     "generate_with_ip_adapter",
-    "Generate an image guided by a reference image's style/subject via IP-Adapter, plus a text prompt. Requires the ComfyUI_IPAdapter_plus custom nodes. Upload the reference first with upload_image, then pass its filename as reference_image. Unspecified params fall back to your defaults; checkpoint auto-resolves. Returns prompt_id immediately; asset_id arrives in the completion notification.",
+    "Generate an image guided by a reference image's style/subject via IP-Adapter, plus a text prompt. Requires the ComfyUI_IPAdapter_plus custom nodes. Upload the reference first with upload_image, then pass its filename as reference_image. Unspecified params fall back to your defaults; checkpoint auto-resolves. Returns prompt_id immediately; asset_id arrives in the completion notification. Requires a running ComfyUI with ComfyUI_IPAdapter_plus and a matching IP-Adapter model installed, or the workflow will fail at execution time.",
     {
       prompt: z.string().describe("Positive text prompt"),
       reference_image: z.string().describe("Filename of the (already-uploaded) reference image in ComfyUI's input dir"),
-      weight: z.number().optional().describe("IP-Adapter weight (default 0.8)"),
+      weight: z.number().optional().describe("IP-Adapter influence on the output, typically 0.0-1.0 (default 0.8); higher = closer to the reference"),
       preset: z.string().optional().describe("IPAdapterUnifiedLoader preset (default 'PLUS (high strength)')"),
       ...commonShape,
     },

--- a/src/tools/generation-tracker.ts
+++ b/src/tools/generation-tracker.ts
@@ -6,8 +6,7 @@ import { errorToToolResult } from "../utils/errors.js";
 export function registerGenerationTrackerTools(server: McpServer): void {
   server.tool(
     "suggest_settings",
-    "Suggest proven sampler/scheduler/steps/CFG settings based on local generation history. " +
-      "Query by model family, LoRA hash, or text search on model/LoRA names.",
+    "Recommend concrete, proven sampler/scheduler/steps/CFG (and denoise/shift/LoRA) settings derived from THIS MCP server's local generation-history database (populated as you run workflows; not from ComfyUI). Read-only and works without a running ComfyUI. Narrow results by model_family, lora_hash, or a name search; with no filter it returns the top settings across all history. Returns a ranked list with each combo's reuse count, or a 'no history' message until you have generated images. Use this for ready-to-apply values; use generation_stats for aggregate counts and breakdowns rather than specific suggestions.",
     {
       model_family: z
         .string()
@@ -93,12 +92,12 @@ export function registerGenerationTrackerTools(server: McpServer): void {
 
   server.tool(
     "generation_stats",
-    "Show local generation tracking statistics — total runs, unique combos, breakdown by model family.",
+    "Show statistics from this MCP server's local generation-history database (populated as you run workflows; not from ComfyUI itself): total generations, count of unique sampler/scheduler/steps/CFG combos, a per-model-family breakdown, and the most-reused settings. Read-only; works without a running ComfyUI. Returns empty stats until you have generated images. For concrete recommended settings rather than aggregate counts, use suggest_settings.",
     {
       model_family: z
         .string()
         .optional()
-        .describe("Filter stats to a specific model family"),
+        .describe("Optional model-family key to scope stats to, e.g. 'sdxl', 'flux', 'qwen_image', 'illustrious'"),
     },
     async (args) => {
       try {

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -183,9 +183,7 @@ export function registerImageManagementTools(server: McpServer): void {
   // ── list_output_images ────────────────────────────────────────────────────
   server.tool(
     "list_output_images",
-    "List recently generated images from ComfyUI's output directory. " +
-      "Returns filenames sorted newest-first. Requires COMFYUI_PATH. " +
-      "For remote ComfyUI, use get_history to find filenames, then get_image to fetch them.",
+    "List recently generated image files from ComfyUI's local output/ directory (filesystem scan), newest-first, with file size and modification time. Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the image data itself. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the actual bytes. Read-only.",
     {
       limit: z
         .number()

--- a/src/tools/memory-management.ts
+++ b/src/tools/memory-management.ts
@@ -82,7 +82,7 @@ export function registerMemoryManagementTools(server: McpServer): void {
 
   server.tool(
     "get_embeddings",
-    "List installed textual inversion embeddings. These can be used in prompts with the syntax embedding:name (e.g. embedding:easynegative).",
+    "List textual-inversion embeddings installed on the connected ComfyUI server (read from its /api/embeddings endpoint, i.e. the models/embeddings folder). Requires a running, reachable ComfyUI (local or remote); takes no parameters. Returns the embedding names; reference them in positive or negative prompts as embedding:name (e.g. embedding:easynegative). Read-only.",
     {},
     async () => {
       try {

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -13,13 +13,13 @@ const modelTypeEnum = z.enum(MODEL_SUBDIRS);
 export function registerModelManagementTools(server: McpServer): void {
   server.tool(
     "search_models",
-    "Search HuggingFace for models compatible with ComfyUI (checkpoints, LoRAs, VAEs, etc.)",
+    "Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, ControlNets, etc.). Read-only and network-only: queries HuggingFace over HTTP, does NOT require a running ComfyUI or COMFYUI_PATH and does not download anything. Returns a ranked list with modelId, author, downloads, likes, and tags. Pick a result's download URL and pass it to download_model to install it locally. For packs of custom nodes (not models) use search_custom_nodes.",
     {
       query: z.string().describe("Search query (e.g. 'SDXL', 'flux', 'controlnet')"),
       filter: z
         .string()
         .optional()
-        .describe("HuggingFace tag filter (e.g. 'diffusers', 'text-to-image')"),
+        .describe("Optional HuggingFace pipeline/library tag to narrow results, e.g. 'diffusers' or 'text-to-image'"),
       limit: z
         .number()
         .int()
@@ -90,7 +90,7 @@ export function registerModelManagementTools(server: McpServer): void {
 
   server.tool(
     "list_local_models",
-    "List model files installed in the local ComfyUI models directory",
+    "List model files installed in the local ComfyUI models/ directory (filesystem scan), grouped by type with size and modified time. Read-only; requires COMFYUI_PATH (local installs only) and does NOT contact ComfyUI or the network. Use to see which models are already available locally before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them.",
     {
       model_type: modelTypeEnum
         .optional()

--- a/src/tools/queue-management.ts
+++ b/src/tools/queue-management.ts
@@ -12,7 +12,7 @@ import { errorToToolResult } from "../utils/errors.js";
 export function registerQueueManagementTools(server: McpServer): void {
   server.tool(
     "get_queue",
-    "Get the current ComfyUI execution queue showing running and pending jobs.",
+    "Get the current ComfyUI execution queue: the job running now plus all pending jobs, each with its prompt_id and position. Read-only; requires a reachable ComfyUI server (works against local or remote --comfyui-url). Returns JSON with running and pending arrays. Use this to see what is in flight before cancel_job (running) or cancel_queued_job/clear_queue (pending); use get_job_status or get_history for the outcome of one specific prompt_id.",
     {},
     async () => {
       try {
@@ -33,7 +33,7 @@ export function registerQueueManagementTools(server: McpServer): void {
 
   server.tool(
     "get_job_status",
-    "Check the execution status of a ComfyUI prompt/job by its ID.",
+    "Check the status of ONE ComfyUI job by its prompt_id (the id returned by enqueue_workflow). Queries the connected ComfyUI server; requires it to be running. Returns JSON with three booleans — running (executing now), pending (queued, not yet started), and done (finished or no longer tracked). Use get_queue to see the whole queue at once, and get_history for a finished job's full details and output filenames.",
     {
       prompt_id: z.string().describe("The prompt ID returned by enqueue_workflow"),
     },
@@ -56,13 +56,13 @@ export function registerQueueManagementTools(server: McpServer): void {
 
   server.tool(
     "cancel_job",
-    "Interrupt/cancel the currently running ComfyUI job. Optionally target a specific running job by prompt_id.",
+    "Interrupt the CURRENTLY RUNNING ComfyUI job, optionally only when its prompt_id matches. Stops in-progress execution — the partial result is discarded and not recoverable — and does NOT remove pending/queued jobs. Requires a reachable ComfyUI server. Use this for the job actively executing now; use cancel_queued_job to remove one specific PENDING job, or clear_queue to drop ALL pending jobs. Returns a confirmation (or a no-op status when nothing is running).",
     {
       prompt_id: z
         .string()
         .optional()
         .describe(
-          "Optional prompt_id to target a specific running job. If omitted, interrupts the current job.",
+          "Optional. If given, only interrupts the running job when its prompt_id matches; omit to interrupt whatever is currently running.",
         ),
     },
     async (args) => {

--- a/src/tools/registry-search.ts
+++ b/src/tools/registry-search.ts
@@ -6,9 +6,9 @@ import { errorToToolResult } from "../utils/errors.js";
 export function registerRegistrySearchTools(server: McpServer): void {
   server.tool(
     "search_custom_nodes",
-    "Search the ComfyUI Registry for custom node packs by keyword",
+    "Search the public ComfyUI Registry (registry.comfy.org) for custom node packs by keyword. Read-only and network-only: queries the hosted registry over HTTP and does NOT require a running ComfyUI or COMFYUI_PATH. Returns a ranked list of packs with id, name, author, install count, and latest version. Use to discover packs to install; pass a returned id to get_node_pack_details for full info. This searches node PACKS, not models (use search_models) and not local installs (use list_local_models).",
     {
-      query: z.string().describe("Search query for custom node packs"),
+      query: z.string().describe("Keyword(s) to match against pack name/description, e.g. 'impact', 'controlnet aux'"),
       limit: z
         .number()
         .int()
@@ -50,9 +50,9 @@ export function registerRegistrySearchTools(server: McpServer): void {
 
   server.tool(
     "get_node_pack_details",
-    "Get detailed information about a specific ComfyUI custom node pack from the Registry",
+    "Get full details for one ComfyUI custom node pack from the public ComfyUI Registry: description, author, license, repository, install count, latest version, the node types it provides, and recent version changelogs. Read-only and network-only (hosted registry over HTTP); does not require a running ComfyUI. Look up the pack id via search_custom_nodes first.",
     {
-      id: z.string().describe("Node pack ID (e.g. 'comfyui-impact-pack')"),
+      id: z.string().describe("Exact registry pack id (the 'id' field from search_custom_nodes), e.g. 'comfyui-impact-pack'"),
     },
     async (args) => {
       try {

--- a/src/tools/skill-generator.ts
+++ b/src/tools/skill-generator.ts
@@ -8,7 +8,7 @@ import { dirname, join } from "node:path";
 export function registerSkillGeneratorTools(server: McpServer): void {
   server.tool(
     "generate_node_skill",
-    "Analyze a ComfyUI custom node pack and generate a Claude skill (.md) file describing all its nodes, inputs/outputs, and usage examples. Accepts a ComfyUI Registry ID or a GitHub repository URL as the source.",
+    "Generate a Claude skill (SKILL.md) documenting a ComfyUI custom node pack: its nodes, inputs/outputs, and example workflows. Accepts a ComfyUI Registry ID (resolved via api.comfy.org) or a GitHub repository URL. Fetches the repo README and scans its Python NODE_CLASS_MAPPINGS and example workflows over the network (uses GITHUB_TOKEN if set to avoid rate limits), so internet access is required. If a ComfyUI server is reachable it enriches node input/output types from /object_info, but the server is optional. Returns the SKILL.md markdown; if install_in is set, also creates that directory (recursively) and writes SKILL.md there, overwriting any existing file.",
     {
       source: z
         .string()
@@ -19,7 +19,7 @@ export function registerSkillGeneratorTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Optional directory path to save the generated SKILL.md file",
+          "Optional directory to write the generated SKILL.md into. Created recursively if missing; an existing SKILL.md is overwritten. Omit to only return the markdown without touching disk.",
         ),
     },
     async (args) => {

--- a/src/tools/workflow-autoload.ts
+++ b/src/tools/workflow-autoload.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   discoverWorkflows,
@@ -41,8 +42,12 @@ export async function registerAutoloadedWorkflows(server: McpServer): Promise<vo
       .filter((s, i, a) => a.indexOf(s) === i)
       .join(", ");
     const description =
-      `Run the autoloaded workflow "${wf.toolName}" (from ${wf.filePath}). ` +
-      `Params: ${paramSummary || "(none)"}`;
+      `Enqueue the autoloaded ComfyUI workflow "${wf.toolName}" ` +
+      `(loaded from ${basename(wf.filePath)}) for execution and return immediately ` +
+      `with its prompt_id and queue position — it does NOT wait for the result; ` +
+      `poll get_job_status or get_history afterwards. Requires a running ComfyUI server. ` +
+      `Each parameter below substitutes a PARAM_* placeholder in the saved workflow, and ` +
+      `all parameters are required. Params: ${paramSummary || "(none)"}`;
 
     server.tool(wf.toolName, description, shape, async (args) => {
       try {

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -69,7 +69,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
   // 1. create_workflow
   server.tool(
     "create_workflow",
-    `Create a ComfyUI workflow from a named template. Available templates: ${TEMPLATE_NAMES.join(", ")}. Returns the complete workflow JSON ready for execution or further modification.`,
+    `Create a ready-to-run ComfyUI API-format workflow from a built-in template (${TEMPLATE_NAMES.join(", ")}). Pure local generation — does not contact ComfyUI and has no side effects. Returns the complete workflow JSON; pass it to validate_workflow or enqueue_workflow. Unsupplied params fall back to template defaults, so the result may reference checkpoints/models that must exist on your ComfyUI server before it will execute.`,
     {
       template: z
         .enum(TEMPLATE_NAMES as [string, ...string[]])
@@ -79,7 +79,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
         .optional()
         .default({})
         .describe(
-          "Template parameters (e.g. checkpoint, positive_prompt, negative_prompt, width, height, steps, cfg, seed, sampler_name, scheduler, denoise, image_path, mask_path, upscale_model)",
+          "Template parameters; recognized keys depend on the template. txt2img: checkpoint, positive_prompt, negative_prompt, width, height, steps, cfg, seed, sampler_name, scheduler. img2img/inpaint add image_path (and mask_path for inpaint) and denoise. upscale adds upscale_model. Unknown keys are ignored; omitted keys use template defaults.",
         ),
     },
     async ({ template, params }) => {
@@ -145,7 +145,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
   // 3. get_node_info
   server.tool(
     "get_node_info",
-    "Query ComfyUI's /object_info endpoint to get available node type definitions. Optionally filter by node type name (substring match). Returns node inputs, outputs, and descriptions.",
+    "Query a running ComfyUI server's /object_info endpoint for installed node type definitions (inputs, outputs, category, description). Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Note: when more than 20 node types match, returns only a summarized list (name, display_name, category, description) and asks you to narrow the filter to get full input/output schemas; 20 or fewer returns complete definitions.",
     {
       node_type: z
         .string()

--- a/src/tools/workflow-execute.ts
+++ b/src/tools/workflow-execute.ts
@@ -66,7 +66,7 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
 
   server.tool(
     "get_system_stats",
-    "Get ComfyUI system information including GPU, VRAM, Python version, and OS details.",
+    "Get system information from the connected ComfyUI server: GPU device(s), total/free VRAM, ComfyUI/Python/PyTorch versions, and OS details. Requires a running ComfyUI server (works against local or remote targets); read-only, takes no parameters. Returns the raw /system_stats JSON. Use to confirm connectivity and check available VRAM before enqueuing large workflows. Errors if the server is unreachable.",
     {},
     async () => {
       try {

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -17,7 +17,7 @@ import { convertToMermaid } from "../services/mermaid-converter.js";
 export function registerWorkflowLibraryTools(server: McpServer): void {
   server.tool(
     "list_workflows",
-    "List saved workflows from the ComfyUI user library.",
+    "List the filenames of workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI). Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of .json filenames; pass a filename to get_workflow or analyze_workflow to load one. Returns \"No saved workflows found.\" when the library is empty.",
     {},
     async () => {
       try {
@@ -126,7 +126,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
 
   server.tool(
     "save_workflow",
-    "Save a workflow to the ComfyUI user library so it appears in the web UI. Accepts either API format or UI format JSON.",
+    "Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. Accepts API-format or UI-format JSON. Returns a confirmation message, or the HTTP status and error text on failure.",
     {
       filename: z
         .string()
@@ -135,7 +135,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         ),
       workflow: z
         .record(z.any())
-        .describe("Workflow JSON to save (API or UI format)"),
+        .describe("Workflow JSON to save (API or UI format). Stored verbatim; not validated before saving."),
     },
     async (args) => {
       try {


### PR DESCRIPTION
## Summary

Improves MCP tool **definitions** (descriptions + zod `.describe()` texts) to raise Glama's Tool Definition Quality Score. Targets Glama's two weakest dimensions across the server — **Usage Guidelines** and **Behavior** — so each touched description now:

- states its data **source** (connected ComfyUI server / local filesystem / hosted registry / HuggingFace / this server's local history DB)
- states **return shape**
- discloses **preconditions & side effects** (requires running ComfyUI, local-only `COMFYUI_PATH`, network-only, read-only, mutates disk, async/non-blocking, not recoverable, etc.)
- **disambiguates vs sibling tools** ("use X instead of Y when Z")

This is a **description-only** change. No runtime logic, handler bodies, schema types, or required-ness were modified.

## Tools updated

- `workflow-library`: `list_workflows`, `save_workflow` (+ `workflow` param)
- `workflow-compose`: `create_workflow` (+ `params` param), `get_node_info`
- `workflow-execute`: `get_system_stats`
- `skill-generator`: `generate_node_skill` (+ `install_in` param)
- `queue-management`: `get_queue`, `get_job_status`, `cancel_job` (+ `prompt_id` param)
- `registry-search`: `search_custom_nodes` (+ `query`), `get_node_pack_details` (+ `id`)
- `model-management`: `search_models` (+ `filter`), `list_local_models`
- `memory-management`: `get_embeddings`
- `generation-tracker`: `generation_stats` (+ `model_family`), `suggest_settings`
- `image-management`: `list_output_images`
- `generate-conditioned`: `commonShape` field descriptions; `generate_with_controlnet` (+ `strength`); `generate_with_ip_adapter` (+ `weight`)
- autoloaded-workflow factory: dynamic-tool description (now references source basename, notes enqueue-and-return-immediately, requires running ComfyUI, all params required) and per-param `.describe()` tying each generated param to its `PARAM_*` placeholder

## Notes

- The provided `list_local_models` text referenced a `download_civitai_model` tool that does **not** exist in this codebase; that reference was dropped to keep the description accurate (kept `download_model`, which is real).
- `get_job_status` / `suggest_settings` were written from their handlers (e.g. `getJobStatus` returns `{ running, pending, done }`).

## Verification

- `npm run build` — clean (tsc)
- `npm test` — 101/101 passing; no test asserts exact description strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)