### PR TITLE
feat(experimental): cloudflared tunnel helper + AI SDK chat POC for embedded agent panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,14 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.79",
+        "@ai-sdk/google": "^3.0.79",
+        "@ai-sdk/openai": "^3.0.65",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@stable-canvas/comfyui-client": "^1.5.9",
+        "ai": "^6.0.191",
         "better-sqlite3": "^12.6.2",
+        "cloudflared": "^0.7.1",
         "dotenv": "^16.4.7",
         "zod": "^3.24.2"
       },
@@ -29,6 +34,100 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.79",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.79.tgz",
+      "integrity": "sha512-saEX+h5JDOkT9P/+REKDyikbnJiToFuLipgNcsmu4Zr3GW5kW1m9HhvrPK+vj63itIOsoZU6tmVIjkrePOlIUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.120",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.120.tgz",
+      "integrity": "sha512-MYKAeD2q7/sa1ZdqtL2tw0Me0B8Tok6Q/fhkJDhJl39dG8u+VBlWO9yk9lcdm784bM418o1EKObo4aOxs6+18Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.79",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.79.tgz",
+      "integrity": "sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.65",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.65.tgz",
+      "integrity": "sha512-ZlVoWH+zrdiYDiUt6n/xvfCsk33mzsB81TUQkBRVx79rxU1FKZqVH9J/QCtEpSLqx0cUzjvtIw9l9p7EbUv+dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@epic-web/invariant": {
@@ -539,6 +638,15 @@
         }
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
@@ -895,6 +1003,12 @@
       "integrity": "sha512-20SaRj8CfBms5ucfUHPwX5uhSuWaSjNCNSVFgTQ/cBq0A8myZiyFmP3k9IF1uisshVwOwdFEsdNLIbr3DnszUA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -938,6 +1052,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1066,6 +1189,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.191",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.191.tgz",
+      "integrity": "sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.120",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -1293,6 +1434,16 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cloudflared": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cloudflared/-/cloudflared-0.7.1.tgz",
+      "integrity": "sha512-jJn1Gu9Tf4qnIu8tfiHZ25Hs8rNcRYSVf8zAd97wvYdOCzftm1CTs1S/RPhijjGi8gUT1p9yzfDi9zYlU/0RwA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "cloudflared": "lib/cloudflared.js"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1619,9 +1770,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2036,6 +2187,12 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
+    "dev:agent-poc": "tsx src/experimental/run.ts",
     "start": "node dist/index.js",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
@@ -25,9 +26,14 @@
     "release:major": "npm version major && git push --follow-tags"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.79",
+    "@ai-sdk/google": "^3.0.79",
+    "@ai-sdk/openai": "^3.0.65",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@stable-canvas/comfyui-client": "^1.5.9",
+    "ai": "^6.0.191",
     "better-sqlite3": "^12.6.2",
+    "cloudflared": "^0.7.1",
     "dotenv": "^16.4.7",
     "zod": "^3.24.2"
   },

--- a/src/__tests__/experimental/chat-handler.test.ts
+++ b/src/__tests__/experimental/chat-handler.test.ts
@@ -1,0 +1,74 @@
+import { simulateReadableStream } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
+import { describe, expect, it } from "vitest";
+
+import { handleChatRequest, tools } from "../../experimental/chat-handler.js";
+
+// ---------------------------------------------------------------------------
+// Light test of the experimental chat handler with the model mocked.
+// No provider keys, no network — MockLanguageModelV3 emits a canned stream.
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const helloModel = new MockLanguageModelV3({
+  doStream: async () => ({
+    stream: simulateReadableStream({
+      chunks: [
+        { type: "text-start", id: "t1" },
+        { type: "text-delta", id: "t1", delta: "Hello" },
+        { type: "text-delta", id: "t1", delta: ", world!" },
+        { type: "text-end", id: "t1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 3, outputTokens: 5, totalTokens: 8 },
+        },
+      ],
+      chunkDelayInMs: null,
+      initialDelayInMs: null,
+    }),
+  }),
+});
+
+describe("handleChatRequest", () => {
+  it("streams a UI message response using the (mocked) model", async () => {
+    const req = makeRequest({
+      messages: [
+        { id: "m1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      ],
+    });
+
+    const res = await handleChatRequest(req, { model: helloModel });
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+    // UI message stream protocol uses server-sent events.
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const text = await res.text();
+    // The streamed text deltas should be present in the SSE body.
+    expect(text).toContain("Hello");
+    expect(text).toContain("world!");
+  });
+
+  it("exposes a single server-side generate_image tool with an execute fn", async () => {
+    expect(Object.keys(tools)).toEqual(["generate_image"]);
+    const result = await tools.generate_image.execute!(
+      { prompt: "a cat", width: 512, height: 512 },
+      { toolCallId: "tc1", messages: [] },
+    );
+    expect(result).toMatchObject({
+      status: "stubbed",
+      prompt: "a cat",
+      width: 512,
+      height: 512,
+    });
+  });
+});

--- a/src/__tests__/services/tunnel.test.ts
+++ b/src/__tests__/services/tunnel.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock the `cloudflared` package so no real binary is installed or spawned and
+// no network/tunnel is created. We capture the args passed to Tunnel.quick and
+// drive the fake tunnel's events by hand.
+// ---------------------------------------------------------------------------
+
+// vi.mock is hoisted above imports, so the mock state and the fake Tunnel must
+// be created with vi.hoisted() to be available inside the factory. The require
+// of node:events also happens here so it is ready before the factory runs.
+const h = vi.hoisted(() => {
+  const { EventEmitter } = require("node:events") as typeof import("node:events");
+  class FakeTunnel extends EventEmitter {
+    stop = vi.fn();
+  }
+  const quickCalls: Array<{ url?: string; options?: Record<string, unknown> }> = [];
+  const installMock = vi.fn(async (to: string) => to);
+  const useMock = vi.fn();
+  const state: { lastTunnel: FakeTunnel | null } = { lastTunnel: null };
+  return { FakeTunnel, quickCalls, installMock, useMock, state };
+});
+
+const { quickCalls, installMock, useMock, state } = h;
+
+vi.mock("cloudflared", () => ({
+  // Pretend the bundled binary exists so ensureBinary() is a no-op.
+  bin: "/fake/cloudflared",
+  install: h.installMock,
+  use: h.useMock,
+  Tunnel: {
+    quick: (url?: string, options?: Record<string, unknown>) => {
+      h.quickCalls.push({ url, options });
+      const t = new h.FakeTunnel();
+      h.state.lastTunnel = t;
+      return t;
+    },
+  },
+}));
+
+// Make ensureBinary believe the bundled binary is present.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (p: string) => (p === "/fake/cloudflared" ? true : actual.existsSync(p)),
+  };
+});
+
+import { startQuickTunnel } from "../../services/tunnel.js";
+
+describe("startQuickTunnel", () => {
+  beforeEach(() => {
+    quickCalls.length = 0;
+    installMock.mockClear();
+    useMock.mockClear();
+    state.lastTunnel = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("wires Tunnel.quick with the local URL and the expected args, and resolves on `url`", async () => {
+    const promise = startQuickTunnel(8765);
+
+    // Tunnel.quick should be invoked synchronously after ensureBinary().
+    await vi.waitFor(() => expect(quickCalls).toHaveLength(1));
+
+    const call = quickCalls[0];
+    expect(call.url).toBe("http://localhost:8765");
+    expect(call.options).toEqual({
+      "--config": process.platform === "win32" ? "NUL" : "/dev/null",
+      "--edge-ip-version": "4",
+    });
+
+    // Did NOT need to install since the bundled binary "exists".
+    expect(installMock).not.toHaveBeenCalled();
+
+    // Emit the url event -> promise resolves with the public URL.
+    state.lastTunnel!.emit("url", "https://random-poc.trycloudflare.com");
+
+    const handle = await promise;
+    expect(handle.url).toBe("https://random-poc.trycloudflare.com");
+    expect(handle.getState()).toMatchObject({
+      status: "running",
+      url: "https://random-poc.trycloudflare.com",
+    });
+  });
+
+  it("stop() tears down the tunnel and marks state stopped", async () => {
+    const promise = startQuickTunnel(9000);
+    await vi.waitFor(() => expect(quickCalls).toHaveLength(1));
+    state.lastTunnel!.emit("url", "https://abc.trycloudflare.com");
+    const handle = await promise;
+
+    handle.stop();
+    expect(state.lastTunnel!.stop).toHaveBeenCalledTimes(1);
+    expect(handle.getState().status).toBe("stopped");
+  });
+
+  it("rejects when the tunnel errors before becoming ready", async () => {
+    const promise = startQuickTunnel(9100);
+    await vi.waitFor(() => expect(quickCalls).toHaveLength(1));
+    state.lastTunnel!.emit("error", new Error("boom"));
+    await expect(promise).rejects.toThrow(/boom/);
+  });
+
+  it("rejects when cloudflared exits before the url event", async () => {
+    const promise = startQuickTunnel(9200);
+    await vi.waitFor(() => expect(quickCalls).toHaveLength(1));
+    state.lastTunnel!.emit("exit", 1, null);
+    await expect(promise).rejects.toThrow(/exited before tunnel was ready/);
+  });
+});

--- a/src/experimental/agent-poc.ts
+++ b/src/experimental/agent-poc.ts
@@ -1,0 +1,199 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { logger } from "../utils/logger.js";
+import { handleChatRequest } from "./chat-handler.js";
+import { startQuickTunnel, type QuickTunnel } from "../services/tunnel.js";
+
+// ---------------------------------------------------------------------------
+// Experimental entry point for the embedded-agent-panel POC.
+//
+// Starts a tiny HTTP server hosting `POST /api/chat` (AI SDK stream) and a
+// `GET /health` probe, and OPTIONALLY opens a cloudflared quick tunnel so a
+// remote / HTTPS ComfyUI page can reach it (solves mixed-content + remote
+// installs — see design/embedded-agent-panel.md).
+//
+// This is gated behind COMFYUI_MCP_AGENT_POC=1 and is invoked from a separate
+// module. It MUST NOT run during normal MCP startup or tests.
+// ---------------------------------------------------------------------------
+
+export interface AgentPocOptions {
+  port?: number;
+  host?: string;
+  /** Open a cloudflared quick tunnel and log the public URL. */
+  tunnel?: boolean;
+}
+
+export interface AgentPocHandle {
+  /** Local URL the chat server is listening on. */
+  localUrl: string;
+  /** Public tunnel URL, if a tunnel was opened. */
+  publicUrl: string | null;
+  stop(): Promise<void>;
+}
+
+const DEFAULT_PORT = 8765;
+const DEFAULT_HOST = "127.0.0.1";
+
+/** Convert a Node IncomingMessage into a Fetch-style Request. */
+async function toFetchRequest(
+  req: IncomingMessage,
+  host: string,
+  port: number,
+): Promise<Request> {
+  const url = `http://${host}:${port}${req.url ?? "/"}`;
+  const method = req.method ?? "GET";
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const hasBody = method !== "GET" && method !== "HEAD";
+  let body: string | undefined;
+  if (hasBody) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk as Buffer);
+    }
+    body = Buffer.concat(chunks).toString("utf-8");
+  }
+
+  return new Request(url, { method, headers, body });
+}
+
+/** Pipe a Fetch-style Response into a Node ServerResponse. */
+async function sendFetchResponse(
+  res: ServerResponse,
+  response: Response,
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  res.writeHead(response.status, headers);
+
+  if (response.body) {
+    // response.body is a web ReadableStream; bridge it to the Node response.
+    // Await pipeline so downstream/stream errors (e.g. client disconnect mid-
+    // stream) reject here instead of surfacing as an unhandled 'error' event.
+    const source = Readable.fromWeb(
+      response.body as Parameters<typeof Readable.fromWeb>[0],
+    );
+    await pipeline(source, res);
+  } else {
+    res.end(await response.text());
+  }
+}
+
+/**
+ * Start the experimental agent POC HTTP server (and optional tunnel).
+ * Returns a handle for shutdown. Callers gate this behind the env flag.
+ */
+export async function startAgentPoc(
+  options: AgentPocOptions = {},
+): Promise<AgentPocHandle> {
+  const envPort = process.env.COMFYUI_MCP_AGENT_PORT
+    ? Number(process.env.COMFYUI_MCP_AGENT_PORT)
+    : undefined;
+  const port =
+    options.port ?? (envPort && !Number.isNaN(envPort) ? envPort : DEFAULT_PORT);
+  const host = options.host ?? DEFAULT_HOST;
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res, host, port);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const localUrl = `http://${host}:${port}`;
+  logger.info(`[agent-poc] chat server listening on ${localUrl}/api/chat`);
+
+  let tunnel: QuickTunnel | null = null;
+  if (options.tunnel) {
+    try {
+      tunnel = await startQuickTunnel(port);
+      logger.info(`[agent-poc] public URL: ${tunnel.url}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`[agent-poc] failed to open tunnel: ${message}`);
+    }
+  }
+
+  return {
+    localUrl,
+    publicUrl: tunnel?.url ?? null,
+    stop: async () => {
+      tunnel?.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  host: string,
+  port: number,
+): Promise<void> {
+  // CORS open: the tunnel is the perimeter (per the design's security model).
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Headers", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ status: "ok" }));
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/api/chat") {
+    try {
+      const request = await toFetchRequest(req, host, port);
+      const response = await handleChatRequest(request);
+      await sendFetchResponse(res, response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`[agent-poc] /api/chat error: ${message}`);
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+      }
+      res.end(JSON.stringify({ error: message }));
+    }
+    return;
+  }
+
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "Not found" }));
+}
+
+/**
+ * Gated bootstrap. Only starts the POC when COMFYUI_MCP_AGENT_POC is truthy.
+ * Safe to call unconditionally from a side entry; a no-op otherwise.
+ */
+export async function maybeStartAgentPoc(): Promise<AgentPocHandle | null> {
+  if (!process.env.COMFYUI_MCP_AGENT_POC) {
+    return null;
+  }
+  return startAgentPoc({
+    tunnel: process.env.COMFYUI_MCP_AGENT_TUNNEL === "1",
+  });
+}

--- a/src/experimental/agent-poc.ts
+++ b/src/experimental/agent-poc.ts
@@ -1,3 +1,4 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -16,6 +17,11 @@ import { startQuickTunnel, type QuickTunnel } from "../services/tunnel.js";
 //
 // This is gated behind COMFYUI_MCP_AGENT_POC=1 and is invoked from a separate
 // module. It MUST NOT run during normal MCP startup or tests.
+//
+// Security: `/api/chat` requires a bearer token (auto-generated, or
+// COMFYUI_MCP_AGENT_TOKEN) so a leaked tunnel URL alone cannot spend provider
+// keys. Request bodies are size-capped. The model is chosen server-side
+// (see provider-registry) — clients cannot pick arbitrary models.
 // ---------------------------------------------------------------------------
 
 export interface AgentPocOptions {
@@ -23,6 +29,10 @@ export interface AgentPocOptions {
   host?: string;
   /** Open a cloudflared quick tunnel and log the public URL. */
   tunnel?: boolean;
+  /** Bearer token required on /api/chat. Auto-generated if omitted. */
+  token?: string;
+  /** Max accepted request body size in bytes for /api/chat (default 1 MiB). */
+  maxBodyBytes?: number;
 }
 
 export interface AgentPocHandle {
@@ -30,19 +40,35 @@ export interface AgentPocHandle {
   localUrl: string;
   /** Public tunnel URL, if a tunnel was opened. */
   publicUrl: string | null;
+  /** Bearer token clients must send as `Authorization: Bearer <token>`. */
+  token: string;
   stop(): Promise<void>;
 }
 
 const DEFAULT_PORT = 8765;
 const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024; // 1 MiB
 
-/** Convert a Node IncomingMessage into a Fetch-style Request. */
+class PayloadTooLargeError extends Error {
+  constructor(public readonly limit: number) {
+    super(`Request body exceeds the ${limit}-byte limit`);
+    this.name = "PayloadTooLargeError";
+  }
+}
+
+interface RequestContext {
+  host: string;
+  port: number;
+  token: string;
+  maxBodyBytes: number;
+}
+
+/** Convert a Node IncomingMessage into a Fetch-style Request (body size-capped). */
 async function toFetchRequest(
   req: IncomingMessage,
-  host: string,
-  port: number,
+  ctx: RequestContext,
 ): Promise<Request> {
-  const url = `http://${host}:${port}${req.url ?? "/"}`;
+  const url = `http://${ctx.host}:${ctx.port}${req.url ?? "/"}`;
   const method = req.method ?? "GET";
 
   const headers = new Headers();
@@ -59,8 +85,16 @@ async function toFetchRequest(
   let body: string | undefined;
   if (hasBody) {
     const chunks: Buffer[] = [];
+    let total = 0;
     for await (const chunk of req) {
-      chunks.push(chunk as Buffer);
+      const buf = chunk as Buffer;
+      total += buf.length;
+      // Cap the body while reading so a huge/chunked POST can't exhaust memory
+      // before JSON parsing (the server may be exposed via the tunnel).
+      if (total > ctx.maxBodyBytes) {
+        throw new PayloadTooLargeError(ctx.maxBodyBytes);
+      }
+      chunks.push(buf);
     }
     body = Buffer.concat(chunks).toString("utf-8");
   }
@@ -92,9 +126,23 @@ async function sendFetchResponse(
   }
 }
 
+/** Constant-time `Authorization: Bearer <token>` check. */
+function isAuthorized(req: IncomingMessage, token: string): boolean {
+  const header = req.headers["authorization"];
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return false;
+  const m = /^Bearer\s+(.+)$/i.exec(value.trim());
+  if (!m) return false;
+  const provided = Buffer.from(m[1].trim());
+  const expected = Buffer.from(token);
+  return (
+    provided.length === expected.length && timingSafeEqual(provided, expected)
+  );
+}
+
 /**
  * Start the experimental agent POC HTTP server (and optional tunnel).
- * Returns a handle for shutdown. Callers gate this behind the env flag.
+ * Returns a handle (incl. the bearer token). Callers gate this behind the env flag.
  */
 export async function startAgentPoc(
   options: AgentPocOptions = {},
@@ -105,9 +153,19 @@ export async function startAgentPoc(
   const port =
     options.port ?? (envPort && !Number.isNaN(envPort) ? envPort : DEFAULT_PORT);
   const host = options.host ?? DEFAULT_HOST;
+  const token =
+    options.token ??
+    process.env.COMFYUI_MCP_AGENT_TOKEN ??
+    randomBytes(24).toString("hex");
+  const ctx: RequestContext = {
+    host,
+    port,
+    token,
+    maxBodyBytes: options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+  };
 
   const server = createServer((req, res) => {
-    void handleRequest(req, res, host, port);
+    void handleRequest(req, res, ctx);
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -120,6 +178,9 @@ export async function startAgentPoc(
 
   const localUrl = `http://${host}:${port}`;
   logger.info(`[agent-poc] chat server listening on ${localUrl}/api/chat`);
+  logger.info(
+    `[agent-poc] session token (send as 'Authorization: Bearer <token>'): ${token}`,
+  );
 
   let tunnel: QuickTunnel | null = null;
   if (options.tunnel) {
@@ -135,6 +196,7 @@ export async function startAgentPoc(
   return {
     localUrl,
     publicUrl: tunnel?.url ?? null,
+    token,
     stop: async () => {
       tunnel?.stop();
       await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -145,12 +207,12 @@ export async function startAgentPoc(
 async function handleRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  host: string,
-  port: number,
+  ctx: RequestContext,
 ): Promise<void> {
-  // CORS open: the tunnel is the perimeter (per the design's security model).
+  // CORS: the tunnel + bearer token are the perimeter. `*` is safe here because
+  // requests are non-credentialed and must carry the Authorization header below.
   res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Headers", "*");
+  res.setHeader("Access-Control-Allow-Headers", "authorization, content-type");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
 
   if (req.method === "OPTIONS") {
@@ -159,24 +221,47 @@ async function handleRequest(
     return;
   }
 
+  // Health probe stays open (no secret, no provider spend).
   if (req.method === "GET" && req.url === "/health") {
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ status: "ok" }));
     return;
   }
 
+  // Everything past here requires the bearer token.
+  if (!isAuthorized(req, ctx.token)) {
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "Unauthorized" }));
+    return;
+  }
+
   if (req.method === "POST" && req.url === "/api/chat") {
+    const contentType = req.headers["content-type"] ?? "";
+    if (!contentType.includes("application/json")) {
+      res.writeHead(415, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({ error: "Expected content-type: application/json" }),
+      );
+      return;
+    }
     try {
-      const request = await toFetchRequest(req, host, port);
+      const request = await toFetchRequest(req, ctx);
       const response = await handleChatRequest(request);
       await sendFetchResponse(res, response);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(`[agent-poc] /api/chat error: ${message}`);
-      if (!res.headersSent) {
+      if (res.headersSent) {
+        // Streaming already started — destroy the socket rather than corrupt
+        // the stream protocol by appending a JSON error body to it.
+        res.destroy(err instanceof Error ? err : new Error(message));
+      } else if (err instanceof PayloadTooLargeError) {
+        res.writeHead(413, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: message }));
+      } else {
         res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: message }));
       }
-      res.end(JSON.stringify({ error: message }));
     }
     return;
   }

--- a/src/experimental/chat-handler.ts
+++ b/src/experimental/chat-handler.ts
@@ -1,0 +1,92 @@
+import {
+  convertToModelMessages,
+  stepCountIs,
+  streamText,
+  tool,
+  type LanguageModel,
+  type ToolSet,
+  type UIMessage,
+} from "ai";
+import { z } from "zod";
+
+import { resolveModel } from "./provider-registry.js";
+
+// ---------------------------------------------------------------------------
+// Experimental AI SDK chat handler for the embedded-agent-panel POC.
+//
+// `POST /api/chat` -> streamText({ model, messages, tools }).toUIMessageStreamResponse()
+//
+// Includes ONE server-side tool end-to-end (`generate_image`) which, for the
+// POC, returns a stub result. Wiring the real comfyui-mcp generate tools is a
+// later phase (see design/embedded-agent-panel.md, build order step 5).
+//
+// This module is only reached behind COMFYUI_MCP_AGENT_POC.
+// ---------------------------------------------------------------------------
+
+/**
+ * The single server-side tool for the POC. Has an `execute` so the AI SDK runs
+ * it on the server and feeds the result back into the model automatically.
+ */
+export const tools = {
+  generate_image: tool({
+    description:
+      "Generate an image from a text prompt using ComfyUI. (POC stub — returns a placeholder result instead of running a real workflow.)",
+    inputSchema: z.object({
+      prompt: z.string().describe("The text prompt to generate an image from."),
+      width: z.number().int().positive().optional().describe("Image width in pixels."),
+      height: z.number().int().positive().optional().describe("Image height in pixels."),
+    }),
+    execute: async ({ prompt, width, height }) => {
+      // POC stub: real implementation will enqueue a ComfyUI workflow and
+      // return the resulting asset id / image URL.
+      return {
+        status: "stubbed",
+        prompt,
+        width: width ?? 1024,
+        height: height ?? 1024,
+        imageUrl: "https://example.invalid/poc-placeholder.png",
+        note: "Placeholder result from the POC. No real workflow was executed.",
+      };
+    },
+  }),
+} satisfies ToolSet;
+
+export interface ChatHandlerOptions {
+  /** Override the model (mainly for tests). Defaults to the provider registry. */
+  model?: LanguageModel;
+  /** Optional `provider:model` id forwarded to the registry. */
+  modelId?: string;
+  /** System prompt for the agent. */
+  system?: string;
+}
+
+const DEFAULT_SYSTEM =
+  "You are an assistant embedded in ComfyUI. You can generate images with the generate_image tool.";
+
+/**
+ * Handle a chat request. Accepts a Fetch-style `Request` whose JSON body is
+ * `{ messages: UIMessage[], model?: string }` and returns a streaming
+ * `Response` (UI message stream protocol).
+ */
+export async function handleChatRequest(
+  req: Request,
+  options: ChatHandlerOptions = {},
+): Promise<Response> {
+  const body = (await req.json()) as {
+    messages?: UIMessage[];
+    model?: string;
+  };
+  const messages = body.messages ?? [];
+
+  const model = options.model ?? resolveModel(options.modelId ?? body.model);
+
+  const result = streamText({
+    model,
+    system: options.system ?? DEFAULT_SYSTEM,
+    messages: await convertToModelMessages(messages),
+    tools,
+    stopWhen: stepCountIs(5),
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/src/experimental/provider-registry.ts
+++ b/src/experimental/provider-registry.ts
@@ -34,7 +34,32 @@ const DEFAULT_MODEL = "anthropic:claude-sonnet-4-5";
 // parameter type to the registry's loose template-literal overload.
 type RegistryModelId = Parameters<typeof registry.languageModel>[0];
 
+/**
+ * The set of model ids a request is allowed to select: the server default
+ * (COMFYUI_MCP_AGENT_MODEL or DEFAULT_MODEL) plus any explicitly allow-listed
+ * via COMFYUI_MCP_AGENT_ALLOWED_MODELS (comma-separated `provider:model`).
+ */
+function allowedModels(): Set<string> {
+  const set = new Set<string>([DEFAULT_MODEL]);
+  const envDefault = process.env.COMFYUI_MCP_AGENT_MODEL?.trim();
+  if (envDefault) set.add(envDefault);
+  const extra = process.env.COMFYUI_MCP_AGENT_ALLOWED_MODELS;
+  if (extra) {
+    for (const m of extra.split(",")) {
+      const t = m.trim();
+      if (t) set.add(t);
+    }
+  }
+  return set;
+}
+
 export function resolveModel(id?: string): LanguageModel {
-  const modelId = id ?? process.env.COMFYUI_MCP_AGENT_MODEL ?? DEFAULT_MODEL;
+  const fallback = process.env.COMFYUI_MCP_AGENT_MODEL?.trim() || DEFAULT_MODEL;
+  // Only honour a client-supplied model id if it is explicitly allow-listed.
+  // Otherwise ignore it and use the server default — this stops a leaked tunnel
+  // URL from letting a caller select arbitrary (expensive) models on your keys.
+  const requested = id?.trim();
+  const modelId =
+    requested && allowedModels().has(requested) ? requested : fallback;
   return registry.languageModel(modelId as RegistryModelId);
 }

--- a/src/experimental/provider-registry.ts
+++ b/src/experimental/provider-registry.ts
@@ -1,0 +1,40 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+import { createProviderRegistry } from "ai";
+import type { LanguageModel } from "ai";
+
+// ---------------------------------------------------------------------------
+// Provider registry for the experimental embedded-agent-panel POC.
+//
+// Picks the language model per request from a single registry, keyed by a
+// `provider:model` string (the AI SDK default separator). Default is Anthropic
+// with the model from COMFYUI_MCP_AGENT_MODEL. Provider API keys are read from
+// the usual env vars by each provider package (ANTHROPIC_API_KEY, etc.).
+//
+// Not part of the default MCP server — only used behind COMFYUI_MCP_AGENT_POC.
+// ---------------------------------------------------------------------------
+
+export const registry = createProviderRegistry({
+  anthropic,
+  openai,
+  google,
+});
+
+const DEFAULT_MODEL = "anthropic:claude-sonnet-4-5";
+
+/**
+ * Resolve the language model for a request.
+ *
+ * @param id Optional `provider:model` id (e.g. "anthropic:claude-sonnet-4-5").
+ *   Falls back to COMFYUI_MCP_AGENT_MODEL, then a sensible default.
+ */
+// The registry's languageModel() is typed against a strict union of known
+// model ids. We accept any `provider:model` string at runtime, so widen the
+// parameter type to the registry's loose template-literal overload.
+type RegistryModelId = Parameters<typeof registry.languageModel>[0];
+
+export function resolveModel(id?: string): LanguageModel {
+  const modelId = id ?? process.env.COMFYUI_MCP_AGENT_MODEL ?? DEFAULT_MODEL;
+  return registry.languageModel(modelId as RegistryModelId);
+}

--- a/src/experimental/run.ts
+++ b/src/experimental/run.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { logger } from "../utils/logger.js";
+import { maybeStartAgentPoc } from "./agent-poc.js";
+
+// ---------------------------------------------------------------------------
+// Standalone runner for the experimental embedded-agent-panel POC.
+//
+// This is intentionally NOT imported by src/index.ts — the default MCP server
+// (stdio / HTTP) never touches the POC. Run it explicitly, e.g.:
+//
+//   COMFYUI_MCP_AGENT_POC=1 ANTHROPIC_API_KEY=... npx tsx src/experimental/run.ts
+//   COMFYUI_MCP_AGENT_POC=1 COMFYUI_MCP_AGENT_TUNNEL=1 ... node dist/experimental/run.js
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const handle = await maybeStartAgentPoc();
+  if (!handle) {
+    logger.warn(
+      "[agent-poc] COMFYUI_MCP_AGENT_POC is not set — nothing to run. Set it to 1 to start the POC.",
+    );
+    return;
+  }
+
+  logger.info(`[agent-poc] ready at ${handle.localUrl}/api/chat`);
+  if (handle.publicUrl) {
+    logger.info(`[agent-poc] public URL: ${handle.publicUrl}`);
+  }
+
+  const shutdown = (): void => {
+    logger.info("[agent-poc] shutting down...");
+    void handle.stop().then(() => process.exit(0));
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((err) => {
+  logger.error("[agent-poc] fatal error", err);
+  process.exit(1);
+});

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -104,18 +104,29 @@ export async function startQuickTunnel(port: number): Promise<QuickTunnel> {
   return await new Promise<QuickTunnel>((resolve, reject) => {
     let settled = false;
 
+    // Detach all listeners so nothing leaks once we've settled the promise
+    // (especially on the pre-ready failure paths, where the caller never gets
+    // a handle to call stop()).
+    const teardownListeners = (): void => {
+      t.off("url", onUrl);
+      t.off("stderr", onStderr);
+      t.off("error", onError);
+      t.off("exit", onExit);
+    };
+
     const stop = (): void => {
       try {
         t.stop();
       } catch {
         // Process already gone — fine.
       }
+      teardownListeners();
       state.status = "stopped";
       state.url = null;
       state.error = null;
     };
 
-    t.on("url", (url) => {
+    function onUrl(url: string): void {
       logger.info(`[tunnel] URL: ${url}`);
       state.status = "running";
       state.url = url;
@@ -129,15 +140,15 @@ export async function startQuickTunnel(port: number): Promise<QuickTunnel> {
           stop,
         });
       }
-    });
+    }
 
-    t.on("stderr", (data) => {
+    function onStderr(data: string): void {
       for (const line of data.split("\n")) {
         if (line.trim()) logger.info(`[tunnel] ${line}`);
       }
-    });
+    }
 
-    t.on("error", (err) => {
+    function onError(err: Error): void {
       const message = err.message;
       logger.error(`[tunnel] error: ${message}`);
       state.status = "error";
@@ -146,11 +157,19 @@ export async function startQuickTunnel(port: number): Promise<QuickTunnel> {
 
       if (!settled) {
         settled = true;
+        // Pre-ready failure: stop the process and detach listeners so a
+        // cloudflared that errors without exiting can't leak.
+        try {
+          t.stop();
+        } catch {
+          // Already gone — fine.
+        }
+        teardownListeners();
         reject(err);
       }
-    });
+    }
 
-    t.on("exit", (code, signal) => {
+    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
       logger.warn(`[tunnel] exited code=${code} signal=${signal}`);
 
       // An exit before the `url` event means the tunnel never came up.
@@ -159,11 +178,17 @@ export async function startQuickTunnel(port: number): Promise<QuickTunnel> {
         state.status = "error";
         state.url = null;
         state.error = `cloudflared exited before tunnel was ready (code=${code})`;
+        teardownListeners();
         reject(new Error(state.error));
       } else if (state.status !== "stopped") {
         state.status = "stopped";
         state.url = null;
       }
-    });
+    }
+
+    t.on("url", onUrl);
+    t.on("stderr", onStderr);
+    t.on("error", onError);
+    t.on("exit", onExit);
   });
 }

--- a/src/services/tunnel.ts
+++ b/src/services/tunnel.ts
@@ -1,0 +1,169 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { bin, install, use, Tunnel } from "cloudflared";
+
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// Cloudflared quick-tunnel helper.
+//
+// The binary-ensure + `Tunnel.quick(...)` mechanic is adapted (nearly verbatim)
+// from the MIT-licensed Ungate project's tunnel-manager:
+//   https://github.com/orchidfiles/ungate
+//   apps/extension/src/tunnel-manager.ts
+//
+// This is part of the experimental embedded-agent-panel POC (see
+// design/embedded-agent-panel.md). It is NOT wired into the default MCP
+// stdio/HTTP startup path — it is only reached behind the
+// COMFYUI_MCP_AGENT_POC flag via src/experimental/agent-poc.ts.
+// ---------------------------------------------------------------------------
+
+// Where we cache a downloaded cloudflared binary when the bundled `bin` is
+// missing (mirrors Ungate's `~/.ungate/bin` location).
+const CLOUDFLARED_BIN_DIR = path.join(os.homedir(), ".comfyui-mcp", "bin");
+
+function getCloudflaredBinPath(): string {
+  return path.join(
+    CLOUDFLARED_BIN_DIR,
+    process.platform === "win32" ? "cloudflared.exe" : "cloudflared",
+  );
+}
+
+// Quick tunnels do not use a config file. Pointing --config at the platform
+// null device prevents cloudflared from picking up an ambient config.
+function getCloudflaredConfigArg(): string {
+  return process.platform === "win32" ? "NUL" : "/dev/null";
+}
+
+export type TunnelStatus =
+  | "stopped"
+  | "starting"
+  | "installing"
+  | "running"
+  | "error";
+
+export interface TunnelState {
+  status: TunnelStatus;
+  url: string | null;
+  error: string | null;
+}
+
+export interface QuickTunnel {
+  /** Public https://<rand>.trycloudflare.com URL. */
+  url: string;
+  /** Reactive view of the tunnel lifecycle state. */
+  getState(): TunnelState;
+  /** Tear the tunnel down. Idempotent. */
+  stop(): void;
+}
+
+/**
+ * Ensure a cloudflared binary is available for the `cloudflared` package to
+ * spawn. If the bundled `bin` exists we use it as-is; otherwise we reuse a
+ * previously-downloaded binary in CLOUDFLARED_BIN_DIR, or download one.
+ *
+ * Ported from Ungate's `ensureBinary` (simplified — no legacy-path rename).
+ */
+async function ensureBinary(): Promise<void> {
+  if (fs.existsSync(bin)) {
+    return;
+  }
+
+  const userBinPath = getCloudflaredBinPath();
+  if (fs.existsSync(userBinPath)) {
+    use(userBinPath);
+    return;
+  }
+
+  logger.info("[tunnel] Downloading cloudflared binary...");
+  fs.mkdirSync(CLOUDFLARED_BIN_DIR, { recursive: true });
+  const installedPath = await install(userBinPath);
+  use(installedPath);
+  logger.info("[tunnel] cloudflared installed successfully");
+}
+
+/**
+ * Start a Cloudflare quick tunnel that exposes http://localhost:<port> on a
+ * public HTTPS URL. Resolves once the `url` event fires; rejects if the
+ * cloudflared process errors or exits before becoming ready.
+ *
+ * @param port Local port to expose (e.g. the POC chat server's port).
+ */
+export async function startQuickTunnel(port: number): Promise<QuickTunnel> {
+  const state: TunnelState = { status: "starting", url: null, error: null };
+
+  await ensureBinary();
+
+  const t = Tunnel.quick(`http://localhost:${port}`, {
+    "--config": getCloudflaredConfigArg(),
+    "--edge-ip-version": "4",
+  });
+
+  return await new Promise<QuickTunnel>((resolve, reject) => {
+    let settled = false;
+
+    const stop = (): void => {
+      try {
+        t.stop();
+      } catch {
+        // Process already gone — fine.
+      }
+      state.status = "stopped";
+      state.url = null;
+      state.error = null;
+    };
+
+    t.on("url", (url) => {
+      logger.info(`[tunnel] URL: ${url}`);
+      state.status = "running";
+      state.url = url;
+      state.error = null;
+
+      if (!settled) {
+        settled = true;
+        resolve({
+          url,
+          getState: () => ({ ...state }),
+          stop,
+        });
+      }
+    });
+
+    t.on("stderr", (data) => {
+      for (const line of data.split("\n")) {
+        if (line.trim()) logger.info(`[tunnel] ${line}`);
+      }
+    });
+
+    t.on("error", (err) => {
+      const message = err.message;
+      logger.error(`[tunnel] error: ${message}`);
+      state.status = "error";
+      state.url = null;
+      state.error = message;
+
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    t.on("exit", (code, signal) => {
+      logger.warn(`[tunnel] exited code=${code} signal=${signal}`);
+
+      // An exit before the `url` event means the tunnel never came up.
+      if (!settled) {
+        settled = true;
+        state.status = "error";
+        state.url = null;
+        state.error = `cloudflared exited before tunnel was ready (code=${code})`;
+        reject(new Error(state.error));
+      } else if (state.status !== "stopped") {
+        state.status = "stopped";
+        state.url = null;
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Proof-of-concept backend for the **embedded agent panel** (`design/embedded-agent-panel.md`): a cloudflared quick-tunnel helper plus a Vercel AI SDK chat endpoint. This is the v1 of build-order steps 1–2 in the design doc.

**Everything is gated behind `COMFYUI_MCP_AGENT_POC` and lives in isolated modules.** The default MCP stdio/HTTP startup (`src/index.ts`) is untouched — the POC never runs during normal startup or tests.

## Deliverables

- **`src/services/tunnel.ts`** — `startQuickTunnel(port)` using the [`cloudflared`](https://www.npmjs.com/package/cloudflared) npm package: ensures the binary (`bin`/`install`/`use`), then `Tunnel.quick(http://localhost:${port}, { '--config': null-device, '--edge-ip-version': '4' })`, resolving on the `url` event and rejecting on early `error`/`exit`. Tracks a small lifecycle state. Tunnel mechanic adapted (nearly verbatim) from the **MIT-licensed [Ungate](https://github.com/orchidfiles/ungate)** project's `tunnel-manager.ts` (attributed in-file).
- **`src/experimental/chat-handler.ts`** — `POST /api/chat` calling `streamText({ model, messages, tools, stopWhen }).toUIMessageStreamResponse()`, with **one server-side tool** end-to-end (`generate_image`, a POC stub). Wiring real comfyui-mcp tools is a later phase.
- **`src/experimental/provider-registry.ts`** — `createProviderRegistry` over `@ai-sdk/anthropic` (default), `@ai-sdk/openai`, `@ai-sdk/google`; model id from `COMFYUI_MCP_AGENT_MODEL`.
- **`src/experimental/agent-poc.ts` + `run.ts`** — env-gated tiny Node HTTP server hosting `/api/chat` + `/health`, optionally opening a quick tunnel and logging the public URL. CORS open (tunnel is the perimeter, per the design). Run with `npm run dev:agent-poc` (requires `COMFYUI_MCP_AGENT_POC=1`).

The current AI SDK API (`streamText`, `tool`, `convertToModelMessages` (now async), `toUIMessageStreamResponse`, `UIMessage`, `createProviderRegistry`) was verified against the installed **AI SDK v6** docs via Context7 before writing.

## New dependencies

`cloudflared`, `ai`, `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`. Expected for this POC PR; please review before merge.

## Verification

- `npm run build` — zero TS errors (the gate). ✅
- `npm test` — 1225 tests pass (incl. new ones). ✅
- New tests use **no real network**:
  - `tunnel.test.ts` mocks the `cloudflared` package (no binary install/spawn) and asserts `Tunnel.quick` is wired with the right local URL/args and resolves on `url`, plus `error`/`exit`/`stop` paths.
  - `chat-handler.test.ts` mocks the model via `ai/test`'s `MockLanguageModelV3` and asserts the streamed UI-message `Response`.
- A code-review pass surfaced one robustness finding (streaming errors after headers sent); fixed by awaiting `stream/promises` `pipeline` in the Node response bridge.

**Live tunnel + live-model verification is deferred to the maintainer** (requires real cloudflared egress and provider API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)