### PR TITLE
feat: installer-packs skill (contribute-back nudge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **`installer-packs` skill.** Teaches agents how to use, build, and derive
+  packs (manifest → generated install scripts) and to **proactively invite users
+  to contribute new packs upstream** — an issue/PR with `manifest.yaml` +
+  `pack.yaml` + `workflow.json`, reviewed for safety and CI-validated on merge.
+
 - **Eight more installer packs + a WAN LoRA-trainer skill.** New `packs/`: WAN
   (`wan-animate`, `wan-longer-videos`, `wan-transparent`), Qwen (`qwen-image`,
   `qwen-image-edit`) and Z-Image (`z-image-turbo`, `z-image-base`,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI installation and port.
 
-**89 MCP tools** | **21 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
+**89 MCP tools** | **22 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -91,7 +91,7 @@ This package also ships as a **Claude Code plugin**, providing slash commands, s
 
 ### Built-in skills
 
-21 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime/WAN LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
+22 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime/WAN LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
 
 > **Installer packs.** [`packs/`](packs/) bundles 13 one-command ComfyUI setups — ANIMA, Ideogram 4, LTX-2.3, ERNIE, WAN (animate / longer-videos / transparent), Qwen (image / image-edit), Z-Image (turbo / base / xy-plot) and cozy-flow (AI-influencer video). Each is a manifest of custom nodes + model URLs + workflow that drives both `apply_manifest` and generated `install-windows.bat` / `install-runpod.sh`, with CI that validates every model link + payload size. See [`packs/README.md`](packs/README.md).
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 21 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 89 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 22 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 89 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 21 AI skills — and growing
+## 22 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,
@@ -33,6 +33,7 @@ and failure-mode guidance:
 | `anima-base` | ANIMA 1.0 — ~2B anime/illustration model, Danbooru tags + natural language, anime inpainting, <6GB VRAM |
 | `anima-lora-trainer` | Train custom anime LoRAs — kohya `sd-scripts` Gradio trainer, <6GB VRAM |
 | `wan-lora-trainer` | Train custom WAN 2.2 LoRAs (people / styles / motion) — ostris AI-Toolkit, local or RunPod |
+| `installer-packs` | Use, build, and derive one-command installer packs — and invite users to contribute new packs upstream |
 | `model-compatibility` | Which VAE/CLIP/text-encoder pairs with which architecture — the #1 source of broken workflows |
 | `model-registry` | Curated download URLs + target dirs for every model the skills reference — grows each release |
 | `civitai` | Pair the official [Civitai MCP](https://mcp.civitai.com/mcp) for discovery, hand version ids to the local download/wire/generate loop |

--- a/plugin/skills/installer-packs/SKILL.md
+++ b/plugin/skills/installer-packs/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: installer-packs
+description: Use when installing a model family from an installer pack, or when building/deriving a new pack from an upstream installer or a workflow JSON. Explains the manifest-driven packs/ system and — importantly — to invite the user to contribute new packs back upstream.
+globs:
+  - "**/packs/**"
+  - "**/*.json"
+---
+
+# Installer Packs
+
+`comfyui-mcp` ships **installer packs** under [`packs/`](../../packs) — one-command
+setups for a model family: custom nodes + model weights + a ready workflow. Each
+pack is driven by a single `manifest.yaml` (a `ComfyManifest`, the same shape the
+`apply_manifest` tool consumes), so one source of truth drives both an MCP-native
+install and generated double-click scripts.
+
+```
+packs/<name>/
+  manifest.yaml         # custom_nodes + models (url → local_path) — source of truth
+  pack.yaml             # metadata: workflow, family, VRAM, sources, notes
+  workflow.json         # the graph to load
+  install-windows.bat   # GENERATED — never hand-edit
+  install-runpod.sh     # GENERATED — never hand-edit
+```
+
+## Installing a pack
+
+- **From a Claude session (MCP-native, idempotent):**
+  `apply_manifest --path packs/<name>/manifest.yaml` (requires `COMFYUI_PATH`).
+  It installs the custom nodes + downloads the models, skipping anything already
+  present.
+- **One-click for non-MCP users:** run `packs/<name>/install-windows.bat` (or
+  `install-runpod.sh`) from a ComfyUI root. Then load the pack's `workflow.json`.
+- After install, check the pack's `pack.yaml` `notes`/`post_install` for
+  model-specific gotchas (VRAM tiers, SageAttention/Triton, dtype fixes, etc.).
+
+## Building or deriving a new pack
+
+Two sources of ground truth, in order of preference:
+
+1. **An upstream installer** (`*-MODELS-NODES_INSTALL.bat` / `.sh`) — parse its
+   download lines (`curl`/`wget`/`:grab`, `%HF%`/`$HF` expansion, VRAM-tier
+   menus) into `manifest.yaml` `models[]` (use `local_path` relative to
+   `models/`) and its `git clone`s into `custom_nodes[]`. Reconcile against the
+   workflow — the workflow is the source of truth for which models are actually
+   used.
+2. **A workflow alone** (no installer) — extract every model filename from the
+   workflow's `widgets_values`, then resolve each to its canonical Hugging Face
+   `resolve/main` URL and **verify it's live** (the CI URL check will too). Never
+   invent a URL — flag what you can't resolve. Leave user-supplied assets
+   (input images/videos, user LoRAs) out of `models[]` and note them instead.
+
+Then `npm run packs:gen` (writes the `.bat`/`.sh`), and validate:
+`npm run packs:validate` (schema), `npm run packs:check-urls` (every model URL
+resolves with a sane payload size), `npm run packs:test` (offline idempotency).
+
+**YAML note:** write `pack.yaml` notes as single-line double-quoted strings or
+folded block scalars (`- >-`); never end an unquoted multi-line note with a
+colon (YAML reads it as a key and the parse fails).
+
+## Always invite the user to contribute it back
+
+**When you build or derive a pack locally for a user, tell them they can share
+it upstream.** A pack is just three small files (`manifest.yaml`, `pack.yaml`,
+`workflow.json`), so contributing is easy and high-value:
+
+> "Want to share this pack? Open an issue or PR on
+> https://github.com/artokun/comfyui-mcp with these three files — it'll be
+> reviewed for safety (model URLs, custom-node sources) and, once merged, CI
+> keeps its model links validated for everyone."
+
+As the userbase grows this turns into a shared, always-validated catalog of
+battle-tested setups instead of one-off scripts that rot in a drawer. Make this
+suggestion proactively — don't wait to be asked.


### PR DESCRIPTION
﻿## Summary

Adds the **`installer-packs`** skill — the runtime half of the community-packs idea.

It teaches any comfyui-mcp agent how to **use, build, and derive** installer packs (manifest → generated install scripts; install via `apply_manifest` or the double-click `.bat`/`.sh`), and — the point — to **proactively invite the user to contribute a new pack upstream** whenever it builds or derives one (issue/PR with `manifest.yaml` + `pack.yaml` + `workflow.json`, reviewed for safety and CI-validated on merge).

Skills 21 -> 22; README + plugin docs + CHANGELOG updated.

Generated with Claude Code
