### PR TITLE
fix(docs): register installer-packs blog in nav (fixes 500)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "ComfyUI MCP",
-  "description": "Claude Code plugin + MCP server for ComfyUI - 88 tools, 14 AI skills, live graph editing from your Claude session. Generate images and video, manage models and custom nodes.",
+  "description": "Claude Code plugin + MCP server for ComfyUI - 89 tools, 22 AI skills, 13 installer packs, live graph editing from your Claude session. Generate images and video, manage models and custom nodes.",
   "colors": {
     "primary": "#2563EB",
     "light": "#60A5FA",
@@ -86,6 +86,7 @@
             "group": "Blog",
             "pages": [
               "blog/index",
+              "blog/installer-packs-that-cant-rot",
               "blog/the-channel-that-talks-back",
               "blog/comfyui-mcp-tdqs-case-study"
             ]


### PR DESCRIPTION
﻿Fixes a 500 on /blog/installer-packs-that-cant-rot: the page existed but was never added to docs.json navigation, which Mintlify requires. Also refreshes the stale site description (89 tools / 22 skills / 13 packs).
