### PR TITLE
docs(blog): model-highlight series (8 posts)

### DIFF
--- a/docs/blog/anima-comfyui.mdx
+++ b/docs/blog/anima-comfyui.mdx
@@ -1,0 +1,332 @@
+---
+title: "ANIMA 1.0: The Tiny Anime Model for ComfyUI (Under 6 GB)"
+description: "ANIMA 1.0 is a ~2B anime text-to-image model for ComfyUI. Danbooru tags + natural language, anime inpainting, and LoRA training — all under 6 GB VRAM."
+keywords:
+  - ANIMA anime model ComfyUI
+  - anime text to image local
+  - low VRAM anime AI
+  - ANIMA LoRA training
+  - Danbooru tag anime model
+  - anime inpainting ComfyUI
+  - Cosmos-Predict2 anime
+  - ANIMA vs Illustrious
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · anima · anime · ComfyUI · model highlight_
+
+Every "best anime model" list in 2026 assumes you've got a 12-to-16 GB card and
+patience for a 6.5 GB SDXL checkpoint. **ANIMA 1.0** quietly ignores that
+assumption. It's a **~2B-parameter** anime/illustration model that **generates —
+and trains LoRAs — under 6 GB of VRAM**, takes **Danbooru tags *and* plain
+English** in the same prompt, and ships with a real **anime inpainting**
+workflow. It's the tiny-but-mighty entry in our model-highlight series: not the
+biggest, but arguably the best anime-quality-per-gigabyte you can run locally.
+
+Below: what ANIMA actually is (and the architecture surprise under the hood), the
+inpainting and ControlNet workflow, how to **train your own anime LoRA** on a
+6 GB card, how it stacks up against the SDXL-lineage giants, and the fastest path
+to running it — a one-command install with
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
+[sidebar Panel](/panel), instead of hand-downloading a dozen files into five
+folders.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the `anima` pack
+> (`apply_manifest --path packs/anima/manifest.yaml`, or run the generated
+> installer from your ComfyUI root), and drive the graph from your own Claude
+> session via the Panel. Jump to [Install](#install-anima-in-comfyui).
+
+## What is ANIMA 1.0?
+
+ANIMA is a **~2B-parameter anime and illustration text-to-image model** from
+**CircleStone Labs** (built in collaboration with Comfy Org). Here's the part
+that makes it different from every other anime model you've used: it is **not**
+SDXL-lineage. ANIMA is a fine-tune of **NVIDIA's Cosmos-Predict2-2B-Text2Image**
+— a **DiT / flow-matching** architecture — paired with a **Qwen3-0.6B** text
+encoder and the **Qwen-Image VAE**. Per the model card, it was trained on
+"several million anime images and about 800k non-anime artistic images," with
+**no synthetic data** and a stated anime knowledge cutoff of September 2025.
+
+The pitch is "tiny but mighty": a modern transformer image model small enough to
+run anywhere SDXL or Illustrious runs, tuned specifically for **anime, manga, and
+illustrated characters and styles**. It is honestly *not* a realism model — the
+authors say so plainly, and so do we.
+
+**It speaks two prompt languages at once.** ANIMA's standout feature is that it
+accepts **Danbooru-style tags AND natural-language sentences in the same
+prompt** — you can write `1girl, solo, silver hair, neon city` and then add
+"standing in the rain, cinematic lighting, medium close-up" right after it. That
+flexibility comes from the Qwen text encoder, and it's the thing tag-only
+SDXL models can't really do.
+
+**The honest caveats.** ANIMA is young. Community reviewers have noted that the
+base model's default output can look flat without aesthetic LoRAs, that very
+obscure or very recent artists may be under-represented, and that pose control is
+strongest for poses that exist as Danbooru tags. The bundled aesthetic LoRAs and
+the ControlNet stack exist precisely to address the first two. If you want
+maximum out-of-the-box polish on a big GPU, an Illustrious/NoobAI/Animagine
+fine-tune may still edge it — see [the comparison below](#anima-vs-the-sdxl-anime-giants).
+
+> **License — read this before commercial work.** The **weights** ship under the
+> **CircleStone Labs Non-Commercial License** (with NVIDIA Open Model License
+> terms on derivatives) — you can't host them in a paid generation service or
+> embed them in a monetized product without a separate commercial license. But
+> per the current model card, the **images you generate are usable
+> commercially** — you can sell prints, take commissions, and use outputs as
+> game/VN assets. That's an unusual and generous split. Licenses change; verify
+> the current text on the [model card](https://huggingface.co/circlestone-labs/Anima)
+> before relying on it.
+
+## Install ANIMA in ComfyUI
+
+ANIMA loads with **standard split-file loaders** — not a single checkpoint. You
+need a diffusion model, a text encoder, and a VAE in three different folders, plus
+the ControlNet, LoRAs, and detailer models if you want the full kit:
+
+| File | Folder |
+|------|--------|
+| `anima-base-v1.0.safetensors` (DiT, ~4 GB) | `models/diffusion_models/` |
+| `qwen_3_06b_base.safetensors` (text encoder) | `models/text_encoders/` |
+| `qwen_image_vae.safetensors` (VAE, ~254 MB) | `models/vae/` |
+| `anima-lllite-*.safetensors` (inpaint / depth / lineart / pose) | `models/controlnet/` |
+| `anima-turbo-lora-v0.1.safetensors` + aesthetic LoRAs | `models/loras/` |
+
+The official weights live on the [CircleStone Labs HF repo](https://huggingface.co/circlestone-labs/Anima);
+the pack pulls from a CI-validated mirror.
+
+### The fast way — comfyui-mcp + the Panel
+
+Wiring three loaders by hand and chasing a dozen files into five folders is
+exactly the busywork the [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+**`anima` pack** removes. One declarative manifest installs the custom nodes
+(including the `ComfyUI-Anima-LLLite` inpainting node) and pulls every model to
+the correct folder — and the same manifest drives both an MCP-native install and
+a generated double-click installer:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/anima/manifest.yaml
+```
+
+Run the generated installer from your **ComfyUI root** (the folder containing
+`custom_nodes/` and `models/`), restart ComfyUI, and load
+`packs/anima/workflow.json`. Because the pack ships with the [plugin](/plugin),
+your **own Claude session can drive the live graph through the
+[Panel](/panel)** — add/wire nodes, set widgets, swap LoRAs, and iterate on
+prompts conversationally, with full undo and no API keys. Every model URL in the
+pack is CI-validated for reachability and size, so a link never quietly rots
+([here's why that matters](/blog/installer-packs-that-cant-rot)).
+
+## Anime inpainting (the Anima-LLLite workflow)
+
+ANIMA's inpainting isn't a bolt-on — it's a dedicated **Anima-LLLite ControlNet**.
+LLLite ("LoRA-Lite") patches the **MODEL** directly rather than feeding standard
+ControlNet conditioning, so the pack uses a special `AnimaLLLiteApply` node from
+`ComfyUI-Anima-LLLite` (kohya-ss). The inpaint flow is clean:
+
+1. Load an image and paint a mask over the region you want to redraw.
+2. `VAEEncode` the source image, then `SetLatentNoiseMask` with the mask.
+3. Patch the model with `anima-lllite-inpainting-v1.safetensors` via
+   `AnimaLLLiteApply`, fed the same image + mask.
+4. Sample. The masked area is regenerated from your prompt while everything
+   outside it is preserved.
+
+The same `AnimaLLLiteApply` node powers ANIMA's other control modes — just swap
+the `lllite_name` and feed a preprocessed control image:
+
+| LLLite | Control source |
+|--------|----------------|
+| `anima-lllite-pose-1` | OpenPose (`DWPreprocessor`) |
+| `anima-lllite-depth-1` | Depth (`DepthAnythingV2Preprocessor`) |
+| `anima-lllite-lineart-1` | Lineart |
+| `anima-lllite-inpainting-v1` | Painted mask |
+
+> **Gotcha:** `AnimaLLLiteApply` is **not** a standard ControlNet node. If it's
+> missing, install `ComfyUI-Anima-LLLite` (the pack does this for you).
+
+## Train your own anime LoRA (under 6 GB)
+
+This is where ANIMA's small size pays off twice. Because the model is ~2B params,
+you can **train a character or style LoRA on the same ~6 GB card you generate
+with** — no rented A100 required. The comfyui-mcp **`anima-lora-trainer` skill**
+walks through Citron's local **Gradio** trainer, which drives
+**kohya-ss/sd-scripts** under the hood with an Anima-specific network module.
+
+The short version:
+
+- **Dataset:** a flat folder of images, each with a matching `.txt` caption of
+  the same basename. Caption in the same Danbooru-tags-plus-natural-language
+  style you'll prompt with.
+- **Defaults that fit 6 GB:** `network_dim 32`, resolution `768`, batch `1`,
+  `AdamW8bit`, gradient checkpointing + latent/text-encoder caching, `bf16`
+  (`fp16` on older GPUs). OOM? Drop to `network_dim 8` and/or `resolution 512`.
+- **Output:** a standard `.safetensors` LoRA. Drop it into `models/loras/`, load
+  it with `LoraLoaderModelOnly` or rgthree's Power Lora Loader, and stack it with
+  the turbo LoRA for fast 12-step generation.
+
+A GTX 1060 6 GB can train (slowly); pre-Pascal GPUs are unsupported. Full
+parameters, the `accelerate launch` command, and dataset rules are in the
+`anima-lora-trainer` skill.
+
+## ANIMA vs the SDXL anime giants
+
+There's no single "best" anime model in 2026 — the community consensus is
+division of labor. Here's where ANIMA fits:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **ANIMA 1.0** | **Lowest VRAM** (under 6 GB), **natural language + tags together**, **local LoRA training on the same card**, a modern DiT base, generous output license |
+| **Illustrious / WAI** | A polished daily driver with a massive community LoRA ecosystem |
+| **NoobAI-XL** | The widest character/artist/concept coverage (Danbooru + e621, ~13M images) |
+| **Animagine XL 4.0** | Maximum out-of-the-box detail and character consistency on a bigger card |
+
+The SDXL-lineage models are larger, more mature, and have years of community
+fine-tunes behind them — if you have the VRAM and want plug-and-play polish,
+they're strong. ANIMA's argument is different: it's a **dedicated anime model
+that's small enough to run and *train* on hardware those models strain**, with a
+text encoder that understands sentences. If your bottleneck is a 6–8 GB card, or
+you want to fine-tune without renting a GPU, ANIMA is the easy call.
+
+For non-anime work, this series covers the other specialists: the open-weight
+text-and-layout champion in [our Ideogram 4 post](/blog/ideogram-4-comfyui), and
+the speed/low-VRAM generalist in [our Z-Image post](/blog/z-image-comfyui).
+
+## System & VRAM requirements
+
+ANIMA's whole selling point is that it's light:
+
+| Component | Size | Note |
+|-----------|------|------|
+| DiT (`anima-base-v1.0`) | ~4 GB fp | The model itself |
+| Text encoder (Qwen3-0.6B) | ~1.2 GB | Small |
+| VAE (Qwen-Image) | ~254 MB | Tiny |
+| **Generation** | **under 6 GB VRAM** | Runs anywhere SDXL/Illustrious runs |
+| **LoRA training** | **~6 GB VRAM** | Same low-VRAM profile |
+
+A community **GGUF** quant (`Abiray/Anima-base-v1.0-GGUF`) exists for even lower
+memory, but it needs a GGUF loader node and is **not** included in this pack —
+*unverified against this workflow*.
+
+## Settings that matter
+
+ANIMA has two distinct modes, and they want **different** settings:
+
+| Mode | Steps | CFG | Sampler | Scheduler | Denoise |
+|------|-------|-----|---------|-----------|---------|
+| **Turbo LoRA** (shipped default) | **12** | **1.0** | `er_sde` | `simple` | 1.0 |
+| **Base** (max quality) | **30–50** | **4–5** | `er_sde` | `simple` | 1.0 |
+| Upscale pass (UltimateSDUpscale) | 12 | 1.0 | `er_sde` | `simple` | 0.28 |
+
+The pack's default enables `anima-turbo-lora-v0.1` for fast 12-step previews. For
+maximum quality, drop the turbo LoRA, switch to 30–50 steps at CFG 4–5, and
+optionally enable the three bundled aesthetic LoRAs (`anima-highres-aesthetic-boost`,
+`anima-preview-3-masterpieces-v5`, `anima_p3_rdbt_v0.29.b.122`).
+
+**Sampler character (from the model card):** `er_sde` gives neutral style, flat
+colors, sharp lines; `euler_ancestral` softens/thins lines;
+`dpmpp_2m_sde_gpu` adds variety. A `beta57` scheduler (via RES4LYF) leans
+painterly.
+
+**Use a recommended resolution** to avoid distortion: 1024x1024 (1:1),
+896x1152 (3:4), 832x1216 (5:8), 768x1344 (9:16), or 640x1536 (9:21).
+
+## Prompt style
+
+ANIMA's recommended formula stacks tags and prose:
+
+```
+masterpiece, best quality, score_7, safe, highres, official art,
+1girl, solo,
+@artist name,
+clean lineart, detailed eyes, soft shading,
+
+A young anime woman with long silver hair and blue eyes stands in a rainy neon
+city at night. She wears a black futuristic jacket with glowing blue details.
+Medium close-up, wet pavement reflections, soft background blur, cinematic
+lighting.
+```
+
+The structure: **quality tags → subject/count tags → optional `@artist name` →
+anime style tags → 2–4 natural-language sentences** (subject, outfit, pose,
+composition, background, lighting, mood). Tags are lowercase with **spaces, not
+underscores** — the only exception is score tags like `score_7`. Artist tags use
+the `@artist name` form; browse names at the community
+[Anima Style Explorer](https://thetacursed.github.io/Anima-Style-Explorer/).
+
+Unlike Flux or Qwen, ANIMA **does** use a real negative prompt (a second text
+encode, since base mode runs CFG above 1):
+
+```
+worst quality, low quality, score_1, score_2, score_3, artist name, bad anatomy,
+bad hands, extra fingers, text, watermark, signature, simple background
+```
+
+## What to make with it
+
+- **Original characters & OCs** — design sheets, portraits, full-body refs
+- **Fan art** — established Danbooru/Gelbooru artists imitate best
+- **Manga / illustration panels** — clean lineart and soft shading
+- **Concept and VN/game assets** — generous output license makes this practical
+- **Custom-style LoRAs** — train a personal art style on a 6 GB card
+- **Edits & fixes** — anime inpainting to repaint hands, faces, or backgrounds
+
+## Troubleshooting
+
+- **Weird / distorted images.** Use a recommended resolution (1024x1024,
+  896x1152, 832x1216, 768x1344, 640x1536).
+- **Turbo output looks washed/flat.** That's turbo at CFG 1. Switch to base mode
+  (drop the turbo LoRA, 30–50 steps, CFG 4–5) for max quality.
+- **`AnimaLLLiteApply` missing.** Install `ComfyUI-Anima-LLLite` — it is not a
+  standard ControlNet node.
+- **CLIP loads but output is garbage.** Confirm the `CLIPLoader` `type` is
+  `stable_diffusion` and the file is `qwen_3_06b_base.safetensors` (the Qwen3-0.6B
+  *base*, not a chat/edit Qwen).
+- **Inpainting ignores the mask.** Make sure both `SetLatentNoiseMask` *and* the
+  inpainting `AnimaLLLiteApply` receive the painted mask.
+- **OOM while training.** Drop to `network_dim 8` and/or `resolution 512`, keep
+  batch 1, use AdamW8bit.
+
+## FAQ
+
+**How big is ANIMA, and what's it built on?** ~2B parameters — a fine-tune of
+**NVIDIA Cosmos-Predict2-2B-Text2Image** (a DiT / flow model), with a Qwen3-0.6B
+text encoder and the Qwen-Image VAE. It is not SDXL-lineage.
+
+**How much VRAM do I need?** Under 6 GB to generate, ~6 GB to train a LoRA. It
+runs anywhere SDXL or Illustrious runs.
+
+**Can I use Danbooru tags or natural language?** Both — in the same prompt.
+That's ANIMA's signature feature.
+
+**Can I sell what I make with it?** Per the current model card, yes — generated
+images are usable commercially (prints, commissions, game/VN assets). The
+**weights** themselves are non-commercial; you can't host them in a paid service
+without a separate license. Verify the current license before relying on it.
+
+**Can I really train a LoRA on a low-end GPU?** Yes — the `anima-lora-trainer`
+skill uses kohya sd-scripts at defaults that fit ~6 GB (network_dim 32, res 768,
+batch 1). A GTX 1060 6 GB works, just slowly.
+
+**Is it better than Illustrious / NoobAI / Animagine?** For lowest VRAM,
+tag-plus-natural-language prompting, and local training, ANIMA wins. For
+out-of-the-box polish and the largest LoRA ecosystem on a bigger card, the mature
+SDXL fine-tunes still lead. Different jobs.
+
+**Does it do realism?** No. ANIMA is explicitly an anime/illustration model and
+isn't tuned for photorealistic output.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
+   [plugin](/plugin).
+2. Apply the **`anima` pack** — nodes + every model land in the right folders,
+   CI-validated, with the Anima-LLLite inpainting node included.
+3. Open the [Panel](/panel) and let your Claude session wire the graph, swap
+   LoRAs, and iterate on tag-plus-prose prompts for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:**
+[Z-Image](/blog/z-image-comfyui) — the speed-and-low-VRAM generalist — and a
+deeper dive on training ANIMA LoRAs from scratch.

--- a/docs/blog/ernie-image-comfyui.mdx
+++ b/docs/blog/ernie-image-comfyui.mdx
@@ -1,0 +1,277 @@
+---
+title: "Run ERNIE-Image Locally in ComfyUI (Apache-2.0, 2026)"
+description: "Run Baidu's ERNIE-Image — the Apache-2.0, 8B text-to-image model with sharp multilingual EN/CN/JP text — locally in ComfyUI. Install, settings, VRAM."
+keywords:
+  - ERNIE Image ComfyUI
+  - ERNIE Image local
+  - Apache 2.0 text to image
+  - ERNIE Image Turbo
+  - multilingual text to image
+  - ERNIE vs Z-Image
+  - Baidu ERNIE Image
+  - open source AI image model
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · ernie · image · ComfyUI · model highlight_
+
+Most "open" image models come with an asterisk: open weights, closed wallet —
+great until you ship something commercial and the license bites. **ERNIE-Image**
+is the rare one that doesn't. Baidu shipped it under a real **Apache-2.0** license,
+it renders **crisp multilingual text** (English, Chinese, Japanese) better than
+almost anything its size, and the Turbo build runs **under 8 GB of VRAM** in about
+8 steps. You can run the whole thing **locally in ComfyUI** — no API key, no
+per-image fee, no non-commercial clause hanging over your head.
+
+Below: what ERNIE-Image actually is (and the one thing people keep getting wrong
+about it), how it stacks up against Ideogram 4 and Z-Image, the VRAM you need, and
+the fastest way to get it running — a one-command install with
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+instead of hand-downloading GGUFs and untangling a contaminated installer.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the `ernie` pack
+> (`apply_manifest --path packs/ernie/manifest.yaml`, or run the generated
+> `install-windows.bat` / `install-runpod.sh`), and drive the graph from your own
+> Claude session via the Panel. Jump to [Install](#install-ernie-image-in-comfyui).
+
+## What is ERNIE-Image?
+
+ERNIE-Image (released **April 15, 2026** by Baidu's ERNIE-Image team) is an
+**open-weight, single-stream Diffusion Transformer** with **about 8B DiT
+parameters**. In ComfyUI it's paired with a **Ministral-3-3B** text encoder and the
+**Flux 2 VAE**, plus an optional **3B Prompt Enhancer** that auto-expands short
+prompts into richer descriptions. ComfyUI added **day-0 support** in April 2026.
+
+**The license is the headline — and it's genuinely permissive.** ERNIE-Image ships
+under **Apache-2.0**, which allows commercial use, modification, and redistribution,
+full stop. That's a real difference from [Ideogram 4](/blog/ideogram-4-comfyui),
+which is open *weight* but under a **Non-Commercial** agreement (commercial use
+needs a paid license). With ERNIE you can put it in a product on day one. No gated
+download drama, no "for research only" footnote.
+
+### Why text and layout are its superpower
+
+This is the part that holds up to scrutiny. Per Baidu's published benchmarks,
+ERNIE-Image hits:
+
+- **LongTextBench ~0.9733** — state-of-the-art for long, layout-sensitive text
+  rendering among open models.
+- **GenEval ~0.8856 overall** — strong compositional accuracy, with a notable lead
+  on **position understanding** and **attribute binding**.
+
+A character-aware encoder trained on Baidu's web-scale **CJK** text-image corpus is
+the reason Chinese (and Japanese) glyphs come out clean — stroke order and radical
+composition, not mangled approximations. *(Benchmark figures are vendor-reported;
+treat the "state-of-the-art" framing as scoped to text rendering and structured
+layout, not general photorealism.)*
+
+The practical version: if the image has to **carry words** — a poster headline, a
+sign, a manga speech bubble, a UI mockup, multilingual packaging — ERNIE is the
+open model to reach for. Write the exact string you want in quotes and it renders
+it.
+
+There are two builds. **ERNIE-Image** (base) takes ~50 steps for peak quality.
+**ERNIE-Image-Turbo** is distilled (Distribution Matching Distillation + RL) and is
+high-fidelity in **~8 steps at cfg 1** — that's the one the pack ships, and the one
+that fits under 8 GB.
+
+## It is TEXT-TO-IMAGE — not an editor (read this)
+
+The single most common ERNIE confusion: people expect it to **edit a photo**. It
+doesn't. **ERNIE-Image is a text-to-image generator.** You describe an image and it
+paints one from scratch. It does **not** follow grounded edit instructions like
+"change the shirt to red" or "remove the person on the left."
+
+The shipped workflow *does* have an "image-to-image" path, and that's where the
+confusion starts — but that path is **denoise-based refinement** (a style/detail
+pass over one source image at low denoise), **not** instruction editing. If your
+job is "change X in this photo," reach for **Qwen-Image-Edit** or **Flux Kontext**
+instead. ERNIE's lane is generation, especially text- and layout-heavy generation.
+
+## ERNIE-Image vs Ideogram 4 vs Z-Image
+
+There's no single "best" — pick by the job:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **ERNIE-Image** | **Truly permissive (Apache-2.0)** commercial use, **multilingual EN/CN/JP text**, posters/signage/manga layouts, runs **under 8 GB** |
+| **Ideogram 4** | **Area-prompting** with structured JSON bounding boxes, fine-grained poster/logo **layout control**, brand-color accuracy |
+| **Z-Image Turbo** | **Raw speed + low VRAM** general-purpose ideation (~2.5s), LoRA-training stability on the base |
+| **Qwen-Image** | A larger, popular dev model also strong on long text |
+
+Where rivals win: **[Ideogram 4](/blog/ideogram-4-comfyui)** gives you explicit
+spatial control — draw bounding boxes, place text and objects by region — which
+ERNIE doesn't expose (you steer ERNIE with descriptive prose). **[Z-Image](/blog/z-image-comfyui)**
+is the speed king for fast general ideation. But ERNIE wins decisively on the two
+axes that matter for production text work: a **permissive license** and **clean
+multilingual typography**. Each of those models gets its own post in this series —
+this one is ERNIE's spotlight for **commercial-safe, text-rich images**.
+
+## System & VRAM requirements
+
+The official non-quantized release targets a **24 GB** card. The pack sidesteps
+that by shipping the **Turbo GGUF**, so you pick a quant to fit your GPU:
+
+| Quant | VRAM | Notes |
+|-------|------|-------|
+| **Q5_K_S** | **under 8 GB** | Smallest; the under-8 GB target |
+| **Q6_K** | 8–12 GB | Quality/VRAM middle ground |
+| **Q8_0** | 12–16 GB+ | Highest fidelity; the pack's default |
+
+The Ministral-3-3B encoder and Flux 2 VAE add a few GB on top. The pack ships
+**Q8_0**; if you're tight on VRAM, edit the quant in the filename (e.g.
+`ernie-image-turbo-Q5_K_S.gguf`) before installing. Running the bundled ERNIE↔Z-Image
+*combo* pipelines loads two UNets, so budget for both or just run the single-model
+ERNIE group.
+
+## Install ERNIE-Image in ComfyUI
+
+The manual route works: update ComfyUI, install the GGUF + a handful of node packs,
+and drop the files into the right folders.
+
+| File | Folder |
+|------|--------|
+| `ernie-image-turbo-Q8_0.gguf` (Turbo DiT) | `models/unet/` |
+| `ministral-3-3b.safetensors` (text encoder, load as CLIP type `flux2`) | `models/text_encoders/` |
+| `ernie-image-prompt-enhancer.safetensors` (optional enhancer) | `models/text_encoders/` |
+| `flux2-vae.safetensors` (VAE) | `models/vae/` |
+| `4x-ClearRealityV1.pth` (upscaler) | `models/upscale_models/` |
+
+(Canonical weights live in the official **Comfy-Org/ERNIE-Image** HF repo, Apache-2.0,
+with the same filenames as the third-party mirror.)
+
+### A real-world install gotcha
+
+If you grab the popular third-party installer, beware: **it's contaminated with
+Z-Image leftovers.** The upstream scripts are copy-pasted from a Z-Image pack —
+their headers literally say "Z-IMAGE-BASE" and they download Z-Image-only files
+(`z_image_turbo-*.gguf`, `Qwen3-4B-*.gguf`, `ae.safetensors`) that **ERNIE never
+uses**. Pull those by mistake and you waste disk and end up wiring the wrong VAE.
+**The comfyui-mcp `ernie` pack excludes them** — it installs only ERNIE's actual
+files (`ernie-image-turbo`, `ministral-3-3b`, `flux2-vae`, and the optional enhancer).
+
+### The fast way — comfyui-mcp + the Panel
+
+Untangling that installer by hand is exactly the busywork the
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) **`ernie` pack** removes. One
+declarative manifest installs the custom nodes (ComfyUI-GGUF, rgthree, KJNodes,
+essentials, RES4LYF, and friends) and pulls every model to the correct folder —
+ERNIE-only, no Z-Image cruft — and the same manifest drives both an MCP-native
+install and the generated double-click scripts:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/ernie/manifest.yaml
+
+# or one-click
+packs/ernie/install-windows.bat      # Windows
+packs/ernie/install-runpod.sh        # RunPod / Linux
+```
+
+Then load `packs/ernie/workflow.json`. Because the pack ships with the
+[plugin](/plugin), your **own Claude session can drive the live graph through the
+[Panel](/panel)** — add/wire nodes, set widgets, and iterate on prompts
+conversationally, with full Ctrl+Z undo and no extra API keys. Every model URL in
+the pack is CI-validated for reachability and size, so a link never quietly rots
+([here's why that matters](/blog/installer-packs-that-cant-rot)).
+
+## Settings that matter
+
+The pack's workflow is tuned already, but for reference — these are the Turbo
+defaults extracted from the shipped graph:
+
+| Setting | Value |
+|---------|-------|
+| Steps | **8–9** (Turbo) |
+| CFG | **1** |
+| Sampler | **euler** |
+| Scheduler | **simple** |
+| Denoise | **1.0** (txt2img) · **0.35–0.4** (img2img refine) |
+| `ModelSamplingAuraFlow` shift | **3.1** |
+| Resolution | 1920×1088 shipped (`EmptySD3LatentImage`); 1024–2048 long edge is reasonable |
+
+A few notes that save grief:
+
+- **Keep `ModelSamplingAuraFlow` shift at 3.1.** It's applied to the model before
+  sampling; drop it and Turbo output goes soft/undercooked.
+- **CFG 1 means negative conditioning is effectively inert.** The graph still wires
+  a `ConditioningZeroOut` as the negative — that's normal, not a bug.
+- **Base (non-Turbo) `ernie-image`?** Bump to ~50 steps and raise cfg (≈3.5–5)
+  since it isn't distilled.
+- **Use the Prompt Enhancer for short prompts**, turn it off (`ComfySwitchNode`
+  false) once you've written a detailed prompt yourself.
+
+## What to make with it
+
+ERNIE's sweet spots all share one trait — the image has to say something:
+
+- **Multilingual posters & key visuals** — EN/CN/JP headlines that render cleanly.
+- **Text-heavy designs** — signage, packaging, menus, UI mockups, ad creatives.
+- **Manga / anime layouts** — multi-panel pages and storyboards with legible speech
+  bubbles (write the literal string in quotes).
+- **Structured multi-object scenes** — ERNIE's strong instruction following handles
+  complex, knowledge-heavy prompts.
+- **Fast ideation** — Turbo's 8-step generation makes iterating on concepts cheap.
+
+Prompting tip: lead with the **exact text** you want, in quotes — e.g. *a vintage
+travel poster, bold title reading "KYOTO" at the top* — then describe style and
+layout in plain, structured prose. That's ERNIE's headline strength.
+
+## Troubleshooting
+
+- **`UnetLoaderGGUF` / `CLIPLoaderGGUF` missing** → install **ComfyUI-GGUF** (city96).
+- **`Power Lora Loader` / `Image Comparer` missing** → install **rgthree-comfy**.
+- **`ImageResize+` missing** → install **ComfyUI_essentials**.
+- **`TextGenerate` (enhancer) missing** → install via ComfyUI-Manager search, or set
+  the `ComfySwitchNode` to the raw prompt (switch=false) and skip enhancement.
+- **CLIP type error on Ministral** → set `CLIPLoader` `type` to **`flux2`** (not
+  `qwen_image` / `lumina2`; `lumina2` belongs to the Z-Image encoder).
+- **Wrong-VAE artifacts** → ERNIE must use **`flux2-vae.safetensors`**;
+  `ae.safetensors` is the Z-Image VAE.
+- **Blurry / undercooked output** → confirm `ModelSamplingAuraFlow shift=3.1` is
+  wired and steps ≥ 8 for Turbo.
+- **You wanted to EDIT a photo and it ignored you** → expected. ERNIE is txt2img;
+  use Qwen-Image-Edit or Flux Kontext for grounded edits.
+- **Installer pulled Z-Image files too** → that's the contaminated upstream script;
+  use the `ernie` pack, which excludes them.
+
+## FAQ
+
+**Is ERNIE-Image open source?** Yes — genuinely. It's released under **Apache-2.0**,
+which permits commercial use, modification, and redistribution. Unlike Ideogram 4's
+non-commercial license, there's no separate paid agreement to ship commercially.
+
+**Can ERNIE-Image edit my photos?** No. It's **text-to-image** only. The workflow's
+"image-to-image" is a low-denoise refine pass, not instruction editing. For "change
+X in this photo," use Qwen-Image-Edit or Flux Kontext.
+
+**How much VRAM do I need?** The Turbo GGUF runs in **under 8 GB** at the Q5_K_S
+quant; Q6_K wants 8–12 GB and Q8_0 wants 12–16 GB+. The non-quantized official
+release targets a 24 GB card.
+
+**How many parameters?** About **8B** — a single-stream Diffusion Transformer, paired
+with a Ministral-3-3B text encoder and the Flux 2 VAE.
+
+**Is it good at non-English text?** Yes — that's a core strength. It renders
+**English, Chinese, and Japanese** cleanly thanks to a character-aware encoder
+trained on a large CJK corpus.
+
+**ERNIE-Image vs Z-Image — which should I use?** [Z-Image](/blog/z-image-comfyui)
+for the fastest general-purpose ideation; **ERNIE** when you need a permissive
+license plus precise multilingual text and structured layouts.
+
+**Why is the text so accurate?** Reported **LongTextBench ~0.9733** — ERNIE was
+designed for layout-sensitive, multilingual text rendering, not as an afterthought.
+(Figures are vendor-reported; scope the claim to text/layout.)
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+2. Apply the **`ernie` pack** — nodes + ERNIE-only models land in the right folders, validated, with the Z-Image cruft stripped out.
+3. Open the [Panel](/panel) and let your Claude session write multilingual prompts and wire the graph for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:**
+[Z-Image](/blog/z-image-comfyui) — the speed-and-low-VRAM champion, and how its
+Turbo distillation gets you a usable image in a couple of seconds.

--- a/docs/blog/index.mdx
+++ b/docs/blog/index.mdx
@@ -1,21 +1,67 @@
 ---
 title: Blog
-description: Notes on building comfyui-mcp — tool design, quality, and lessons from shipping an MCP server.
+description: Notes on building comfyui-mcp — tool design, quality, and a model-highlight series on the open image & video models you can run locally.
 ---
 
 Writing about building [comfyui-mcp](https://github.com/artokun/comfyui-mcp): tool design, schema
 quality, and what we learn shipping an MCP server people actually use.
 
-## Posts
+## Model highlights
 
-<Card
-  title="How to Run Ideogram 4 Locally in ComfyUI (2026 Guide)"
-  href="/blog/ideogram-4-comfyui"
->
-  The 9.3B open-weight text-to-image king of readable text and design layout —
-  run it locally, no API key. Install, a VRAM/quant table, JSON area prompting,
-  and a one-command setup. First in the model-highlight series. _June 16, 2026_
+A chronological tour of the open image & video models you can run locally in
+ComfyUI — what each is best at, and how to set it up in one command with a
+comfyui-mcp pack and the [Panel](/panel). Oldest first, ending on the current
+open-weight champ, Ideogram 4.
+
+<CardGroup cols={2}>
+
+<Card title="WAN 2.2" href="/blog/wan-2.2-comfyui">
+  The open-source video king — how the high/low-noise experts actually work,
+  I2V/T2V, GGUF tiers, and longer videos.
 </Card>
+
+<Card title="Qwen-Image & Qwen-Image-Edit" href="/blog/qwen-image-comfyui">
+  20B text-to-image plus instruction editing and manual-mask inpainting, with a
+  WAN 2.2 refine combo.
+</Card>
+
+<Card title="WAN Animate 2.2" href="/blog/wan-animate-comfyui">
+  Drive a character with a reference video — v2v character & motion replace from
+  a single image.
+</Card>
+
+<Card title="WAN Transparent Expressions" href="/blog/wan-transparent-comfyui">
+  Alpha-channel character expression sprites (looping WebP/GIF) for SillyTavern
+  and VTuber overlays.
+</Card>
+
+<Card title="Z-Image (Turbo & Base)" href="/blog/z-image-comfyui">
+  6B, runs under 8 GB — the low-VRAM speed king. Turbo vs Base, ControlNet, and
+  your own LoRAs.
+</Card>
+
+<Card title="ERNIE-Image" href="/blog/ernie-image-comfyui">
+  Apache-2.0 text-to-image with razor-sharp multilingual text rendering, under
+  8 GB VRAM.
+</Card>
+
+<Card title="ANIMA 1.0" href="/blog/anima-comfyui">
+  A ~2B anime model that generates and trains under 6 GB — Danbooru tags plus
+  natural language.
+</Card>
+
+<Card title="LTX-2.3" href="/blog/ltx-2.3-comfyui">
+  Fast GGUF video (T2V/I2V) and the LTX Director timeline editor inside ComfyUI.
+</Card>
+
+<Card title="Ideogram 4 — the finale" href="/blog/ideogram-4-comfyui">
+  The 9.3B open-weight king of readable in-image text and design layout, with
+  JSON area prompting.
+</Card>
+
+</CardGroup>
+
+## Posts
 
 <Card
   title="Installer packs that can't rot: one manifest, every install"

--- a/docs/blog/ltx-2.3-comfyui.mdx
+++ b/docs/blog/ltx-2.3-comfyui.mdx
@@ -1,0 +1,308 @@
+---
+title: "LTX-2.3 in ComfyUI: Fast GGUF Video + LTX Director"
+description: "Run LTX-2.3 — Lightricks' 22B GGUF text-to-video & image-to-video model — locally in ComfyUI. Install, VRAM tiers, LTX Director timeline, and the kornia fix."
+keywords:
+  - LTX-2.3 ComfyUI
+  - LTX Video ComfyUI
+  - LTX GGUF
+  - LTX Director timeline
+  - LTX-2.3 image to video
+  - Lightricks LTX-2
+  - local AI video ComfyUI
+  - LTX-2.3 install
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · ltx · video · ComfyUI · model highlight_
+
+Most open video models make you pick two of three: fast, local, or good. **LTX-2.3**
+is the one that gets uncomfortably close to all three — a 22B diffusion transformer
+that generates **synchronized video and audio**, ships as a low-VRAM **GGUF UNet**,
+and runs entirely **locally in ComfyUI** with no API key and no per-second cloud
+bill. This is the video entry in our model-highlight series, and the case for it is
+simple: it is one of the fastest genuinely-open audio-video models you can self-host
+today, and the new **LTX Director** timeline editor turns a single prompt box into
+something that feels like an actual NLE.
+
+Below: what LTX-2.3 actually is (and the version-naming mess), the timeline editor,
+the GGUF VRAM tiers, how it stacks up against WAN 2.2, the fastest way to install
+it, and the one import bug everyone hits.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the `ltx-2.3` pack
+> (run the generated `install-windows.bat` / `install-runpod.sh`, or
+> `apply_manifest --path packs/ltx-2.3/manifest.yaml`), run the bundled
+> **kornia fix**, and drive the graph from your own Claude session via the
+> [Panel](/panel). Jump to [Install](#install-ltx-2-3-in-comfyui).
+
+## A quick word on the name (it is not "LTX 3.2")
+
+You will see this model called "LTX 3.2," "LTXV2.3," and a dozen other scrambles.
+There is no LTX 3.2. The correct name is **LTX-2.3** — a point release in the
+**LTX-2** family. The lineage:
+
+- **LTX-Video** (2024) — Lightricks' first open text-to-video model.
+- **LTX-2 / LTX-V2** (early 2026) — the ~19B-class DiT audio-video foundation
+  model: the first production-ready **open-weight** model to generate synchronized
+  audio and video in one pass, up to native **4K @ 50fps** and ~20s clips,
+  Apache 2.0.
+- **LTX-2.3** (~March 2026) — a **~22B** DiT update with a rebuilt VAE (sharper
+  textures, faces, hair, and on-screen text), a much larger text-projection
+  connector for better prompt adherence, improved 9:16 portrait, cleaner
+  synchronized audio, and LoRA support. The big distribution change: **2.3 ships
+  primarily as GGUF UNets** plus separate VAE / text-encoder / text-projection
+  files — not one bundled checkpoint.
+
+When someone says "LTX 3.2" or "LTX2.3," they mean **LTX-2.3**. We'll use the
+correct name throughout.
+
+## What is LTX-2.3?
+
+LTX-2.3 is a DiT-based video foundation model from Lightricks that does
+**text-to-video (T2V)** and **image-to-video (I2V)**, and — uniquely among the
+fast open models — generates **matching audio** in the same pass. A few details
+that matter for running it locally:
+
+- **~22B parameters**, distributed as a **GGUF UNet** quant of the
+  `ltx-2.3-22b-dev` model, loaded with **`UnetLoaderGGUF`** (from the
+  ComfyUI-GGUF node) rather than the usual `CheckpointLoaderSimple`.
+- **Separate video and audio VAEs** (`LTX23_video_vae_bf16` and
+  `LTX23_audio_vae_bf16`). Because the UNet is a bare GGUF, the VAE no longer
+  comes "for free" with a checkpoint — you load it explicitly with `VAELoader`.
+- A **Gemma 3 12B** text encoder (`gemma_3_12B_it_fp4_mixed`, loaded via
+  `CLIPLoader` with `type: ltxv`), plus the enlarged **text-projection** file
+  new in 2.3 (`ltx-2.3_text_projection_bf16`).
+- A **distilled fast path**: apply the distilled LoRA
+  (`ltx-2.3-22b-distilled-lora-384-1.1`) to the dev UNet for **8-step**
+  generation, or run the dev model straight at **~20 steps** for higher quality.
+- An **x2 spatial latent upscaler** (`ltx-2.3-spatial-upscaler-x2-1.1`) for a
+  two-stage "generate small, upscale in latent space" pipeline, plus an IC-LoRA
+  detailer for refinement.
+
+> **Open weight, attribute carefully.** LTX-2 was released under **Apache 2.0**,
+> which is genuinely permissive — a real contrast to most "open" video models.
+> LTX-2.3's exact license and the canonical repo you should pull from
+> (`huggingface.co/Lightricks`) are worth confirming before commercial use; some
+> community write-ups treat 2.3's terms as identical to LTX-2's, which we have not
+> independently verified. Flagging it so you check rather than assume.
+
+## The LTX Director timeline editor
+
+The headline community add-on for LTX-2.3 is **LTX Director** — a custom node by
+**WhatDreamsCost** that drops a real **timeline editor inside ComfyUI**. Instead of
+one prompt and one clip, you compose a sequence on a timeline and let the model
+relay between segments.
+
+What it gives you:
+
+- **A functional timeline** where you place **image, text, and audio segments**,
+  then trim, cut, rearrange, and combine them — closer to an indie NLE than a node
+  graph.
+- **Prompt Relay** — change the prompt *across* the video, so different stretches
+  of the same clip can describe different action, framing, or mood (granular,
+  per-segment control rather than one global prompt).
+- **Multiple keyframes** — any number of them, including the classic
+  **first / middle / last frame** workflows, which is the easiest way to pin a
+  shot's start and end.
+- **Custom audio** — import, trim, and combine your own audio clips, instead of
+  relying only on the model's generated track.
+- **Built-in T2V and I2V**, with image resize handled for you.
+
+A couple of honest caveats: LTX Director is a **third-party** node (built fast — its
+author shipped it in about six days in May 2026), and it needs up-to-date
+`ComfyUI-LTXVideo` and `ComfyUI-KJNodes` to work. Both are installed by the
+`ltx-2.3` pack. It's framed as Wan- and LTX-compatible, but it's purpose-built for
+LTX-2.3 — treat anything beyond that as "try it and see."
+
+## Alternate and GGUF base models (including "sulphur")
+
+Because the UNet is just a GGUF, you can **swap in any LTX-2.3-compatible base
+model** by pointing `UnetLoaderGGUF` at a different file and keeping the rest of the
+2.3 graph identical (same 2.3 VAE, Gemma 3 encoder, and text projection).
+
+The most-asked-about alternate is the community **Sulphur 2** finetune — an
+uncensored, realism-leaning **derivative of LTX-2.3** (22B), marketed as a drop-in
+replacement inside existing 2.3 graphs. Compatibility caveats worth knowing:
+
+- It is a **finetune, not a new architecture**, and it targets the **LTX-2.3**
+  stack specifically. It is **not** LTX-2 (19B) compatible — mixing a 2.3 UNet with
+  a 2.0 VAE/encoder produces garbage.
+- The real base files are `sulphur_dev_bf16` (~46 GB) and `sulphur_dev_fp8mixed`
+  (~29 GB); GGUF quants are published separately (e.g.
+  `sulphur_dev-<quant>.gguf`). There is no file literally named
+  "sulphur2Base_dev.safetensors" — that's shorthand.
+- It's a third-party derivative with its own hosting and license. **Verify the repo
+  and terms yourself** before downloading; we're noting it exists, not endorsing a
+  specific mirror.
+
+General rule for any alternate LTX base: confirm the **version it was trained on**
+(2.3 22B vs 2.0 19B), keep the matching VAE + text encoder + text projection, and
+if you only have a LoRA, apply it with `LoraLoaderModelOnly` instead of swapping the
+whole UNet.
+
+## LTX-2.3 vs WAN 2.2
+
+The other open-video model everyone benchmarks against is **WAN 2.2**. The short
+version:
+
+| Pick… | When you want… |
+|-------|----------------|
+| **LTX-2.3** | **Speed** + low VRAM via GGUF, **native synchronized audio**, the LTX Director timeline, fast 8-step distilled drafts |
+| **WAN 2.2** | Maximum motion fidelity from its high/low-noise expert split; a large LoRA ecosystem; strongest when you have VRAM and time to spend |
+
+LTX-2.3's pitch is throughput and the audio track; WAN 2.2's is raw quality from its
+two-expert design. We're giving WAN 2.2 its own deep-dive on how the high/low-noise
+experts actually work — that post is coming in this series. For now: if you want fast
+local clips with sound, LTX-2.3; if you want to push motion quality and don't mind
+the cost, WAN 2.2.
+
+## VRAM and GGUF tiers
+
+The whole point of the GGUF distribution is fitting LTX-2.3's 22B UNet on consumer
+cards. Pick the quant that matches your GPU:
+
+| GGUF quant | VRAM | Notes |
+|------------|------|-------|
+| **Q4_K_S** | **<12 GB** | Smallest footprint; best for 8–12 GB cards |
+| **Q5_K_S** | **12–16 GB** | Balanced quality/VRAM |
+| **Q8_0** | **24 GB+** | Highest quality quant; for 24 GB cards like the 4090 |
+
+Keep only the quant you'll use — the pack lists all three so it's self-contained,
+but you don't need to download every one. The separate VAEs and the FP4 Gemma
+encoder add a few more GB on top. Plan for **8 GB as a realistic floor** (Q4_K_S,
+small resolution, short clips) and 24 GB for comfortable Q8_0 work with the
+two-stage upscale.
+
+## Install LTX-2.3 in ComfyUI
+
+The manual route works: update ComfyUI, install the custom nodes (ComfyUI-GGUF,
+ComfyUI-LTXVideo, KJNodes, RES4LYF, VideoHelperSuite, and friends), and download
+each model into the right folder:
+
+| File | Folder |
+|------|--------|
+| `ltx-2.3-22b-dev-<Q4_K_S\|Q5_K_S\|Q8_0>.gguf` (UNet) | `models/unet/` |
+| `LTX23_video_vae_bf16.safetensors` | `models/vae/` |
+| `LTX23_audio_vae_bf16.safetensors` (audio sync) | `models/vae/` |
+| `gemma_3_12B_it_fp4_mixed.safetensors` (text encoder) | `models/text_encoders/` |
+| `ltx-2.3_text_projection_bf16.safetensors` | `models/text_encoders/` |
+| `ltx-2.3-spatial-upscaler-x2-1.1.safetensors` | `models/latent_upscale_models/` |
+| `ltx-2.3-22b-distilled-lora-384-1.1.safetensors` (fast path) | `models/loras/` |
+
+(Official weights live in the **Lightricks** HF org; the pack's installer pulls
+matching files from a third-party mirror — verify against the official repo if
+licensing matters to you.)
+
+### The fast way — comfyui-mcp + the Panel
+
+Cloning a dozen custom nodes and downloading the right GGUF quant plus two VAEs to
+the right folders is exactly the busywork the
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) **`ltx-2.3` pack** removes.
+One declarative manifest installs the nodes and pulls every model to the correct
+folder — and the same manifest drives both an MCP-native install and the generated
+double-click scripts:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/ltx-2.3/manifest.yaml
+
+# or one-click — run from your ComfyUI root
+packs/ltx-2.3/install-windows.bat      # Windows
+packs/ltx-2.3/install-runpod.sh        # RunPod / Linux
+```
+
+After install, **run the bundled kornia fix** (see Troubleshooting) and restart
+ComfyUI. Because the pack ships with the [plugin](/plugin), your **own Claude
+session can drive the live graph through the [Panel](/panel)** — add and wire the
+GGUF loader, VAE loaders, scheduler, and sampler, set widgets, and iterate on
+prompts conversationally, with full undo and no extra API keys. No `workflow.json`
+ships with this pack yet; import one from the LTX Director / ComfyUI-LTXVideo
+examples and let your agent adapt it.
+
+## Settings that matter
+
+LTX-2.3 uses LTX-specific nodes (`LTXVConditioning`, `EmptyLTXVLatentVideo`,
+`LTXVScheduler`, `SamplerCustomAdvanced`) rather than a plain `KSampler`. Two
+profiles:
+
+| Path | sampler | steps | cfg | When |
+|------|---------|-------|-----|------|
+| **Dev (quality)** | euler / res_2s | **~20** | **3** (4 with distilled LoRA on base) | Final renders |
+| **Distilled (fast)** | euler | **8** | **1.0** | Drafts, iteration |
+
+Other constraints to respect:
+
+- **Frame count must be `8n + 1`** — 49, 81, 97, 121, 161… (121 is the
+  recommended default at 25fps ≈ 5s).
+- **Resolution in multiples of 32** — start small (e.g. 768×512), then **x2 latent
+  upscale** to 1536×1024 in a second stage.
+- **Frame rate** is conditioned via `LTXVConditioning` (25fps standard; 24/30 also
+  fine).
+- **OOM mitigation:** launch ComfyUI with **`--reserve-vram 10 --cache-none`**
+  (these are the pack's default `launch_args`). On low-VRAM cards, also drop to a
+  smaller quant, reduce frame count, and use a tiled VAE decode
+  (`LTXVSpatioTemporalTiledVAEDecode`).
+
+## Troubleshooting
+
+- **`ComfyUI-LTXVideo` fails to import — kornia `pad` ImportError.** This is *the*
+  bug everyone hits. **kornia 0.8.3+** stopped exporting `pad` from
+  `kornia.geometry.transform.pyramid`, so the node won't load. The pack ships the
+  fix: run **`fix-ltxvideo-kornia.bat`** (or `.sh`) from your
+  `ComfyUI_windows_portable` folder. It patches
+  `custom_nodes/ComfyUI-LTXVideo/pyramid_blending.py` — removes the broken `pad,`
+  import, inserts `pad = F.pad` as a shim, and writes a `.bak_kornia_fix` backup
+  first. It's idempotent, so re-running is safe.
+- **Torch / CUDA mismatch or a node upgrades torch.** The RunPod installer pins a
+  known-good stack (torch 2.4.0 / cu121, torchvision 0.19.0, torchaudio 2.4.0,
+  xformers 0.0.27.post2) and pins `ComfyUI-LTXVideo` to a specific commit for
+  workflow compatibility. If a node's `requirements.txt` quietly upgrades torch and
+  breaks CUDA, reinstall the pinned stack; don't let nodes bump torch.
+- **OOM on 24 GB.** Use the `--reserve-vram 10 --cache-none` launch args, a smaller
+  GGUF quant, fewer frames (81 or 49), and a tiled VAE decode. Always clear VRAM
+  before switching to LTX from another model family.
+- **No audio in the output.** You must load the **audio VAE**
+  (`LTX23_audio_vae_bf16`) — it's separate from the video VAE.
+- **Same seed, different result across machines.** Expected — output varies with
+  GPU, driver, CUDA, and ComfyUI version.
+
+## FAQ
+
+**Is it "LTX 3.2"?** No. There is no LTX 3.2. The model is **LTX-2.3**, a point
+release of the LTX-2 family.
+
+**Can I run it locally / offline?** Yes — fully local in ComfyUI, no API key and no
+network call at generation time.
+
+**How much VRAM do I need?** ~8 GB floor with the **Q4_K_S** GGUF at small
+resolutions; **Q5_K_S** for 12–16 GB, **Q8_0** for 24 GB+.
+
+**Does it generate audio?** Yes — synchronized audio and video in one pass, via a
+**separate audio VAE** you load alongside the video VAE.
+
+**Dev vs distilled — which do I use?** Distilled (8 steps, cfg 1.0) for fast
+drafts; dev (~20 steps, cfg 3) for final quality.
+
+**What is LTX Director?** A community timeline-editor node (by WhatDreamsCost) that
+adds keyframes, prompt relay across the clip, custom audio, and built-in T2V/I2V to
+LTX-2.3 inside ComfyUI.
+
+**Is it really open / free?** LTX-2 shipped under **Apache 2.0**. LTX-2.3's exact
+terms are worth confirming on the official Lightricks repo before commercial use —
+and the "sulphur" finetune is a separate third-party project with its own license.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
+   [plugin](/plugin).
+2. Apply the **`ltx-2.3` pack** — GGUF UNet, both VAEs, the Gemma encoder, text
+   projection, upscaler, and LoRAs land in the right folders, validated.
+3. Run the bundled **kornia fix**, restart, then open the [Panel](/panel) and let
+   your Claude session wire the GGUF graph and build prompts for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:** the
+[WAN 2.2 video stack](/blog/wan-2.2-comfyui) — how the high/low-noise experts
+actually work. Want the design counterpart instead? See
+[Ideogram 4 in ComfyUI](/blog/ideogram-4-comfyui).

--- a/docs/blog/qwen-image-comfyui.mdx
+++ b/docs/blog/qwen-image-comfyui.mdx
@@ -1,0 +1,319 @@
+---
+title: "Qwen-Image & Qwen-Image-Edit in ComfyUI (2026 Guide)"
+description: "Run Qwen-Image 20B and Qwen-Image-Edit locally in ComfyUI: instruction editing, manual-mask inpainting, the WAN 2.2 refine combo, and GGUF VRAM tiers."
+keywords:
+  - Qwen-Image ComfyUI
+  - Qwen Image Edit
+  - Qwen image inpainting
+  - Qwen vs Flux
+  - Qwen-Image 20B
+  - Qwen Image GGUF
+  - instruction image editing local
+  - Qwen Lightning LoRA
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · qwen · image · editing · ComfyUI · model highlight_
+
+Most image models make you choose: paint a beautiful scene, *or* actually edit
+the one you already have. **Qwen-Image** refuses the trade. It's a 20B
+text-to-image model with class-leading multilingual text rendering — and its
+sibling **Qwen-Image-Edit** turns plain-English instructions ("make the jacket
+red," "remove the person on the left") into clean, faithful edits, with an
+optional **manual-mask "super inpainting"** mode for surgical local changes. All
+of it runs **locally in ComfyUI**, no API key, no per-image fee.
+
+This is a model-highlight post for the whole Qwen-Image family: the 20B base
+model, the instruction editor, the mask-based inpainter, and the
+**Qwen + WAN 2.2 refine combo** that pushes the base output toward photoreal.
+Below: what each genuinely does best, how it stacks up against Flux and Ideogram,
+the VRAM you need, and the fastest way to get it running — a one-command install
+with [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the
+[sidebar Panel](/panel), instead of hand-downloading 40+ GB of weights and
+juggling two text encoders.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the `qwen-image` pack
+> (`apply_manifest --path packs/qwen-image/manifest.yaml`) for the 20B T2I + WAN
+> combo, and/or the `qwen-image-edit` pack for instruction editing and
+> mask inpainting. Then drive the graph from your own Claude session via the
+> Panel. Jump to [Install](#install-qwen-image-in-comfyui).
+
+## What is Qwen-Image?
+
+Qwen-Image is the open-weight image foundation model from Alibaba's **Tongyi /
+Qwen team**, first released August 2025 ([QwenLM/Qwen-Image](https://github.com/QwenLM/Qwen-Image)).
+It's a **20B-parameter MMDiT** (Multimodal Diffusion Transformer) paired with a
+**Qwen2.5-VL** vision-language model as the text encoder, and — unlike a lot of
+"open weight" releases — it ships under the genuinely permissive **Apache 2.0**
+license, so commercial use is on the table out of the box.
+
+Its headline strength is **text in images, especially multilingual text.** Qwen
+accurately renders English, Chinese, Japanese, and Korean, and is one of the few
+open models that handles **multi-line, paragraph-level layouts** in Chinese and
+English without dissolving into gibberish (per the
+[Qwen team](https://github.com/QwenLM/Qwen-Image) and
+[ComfyUI's launch writeup](https://blog.comfy.org/p/qwen-image-in-comfyui-new-era-of)).
+It generates at roughly 1.6 megapixels natively and earned native ComfyUI support
+on day-ish one ([August 5, 2025](https://comfyui-wiki.com/en/news/2025-08-05-qwen-image)).
+
+This pack ships a **distilled GGUF** build of the 20B model plus **Lightning
+acceleration LoRAs** (8-step and 4-step), so you can trade a little quality for a
+lot of speed and a much smaller VRAM footprint.
+
+## Qwen-Image-Edit: instruction editing that listens
+
+The reason Qwen earns a family post is **Qwen-Image-Edit**. Instead of starting
+from a blank latent, you load an image and tell the model what to change in
+natural language. Because the editor uses the same **Qwen2.5-VL** encoder, it
+"sees" the source through the vision model and applies the instruction while
+preserving the rest of the frame.
+
+It handles both ends of the editing spectrum:
+
+- **Low-level appearance edits** — add, remove, or modify elements; lighting
+  shifts; color tweaks; relighting — while keeping realism and prompt adherence.
+- **High-level semantic edits** — object rotation, style transfer, IP/character
+  creation, background swaps.
+- **Bilingual text editing** — directly add, delete, or change text *inside* an
+  image while preserving the original font, size, and style.
+
+### Better at following instructions than Kontext
+
+The common community read is that **Qwen-Image-Edit follows free-form
+instructions more reliably than FLUX.1 Kontext**, with stronger visual-appearance
+control — natural lighting and color adjustments that hold realism
+([MimicPC](https://www.mimicpc.com/learn/qwen-image-edit-vs-flux-kontext-which-better-for-image-editing),
+[CoreViz](https://coreviz.io/blog/qwen-image-edit-vs-kontext-flux-max-image-editing-with-ai)).
+Kontext still earns wins of its own — it can be more precise *when you hand it a
+very explicit prompt*, and reviewers often give it the nod on character
+consistency and certain text-modification tasks. So this isn't "Qwen always
+beats Kontext"; it's "Qwen is the more forgiving instruction-follower, and it's
+local and Apache-licensed." Treat the comparison as task-dependent and test on
+your own images.
+
+### Manual-mask "super inpainting" for precise local edits
+
+Instruction editing is global by nature — you describe a change and trust the
+model to localize it. When you need **surgical** control, the
+`qwen-image-edit` pack also ships a **manual-mask inpainting** variant
+(`workflow-inpainting.json`). You paint a mask over exactly the region you want
+changed, and the graph restricts the edit there using
+`SetLatentNoiseMask` + `GrowMaskWithBlur` + `ImageCompositeMasked`, so the
+unmasked pixels are composited back untouched. That's the "edit only the jacket /
+only the sky / only this object" workflow — replace backgrounds, insert or remove
+objects, relight a region, all while preserving local detail
+([Stable Diffusion Art](https://stable-diffusion-art.com/qwen-image-edit-inpaint/)).
+
+The standard `workflow.json` is the instruction-edit graph; reach for
+`workflow-inpainting.json` when "describe it and hope" isn't precise enough.
+
+## The Qwen + WAN 2.2 refine combo
+
+The `qwen-image` pack isn't just a T2I model — it's a **two-stage combo
+pipeline.** Qwen-Image generates the base image, then a **WAN 2.2 T2V A14B
+low-noise** stage refines it. WAN 2.2's video models are unusually good at
+high-frequency detail and texture, so running the low-noise expert as a refiner
+cleans up skin, fabric, and fine structure that the distilled Qwen base can leave
+a touch soft. Both stages, plus their VAEs and acceleration LoRAs (WAN 2.1
+FusionX and the WAN 2.2 4-step low-noise Lightning LoRA), are installed by the
+pack.
+
+One important honesty note from the pack itself: **`qwen-image` ships
+`workflow: null`.** The combo graph (`QWEN_COMBO_ULTRA_WORKFLOW.json`) is **not
+bundled** — you load it separately. The pack reliably lands every model and node
+in the right folder; the matching combo workflow is loaded on top. (The
+`qwen-image-edit` pack, by contrast, *does* ship its workflows:
+`workflow.json` and `workflow-inpainting.json`.)
+
+## Qwen vs Ideogram, Flux, and ERNIE
+
+There's no single "best" — pick by the job:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **Qwen-Image** | Multilingual **text rendering** (EN/中文/日本語/한국어), paragraph-level layouts, **instruction editing + inpainting**, Apache-2.0 commercial use, the WAN refine combo |
+| **Ideogram 4** | The best open-weight **typography + design layout** with structured JSON area-prompting (posters, logos, packaging) — see our [Ideogram 4 post](/blog/ideogram-4-comfyui) |
+| **FLUX.2 / Kontext** | **Photorealism** as a mature default, and precise edits when you write very explicit prompts |
+| **ERNIE-Image** | Another Apache-2.0 option with strong CN/JP/EN text *(post coming in this series)* |
+
+Where rivals win: **Ideogram 4** edges Qwen on pure typography and spatial layout
+control (it's purpose-built for it, and its English OCR accuracy leads the
+open-weight pack — details in [its post](/blog/ideogram-4-comfyui)); **Flux**
+remains the go-to for photoreal portraits and is the lighter download. Qwen's
+trump cards are **editing**, **multilingual text**, and a **truly permissive
+license**. Each of those models gets its own model-highlight post — Qwen earns
+this one for being the local **edit-anything** model.
+
+## System & VRAM requirements
+
+The full BF16 Qwen-Image is **40+ GB** — nearly double FLUX.1 Kontext — which is
+exactly why this pack uses **distilled GGUF** builds plus Lightning LoRAs. GGUF
+quantization is what brings it down to consumer cards. Rough tiers (community
+figures; your mileage varies with RAM, resolution, and the text encoder/VAE
+overhead of roughly 8–10 GB):
+
+| Tier | VRAM | Notes |
+|------|------|-------|
+| **Q4_K_S** | **< 12 GB** | Recommended default; the manifest ships this tier active |
+| **Q5_K_S** | **12–24 GB** | Quality/VRAM middle ground |
+| **Q8_0** | **24 GB+** | Best quality; shipped active in the edit pack's workflow |
+
+Add the **Lightning LoRA** (4- or 8-step) and the diffusion pass gets much
+lighter — community setups run Qwen with Lightning on as little as ~8 GB VRAM with
+enough system RAM ([itch.io guide](https://itch.io/blog/1009845/qwen-lightning-v11-for-comfyui-full-step-by-step-setup-workflow-8gb-vram),
+[Thunder Compute](https://www.thundercompute.com/blog/qwen-image-edit-comfyui)).
+Treat 12 GB as a comfortable floor for the Q4 tier and 24 GB+ for Q8 quality.
+
+## Install Qwen-Image in ComfyUI
+
+The manual route works — but it's fiddly. You're pulling a distilled GGUF UNet,
+**two** Qwen2.5-VL text-encoder GGUFs (the UD quant *and* the mmproj vision
+projector, for edit), a VAE, and several LoRAs, all into the correct folders,
+then making sure you're on a Nightly ComfyUI build for the GGUF loader and
+step-distill LoRA. The `qwen-image` combo additionally needs the WAN 2.2
+low-noise UNet, the umt5-xxl encoder, the WAN VAE, and WAN LoRAs.
+
+### The fast way — comfyui-mcp + the Panel
+
+That folder-juggling is exactly the busywork the
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) packs remove. One
+declarative manifest installs every custom node (ComfyUI-GGUF, rgthree, KJNodes,
+Easy-Use, and more) and pulls each model to the right path, validated:
+
+```bash
+# 20B T2I + WAN 2.2 refine combo
+apply_manifest --path packs/qwen-image/manifest.yaml
+
+# Instruction editing + manual-mask "super inpainting"
+apply_manifest --path packs/qwen-image-edit/manifest.yaml
+```
+
+Both packs run from a [Claude Code](https://github.com/artokun/comfyui-mcp)
+session with `COMFYUI_PATH` set (run the generated installer from your ComfyUI
+root — the folder containing `custom_nodes/` and `models/`). After install,
+restart ComfyUI (or use ComfyUI-Manager → Install missing custom nodes).
+
+Then load the workflow:
+
+- **`qwen-image`** ships `workflow: null` — load `QWEN_COMBO_ULTRA_WORKFLOW.json`
+  separately (the combo graph isn't bundled).
+- **`qwen-image-edit`** ships `workflow.json` (instruction editing) and
+  `workflow-inpainting.json` (manual-mask inpainting) — load whichever fits.
+
+Because both packs ship with the [plugin](/plugin), your **own Claude session can
+drive the live graph through the [Panel](/panel)** — load images, paint masks,
+wire nodes, tweak the edit instruction, and iterate conversationally, with full
+Ctrl+Z undo and no extra API keys. Every model URL in the packs is CI-validated
+for reachability and size, so a link never quietly rots
+([why that matters](/blog/installer-packs-that-cant-rot)).
+
+## Settings that matter
+
+The packs' workflows are tuned, but for reference (from the bundled skills):
+
+- **Lightning 4-step:** steps **4**, cfg **1.0**, sampler **euler**, scheduler
+  **simple**, denoise **1.0** — fastest, good quality.
+- **Lightning 8-step:** steps **8**, cfg **1.0** (or **2.5** for character
+  detail), euler / simple — better detail.
+- **Standard (no LoRA):** steps **40–50**, cfg **4.0**, euler / simple, with
+  `ModelSamplingAuraFlow` **shift 3.1** (Lightning bakes the shift in, so skip it
+  there).
+- **Negative conditioning:** use `ConditioningZeroOut` for Qwen — keyword-spam
+  negatives don't help.
+- **Resolutions:** native ~1.6 MP — e.g. 1328×1328 (square), 1104×1472 (3:4
+  portrait), 1664×928 (16:9). Use **832×480** if you're feeding a WAN video stage.
+- **Editing denoise:** Lightning uses denoise **1.0** (the model preserves
+  structure via conditioning); for standard img2img editing, **0.5–0.8** keeps it
+  closer to the source.
+
+## What to make with it
+
+- **Edit anything by instruction** — "change the black cat into a girl in a black
+  bodysuit," "make the sky a dramatic sunset," "remove the person on the left and
+  fill the background." Load image → describe → done.
+- **Surgical inpainting** — paint a mask, change only that region: swap a
+  background, relight a face, insert or delete one object, fix a logo, all with
+  local detail preserved.
+- **Multilingual text images** — posters, signage, and layouts with clean EN /
+  中文 / 日本語 / 한국어 text, including multi-line paragraphs.
+- **Combo T2I → refine** — generate the base with Qwen, then let the WAN 2.2
+  low-noise expert sharpen texture and detail.
+
+## Troubleshooting
+
+- **`mat1 and mat2 shapes cannot be multiplied`.** The classic Qwen-Edit error.
+  Fix: put **both** Qwen2.5-VL text encoders
+  (`Qwen2.5-VL-7B-Instruct-UD-*.gguf` **and**
+  `Qwen2.5-VL-7B-Instruct-mmproj-BF16.gguf`) in **`models/text_encoders/`** per
+  the city96 ComfyUI-GGUF guidance, then reload the workflow / restart ComfyUI so
+  the loader re-scans the folder. The mmproj vision projector is what the image
+  edit needs auto-paired; without it, the shapes don't line up. (The pack
+  installs both — this only bites manual installs.)
+- **Lightning step-distill errors out.** The 8-step Qwen-Image Lightning LoRA and
+  the GGUF UNet loader need an up-to-date ComfyUI — choose the **Nightly** build
+  (ComfyUI-Manager → Update → switch to nightly).
+- **`Torch not compiled with CUDA enabled`.** Reinstall the CUDA build of torch
+  into the ComfyUI python, e.g.:
+  ```bash
+  python -m pip install --force-reinstall torch torchvision torchaudio \
+    --index-url https://download.pytorch.org/whl/cu121
+  ```
+  (match `cuXXX` to your CUDA version).
+- **OOM at high res / Q8.** Drop a GGUF tier (Q8 → Q5 → Q4), enable the Lightning
+  LoRA, generate smaller first, or use a 24 GB+ GPU.
+- **Edit changed the whole image.** Instruction editing is global — switch to
+  `workflow-inpainting.json` and mask the exact region.
+- **Same seed, different image across machines.** Expected — output varies with
+  GPU / driver / CUDA / ComfyUI version.
+
+## FAQ
+
+**Is Qwen-Image open source?** Yes — it's released under **Apache 2.0**, which
+permits commercial use. That's a real differentiator versus non-commercial
+"open weight" releases like Ideogram 4.
+
+**How big is the model?** The full BF16 build is **40+ GB**. This pack uses
+distilled GGUF quants (Q4 / Q5 / Q8) plus Lightning LoRAs to fit consumer GPUs.
+
+**How much VRAM do I need?** Roughly **< 12 GB** for the Q4_K_S tier, **12–24 GB**
+for Q5, and **24 GB+** for Q8. With the Lightning LoRA, community setups run on as
+little as ~8 GB plus enough system RAM.
+
+**Is Qwen-Image-Edit better than Flux Kontext?** For **following free-form
+instructions** and visual-appearance edits, the community consensus leans Qwen,
+and it's local + Apache-licensed. Kontext can be more precise with very explicit
+prompts and is often praised for character consistency. It's task-dependent —
+test on your own images.
+
+**Can it do precise local edits?** Yes — use the `qwen-image-edit` pack's
+`workflow-inpainting.json`, paint a mask, and the edit is restricted to that
+region while the rest is composited back untouched.
+
+**What's the WAN 2.2 combo for?** It's a refine stage: Qwen generates the base
+image, then the WAN 2.2 T2V A14B low-noise expert sharpens detail and texture.
+Both stages install with the `qwen-image` pack.
+
+**Why does the `qwen-image` pack have no workflow?** By design — it ships
+`workflow: null`. Load `QWEN_COMBO_ULTRA_WORKFLOW.json` separately; the combo
+graph isn't bundled with the installer.
+
+**Does it render Chinese and Japanese text well?** Yes — multilingual text is
+Qwen-Image's signature strength, including multi-line, paragraph-level Chinese and
+English layouts.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
+   [plugin](/plugin).
+2. Apply the **[`qwen-image`](https://github.com/artokun/comfyui-mcp)** pack (20B
+   T2I + WAN combo) and/or **`qwen-image-edit`** (instruction editing + mask
+   inpainting) — nodes and models land in the right folders, validated.
+3. Open the [Panel](/panel) and let your Claude session load images, paint masks,
+   and wire the graph for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:**
+ERNIE-Image — another Apache-2.0 text powerhouse — and the WAN 2.2 video stack
+that powers Qwen's refine combo.

--- a/docs/blog/wan-2.2-comfyui.mdx
+++ b/docs/blog/wan-2.2-comfyui.mdx
@@ -1,0 +1,331 @@
+---
+title: "WAN 2.2 in ComfyUI: The Open Video King (2026 Guide)"
+description: "Run WAN 2.2 — the open-source MoE video model — locally in ComfyUI. High/low-noise experts, I2V & T2V, GGUF VRAM tiers, Lightning, one-command install."
+keywords:
+  - WAN 2.2 ComfyUI
+  - WAN 2.2 high noise low noise
+  - WAN 2.2 image to video
+  - WAN 2.2 GGUF
+  - WAN 2.2 text to video
+  - open source video model
+  - WAN 2.2 Lightning LoRA
+  - WAN 2.2 vs LTX
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · wan · video · ComfyUI · model highlight_
+
+Most open video models make you choose: cinematic motion *or* a GPU you can
+actually afford. **WAN 2.2** refuses the trade. It's the Apache-2.0 model that
+brought a **Mixture-of-Experts** design to video diffusion — two 14B experts that
+hand off mid-denoise — and it runs **locally in ComfyUI**, no API key, no
+per-second cloud fee. This is the next entry in our model-highlight series after
+[Ideogram 4](/blog/ideogram-4-comfyui), and it earns its own spotlight: by most
+open-weight measures, WAN 2.2 is the cinematic-motion king you can self-host today.
+
+Below: how the high-noise and low-noise experts actually work (the part everyone
+gets wrong), I2V vs T2V vs longer-video stitching, how it stacks up against
+LTX-2.3, the VRAM tiers from a 24 GB 4090 down to under 12 GB, and the fastest way
+to run it — a one-command install with
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+instead of hand-downloading dozens of GB of GGUFs and wiring two samplers by hand.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the
+> `wan-longer-videos` pack (`apply_manifest --path packs/wan-longer-videos/manifest.yaml`,
+> or run the generated installer), and drive the graph from your own Claude session
+> via the Panel. Jump to [Install](#install-wan-2-2-in-comfyui).
+
+## What is WAN 2.2?
+
+WAN 2.2 is the open-source video generation family from the Wan-AI (Alibaba) team,
+released under **Apache 2.0** — genuinely open source, commercial use included, no
+gated download and no baked-in license trap. The flagship is the **A14B** series: a
+**dual-expert Mixture-of-Experts** with a high-noise expert and a low-noise expert
+at roughly **14B parameters each** (≈27B total, but only **~14B active per step**,
+so inference cost and VRAM stay close to a single 14B model). There's also a
+smaller dense **TI2V-5B** for lighter rigs. ([Wan-AI on HuggingFace](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B), [Wan2.2 GitHub](https://github.com/Wan-Video/Wan2.2))
+
+Why it's the open video king right now:
+
+- **Cinematic motion, not "AI float."** WAN 2.2 was trained with curated aesthetic
+  labels (lighting, composition, contrast, color tone) and, per the team, on
+  **+65.6% more images and +83.2% more videos** than WAN 2.1 — which shows up as
+  weighty, controllable camera work and steadier subjects. ([Wan2.2 README](https://github.com/Wan-Video/Wan2.2/blob/main/README.md))
+- **Truly open license.** Apache 2.0 means you can ship commercial work, fine-tune,
+  and redistribute. Contrast that with open-*weight* models that carry
+  non-commercial terms.
+- **A massive ecosystem.** Lightning distill LoRAs, FusionX, remix checkpoints, and
+  thousands of community LoRAs already target the 2.2 hi/lo split — more than any
+  other open video model.
+
+A fair scope note: "best open video model" is a motion-and-realism claim widely
+echoed by reviewers, not a single audited benchmark. Speed-first rivals beat it on
+raw throughput (see the comparison below). We scope the win to **cinematic I2V/T2V
+quality on consumer hardware**.
+
+## How the high-noise and low-noise experts work
+
+This is the part worth slowing down for, because it's *the* thing that makes WAN
+2.2 different from a normal single-model diffusion video pipeline — and the thing
+that breaks if you wire it wrong.
+
+Diffusion denoises a video from pure noise to a clean result over N steps. WAN 2.2
+splits that journey between **two specialist experts**, switching once partway
+through based on the noise level (signal-to-noise ratio):
+
+- **High-noise expert — early steps.** Runs first, while the latent is still mostly
+  noise. It establishes **overall layout, composition, motion, and camera
+  structure** — the "what moves where" of the shot.
+- **Low-noise expert — late steps.** Takes over for the back half, when the rough
+  structure exists. It **refines texture, detail, and fidelity** — the "make it
+  sharp and real" pass.
+
+Because only one expert is active at a time, you get the capacity of a ~27B model
+at roughly the compute and VRAM of a 14B one. ([Wan2.2-I2V-A14B model card](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B))
+
+### The hi/lo split at sampling
+
+In ComfyUI native graphs you implement the handoff with **two `KSamplerAdvanced`
+nodes in a two-pass chain**, one per expert. The high pass denoises the first
+portion of the steps and **returns the leftover noise**; the low pass picks up
+exactly where it left off and finishes:
+
+```text
+UNETLoader (HighNoise) → ModelSamplingSD3 (shift) → [Lightning LoRA Hi] → MODEL_HI
+UNETLoader (LowNoise)  → ModelSamplingSD3 (shift) → [Lightning LoRA Lo] → MODEL_LO
+
+KSamplerAdvanced (Hi: MODEL_HI, steps 0→2, add_noise=enable,  return_leftover=enable)
+  → noisy LATENT
+KSamplerAdvanced (Lo: MODEL_LO, steps 2→4, add_noise=disable, return_leftover=disable)
+  → final LATENT  → VAEDecode → VHS_VideoCombine → MP4
+```
+
+The non-negotiable rules:
+
+- **You must use both experts.** WAN 2.2 was trained as a split-noise model;
+  running a single model for all steps produces broken, low-quality output. (This
+  is the #1 mistake people port over from WAN 2.1.)
+- **The split point is where the experts swap.** With 4 Lightning steps the swap is
+  at step 2 (the Hi pass runs steps 0→2, the Lo pass 2→4). With 20 standard steps,
+  swap at step 10.
+- **`ModelSamplingSD3` on both models.** WAN 2.2 uses flow matching; apply the
+  shift to each UNET — **shift 5** for Lightning/distilled, **shift 8** for the
+  standard 20-step path.
+- **Both passes share the same conditioning.** Positive/negative (and, for I2V, the
+  `WanFirstLastFrameToVideo` outputs) feed both samplers.
+
+### LoRAs and Lightning apply to BOTH experts
+
+This trips up newcomers constantly: a WAN 2.2 LoRA isn't one file, it's a **paired
+hi/lo set**, and you load the high-noise variant on the Hi path and the low-noise
+variant on the Lo path. That's true for:
+
+- **Lightning 4-step distill LoRAs** — the speed trick that drops a clip from
+  ~5–10 minutes (20 steps) to roughly ~70 seconds (4 steps). Hi LoRA → Hi model,
+  Lo LoRA → Lo model.
+- **FusionX, style, and concept LoRAs** — same rule, match the variant to the pass.
+
+The `wan-longer-videos` pack ships the matched pairs already:
+`Wan2.2-Lightning_I2V-A14B-4steps-lora_HIGH/LOW` for I2V and the
+`Wan2.2-Lightning_T2V-v1.1-A14B-4steps-lora_HIGH/LOW` pair for T2V, plus the
+`Wan2.1_T2V_14B_FusionX_LoRA`. Mismatch the halves and you'll get muddy structure
+or mushy detail — the symptom maps directly to which expert got the wrong LoRA.
+
+## I2V, T2V, and longer-video extend
+
+WAN 2.2 A14B ships as **two separate expert pairs** — one for image-to-video, one
+for text-to-video — and the `wan-longer-videos` pack installs all four GGUFs so you
+can do either without re-downloading.
+
+- **I2V / first-last-frame (FLF).** Feed a start image (and optionally an end
+  image) and WAN animates between them. This path adds `CLIPVisionEncode` and
+  `WanFirstLastFrameToVideo`, and is the strongest open option for "take this still
+  and make it move." Default resolution 480×720 portrait or 832×480 landscape,
+  81 frames at 16 fps ≈ 5 seconds. See the
+  [wan-flf-video skill](https://github.com/artokun/comfyui-mcp/blob/main/plugin/skills/wan-flf-video/SKILL.md).
+- **T2V.** Pure text → video. No image nodes — it uses `EmptyHunyuanLatentVideo`
+  for the initial latent and text-only conditioning. Describe **motion and
+  temporal progression** ("camera slowly pans", "petals drift in the breeze"),
+  not just a static scene. See the
+  [wan-t2v-video skill](https://github.com/artokun/comfyui-mcp/blob/main/plugin/skills/wan-t2v-video/SKILL.md).
+- **Longer videos.** A single WAN clip is ~5 seconds (81 frames; frame count must
+  be `4n + 1`). The pack's namesake **video-extend chain stitches successive clips
+  into longer sequences**, then runs **ClearReality upscaling** and **RIFE frame
+  interpolation** to smooth the result back up to higher frame rates. That's the
+  whole point of `wan-longer-videos`: get past the 5-second wall without ghosting
+  at the seams.
+
+## WAN 2.2 vs LTX-2.3 and the alternatives
+
+There's no universal winner — pick by the job:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **WAN 2.2** | **Cinematic motion realism**, image-to-video from a reference still, flexible VRAM (FP8/GGUF down to consumer cards), the largest LoRA/remix ecosystem |
+| **LTX-2.3** | **Raw speed and volume** — reviewers cite it as dramatically faster per clip, stable at 720p, with one-pass audio for quick drafts |
+| **WAN 2.2 TI2V-5B** | A lighter dense model for **lower-VRAM rigs** and faster iteration when you don't need the full A14B quality |
+
+The recurring take from 2026 round-ups: **LTX-2.3 wins throughput and built-in
+audio; WAN 2.2 wins cinematic motion and image-to-video fidelity**, and its MoE +
+FP8/GGUF path fits 16 GB cards where a dense model can't. ([WaveSpeed: LTX-2.3 vs WAN 2.2](https://wavespeed.ai/blog/posts/ltx-2-3-vs-wan-2-2-comparison-2026/), [Thunder Compute: WAN 2.2 in ComfyUI](https://www.thundercompute.com/blog/wan-2-2-comfyui-ai-video-model)) Treat the "18x faster" style figures as
+**vendor/blog benchmarks, not independently audited** — they vary wildly with
+resolution, steps, and hardware. Each rival gets its own post:
+[LTX-2.3](/blog/ltx-2.3-comfyui) and [WAN Animate](/blog/wan-animate-comfyui) are
+next in the series.
+
+## VRAM and GGUF tiers
+
+WAN 2.2 A14B is VRAM-hungry — two 14B experts plus a UMT5-XXL encoder, a VAE
+decode, and (in the longer-video chain) RIFE interpolation running back to back.
+The fix is **GGUF quantization**, and the pack's installer is interactive: it
+offers three tiers so you match the quant to your card.
+
+| GGUF tier | VRAM target | Notes |
+|-----------|-------------|-------|
+| **Q4_K_S** | under 12 GB | Smallest quant for entry GPUs; some quality trade |
+| **Q5_K_S** | 12–24 GB | Balanced middle tier |
+| **Q8_0** | 24 GB+ | Best quality; **what this pack ships and the workflow references** |
+
+The pack pins **Q8_0** because that's exactly what `workflow.json` points at. To go
+lower, swap the `unet/Wan2.2-*-Q8_0.gguf` files for the `-Q5_K_S` or `-Q4_K_S`
+variants from the same `Aitrepreneur/FLX` repo and re-point the `UnetLoaderGGUF`
+nodes. To reduce OOM risk, the pack also launches ComfyUI with
+`--reserve-vram 2` so the GGUF UNet, VAE decode, and RIFE pass don't collide.
+
+## Install WAN 2.2 in ComfyUI
+
+The manual route works: update ComfyUI, clone the needed custom nodes
+(ComfyUI-GGUF, VideoHelperSuite, Frame-Interpolation, KJNodes, rgthree, Easy-Use),
+and download every GGUF, the UMT5-XXL encoder, the WAN 2.1 VAE, the Lightning +
+FusionX LoRAs, and the ClearReality upscaler into the right folders. That's a lot
+of files in a lot of exact places.
+
+| File | Folder |
+|------|--------|
+| `Wan2.2-I2V-A14B-HighNoise-Q8_0.gguf` / `-LowNoise-Q8_0.gguf` | `models/unet/` |
+| `Wan2.2-T2V-A14B-HighNoise-Q8_0.gguf` / `-LowNoise-Q8_0.gguf` | `models/unet/` |
+| `umt5-xxl-encoder-Q5_K_S.gguf` (text encoder) | `models/text_encoders/` |
+| `wan_2.1_vae.safetensors` | `models/vae/` |
+| `Wan2.2-Lightning_*-4steps-lora_HIGH/LOW` + `Wan2.1_T2V_14B_FusionX_LoRA` | `models/loras/` |
+| `4x-ClearRealityV1.pth` | `models/upscale_models/` |
+
+### The fast way — comfyui-mcp + the Panel
+
+Pulling all of that to the right folders and wiring two samplers by hand is exactly
+the busywork the [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+**[`wan-longer-videos` pack](https://github.com/artokun/comfyui-mcp/tree/main/packs/wan-longer-videos)**
+removes. One declarative manifest installs the custom nodes and pulls every model
+to the correct folder — and the same manifest drives both an MCP-native install and
+the generated installer script:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/wan-longer-videos/manifest.yaml
+
+# or run the generated interactive installer from your ComfyUI root
+# (the folder containing custom_nodes/ and models/) — it offers the
+# Q4_K_S / Q5_K_S / Q8_0 quant choice
+WAN2_2-ULTRA-MODELS-NODES_INSTALL.bat
+```
+
+Then restart ComfyUI and load `packs/wan-longer-videos/workflow.json` (the first
+RIFE run auto-downloads `rife49.pth`). Because the pack ships with the
+[plugin](/plugin), your **own Claude session can drive the live graph through the
+[Panel](/panel)** — add/wire nodes, set the hi/lo split, swap LoRAs, and iterate on
+prompts conversationally, with full Ctrl+Z undo and no extra API keys. Every model
+URL in the pack is CI-validated for reachability and size, so a link never quietly
+rots ([here's why that matters](/blog/installer-packs-that-cant-rot)).
+
+## Settings that matter
+
+The pack's workflow is tuned already, but for reference:
+
+- **GGUF loaders.** `UnetLoaderGGUF` reads the hi/lo experts from `models/unet/`;
+  `CLIPLoaderGGUF` (type `wan`) loads the UMT5-XXL encoder. Swap quant tiers here.
+- **Lightning 4-step.** With the paired hi/lo Lightning LoRAs: 4 steps, **cfg 1.0**,
+  sampler `euler` (T2V) or `uni_pc` + `beta` scheduler (I2V/FLF), shift **5**, split
+  at step 2. This is the everyday speed config.
+- **Standard 20-step.** Drop the Lightning LoRAs, shift **8**, cfg **3.5–4**,
+  `euler` + `simple`, split at step 10 — for maximum quality when you have time.
+- **FusionX LoRA** layers in extra motion/detail; stack it on both passes like any
+  other hi/lo LoRA.
+- **RIFE + ClearReality.** RIFE (VFI) interpolates frames to smooth motion;
+  `4x-ClearRealityV1` upscales. Both run after decode in the longer-video chain.
+- **Frame math.** Width/height divisible by 16; frame count `4n + 1` (81 ≈ 5s at
+  16 fps). Always include the quality negative prompt the skills ship.
+
+## What to make with it
+
+- **Image-to-video** — bring a single illustration, photo, or render to life with a
+  controllable camera move.
+- **First-last-frame transitions & morphs** — animate cleanly between two stills
+  (add a morph LoRA on both passes for true metamorphosis).
+- **Text-to-video b-roll** — cinematic establishing shots, product motion,
+  atmospheric loops.
+- **Longer sequences** — stitch multiple clips past the 5-second wall, then RIFE +
+  upscale for a smooth finish.
+- **Stylized scenes** — the aesthetic-labeled training makes lighting/color
+  direction in the prompt actually land.
+
+## Troubleshooting
+
+- **"Torch not compiled with CUDA enabled."** A CPU-only torch got installed.
+  Reinstall the CUDA build into ComfyUI's python — for the portable build:
+
+  ```bash
+  python_embeded\python.exe -m pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+  ```
+
+- **Broken / mushy output.** You're almost certainly running one expert instead of
+  two, or you mismatched the hi/lo LoRAs. Confirm the two-pass `KSamplerAdvanced`
+  split and that Hi LoRA → Hi model, Lo LoRA → Lo model.
+- **OOM during generation or RIFE.** Drop to a Q5_K_S or Q4_K_S GGUF tier, lower
+  resolution/frame count, and keep `--reserve-vram 2`.
+- **`rife49.pth` missing.** It's not in the installer — ComfyUI-Frame-Interpolation
+  fetches it automatically on first RIFE run into
+  `custom_nodes/ComfyUI-Frame-Interpolation/ckpts/rife/`.
+- **Static / "motionless image" result.** Strengthen motion language in the prompt
+  and verify the negative prompt includes the motionless/static quality terms.
+
+## FAQ
+
+**Is WAN 2.2 open source or open weight?** Genuinely **open source** — Apache 2.0,
+commercial use allowed, no gated download. ([model card](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B))
+
+**What is the high-noise / low-noise split?** WAN 2.2 A14B is a Mixture-of-Experts:
+a high-noise expert handles early denoising (layout, motion, composition) and a
+low-noise expert handles late denoising (texture, detail). You run them as a
+two-pass sampler chain and must use both.
+
+**Do I really need both models?** Yes. It was trained split-noise; a single model
+for all steps gives broken output. This is the most common WAN 2.1 → 2.2 mistake.
+
+**How much VRAM do I need?** With GGUF: under 12 GB on Q4_K_S, 12–24 GB on Q5_K_S,
+and 24 GB+ for the Q8_0 the pack ships.
+
+**Can I run it locally / offline?** Yes — fully local in ComfyUI, no API key and no
+network call at generation time (after the one-time model download).
+
+**How long can clips be?** A single A14B clip is ~5 seconds (81 frames at 16 fps).
+The `wan-longer-videos` extend chain stitches clips into longer sequences and
+smooths them with RIFE.
+
+**Do Lightning and other LoRAs apply to both experts?** Yes — WAN 2.2 LoRAs come as
+paired hi/lo files; load the high variant on the Hi path and the low variant on the
+Lo path.
+
+**WAN 2.2 or LTX-2.3?** WAN 2.2 for cinematic motion and image-to-video; LTX-2.3
+for speed, volume, and built-in audio. (Speed figures quoted online are
+vendor/blog benchmarks, not independently audited.)
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+2. Apply the **[`wan-longer-videos` pack](https://github.com/artokun/comfyui-mcp/tree/main/packs/wan-longer-videos)** — nodes + the four hi/lo GGUFs, encoder, VAE, LoRAs, and upscaler land in the right folders, validated. Pick your quant tier.
+3. Open the [Panel](/panel) and let your Claude session set the hi/lo split, swap LoRAs, and stitch longer clips for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:**
+[WAN Animate](/blog/wan-animate-comfyui) for driving characters from a reference
+performance, and [LTX-2.3](/blog/ltx-2.3-comfyui) — the speed-first challenger.

--- a/docs/blog/wan-animate-comfyui.mdx
+++ b/docs/blog/wan-animate-comfyui.mdx
@@ -1,0 +1,274 @@
+---
+title: "WAN Animate 2.2 in ComfyUI: Character Replace (2026)"
+description: "Replace any character in a video from ONE reference image, or transfer motion to a still, with WAN Animate 2.2 in ComfyUI. Install, VRAM, fixes."
+keywords:
+  - WAN Animate ComfyUI
+  - WAN Animate 2.2
+  - AI video character replace
+  - WAN VACE
+  - Wan Animate install
+  - video to video ComfyUI
+  - motion transfer AI video
+  - kijai WanVideoWrapper
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · wan · video · ComfyUI · model highlight_
+
+Most "AI video" tools let you make a clip from scratch and then leave you stranded
+the moment you want to put *your* character into *that* performance. **WAN Animate
+2.2** is the open model that nails the part everyone actually wants: hand it **one
+reference image** and a **driving video**, and it either drops your character into
+the existing footage — same lighting, same camera, same motion — or animates your
+still to copy the performer's pose and expression frame for frame. And you can run
+the whole thing **locally in ComfyUI**, no API, no per-second render fee.
+
+Below: what it's genuinely best at (with the paper's receipts), how it works under
+the hood, where it sits relative to **WAN VACE** and the rest of the WAN stack, the
+VRAM you need, and the fastest way to get it running — a one-command install with
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [sidebar Panel](/panel),
+instead of hand-cloning six custom-node repos and chasing dtype errors.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the `wan-animate` pack
+> (`apply_manifest --path packs/wan-animate/manifest.yaml`, or run the generated
+> installer), install SageAttention + Triton with the bundled `.bat`, then drive
+> the graph from your own Claude session via the Panel. Jump to
+> [Install](#install-wan-animate-2-2-in-comfyui).
+
+## What is WAN Animate 2.2?
+
+WAN Animate (from Alibaba's WAN team, released **September 19, 2025** as
+`Wan2.2-Animate-14B`) is a **unified character animation and replacement** model
+built on the Wan-I2V video foundation with a Diffusion Transformer (DiT) backbone.
+One architecture, two jobs:
+
+- **Animation mode** — animate a static character image so it copies the **body
+  motion, facial expression, and lip movement** of a driving video. Upload a photo
+  + a performance, get your character performing it.
+- **Replacement mode** — swap the character already in a video for your reference
+  character, while **preserving the original lighting, color tone, and camera** so
+  the swap blends into the scene.
+
+Critically, it's **Apache 2.0 licensed** — fully permissive, commercial use
+included. That's rare in the video-model space and is the main reason it caught on
+so fast versus the closed Runway/ByteDance options. (The weights and inference code
+are on [Hugging Face](https://huggingface.co/Wan-AI/Wan2.2-Animate-14B).)
+
+### Why it's the v2v "character replace" king
+
+This is the headline, and the paper backs it up. In
+[the Wan-Animate paper](https://arxiv.org/html/2509.14055v1), the authors position
+it as *"the most comprehensive and highest-performing open-source model to date"*
+for character animation, with:
+
+- **Quantitative wins** over open baselines (reported SSIM 0.834 / LPIPS 0.205 /
+  FVD 94.65 on portrait data).
+- **Human-preference wins** vs. closed-source **Runway Act-Two** and ByteDance
+  **DreamActor-M1** in a 20-participant study.
+- A clean read on the open competition: **Animate Anyone** *"exhibits significantly
+  lower generation quality"* (UNet-based foundation), **VACE** shows *"instability
+  in character animation tasks,"* and **DreamActor-M1** *"tends to have slightly
+  lower quality in local details."*
+
+A fair caveat: those benchmarks and the human study are run by the model's own
+authors, so treat the "beats everyone" framing as **strongest for character
+animation/replacement specifically**, not as a universal video-quality crown.
+Independent reviewers consistently scope the win the same way — and so do we.
+
+## How WAN Animate works
+
+The pack wires up the full kijai pipeline, but it helps to know what each piece
+does:
+
+- **Pose / detection (ViTPose + YOLO).** A **YOLOv10** detector finds the person,
+  then **ViTPose-L (or -H) WholeBody** extracts 2D whole-body skeleton keypoints
+  per frame. Those skeleton signals are spatially aligned to the character and used
+  to drive body motion. (Runs via
+  [ComfyUI-WanAnimatePreprocess](https://github.com/kijai/ComfyUI-WanAnimatePreprocess).)
+- **Face / expression.** Rather than abstract landmarks, the model feeds the **raw
+  face crop** directly into dedicated "Face Blocks" in the DiT — that's why
+  expression and lip-sync come through so cleanly.
+- **Segmentation masking (SeC).** Replacement mode needs a precise mask of the
+  character to remove. The pack defaults to **SeC** (Segment Concept, `SeC-4B`), a
+  concept-driven video segmenter that uses a vision-language model for robust
+  tracking through scene changes — it reports an **11.8-point gain over SAM 2.1** on
+  the SeCVOS benchmark ([SeC paper](https://arxiv.org/abs/2507.15852)). A SAM2
+  auto-mask path is bundled but muted by default.
+- **Relight LoRA.** An auxiliary LoRA (trained on IC-Light-synthesized lighting
+  pairs) adjusts the new character's lighting and color tone to match the
+  destination scene — the difference between a "pasted-in" swap and a believable one.
+- **lightx2v speed LoRA.** A step-distill LoRA (`lightx2v_I2V_14B_480p_cfg_step_distill`)
+  that collapses sampling to a handful of steps for dramatically faster generation.
+
+The diffusion model itself is the **14B fp8-scaled WAN Animate** checkpoint
+(`Wan2_2-Animate-14B_fp8_scaled_e4m3fn_KJ_v2`), paired with the umT5-XXL text
+encoder, the Wan 2.1 VAE, and CLIP-vision — all pulled to the right folders by the
+pack.
+
+## Where WAN VACE fits
+
+You'll hear **WAN VACE** in the same breath as Animate, so here's the clean split.
+**VACE** ("All-in-One Video Creation and Editing,"
+[ali-vilab/VACE](https://github.com/ali-vilab/VACE)) is the *generalist* — one
+framework for reference-to-video, video-to-video editing, masked editing, and
+free composition of those tasks (Move-Anything, Swap-Anything, Animate-Anything,
+Expand-Anything, etc.). It's the Swiss-army knife.
+
+**WAN Animate is the specialist.** It does one family of jobs — drive/replace a
+character — and does it better than VACE does that *specific* job. The Wan-Animate
+paper explicitly calls out VACE's instability on character tasks. So:
+
+- Reach for **Animate** when the job is "put this character into this performance"
+  or "make this still copy this motion." Best identity, expression, and
+  scene-blending.
+- Reach for **VACE** when you need broad, mix-and-match video editing (inpaint,
+  outpaint, extend, generic reference control) and character fidelity isn't the
+  whole point.
+
+If you're already running our WAN stack, note that the WAN 2.2 T2V pack also ships
+**VACE modules** for reference/pose/depth conditioning on text-to-video — see the
+[WAN 2.2 post](/blog/wan-2.2-comfyui) for that side.
+
+## WAN Animate vs. the rest of your video stack
+
+There's no single "best" — pick by the job:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **WAN Animate 2.2** | **Character replace** in existing footage, or **motion/expression transfer** to a still — best identity + scene blending, Apache 2.0 |
+| **WAN VACE** | A **general** video edit framework — inpaint/outpaint/extend/reference, mix-and-match tasks |
+| **WAN 2.2 T2V** | Original video **from text** (dual hi/lo experts, lightning LoRAs) — see [the WAN 2.2 post](/blog/wan-2.2-comfyui) |
+| **LTX-Video** | Fast, real-time-ish generation on lower VRAM (its own post is coming) |
+
+Where rivals win: VACE for breadth of edit types, T2V for from-scratch creation,
+LTX for raw speed. WAN Animate earns the spotlight for the one thing it's built
+to dominate — **driving a character with another character's performance.**
+
+## System & VRAM requirements
+
+The pack targets the **14B fp8-scaled** build. Plan for **24 GB+** for a smooth
+720p experience on a single card:
+
+| Build | VRAM | Notes |
+|-------|------|-------|
+| fp8-scaled (pack default) | **24 GB+ comfortable** | 14B diffusion + umT5 + VAE + CLIP-vision + SeC; WanVideoWrapper offload/block-swap helps |
+| GGUF (e.g. Q4_K) | **~8–12 GB** | Community quants ([QuantStack GGUF](https://huggingface.co/QuantStack/Wan2.2-Animate-14B-GGUF)); 480p, slower, needs ~32 GB system RAM |
+
+Treat 24 GB as the target floor for fp8 at 720p. On a 24 GB RTX 4090 you're in good
+shape; for 16 GB and below, drop to a GGUF quant and lower resolution. (Numbers vary
+with clip length, resolution, and offload settings — flag this as approximate.)
+
+## Install WAN Animate 2.2 in ComfyUI
+
+The manual route is real work: clone the **WanVideoWrapper**, **KJNodes**,
+**VideoHelperSuite**, **segment-anything-2**, **SecNodes**, and
+**WanAnimatePreprocess** custom-node repos, then download the diffusion model,
+encoder, VAE, CLIP-vision, two LoRAs, the SeC model, and the ViTPose/YOLO ONNX
+detection files — each into a different folder.
+
+### The fast way — comfyui-mcp + the Panel
+
+That folder-juggling is exactly what the
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) **`wan-animate` pack** removes.
+One declarative manifest installs every custom node and pulls every model to the
+correct folder — and the same manifest drives both an MCP-native install and the
+generated double-click scripts:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/wan-animate/manifest.yaml
+
+# or run the generated installer from your ComfyUI root
+# (the folder containing custom_nodes/ and models/)
+```
+
+> **Required: SageAttention + Triton.** The WanVideoWrapper sampler needs them.
+> Run the bundled `install_triton_and_sageattention_auto.bat` from your portable
+> Python folder (`...\ComfyUI_windows_portable\python_embeded\`) **before your first
+> generate**. It detects your Torch/CUDA, installs `triton-windows` and the matching
+> woct0rdho SageAttention wheel, and drops the Python include/libs zip so Triton can
+> compile. Restart ComfyUI afterward, then load `workflow.json`.
+
+Because the pack ships with the [plugin](/plugin), your **own Claude session can
+drive the live graph through the [Panel](/panel)** — load the reference image,
+point at the driving video, pick the SeC vs. auto-mask path, set widgets, and
+iterate conversationally, with full Ctrl+Z undo and no extra API keys. Every model
+URL in the pack is CI-validated for reachability and size, so a link never quietly
+rots.
+
+## What to make with it
+
+- **Character / outfit / object replace** — drop your hero, your VTuber, or your
+  client's mascot into existing footage with the original lighting preserved.
+- **Motion transfer to a still** — animate a single portrait or concept-art
+  character to copy a real performance (dance, dialogue, gestures).
+- **Virtual influencers & avatars** — consistent identity driven by an actor.
+- **Lip-sync dialogue** — the raw-face-crop conditioning makes mouth movement
+  track the driving clip.
+- **Previz & stand-in swaps** — block a scene with one actor, swap the character in
+  post.
+
+## Troubleshooting
+
+- **`self and mat2 must have the same dtype` (WanVideoWrapper).** The known fix:
+  **delete and re-clone** `kijai/ComfyUI-WanVideoWrapper`, then reinstall its
+  requirements with the portable Python —
+  `python_embeded\python.exe -m pip install -r ComfyUI-WanVideoWrapper\requirements.txt`.
+- **RTX 5000-series: onnxruntime "QuickGelu" / CUDA-provider error** on the ViTPose
+  detection pass. Pin the version: `pip install onnxruntime==1.20.1`.
+- **`Torch not compiled with CUDA enabled`.** Your torch is a CPU build. Reinstall
+  from the matching CUDA index, e.g.
+  `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128`
+  (use the `cuXXX` matching your driver).
+- **Triton/SageAttention errors at sampling.** Re-run
+  `install_triton_and_sageattention_auto.bat` from `python_embeded\` and restart.
+- **Masking is wrong / character not isolated.** The shipped workflow defaults to
+  **SeC** (manual/prompted); the SAM2 auto path is muted. Pick the matching
+  mask / background_image getter per the in-graph notes.
+- **Missing nodes after install.** Restart ComfyUI, or use ComfyUI-Manager →
+  *Install missing custom nodes* to pull any node Python deps.
+
+## FAQ
+
+**What does WAN Animate 2.2 actually do?** Two things from one model: **animate** a
+static character image to copy a driving video's motion/expression, or **replace**
+the character in a video with your reference character while keeping the original
+lighting and camera.
+
+**Do I need a reference video?** Yes — Animate is **video-to-video**. You bring a
+reference image (the character) *and* a driving video (the performance/footage).
+For text-to-video from scratch, use the [WAN 2.2 T2V](/blog/wan-2.2-comfyui) stack
+instead.
+
+**Is it free / commercial-use OK?** Yes. The weights are **Apache 2.0** — the most
+permissive license in open video, commercial use included.
+
+**How much VRAM do I need?** ~24 GB for the fp8 build at 720p; GGUF quants bring it
+to roughly 8–12 GB at 480p with more system RAM and slower runs.
+
+**WAN Animate vs. WAN VACE — which one?** Animate for character drive/replace
+(better identity and blending); VACE for general all-in-one video editing. The
+Animate paper notes VACE is unstable on character-specific tasks.
+
+**Why does it need SageAttention and Triton?** The WanVideoWrapper sampler depends
+on them. The pack ships an auto-installer that matches your Torch/CUDA — run it once
+before your first generation.
+
+**Is it better than Runway Act-Two or DreamActor-M1?** In the authors' human
+study, yes — users preferred WAN Animate. That study is vendor-run, so read it as
+"competitive with / preferred over the closed tools for character animation,"
+not a universal benchmark.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+2. Apply the **`wan-animate` pack** — nodes + models land in the right folders, validated.
+3. Run `install_triton_and_sageattention_auto.bat`, restart, and load `workflow.json`.
+4. Open the [Panel](/panel) and let your Claude session load the image, point at the driving video, and iterate.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:** the
+[WAN 2.2 video stack](/blog/wan-2.2-comfyui) and a fast-and-light counterpoint with
+LTX-Video — or jump back to [Ideogram 4](/blog/ideogram-4-comfyui), the open-weight
+text-and-layout king.

--- a/docs/blog/wan-transparent-comfyui.mdx
+++ b/docs/blog/wan-transparent-comfyui.mdx
@@ -1,0 +1,265 @@
+---
+title: "WAN Transparent Expressions in ComfyUI: Alpha Sprites"
+description: "Make looping, transparent-background animated character expressions with WAN 2.2 I2V + BiRefNet in ComfyUI — RGBA WebP/GIF sprites for SillyTavern."
+keywords:
+  - WAN transparent ComfyUI
+  - SillyTavern expression sprites
+  - transparent background AI video
+  - ComfyUI RGBA video
+  - WAN 2.2 I2V ComfyUI
+  - BiRefNet ComfyUI RMBG
+  - animated VTuber overlay
+  - transparent WebP GIF AI
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · wan · video · ComfyUI · model highlight_
+
+Static character portraits are fine. A character whose face actually *moves* —
+who blinks, smiles, and tilts their head on a clean transparent loop — is the
+thing that makes a chat UI feel alive. This post is about a small, niche, weirdly
+satisfying corner of local AI video: using **WAN 2.2 image-to-video** in
+**ComfyUI** to produce **looping, alpha-channel animated expressions** you can
+drop straight into [SillyTavern](https://docs.sillytavern.app/extensions/expression-images/),
+a VTuber overlay, or any chat front-end as transparent sprites.
+
+It's not a flashy general-purpose model release — it's a *recipe*. And it's a
+great one. Below: what it produces and why it's worth the trouble, the exact
+node pipeline (WAN 2.2 I2V GGUF → per-frame matting with BiRefNet → RGBA
+WebP/GIF), the VRAM you need, and the fastest way to get it running — a
+one-command [comfyui-mcp](https://github.com/artokun/comfyui-mcp) install plus
+the [sidebar Panel](/panel), instead of hand-wiring a GGUF video graph and a
+background-removal chain.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the
+> `wan-transparent` pack (`apply_manifest --path packs/wan-transparent/manifest.yaml`,
+> or run the generated installer), load the workflow, and let your own Claude
+> session drive the graph from the Panel. Jump to
+> [Install](#install-wan-transparent-expressions-in-comfyui).
+
+## What is "WAN 2.2 Transparent Expressions"?
+
+It's an **image-to-video pipeline**, not a new checkpoint. You feed it a single
+character image (your SillyTavern card art, a VTuber model render, an OC
+illustration), prompt a short motion — *smiling warmly*, *looking surprised*,
+*pouting* — and WAN 2.2 I2V animates a few seconds of it. Then every frame gets
+the background **cut out**, so the export is a **looping, transparent-background**
+animation: a lossless **pingpong WebP** plus a **GIF**, both carrying an alpha
+channel.
+
+The target use is **SillyTavern expression sprites**. SillyTavern's Expression
+Images extension shows a per-character image that swaps as the model classifies
+the conversation's emotion — joy, anger, sadness, curiosity, and so on (the
+local classifier defaults to the 28-label GoEmotions set). The catch: those
+sprites look right *only* if they have a **transparent background**, or the
+character shows up sitting in an ugly solid box over your chat. WebP and
+transparent PNG are the recommended formats for exactly that reason. This recipe
+gives you *animated* versions of those sprites — alpha intact.
+
+**Why it's niche-but-great.** Most people stop at static expression packs. An
+animated, alpha-channel expression set is a step up that almost nobody bothers
+to make, because the pipeline is fiddly: video model + per-frame matting +
+correct lossless export + the right filenames. Wire it once and you've got a
+repeatable little factory for living character sprites.
+
+## How it works (the pipeline)
+
+There are two honest ways to get transparent AI video, and this recipe uses the
+second:
+
+1. **Native alpha models** (e.g. [Wan-Alpha](https://github.com/WeChatCV/Wan-Alpha))
+   jointly generate RGB *and* an alpha channel with a custom VAE. Beautiful for
+   semi-transparency and fine edges — but it's a different model stack.
+2. **Generate opaque, then matte per frame.** Animate normally with stock WAN
+   2.2 I2V, then remove the background from every frame and re-assemble as RGBA.
+
+This pack takes route 2 because it's robust, uses the WAN weights you may
+already have, and the matting model is excellent on illustrated characters.
+Stages:
+
+- **Animate — WAN 2.2 I2V A14B (Q8_0 GGUF).** WAN 2.2's I2V model is a
+  two-expert (high-noise / low-noise) A14B setup, loaded here as **Q8_0 GGUF**
+  via `UnetLoaderGGUF` to keep VRAM sane. **Lightning I2V 4-step LoRAs** (high +
+  low) collapse it to a fast 4-step sample, so you're not waiting minutes per
+  expression. Text encoder is `umt5-xxl` (GGUF), VAE is the WAN 2.1 VAE.
+- **Matte every frame — BiRefNet via ComfyUI-RMBG.** Each generated frame goes
+  through the [ComfyUI-RMBG](https://github.com/1038lab/ComfyUI-RMBG)
+  `BiRefNetRMBG` node in **Alpha** output mode, using the
+  **`BiRefNet_toonout`** matting model. ToonOut is a BiRefNet fork fine-tuned on
+  ~1,200 anime/illustration images; on toon-style art it pushes pixel accuracy
+  from ~95% to ~99.5% versus stock background removers — which is *exactly* the
+  edge quality you want on a face that's animating. Output is **RGBA**.
+- **Export looping RGBA — VHS_VideoCombine.** The
+  [VideoHelperSuite](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite)
+  `VHS_VideoCombine` node writes a **lossless, pingpong WebP** (plays forward
+  then reverse for a seamless loop) plus a **GIF**, preserving the alpha channel.
+  Pingpong is the trick that hides the "video ends and snaps back" seam.
+- **Normalize filenames — Expression-RENAMER.** ComfyUI saves files with a
+  numeric suffix (`happy_00001.webp`). SillyTavern wants the sprite named for the
+  emotion (`happy.webp`). The bundled `expression-renamer.bat` keeps everything
+  before the first underscore plus the extension — `happy_00001.webp` →
+  `happy.webp` — across a whole output folder in one run.
+
+Drop the renamed files into
+`SillyTavern/public/characters/<your-character>/`, and the expressions extension
+picks them up. Animated WebP sprites just work there.
+
+## System & VRAM requirements
+
+This is a *video* workflow, so it's heavier than an image pack — but the GGUF
+quant + 4-step LoRAs keep it friendly:
+
+| Build | VRAM | Notes |
+|-------|------|-------|
+| WAN 2.2 I2V **Q8_0 GGUF** (pack default) | **~12–24 GB** | Two A14B experts swapped in/out; Lightning 4-step keeps it fast |
+| Smaller GGUF quant (Q5 / Q4) | **<12 GB** | Drop the I2V quant if you're tight on VRAM (quality trade) |
+
+The BiRefNet matting pass adds a little overhead (its resolution defaults to
+1024, tunable 512–2048). Short clips at sprite resolution are the sweet spot —
+you don't need 1080p for a 256–512px chat portrait, and smaller frames matte
+faster and cleaner. *(VRAM figures are the pack's stated range; your exact
+ceiling depends on clip length, resolution, and frame count.)*
+
+## Install WAN Transparent Expressions in ComfyUI
+
+The manual route is doable but tedious: install seven-plus custom-node repos
+(GGUF loader, RMBG, VideoHelperSuite, rgthree, Easy-Use, WAS, tinyterra),
+download the WAN 2.2 I2V high/low UNets, the umt5 encoder, the WAN VAE, both
+Lightning LoRAs, and the BiRefNet matting model — each into the correct folder —
+then wire the matting and export chain by hand.
+
+| File | Folder |
+|------|--------|
+| `Wan2.2-I2V-A14B-HighNoise-Q8_0.gguf` | `models/unet/` |
+| `Wan2.2-I2V-A14B-LowNoise-Q8_0.gguf` | `models/unet/` |
+| `Wan2.2-Lightning_I2V-A14B-4steps-lora_HIGH_fp16.safetensors` | `models/loras/` |
+| `Wan2.2-Lightning_I2V-A14B-4steps-lora_LOW_fp16.safetensors` | `models/loras/` |
+| `umt5-xxl-encoder-Q5_K_S.gguf` | `models/text_encoders/` |
+| `wan_2.1_vae.safetensors` | `models/vae/` |
+| `BiRefNet_toonout.safetensors` | `models/RMBG/BiRefNet/` |
+
+### The fast way — comfyui-mcp + the Panel
+
+Wiring a GGUF video graph plus a per-frame matting chain is exactly the busywork
+the [comfyui-mcp](https://github.com/artokun/comfyui-mcp) **`wan-transparent`
+pack** removes. One declarative manifest installs every custom node and pulls
+only the subset of WAN 2.2 weights the transparent workflow actually references
+(the I2V branch, Q8_0) plus the BiRefNet matting model — and the same manifest
+drives both an MCP-native install and the generated double-click script:
+
+```bash
+# MCP-native (from a Claude Code session, with COMFYUI_PATH set)
+apply_manifest --path packs/wan-transparent/manifest.yaml
+
+# or run the generated installer from your ComfyUI root
+WAN2_2-ULTRA-MODELS-NODES_INSTALL.bat
+```
+
+Then load `packs/wan-transparent/workflow.json`. On first run, the
+`BiRefNetRMBG` node auto-downloads `BiRefNet_toonout` to
+`models/RMBG/BiRefNet/` if the manifest didn't already place it. After
+generating, run `expression-renamer.bat` in your output folder to normalize the
+sprite names for SillyTavern.
+
+Because the pack ships with the [plugin](/plugin), your **own Claude session can
+drive the live graph through the [Panel](/panel)** — swap the input image, edit
+the motion prompt, set frame count, and re-run conversationally, with full undo
+and no API keys. Every model URL in the pack is CI-validated for reachability
+and size, so links don't quietly rot
+([why that matters](/blog/installer-packs-that-cant-rot)).
+
+> New to the WAN stack? Start with the base
+> [WAN 2.2 in ComfyUI](/blog/wan-2.2-comfyui) post for how the high/low-noise
+> experts work, and see [WAN Animate](/blog/wan-animate-comfyui) for
+> motion-transfer character animation.
+
+## What to make with it
+
+- **SillyTavern expression sprites.** The headline use — a full animated
+  expression set (joy, sadness, surprise, anger, neutral, …), each a looping
+  transparent WebP, named the way the extension expects.
+- **VTuber-style overlays.** Transparent animated character loops drop straight
+  onto a stream scene or chat overlay with no green-screen keying.
+- **Transparent stickers / reactions.** Looping alpha WebPs for Discord,
+  Telegram, or any UI that renders animated transparent images.
+- **Living avatars for chat front-ends.** Any app that swaps a portrait by mood
+  can use these in place of flat PNGs.
+
+## Settings that matter
+
+- **Keep clips short.** A 1–3 second loop is plenty for an expression sprite;
+  longer clips cost VRAM and time and rarely loop better.
+- **Sprite resolution, not cinema.** Generate near the size you'll display
+  (256–512px). BiRefNet mattes faster and cleaner on smaller frames.
+- **Lightning 4-step LoRAs stay on.** They're what make per-expression
+  generation fast; leave both high and low LoRAs loaded.
+- **Matting resolution.** `BiRefNetRMBG` defaults to 1024; nudge up toward 2048
+  for hairline edges, down toward 512 to save memory.
+- **Lossless + pingpong on the export.** Lossless WebP avoids alpha-edge
+  compression fringing; pingpong gives the seamless loop.
+- **Subtle prompts loop best.** Small, reversible motions (a blink, a soft
+  smile, a slight head tilt) pingpong cleanly; big one-way motion fights the loop.
+
+## Troubleshooting
+
+- **Background isn't fully transparent / haloed edges.** Confirm `BiRefNetRMBG`
+  is in **Alpha** output mode with `BiRefNet_toonout` selected, raise the matting
+  resolution, and enable foreground refinement. ToonOut is tuned for illustrated
+  characters — photoreal humans may matte better with a different RMBG model.
+- **Sprite shows a solid box in SillyTavern.** The file lost its alpha — export
+  as **WebP/PNG**, not JPEG (JPEG can't hold transparency), and keep WebP
+  lossless.
+- **SillyTavern doesn't pick up the sprite.** Filenames must match the emotion
+  label (`happy.webp`, not `happy_00001.webp`). Run `expression-renamer.bat`,
+  and drop files in `public/characters/<character>/`.
+- **OOM during generation.** Use a smaller I2V GGUF quant, shorten the clip,
+  lower the resolution/frame count, or clear the cache between runs.
+- **CUDA breaks after installing a node.** A custom node can drag in a Torch
+  build that mismatches your CUDA. Reinstall the matching wheel, e.g.
+  `pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121`.
+- **Loop has a visible snap.** Enable **pingpong** on `VHS_VideoCombine` and
+  prompt smaller, reversible motion.
+
+## FAQ
+
+**Does this generate true RGBA video, or remove the background afterward?** It
+removes the background **per frame** (BiRefNet matting), then re-assembles as
+RGBA. That's different from native-alpha models like Wan-Alpha, which generate
+the alpha channel directly. Route-2 matting is robust and reuses standard WAN
+weights.
+
+**Do I need WAN 2.2 specifically?** The pack targets WAN 2.2 I2V A14B (Q8_0
+GGUF) with the Lightning 4-step LoRAs. The matting + export half of the pipeline
+is model-agnostic, but the pack is built and validated around the WAN 2.2 I2V
+stack.
+
+**What's `BiRefNet_toonout`?** A BiRefNet background-removal model fine-tuned on
+anime/illustration characters (the ToonOut project), markedly more accurate on
+toon-style art than general removers — ideal for character sprites.
+
+**Why WebP *and* GIF?** WebP gives lossless quality with a real alpha channel
+(the recommended SillyTavern format); GIF is a universal fallback for tools that
+don't render animated WebP. The pack exports both.
+
+**How much VRAM do I need?** Roughly 12–24 GB for the Q8_0 I2V build; drop to a
+smaller GGUF quant for under 12 GB. Short, low-res clips help a lot.
+
+**Will these work as static sprites too?** Yes — a single matted frame is just a
+transparent PNG/WebP, so the same pipeline doubles as a high-quality static
+background remover for character art.
+
+**Is this only for SillyTavern?** No. Anything that renders animated transparent
+images — VTuber overlays, stream scenes, Discord stickers, custom chat UIs — can
+use the output. SillyTavern is just the cleanest fit.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+2. Apply the **`wan-transparent` pack** — custom nodes + the WAN 2.2 I2V subset + the BiRefNet matting model land in the right folders, validated.
+3. Open the [Panel](/panel) and let your Claude session swap input images, tweak motion prompts, and batch out a full expression set for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:**
+the [WAN Animate](/blog/wan-animate-comfyui) stack — driving a still character
+with reference motion.

--- a/docs/blog/z-image-comfyui.mdx
+++ b/docs/blog/z-image-comfyui.mdx
@@ -1,0 +1,305 @@
+---
+title: "Z-Image in ComfyUI: The Low-VRAM Speed King (2026)"
+description: "Run Z-Image Turbo and Base — Alibaba's 6B text-to-image model — locally in ComfyUI under 8 GB VRAM. Install, GGUF tips, LoRA training, and the V2 ULTRA workflow."
+keywords:
+  - Z-Image ComfyUI
+  - Z-Image Turbo
+  - Z-Image Base
+  - low VRAM text to image
+  - Z-Image LoRA training
+  - Z-Image GGUF
+  - Alibaba Tongyi Z-Image
+  - 6B image model local
+---
+
+_by [artokun](https://github.com/artokun) · June 16, 2026 · z-image · image · ComfyUI · model highlight_
+
+Most "run it locally" image models come with a catch: a 24 GB card, a 50 GB
+download, or a five-second wait per frame. **Z-Image** quietly breaks all three.
+It's a **6B-parameter** text-to-image model from **Alibaba's Tongyi-MAI lab** that,
+as a GGUF quant, generates photoreal 1024px images **under 8 GB of VRAM** — and on
+a 4090 it does it in roughly **2.3 seconds at 8 steps**. This is the low-VRAM speed
+entry in our model-highlight series, and it earns the title.
+
+Below: what Z-Image actually is, the **Turbo vs Base** split (fast vs trainable),
+the V2 ULTRA workflow extras (ControlNet, Detail Daemon, an 8-step LoRA, and the
+fix for Z-Image's infamous "same seed, same image" problem), how to **train your
+own Z-Image LoRAs**, where it beats — and loses to — the alternatives, and the
+fastest way to get it running: a one-command install with
+[comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel),
+instead of hand-downloading GGUFs into the right folders.
+
+> **TL;DR — one-command setup.** Install comfyui-mcp, apply the
+> [`z-image-turbo`](/packs/z-image-turbo) pack (fast) or
+> [`z-image-base`](/packs/z-image-base) pack (trainable) — nodes + GGUF models land
+> in the right folders, validated — and drive the graph from your own Claude session
+> through the [Panel](/panel). Jump to [Install](#install-z-image-in-comfyui).
+
+## What is Z-Image?
+
+Z-Image (released by **Alibaba's Tongyi-MAI lab**; Turbo landed November 27, 2025,
+Base in January 2026) is a **~6B-parameter** text-to-image model built on a
+**Scalable Single-Stream DiT (S3-DiT)** architecture — text tokens, visual semantic
+tokens, and image VAE tokens are concatenated into one unified input stream, which
+is a big part of why it stays so parameter-efficient. It uses a **Qwen3-4B** text
+encoder (not CLIP-L/T5), and the **same `ae.safetensors` VAE as Flux**.
+
+The headline isn't size — it's the efficiency-to-quality ratio. With only 6B
+params, Tongyi claims output **comparable to closed-source flagships in the 20B+
+range**, and reviewers consistently call out its **photorealistic portraits** and
+solid **English + Chinese text rendering**. A fair flag: that "rivals 20B models"
+line is a vendor framing, scoped most strongly to **photoreal people and general
+scenes** — treat it as "punches well above its weight," not a universal SOTA claim.
+
+What makes it the **low-VRAM speed king**: as a GGUF quant the diffusion model fits
+in **under 8 GB**, and Turbo needs only ~8 steps. People are running it on
+6 GB cards. That's the pitch — flagship-ish quality on hardware that can't touch
+Flux.2 or a 9.3B [Ideogram 4](/blog/ideogram-4-comfyui).
+
+## Turbo vs Base — pick by the job
+
+Z-Image ships in two flavors, and the difference is the whole story:
+
+| | **Z-Image Turbo** | **Z-Image Base** |
+|---|---|---|
+| Built for | **Speed** | **Quality + training** |
+| Distillation | Decoupled-DMD distilled | Non-distilled foundation model |
+| Steps | **~4–8** (sub-second on data-center GPUs) | **~30–50**, CFG 3–5 |
+| Negative prompt | Not effective (CFG baked in) | **Supported** at CFG > 1 |
+| Best at | Fast ideation, batch iteration | Diverse styles, finetuning, LoRA training |
+| Pick the pack | [`z-image-turbo`](/packs/z-image-turbo) | [`z-image-base`](/packs/z-image-base) |
+
+**Turbo** is the one you reach for first: ~4–8-step sampling, sub-second latency on
+beefy GPUs, ~2.3s for 1024px on a 4090. It's distilled, so it bakes CFG in — meaning
+**negative prompts don't really work**; you steer with the positive prompt instead.
+
+**Base** is the non-distilled foundation model. It costs you steps (30–50) and time,
+but it gives back a **higher artistic ceiling, more diverse styles, real negative
+prompts, and — critically — it's the finetuning-friendly variant**. If you're
+training LoRAs, you train on Base. The handy part: **a LoRA trained on Base
+generally applies to the Turbo workflow too** (verify on your own LoRA), so you can
+train once and deploy on the fast path.
+
+## The V2 ULTRA workflow extras
+
+Both packs ship a tuned **V2 ULTRA** workflow that's a lot more than a bare KSampler.
+Highlights:
+
+- **Fun-ControlNet-Union** — one ControlNet patch covering Canny, HED, Depth, Pose,
+  and MLSD (loaded via `ModelPatchLoader` → the Z-Image Fun ControlNet node).
+  Recommended strength ~0.65–0.80. Base uses the `Z-Image-Fun-Controlnet-Union-2.1`
+  weights; Turbo uses `Z-Image-Turbo-Fun-Controlnet-Union` fp8.
+- **Detail Daemon** ([ComfyUI-Detail-Daemon](https://github.com/Jonseed/ComfyUI-Detail-Daemon))
+  — a detailer pass that adds fine texture and skin/fabric detail without re-rolling
+  the composition.
+- **8-step distill LoRA** (Base pack) —
+  `Z-Image-Fun-Lora-Distill-8-Steps` lets the Base model run at Turbo-like step
+  counts when you want speed from the trainable model.
+- **SeedVarianceEnhancer** (Turbo pack) — the fix for Z-Image's most-complained-about
+  quirk. Turbo's early sampling step **over-determines** the image, so different
+  seeds produce near-identical results ("same seed, same image" — really "every seed,
+  same image"). SeedVarianceEnhancer injects controlled, prompt-related noise into
+  the text embeddings between the encoder and the sampler, restoring real
+  seed-to-seed diversity. (Per the
+  [upstream issue](https://github.com/Tongyi-MAI/Z-Image/issues/16) this is a known
+  trait of the distilled model, not a bug in your graph.)
+- txt2img / img2img / inpainting branches with **rgthree group toggles**, plus a
+  `4x-ClearRealityV1` upscale path.
+
+## Train your own Z-Image LoRAs
+
+Z-Image's low-VRAM advantage carries straight into **training**. Because it's a
+~6B **single-stream** model (no WAN-style hi/lo expert split), it's the lightest
+LoRA-training target in our stack — a 4090 is comfortable, and smaller cards work
+with float8 quantization at 512–768 resolution.
+
+Use the **[`ai-toolkit-trainer`](/plugin) skill** (ostris **AI-Toolkit**, MIT — a
+standalone web-UI trainer, not a ComfyUI node) to train. Sensible starting points
+for Z-Image:
+
+| Param | Starting point |
+|-------|----------------|
+| Linear rank / dim | 16–32 (32 for detailed characters/styles) |
+| Learning rate | 1e-4 (5e-5 for tighter identity) |
+| Steps | 1500–3000 (dataset-dependent) |
+| Resolution | 768 (or 1024 — Z-Image's native range) |
+| Multi-stage | **OFF** (single-stream model, not WAN's MoE) |
+| Optimizer / Quant | AdamW8bit / float8 (enables sub-12 GB training) |
+
+*(These are aggregated community starting points, not read from AI-Toolkit's
+`config/examples/*.yml` — open the actual example config in your clone and tune.)*
+
+**Train on Base, deploy anywhere.** Then drop the resulting `.safetensors` into
+`models/loras/` and compare your candidates side by side with the
+[`z-image-xy-plot`](/packs/z-image-xy-plot) pack — a utility workflow that renders a
+labelled XY grid of multiple trained LoRAs (and/or checkpoints) at once. Bring your
+own LoRAs; that pack installs none.
+
+## Z-Image vs the alternatives
+
+There's no single "best" — pick by the job:
+
+| Pick… | When you need… |
+|-------|----------------|
+| **Z-Image Turbo** | **Speed + low VRAM** — fast ideation, batch iteration under 8 GB |
+| **Z-Image Base** | **Trainable** photoreal base, diverse styles, LoRA finetuning |
+| **Ideogram 4** | Readable **in-image text**, posters, logos, layout control |
+| **Flux.2** | Top-tier **photorealism** and a mature production default |
+| **Qwen-Image** | Text + multilingual on a larger dev model |
+
+Where Z-Image wins: **VRAM and speed**, full stop — nothing else here runs flagship-
+ish quality in 6–8 GB at this pace, and Base is genuinely cheap to finetune. Where
+it loses: in-image **typography and layout** go to [Ideogram 4](/blog/ideogram-4-comfyui)
+(a 9.3B model purpose-built for text), and the last 5% of large-scene
+**photorealism** still favors Flux.2. Both of those get their own posts in this
+series — *teaser:* the Flux photoreal deep-dive and the Ideogram text breakdown are
+next up.
+
+## System & VRAM requirements (GGUF)
+
+Z-Image is distributed here as **GGUF** quants, loaded through
+[ComfyUI-GGUF](https://github.com/city96/ComfyUI-GGUF) (`UnetLoaderGGUF` /
+`CLIPLoaderGGUF`). The quant tier is your VRAM lever:
+
+| Quant | VRAM (rough) | Notes |
+|-------|--------------|-------|
+| **Q5_K_S** | **under 8 GB** | The low-VRAM pick |
+| **Q8_0** | ~12–16 GB | Best quality; what both V2 workflows ship pinned to |
+| BF16 (full) | ~14–16 GB | Top-tier consumer cards |
+
+**Heads-up on quants:** the installer menu offers a **Q6_K** option, but **no Q6_K
+GGUF exists on the Aitrepreneur/FLX mirror** — use **Q5_K_S** (under 8 GB) or
+**Q8_0** (best quality) instead. The shipped workflows pin Q8_0; to drop to the
+low-VRAM tier, just point the `UnetLoaderGGUF` widget at the `Q5_K_S` filename (or
+uncomment that tier in the pack's `manifest.yaml`). The text encoder is
+`Qwen3-4B-UD-Q6_K_XL.gguf` and the VAE is the Flux `ae.safetensors`.
+
+## Install Z-Image in ComfyUI
+
+The manual route works: install [ComfyUI-GGUF](https://github.com/city96/ComfyUI-GGUF)
+plus the workflow's other custom nodes, download the GGUF UNet, Qwen3-4B encoder,
+VAE, ControlNet patch, and upscaler into the right folders, then load the workflow.
+That's a lot of click-and-place.
+
+### The fast way — comfyui-mcp + the Panel
+
+The [comfyui-mcp](https://github.com/artokun/comfyui-mcp) packs remove all of it.
+One declarative manifest installs every custom node (ComfyUI-GGUF, rgthree, KJNodes,
+Detail Daemon, controlnet_aux, and more) and pulls each model to the correct folder —
+and the same manifest drives both an MCP-native install and the generated
+double-click scripts:
+
+```bash
+# Z-Image Turbo (fast, under 8 GB) — MCP-native from a Claude Code session
+apply_manifest --path packs/z-image-turbo/manifest.yaml
+
+# Z-Image Base (trainable, more styles)
+apply_manifest --path packs/z-image-base/manifest.yaml
+
+# or one-click, run from your ComfyUI root
+packs/z-image-turbo/install-windows.bat      # Windows
+packs/z-image-turbo/install-runpod.sh        # RunPod / Linux
+```
+
+Want to compare trained LoRAs? Add the
+[`z-image-xy-plot`](/packs/z-image-xy-plot) pack. Run the generated installer from
+your **ComfyUI root** (the folder containing `custom_nodes/` and `models/`), then
+restart ComfyUI (or use ComfyUI-Manager → *Install missing custom nodes*) and load
+`workflow.json`.
+
+Because the packs ship with the [plugin](/plugin), your **own Claude session can
+drive the live graph through the [Panel](/panel)** — swap quant tiers, wire the
+ControlNet, toggle the Detail Daemon, and iterate on prompts conversationally, with
+full Ctrl+Z undo and no API keys. Every model URL is CI-validated for reachability
+and size, so a link never quietly rots.
+
+## Settings that matter
+
+The packs ship tuned, but for reference (community-tested presets):
+
+| Use | Steps | CFG | Sampler | Scheduler |
+|-----|-------|-----|---------|-----------|
+| **Turbo — sharpest** | 10 | 1.0 | `dpmpp_sde` | `beta` |
+| **Turbo — author pick** | 14 | 1.0 | `res_2s` | `simple` |
+| **Turbo — beauty/fashion** | 10 | 1.0 | `euler_ancestral` | `beta` |
+| **Base — full quality** | 22–30 | 4.0 | `res_2s` | `beta` |
+
+- **Prompt in natural language**, not tags — the Qwen3 encoder is an LLM, so
+  "Professional headshot of a confident businesswoman, soft studio lighting, sharp
+  focus on the eyes, Canon EOS R5" beats "masterpiece, best quality, 1girl."
+- **Turbo has no working negative prompt** — steer with the positive prompt.
+- **Native resolutions:** 1024×1024 (or 1328×1328 native), 896×1152, 832×1216,
+  1280×720. **Dimensions must be divisible by 16.**
+- **ControlNet** pairs best with `res_2s` / `res_5s` + a `beta57` scheduler.
+
+## What to make with it
+
+- **Photoreal portraits & fashion** — Z-Image's standout strength; the go-to for
+  faces, headshots, and editorial looks at low VRAM.
+- **Fast batch ideation** — Turbo's speed makes it ideal for spinning dozens of
+  concepts, then refining the keepers on Base.
+- **Custom characters & styles** — train a LoRA on Base, deploy on Turbo.
+- **Guided composition** — Fun-ControlNet for pose/depth/canny-driven scenes.
+
+## Troubleshooting
+
+- **"Torch not compiled with CUDA enabled."** A CPU-only torch is installed.
+  Reinstall the matching CUDA torch wheel (e.g. cu126/cu128) into the ComfyUI
+  `python_embeded` / venv.
+- **Pascal / Maxwell cards (GTX 10xx / 9xx) fail or fall back to CPU.** Newer cu12x
+  wheels dropped those compute capabilities — reinstall the **cu126** torch build
+  from `https://download.pytorch.org/whl/cu126`.
+- **No Q6_K file found.** Expected — there's no Q6_K on the mirror. Use **Q5_K_S**
+  or **Q8_0**.
+- **Every seed produces the same image (Turbo).** A known trait of the distilled
+  model. Use the **SeedVarianceEnhancer** node (shipped in the Turbo pack) to restore
+  diversity, or generate on Base.
+- **Missing custom nodes after install.** Restart ComfyUI, or use ComfyUI-Manager →
+  *Install missing custom nodes* to pull node Python deps.
+- **OOM.** Drop to the **Q5_K_S** GGUF, lower the resolution, and confirm you've set
+  `clear_vram` before switching from another model family.
+
+## FAQ
+
+**Is Z-Image open source?** The weights are openly published by Tongyi-MAI on
+HuggingFace and widely usable locally. Confirm the exact license terms on the model
+card for your use case (*unverified here* — check before commercial use).
+
+**Turbo or Base — which should I install?** Turbo for speed and fast iteration under
+8 GB; Base if you want maximum quality, diverse styles, working negative prompts, or
+you're training LoRAs.
+
+**How much VRAM do I really need?** The **Q5_K_S** GGUF runs **under 8 GB**; Q8_0
+wants ~12–16 GB. People run it on 6 GB cards with low quants.
+
+**How fast is it?** Turbo does a 1024px image in roughly **2.3 seconds at 8 steps**
+on an RTX 4090; sub-second on data-center GPUs.
+
+**Can I train a Z-Image LoRA, and on which model?** Yes — train on **Base** with the
+[`ai-toolkit-trainer`](/plugin) skill; a Base-trained LoRA generally works in the
+Turbo workflow too.
+
+**Why don't negative prompts work in Turbo?** Turbo is DMD-distilled with CFG baked
+in, so the negative conditioning has little effect. Use Base for real negative
+prompts, or steer Turbo via the positive prompt.
+
+**Why is there no Q6_K download?** The installer menu lists it, but no Q6_K GGUF is
+published on the Aitrepreneur/FLX mirror — use Q5_K_S or Q8_0.
+
+---
+
+## Get it running in one command
+
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
+   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+2. Apply the [`z-image-turbo`](/packs/z-image-turbo) pack (fast) or
+   [`z-image-base`](/packs/z-image-base) pack (trainable) — nodes + GGUF models land
+   in the right folders, validated.
+3. Open the [Panel](/panel) and let your Claude session wire the ControlNet, swap
+   quant tiers, and iterate on prompts for you.
+
+That's the whole point of the project: expert ComfyUI setups that install in one
+step and drive themselves from your own agent session. **Next in the series:** the
+Flux photoreal deep-dive — and how it stacks up against everything here. For
+information-carrying images with readable text, see
+[Ideogram 4 in ComfyUI](/blog/ideogram-4-comfyui).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,10 +86,23 @@
             "group": "Blog",
             "pages": [
               "blog/index",
-              "blog/ideogram-4-comfyui",
               "blog/installer-packs-that-cant-rot",
               "blog/the-channel-that-talks-back",
               "blog/comfyui-mcp-tdqs-case-study"
+            ]
+          },
+          {
+            "group": "Model Highlights",
+            "pages": [
+              "blog/wan-2.2-comfyui",
+              "blog/qwen-image-comfyui",
+              "blog/wan-animate-comfyui",
+              "blog/wan-transparent-comfyui",
+              "blog/z-image-comfyui",
+              "blog/ernie-image-comfyui",
+              "blog/anima-comfyui",
+              "blog/ltx-2.3-comfyui",
+              "blog/ideogram-4-comfyui"
             ]
           }
         ]


### PR DESCRIPTION
﻿## Model-highlight series (8 posts)

Completes the chronological series that ends on the Ideogram 4 flagship. One post per model, each matching the locked template: hype-but-honest, SEO frontmatter (title/desc/keywords), VRAM/quant guidance, a one-command pack + Panel CTA, FAQ, and cross-links.

- WAN 2.2 (high/low-noise experts explained), WAN Animate 2.2, WAN Transparent, Qwen-Image & Edit, Z-Image (Turbo/Base), ERNIE-Image, ANIMA 1.0, LTX-2.3.
- Adds a **Model Highlights** nav group in docs.json and a CardGroup on the blog index.
- Each post researched via web (capabilities, comparisons, hype quotes, SEO) and grounded in its comfyui-mcp pack/skill; vendor/benchmark claims are scoped and unverified items flagged in-text.

Generated with Claude Code
