### PR TITLE
fix(blog): MDX angle-bracket break on two posts (500)

### DIFF
--- a/docs/blog/ltx-2.3-comfyui.mdx
+++ b/docs/blog/ltx-2.3-comfyui.mdx
@@ -127,7 +127,7 @@ replacement inside existing 2.3 graphs. Compatibility caveats worth knowing:
   a 2.0 VAE/encoder produces garbage.
 - The real base files are `sulphur_dev_bf16` (~46 GB) and `sulphur_dev_fp8mixed`
   (~29 GB); GGUF quants are published separately (e.g.
-  `sulphur_dev-<quant>.gguf`). There is no file literally named
+  `sulphur_dev-QUANT.gguf`). There is no file literally named
   "sulphur2Base_dev.safetensors" — that's shorthand.
 - It's a third-party derivative with its own hosting and license. **Verify the repo
   and terms yourself** before downloading; we're noting it exists, not endorsing a
@@ -179,7 +179,7 @@ each model into the right folder:
 
 | File | Folder |
 |------|--------|
-| `ltx-2.3-22b-dev-<Q4_K_S\|Q5_K_S\|Q8_0>.gguf` (UNet) | `models/unet/` |
+| `ltx-2.3-22b-dev-Q4_K_S.gguf` (or Q5_K_S / Q8_0; UNet) | `models/unet/` |
 | `LTX23_video_vae_bf16.safetensors` | `models/vae/` |
 | `LTX23_audio_vae_bf16.safetensors` (audio sync) | `models/vae/` |
 | `gemma_3_12B_it_fp4_mixed.safetensors` (text encoder) | `models/text_encoders/` |

--- a/docs/blog/wan-transparent-comfyui.mdx
+++ b/docs/blog/wan-transparent-comfyui.mdx
@@ -100,7 +100,7 @@ Stages:
   `happy.webp` — across a whole output folder in one run.
 
 Drop the renamed files into
-`SillyTavern/public/characters/<your-character>/`, and the expressions extension
+`SillyTavern/public/characters/your-character/`, and the expressions extension
 picks them up. Animated WebP sprites just work there.
 
 ## System & VRAM requirements
@@ -210,7 +210,7 @@ and size, so links don't quietly rot
   lossless.
 - **SillyTavern doesn't pick up the sprite.** Filenames must match the emotion
   label (`happy.webp`, not `happy_00001.webp`). Run `expression-renamer.bat`,
-  and drop files in `public/characters/<character>/`.
+  and drop files in `public/characters/your-character/`.
 - **OOM during generation.** Use a smaller I2V GGUF quant, shorten the clip,
   lower the resolution/frame count, or clear the cache between runs.
 - **CUDA breaks after installing a node.** A custom node can drag in a Torch


### PR DESCRIPTION
﻿Fixes a 500 on /blog/ltx-2.3-comfyui and /blog/wan-transparent-comfyui: Mintlify parses `<word>` as JSX even inside inline code, crashing just those pages (the site-wide deploy check still passes). Replaced the angle-bracket placeholders with safe forms. The other 7 model-highlight posts were checked and are clean.
