### PR TITLE
docs(tools): remove per-tool screenshot placeholders

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,9 +25,10 @@ category plus the matching `navigation` tab in `docs.json`.
 
 ## Images / examples
 
-Screenshots use a `[Screenshot coming soon]` placeholder (`images/placeholder.svg`). Drop real
-images under `images/` and update the `<Frame>` `src` (and fill in the example skeletons) as
-they become available.
+The generated **tool reference** pages carry no screenshots — a placeholder image per tool is
+noise, not clarity. Narrative pages (e.g. the docs home hero) may still use a `<Frame>` with
+`images/placeholder.svg`; drop a real image under `images/` and update the `src` when available.
+Example payloads in the tool reference are generated skeletons (the "Example coming soon" note).
 
 ## Deploy
 

--- a/docs/tools/api-nodes.mdx
+++ b/docs/tools/api-nodes.mdx
@@ -10,10 +10,6 @@ icon: "cloud"
 
 List hosted partner/API nodes available on the connected ComfyUI (e.g. Flux/BFL, Ideogram, Kling, Stability). These call external image/video providers and run server-side, requiring a Comfy account/API key configured on the ComfyUI server. Returns an empty list if the server has no API nodes (or they are disabled).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_api_nodes — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="filter" type="string">
@@ -36,10 +32,6 @@ List hosted partner/API nodes available on the connected ComfyUI (e.g. Flux/BFL,
 ## get_api_node_schema
 
 Return the input schema for a specific API/partner node from the connected ComfyUI's /object_info. Lists visible inputs (with types/defaults/options), hidden inputs (server-filled auth), and outputs. Use list_api_nodes first to find a class_type.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_api_node_schema — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -65,10 +57,6 @@ Return the input schema for a specific API/partner node from the connected Comfy
 ## generate_with_api_node
 
 Build a minimal single-node workflow that runs a chosen API/partner node with the provided inputs and enqueue it. Returns immediately with the prompt_id (use get_job_status / get_history for results). Do NOT pass auth credentials in inputs — the ComfyUI server injects those from its logged-in session. Use get_api_node_schema to discover valid inputs.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_with_api_node — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -10,10 +10,6 @@ icon: "images"
 
 Fetch a registered asset's bytes and return them as an inline image so the agent can see the result. Use this after enqueue_workflow completes (asset_id is included in the completion notification) to inspect, critique, or compare generated images. Only supports image mime types (PNG/JPEG/WebP); audio/video assets must be saved to disk via get_image.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="view_image — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="asset_id" type="string" required>
@@ -38,10 +34,6 @@ Fetch a registered asset's bytes and return them as an inline image so the agent
 ## get_image
 
 Fetch a generated image from ComfyUI and return it as an inline image. Works with remote ComfyUI instances — does not require COMFYUI_PATH. Use get_history first to obtain the filename.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_image — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -76,10 +68,6 @@ Fetch a generated image from ComfyUI and return it as an inline image. Works wit
 ## convert_image
 
 Re-encode a generated image to PNG, JPEG, or WebP and return it inline as an image content block. Source can be a registered asset_id or a path under the local ComfyUI output directory. Optionally writes the converted image back under the output directory and reports source/output size plus bytes saved.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="convert_image — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -127,10 +115,6 @@ Re-encode a generated image to PNG, JPEG, or WebP and return it inline as an ima
 
 Upload a generated ComfyUI output to cloud storage. Source can be asset_id or a local path under COMFYUI_PATH/output. Destination can be S3, Azure Blob, HTTP PUT, or HuggingFace via the hf CLI.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="upload_output — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="asset_id" type="string">
@@ -162,10 +146,6 @@ Upload a generated ComfyUI output to cloud storage. Source can be asset_id or a 
 
 Upload a local image file to the connected ComfyUI's input/ directory via the HTTP /upload/image endpoint so it can be referenced in LoadImage nodes. Works for both local and remote ComfyUI. Returns the stored filename.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="upload_image — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="source_path" type="string" required>
@@ -193,10 +173,6 @@ Upload a local image file to the connected ComfyUI's input/ directory via the HT
 ## upload_video
 
 Upload a local video file (.mp4, .mov, .webm, .avi, .mkv, .m4v) to the connected ComfyUI's input/ directory via the HTTP /upload/image endpoint for use in video-loading nodes such as VHS_LoadVideo (ComfyUI-VideoHelperSuite). Works for both local and remote ComfyUI. Returns the stored filename. Use upload_image for images or upload_audio for audio.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="upload_video — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -226,10 +202,6 @@ Upload a local video file (.mp4, .mov, .webm, .avi, .mkv, .m4v) to the connected
 
 Upload a local audio file (.wav, .mp3, .flac, .ogg, .m4a, .aac) to the connected ComfyUI's input/ directory via the HTTP /upload/image endpoint for use in audio-conditioned workflows (e.g. LoadAudio). Works for both local and remote ComfyUI. Returns the stored filename. Use upload_image for images or upload_video for video.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="upload_audio — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="source_path" type="string" required>
@@ -258,10 +230,6 @@ Upload a local audio file (.wav, .mp3, .flac, .ogg, .m4a, .aac) to the connected
 
 List recently generated image files from ComfyUI's local output/ directory (filesystem scan), newest-first, with file size and modification time. Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the image data itself. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the actual bytes. Read-only.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_output_images — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="limit" type="integer">
@@ -288,10 +256,6 @@ List recently generated image files from ComfyUI's local output/ directory (file
 
 List recently generated assets from the in-memory registry, newest-first. Assets are registered automatically when a workflow completes successfully. The registry is ephemeral and clears on server restart; records expire after COMFYUI_ASSET_TTL_HOURS (default 24h).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_assets — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="limit" type="integer">
@@ -317,10 +281,6 @@ List recently generated assets from the in-memory registry, newest-first. Assets
 ## get_asset_metadata
 
 Get full provenance for a registered asset including the workflow snapshot that produced it. Use this to inspect the parameters that generated an image before calling regenerate with overrides.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_asset_metadata — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -10,10 +10,6 @@ icon: "puzzle"
 
 Search the public ComfyUI Registry (registry.comfy.org) for custom node packs by keyword. Read-only and network-only: queries the hosted registry over HTTP and does NOT require a running ComfyUI or COMFYUI_PATH. Returns a ranked list of packs with id, name, author, install count, and latest version. Use to discover packs to install; pass a returned id to get_node_pack_details for full info. This searches node PACKS, not models (use search_models) and not local installs (use list_local_models).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="search_custom_nodes — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="query" type="string" required>
@@ -45,10 +41,6 @@ Search the public ComfyUI Registry (registry.comfy.org) for custom node packs by
 
 Get full details for one ComfyUI custom node pack from the public ComfyUI Registry: description, author, license, repository, install count, latest version, the node types it provides, and recent version changelogs. Read-only and network-only (hosted registry over HTTP); does not require a running ComfyUI. Look up the pack id via search_custom_nodes first.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_node_pack_details — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="id" type="string" required>
@@ -73,10 +65,6 @@ Get full details for one ComfyUI custom node pack from the public ComfyUI Regist
 ## install_custom_node
 
 Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), git URL, or name. Uses the ComfyUI-Manager HTTP API (works against remote instances) and falls back to the cm-cli subprocess when forced. A ComfyUI restart may be required to load newly installed nodes.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="install_custom_node — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -121,10 +109,6 @@ Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), 
 
 Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="update_custom_node — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="id" type="string" required>
@@ -158,10 +142,6 @@ Update an installed ComfyUI custom node pack, or pass 'all' to update every inst
 ## reinstall_custom_node
 
 Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback. A ComfyUI restart may be required.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="reinstall_custom_node — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -200,10 +180,6 @@ Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-
 
 Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Single-pack repair uses the ComfyUI-Manager HTTP API; 'all' and forced runs use the cm-cli subprocess (requires a local ComfyUI install).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="fix_custom_node — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="id" type="string" required>
@@ -238,10 +214,6 @@ Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'al
 
 List installed ComfyUI custom node packs with their version and enabled/disabled state. Uses the ComfyUI-Manager HTTP API (works against remote instances); the cm-cli fallback returns names only.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_installed_nodes — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="mode" type="enum">
@@ -268,10 +240,6 @@ List installed ComfyUI custom node packs with their version and enabled/disabled
 
 Reconcile the Python dependencies of all installed custom node packs (comfy-cli `node uv-sync` analogue). Runs cm-cli restore-dependencies as a subprocess and requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="sync_node_dependencies — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -290,10 +258,6 @@ Reconcile the Python dependencies of all installed custom node packs (comfy-cli 
 ## extract_workflow_dependencies
 
 Analyze a ComfyUI workflow (API JSON) and determine which custom node packs it requires. Maps each node class_type to its owning node pack using ComfyUI-Manager mappings and the server's installed node definitions, reporting which packs are installed vs missing. Works remotely (HTTP only) — mirrors `comfy-cli node deps-in-workflow`.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="extract_workflow_dependencies — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -320,10 +284,6 @@ Analyze a ComfyUI workflow (API JSON) and determine which custom node packs it r
 
 Resolve and install the custom node packs a ComfyUI workflow requires via ComfyUI-Manager. Determines the missing packs, resets the Manager queue, queues the installs, starts the worker, and reports what was installed/already-present/unresolved. Runs server-side through ComfyUI-Manager on the connected instance (works against a local OR remote --comfyui-url target); a ComfyUI restart is typically needed before new nodes load. Mirrors `comfy-cli node install-deps`.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="install_workflow_dependencies — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="workflow" type="string | object" required>
@@ -349,10 +309,6 @@ Resolve and install the custom node packs a ComfyUI workflow requires via ComfyU
 
 Save a snapshot of the current ComfyUI custom-node and version state via ComfyUI-Manager (mirrors `comfy node save-snapshot`). With no name, Manager assigns a timestamped snapshot (works against remote instances). Provide a name to write a custom-named snapshot file — this requires a local ComfyUI install and is unavailable in remote (--comfyui-url) mode.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="save_node_snapshot — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="name" type="string">
@@ -375,10 +331,6 @@ Save a snapshot of the current ComfyUI custom-node and version state via ComfyUI
 ## restore_node_snapshot
 
 Restore a previously saved custom-node snapshot via ComfyUI-Manager (mirrors `comfy node restore-snapshot`). ComfyUI-Manager applies the custom-node changes on the next ComfyUI restart. Use list_node_snapshots to find available snapshot names.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="restore_node_snapshot — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -405,10 +357,6 @@ Restore a previously saved custom-node snapshot via ComfyUI-Manager (mirrors `co
 
 List available custom-node snapshots known to ComfyUI-Manager (mirrors `comfy node` snapshot listing).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_node_snapshots — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -427,10 +375,6 @@ List available custom-node snapshots known to ComfyUI-Manager (mirrors `comfy no
 ## bisect_start
 
 Begin a binary-search (bisect) session over installed ComfyUI custom nodes to find which one causes a problem. Enables half the nodes and disables the rest for the first test round, then guide the search with bisect_good / bisect_bad. Prefers the ComfyUI-Manager HTTP API; falls back to toggling .disabled directory suffixes for local installs. A ComfyUI restart may be needed for changes to take effect.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="bisect_start — screenshot coming soon" />
-</Frame>
 
 <Note>This tool takes no parameters.</Note>
 
@@ -451,10 +395,6 @@ Begin a binary-search (bisect) session over installed ComfyUI custom nodes to fi
 
 Mark the currently enabled set of custom nodes as GOOD (the problem is absent with this set). Narrows the bisection to the disabled candidates and enables the next subset to test. Resolves and reports the culprit when one node remains.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="bisect_good — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -473,10 +413,6 @@ Mark the currently enabled set of custom nodes as GOOD (the problem is absent wi
 ## bisect_bad
 
 Mark the currently enabled set of custom nodes as BAD (the problem is present with this set). Narrows the bisection to the enabled subset and enables the next subset to test. Resolves and reports the culprit when one node remains.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="bisect_bad — screenshot coming soon" />
-</Frame>
 
 <Note>This tool takes no parameters.</Note>
 
@@ -497,10 +433,6 @@ Mark the currently enabled set of custom nodes as BAD (the problem is present wi
 
 Re-enable all custom nodes and clear the current bisect session. Use this to abort a bisection or restore the installation after the search completes.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="bisect_reset — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -520,10 +452,6 @@ Re-enable all custom nodes and clear the current bisect session. Use this to abo
 
 Report the current bisect session state: status (idle/running/resolved), the remaining candidate node set, which nodes are enabled this round, and the identified culprit if resolved.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="bisect_status — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -542,10 +470,6 @@ Report the current bisect session state: status (idle/running/resolved), the rem
 ## scaffold_custom_node
 
 Generate a new ComfyUI custom-node pack from a template into &lt;COMFYUI_PATH&gt;/custom_nodes/&lt;name&gt;/. Writes pyproject.toml (with the [tool.comfy] PublisherId/DisplayName/Icon table the Comfy Registry requires), __init__.py exporting NODE_CLASS_MAPPINGS / NODE_DISPLAY_NAME_MAPPINGS, and src/nodes.py containing a runnable sample node (INPUT_TYPES/RETURN_TYPES/FUNCTION/CATEGORY), plus .comfyignore and .gitignore. Optionally emits a web/js frontend stub (wiring WEB_DIRECTORY) and a GitHub Actions publish workflow (with_ci). This is the FIRST step of the author loop: scaffold here, then restart_comfyui to load it, test it, and finally publish_custom_node. LOCAL-ONLY: it writes to your local ComfyUI install and requires COMFYUI_PATH (it does nothing for a remote --comfyui-url target). Names must be a safe lowercase slug and cannot escape custom_nodes/; an existing non-empty directory is left untouched unless overwrite is true. Use this to CREATE a pack you author — to install someone else's pack use install_custom_node instead.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="scaffold_custom_node — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -594,10 +518,6 @@ Generate a new ComfyUI custom-node pack from a template into &lt;COMFYUI_PATH&gt
 
 Test that a custom-node pack actually loads in ComfyUI — the middle step of the author loop (scaffold_custom_node → verify_custom_node → publish_custom_node). Restarts the local ComfyUI and waits for it to become ready, then checks that the pack's node class_types appear in /object_info. A node that fails to import (a missing dependency or a syntax error) simply never registers, so any missing class_types pinpoint a broken pack. Provide class_types explicitly, or a pack `name` whose __init__.py declares NODE_CLASS_MAPPINGS (the keys are inferred). LOCAL-ONLY: needs COMFYUI_PATH and a managed local ComfyUI. Set restart:false to check the already-running server without restarting it.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="verify_custom_node — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="name" type="string">
@@ -626,10 +546,6 @@ Test that a custom-node pack actually loads in ComfyUI — the middle step of th
 ## publish_custom_node
 
 Publish a local custom-node pack to the public Comfy Registry (registry.comfy.org) by running `comfy node publish` inside the pack directory. First validates the pack's pyproject.toml has the required [project].name, [project].version and [tool.comfy].PublisherId (refusing the scaffold placeholder), then publishes using the API key from the REGISTRY_ACCESS_TOKEN environment variable (passed to comfy-cli via the environment, never via logged arguments). This is the LAST step of the author loop and an IRREVERSIBLE, EXTERNAL action: it creates/updates a PUBLIC registry version that this tool cannot undo. Requires comfy-cli installed and REGISTRY_ACCESS_TOKEN set. LOCAL-ONLY: it reads and runs against a pack on the local filesystem and is meaningless for a remote --comfyui-url target. To create a pack first, use scaffold_custom_node.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="publish_custom_node — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/defaults-stats-skills.mdx
+++ b/docs/tools/defaults-stats-skills.mdx
@@ -10,10 +10,6 @@ icon: "sliders"
 
 Return the merged view of generation defaults with per-source attribution. Precedence (lowest → highest): config file → COMFYUI_DEFAULT_* env vars → runtime overrides via set_defaults. Per-call MCP tool args always win over these defaults when consumed by a workflow-construction tool.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_defaults — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -32,10 +28,6 @@ Return the merged view of generation defaults with per-source attribution. Prece
 ## set_defaults
 
 Update generation defaults. By default updates the in-memory runtime layer (lost on restart). Pass persist=true to also write the change into the config file (~/.config/comfyui-mcp/config.json by default). Use this to avoid repeating common values like width, height, steps, cfg, sampler, checkpoint.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="set_defaults — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -64,10 +56,6 @@ Update generation defaults. By default updates the in-memory runtime layer (lost
 ## suggest_settings
 
 Recommend concrete, proven sampler/scheduler/steps/CFG (and denoise/shift/LoRA) settings derived from THIS MCP server's local generation-history database (populated as you run workflows; not from ComfyUI). Read-only and works without a running ComfyUI. Narrow results by model_family, lora_hash, or a name search; with no filter it returns the top settings across all history. Returns a ranked list with each combo's reuse count, or a 'no history' message until you have generated images. Use this for ready-to-apply values; use generation_stats for aggregate counts and breakdowns rather than specific suggestions.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="suggest_settings — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -101,10 +89,6 @@ Recommend concrete, proven sampler/scheduler/steps/CFG (and denoise/shift/LoRA) 
 
 Show statistics from this MCP server's local generation-history database (populated as you run workflows; not from ComfyUI itself): total generations, count of unique sampler/scheduler/steps/CFG combos, a per-model-family breakdown, and the most-reused settings. Read-only; works without a running ComfyUI. Returns empty stats until you have generated images. For concrete recommended settings rather than aggregate counts, use suggest_settings.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generation_stats — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="model_family" type="string">
@@ -127,10 +111,6 @@ Show statistics from this MCP server's local generation-history database (popula
 ## generate_node_skill
 
 Generate a Claude skill (SKILL.md) documenting a ComfyUI custom node pack: its nodes, inputs/outputs, and example workflows. Accepts a ComfyUI Registry ID (resolved via api.comfy.org) or a GitHub repository URL. Uses a read-through cache under ~/.comfyui-mcp/skill-cache (override COMFYUI_SKILL_CACHE_DIR); set refresh:true to bypass it. On cache miss, fetches the repo README and scans its Python NODE_CLASS_MAPPINGS and example workflows over the network (uses GITHUB_TOKEN if set to avoid rate limits), so internet access is required. If a ComfyUI server is reachable it enriches node input/output types from /object_info, but the server is optional. Returns the SKILL.md markdown with structured cache metadata; if install_in is set, also creates that directory (recursively) and writes SKILL.md there, overwriting any existing file.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_node_skill — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/image-generation.mdx
+++ b/docs/tools/image-generation.mdx
@@ -10,10 +10,6 @@ icon: "image"
 
 Generate an image from a text prompt — the high-level entry point. Builds a txt2img workflow, filling any unspecified parameter from your configured defaults (set_defaults / COMFYUI_DEFAULT_* / config file), auto-selecting a local checkpoint when none is given. Returns the prompt_id immediately; the resulting asset_id arrives in the completion notification and can be passed to view_image or regenerate. For full control over the node graph, use create_workflow + enqueue_workflow instead.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_image — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="prompt" type="string" required>
@@ -68,10 +64,6 @@ Generate an image from a text prompt — the high-level entry point. Builds a tx
 ## generate_with_controlnet
 
 Generate an image conditioned by a ControlNet preprocessed image (pose skeleton, depth, canny, normal, etc.) plus a text prompt. Upload the control image first with upload_image, then pass its filename as control_image. Unspecified params fall back to your defaults; checkpoint and controlnet_model auto-resolve from local models. Returns prompt_id immediately; asset_id arrives in the completion notification. control_image must already be a preprocessed map (this tool does not run the preprocessor); requires a running ComfyUI with a matching controlnet model in models/controlnet/.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_with_controlnet — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -135,10 +127,6 @@ Generate an image conditioned by a ControlNet preprocessed image (pose skeleton,
 
 Generate an image guided by a reference image's style/subject via IP-Adapter, plus a text prompt. Requires the ComfyUI_IPAdapter_plus custom nodes. Upload the reference first with upload_image, then pass its filename as reference_image. Unspecified params fall back to your defaults; checkpoint auto-resolves. Returns prompt_id immediately; asset_id arrives in the completion notification. Requires a running ComfyUI with ComfyUI_IPAdapter_plus and a matching IP-Adapter model installed, or the workflow will fail at execution time.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_with_ip_adapter — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="prompt" type="string" required>
@@ -201,10 +189,6 @@ Generate an image guided by a reference image's style/subject via IP-Adapter, pl
 
 Re-enqueue the workflow that produced an existing asset, optionally applying parameter overrides. Overrides are applied to any node input matching the key name (e.g. cfg, steps, sampler_name, scheduler, seed, denoise, text). Seeds are re-randomized by default so each regenerate yields a fresh image unless seed is explicitly passed in overrides.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="regenerate — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="asset_id" type="string" required>
@@ -235,10 +219,6 @@ Re-enqueue the workflow that produced an existing asset, optionally applying par
 ## generate_audio
 
 Generate audio from a text prompt — supports ACE Step 1.5 and Stable Audio 3 model families. Builds the appropriate workflow graph, filling unspecified parameters from your configured defaults (set_defaults / COMFYUI_DEFAULT_* / config file), auto-selecting local models when needed. Returns the prompt_id immediately; the resulting audio asset_id arrives in the completion notification. Requires a running ComfyUI with the corresponding model files installed.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="generate_audio — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -10,10 +10,6 @@ icon: "wrench"
 
 Install ComfyUI locally: git-clone it into a target directory, create a dedicated workspace virtualenv (&lt;target&gt;/.venv), and install Python requirements INTO that venv (never the Python running this MCP server) via pip or uv. ComfyUI-Manager is installed from manager_requirements.txt when present, else git-cloned as a fallback. Mirrors `comfy-cli install`. LOCAL, subprocess-only and independent of any remote --comfyui-url target; the target dir must be empty or non-existent (an existing install is never overwritten). Runs SYNCHRONOUSLY and can take several minutes (large git clone + full torch/dependency install); the call blocks until done. On success returns a JSON report &#123; installed, targetPath, venvPath, comfyuiUrl, managerInstalled, managerVia, version, pythonInstaller, steps[] &#125;. Does NOT start ComfyUI.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="install_comfyui — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="target_path" type="string" required>
@@ -48,10 +44,6 @@ Install ComfyUI locally: git-clone it into a target directory, create a dedicate
 
 Update the ComfyUI core install: runs `git pull` in the configured ComfyUI directory and reinstalls its Python requirements (auto-detecting uv vs pip). Requires a local install (COMFYUI_PATH); returns a clear error when targeting a remote instance via --comfyui-url.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="update_comfyui — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -71,10 +63,6 @@ Update the ComfyUI core install: runs `git pull` in the configured ComfyUI direc
 
 Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues update_all, then starts the queue worker). Mirrors `comfy-cli update all`. This does NOT update ComfyUI core — use update_comfyui for that. Works against the connected instance (local or remote); updates run asynchronously and a ComfyUI restart may be required afterward.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="update_all — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -93,10 +81,6 @@ Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues updat
 ## apply_manifest
 
 Apply a local ComfyUI setup manifest from an inline object or .json/.yaml/.yml file. LOCAL-ONLY: requires COMFYUI_PATH. Composes existing custom-node installs and model downloads, installs pip packages into the ComfyUI Python environment, and reports apt entries as skipped because system packages require manual/root installation.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="apply_manifest — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -124,10 +108,6 @@ Apply a local ComfyUI setup manifest from an inline object or .json/.yaml/.yml f
 
 Report the active ComfyUI workspace (mirrors `comfy-cli which`): the local installation path being used (from COMFYUI_PATH or auto-detection), the source of that path, any persisted default workspace, and the resolved API target the MCP server talks to.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_workspace — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -146,10 +126,6 @@ Report the active ComfyUI workspace (mirrors `comfy-cli which`): the local insta
 ## set_default_workspace
 
 Persist a default ComfyUI workspace path to the MCP config file (mirrors `comfy-cli set-default`). The value is stored under the OS config dir (e.g. ~/.config/comfyui-mcp/workspace.json) and reported by get_workspace/list_workspaces. Does NOT change the live API target.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="set_default_workspace — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -176,10 +152,6 @@ Persist a default ComfyUI workspace path to the MCP config file (mirrors `comfy-
 
 List known/auto-detected ComfyUI installations on this machine. Scans common install locations across macOS, Linux, and Windows and marks which one is active and which is the saved default.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_workspaces — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -199,10 +171,6 @@ List known/auto-detected ComfyUI installations on this machine. Scans common ins
 
 Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). Degrades gracefully: local probes are omitted when no local path is configured or tools are unavailable.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_environment — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -221,10 +189,6 @@ Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance 
 ## configure_manager
 
 Configure ComfyUI-Manager settings, mirroring `comfy-cli manager` subcommands. Most actions use the ComfyUI-Manager HTTP API (works against remote ComfyUI); set_network_mode and set_security_level have no HTTP setter and are written to Manager's config.ini (requires a known local ComfyUI path; restart ComfyUI to apply).
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="configure_manager — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -10,10 +10,6 @@ icon: "box"
 
 Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, ControlNets, etc.). Read-only and network-only: queries HuggingFace over HTTP, does NOT require a running ComfyUI or COMFYUI_PATH and does not download anything. Returns a ranked list with modelId, author, downloads, likes, and tags. Pick a result's download URL and pass it to download_model to install it locally. For packs of custom nodes (not models) use search_custom_nodes.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="search_models — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="query" type="string" required>
@@ -44,10 +40,6 @@ Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, C
 ## download_model
 
 Download a model file to the ComfyUI models directory from a URL (HuggingFace, direct HTTP(S), s3://, or Azure Blob)
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="download_model — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -84,10 +76,6 @@ Download a model file to the ComfyUI models directory from a URL (HuggingFace, d
 
 Download a model from CivitAI into the local ComfyUI models/ directory and return the saved absolute path. Resolves a CivitAI model id (latest version) or a model-version id to a download URL via the CivitAI REST API, then streams the file to disk. LOCAL-ONLY: writes under &lt;COMFYUI_PATH&gt;/models/&lt;target_subfolder&gt;/ and errors when COMFYUI_PATH is unset (e.g. a remote --comfyui-url target). Provide at least one of model_id or model_version_id. Gated/early-access models require CIVITAI_API_TOKEN (sent as a bearer header, never in the URL); without it they fail.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="download_civitai_model — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="target_subfolder" type="enum" required>
@@ -122,10 +110,6 @@ Download a model from CivitAI into the local ComfyUI models/ directory and retur
 
 List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_local_models — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="model_type" type="enum">
@@ -148,10 +132,6 @@ List model files available to the connected ComfyUI, grouped by type. Read-only.
 ## remove_model
 
 Delete a model file from the local ComfyUI models directory. The path must stay within models/ (path traversal and absolute escapes are rejected).
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="remove_model — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -178,10 +158,6 @@ Delete a model file from the local ComfyUI models directory. The path must stay 
 
 List textual-inversion embeddings installed on the connected ComfyUI server (read from its /api/embeddings endpoint, i.e. the models/embeddings folder). Requires a running, reachable ComfyUI (local or remote); takes no parameters. Returns the embedding names; reference them in positive or negative prompts as embedding:name (e.g. embedding:easynegative). Read-only.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_embeddings — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -200,10 +176,6 @@ List textual-inversion embeddings installed on the connected ComfyUI server (rea
 ## clear_vram
 
 Free GPU VRAM by unloading cached models from ComfyUI. Use this between generation runs with different model families (e.g. switching from SDXL to Flux) or when running low on VRAM. Optionally unload only models or only memory.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="clear_vram — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/process-control.mdx
+++ b/docs/tools/process-control.mdx
@@ -10,10 +10,6 @@ icon: "power"
 
 Start ComfyUI using process info saved from a previous stop_comfyui call. Supports both Desktop app and manual Python installs. Polls the API for bounded readiness before reporting ready.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="start_comfyui — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -33,10 +29,6 @@ Start ComfyUI using process info saved from a previous stop_comfyui call. Suppor
 
 Stop the running ComfyUI process. Captures process info so it can be restarted with start_comfyui. Kills the process tree and resets the WebSocket client.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="stop_comfyui — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -55,10 +47,6 @@ Stop the running ComfyUI process. Captures process info so it can be restarted w
 ## restart_comfyui
 
 Restart ComfyUI: stops the running process (capturing its config), waits for the port to free, relaunches with the same arguments, and polls the API for bounded readiness.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="restart_comfyui — screenshot coming soon" />
-</Frame>
 
 <Note>This tool takes no parameters.</Note>
 

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -10,10 +10,6 @@ icon: "pen-ruler"
 
 Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2img, img2img, upscale, inpaint, controlnet, ip_adapter, ace_step_15, stable_audio_3). Pure local generation — does not contact ComfyUI and has no side effects. Returns the complete workflow JSON; pass it to validate_workflow or enqueue_workflow. Unsupplied params fall back to template defaults, so the result may reference checkpoints/models that must exist on your ComfyUI server before it will execute.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="create_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="template" type="enum" required>
@@ -41,10 +37,6 @@ Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2
 ## modify_workflow
 
 Apply modification operations to an existing ComfyUI workflow. Supports: set_input, add_node, remove_node, connect, insert_between. Returns the modified workflow JSON and IDs of any newly added nodes.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="modify_workflow — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -75,10 +67,6 @@ Apply modification operations to an existing ComfyUI workflow. Supports: set_inp
 
 Validate a ComfyUI workflow without executing it. Checks for missing node types, broken connections, invalid output indices, missing models, and other issues. Returns a list of errors and warnings.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="validate_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="workflow" type="string | object" required>
@@ -104,10 +92,6 @@ Validate a ComfyUI workflow without executing it. Checks for missing node types,
 
 Query a running ComfyUI server's /object_info endpoint for installed node type definitions (inputs, outputs, category, description). Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Note: when more than 20 node types match, returns only a summarized list (name, display_name, category, description) and asks you to narrow the filter to get full input/output schemas; 20 or fewer returns complete definitions.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_node_info — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="node_type" type="string">
@@ -130,10 +114,6 @@ Query a running ComfyUI server's /object_info endpoint for installed node type d
 ## workflow_to_dsl
 
 Convert a ComfyUI API-format workflow into a compact, human/LLM-readable DSL — easier to read and edit than raw JSON, and round-trips losslessly back via dsl_to_workflow. Connections render as `key &lt;- nodeId.outputIndex`, literals as `key = &lt;JSON&gt;`. (Experimental.)
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="workflow_to_dsl — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -160,10 +140,6 @@ Convert a ComfyUI API-format workflow into a compact, human/LLM-readable DSL —
 
 Convert the compact workflow DSL (see workflow_to_dsl) back into executable ComfyUI API-format JSON. Useful for authoring/editing workflows in the legible DSL, then converting to run with enqueue_workflow. (Experimental.)
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="dsl_to_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="dsl" type="string" required>
@@ -188,10 +164,6 @@ Convert the compact workflow DSL (see workflow_to_dsl) back into executable Comf
 ## visualize_workflow
 
 Convert a ComfyUI workflow JSON into a Mermaid flowchart diagram. Returns mermaid syntax showing nodes grouped by category (loading, conditioning, sampling, image, output) with connections labeled by data type.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="visualize_workflow — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -223,10 +195,6 @@ Convert a ComfyUI workflow JSON into a Mermaid flowchart diagram. Returns mermai
 ## visualize_workflow_hierarchical
 
 Visualize a large ComfyUI workflow as a hierarchical diagram. Detects logical sections using node categories from /object_info, resolves Get/Set virtual wires, and produces either a compact overview (sections as summary nodes), a detailed view of one section, or a text listing of all sections. Best for workflows with 20+ nodes.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="visualize_workflow_hierarchical — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -264,10 +232,6 @@ Visualize a large ComfyUI workflow as a hierarchical diagram. Detects logical se
 ## mermaid_to_workflow
 
 Convert a Mermaid flowchart diagram back into a ComfyUI workflow JSON. Parses node definitions, connections (with data type labels), and widget values from the mermaid syntax. Resolves node types and wires connections using ComfyUI's /object_info schemas. Fills missing inputs with defaults. Returns a valid, executable ComfyUI API workflow.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="mermaid_to_workflow — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/workflow-execution.mdx
+++ b/docs/tools/workflow-execution.mdx
@@ -10,10 +10,6 @@ icon: "play"
 
 Submit a ComfyUI workflow for execution and return immediately with the prompt_id and queue position. Does not wait for completion. Use get_job_status to check progress later, or get_history to retrieve results and images after completion.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="enqueue_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="workflow" type="object" required>
@@ -42,10 +38,6 @@ Submit a ComfyUI workflow for execution and return immediately with the prompt_i
 
 Get system information from the connected ComfyUI server: GPU device(s), total/free VRAM, ComfyUI/Python/PyTorch versions, and OS details. Requires a running ComfyUI server (works against local or remote targets); read-only, takes no parameters. Returns the raw /system_stats JSON. Use to confirm connectivity and check available VRAM before enqueuing large workflows. Errors if the server is unreachable.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_system_stats — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -65,10 +57,6 @@ Get system information from the connected ComfyUI server: GPU device(s), total/f
 
 Get the current ComfyUI execution queue: the job running now plus all pending jobs, each with its prompt_id and position. Read-only; requires a reachable ComfyUI server (works against local or remote --comfyui-url). Returns JSON with running and pending arrays. Use this to see what is in flight before cancel_job (running) or cancel_queued_job/clear_queue (pending); use get_job_status or get_history for the outcome of one specific prompt_id.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_queue — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -87,10 +75,6 @@ Get the current ComfyUI execution queue: the job running now plus all pending jo
 ## get_job_status
 
 Check the status of ONE ComfyUI job by its prompt_id (the id returned by enqueue_workflow). Queries the connected ComfyUI server; requires it to be running. Returns JSON with running, pending, and done booleans, plus optional status_str, error details, and execution_stats from ComfyUI history once the job is done. Use get_queue to see the whole queue at once, and get_history for full output filenames.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_job_status — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -117,10 +101,6 @@ Check the status of ONE ComfyUI job by its prompt_id (the id returned by enqueue
 
 Interrupt the CURRENTLY RUNNING ComfyUI job, optionally only when its prompt_id matches. Stops in-progress execution — the partial result is discarded and not recoverable — and does NOT remove pending/queued jobs. Requires a reachable ComfyUI server. Use this for the job actively executing now; use cancel_queued_job to remove one specific PENDING job, or clear_queue to drop ALL pending jobs. Returns a confirmation (or a no-op status when nothing is running).
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="cancel_job — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="prompt_id" type="string">
@@ -143,10 +123,6 @@ Interrupt the CURRENTLY RUNNING ComfyUI job, optionally only when its prompt_id 
 ## cancel_queued_job
 
 Remove a specific pending job from the ComfyUI queue by prompt_id. Does not affect running jobs.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="cancel_queued_job — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -173,10 +149,6 @@ Remove a specific pending job from the ComfyUI queue by prompt_id. Does not affe
 
 Clear all pending jobs from the ComfyUI queue. Does not affect the currently running job.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="clear_queue — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -195,10 +167,6 @@ Clear all pending jobs from the ComfyUI queue. Does not affect the currently run
 ## get_history
 
 Get execution history for a ComfyUI prompt. Returns status, timing, cached nodes, output details, and full error information including Python tracebacks. Use after a failed enqueue_workflow to diagnose what went wrong.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_history — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -222,10 +190,6 @@ Get execution history for a ComfyUI prompt. Returns status, timing, cached nodes
 ## get_logs
 
 Get ComfyUI server runtime logs. Useful for debugging execution errors, model loading issues, missing nodes, and Python tracebacks.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_logs — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -252,10 +216,6 @@ Get ComfyUI server runtime logs. Useful for debugging execution errors, model lo
 ## health_check
 
 Pre-flight diagnostic for the connected ComfyUI: one call that aggregates the signals an agent should check before dispatching a batch. Reports ComfyUI version/Python/PyTorch, GPU name + VRAM free/total, system RAM free, queue depth (running + pending), per-category /models populations (catches empty dropdowns from a misconfigured extra_model_paths.yaml), and recent errors from /internal/logs. Read-only — no mutation. Use this when a job fails for an unexpected reason, before a long batch run, or to confirm a remote ComfyUI is healthy. Originally contributed by github.com/joaolvivas.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="health_check — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -10,10 +10,6 @@ icon: "folder-open"
 
 List the filenames of workflows saved in the connected ComfyUI server's user library (the same workflows visible in the ComfyUI web UI). Requires a running ComfyUI server. Takes no parameters. Returns a numbered list of .json filenames; pass a filename to get_workflow or analyze_workflow to load one. Returns "No saved workflows found." when the library is empty.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="list_workflows — screenshot coming soon" />
-</Frame>
-
 <Note>This tool takes no parameters.</Note>
 
 ### Example
@@ -32,10 +28,6 @@ List the filenames of workflows saved in the connected ComfyUI server's user lib
 ## get_workflow
 
 Load a saved workflow and return its raw JSON. Use analyze_workflow instead if you just need to understand the workflow — it returns a structured summary without flooding context with JSON. Use get_workflow only when you need the actual JSON for enqueue_workflow, modify_workflow, or save_workflow.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="get_workflow — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -65,10 +57,6 @@ Load a saved workflow and return its raw JSON. Use analyze_workflow instead if y
 
 Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. Accepts API-format or UI-format JSON. Returns a confirmation message, or the HTTP status and error text on failure.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="save_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="filename" type="string" required>
@@ -97,10 +85,6 @@ Save a workflow JSON to the connected ComfyUI server's user library so it appear
 ## analyze_workflow
 
 Load a saved workflow and return a structured analysis — sections, node settings, connections, and data flow. Use this to understand any workflow before modifying or executing it. Returns a concise text summary (not raw JSON) optimized for AI reasoning. Prefer this over get_workflow unless you need the raw JSON for enqueue_workflow or modify_workflow.
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="analyze_workflow — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 
@@ -133,10 +117,6 @@ Load a saved workflow and return a structured analysis — sections, node settin
 
 Extract embedded ComfyUI workflow metadata from a PNG file. ComfyUI stores the full workflow (API format) and prompt data in PNG tEXt chunks. Use this to reverse-engineer how any ComfyUI image was generated.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="workflow_from_image — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="image_path" type="string" required>
@@ -162,10 +142,6 @@ Extract embedded ComfyUI workflow metadata from a PNG file. ComfyUI stores the f
 
 Capture a provenance lock for a saved workflow so it can be exactly reproduced later. Walks the workflow's model loaders (CheckpointLoaderSimple, UNETLoader, VAELoader, LoraLoader, ControlNetLoader, etc.), SHA-256s every referenced model file, records the git commit currently checked out for every custom node pack the workflow's class_types come from, and captures ComfyUI's reported version. Writes `&lt;filename&gt;.lock.json` next to the workflow in ComfyUI's user library. Requires a local install (COMFYUI_PATH) — SHA-256 needs raw file bytes and pack commits come from `custom_nodes/*/.git/HEAD`. Pair with verify_workflow_lock later to detect drift.
 
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="lock_workflow — screenshot coming soon" />
-</Frame>
-
 ### Parameters
 
 <ParamField path="filename" type="string" required>
@@ -190,10 +166,6 @@ Capture a provenance lock for a saved workflow so it can be exactly reproduced l
 ## verify_workflow_lock
 
 Compare a saved workflow's lock file against the current state of the local install and report drift. Loads `&lt;filename&gt;.lock.json` from ComfyUI's user library, re-computes a current lock from the same workflow, and diffs: which models have a different SHA-256, which custom node packs are on a different commit, whether ComfyUI's version changed. Use before re-running an important workflow days or weeks later to confirm it'll behave the same. Requires a local install (COMFYUI_PATH). Returns a structured drift report (empty arrays everywhere mean perfect parity).
-
-<Frame caption="Screenshot coming soon">
-  <img src="/images/placeholder.svg" alt="verify_workflow_lock — screenshot coming soon" />
-</Frame>
 
 ### Parameters
 

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -257,12 +257,6 @@ function renderTool(t: CapturedTool): string {
   const lines: string[] = [];
   lines.push(`## ${t.name}`, "");
   lines.push(esc(t.description), "");
-  lines.push(
-    `<Frame caption="Screenshot coming soon">`,
-    `  <img src="/images/placeholder.svg" alt="${t.name} — screenshot coming soon" />`,
-    `</Frame>`,
-    "",
-  );
 
   if (paramNames.length > 0) {
     lines.push("### Parameters", "");


### PR DESCRIPTION
﻿Removes the per-tool "Screenshot coming soon" placeholders from the auto-generated tool reference — a placeholder image per tool is noise, not clarity.

- Fixes the generator (`scripts/gen-tool-docs.ts`) so it no longer emits the placeholder `<Frame>`.
- Strips the 89 existing blocks from `docs/tools/*.mdx`.
- Keeps the docs-home hero placeholder (a sensible screenshot spot) and the "Example coming soon" skeleton notes.
- README convention note updated.
