### PR TITLE
docs: reframe the panel for the orchestrator (drop --channels install)

### DIFF
--- a/docs/blog/anima-comfyui.mdx
+++ b/docs/blog/anima-comfyui.mdx
@@ -318,12 +318,10 @@ isn't tuned for photorealistic output.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
-   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
-   [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`anima` pack** — nodes + every model land in the right folders,
    CI-validated, with the Anima-LLLite inpainting node included.
-3. Open the [Panel](/panel) and let your Claude session wire the graph, swap
+3. Open the [Panel](/panel) and let the panel's agent wire the graph, swap
    LoRAs, and iterate on tag-plus-prose prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one

--- a/docs/blog/ernie-image-comfyui.mdx
+++ b/docs/blog/ernie-image-comfyui.mdx
@@ -267,9 +267,9 @@ designed for layout-sensitive, multilingual text rendering, not as an afterthoug
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ernie` pack** — nodes + ERNIE-only models land in the right folders, validated, with the Z-Image cruft stripped out.
-3. Open the [Panel](/panel) and let your Claude session write multilingual prompts and wire the graph for you.
+3. Open the [Panel](/panel) and let the panel's agent write multilingual prompts and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**

--- a/docs/blog/ideogram-4-comfyui.mdx
+++ b/docs/blog/ideogram-4-comfyui.mdx
@@ -248,9 +248,9 @@ model's core design goal, not an afterthought.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ideogram` pack** — nodes + ~50 GB of models land in the right folders, validated.
-3. Open the [Panel](/panel) and let your Claude session build area-prompts and wire the graph for you.
+3. Open the [Panel](/panel) and let the panel's agent build area-prompts and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **That wraps the

--- a/docs/blog/ltx-2.3-comfyui.mdx
+++ b/docs/blog/ltx-2.3-comfyui.mdx
@@ -306,13 +306,11 @@ and the "sulphur" finetune is a separate third-party project with its own licens
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
-   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
-   [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`ltx-2.3` pack** — GGUF UNet, both VAEs, the Gemma encoder, text
    projection, upscaler, and LoRAs land in the right folders, validated.
 3. Run the bundled **kornia fix**, restart, then open the [Panel](/panel) and let
-   your Claude session wire the GGUF graph and build prompts for you.
+   the panel's agent wire the GGUF graph and build prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**

--- a/docs/blog/qwen-image-comfyui.mdx
+++ b/docs/blog/qwen-image-comfyui.mdx
@@ -304,13 +304,11 @@ English layouts.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
-   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the
-   [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **[`qwen-image`](https://github.com/artokun/comfyui-mcp)** pack (20B
    T2I + WAN combo) and/or **`qwen-image-edit`** (instruction editing + mask
    inpainting) — nodes and models land in the right folders, validated.
-3. Open the [Panel](/panel) and let your Claude session load images, paint masks,
+3. Open the [Panel](/panel) and let the panel's agent load images, paint masks,
    and wire the graph for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one

--- a/docs/blog/wan-2.2-comfyui.mdx
+++ b/docs/blog/wan-2.2-comfyui.mdx
@@ -321,9 +321,9 @@ vendor/blog benchmarks, not independently audited.)
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **[`wan-longer-videos` pack](https://github.com/artokun/comfyui-mcp/tree/main/packs/wan-longer-videos)** — nodes + the four hi/lo GGUFs, encoder, VAE, LoRAs, and upscaler land in the right folders, validated. Pick your quant tier.
-3. Open the [Panel](/panel) and let your Claude session set the hi/lo split, swap LoRAs, and stitch longer clips for you.
+3. Open the [Panel](/panel) and let the panel's agent set the hi/lo split, swap LoRAs, and stitch longer clips for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**

--- a/docs/blog/wan-animate-comfyui.mdx
+++ b/docs/blog/wan-animate-comfyui.mdx
@@ -262,10 +262,10 @@ not a universal benchmark.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`wan-animate` pack** — nodes + models land in the right folders, validated.
 3. Run `install_triton_and_sageattention_auto.bat`, restart, and load `workflow.json`.
-4. Open the [Panel](/panel) and let your Claude session load the image, point at the driving video, and iterate.
+4. Open the [Panel](/panel) and let the panel's agent load the image, point at the driving video, and iterate.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**

--- a/docs/blog/wan-transparent-comfyui.mdx
+++ b/docs/blog/wan-transparent-comfyui.mdx
@@ -255,9 +255,9 @@ use the output. SillyTavern is just the cleanest fit.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the **`wan-transparent` pack** — custom nodes + the WAN 2.2 I2V subset + the BiRefNet matting model land in the right folders, validated.
-3. Open the [Panel](/panel) and let your Claude session swap input images, tweak motion prompts, and batch out a full expression set for you.
+3. Open the [Panel](/panel) and let the panel's agent swap input images, tweak motion prompts, and batch out a full expression set for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one
 step and drive themselves from your own agent session. **Next in the series:**

--- a/docs/blog/z-image-comfyui.mdx
+++ b/docs/blog/z-image-comfyui.mdx
@@ -291,12 +291,11 @@ published on the Aitrepreneur/FLX mirror — use Q5_K_S or Q8_0.
 
 ## Get it running in one command
 
-1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
-   (`claude mcp add comfyui -- npx -y comfyui-mcp --channels`) and the [plugin](/plugin).
+1. Install [comfyui-mcp](https://github.com/artokun/comfyui-mcp) and the [Panel](/panel) — the panel auto-starts a background agent on your Claude subscription (no API keys; sign in with `claude` once).
 2. Apply the [`z-image-turbo`](/packs/z-image-turbo) pack (fast) or
    [`z-image-base`](/packs/z-image-base) pack (trainable) — nodes + GGUF models land
    in the right folders, validated.
-3. Open the [Panel](/panel) and let your Claude session wire the ControlNet, swap
+3. Open the [Panel](/panel) and let the panel's agent wire the ControlNet, swap
    quant tiers, and iterate on prompts for you.
 
 That's the whole point of the project: expert ComfyUI setups that install in one

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -123,17 +123,37 @@ Applies to `start_comfyui` / `restart_comfyui` when comfyui-mcp manages a local 
   Sliding window (seconds) over which auto-restart attempts are counted.
 </ParamField>
 
-## Channels — drive the ComfyUI sidebar panel from your own agent session
+## Panel orchestrator & the bridge
 
-Start the server with `--channels` (or `COMFYUI_MCP_CHANNELS=1`) and install the
-[comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel) pack in ComfyUI.
-The server hosts a loopback WebSocket bridge the panel connects to, and registers
-eight `panel_*` MCP tools (`panel_status`, `panel_get_graph`, `panel_add_node`,
-`panel_remove_node`, `panel_connect`, `panel_disconnect`, `panel_set_widget`,
-`panel_say`, `panel_inbox`) — **your own Claude Code session is the agent**, editing
-the live graph through its MCP connection. No LLM API keys are involved; every
-graph mutation is undoable with Ctrl+Z. Messages typed into the panel queue for
-`panel_inbox` and are pushed as channel events on hosts that support them.
+The [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel) sidebar is
+driven by the **panel orchestrator** — a background process that owns a loopback
+WebSocket bridge and runs an autonomous Claude Agent SDK session per panel tab on
+your **Claude subscription** (no API keys). The panel pack auto-starts it on
+ComfyUI load, so you normally don't run anything by hand — see
+[Sidebar Panel](/panel). To run it yourself:
+
+```bash
+npx -y comfyui-mcp --panel-orchestrator
+```
+
+<ParamField path="COMFYUI_MCP_PANEL_ORCHESTRATOR" type="boolean" default="false">
+  Run the panel orchestrator instead of an MCP server (same as `--panel-orchestrator`).
+</ParamField>
+<ParamField path="COMFYUI_MCP_PANEL_MODEL" type="string" default="claude-opus-4-8">
+  Model for the background panel agents.
+</ParamField>
+<ParamField path="COMFYUI_MCP_BRIDGE_PORT" type="number" default="9101">
+  Loopback port for the panel WebSocket bridge.
+</ParamField>
+
+### Channels mode (interactive / advanced)
+
+`--channels` (or `COMFYUI_MCP_CHANNELS=1`) starts the same bridge **and**
+registers the `panel_*` MCP tools in the current session, so *your own* Claude
+Code session can drive the live graph the panel shows — the interactive
+alternative to the orchestrator. Because it binds the same bridge port, run
+**one or the other**: a `--channels` session and the orchestrator will fight over
+port `9101`.
 
 ```bash
 claude mcp add comfyui -- npx -y comfyui-mcp --channels
@@ -141,9 +161,6 @@ claude mcp add comfyui -- npx -y comfyui-mcp --channels
 
 <ParamField path="COMFYUI_MCP_CHANNELS" type="boolean" default="false">
   Enable channels mode without the CLI flag.
-</ParamField>
-<ParamField path="COMFYUI_MCP_BRIDGE_PORT" type="number" default="9101">
-  Loopback port for the panel WebSocket bridge.
 </ParamField>
 
 ## Job watching

--- a/docs/panel.mdx
+++ b/docs/panel.mdx
@@ -1,53 +1,69 @@
 ---
 title: "Sidebar Panel"
-description: "ComfyUI MCP Panel — your Claude Code session inside ComfyUI's sidebar, editing the live graph over MCP. No API keys. Live on ComfyUI-Manager and the Comfy Registry."
+description: "ComfyUI MCP Panel — an autonomous agent in ComfyUI's sidebar that runs on your Claude subscription. No API keys. Live on ComfyUI-Manager and the Comfy Registry."
 icon: "comments"
 ---
 
 <Note>
-  **✅ v0.3 is live on ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel).**
-  The polished public release — native ComfyUI design system, live activity cards
-  for every agent edit, multi-tab support. Search **`comfyui-mcp-panel`** in
-  ComfyUI-Manager to install.
+  **✅ Live on ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel).**
+  Search **`comfyui-mcp-panel`** in ComfyUI-Manager to install. See the
+  [changelog](/changelog) for what's new.
 </Note>
 
-**[comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel)** puts your
-Claude Code session inside ComfyUI's sidebar. Type "add a KSampler and wire it
-to my checkpoint" — in the panel or in your terminal — and watch nodes appear
-on the canvas. Every edit is undoable with **Ctrl+Z**.
+**[comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel)** puts an
+autonomous agent in ComfyUI's sidebar. Ask it for an image, a workflow, or a
+change — it works against your ComfyUI and replies right there. The agent runs
+**in the background on your Claude subscription**, so your own Claude Code
+session stays free.
 
 ```
-you ⇄ Claude Code ⇄ comfyui-mcp (--channels) ⇄ ws://127.0.0.1:9101 ⇄ panel ⇄ your graph
+you ⇄ panel ⇄ ws://127.0.0.1:9101 (bridge) ⇄ panel orchestrator ⇄ background Claude agent (your subscription)
 ```
 
-**No API keys, no per-token billing.** Your existing Claude subscription is the
-agent; the panel is its window into your graph. The MCP server hosts a
-loopback-only WebSocket bridge; the panel executes a **fixed allowlist** of
-graph commands (no arbitrary JavaScript).
+**No API keys, no per-token billing.** The agent authenticates with your on-disk
+Claude login. The bridge is loopback-only, and the panel executes a **fixed
+allowlist** of graph commands (no arbitrary JavaScript).
 
-## Setup
+## Setup — it just works
 
-1. Install the pack — **via ComfyUI-Manager** (search `comfyui-mcp-panel`) or git:
+1. **Install the pack** — via ComfyUI-Manager (search `comfyui-mcp-panel`) or git:
 
    ```bash
    cd ComfyUI/custom_nodes
    git clone https://github.com/artokun/comfyui-mcp-panel
    ```
 
-2. Add comfyui-mcp to Claude Code with channels mode:
+2. **Sign in to Claude** once, so the background agent can use your subscription:
 
    ```bash
-   claude mcp add comfyui -- npx -y comfyui-mcp --channels
+   claude   # or: claude setup-token
    ```
 
-3. Restart ComfyUI. The **Agent** tab appears in the sidebar and auto-connects
-   to the bridge (`ws://127.0.0.1:9101`, configurable via
-   `COMFYUI_MCP_BRIDGE_PORT`).
+3. **Restart ComfyUI.** The pack auto-starts the panel orchestrator
+   (`npx -y comfyui-mcp --panel-orchestrator`), the **Agent** tab appears in the
+   sidebar, and it connects to the bridge (`ws://127.0.0.1:9101`). Type a request
+   and the agent responds.
 
-## The `panel_*` tools
+That's it — no `claude mcp add`, no API key. Prerequisites are Node.js/`npx` on
+your PATH and the Claude login above. To run the orchestrator yourself instead,
+set `COMFYUI_MCP_NO_AUTOSPAWN=1` and launch `npx -y comfyui-mcp --panel-orchestrator`;
+change the bridge port with `COMFYUI_MCP_BRIDGE_PORT`.
 
-Registered only in channels mode (they don't appear in the standard
-[Tool Reference](/tools/image-generation), which documents the always-on set):
+## What it can do
+
+The agent loads comfyui-mcp's model skills (IDEOGRAM, WAN, LTX, Qwen, and more),
+so it already knows the models you run. It can generate images, video and audio,
+inspect and manage your ComfyUI, and reason about your setup — then reply in the
+panel chat.
+
+## Driving the live graph
+
+The bridge exposes a **fixed allowlist** of graph commands — read the graph,
+add / remove / wire nodes, set widgets, run the workflow, save — each undoable
+with **Ctrl+Z**. These `panel_*` tools are available to a Claude Code session you
+connect with `comfyui-mcp --channels` (the interactive path, where *your* session
+edits the graph you're viewing), and are being wired into the autonomous
+orchestrator agent.
 
 | Tool | Effect |
 |---|---|
@@ -68,20 +84,11 @@ Registered only in channels mode (they don't appear in the standard
 | `panel_inbox` | Drain messages the user typed into the panel |
 
 Every tool accepts an optional `tab_id` — each browser tab holds its own
-connection, and routing defaults to the only tab or the tab the user last
-typed in.
-
-## Two-way conversation
-
-Messages typed into the panel are **pushed straight into your Claude Code
-session** as channel events — no polling, no "watch the panel" loop. The
-server declares the `claude/channel` capability and forwards each panel
-message as a `notifications/claude/channel` notification; Claude Code
-injects it into the conversation and Claude replies with `panel_say`.
-On MCP hosts without channel support, `panel_inbox` is the pull fallback.
+connection, and routing defaults to the only tab or the tab the user last typed
+in.
 
 ## See also
 
-- [Channels mode configuration](/configuration#channels--drive-the-comfyui-sidebar-panel-from-your-own-agent-session)
-- [The Claude Code plugin](/plugin) — 15 skills, slash commands, agents
+- [Bridge / channels configuration](/configuration)
+- [The Claude Code plugin](/plugin) — model skills, slash commands, agents
 - [comfyui-mcp on GitHub](https://github.com/artokun/comfyui-mcp) · [comfyui-mcp-panel on GitHub](https://github.com/artokun/comfyui-mcp-panel)

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -87,17 +87,18 @@ Mermaid), `/comfy:batch`, `/comfy:compare`, `/comfy:convert`, `/comfy:gallery`,
 - **comfy-debugger** — root-causes failed workflows from history + logs
 - **comfy-optimizer** — VRAM and speed tuning for a given GPU
 
-## Live graph editing — no API keys
+## The sidebar panel — no API keys
 
 <Note>
   The sidebar panel ships as its own pack — **live on ComfyUI-Manager / the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel)** (search `comfyui-mcp-panel`). Full guide: [Sidebar Panel](/panel).
 </Note>
 
-With [channels mode](/configuration#channels--drive-the-comfyui-sidebar-panel-from-your-own-agent-session)
-and the [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel)
-sidebar pack, your Claude session edits the live ComfyUI graph: add nodes,
-wire slots, set widgets — all Ctrl+Z-undoable, all driven by your existing
-Claude subscription rather than per-token API billing.
+The [comfyui-mcp-panel](https://github.com/artokun/comfyui-mcp-panel) sidebar runs
+an autonomous agent on your **Claude subscription** (no per-token API billing).
+Install the pack and it auto-starts the [panel orchestrator](/configuration); ask
+it for an image, a workflow, or a change and it works against your ComfyUI. To
+drive the live graph from *your own* Claude Code session instead, use
+[channels mode](/configuration):
 
 ```bash
 claude mcp add comfyui -- npx -y comfyui-mcp --channels


### PR DESCRIPTION
## What

Reframe the docs for the **autonomous panel orchestrator** model (shipped in #39 / v0.14.0). The panel is now driven by a background agent the panel pack auto-starts on your Claude subscription — so the old "wire `--channels` into your interactive session" instructions are wrong and would conflict with the orchestrator over the bridge port.

## Changes

- **`panel.mdx`** — leads with the autonomous background agent on your subscription; auto-start setup (install pack → sign in to Claude → open ComfyUI); drops the hardcoded `v0.3` callout (changelog carries versions); honest about live-graph editing (the interactive `--channels` path, being wired into the orchestrator); removes the false "channel push wakes your session" claim.
- **`configuration.mdx`** — leads with the panel orchestrator + bridge env (`COMFYUI_MCP_PANEL_ORCHESTRATOR`, `COMFYUI_MCP_PANEL_MODEL`, `COMFYUI_MCP_BRIDGE_PORT`); reframes `--channels` as the interactive/advanced alternative and notes they share the port (run one or the other).
- **`plugin.mdx`** — panel section points at the auto-start orchestrator; fixes a stale anchor.
- **9 model-highlight blog CTAs** — "Get it running in one command" now installs the [Panel](/panel) (auto-starts the agent) instead of `claude mcp add ... --channels`; "your Claude session" → "the panel's agent".

Historical references (`CHANGELOG.md`, the weekly changelogs, the new blog/design docs) intentionally keep `--channels` in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)