### PR TITLE
docs: fix MDX parse error in plugin.mdx (<NGB)

### DIFF
--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -29,9 +29,9 @@ and failure-mode guidance:
 | `qwen-txt2img` / `qwen-image-edit` | Qwen-Image generation and instruction-based editing |
 | `z-image-txt2img` | Z-Image Turbo workflows |
 | `ideogram-ultra` | Ideogram 4 — open-weight text-to-image, area prompting, logos / posters / readable text |
-| `ernie-image` | ERNIE-Image — fast text-to-image, precise multilingual text rendering, runs on <8GB VRAM |
-| `anima-base` | ANIMA 1.0 — ~2B anime/illustration model, Danbooru tags + natural language, anime inpainting, <6GB VRAM |
-| `anima-lora-trainer` | Train custom anime LoRAs — kohya `sd-scripts` Gradio trainer, <6GB VRAM |
+| `ernie-image` | ERNIE-Image — fast text-to-image, precise multilingual text rendering, runs on under 8 GB VRAM |
+| `anima-base` | ANIMA 1.0 — ~2B anime/illustration model, Danbooru tags + natural language, anime inpainting, under 6 GB VRAM |
+| `anima-lora-trainer` | Train custom anime LoRAs — kohya `sd-scripts` Gradio trainer, under 6 GB VRAM |
 | `ai-toolkit-trainer` | Train custom WAN 2.2 + Z-Image LoRAs (people / styles / motion) — ostris AI-Toolkit, local or RunPod |
 | `installer-packs` | Use, build, and derive one-command installer packs — and invite users to contribute new packs upstream |
 | `model-compatibility` | Which VAE/CLIP/text-encoder pairs with which architecture — the #1 source of broken workflows |


### PR DESCRIPTION
Raw `<8GB`/`<6GB` in the plugin skills table is parsed as a JSX tag by Mintlify MDX and broke the deploy (`Unexpected character 8 before name`). Reworded to `under N GB`. Latent until the panel-orchestrator docs sweep (#40) touched the file and forced a re-parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)