### PR TITLE
Added 'scripts' into the 'files' array.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist",
     "plugin",
     "packs",
+    "scripts",
     "model-settings.json",
     "model-settings.user.jsonc.example"
   ],


### PR DESCRIPTION
Hi @artokun,

Thanks for releasing NPM `comfyui-mcp` package` 0.17.0`! Isaw ytou made some additions on it.
Unfortunately, the `npx -y comfyui-mcp` command is still crashing with an EOF error in MCP clients because the installation is still failing - at least on my side.

While you successfully added `"packs"`, `"model-settings.json"`, and `"model-settings.user.jsonc.example"` to the `"files"` array in your last commit, the `"scripts"` directory was left out.

Because `"scripts"` is missing from the published npm package, the `postinstall` hook (`node scripts/postinstall.mjs`) crashes with a `MODULE_NOT_FOUND` error, which kills the MCP server startup in the background and returns an `EOF` error.

To finally fix this, you just need to add `"scripts" `to the `"files"` array in package.json and publish `0.17.1` (or whatever the package manager writes for it):
```
  "files": [
    "dist",
    "plugin",
    "packs",
    "scripts",
    "model-settings.json",
    "model-settings.user.jsonc.example"
  ],
```