### PR TITLE
feat: remote ComfyUI behind path prefix + generic auth headers (#52)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,18 @@
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
 # COMFYUI_PATH=/Users/you/Documents/ComfyUI
+
+# Remote self-hosted ComfyUI behind a reverse proxy / API gateway:
+# COMFYUI_URL preserves a path prefix (e.g. /comfyapi), and the COMFYUI_AUTH_*
+# vars attach a generic auth header to every ComfyUI request (this is NOT Comfy
+# Cloud — that's COMFYUI_API_KEY). Examples:
+#   COMFYUI_AUTH_TOKEN=secret                                -> Authorization: Bearer secret
+#   COMFYUI_AUTH_HEADER=X-API-Key  COMFYUI_AUTH_TOKEN=secret -> X-API-Key: secret
+# COMFYUI_URL=https://comfy.example.com/comfyapi
+# COMFYUI_AUTH_HEADER=Authorization
+# COMFYUI_AUTH_SCHEME=Bearer
+# COMFYUI_AUTH_TOKEN=
+
 HUGGINGFACE_TOKEN=
 GITHUB_TOKEN=
 CIVITAI_API_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Added
+
+- **Remote self-hosted ComfyUI behind a reverse proxy / API gateway (#52).**
+  `COMFYUI_URL` now **preserves a path prefix** (e.g. `https://host/comfyapi`),
+  so requests route under the prefix instead of hitting `/prompt`,
+  `/system_stats`, … at the root. New `COMFYUI_AUTH_TOKEN` (+ optional
+  `COMFYUI_AUTH_HEADER`, default `Authorization`, and `COMFYUI_AUTH_SCHEME`,
+  default `Bearer`) attaches a generic auth header to **every** ComfyUI request
+  — both the direct HTTP calls and the underlying client/WebSocket library.
+  This is independent of Comfy Cloud mode (`COMFYUI_API_KEY` / `X-API-Key`), so
+  a normal self-hosted instance behind a gateway no longer gets misread as
+  Comfy Cloud. Requested by [@NitishMamadgi](https://github.com/NitishMamadgi).
+
 ## [0.17.1] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -449,12 +449,15 @@ The server auto-detects your ComfyUI installation and port. Override with enviro
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `COMFYUI_URL` | | Full ComfyUI URL, e.g. `https://comfy.example.com:8443` — overrides `COMFYUI_HOST`/`PORT`/`SSL` and skips auto-detection. Non-loopback hosts opt into **remote mode**. |
+| `COMFYUI_URL` | | Full ComfyUI URL, e.g. `https://comfy.example.com:8443` — overrides `COMFYUI_HOST`/`PORT`/`SSL` and skips auto-detection. A **path prefix is preserved** (e.g. `https://host/comfyapi`) for reverse-proxied instances. Non-loopback hosts opt into **remote mode**. |
 | `COMFYUI_HOST` | `127.0.0.1` | ComfyUI server address |
 | `COMFYUI_PORT` | *(auto-detect)* | ComfyUI server port (tries 8188, then 8000) |
 | `COMFYUI_PATH` | *(auto-detect)* | Path to ComfyUI data directory. Auto-detection suppressed in remote/cloud modes. |
 | `COMFYUI_API_KEY` | | Comfy Cloud API key. When set, **cloud mode** is active and the server talks to `cloud.comfy.org`. Never logged. |
 | `COMFYUI_CLOUD_URL` | `https://cloud.comfy.org` | Override the Comfy Cloud endpoint (testing/staging). |
+| `COMFYUI_AUTH_TOKEN` | | Generic auth token for a **self-hosted ComfyUI behind a reverse proxy / API gateway** (distinct from Comfy Cloud). When set, attached to every ComfyUI request. Never logged. |
+| `COMFYUI_AUTH_HEADER` | `Authorization` | Header name for `COMFYUI_AUTH_TOKEN` (e.g. `X-API-Key`). |
+| `COMFYUI_AUTH_SCHEME` | `Bearer` for `Authorization`, else none | Scheme prefix on the token value (e.g. `Bearer`, `Token`). |
 | `CIVITAI_API_TOKEN` | | CivitAI API token for model downloads |
 | `HUGGINGFACE_TOKEN` | | HuggingFace token for higher API rate limits |
 | `GITHUB_TOKEN` | | GitHub token for skill generation (avoids rate limits) |
@@ -492,6 +495,21 @@ Point the server at a ComfyUI running anywhere — no local install required:
 ```bash
 npx -y comfyui-mcp --comfyui-url http://192.168.1.50:8188
 npx -y comfyui-mcp --http --comfyui-url https://comfy.example.com:8443
+```
+
+**Behind a reverse proxy / API gateway** (path prefix + auth header) — for a
+self-hosted ComfyUI exposed under a prefixed route with its own auth layer (this
+is *not* Comfy Cloud, which is `COMFYUI_API_KEY`):
+
+```bash
+COMFYUI_URL=https://gateway.example.com/comfyapi \
+COMFYUI_AUTH_TOKEN=your-token \
+  npx -y comfyui-mcp --http        # → Authorization: Bearer your-token, requests under /comfyapi
+
+# custom header / scheme:
+COMFYUI_URL=https://gateway.example.com/comfyapi \
+COMFYUI_AUTH_HEADER=X-API-Key COMFYUI_AUTH_TOKEN=your-token \
+  npx -y comfyui-mcp --http        # → X-API-Key: your-token
 ```
 
 ### Auto-detection

--- a/src/__tests__/comfyui/fetch.test.ts
+++ b/src/__tests__/comfyui/fetch.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the config layer so we can drive getComfyUIAuthHeaders per test.
+const authHeaders = vi.fn<() => Record<string, string>>();
+vi.mock("../../config.js", () => ({
+  getComfyUIAuthHeaders: () => authHeaders(),
+}));
+
+import { comfyuiFetch } from "../../comfyui/fetch.js";
+
+describe("comfyuiFetch", () => {
+  const fetchMock = vi.fn(async () => new Response("ok"));
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockClear();
+    authHeaders.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("is a passthrough when no auth is configured", async () => {
+    authHeaders.mockReturnValue({});
+    await comfyuiFetch("http://comfy/prompt", { method: "POST" });
+    expect(fetchMock).toHaveBeenCalledWith("http://comfy/prompt", { method: "POST" });
+  });
+
+  it("injects the configured auth header", async () => {
+    authHeaders.mockReturnValue({ Authorization: "Bearer abc" });
+    await comfyuiFetch("http://comfy/system_stats");
+    const [, init] = fetchMock.mock.calls[0];
+    expect(new Headers((init as RequestInit).headers).get("Authorization")).toBe("Bearer abc");
+  });
+
+  it("preserves caller headers (e.g. Content-Type) alongside auth", async () => {
+    authHeaders.mockReturnValue({ "X-API-Key": "k" });
+    await comfyuiFetch("http://comfy/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("Content-Type")).toBe("application/json");
+    expect(headers.get("X-API-Key")).toBe("k");
+  });
+
+  it("does not clobber an explicit auth header set by the caller", async () => {
+    authHeaders.mockReturnValue({ Authorization: "Bearer fromconfig" });
+    await comfyuiFetch("http://comfy/prompt", {
+      headers: { Authorization: "Bearer explicit" },
+    });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(new Headers((init as RequestInit).headers).get("Authorization")).toBe("Bearer explicit");
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -66,3 +66,73 @@ describe("config mode detection", () => {
     expect(() => mod.getApiKey()).toThrow(/COMFYUI_API_KEY/);
   });
 });
+
+describe("remote self-hosted: path prefix + generic auth (#52)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_URL = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_PORT = "8188";
+    process.env.COMFYUI_AUTH_HEADER = "";
+    process.env.COMFYUI_AUTH_SCHEME = "";
+    process.env.COMFYUI_AUTH_TOKEN = "";
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+    vi.restoreAllMocks();
+  });
+
+  it("preserves a path prefix from COMFYUI_URL into the base URL", async () => {
+    process.env.COMFYUI_URL = "https://host.example.com/comfyapi";
+    const mod = await import("../config.js");
+    expect(mod.isRemoteMode()).toBe(true);
+    expect(mod.getComfyUIBasePath()).toBe("/comfyapi");
+    expect(mod.getComfyUIBaseUrl()).toBe("https://host.example.com:443/comfyapi");
+  });
+
+  it("no prefix → base URL has no trailing path", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIBasePath()).toBe("");
+    expect(mod.getComfyUIBaseUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("no auth configured → empty headers", async () => {
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({});
+  });
+
+  it("COMFYUI_AUTH_TOKEN defaults to Authorization: Bearer", async () => {
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({ Authorization: "Bearer abc123" });
+  });
+
+  it("custom header with no scheme → raw token (X-API-Key)", async () => {
+    process.env.COMFYUI_AUTH_HEADER = "X-API-Key";
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({ "X-API-Key": "abc123" });
+  });
+
+  it("custom scheme on Authorization", async () => {
+    process.env.COMFYUI_AUTH_SCHEME = "Token";
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({ Authorization: "Token abc123" });
+  });
+
+  it("generic auth does NOT enable Comfy Cloud mode", async () => {
+    process.env.COMFYUI_URL = "https://host.example.com/comfyapi";
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    const mod = await import("../config.js");
+    expect(mod.isCloudMode()).toBe(false);
+    expect(mod.isRemoteMode()).toBe(true);
+  });
+});

--- a/src/__tests__/services/manager-config.test.ts
+++ b/src/__tests__/services/manager-config.test.ts
@@ -11,8 +11,8 @@ vi.mock("node:fs", () => ({
 // Mock config so we control comfyuiPath and the API host/protocol.
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/fake/ComfyUI" as string | undefined },
-  getComfyUIApiHost: () => "127.0.0.1:8188",
-  getComfyUIProtocol: () => "http" as const,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
 }));
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -25,8 +25,9 @@ vi.mock("../../config.js", () => {
   };
   return {
     config,
-    getComfyUIApiHost: () => `${config.comfyuiHost}:${config.resolvedPort}`,
-    getComfyUIProtocol: () => (config.comfyuiSsl ? "https" : "http"),
+    getComfyUIBaseUrl: () =>
+      `${config.comfyuiSsl ? "https" : "http"}://${config.comfyuiHost}:${config.resolvedPort}`,
+    getComfyUIAuthHeaders: () => ({}),
   };
 });
 

--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -21,8 +21,8 @@ const legacySnapshotDir = join(
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/fake/comfyui" as string | undefined },
-  getComfyUIApiHost: () => "127.0.0.1:8188",
-  getComfyUIProtocol: () => "http",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
 }));
 
 const fsMocks = vi.hoisted(() => ({

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -13,8 +13,8 @@ const mockResetClient = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
-  getComfyUIApiHost: () => "127.0.0.1:8188",
-  getComfyUIProtocol: () => "http",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
   isRemoteMode: () => false,
 }));
 

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -10,8 +10,8 @@ const mockConfig = vi.hoisted(() => ({
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
-  getComfyUIApiHost: () => "127.0.0.1:8188",
-  getComfyUIProtocol: () => "http",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
 }));
 
 vi.mock("node:child_process", () => ({

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -24,8 +24,8 @@ const h = vi.hoisted(() => {
 
 vi.mock("../../config.js", () => ({
   config: h.mockConfig,
-  getComfyUIApiHost: () => "127.0.0.1:8188",
-  getComfyUIProtocol: () => "http",
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
 }));
 
 vi.mock("../../comfyui/client.js", () => ({

--- a/src/__tests__/transport/comfyui-url.test.ts
+++ b/src/__tests__/transport/comfyui-url.test.ts
@@ -7,6 +7,7 @@ describe("parseComfyUIUrl", () => {
       host: "127.0.0.1",
       port: 8188,
       ssl: false,
+      basePath: "",
     });
   });
 
@@ -15,6 +16,7 @@ describe("parseComfyUIUrl", () => {
       host: "comfy.example.com",
       port: 8443,
       ssl: true,
+      basePath: "",
     });
   });
 
@@ -23,6 +25,7 @@ describe("parseComfyUIUrl", () => {
       host: "comfy.example.com",
       port: 443,
       ssl: true,
+      basePath: "",
     });
   });
 
@@ -31,6 +34,7 @@ describe("parseComfyUIUrl", () => {
       host: "comfy.local",
       port: 80,
       ssl: false,
+      basePath: "",
     });
   });
 
@@ -39,6 +43,7 @@ describe("parseComfyUIUrl", () => {
       host: "192.168.1.50",
       port: 8000,
       ssl: false,
+      basePath: "",
     });
   });
 
@@ -48,5 +53,27 @@ describe("parseComfyUIUrl", () => {
 
   it("throws on a non-URL string", () => {
     expect(() => parseComfyUIUrl("not a url")).toThrow();
+  });
+
+  // ── Path prefix (reverse proxy / API gateway, issue #52) ──────────────────
+  it("preserves a path prefix", () => {
+    expect(parseComfyUIUrl("https://host.example.com/comfyapi")).toEqual({
+      host: "host.example.com",
+      port: 443,
+      ssl: true,
+      basePath: "/comfyapi",
+    });
+  });
+
+  it("strips a trailing slash from the prefix", () => {
+    expect(parseComfyUIUrl("https://host:8443/comfyapi/").basePath).toBe("/comfyapi");
+  });
+
+  it("preserves a nested path prefix", () => {
+    expect(parseComfyUIUrl("https://host/api/comfy").basePath).toBe("/api/comfy");
+  });
+
+  it("treats a bare root path as no prefix", () => {
+    expect(parseComfyUIUrl("http://127.0.0.1:8188/").basePath).toBe("");
   });
 });

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -2,12 +2,14 @@ import { Client } from "@stable-canvas/comfyui-client";
 import {
   config,
   getComfyUIApiHost,
-  getComfyUIProtocol,
+  getComfyUIBasePath,
+  getComfyUIBaseUrl,
   isCloudMode,
   isRemoteMode,
 } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { ComfyUIError, ConnectionError } from "../utils/errors.js";
+import { comfyuiFetch } from "./fetch.js";
 import * as cloudClient from "./cloud-client.js";
 import type { ObjectInfo, SystemStats, QueueStatus } from "./types.js";
 
@@ -59,9 +61,13 @@ export function getClient(): Client {
   if (!clientInstance) {
     clientInstance = new Client({
       api_host: getComfyUIApiHost(),
+      // Path prefix for reverse-proxied / gateway'd ComfyUI (e.g. "/comfyapi").
+      api_base: getComfyUIBasePath(),
       ssl: config.comfyuiSsl,
       clientId: "comfyui-mcp",
-      // Node 22+ provides global WebSocket
+      // Inject generic auth headers (COMFYUI_AUTH_*) on the library's own HTTP
+      // calls; a no-op when unset. Node 22+ provides global WebSocket.
+      fetch: comfyuiFetch,
     });
     logger.info("ComfyUI client created", {
       host: getComfyUIApiHost(),
@@ -177,12 +183,12 @@ export async function backfillObjectInfo(
   const missing = [...new Set(nodeTypes)].filter((t) => t && !(t in oi));
   if (missing.length === 0) return objectInfo;
 
-  const base = `${getComfyUIProtocol()}://${getComfyUIApiHost()}/object_info`;
+  const base = `${getComfyUIBaseUrl()}/object_info`;
   const merged = { ...oi };
   await Promise.all(
     missing.map(async (t) => {
       try {
-        const res = await fetch(`${base}/${encodeURIComponent(t)}`);
+        const res = await comfyuiFetch(`${base}/${encodeURIComponent(t)}`);
         if (!res.ok) return;
         const def = (await res.json()) as Record<string, unknown>;
         if (def && def[t]) {
@@ -230,8 +236,8 @@ export async function enqueuePrompt(
   // must travel to the server. It also cannot enqueue at the front. When either
   // is needed, POST /prompt directly.
   if ((extraData && Object.keys(extraData).length > 0) || opts?.front) {
-    const url = `${getComfyUIProtocol()}://${getComfyUIApiHost()}/prompt`;
-    const res = await fetch(url, {
+    const url = `${getComfyUIBaseUrl()}/prompt`;
+    const res = await comfyuiFetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/src/comfyui/fetch.ts
+++ b/src/comfyui/fetch.ts
@@ -1,0 +1,24 @@
+import { getComfyUIAuthHeaders } from "../config.js";
+
+/**
+ * `fetch` wrapper for ComfyUI HTTP requests that injects the configured generic
+ * auth header(s) (COMFYUI_AUTH_* — for self-hosted ComfyUI behind a reverse
+ * proxy / API gateway). A no-op when no auth is configured. Explicit headers on
+ * the call always win, so it never clobbers a per-request `Content-Type`.
+ *
+ * Use this instead of the global `fetch` for every call to the user's ComfyUI
+ * server. Non-ComfyUI requests (HuggingFace, Civitai, Comfy Cloud) keep using
+ * plain `fetch` — Comfy Cloud has its own X-API-Key path in cloud-client.ts.
+ */
+export function comfyuiFetch(
+  input: string | URL | Request,
+  init: RequestInit = {},
+): Promise<Response> {
+  const auth = getComfyUIAuthHeaders();
+  if (Object.keys(auth).length === 0) return fetch(input, init);
+  const headers = new Headers(init.headers);
+  for (const [name, value] of Object.entries(auth)) {
+    if (!headers.has(name)) headers.set(name, value);
+  }
+  return fetch(input, { ...init, headers });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -208,9 +208,16 @@ const configSchema = z.object({
   comfyuiHost: z.string().default("127.0.0.1"),
   comfyuiPort: z.coerce.number().int().positive().optional(),
   comfyuiSsl: z.coerce.boolean().default(false),
+  comfyuiBasePath: z.string().default(""),
   comfyuiPath: z.string().optional(),
   comfyuiApiKey: z.string().optional(),
   comfyuiCloudUrl: z.string().default("https://cloud.comfy.org"),
+  // Generic auth for self-hosted ComfyUI behind a reverse proxy / API gateway
+  // (distinct from Comfy Cloud's COMFYUI_API_KEY). Applied to every ComfyUI
+  // HTTP request in local/remote modes when a token is set.
+  comfyuiAuthHeader: z.string().optional(),
+  comfyuiAuthScheme: z.string().optional(),
+  comfyuiAuthToken: z.string().optional(),
   huggingfaceToken: z.string().optional(),
   githubToken: z.string().optional(),
   civitaiApiToken: z.string().optional(),
@@ -234,6 +241,7 @@ const parsedConfig = configSchema.parse({
   comfyuiHost: urlOverride?.host ?? process.env.COMFYUI_HOST,
   comfyuiPort: urlOverride?.port ?? (process.env.COMFYUI_PORT || undefined),
   comfyuiSsl: urlOverride?.ssl ?? process.env.COMFYUI_SSL,
+  comfyuiBasePath: urlOverride?.basePath ?? "",
   comfyuiPath: resolveComfyUIPath(process.env.COMFYUI_PATH, {
     remoteUrl: remoteUrlActive,
     cloud: cloudActive,
@@ -241,6 +249,9 @@ const parsedConfig = configSchema.parse({
   }),
   comfyuiApiKey: cloudApiKey,
   comfyuiCloudUrl: process.env.COMFYUI_CLOUD_URL,
+  comfyuiAuthHeader: process.env.COMFYUI_AUTH_HEADER,
+  comfyuiAuthScheme: process.env.COMFYUI_AUTH_SCHEME,
+  comfyuiAuthToken: process.env.COMFYUI_AUTH_TOKEN,
   huggingfaceToken: process.env.HUGGINGFACE_TOKEN,
   githubToken: process.env.GITHUB_TOKEN,
   civitaiApiToken: process.env.CIVITAI_API_TOKEN,
@@ -301,4 +312,39 @@ export function getComfyUIApiHost(): string {
 
 export function getComfyUIProtocol(): "http" | "https" {
   return config.comfyuiSsl ? "https" : "http";
+}
+
+/** The URL path prefix ComfyUI is mounted under (e.g. "/comfyapi"), or "". */
+export function getComfyUIBasePath(): string {
+  return config.comfyuiBasePath;
+}
+
+/**
+ * Canonical base URL for ComfyUI HTTP requests: protocol + host:port + path
+ * prefix, no trailing slash. Append endpoint paths (e.g. `/system_stats`) to
+ * this so reverse-proxied / path-prefixed instances route correctly.
+ */
+export function getComfyUIBaseUrl(): string {
+  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}${config.comfyuiBasePath}`;
+}
+
+/**
+ * Generic auth header(s) for a self-hosted ComfyUI behind a gateway/proxy.
+ * Empty when no token is configured. Examples:
+ *   COMFYUI_AUTH_TOKEN=abc                       → Authorization: Bearer abc
+ *   COMFYUI_AUTH_HEADER=X-API-Key TOKEN=abc      → X-API-Key: abc
+ *   COMFYUI_AUTH_SCHEME=Token TOKEN=abc          → Authorization: Token abc
+ * This is independent of Comfy Cloud mode (COMFYUI_API_KEY / X-API-Key).
+ */
+export function getComfyUIAuthHeaders(): Record<string, string> {
+  const token = config.comfyuiAuthToken?.trim();
+  if (!token) return {};
+  const header = config.comfyuiAuthHeader?.trim() || "Authorization";
+  // An unset/empty scheme defaults to "Bearer" for the Authorization header and
+  // to none (raw token) for any custom header. Set COMFYUI_AUTH_SCHEME to force
+  // a specific scheme (e.g. "Token").
+  const scheme =
+    config.comfyuiAuthScheme?.trim() ||
+    (header.toLowerCase() === "authorization" ? "Bearer" : "");
+  return { [header]: scheme ? `${scheme} ${token}` : token };
 }

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -9,8 +9,7 @@ import {
 } from "../comfyui/client.js";
 import {
   getCloudUrl,
-  getComfyUIApiHost,
-  getComfyUIProtocol,
+  getComfyUIBaseUrl,
   isCloudMode,
 } from "../config.js";
 import { attachExecutionListeners } from "../comfyui/events.js";
@@ -123,8 +122,7 @@ function buildImageUrl(
     const base = getCloudUrl().replace(/\/+$/, "");
     return `${base}/api/view?${params.toString()}`;
   }
-  const host = getComfyUIApiHost();
-  return `${getComfyUIProtocol()}://${host}/view?${params.toString()}`;
+  return `${getComfyUIBaseUrl()}/view?${params.toString()}`;
 }
 
 export function buildCompletionNotification(

--- a/src/services/manager-config.ts
+++ b/src/services/manager-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -30,11 +31,11 @@ async function managerFetch(
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const url = `${getComfyUIProtocol()}://${getComfyUIApiHost()}${path}`;
+  const url = `${getComfyUIBaseUrl()}${path}`;
   logger.debug("ComfyUI-Manager API request", { url, method: init?.method ?? "GET" });
   let res: Response;
   try {
-    res = await fetch(url, init);
+    res = await comfyuiFetch(url, init);
   } catch (err) {
     throw new ManagerConfigError(
       `Could not reach ComfyUI-Manager at ${url}. Is ComfyUI running with ComfyUI-Manager installed?`,

--- a/src/services/node-bisect.ts
+++ b/src/services/node-bisect.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, renameSync } from "node:fs";
 import { join } from "node:path";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { NodeBisectError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -145,7 +146,7 @@ function advance(state: BisectState, newRange: string[]): BisectState {
 // ---------------------------------------------------------------------------
 
 function managerBase(): string {
-  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  return getComfyUIBaseUrl();
 }
 
 /** Small local fetch helper for the ComfyUI-Manager API. */
@@ -157,7 +158,7 @@ async function managerFetch(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(`${managerBase()}${path}`, {
+    const res = await comfyuiFetch(`${managerBase()}${path}`, {
       ...init,
       signal: controller.signal,
       headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2,7 +2,8 @@ import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -110,7 +111,7 @@ type ManagerTaskKind =
 // ---------------------------------------------------------------------------
 
 function managerBaseUrl(): string {
-  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  return getComfyUIBaseUrl();
 }
 
 interface ManagerFetchOptions {
@@ -133,7 +134,7 @@ async function managerFetch<T>(
 
   let res: Response;
   try {
-    res = await fetch(url, {
+    res = await comfyuiFetch(url, {
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { NodeSnapshotError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -34,7 +35,7 @@ export interface ListSnapshotsResult {
 }
 
 function managerBaseUrl(): string {
-  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  return getComfyUIBaseUrl();
 }
 
 /**
@@ -50,7 +51,7 @@ async function managerFetch(
 
   let res: Response;
   try {
-    res = await fetch(url, init);
+    res = await comfyuiFetch(url, init);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new NodeSnapshotError(

--- a/src/services/node-verify.ts
+++ b/src/services/node-verify.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { restartComfyUI } from "./process-control.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -51,8 +52,8 @@ const defaultDeps: VerifyDeps = {
     return { ready: result.readiness?.ready ?? false, message: result.message };
   },
   fetchObjectInfoKeys: async () => {
-    const url = `${getComfyUIProtocol()}://${getComfyUIApiHost()}/object_info`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    const url = `${getComfyUIBaseUrl()}/object_info`;
+    const res = await comfyuiFetch(url, { signal: AbortSignal.timeout(30_000) });
     if (!res.ok) {
       throw new ComfyUIError(
         `Failed to fetch /object_info: ${res.status} ${res.statusText}`,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,7 +1,8 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { platform } from "node:os";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
-import { config, getComfyUIApiHost, getComfyUIProtocol, isRemoteMode } from "../config.js";
+import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -322,9 +323,8 @@ function getRestartPolicy(): RestartPolicy {
 }
 
 async function waitForApiReady(): Promise<StartupReadinessResult> {
-  const host = getComfyUIApiHost();
   const { intervalMs, maxTries } = getStartupReadinessConfig();
-  const probeUrl = `${getComfyUIProtocol()}://${host}/system_stats`;
+  const probeUrl = `${getComfyUIBaseUrl()}/system_stats`;
   const start = Date.now();
   let attempts = 0;
 
@@ -334,7 +334,7 @@ async function waitForApiReady(): Promise<StartupReadinessResult> {
       const timeout = setTimeout(() => controller.abort(), 2000);
       let res: Response;
       try {
-        res = await fetch(probeUrl, { signal: controller.signal });
+        res = await comfyuiFetch(probeUrl, { signal: controller.signal });
       } finally {
         clearTimeout(timeout);
       }

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -2,7 +2,8 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { platform } from "node:os";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -138,7 +139,7 @@ function requireComfyUIPath(): string {
 // ---------------------------------------------------------------------------
 
 function managerBaseUrl(): string {
-  return `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  return getComfyUIBaseUrl();
 }
 
 interface ManagerFetchResult {
@@ -156,7 +157,7 @@ async function managerFetch(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(url, { ...init, signal: controller.signal });
+    const res = await comfyuiFetch(url, { ...init, signal: controller.signal });
     let body: unknown = null;
     const text = await res.text();
     if (text) {

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -1,6 +1,7 @@
 import type { WorkflowJSON, ObjectInfo } from "../comfyui/types.js";
 import { getObjectInfo } from "../comfyui/client.js";
-import { getComfyUIProtocol, getComfyUIApiHost } from "../config.js";
+import { getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -117,8 +118,7 @@ export interface WorkflowDepsDeps {
   queueStatus: () => Promise<ManagerQueueStatus>;
 }
 
-const managerBase = (): string =>
-  `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+const managerBase = (): string => getComfyUIBaseUrl();
 
 /**
  * Minimal local fetch wrapper for ComfyUI-Manager endpoints.
@@ -132,7 +132,7 @@ async function managerFetch(
   logger.debug("Manager API request", { url, method: init?.method ?? "GET" });
   let res: Response;
   try {
-    res = await fetch(url, init);
+    res = await comfyuiFetch(url, init);
   } catch (err) {
     throw new ComfyUIError(
       `Failed to reach ComfyUI-Manager at ${url}: ${err instanceof Error ? err.message : err}. ` +

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { config, getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
 import { ValidationError } from "../utils/errors.js";
@@ -154,7 +154,7 @@ export interface WorkspaceInfo {
 
 export async function getWorkspace(): Promise<WorkspaceInfo> {
   const cfg = await readWorkspaceConfig();
-  const apiTarget = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  const apiTarget = getComfyUIBaseUrl();
 
   let source: WorkspaceInfo["workspace_source"];
   if (config.comfyuiPath) {
@@ -406,7 +406,7 @@ const KEY_PACKAGES = [
 ];
 
 export async function getEnvironment(): Promise<EnvironmentInfo> {
-  const apiTarget = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  const apiTarget = getComfyUIBaseUrl();
 
   // 1. Running instance via /system_stats (works for remote targets too)
   const running: EnvironmentInfo["running_instance"] = {

--- a/src/transport/comfyui-url.ts
+++ b/src/transport/comfyui-url.ts
@@ -2,12 +2,29 @@ export interface ComfyUITarget {
   host: string;
   port: number;
   ssl: boolean;
+  /**
+   * Normalized URL path prefix the ComfyUI instance is mounted under, e.g.
+   * "/comfyapi" for `https://host/comfyapi`. Empty string when mounted at root.
+   * No trailing slash. Preserved so reverse-proxy / API-gateway setups route
+   * correctly instead of hitting `/prompt`, `/system_stats`, … at the root.
+   */
+  basePath: string;
 }
 
 /**
- * Parse a full ComfyUI URL (e.g. http://127.0.0.1:8188, https://comfy.example.com)
- * into host/port/ssl. Used by --comfyui-url / COMFYUI_URL to target any (incl.
- * remote) ComfyUI instance, overriding the COMFYUI_HOST/PORT/SSL env vars.
+ * Trim a URL pathname into a base prefix: no trailing slash, and "" for the
+ * root ("" or "/"). "/comfyapi/" → "/comfyapi".
+ */
+function normalizeBasePath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, "");
+  return trimmed === "" || trimmed === "/" ? "" : trimmed;
+}
+
+/**
+ * Parse a full ComfyUI URL (e.g. http://127.0.0.1:8188, https://comfy.example.com,
+ * https://host/comfyapi) into host/port/ssl/basePath. Used by --comfyui-url /
+ * COMFYUI_URL to target any (incl. remote, reverse-proxied) ComfyUI instance,
+ * overriding the COMFYUI_HOST/PORT/SSL env vars.
  */
 export function parseComfyUIUrl(url: string): ComfyUITarget {
   const u = new URL(url);
@@ -16,5 +33,5 @@ export function parseComfyUIUrl(url: string): ComfyUITarget {
   }
   const ssl = u.protocol === "https:";
   const port = u.port ? Number(u.port) : ssl ? 443 : 80;
-  return { host: u.hostname, port, ssl };
+  return { host: u.hostname, port, ssl, basePath: normalizeBasePath(u.pathname) };
 }


### PR DESCRIPTION
Closes #52.

Supports a self-hosted ComfyUI exposed under a **reverse proxy / API gateway** — the two things that broke before:

### 1. Path prefix is preserved
`COMFYUI_URL=https://host/comfyapi` now keeps `/comfyapi`, so requests route under the prefix instead of hitting `/prompt`, `/system_stats`, … at the root.
- `parseComfyUIUrl()` returns a normalized `basePath`.
- New `getComfyUIBaseUrl()` (`protocol://host:port<basePath>`) is the single base for every ComfyUI HTTP call.
- The `@stable-canvas/comfyui-client` library gets `api_base`, so **its** HTTP + WebSocket route under the prefix too.

### 2. Generic auth headers — independent of Comfy Cloud
A normal gateway-auth'd instance was misread as Comfy Cloud (`COMFYUI_API_KEY` → cloud mode). New, separate config:
| Var | Default | |
|---|---|---|
| `COMFYUI_AUTH_TOKEN` | — | the token; when set, attached to every ComfyUI request |
| `COMFYUI_AUTH_HEADER` | `Authorization` | header name (e.g. `X-API-Key`) |
| `COMFYUI_AUTH_SCHEME` | `Bearer` for `Authorization`, else none | scheme prefix (e.g. `Token`) |

```bash
COMFYUI_URL=https://gw.example.com/comfyapi COMFYUI_AUTH_TOKEN=t npx -y comfyui-mcp   # Authorization: Bearer t
COMFYUI_URL=https://gw.example.com/comfyapi COMFYUI_AUTH_HEADER=X-API-Key COMFYUI_AUTH_TOKEN=t npx -y comfyui-mcp   # X-API-Key: t
```
A new `comfyuiFetch()` wrapper injects the header on every ComfyUI request (without clobbering explicit headers) and is passed as the library's `fetch`.

### Scope
Migrated all ComfyUI fetch sites (client + 9 services) to `getComfyUIBaseUrl()` + `comfyuiFetch()`. Cloud mode untouched.

### Tests
New coverage for prefix parsing, auth-header shapes, and the `comfyuiFetch` header merge; updated service-test config mocks. **592 passing**, build + lint + install-smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)