### PR TITLE
fix(tools): 6 live-tested MCP tool robustness fixes

### DIFF
--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -101,6 +101,46 @@ describe("listNodeSnapshots", () => {
     fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
     await expect(listNodeSnapshots()).rejects.toBeInstanceOf(NodeSnapshotError);
   });
+
+  it("returns a graceful 'unsupported' result on 404 (Manager build lacks /snapshot/*)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const result = await listNodeSnapshots();
+    expect(result.unsupported).toBe(true);
+    expect(result.snapshots).toEqual([]);
+    expect(result.message).toMatch(/aren't supported/i);
+  });
+});
+
+describe("snapshot family graceful 404 (unsupported Manager build)", () => {
+  it("save (no name) returns unsupported instead of throwing on a 404", async () => {
+    // First call is the before-list getlist → 404.
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const result = await saveNodeSnapshot();
+    expect(result.unsupported).toBe(true);
+    expect(result.message).toMatch(/aren't supported/i);
+  });
+
+  it("save (named) returns unsupported when get_current 404s", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const result = await saveNodeSnapshot("prod-baseline");
+    expect(result.unsupported).toBe(true);
+    expect(result.method).toBe("file");
+    // No file is written on the unsupported path.
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("restore returns unsupported instead of throwing on a 404", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const result = await restoreNodeSnapshot("prod");
+    expect(result.unsupported).toBe(true);
+    expect(result.name).toBe("prod");
+    expect(result.message).toMatch(/aren't supported/i);
+  });
+
+  it("still throws on a genuine 500 (not an unsupported endpoint)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 500));
+    await expect(restoreNodeSnapshot("prod")).rejects.toBeInstanceOf(NodeSnapshotError);
+  });
 });
 
 describe("saveNodeSnapshot (no name — HTTP path)", () => {

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isAbsolute, join, resolve } from "node:path";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/comfy" as string | undefined },
+}));
+
+const getSystemStats = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: (...a: unknown[]) => getSystemStats(...a),
+}));
+
+import {
+  parseOutputDirFromArgv,
+  localOutputDirFallback,
+  resolveOutputDir,
+} from "../../services/output-dir.js";
+import { config } from "../../config.js";
+
+beforeEach(() => {
+  getSystemStats.mockReset();
+  (config as { comfyuiPath?: string }).comfyuiPath = "/comfy";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseOutputDirFromArgv", () => {
+  it("returns undefined when no relevant flags are present", () => {
+    expect(parseOutputDirFromArgv(["python", "main.py", "--listen"])).toBeUndefined();
+    expect(parseOutputDirFromArgv([])).toBeUndefined();
+    expect(parseOutputDirFromArgv(undefined)).toBeUndefined();
+  });
+
+  it("parses --output-directory <value>", () => {
+    const abs = resolve("/shared/ComfyUI-Shared/output");
+    const got = parseOutputDirFromArgv(["main.py", "--output-directory", abs]);
+    expect(got).toBe(abs);
+  });
+
+  it("parses --output-directory=<value>", () => {
+    const abs = resolve("/shared/out");
+    expect(parseOutputDirFromArgv(["main.py", `--output-directory=${abs}`])).toBe(abs);
+  });
+
+  it("derives <base>/output from --base-directory", () => {
+    const base = resolve("/srv/comfy-base");
+    expect(parseOutputDirFromArgv(["main.py", "--base-directory", base])).toBe(
+      join(base, "output"),
+    );
+  });
+
+  it("lets --output-directory win over --base-directory", () => {
+    const base = resolve("/srv/base");
+    const out = resolve("/srv/explicit-out");
+    const got = parseOutputDirFromArgv([
+      "main.py",
+      "--base-directory",
+      base,
+      "--output-directory",
+      out,
+    ]);
+    expect(got).toBe(out);
+  });
+});
+
+describe("localOutputDirFallback", () => {
+  it("returns <COMFYUI_PATH>/output", () => {
+    expect(localOutputDirFallback()).toBe(resolve("/comfy", "output"));
+  });
+
+  it("throws when COMFYUI_PATH is unset", () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    expect(() => localOutputDirFallback()).toThrow(/COMFYUI_PATH/);
+  });
+});
+
+describe("resolveOutputDir", () => {
+  it("uses the redirected dir reported by /system_stats argv", async () => {
+    const redirected = resolve("/shared/ComfyUI-Shared/output");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", "main.py", "--output-directory", redirected] },
+    });
+    const got = await resolveOutputDir();
+    expect(got).toBe(redirected);
+    expect(got).not.toBe(resolve("/comfy", "output"));
+    expect(isAbsolute(got)).toBe(true);
+  });
+
+  it("falls back to <COMFYUI_PATH>/output when argv has no override", async () => {
+    getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
+    expect(await resolveOutputDir()).toBe(resolve("/comfy", "output"));
+  });
+
+  it("falls back to <COMFYUI_PATH>/output when /system_stats is unreachable", async () => {
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveOutputDir()).toBe(resolve("/comfy", "output"));
+  });
+});

--- a/src/__tests__/services/registry-search.test.ts
+++ b/src/__tests__/services/registry-search.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { searchNodes } from "../../services/registry-client.js";
+import {
+  searchNodes,
+  getNodePackDetails,
+  extractVersionString,
+} from "../../services/registry-client.js";
 
 const NODES = [
   {
@@ -89,5 +93,66 @@ describe("searchNodes (upstream-bug client-side filter)", () => {
     expect(results.length).toBeGreaterThan(0);
     // No filter applied — order matches input
     expect(results[0]?.id).toBe(NODES[0]!.id);
+  });
+});
+
+describe("extractVersionString (registry version is an object, not a string)", () => {
+  it("returns a bare string as-is", () => {
+    expect(extractVersionString("1.2.3")).toBe("1.2.3");
+  });
+
+  it("pulls .version out of the registry's object shape", () => {
+    expect(
+      extractVersionString({ version: "8.28.3", changelog: "", createdAt: "x" }),
+    ).toBe("8.28.3");
+  });
+
+  it("returns undefined for shapes with no usable version", () => {
+    expect(extractVersionString(undefined)).toBeUndefined();
+    expect(extractVersionString(null)).toBeUndefined();
+    expect(extractVersionString({})).toBeUndefined();
+    expect(extractVersionString({ version: 5 })).toBeUndefined();
+  });
+});
+
+describe("getNodePackDetails version rendering (no more [object Object])", () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes the object-shaped latest_version to a version string", async () => {
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: "comfyui-impact-pack",
+          name: "Impact Pack",
+          description: "d",
+          author: "a",
+          repository: "https://github.com/ltdrdata/ComfyUI-Impact-Pack",
+          // The real registry returns an OBJECT here, which used to stringify
+          // to "[object Object]".
+          latest_version: {
+            version: "8.28.3",
+            changelog: "",
+            createdAt: "2026-04-19T17:08:04Z",
+          },
+          versions: [
+            { version: "8.28.3", changelog: "latest" },
+            { version: "8.0.0" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const details = await getNodePackDetails("comfyui-impact-pack");
+    expect(details.latest_version).toBe("8.28.3");
+    expect(typeof details.latest_version).toBe("string");
+    expect(details.versions).toEqual([
+      { version: "8.28.3", changelog: "latest" },
+      { version: "8.0.0", changelog: undefined },
+    ]);
   });
 });

--- a/src/__tests__/services/skill-cache.test.ts
+++ b/src/__tests__/services/skill-cache.test.ts
@@ -175,6 +175,25 @@ describe("generateSkillCached", () => {
     expect(hit.markdown).toBe("# Refreshed Skill");
   });
 
+  it("does not crash on a bare registry id when latest_version is an object (the 'value.toLowerCase is not a function' bug)", async () => {
+    // Simulate the raw registry shape leaking through: latest_version as an
+    // object. resolveVersion must not pass a non-string into safeSegment().
+    getNodePackDetailsMock.mockResolvedValue({
+      latest_version: { version: "8.28.3", changelog: "" },
+      versions: [{ version: "8.28.3" }],
+    });
+
+    const result = await generateSkillCached("comfyui-impact-pack");
+
+    expect(result.cacheHit).toBe(false);
+    expect(result.markdown).toBe("# Generated Skill");
+    // The key point: a usable string version, never an object stringified to
+    // "[object Object]", and no thrown TypeError.
+    expect(typeof result.metadata.version).toBe("string");
+    expect(result.metadata.version).not.toContain("[object Object]");
+    expect(typeof result.safeKey).toBe("string");
+  });
+
   it("falls back to normal generation when cache reads or writes fail", async () => {
     fsMock.readFile.mockRejectedValueOnce(new Error("read denied"));
     fsMock.writeFile.mockRejectedValue(new Error("write denied"));

--- a/src/__tests__/services/workflow-lock.test.ts
+++ b/src/__tests__/services/workflow-lock.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../comfyui/client.js", () => ({
 }));
 
 const { config } = await import("../../config.js");
-const { generateLock, diffLocks } = await import(
+const { generateLock, diffLocks, parseWorkflowLock } = await import(
   "../../services/workflow-lock.js"
 );
 
@@ -143,6 +143,37 @@ describe("generateLock", () => {
       id: "DetachedPack",
       commit_sha: "deadbeef0000000000000000000000000000beef",
     });
+  });
+});
+
+describe("parseWorkflowLock (graceful no-lock)", () => {
+  it("returns null for an empty body instead of throwing (the 'Unexpected end of JSON input' bug)", () => {
+    expect(parseWorkflowLock("")).toBeNull();
+    expect(parseWorkflowLock("   \n  ")).toBeNull();
+  });
+
+  it("returns null for null/undefined (e.g. missing file)", () => {
+    expect(parseWorkflowLock(null)).toBeNull();
+    expect(parseWorkflowLock(undefined)).toBeNull();
+  });
+
+  it("parses a valid lock body", () => {
+    const lock = {
+      generated_at: "2026-06-01T00:00:00Z",
+      comfyui_version: "0.3.20",
+      models: [],
+      node_packs: [],
+    };
+    expect(parseWorkflowLock(JSON.stringify(lock))).toEqual(lock);
+  });
+
+  it("throws a clear ValidationError on genuinely malformed JSON", () => {
+    expect(() => parseWorkflowLock("{ not json")).toThrow(/not valid JSON/i);
+  });
+
+  it("returns null for non-object JSON (e.g. a bare number or array)", () => {
+    expect(parseWorkflowLock("42")).toBeNull();
+    expect(parseWorkflowLock("[]")).toBeNull();
   });
 });
 

--- a/src/services/image-convert.ts
+++ b/src/services/image-convert.ts
@@ -1,9 +1,9 @@
 import { lstat, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import sharp from "sharp";
-import { config } from "../config.js";
 import { AssetRegistry } from "./asset-registry.js";
 import { getOutputImage } from "./image-management.js";
+import { resolveOutputDir } from "./output-dir.js";
 import { ValidationError } from "../utils/errors.js";
 
 export type ConvertImageFormat = "png" | "jpeg" | "webp";
@@ -47,13 +47,11 @@ const SUPPORTED_SOURCE_MIME = /^image\/(png|jpe?g|webp)$/i;
 const DEFAULT_MAX_SOURCE_BYTES = 64 * 1024 * 1024;
 const DEFAULT_LIMIT_INPUT_PIXELS = 100_000_000;
 
-function getOutputDir(): string {
-  if (!config.comfyuiPath) {
-    throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
-    );
-  }
-  return resolve(config.comfyuiPath, "output");
+// Resolve ComfyUI's REAL output directory (honors --output-directory /
+// --base-directory redirects via /system_stats), falling back to
+// <COMFYUI_PATH>/output. Async because it may query the running ComfyUI.
+async function getOutputDir(): Promise<string> {
+  return resolveOutputDir();
 }
 
 function parsePositiveIntEnv(name: string, fallback: number): number {
@@ -77,12 +75,12 @@ function limitInputPixels(): number {
   );
 }
 
-function resolveOutputPath(path: string, label: string): string {
+async function resolveOutputPath(path: string, label: string): Promise<string> {
   if (path.trim().length === 0) {
     throw new ValidationError(`${label} must be a non-empty path.`);
   }
 
-  const outputDir = getOutputDir();
+  const outputDir = await getOutputDir();
   const resolved = isAbsolute(path) ? resolve(path) : resolve(outputDir, path);
   if (resolved === outputDir || !resolved.startsWith(outputDir + sep)) {
     throw new ValidationError(`${label} must stay within the ComfyUI output directory.`);
@@ -91,7 +89,7 @@ function resolveOutputPath(path: string, label: string): string {
 }
 
 async function realOutputRoot(): Promise<string> {
-  return realpath(getOutputDir());
+  return realpath(await getOutputDir());
 }
 
 function isInsideOrEqual(root: string, candidate: string): boolean {
@@ -115,7 +113,7 @@ async function validateExistingOutputAncestors(
   parent: string,
   label: string,
 ): Promise<void> {
-  const outputDir = getOutputDir();
+  const outputDir = await getOutputDir();
   let cursor = parent;
   while (cursor !== outputDir && cursor.startsWith(outputDir + sep)) {
     try {
@@ -135,7 +133,7 @@ async function validateExistingOutputAncestors(
 }
 
 async function resolveSourcePath(path: string): Promise<{ path: string; size: number }> {
-  const lexicalPath = resolveOutputPath(path, "path");
+  const lexicalPath = await resolveOutputPath(path, "path");
   const root = await realOutputRoot();
   const sourcePath = await realpath(lexicalPath).catch(() => undefined);
   if (!sourcePath) {
@@ -157,7 +155,7 @@ async function resolveSourcePath(path: string): Promise<{ path: string; size: nu
 }
 
 async function resolveWritableOutputPath(path: string): Promise<string> {
-  const targetPath = resolveOutputPath(path, "out_path");
+  const targetPath = await resolveOutputPath(path, "out_path");
   const root = await realOutputRoot();
   const parent = dirname(targetPath);
   await validateExistingOutputAncestors(root, parent, "out_path");

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -3,6 +3,7 @@ import { join, basename, extname } from "node:path";
 import { config } from "../config.js";
 import { ValidationError, ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { resolveOutputDir } from "./output-dir.js";
 
 function getInputDir(): string {
   if (!config.comfyuiPath) {
@@ -11,15 +12,6 @@ function getInputDir(): string {
     );
   }
   return join(config.comfyuiPath, "input");
-}
-
-function getOutputDir(): string {
-  if (!config.comfyuiPath) {
-    throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
-    );
-  }
-  return join(config.comfyuiPath, "output");
 }
 
 /**
@@ -189,7 +181,7 @@ export async function listOutputImages(options?: {
   limit?: number;
   pattern?: string;
 }): Promise<OutputImage[]> {
-  const outputDir = getOutputDir();
+  const outputDir = await resolveOutputDir();
   const limit = options?.limit ?? 20;
   const pattern = options?.pattern?.toLowerCase();
 

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -23,15 +23,39 @@ export interface SaveSnapshotResult {
   name: string;
   method: "http" | "file";
   message: string;
+  unsupported?: boolean;
 }
 
 export interface RestoreSnapshotResult {
   name: string;
   message: string;
+  unsupported?: boolean;
 }
 
 export interface ListSnapshotsResult {
   snapshots: string[];
+  unsupported?: boolean;
+  message?: string;
+}
+
+// Shown when this ComfyUI-Manager build doesn't expose the /snapshot/* HTTP
+// API at all (common on the bundled ComfyUI Desktop Manager): every snapshot
+// endpoint 404s. Report it as an unsupported-capability result, not a crash.
+const SNAPSHOTS_UNSUPPORTED_MESSAGE =
+  "Node snapshots aren't supported on this ComfyUI-Manager build — its HTTP API " +
+  "doesn't expose the /snapshot/* endpoints (common on the bundled ComfyUI Desktop " +
+  "Manager). Update ComfyUI-Manager to a build that supports snapshots, or manage " +
+  "snapshots from the ComfyUI-Manager UI / comfy-cli instead.";
+
+/**
+ * True when an error indicates the Manager build simply lacks the snapshot
+ * endpoint (404), as opposed to a transient/server-side failure (e.g. 500) or
+ * a network error, which should still surface.
+ */
+function isSnapshotEndpointUnsupported(err: unknown): boolean {
+  if (!(err instanceof NodeSnapshotError)) return false;
+  const status = (err.details as { status?: number } | undefined)?.status;
+  return status === 404 || status === 405 || status === 501;
 }
 
 function managerBaseUrl(): string {
@@ -145,15 +169,28 @@ function snapshotToYaml(snapshot: unknown): string {
   return `custom_nodes:${toYaml(snapshot, 1)}\n`;
 }
 
-/** GET /snapshot/getlist */
-export async function listNodeSnapshots(): Promise<ListSnapshotsResult> {
+/** GET /snapshot/getlist — raw fetch + parse; throws on any non-2xx. */
+async function fetchSnapshotList(): Promise<string[]> {
   const res = await managerFetch("/snapshot/getlist");
   const data = (await res.json()) as { items?: unknown };
-  const items = Array.isArray(data.items)
+  return Array.isArray(data.items)
     ? data.items.filter((x): x is string => typeof x === "string")
     : [];
-  logger.info(`Listed ${items.length} node snapshot(s)`);
-  return { snapshots: items };
+}
+
+/** GET /snapshot/getlist */
+export async function listNodeSnapshots(): Promise<ListSnapshotsResult> {
+  try {
+    const items = await fetchSnapshotList();
+    logger.info(`Listed ${items.length} node snapshot(s)`);
+    return { snapshots: items };
+  } catch (err) {
+    if (isSnapshotEndpointUnsupported(err)) {
+      logger.info("Snapshot listing unsupported on this ComfyUI-Manager build");
+      return { snapshots: [], unsupported: true, message: SNAPSHOTS_UNSUPPORTED_MESSAGE };
+    }
+    throw err;
+  }
 }
 
 /**
@@ -172,16 +209,29 @@ export async function saveNodeSnapshot(
 
   if (!trimmed) {
     // HTTP-only path — Manager assigns a timestamped name.
-    const before = new Set((await listNodeSnapshots()).snapshots);
-    await managerFetch("/snapshot/save", { method: "POST" });
-    const after = (await listNodeSnapshots()).snapshots;
-    const created = after.find((n) => !before.has(n));
-    const resolved = created ?? after[0] ?? "(unknown)";
-    return {
-      name: resolved,
-      method: "http",
-      message: `Saved snapshot "${resolved}" via ComfyUI-Manager.`,
-    };
+    try {
+      const before = new Set(await fetchSnapshotList());
+      await managerFetch("/snapshot/save", { method: "POST" });
+      const after = await fetchSnapshotList();
+      const created = after.find((n) => !before.has(n));
+      const resolved = created ?? after[0] ?? "(unknown)";
+      return {
+        name: resolved,
+        method: "http",
+        message: `Saved snapshot "${resolved}" via ComfyUI-Manager.`,
+      };
+    } catch (err) {
+      if (isSnapshotEndpointUnsupported(err)) {
+        logger.info("Snapshot save unsupported on this ComfyUI-Manager build");
+        return {
+          name: "",
+          method: "http",
+          message: SNAPSHOTS_UNSUPPORTED_MESSAGE,
+          unsupported: true,
+        };
+      }
+      throw err;
+    }
   }
 
   // Named snapshot — requires a local install to write the file.
@@ -195,7 +245,21 @@ export async function saveNodeSnapshot(
   }
 
   // Capture current state from the running instance via the Manager API.
-  const res = await managerFetch("/snapshot/get_current");
+  let res: Response;
+  try {
+    res = await managerFetch("/snapshot/get_current");
+  } catch (err) {
+    if (isSnapshotEndpointUnsupported(err)) {
+      logger.info("Snapshot capture unsupported on this ComfyUI-Manager build");
+      return {
+        name: trimmed,
+        method: "file",
+        message: SNAPSHOTS_UNSUPPORTED_MESSAGE,
+        unsupported: true,
+      };
+    }
+    throw err;
+  }
   const snapshot = await res.json();
 
   // Honor the comfy-cli contract: the file FORMAT is chosen by extension.
@@ -237,11 +301,19 @@ export async function restoreNodeSnapshot(
   // The Manager stores names without the .json suffix; tolerate either.
   const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
 
-  await managerFetch("/snapshot/restore", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ target }),
-  });
+  try {
+    await managerFetch("/snapshot/restore", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target }),
+    });
+  } catch (err) {
+    if (isSnapshotEndpointUnsupported(err)) {
+      logger.info("Snapshot restore unsupported on this ComfyUI-Manager build");
+      return { name: target, message: SNAPSHOTS_UNSUPPORTED_MESSAGE, unsupported: true };
+    }
+    throw err;
+  }
 
   logger.info(`Requested restore of node snapshot "${target}"`);
   return {

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,0 +1,90 @@
+import { isAbsolute, join, resolve } from "node:path";
+import { config } from "../config.js";
+import { getSystemStats } from "../comfyui/client.js";
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// Resolve ComfyUI's REAL output directory.
+//
+// ComfyUI can be launched with --output-directory (or --base-directory) which
+// redirects generated images away from the default <COMFYUI_PATH>/output (e.g.
+// to a shared drive like ComfyUI-Shared\output). Tools that scan the output
+// directory on the local filesystem (convert_image, list_output_images) must
+// therefore NOT assume <COMFYUI_PATH>/output, or they find nothing after a
+// successful render.
+//
+// The authoritative source is ComfyUI itself: /system_stats reports the launch
+// argv (system.argv), from which we parse --output-directory / --base-directory.
+// We fall back to <COMFYUI_PATH>/output when ComfyUI is unreachable or did not
+// override the directory. Same class of fix as the doubled-COMFYUI_PATH bug.
+// ---------------------------------------------------------------------------
+
+/** Resolve a possibly-relative dir against a base (or COMFYUI_PATH, or cwd). */
+function resolveDir(value: string, base?: string): string {
+  if (isAbsolute(value)) return resolve(value);
+  const root = base ?? config.comfyuiPath ?? process.cwd();
+  return resolve(root, value);
+}
+
+/** Read a flag's value supporting both `--flag value` and `--flag=value`. */
+function flagValue(argv: string[], index: number, flag: string): string | undefined {
+  const token = argv[index];
+  if (token === flag) return argv[index + 1];
+  if (token.startsWith(`${flag}=`)) return token.slice(flag.length + 1);
+  return undefined;
+}
+
+/**
+ * Parse the configured output directory out of ComfyUI's launch argv.
+ * --output-directory wins; otherwise --base-directory implies <base>/output.
+ * Returns undefined when neither flag is present.
+ */
+export function parseOutputDirFromArgv(argv: string[] | undefined): string | undefined {
+  if (!argv || argv.length === 0) return undefined;
+
+  let outputDir: string | undefined;
+  let baseDir: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    outputDir = flagValue(argv, i, "--output-directory") ?? outputDir;
+    baseDir = flagValue(argv, i, "--base-directory") ?? baseDir;
+  }
+
+  const resolvedBase = baseDir ? resolveDir(baseDir) : undefined;
+  if (outputDir) return resolveDir(outputDir, resolvedBase);
+  if (resolvedBase) return join(resolvedBase, "output");
+  return undefined;
+}
+
+/** <COMFYUI_PATH>/output fallback. Throws if COMFYUI_PATH is unset. */
+export function localOutputDirFallback(): string {
+  if (!config.comfyuiPath) {
+    throw new ValidationError(
+      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
+    );
+  }
+  return resolve(config.comfyuiPath, "output");
+}
+
+/**
+ * Resolve the directory ComfyUI actually writes outputs to. Asks the running
+ * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/output.
+ */
+export async function resolveOutputDir(): Promise<string> {
+  try {
+    const stats = await getSystemStats();
+    const fromArgv = parseOutputDirFromArgv(stats.system?.argv);
+    if (fromArgv) {
+      logger.debug("Resolved ComfyUI output directory from launch argv", {
+        outputDir: fromArgv,
+      });
+      return fromArgv;
+    }
+  } catch (err) {
+    logger.debug(
+      "Could not resolve output dir from /system_stats; using COMFYUI_PATH/output",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+  return localOutputDirFallback();
+}

--- a/src/services/registry-client.ts
+++ b/src/services/registry-client.ts
@@ -9,7 +9,7 @@ export interface RegistrySearchResult {
   description: string;
   author: string;
   repository: string;
-  latest_version: string;
+  latest_version?: string;
   total_install: number;
   tags?: string[];
 }
@@ -20,6 +20,23 @@ export interface NodePackDetails extends RegistrySearchResult {
   license?: string;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * The ComfyUI Registry returns `latest_version` (and `versions[]` entries) as
+ * OBJECTS — e.g. `{ version: "8.28.3", changelog, createdAt, ... }` — not as
+ * the bare version string. Naively rendering the object yields "[object
+ * Object]", and passing it where a string is expected throws
+ * "value.toLowerCase is not a function". Coerce to the version string here so
+ * every consumer (search/details renderers, skill cache) gets a clean string.
+ */
+export function extractVersionString(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (value && typeof value === "object") {
+    const v = (value as { version?: unknown }).version;
+    if (typeof v === "string") return v.trim() || undefined;
+  }
+  return undefined;
 }
 
 export interface SearchNodesOptions {
@@ -104,7 +121,17 @@ export async function searchNodes(
   logger.info(
     `Registry search "${query}": fetched ${allNodes.length}, matched ${filtered.length}, returning ${paged.length} (page ${page}, limit ${limit})`,
   );
-  return paged;
+  return paged.map(normalizeSearchResult);
+}
+
+/** Coerce the registry's object-shaped `latest_version` into a string. */
+function normalizeSearchResult(node: RegistrySearchResult): RegistrySearchResult {
+  return {
+    ...node,
+    latest_version: extractVersionString(
+      (node as { latest_version?: unknown }).latest_version,
+    ),
+  };
 }
 
 export async function getNodePackDetails(
@@ -112,5 +139,21 @@ export async function getNodePackDetails(
 ): Promise<NodePackDetails> {
   const data = await registryFetch<NodePackDetails>(`/nodes/${encodeURIComponent(id)}`);
   logger.info(`Fetched details for node pack "${id}"`);
-  return data;
+  const rawVersions = (data as { versions?: unknown }).versions;
+  const versions: Array<{ version: string; changelog?: string }> = [];
+  if (Array.isArray(rawVersions)) {
+    for (const v of rawVersions) {
+      const version = extractVersionString((v as { version?: unknown })?.version);
+      if (version) {
+        versions.push({ version, changelog: (v as { changelog?: string })?.changelog });
+      }
+    }
+  }
+  return {
+    ...data,
+    latest_version: extractVersionString(
+      (data as { latest_version?: unknown }).latest_version,
+    ),
+    versions,
+  };
 }

--- a/src/services/skill-cache.ts
+++ b/src/services/skill-cache.ts
@@ -88,7 +88,13 @@ async function resolveVersion(
   if (!normalized.includes("github.com")) {
     try {
       const details = await deps.getDetails(normalized);
-      return details.latest_version || details.versions?.[0]?.version || `source-${shortHash(normalized)}`;
+      // The registry's version fields can be objects, not strings; only accept
+      // an actual string so safeSegment()'s .toLowerCase() never sees an object
+      // (the "value.toLowerCase is not a function" crash on a bare registry id).
+      const candidate = details.latest_version ?? details.versions?.[0]?.version;
+      if (typeof candidate === "string" && candidate.trim()) {
+        return candidate;
+      }
     } catch (err) {
       logger.warn("Could not resolve node pack version for skill cache; using source hash", {
         source,

--- a/src/services/workflow-lock.ts
+++ b/src/services/workflow-lock.ts
@@ -19,7 +19,7 @@ import { join } from "node:path";
 import { getObjectInfo, getSystemStats } from "../comfyui/client.js";
 import type { WorkflowJSON } from "../comfyui/types.js";
 import { config } from "../config.js";
-import { ProcessControlError } from "../utils/errors.js";
+import { ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
 import { MODEL_SUBDIRS } from "./model-resolver.js";
@@ -251,6 +251,32 @@ export async function generateLock(workflow: WorkflowJSON): Promise<WorkflowLock
     models: lockedModels,
     node_packs: lockedPacks,
   };
+}
+
+/**
+ * Parse a lock file's raw body into a WorkflowLock, tolerating a missing or
+ * empty file. ComfyUI's /api/userdata can return 200 with an empty body for a
+ * file that doesn't exist; feeding that straight to JSON.parse throws
+ * "Unexpected end of JSON input". Returns null when there is no lock present
+ * (empty/whitespace body) so callers can report "no lock" gracefully, and
+ * throws a clear ValidationError only when the body is genuinely malformed.
+ */
+export function parseWorkflowLock(raw: string | null | undefined): WorkflowLock | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    throw new ValidationError(
+      `Lock file exists but is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as WorkflowLock;
 }
 
 export function diffLocks(lock: WorkflowLock, current: WorkflowLock): LockDrift {

--- a/src/tools/node-snapshots.ts
+++ b/src/tools/node-snapshots.ts
@@ -67,8 +67,9 @@ export function registerNodeSnapshotsTools(server: McpServer): void {
     async () => {
       try {
         const result = await listNodeSnapshots();
-        const text =
-          result.snapshots.length === 0
+        const text = result.unsupported
+          ? (result.message ?? "Node snapshots are not supported on this ComfyUI-Manager build.")
+          : result.snapshots.length === 0
             ? "No node snapshots found."
             : `Available node snapshots (${result.snapshots.length}):\n` +
               result.snapshots.map((s) => `- ${s}`).join("\n");

--- a/src/tools/workflow-lock.ts
+++ b/src/tools/workflow-lock.ts
@@ -5,6 +5,7 @@ import type { WorkflowJSON } from "../comfyui/types.js";
 import {
   diffLocks,
   generateLock,
+  parseWorkflowLock,
   type WorkflowLock,
 } from "../services/workflow-lock.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
@@ -19,17 +20,24 @@ async function loadWorkflowFromLibrary(filename: string): Promise<WorkflowJSON> 
   return (await res.json()) as WorkflowJSON;
 }
 
-async function loadLockFromLibrary(filename: string): Promise<WorkflowLock> {
+/**
+ * Load a workflow's lock from the user library. Returns null when no lock is
+ * present — either a 404, or (seen on some builds) a 200 with an empty body.
+ * Only a genuinely malformed JSON body throws.
+ */
+async function loadLockFromLibrary(filename: string): Promise<WorkflowLock | null> {
   const lockName = `${filename}.lock.json`;
   const client = getClient();
   const encoded = encodeURIComponent(`workflows/${lockName}`);
   const res = await client.fetchApi(`/api/userdata/${encoded}`);
+  if (res.status === 404) return null;
   if (!res.ok) {
     throw new ValidationError(
-      `No lock found for "${filename}". Run lock_workflow first to create one.`,
+      `Failed to read lock for "${filename}": ${res.status} ${res.statusText}.`,
     );
   }
-  return (await res.json()) as WorkflowLock;
+  const text = await res.text().catch(() => "");
+  return parseWorkflowLock(text);
 }
 
 async function saveLockToLibrary(filename: string, lock: WorkflowLock): Promise<void> {
@@ -96,6 +104,21 @@ export function registerWorkflowLockTools(server: McpServer): void {
           loadWorkflowFromLibrary(args.filename),
           loadLockFromLibrary(args.filename),
         ]);
+
+        if (!lock) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  `No lock present for "${args.filename}" — there is nothing to verify yet. ` +
+                  `Run lock_workflow on "${args.filename}" first to create ` +
+                  `"${args.filename}.lock.json", then verify_workflow_lock will report drift against it.`,
+              },
+            ],
+          };
+        }
+
         const current = await generateLock(workflow);
         const drift = diffLocks(lock, current);
         const driftCount =


### PR DESCRIPTION
Six robustness fixes surfaced by a live MCP sweep. All reversible, all unit-tested. Build clean, 674 tests green.

## Fixes

1. **convert_image / list_output_images ignored the output-directory redirect.** They scanned `<COMFYUI_PATH>/output`, but this install redirects output via ComfyUI's `--output-directory` (e.g. `ComfyUI-Shared\output`), so they found nothing after a successful render. New `src/services/output-dir.ts` `resolveOutputDir()` asks the running ComfyUI for its real output dir by parsing `/system_stats` `system.argv` (`--output-directory`, else `--base-directory`→`<base>/output`), falling back to `<COMFYUI_PATH>/output` when ComfyUI is unreachable or didn't override it. Same class as the doubled-COMFYUI_PATH fix.

2. **verify_workflow_lock crashed "Unexpected end of JSON input" with no `.lock.json`.** The userdata endpoint can return 200 with an empty body for a missing file, which broke `JSON.parse`. New `parseWorkflowLock()` treats empty/missing as "no lock present"; the tool returns a graceful message and only throws on genuinely malformed JSON.

3 + 5. **Snapshot family 404s on Manager builds without `/snapshot/*` (bundled Desktop Manager).** `list_node_snapshots`, `save_node_snapshot`, and `restore_node_snapshot` now detect a 404/unsupported endpoint and return a clear "snapshots aren't supported on this ComfyUI-Manager build" result instead of a raw 404. Genuine 5xx / network errors still surface as errors.

4. **`[object Object]` version rendering in get_node_pack_details / search_custom_nodes.** The registry's `latest_version` (and `versions[]` entries) are objects (`{ version: "8.28.3", ... }`), not strings. `registry-client` now coerces them via `extractVersionString()`.

6. **generate_node_skill crashed "value.toLowerCase is not a function" on a bare registry id.** Same root cause as #4: the skill cache passed the object-shaped `latest_version` into `safeSegment()` (`.toLowerCase()`). Fixed at the source (#4) and additionally hardened `resolveVersion()` to only accept a real string.

## Tests
New/extended vitest unit tests for each fix: output-dir resolution via mocked `/system_stats`, graceful no-lock parsing, graceful snapshot 404 (list/save/restore) with 5xx still throwing, registry version-string extraction, and bare-id skill generation not crashing.

## Verification
`npm run build` exit 0; `npm test` → 71 files / 674 tests passing.

DO NOT MERGE pending review / live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)