### PR TITLE
fix(api-nodes): serialize v3 dynamic-combo (dotted model.*) inputs so paid v3 API nodes run headlessly

### DIFF
--- a/src/__tests__/services/api-nodes.test.ts
+++ b/src/__tests__/services/api-nodes.test.ts
@@ -18,6 +18,7 @@ import {
   listApiNodes,
   getApiNodeSchema,
   generateWithApiNode,
+  buildApiNodeInputs,
   isApiNode,
   type ApiNodesDeps,
 } from "../../services/api-nodes.js";
@@ -86,6 +87,58 @@ function sampleObjectInfo(): ObjectInfo {
       category: "utils/api helpers",
       display_name: "API Helpers",
     }),
+    // v3 API node with a COMFY_DYNAMICCOMBO_V3 input ("model") that reveals nested
+    // inputs — the Nano Banana 2 shape. Selecting the option exposes
+    // aspect_ratio/resolution/thinking_level (positional widgets) plus an AUTOGROW
+    // image list and an optional files input (neither a positional widget).
+    GeminiNanoBanana2V2: nodeDef({
+      api_node: true,
+      category: "partner/image/Gemini",
+      display_name: "Nano Banana 2",
+      output: ["IMAGE", "STRING", "IMAGE"],
+      output_name: ["IMAGE", "STRING", "thought_image"],
+      input: {
+        required: {
+          prompt: ["STRING", { default: "", multiline: true }],
+          model: [
+            "COMFY_DYNAMICCOMBO_V3",
+            {
+              options: [
+                {
+                  key: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+                  inputs: {
+                    required: {
+                      aspect_ratio: [
+                        "COMBO",
+                        { default: "auto", options: ["auto", "1:1", "16:9"] },
+                      ],
+                      resolution: ["COMBO", { options: ["1K", "2K", "4K"] }],
+                      thinking_level: ["COMBO", { options: ["MINIMAL", "HIGH"] }],
+                      images: [
+                        "COMFY_AUTOGROW_V3",
+                        { template: { names: ["image_1"] }, min: 0 },
+                      ],
+                    },
+                    optional: {
+                      files: ["GEMINI_INPUT_FILES", {}],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          seed: ["INT", { default: 42, control_after_generate: true }],
+          response_modalities: ["COMBO", { options: ["IMAGE", "IMAGE+TEXT"] }],
+        },
+        optional: {
+          system_prompt: ["STRING", { default: "sys", multiline: true }],
+        },
+        hidden: {
+          auth_token_comfy_org: ["AUTH_TOKEN_COMFY_ORG"],
+          api_key_comfy_org: ["API_KEY_COMFY_ORG"],
+        },
+      },
+    }),
   };
 }
 
@@ -122,7 +175,11 @@ describe("listApiNodes", () => {
   it("returns only API nodes, sorted by class_type", async () => {
     const { deps } = makeDeps();
     const nodes = await listApiNodes(undefined, deps);
-    expect(nodes.map((n) => n.class_type)).toEqual(["FluxProImageNode", "KlingVideoNode"]);
+    expect(nodes.map((n) => n.class_type)).toEqual([
+      "FluxProImageNode",
+      "GeminiNanoBanana2V2",
+      "KlingVideoNode",
+    ]);
     expect(nodes.find((n) => n.class_type === "KSampler")).toBeUndefined();
     expect(nodes.find((n) => n.class_type === "SomeOtherNode")).toBeUndefined();
   });
@@ -206,7 +263,8 @@ describe("generateWithApiNode", () => {
 
     const wf = enqueued[0].wf;
     expect(wf["1"].class_type).toBe("FluxProImageNode");
-    expect(wf["1"].inputs).toEqual({ prompt: "a cat", aspect_ratio: "16:9" });
+    // seed (required INT, default 0) is auto-filled; prompt + aspect_ratio as given.
+    expect(wf["1"].inputs).toEqual({ prompt: "a cat", aspect_ratio: "16:9", seed: 0 });
     expect(wf["1"]._meta?.title).toBe("Flux Pro Image");
     // FluxProImageNode outputs IMAGE but is not itself an output node, so a
     // SaveImage is wired to its IMAGE output (index 0) — without a terminal
@@ -229,15 +287,34 @@ describe("generateWithApiNode", () => {
     expect(result.notes.some((n) => /hidden input/i.test(n))).toBe(true);
   });
 
-  it("notes missing required inputs but still enqueues", async () => {
+  it("fills omitted required widget inputs from their schema defaults", async () => {
     const { deps, enqueued } = makeDeps();
     const result = await generateWithApiNode(
       { class_type: "FluxProImageNode", inputs: { prompt: "x" } },
       deps,
     );
     expect(enqueued).toHaveLength(1);
+    // aspect_ratio (combo default "1:1") and seed (INT default 0) are auto-filled,
+    // so they are NOT reported as missing — only inputs with no determinable
+    // default would be.
+    expect(enqueued[0].wf["1"].inputs).toMatchObject({
+      prompt: "x",
+      aspect_ratio: "1:1",
+      seed: 0,
+    });
+    expect(result.notes.some((n) => /Missing required input/i.test(n))).toBe(false);
+  });
+
+  it("notes a required input that has no determinable default", async () => {
+    const { deps, enqueued } = makeDeps();
+    // prompt is a STRING with no default — omitting it leaves it genuinely missing.
+    const result = await generateWithApiNode(
+      { class_type: "FluxProImageNode", inputs: { aspect_ratio: "1:1" } },
+      deps,
+    );
+    expect(enqueued).toHaveLength(1);
     expect(result.notes.some((n) => /Missing required input/i.test(n))).toBe(true);
-    expect(result.notes.some((n) => /aspect_ratio/.test(n))).toBe(true);
+    expect(result.notes.some((n) => /prompt/.test(n))).toBe(true);
   });
 
   it("notes unknown inputs but passes them through", async () => {
@@ -326,5 +403,170 @@ describe("generateWithApiNode", () => {
       generateWithApiNode({ class_type: "KSampler", inputs: {} }, deps),
     ).rejects.toThrow(/not an API\/partner node/i);
     expect(enqueued).toHaveLength(0);
+  });
+
+  // ── v3 dynamic-combo (dotted widget) serialization ────────────────────────
+  // ComfyUI rejects (HTTP 400 "required_input_missing: model.resolution") a flat
+  // form; the canvas serializes the revealed widgets as dotted `model.<nested>`
+  // keys. These prove our builder emits the dotted form the server accepts.
+
+  it("serializes v3 dynamic-combo nested inputs into dotted model.* keys", async () => {
+    const { deps, enqueued } = makeDeps();
+    await generateWithApiNode(
+      {
+        class_type: "GeminiNanoBanana2V2",
+        inputs: {
+          prompt: "a red cube",
+          model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+          aspect_ratio: "16:9",
+          resolution: "2K",
+          thinking_level: "HIGH",
+          seed: 7,
+          response_modalities: "IMAGE",
+        },
+        disable_random_seed: true,
+      },
+      deps,
+    );
+    const inputs = enqueued[0].wf["1"].inputs;
+    expect(inputs).toMatchObject({
+      prompt: "a red cube",
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      "model.aspect_ratio": "16:9",
+      "model.resolution": "2K",
+      "model.thinking_level": "HIGH",
+      seed: 7,
+      response_modalities: "IMAGE",
+    });
+    // The flat nested keys must NOT survive — the server ignores them.
+    expect(inputs).not.toHaveProperty("aspect_ratio");
+    expect(inputs).not.toHaveProperty("resolution");
+    expect(inputs).not.toHaveProperty("thinking_level");
+    // AUTOGROW image list / optional files are not positional widgets → omitted.
+    expect(inputs).not.toHaveProperty("model.images");
+    expect(inputs).not.toHaveProperty("model.files");
+  });
+
+  it("accepts already-dotted nested keys as-is", async () => {
+    const { deps, enqueued } = makeDeps();
+    await generateWithApiNode(
+      {
+        class_type: "GeminiNanoBanana2V2",
+        inputs: {
+          prompt: "x",
+          "model.aspect_ratio": "1:1",
+          "model.resolution": "4K",
+          "model.thinking_level": "MINIMAL",
+          seed: 1,
+          response_modalities: "IMAGE",
+        },
+        disable_random_seed: true,
+      },
+      deps,
+    );
+    expect(enqueued[0].wf["1"].inputs).toMatchObject({
+      "model.aspect_ratio": "1:1",
+      "model.resolution": "4K",
+      "model.thinking_level": "MINIMAL",
+    });
+  });
+
+  it("fills omitted required nested combo inputs from their defaults", async () => {
+    const { deps, enqueued } = makeDeps();
+    await generateWithApiNode(
+      {
+        class_type: "GeminiNanoBanana2V2",
+        inputs: { prompt: "x", response_modalities: "IMAGE" },
+        disable_random_seed: true,
+      },
+      deps,
+    );
+    const inputs = enqueued[0].wf["1"].inputs;
+    expect(inputs).toMatchObject({
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)", // default option key
+      "model.aspect_ratio": "auto", // combo default
+      "model.resolution": "1K", // first option (no default)
+      "model.thinking_level": "MINIMAL", // first option (no default)
+      seed: 42, // top-level INT default
+    });
+  });
+
+  it("does not flag dotted/flat nested combo inputs as unknown", async () => {
+    const { deps } = makeDeps();
+    const result = await generateWithApiNode(
+      {
+        class_type: "GeminiNanoBanana2V2",
+        inputs: {
+          prompt: "x",
+          aspect_ratio: "1:1",
+          "model.resolution": "1K",
+          response_modalities: "IMAGE",
+        },
+        disable_random_seed: true,
+      },
+      deps,
+    );
+    expect(result.notes.some((n) => /Unknown input/.test(n))).toBe(false);
+  });
+});
+
+describe("buildApiNodeInputs (v3 dynamic-combo serialization)", () => {
+  it("emits the dotted model.* form and drops the flat nested keys", async () => {
+    const { deps } = makeDeps();
+    const schema = await getApiNodeSchema("GeminiNanoBanana2V2", deps);
+    const { inputs, consumed } = buildApiNodeInputs(schema, {
+      prompt: "hello",
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      aspect_ratio: "16:9",
+      resolution: "2K",
+      thinking_level: "HIGH",
+      seed: 3,
+      response_modalities: "IMAGE+TEXT",
+    });
+    expect(inputs).toEqual({
+      prompt: "hello",
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      "model.aspect_ratio": "16:9",
+      "model.resolution": "2K",
+      "model.thinking_level": "HIGH",
+      seed: 3,
+      response_modalities: "IMAGE+TEXT",
+    });
+    // The flat nested keys were absorbed by the combo expansion.
+    expect(consumed.has("aspect_ratio")).toBe(true);
+    expect(consumed.has("resolution")).toBe(true);
+    expect(consumed.has("thinking_level")).toBe(true);
+  });
+
+  it("supports a nested object for the combo input", async () => {
+    const { deps } = makeDeps();
+    const schema = await getApiNodeSchema("GeminiNanoBanana2V2", deps);
+    const { inputs } = buildApiNodeInputs(schema, {
+      prompt: "hello",
+      model: {
+        key: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        aspect_ratio: "1:1",
+        resolution: "4K",
+        thinking_level: "HIGH",
+      },
+      response_modalities: "IMAGE",
+    });
+    expect(inputs).toMatchObject({
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      "model.aspect_ratio": "1:1",
+      "model.resolution": "4K",
+      "model.thinking_level": "HIGH",
+    });
+  });
+
+  it("drops hidden auth inputs", async () => {
+    const { deps } = makeDeps();
+    const schema = await getApiNodeSchema("GeminiNanoBanana2V2", deps);
+    const { inputs } = buildApiNodeInputs(schema, {
+      prompt: "x",
+      response_modalities: "IMAGE",
+      api_key_comfy_org: "leaked",
+    });
+    expect(inputs).not.toHaveProperty("api_key_comfy_org");
   });
 });

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -68,6 +68,92 @@ describe("convertUiToApi — bypass / mute resolution", () => {
     expect(workflow["2"].inputs.image).toEqual(["1", 0]);
   });
 
+  it("serializes a v3 dynamic-combo node's nested widgets into dotted model.* keys", () => {
+    // Nano Banana 2 shape: `model` is a COMFY_DYNAMICCOMBO_V3 whose selected
+    // option reveals aspect_ratio/resolution/thinking_level (positional widgets)
+    // plus an AUTOGROW image list (NOT a positional widget). The saved
+    // widgets_values therefore are: [prompt, model, aspect_ratio, resolution,
+    // thinking_level, seed, control_after_generate, response_modalities].
+    const objectInfo = {
+      GeminiNanoBanana2V2: {
+        input: {
+          required: {
+            prompt: ["STRING", { multiline: true }],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                        resolution: ["COMBO", { options: ["1K", "2K", "4K"] }],
+                        thinking_level: ["COMBO", { options: ["MINIMAL", "HIGH"] }],
+                        images: ["COMFY_AUTOGROW_V3", { min: 0 }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT", { default: 42, control_after_generate: true }],
+            response_modalities: ["COMBO", { options: ["IMAGE", "IMAGE+TEXT"] }],
+          },
+        },
+      },
+      SaveImage: {
+        input: { required: { images: ["IMAGE"], filename_prefix: ["STRING"] } },
+      },
+    } as never;
+
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "GeminiNanoBanana2V2",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "IMAGE", type: "IMAGE", links: [1] }],
+          widgets_values: [
+            "a red cube", // prompt
+            "Nano Banana 2 (Gemini 3.1 Flash Image)", // model (combo key)
+            "16:9", // model.aspect_ratio
+            "2K", // model.resolution
+            "HIGH", // model.thinking_level
+            7, // seed
+            "fixed", // control_after_generate (phantom, skipped)
+            "IMAGE", // response_modalities
+          ],
+        },
+        {
+          id: 2,
+          type: "SaveImage",
+          mode: 0,
+          inputs: [{ name: "images", type: "IMAGE", link: 1 }],
+          outputs: [],
+          widgets_values: ["out"],
+        },
+      ],
+      links: [[1, 1, 0, 2, 0, "IMAGE"]],
+    } as never;
+
+    const { workflow } = convertUiToApi(ui, objectInfo);
+    expect(workflow["1"].inputs).toMatchObject({
+      prompt: "a red cube",
+      model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      "model.aspect_ratio": "16:9",
+      "model.resolution": "2K",
+      "model.thinking_level": "HIGH",
+      seed: 7,
+      response_modalities: "IMAGE",
+    });
+    // AUTOGROW images is not a positional widget — it must NOT consume the seed
+    // slot, and no `model.images` key is emitted from widgets_values.
+    expect(workflow["1"].inputs).not.toHaveProperty("model.images");
+    expect(workflow["1"].inputs).not.toHaveProperty("aspect_ratio");
+  });
+
   it("virtual Set/Get bus nodes are dropped and consumers resolve through the bus", () => {
     // LoadImage(1) -> SetNode(2,'BUS');  GetNode(3,'BUS') -> SaveImage(4)
     const ui = {

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -320,6 +320,173 @@ export async function getApiNodeSchema(
   };
 }
 
+// ── V3 dynamic-combo (dotted widget) serialization ──────────────────────────
+//
+// A ComfyUI v3 node can declare a `COMFY_DYNAMICCOMBO_V3` input (e.g. Nano Banana
+// 2's `model`). Selecting an option REVEALS a set of nested inputs. The live
+// canvas serializes those nested widgets into the /prompt API format as DOTTED
+// keys — `model` = the selected option key, and `model.<nested>` = each revealed
+// widget value. The ComfyUI server rebuilds the nested dict from those dotted
+// keys (it 400s with `required_input_missing` for e.g. `model.resolution` if they
+// are absent). Our API-format builders must therefore emit the dotted form rather
+// than the flat one. (Verified against a live server: flat `aspect_ratio` is
+// ignored and `model.aspect_ratio` is the accepted key.)
+
+interface DynamicComboOption {
+  key?: unknown;
+  inputs?: {
+    required?: Record<string, unknown>;
+    optional?: Record<string, unknown>;
+  };
+}
+
+const SIMPLE_WIDGET_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);
+
+/**
+ * If a node input is a v3 dynamic combo, return its option list (each option has
+ * a `key` plus the nested `inputs` it reveals). Returns null otherwise.
+ */
+function dynamicComboOptions(descriptor: ApiNodeInputDescriptor): DynamicComboOption[] | null {
+  const type = descriptor.type;
+  const opts = (descriptor.config as { options?: unknown }).options;
+  if (!Array.isArray(opts)) return null;
+  const typeIsDyn =
+    typeof type === "string" && type.toUpperCase().includes("DYNAMICCOMBO");
+  // Also detect by shape: options that carry nested `inputs` (not plain strings).
+  const shapeIsDyn = opts.some(
+    (o) => o != null && typeof o === "object" && "inputs" in (o as object),
+  );
+  if (!typeIsDyn && !shapeIsDyn) return null;
+  return opts as DynamicComboOption[];
+}
+
+/**
+ * Classify a nested input spec (from a dynamic combo option) as a POSITIONAL
+ * widget (one that carries a scalar value the caller supplies) and resolve its
+ * default. Non-widget nested inputs (AUTOGROW lists, IMAGE/link types) are not
+ * emitted unless the caller explicitly provides a value.
+ */
+function classifyNestedSpec(spec: unknown): { isWidget: boolean; dflt: unknown } {
+  if (!Array.isArray(spec)) return { isWidget: false, dflt: undefined };
+  const [type, cfg] = spec as [unknown, { default?: unknown; options?: unknown[] }?];
+  if (Array.isArray(type)) {
+    // Inline combo: ["1K","2K",...]
+    return { isWidget: true, dflt: cfg?.default ?? type[0] };
+  }
+  const t = String(type).toUpperCase();
+  if (SIMPLE_WIDGET_TYPES.has(t)) {
+    let dflt = cfg?.default;
+    if (dflt === undefined && Array.isArray(cfg?.options) && cfg.options.length) {
+      dflt = cfg.options[0];
+    }
+    return { isWidget: true, dflt };
+  }
+  return { isWidget: false, dflt: undefined };
+}
+
+/**
+ * Build the `inputs` map for an API-node prompt from caller-provided values,
+ * serializing any v3 dynamic-combo input into its dotted `model.<nested>` form.
+ *
+ * The caller may supply nested values in any of three natural shapes — already
+ * dotted (`"model.aspect_ratio"`), flat (`"aspect_ratio"`), or as a nested object
+ * (`model: { key, aspect_ratio }`). Required nested widgets the caller omits are
+ * filled from their schema default so the server doesn't 400. Hidden inputs
+ * (server-injected auth) are dropped. Exported for unit testing.
+ */
+export function buildApiNodeInputs(
+  schema: ApiNodeSchema,
+  provided: Record<string, unknown>,
+): { inputs: Record<string, unknown>; consumed: Set<string> } {
+  const inputs: Record<string, unknown> = {};
+  const consumed = new Set<string>(); // provided keys absorbed by combo expansion
+
+  // Pass 1 — expand dynamic combos into dotted keys.
+  for (const desc of schema.inputs) {
+    const options = dynamicComboOptions(desc);
+    if (!options) continue;
+    const name = desc.name;
+
+    // The selected option key may arrive as a string or inside a nested object.
+    let selected = provided[name];
+    let selObj: Record<string, unknown> | undefined;
+    if (selected != null && typeof selected === "object" && !Array.isArray(selected)) {
+      selObj = selected as Record<string, unknown>;
+      selected = selObj.key ?? selObj.value;
+    }
+    const cfgDefault = (desc.config as { default?: unknown }).default;
+    if (selected === undefined || selected === null) {
+      selected = cfgDefault ?? options[0]?.key;
+    }
+    const option = options.find((o) => o.key === selected) ?? options[0];
+    if (!option) continue;
+
+    consumed.add(name);
+    inputs[name] = option.key ?? selected;
+
+    const emitNested = (
+      nName: string,
+      nSpec: unknown,
+      requiredFill: boolean,
+    ) => {
+      const dottedKey = `${name}.${nName}`;
+      let val: unknown;
+      if (dottedKey in provided) {
+        val = provided[dottedKey];
+        consumed.add(dottedKey);
+      } else if (selObj && nName in selObj) {
+        val = selObj[nName];
+      } else if (nName in provided) {
+        val = provided[nName];
+        consumed.add(nName);
+      }
+      if (val === undefined) {
+        if (!requiredFill) return; // optional / non-widget — omit when absent
+        const info = classifyNestedSpec(nSpec);
+        if (!info.isWidget || info.dflt === undefined) return;
+        val = info.dflt;
+      }
+      inputs[dottedKey] = val;
+    };
+
+    for (const [nName, nSpec] of Object.entries(option.inputs?.required ?? {})) {
+      const info = classifyNestedSpec(nSpec);
+      emitNested(nName, nSpec, info.isWidget);
+    }
+    for (const [nName, nSpec] of Object.entries(option.inputs?.optional ?? {})) {
+      emitNested(nName, nSpec, false);
+    }
+  }
+
+  // Pass 2 — copy remaining provided inputs (skip consumed + hidden).
+  for (const [key, value] of Object.entries(provided)) {
+    if (consumed.has(key)) continue;
+    if (schema.hidden_inputs.includes(key)) continue;
+    if (key in inputs) continue;
+    inputs[key] = value;
+  }
+
+  // Pass 3 — fill any required top-level WIDGET input the caller omitted with its
+  // schema default, so /prompt validation doesn't reject a missing required combo
+  // /scalar (link-type inputs like IMAGE have no default and are left absent).
+  for (const desc of schema.inputs) {
+    if (!desc.required) continue;
+    if (desc.name in inputs) continue;
+    if (dynamicComboOptions(desc)) continue; // already emitted above
+    const cfg = desc.config as { default?: unknown; options?: unknown[] };
+    const type = desc.type;
+    let dflt: unknown;
+    if (Array.isArray(type)) {
+      dflt = cfg.default ?? type[0];
+    } else if (SIMPLE_WIDGET_TYPES.has(String(type).toUpperCase())) {
+      dflt = cfg.default ?? (Array.isArray(cfg.options) ? cfg.options[0] : undefined);
+    }
+    if (dflt !== undefined) inputs[desc.name] = dflt;
+  }
+
+  return { inputs, consumed };
+}
+
 export interface GenerateWithApiNodeArgs {
   class_type: string;
   inputs: Record<string, unknown>;
@@ -349,40 +516,52 @@ export async function generateWithApiNode(
   const notes: string[] = [];
 
   const provided = args.inputs ?? {};
-  const knownNames = new Set(schema.inputs.map((i) => i.name));
 
-  // Warn about inputs that aren't part of the node's visible schema (typos,
-  // or hidden auth fields the server should fill itself).
-  for (const key of Object.keys(provided)) {
-    if (!knownNames.has(key)) {
-      if (schema.hidden_inputs.includes(key)) {
-        notes.push(
-          `Ignoring "${key}": it is a hidden input filled by the ComfyUI server, not the client.`,
-        );
-      } else {
-        notes.push(`Unknown input "${key}" for ${args.class_type} (passing through anyway).`);
+  // Build the prompt inputs, serializing any v3 dynamic-combo input into its
+  // dotted `model.<nested>` form (the canvas does this; a flat form 400s).
+  const { inputs, consumed } = buildApiNodeInputs(schema, provided);
+
+  // Acceptable input names: visible schema names, plus the nested names a dynamic
+  // combo reveals (in both flat and dotted form) — so we don't warn about them.
+  const knownNames = new Set(schema.inputs.map((i) => i.name));
+  for (const desc of schema.inputs) {
+    const options = dynamicComboOptions(desc);
+    if (!options) continue;
+    for (const opt of options) {
+      for (const nName of Object.keys(opt.inputs?.required ?? {})) {
+        knownNames.add(nName);
+        knownNames.add(`${desc.name}.${nName}`);
+      }
+      for (const nName of Object.keys(opt.inputs?.optional ?? {})) {
+        knownNames.add(nName);
+        knownNames.add(`${desc.name}.${nName}`);
       }
     }
   }
 
-  // Check required inputs are present (skip enum/combo selectors that ComfyUI
-  // can default, but still flag genuinely missing scalars).
+  // Warn about inputs that aren't part of the node's visible schema (typos,
+  // or hidden auth fields the server should fill itself).
+  for (const key of Object.keys(provided)) {
+    if (knownNames.has(key) || consumed.has(key)) continue;
+    if (schema.hidden_inputs.includes(key)) {
+      notes.push(
+        `Ignoring "${key}": it is a hidden input filled by the ComfyUI server, not the client.`,
+      );
+    } else {
+      notes.push(`Unknown input "${key}" for ${args.class_type} (passing through anyway).`);
+    }
+  }
+
+  // Check required inputs are present in the built prompt (after combo expansion
+  // and default-filling), and flag any genuinely missing ones.
   const missingRequired = schema.inputs
-    .filter((i) => i.required && !(i.name in provided))
+    .filter((i) => i.required && !(i.name in inputs))
     .map((i) => i.name);
   if (missingRequired.length > 0) {
     notes.push(
       `Missing required input(s): ${missingRequired.join(", ")}. ` +
         `The server may reject the job. Use get_api_node_schema for details.`,
     );
-  }
-
-  // Drop any hidden-input values the caller mistakenly supplied — the server
-  // injects auth credentials itself.
-  const inputs: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(provided)) {
-    if (schema.hidden_inputs.includes(key)) continue;
-    inputs[key] = value;
   }
 
   const workflow: WorkflowJSON = {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -65,6 +65,21 @@ function isWidgetInput(
 }
 
 /**
+ * Whether an input spec is a POSITIONAL widget — one that occupies a slot in the
+ * UI's `widgets_values` array. Inline combos (`["a","b"]`), v3 dynamic combos
+ * (a string type carrying an `options` list), and the standard scalar widget
+ * types all qualify; link/list types (IMAGE, COMFY_AUTOGROW_V3, …) do not.
+ */
+function isPositionalWidgetSpec(spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  const type = spec[0];
+  if (Array.isArray(type)) return true; // inline combo options
+  const cfg = spec[1] as { options?: unknown } | undefined;
+  if (Array.isArray(cfg?.options)) return true; // dynamic combo (options-carrying)
+  return ["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"].includes(String(type));
+}
+
+/**
  * Check if an input has control_after_generate in its spec config.
  * These inputs (like seed, noise_seed) have a phantom "fixed"/"randomize" widget
  * in the UI's widgets_values array that doesn't correspond to any named input.
@@ -834,8 +849,13 @@ export function convertUiToApi(
         // V3 dynamic-combo nested inputs are keyed with the combo's id as a
         // "<combo>.<nested>" prefix (ComfyUI rebuilds the nested dict from these
         // via dynamic_paths). A flat "<nested>" key is rejected as missing.
-        for (const nName of Object.keys(nested)) {
+        // Only POSITIONAL widget nested inputs consume a widgets_values slot —
+        // non-widget nested inputs (AUTOGROW lists like Nano Banana 2's
+        // "images", or IMAGE/link types) have no saved widget value, so skipping
+        // them keeps the positional mapping aligned.
+        for (const [nName, nSpec] of Object.entries(nested)) {
           if (widgetIdx >= widgetValues.length) break;
+          if (!isPositionalWidgetSpec(nSpec)) continue;
           inputs[`${name}.${nName}`] = widgetValues[widgetIdx];
           widgetIdx++;
         }


### PR DESCRIPTION
## Root cause of the 400

ComfyUI **v3 API nodes** can declare a `COMFY_DYNAMICCOMBO_V3` input (e.g. Nano Banana 2 / `GeminiNanoBanana2V2`'s `model`). Selecting an option *reveals* a set of nested inputs (`aspect_ratio`, `resolution`, `thinking_level`, an AUTOGROW `images` list, …).

The live **canvas** serializes those revealed widgets into the `/prompt` API format as **dotted keys**: `model` = the selected option key, and `model.<nested>` = each revealed widget value. The server rebuilds the nested dict from those keys.

Our `generate_with_api_node` built the prompt **straight from the caller's `inputs` with no dynamic-combo expansion**, so flat `aspect_ratio`/`resolution`/`thinking_level` were passed (and ignored) while the dotted `model.*` keys were absent. The server rejects this:

```
POST /prompt  ->  400
node_errors.1.errors:
  required_input_missing  details: resolution      input_name: model.resolution
  required_input_missing  details: thinking_level  input_name: model.thinking_level
  required_input_missing  details: aspect_ratio    input_name: model.aspect_ratio
```

Verified against the live server: with `model.aspect_ratio` / `model.resolution` / `model.thinking_level` present, those errors disappear (the only remaining error was a deliberately-invalid `seed`, used to confirm acceptance without spending credits).

## What was missing

The dotted `model.<nested>` serialization. Two builders needed it:

1. **`generateWithApiNode`** (`generate_with_api_node`) — built inputs verbatim; no expansion at all.
2. **`convertUiToApi`** (the UI/canvas -> API path) — already emitted dotted keys, but consumed a positional `widgets_values` slot for **every** nested key, including non-widget ones (the AUTOGROW `images` list), which misaligned the positional mapping (seed/response_modalities shifted).

## What this PR fixes

- **`buildApiNodeInputs()`** (new, exported, in `api-nodes.ts`): expands any v3 dynamic combo into the dotted form. Accepts the caller's nested values in three natural shapes — already dotted (`"model.aspect_ratio"`), flat (`"aspect_ratio"`), or a nested object (`model: { key, aspect_ratio }`). Fills omitted **required** nested widgets and required top-level widgets from their schema defaults (mirrors `convertUiToApi`), and drops hidden auth inputs. `generateWithApiNode` now uses it, and its unknown/missing-required notes are computed against the expanded result.
- **`convertUiToApi()`**: nested inputs now only consume a `widgets_values` slot when they are **positional widgets** (`isPositionalWidgetSpec`); AUTOGROW lists and link types are skipped, keeping positional alignment correct.

## Scope / what remains

- `enqueue_workflow` passes API-format JSON straight through (by design). An agent that hand-builds a *flat* prompt would still 400 — but the supported builder (`generate_with_api_node`) now emits the correct dotted form, and the UI->API conversion path (`convertUiToApi`) is also correct. No change to `enqueue_workflow` itself.
- AUTOGROW `images`/optional `files` nested inputs are not auto-populated (they have no positional widget value); they pass through only when the caller supplies them explicitly. Wiring image links into a dynamic-combo AUTOGROW slot from `generate_with_api_node` is out of scope here.

The fix for the reported capability gap (run paid v3 dynamic-combo API nodes headlessly) is **complete** for `generate_with_api_node` and the UI->API conversion path.

## Tests

- New v3 dynamic-combo fixture (`GeminiNanoBanana2V2` shape) proving dotted `model.*` serialization in `buildApiNodeInputs`, `generateWithApiNode`, and `convertUiToApi`; covers flat input, already-dotted input, nested-object input, required-default fill, AUTOGROW skip, and hidden-input drop.
- `npm run build`: exit 0. `npm test`: **658 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
