### PR TITLE
Fix model/queue robustness: multi-root model removal, node-verify inference, queue count

### DIFF
--- a/src/__tests__/services/model-resolver-roots.test.ts
+++ b/src/__tests__/services/model-resolver-roots.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { resolve } from "node:path";
+
+// Control config (comfyuiPath) per test.
+vi.mock("../../config.js", () => ({
+  config: {
+    comfyuiPath: "/comfy" as string | undefined,
+    huggingfaceToken: undefined as string | undefined,
+    civitaiApiToken: undefined as string | undefined,
+  },
+}));
+
+// node:fs/promises is mocked so stat answers per-path from a fixture map.
+const statMock = vi.fn();
+vi.mock("node:fs/promises", () => ({
+  copyFile: vi.fn(),
+  link: vi.fn(),
+  mkdir: vi.fn(),
+  readdir: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  stat: (...a: unknown[]) => statMock(...a),
+  utimes: vi.fn(),
+  unlink: vi.fn(),
+}));
+
+// Extra roots are injected; no real config file is read.
+const getExtraModelRootsMock = vi.fn();
+vi.mock("../../services/extra-paths.js", () => ({
+  getExtraModelRoots: (...a: unknown[]) => getExtraModelRootsMock(...a),
+}));
+
+import { config } from "../../config.js";
+import { resolveExistingModelFile } from "../../services/model-resolver.js";
+import { ModelError, ValidationError } from "../../utils/errors.js";
+
+const MODELS_ROOT = resolve("/comfy", "models");
+const EXTRA_LORAS = "E:/extra-drive/loras";
+
+/** stat() resolves to a file for paths in `files`, a dir for `dirs`, else ENOENT. */
+function fsFixture(files: string[], dirs: string[] = []) {
+  const fileSet = new Set(files.map((p) => resolve(p)));
+  const dirSet = new Set(dirs.map((p) => resolve(p)));
+  statMock.mockImplementation(async (p: string) => {
+    const key = resolve(p);
+    if (fileSet.has(key)) return { isFile: () => true, size: 1234 };
+    if (dirSet.has(key)) return { isFile: () => false, size: 0 };
+    throw new Error("ENOENT");
+  });
+}
+
+beforeEach(() => {
+  statMock.mockReset();
+  getExtraModelRootsMock.mockReset();
+  getExtraModelRootsMock.mockResolvedValue([]);
+  config.comfyuiPath = "/comfy";
+});
+
+describe("resolveExistingModelFile — multi-root resolution", () => {
+  it("finds a model under the primary models/ root", async () => {
+    fsFixture([resolve(MODELS_ROOT, "checkpoints/a.safetensors")]);
+
+    const res = await resolveExistingModelFile("checkpoints/a.safetensors");
+
+    expect(res.path).toBe(resolve(MODELS_ROOT, "checkpoints/a.safetensors"));
+    expect(res.root).toBe(MODELS_ROOT);
+    expect(res.info.isFile()).toBe(true);
+    // Primary hit short-circuits before extra roots are queried.
+    expect(getExtraModelRootsMock).not.toHaveBeenCalled();
+  });
+
+  it("finds a model under an extra_model_paths root (e.g. another drive)", async () => {
+    getExtraModelRootsMock.mockResolvedValue([
+      { category: "loras", dir: EXTRA_LORAS, group: "comfyui" },
+    ]);
+    // Absent from primary, present on the extra drive.
+    fsFixture([resolve(EXTRA_LORAS, "cool.safetensors")]);
+
+    const res = await resolveExistingModelFile("loras/cool.safetensors");
+
+    expect(res.path).toBe(resolve(EXTRA_LORAS, "cool.safetensors"));
+    expect(res.root).toBe(resolve(EXTRA_LORAS));
+    expect(res.info.isFile()).toBe(true);
+    expect(getExtraModelRootsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores extra roots for a different category", async () => {
+    getExtraModelRootsMock.mockResolvedValue([
+      { category: "checkpoints", dir: "E:/extra-drive/checkpoints", group: "comfyui" },
+    ]);
+    fsFixture([resolve(EXTRA_LORAS, "cool.safetensors")]); // only the loras drive has it
+
+    await expect(
+      resolveExistingModelFile("loras/cool.safetensors"),
+    ).rejects.toBeInstanceOf(ModelError);
+  });
+
+  it("throws a clear not-found error listing the roots searched", async () => {
+    getExtraModelRootsMock.mockResolvedValue([
+      { category: "loras", dir: EXTRA_LORAS, group: "comfyui" },
+    ]);
+    fsFixture([]); // nothing exists anywhere
+
+    await expect(
+      resolveExistingModelFile("loras/missing.safetensors"),
+    ).rejects.toThrow(/not found/i);
+    // Both the primary and the matching extra root are reported.
+    await expect(
+      resolveExistingModelFile("loras/missing.safetensors"),
+    ).rejects.toThrow(/loras/);
+  });
+
+  it("rejects absolute paths before any filesystem access", async () => {
+    await expect(
+      resolveExistingModelFile("E:/secret/x.safetensors"),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(statMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects traversal escapes even when extra roots exist", async () => {
+    getExtraModelRootsMock.mockResolvedValue([
+      { category: "loras", dir: EXTRA_LORAS, group: "comfyui" },
+    ]);
+    await expect(
+      resolveExistingModelFile("loras/../../../etc/passwd"),
+    ).rejects.toThrow(/outside the models directory/);
+  });
+
+  it("errors clearly when COMFYUI_PATH is unset (remote mode)", async () => {
+    config.comfyuiPath = undefined;
+    await expect(
+      resolveExistingModelFile("loras/x.safetensors"),
+    ).rejects.toThrow(/COMFYUI_PATH/);
+  });
+
+  it("returns a directory match so callers can report 'not a file'", async () => {
+    fsFixture([], [resolve(MODELS_ROOT, "checkpoints")]);
+
+    const res = await resolveExistingModelFile("checkpoints");
+    expect(res.info.isFile()).toBe(false);
+    expect(res.path).toBe(resolve(MODELS_ROOT, "checkpoints"));
+  });
+});

--- a/src/__tests__/services/node-verify.test.ts
+++ b/src/__tests__/services/node-verify.test.ts
@@ -20,6 +20,7 @@ import { config } from "../../config.js";
 import {
   verifyCustomNode,
   parseClassMappingKeys,
+  classTypesForPack,
   type VerifyDeps,
 } from "../../services/node-verify.js";
 import { ProcessControlError, ValidationError } from "../../utils/errors.js";
@@ -122,5 +123,70 @@ describe("verifyCustomNode", () => {
     await expect(
       verifyCustomNode({ classTypes: ["FooNode"] }, makeDeps()),
     ).rejects.toThrow(ProcessControlError);
+  });
+
+  it("infers from a re-exported literal in a non-__init__ pack source file", async () => {
+    // __init__.py only re-exports the mappings (no literal of its own); the
+    // literal lives in a sibling source file.
+    const deps = makeDeps({
+      readPackInit: vi.fn(() => "from .use_everywhere_nodes import NODE_CLASS_MAPPINGS"),
+      readPackSources: vi.fn(() => [
+        "from .x import *",
+        `NODE_CLASS_MAPPINGS = {\n    "FooNode": A,\n    "BarNode": B,\n}`,
+      ]),
+      fetchObjectInfoKeys: vi.fn(async () => ["FooNode", "BarNode", "KSampler"]),
+    });
+    const res = await verifyCustomNode({ name: "cg-use-everywhere" }, deps);
+    expect(res.expected).toEqual(["FooNode", "BarNode"]);
+    expect(res.missing).toEqual([]);
+    expect(res.ready).toBe(true);
+  });
+
+  it("falls back to live /object_info (python_module) for dynamic packs", async () => {
+    // No static literal anywhere; the pack builds mappings at import time, so we
+    // derive its class_types from the running server's /object_info.
+    const deps = makeDeps({
+      readPackInit: vi.fn(() => undefined),
+      readPackSources: vi.fn(() => ["# nothing static here"]),
+      inferPackClassTypes: vi.fn(async () => ["Anything Everywhere", "Seed Everywhere?"]),
+      fetchObjectInfoKeys: vi.fn(async () => [
+        "Anything Everywhere",
+        "Seed Everywhere?",
+        "KSampler",
+      ]),
+    });
+    const res = await verifyCustomNode({ name: "cg-use-everywhere" }, deps);
+    expect(deps.inferPackClassTypes).toHaveBeenCalledWith("cg-use-everywhere");
+    expect(res.expected).toEqual(["Anything Everywhere", "Seed Everywhere?"]);
+    expect(res.loaded).toEqual(["Anything Everywhere", "Seed Everywhere?"]);
+    expect(res.missing).toEqual([]);
+    expect(res.message).toMatch(/inferred from the live/i);
+  });
+
+  it("gives an actionable error when nothing can be inferred", async () => {
+    const deps = makeDeps({
+      readPackInit: vi.fn(() => undefined),
+      readPackSources: vi.fn(() => []),
+      inferPackClassTypes: vi.fn(async () => []),
+    });
+    await expect(
+      verifyCustomNode({ name: "mystery-pack" }, deps),
+    ).rejects.toThrow(/Pass class_types/);
+  });
+});
+
+describe("classTypesForPack", () => {
+  it("keeps only nodes whose python_module belongs to the pack", () => {
+    const objectInfo = {
+      "Anything Everywhere": { python_module: "custom_nodes.cg-use-everywhere" },
+      "Seed Everywhere?": { python_module: "custom_nodes.cg-use-everywhere.nodes" },
+      KSampler: { python_module: "nodes" },
+      OtherNode: { python_module: "custom_nodes.some-other-pack" },
+      Malformed: { name: "no module field" },
+    };
+    expect(classTypesForPack(objectInfo, "cg-use-everywhere")).toEqual([
+      "Anything Everywhere",
+      "Seed Everywhere?",
+    ]);
   });
 });

--- a/src/__tests__/services/queue-manager-edit.test.ts
+++ b/src/__tests__/services/queue-manager-edit.test.ts
@@ -124,3 +124,26 @@ describe("queue-manager pending job inspection/editing", () => {
     expect(deleteQueueItemMock).not.toHaveBeenCalled();
   });
 });
+
+describe("queue_remaining is the real (non-negative) queue count", () => {
+  it("ignores ComfyUI's negative front-enqueue 'number' and reports the live count", async () => {
+    // ComfyUI returns a NEGATIVE `number` (priority counter) for front:true,
+    // which historically leaked through as queue_remaining: -17.
+    enqueuePromptMock.mockResolvedValue({ prompt_id: "new-id", queue_remaining: -17 });
+
+    const result = await moveQueuedJob("pending-a", "front");
+
+    // queue = 1 running + 2 pending = 3 (from the live /queue read), never -17.
+    expect(result.queue_remaining).toBe(3);
+  });
+
+  it("falls back to a clamped (>= 0) hint when the queue can't be re-read", async () => {
+    // First /queue read (getQueuedWorkflow) succeeds; the post-enqueue read fails.
+    getQueueMock.mockResolvedValueOnce(queue).mockRejectedValueOnce(new Error("boom"));
+    enqueuePromptMock.mockResolvedValue({ prompt_id: "new-id", queue_remaining: -17 });
+
+    const result = await moveQueuedJob("pending-a", "front");
+
+    expect(result.queue_remaining).toBe(0);
+  });
+});

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -42,6 +42,13 @@ vi.mock("../../services/civitai-resolver.js", () => ({
   resolveCivitaiModelVersion: (...a: unknown[]) => resolveCivitaiModelVersionMock(...a),
 }));
 
+// Isolate these tests from on-disk extra_model_paths config: no extra roots by
+// default. (Multi-root resolution is covered in model-resolver.test.ts.)
+const getExtraModelRootsMock = vi.fn(async () => [] as Array<{ category: string; dir: string; group: string }>);
+vi.mock("../../services/extra-paths.js", () => ({
+  getExtraModelRoots: (...a: unknown[]) => getExtraModelRootsMock(...a),
+}));
+
 import { config } from "../../config.js";
 import { registerModelExtrasTools } from "../../tools/model-extras.js";
 

--- a/src/services/extra-paths.ts
+++ b/src/services/extra-paths.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, isAbsolute, resolve } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { config } from "../config.js";
 import { ValidationError } from "../utils/errors.js";
@@ -187,6 +187,51 @@ export async function listExtraPaths(
   const resolved = resolveTargetPath(opts);
   const raw = await readConfigFile(resolved.path);
   return summarize(resolved.target, resolved.path, raw);
+}
+
+/** One model search directory contributed by extra_model_paths configuration. */
+export interface ExtraModelRoot {
+  /** The ComfyUI category key (e.g. "checkpoints", "loras") the dir serves. */
+  category: string;
+  /** Absolute directory on disk that ComfyUI loads this category's models from. */
+  dir: string;
+  /** The owning config group name (for diagnostics). */
+  group: string;
+}
+
+/**
+ * Enumerate every model directory declared in the active extra_model_paths /
+ * extra_models_config file — i.e. the same extra roots (often on other drives
+ * like E:\) that ComfyUI itself loads models from. Each entry pairs a category
+ * key with the absolute directory that serves it (paths are resolved against the
+ * group's base_path when relative). Returns [] when no config exists or no local
+ * ComfyUI path is known. Best-effort: never throws (a malformed/unreadable
+ * config yields []), so callers can treat extra roots as an additive search set.
+ */
+export async function getExtraModelRoots(
+  opts: ExtraPathOptions = {},
+): Promise<ExtraModelRoot[]> {
+  let info: ExtraPathsConfigInfo;
+  try {
+    info = await listExtraPaths(opts);
+  } catch {
+    return [];
+  }
+  const roots: ExtraModelRoot[] = [];
+  for (const group of info.groups) {
+    const base = group.base_path?.trim();
+    for (const category of group.categories) {
+      for (const p of category.paths) {
+        const dir = isAbsolute(p)
+          ? resolve(p)
+          : base
+            ? resolve(base, p)
+            : resolve(p);
+        roots.push({ category: category.category, dir, group: group.name });
+      }
+    }
+  }
+  return roots;
 }
 
 function ensureGroup(raw: Record<string, unknown>, name: string): Record<string, unknown> {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
+import type { Stats } from "node:fs";
 import { readdir, stat, mkdir } from "node:fs/promises";
-import { join, basename, resolve, sep, isAbsolute } from "node:path";
+import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config } from "../config.js";
 import { getClient } from "../comfyui/client.js";
-import { ModelError } from "../utils/errors.js";
+import { getExtraModelRoots } from "./extra-paths.js";
+import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { downloadWithCache } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
@@ -211,6 +213,135 @@ export function resolveModelSubfolder(targetSubfolder: string): string {
     );
   }
   return targetDir;
+}
+
+/**
+ * Resolve a relative-to-models path against a known root, keeping the result
+ * strictly INSIDE that root. Rejects absolute inputs, "" / "." (the root
+ * itself), and ".." traversal escapes. Shared by the primary and extra-root
+ * lookups so every candidate gets the same containment guarantee.
+ */
+function containWithinRoot(rootDir: string, relativePath: string): string {
+  const root = resolve(rootDir);
+  const target = resolve(root, relativePath);
+  const rel = relative(root, target);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new ValidationError(
+      `Refusing to operate outside the models directory: ${relativePath}`,
+    );
+  }
+  // Defense-in-depth: the resolved path must be a descendant of the root and
+  // not merely share its string prefix (e.g. "models-evil" vs "models").
+  if (target !== root && !target.startsWith(root + sep)) {
+    throw new ValidationError(
+      `Refusing to operate outside the models directory: ${relativePath}`,
+    );
+  }
+  return target;
+}
+
+export interface ResolvedModelFile {
+  /** Absolute path to the existing entry on disk. */
+  path: string;
+  /** The root directory it was found under (primary models/ or an extra root). */
+  root: string;
+  /** fs.Stats for the entry, so callers don't need to re-stat. */
+  info: Stats;
+}
+
+/**
+ * Locate an existing model file given a path relative to ComfyUI's models/
+ * directory, searching ACROSS every configured root: the primary
+ * `<COMFYUI_PATH>/models` AND every directory declared in
+ * extra_model_paths.yaml / extra_models_config.yaml (e.g. models stored on
+ * another drive such as E:\). This mirrors the set of roots ComfyUI itself
+ * loads from, so a model installed under an extra root can be found (and
+ * removed) the same way as one under the primary install.
+ *
+ * Resolution rules:
+ *  - The primary root is searched with the full relative path.
+ *  - Extra roots are per-category (the first path segment, e.g. "checkpoints"),
+ *    so the remainder of the path is resolved within each matching root.
+ *  - Every candidate is containment-checked against its own root; absolute
+ *    paths and ".." traversal are rejected (security guard preserved).
+ *  - A matching FILE wins; if only a directory matches it is returned so the
+ *    caller can surface a precise "not a file" error.
+ *
+ * Throws ValidationError for absolute/traversal inputs and ModelError when the
+ * entry is not found in any root (the message lists the roots searched).
+ */
+export async function resolveExistingModelFile(
+  relativePath: string,
+): Promise<ResolvedModelFile> {
+  if (!config.comfyuiPath) {
+    throw new ModelError(
+      "COMFYUI_PATH is not configured. Locating/removing a local model operates on " +
+        "the local filesystem and is unavailable when targeting a remote ComfyUI. " +
+        "Set the COMFYUI_PATH environment variable.",
+    );
+  }
+  const raw = (relativePath ?? "").trim();
+  if (!raw) {
+    throw new ValidationError("Model path is required.");
+  }
+  if (isAbsolute(raw)) {
+    throw new ValidationError(
+      `Path must be relative to the models directory, not absolute: ${relativePath}`,
+    );
+  }
+
+  const searched: string[] = [];
+  let dirHit: ResolvedModelFile | undefined;
+
+  // Primary root: <COMFYUI_PATH>/models/<relativePath>. containWithinRoot throws
+  // on traversal/escape, preserving the existing security behavior.
+  const modelsRoot = resolve(getModelsRoot());
+  const primaryTarget = containWithinRoot(modelsRoot, raw);
+  searched.push(modelsRoot);
+  try {
+    const info = await stat(primaryTarget);
+    if (info.isFile()) return { path: primaryTarget, root: modelsRoot, info };
+    dirHit = { path: primaryTarget, root: modelsRoot, info };
+  } catch {
+    // Not present under the primary root; fall through to extra roots.
+  }
+
+  // Extra roots are declared per category, so peel off the first path segment
+  // and resolve the remainder within each matching extra directory.
+  const segments = raw.split(/[/\\]+/).filter(Boolean);
+  const category = segments[0];
+  const remainder = segments.slice(1).join("/");
+  if (category && remainder) {
+    const extraRoots = await getExtraModelRoots();
+    for (const er of extraRoots) {
+      if (er.category !== category) continue;
+      const rootDir = resolve(er.dir);
+      let target: string;
+      try {
+        target = containWithinRoot(rootDir, remainder);
+      } catch {
+        // A remainder that can't safely resolve within this root is skipped
+        // rather than failing the whole lookup.
+        continue;
+      }
+      searched.push(rootDir);
+      try {
+        const info = await stat(target);
+        if (info.isFile()) return { path: target, root: rootDir, info };
+        if (!dirHit) dirHit = { path: target, root: rootDir, info };
+      } catch {
+        // Not present under this extra root; keep searching.
+      }
+    }
+  }
+
+  if (dirHit) return dirHit;
+
+  throw new ModelError(
+    `Model file not found: ${relativePath}. Searched ${searched.length} root(s): ` +
+      `${searched.join(", ")}`,
+    { path: relativePath, searched },
+  );
 }
 
 export async function downloadModel(

--- a/src/services/node-verify.ts
+++ b/src/services/node-verify.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { config, getComfyUIBaseUrl } from "../config.js";
@@ -44,6 +44,20 @@ export interface VerifyDeps {
   fetchObjectInfoKeys: () => Promise<string[]>;
   /** Read a pack's __init__.py contents, or undefined if absent. */
   readPackInit: (packName: string) => string | undefined;
+  /**
+   * Read the contents of every Python source file in a pack folder (recursively,
+   * bounded). Lets inference find a NODE_CLASS_MAPPINGS literal defined in a
+   * submodule and merely re-exported from __init__.py (e.g. cg-use-everywhere's
+   * `from .use_everywhere_nodes import NODE_CLASS_MAPPINGS`). Optional.
+   */
+  readPackSources?: (packName: string) => string[];
+  /**
+   * Infer a pack's registered class_types from the LIVE server: query
+   * /object_info and keep entries whose `python_module` belongs to the pack.
+   * Last-resort fallback for packs that build their mappings dynamically (no
+   * static literal to parse). Optional; requires a running server.
+   */
+  inferPackClassTypes?: (packName: string) => Promise<string[]>;
 }
 
 const defaultDeps: VerifyDeps = {
@@ -79,7 +93,79 @@ const defaultDeps: VerifyDeps = {
       return undefined;
     }
   },
+  readPackSources: (packName: string) => {
+    if (!config.comfyuiPath) return [];
+    const packDir = join(config.comfyuiPath, "custom_nodes", packName);
+    if (!existsSync(packDir)) return [];
+    const sources: string[] = [];
+    const MAX_FILES = 200;
+    // Bounded recursive walk: read .py files, skip vendored / hidden dirs.
+    const walk = (dir: string, depth: number): void => {
+      if (depth > 4 || sources.length >= MAX_FILES) return;
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (sources.length >= MAX_FILES) break;
+        const name = entry.name;
+        if (entry.isDirectory()) {
+          if (name.startsWith(".") || name === "__pycache__" || name === "node_modules") continue;
+          walk(join(dir, name), depth + 1);
+        } else if (entry.isFile() && name.endsWith(".py")) {
+          try {
+            sources.push(readFileSync(join(dir, name), "utf-8"));
+          } catch {
+            // Skip unreadable files.
+          }
+        }
+      }
+    };
+    walk(packDir, 0);
+    return sources;
+  },
+  inferPackClassTypes: async (packName: string) => {
+    const url = `${getComfyUIBaseUrl()}/object_info`;
+    const res = await comfyuiFetch(url, { signal: AbortSignal.timeout(30_000) });
+    if (!res.ok) {
+      throw new ComfyUIError(
+        `Failed to fetch /object_info: ${res.status} ${res.statusText}`,
+        "OBJECT_INFO_FAILED",
+      );
+    }
+    const data = await res.json();
+    if (data === null || typeof data !== "object" || Array.isArray(data)) {
+      throw new ComfyUIError(
+        "Unexpected /object_info response (not a JSON object).",
+        "OBJECT_INFO_FAILED",
+      );
+    }
+    return classTypesForPack(data as Record<string, unknown>, packName);
+  },
 };
+
+/**
+ * Given a parsed /object_info map, return the class_types whose `python_module`
+ * belongs to `packName`. ComfyUI tags each node with a python_module like
+ * "custom_nodes.<folder>" (sometimes with extra ".<submodule>" segments), so we
+ * match when the pack folder name appears as a dot-separated segment.
+ */
+export function classTypesForPack(
+  objectInfo: Record<string, unknown>,
+  packName: string,
+): string[] {
+  const out: string[] = [];
+  for (const [classType, value] of Object.entries(objectInfo)) {
+    if (!value || typeof value !== "object") continue;
+    const mod = (value as Record<string, unknown>).python_module;
+    if (typeof mod !== "string") continue;
+    const segments = mod.split(".");
+    if (segments.includes(packName)) out.push(classType);
+  }
+  return out;
+}
 
 /**
  * Parse NODE_CLASS_MAPPINGS keys from an __init__.py. Best-effort regex (Python
@@ -125,29 +211,40 @@ export async function verifyCustomNode(
     );
   }
 
-  // Resolve the expected class_types: explicit list wins, else infer from the pack.
-  let expected = (options.classTypes ?? []).map((s) => s.trim()).filter(Boolean);
-  if (expected.length === 0) {
-    if (!options.name) {
-      throw new ValidationError(
-        "Provide `class_types` (the NODE_CLASS_MAPPINGS keys to check) or a `name` " +
-          "whose __init__.py declares them.",
-      );
-    }
+  // Resolve the expected class_types: explicit list wins, else infer from the
+  // pack. Inference proceeds in escalating order so common packs need no
+  // class_types argument:
+  //   1. NODE_CLASS_MAPPINGS literal in __init__.py
+  //   2. NODE_CLASS_MAPPINGS literal in ANY pack source file (handles packs that
+  //      define mappings in a submodule and re-export them, e.g. cg-use-everywhere)
+  //   3. (after restart, below) the LIVE /object_info, filtered to this pack's
+  //      python_module — covers packs that build mappings dynamically.
+  const explicit = (options.classTypes ?? []).map((s) => s.trim()).filter(Boolean);
+  let expected = explicit;
+  let inferredFromLiveServer = false;
+  const haveName = !!options.name;
+
+  if (expected.length === 0 && !haveName) {
+    throw new ValidationError(
+      "Provide `class_types` (the NODE_CLASS_MAPPINGS keys to check) or a `name` " +
+        "whose node class_types can be inferred.",
+    );
+  }
+
+  if (expected.length === 0 && options.name) {
+    // 1. __init__.py literal.
     const initPy = deps.readPackInit(options.name);
-    if (!initPy) {
-      throw new ValidationError(
-        `Could not read __init__.py for pack "${options.name}" to infer its node ` +
-          `class_types. Pass class_types explicitly.`,
-      );
+    if (initPy) expected = parseClassMappingKeys(initPy);
+
+    // 2. Any pack source file's literal (re-exported mappings).
+    if (expected.length === 0 && deps.readPackSources) {
+      const seen = new Set<string>();
+      for (const src of deps.readPackSources(options.name)) {
+        for (const key of parseClassMappingKeys(src)) seen.add(key);
+      }
+      expected = [...seen];
     }
-    expected = parseClassMappingKeys(initPy);
-    if (expected.length === 0) {
-      throw new ValidationError(
-        `Could not find NODE_CLASS_MAPPINGS keys in "${options.name}"/__init__.py. ` +
-          `Pass class_types explicitly.`,
-      );
-    }
+    // Step 3 (live /object_info) runs after restart, once the server is ready.
   }
 
   // Restart so newly-added packs are (re)loaded, unless the caller opted out.
@@ -173,6 +270,25 @@ export async function verifyCustomNode(
   }
 
   const registered = new Set(await deps.fetchObjectInfoKeys());
+
+  // 3. Live fallback: still no class_types to check, so derive them from the
+  // running server's /object_info, filtered to this pack's python_module. If the
+  // pack registered any nodes, that proves it imported cleanly.
+  if (expected.length === 0 && options.name && deps.inferPackClassTypes) {
+    expected = await deps.inferPackClassTypes(options.name);
+    inferredFromLiveServer = true;
+  }
+
+  if (expected.length === 0) {
+    throw new ValidationError(
+      `Could not determine node class_types for pack "${options.name}". No ` +
+        `NODE_CLASS_MAPPINGS literal was found in its sources, and ComfyUI's ` +
+        `/object_info reports no nodes from this pack (it may have failed to import, ` +
+        `or its folder name differs from its python_module). Pass class_types ` +
+        `explicitly (the NODE_CLASS_MAPPINGS keys you expect to register).`,
+    );
+  }
+
   const loaded = expected.filter((c) => registered.has(c));
   const missing = expected.filter((c) => !registered.has(c));
 
@@ -190,7 +306,10 @@ export async function verifyCustomNode(
     loaded,
     missing,
     message: ok
-      ? `All ${expected.length} node type(s) registered in ComfyUI. The pack loads correctly.`
+      ? `All ${expected.length} node type(s) registered in ComfyUI. The pack loads correctly.` +
+        (inferredFromLiveServer
+          ? ` (class_types were inferred from the live /object_info for "${options.name}".)`
+          : "")
       : `${missing.length} of ${expected.length} node type(s) are NOT registered: ` +
         `${missing.join(", ")}. The pack likely failed to import — check ComfyUI logs ` +
         `(a missing dependency or a syntax error keeps a node out of /object_info).`,

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -145,6 +145,26 @@ function applyInputUpdates(
   return workflow;
 }
 
+/**
+ * Compute the real number of jobs remaining in the queue (running + pending),
+ * clamped to >= 0. We do NOT trust the `number` field ComfyUI returns from
+ * POST /prompt: that is the queue's monotonic priority counter, and it is
+ * NEGATIVE when a job is enqueued at the front (front:true). Reusing it as a
+ * "remaining" count produced nonsensical values like -17. A direct /queue read
+ * is the authoritative count. Falls back to the (clamped) enqueue hint if the
+ * queue can't be read.
+ */
+async function computeQueueRemaining(fallback?: number): Promise<number | undefined> {
+  try {
+    const queue = await clientGetQueue();
+    return queue.queue_running.length + queue.queue_pending.length;
+  } catch (err) {
+    logger.debug("Could not read /queue for remaining count; using enqueue hint", { err });
+    if (typeof fallback !== "number" || !Number.isFinite(fallback)) return undefined;
+    return Math.max(0, fallback);
+  }
+}
+
 async function requeuePendingJob(
   promptId: string,
   workflow: WorkflowJSON,
@@ -158,10 +178,11 @@ async function requeuePendingJob(
     { front: position === "front" },
   );
   JobWatcher.watch(result.prompt_id, workflow);
+  const queue_remaining = await computeQueueRemaining(result.queue_remaining);
   return {
     old_prompt_id: promptId,
     new_prompt_id: result.prompt_id,
-    queue_remaining: result.queue_remaining,
+    queue_remaining,
     position,
     message: `Pending job ${promptId} was requeued at the ${position}; new prompt_id is ${result.prompt_id}.`,
   };

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -1,92 +1,39 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { stat, unlink } from "node:fs/promises";
-import { join, resolve, relative, isAbsolute, sep } from "node:path";
-import { config } from "../config.js";
-import { downloadModel, MODEL_SUBDIRS } from "../services/model-resolver.js";
+import { unlink } from "node:fs/promises";
+import {
+  downloadModel,
+  resolveExistingModelFile,
+  MODEL_SUBDIRS,
+} from "../services/model-resolver.js";
 import {
   resolveCivitaiModel,
   resolveCivitaiModelVersion,
 } from "../services/civitai-resolver.js";
-import { ModelError, ValidationError, errorToToolResult } from "../utils/errors.js";
-
-/**
- * Resolve the local ComfyUI models directory.
- * Mirrors the (unexported) helper in model-resolver.ts; throws a clear error
- * when COMFYUI_PATH is unavailable (e.g. when targeting a remote ComfyUI).
- */
-function getModelsRoot(): string {
-  if (!config.comfyuiPath) {
-    throw new ModelError(
-      "COMFYUI_PATH is not configured. remove_model operates on the local " +
-        "filesystem and is unavailable when targeting a remote ComfyUI. " +
-        "Set the COMFYUI_PATH environment variable.",
-    );
-  }
-  return resolve(config.comfyuiPath, "models");
-}
-
-/**
- * Resolve a user-supplied relative model path against the models root and
- * confirm the result stays strictly inside the models directory.
- * Rejects path traversal (`..`) and absolute-path escapes.
- */
-function resolveWithinModels(modelsRoot: string, relativePath: string): string {
-  if (isAbsolute(relativePath)) {
-    throw new ValidationError(
-      `Path must be relative to the models directory, not absolute: ${relativePath}`,
-    );
-  }
-
-  const target = resolve(modelsRoot, relativePath);
-  const rel = relative(modelsRoot, target);
-
-  // `rel` starting with ".." (or being absolute on a different root/drive)
-  // means the resolved path escaped the models directory.
-  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
-    throw new ValidationError(
-      `Refusing to operate outside the models directory: ${relativePath}`,
-    );
-  }
-
-  // Defense-in-depth: ensure the resolved path is a descendant of the root.
-  if (!target.startsWith(modelsRoot + sep)) {
-    throw new ValidationError(
-      `Refusing to operate outside the models directory: ${relativePath}`,
-    );
-  }
-
-  return target;
-}
+import { ValidationError, errorToToolResult } from "../utils/errors.js";
 
 export function registerModelExtrasTools(server: McpServer): void {
   server.tool(
     "remove_model",
-    "Delete a model file from the local ComfyUI models directory. The path must " +
-      "stay within models/ (path traversal and absolute escapes are rejected).",
+    "Delete a model file from the local ComfyUI models directories. Resolves the " +
+      "path across ALL configured roots — the primary <COMFYUI_PATH>/models AND " +
+      "every directory in extra_model_paths.yaml / extra_models_config.yaml (e.g. " +
+      "models stored on another drive like E:\\) — the same roots ComfyUI loads " +
+      "from. The path must stay within a known root (path traversal and absolute " +
+      "escapes are rejected).",
     {
       path: z
         .string()
         .min(1)
         .describe(
           "Model file path relative to the ComfyUI models/ directory " +
-            "(e.g. 'checkpoints/sd_xl_base_1.0.safetensors').",
+            "(e.g. 'checkpoints/sd_xl_base_1.0.safetensors'). The leading segment " +
+            "is the category used to locate the file in extra roots too.",
         ),
     },
     async (args) => {
       try {
-        const modelsRoot = getModelsRoot();
-        const target = resolveWithinModels(modelsRoot, args.path);
-
-        let info;
-        try {
-          info = await stat(target);
-        } catch {
-          throw new ModelError(
-            `Model file not found: ${args.path} (resolved to ${target})`,
-            { path: args.path, resolved: target },
-          );
-        }
+        const { path: target, info } = await resolveExistingModelFile(args.path);
 
         if (!info.isFile()) {
           throw new ValidationError(


### PR DESCRIPTION
Fixes three model/queue robustness bugs found during live testing.

## 1. `remove_model` couldn't reach models on `extra_model_paths` drives (e.g. E:\)
`remove_model` only searched `<COMFYUI_PATH>/models`, so a model installed under an `extra_model_paths.yaml` root (a different drive) could not be removed.

- New `getExtraModelRoots()` in `extra-paths.ts` enumerates every model directory declared in the active `extra_model_paths.yaml` / `extra_models_config.yaml` (resolving paths against each group's `base_path`).
- New shared resolver `resolveExistingModelFile()` in `model-resolver.ts` searches the primary models root AND every matching per-category extra root, returning the first existing file.
- Security preserved: each candidate is containment-checked against its own root (absolute paths and `..` traversal rejected); clear not-found error lists the roots searched.

## 2. `verify_custom_node` name-inference failed for `cg-use-everywhere`
Auto class-type inference only parsed a `NODE_CLASS_MAPPINGS` literal in `__init__.py`, which fails for packs that re-export or build mappings dynamically.

Inference now escalates:
1. literal in `__init__.py`
2. literal in any pack `.py` source (handles `from .submodule import NODE_CLASS_MAPPINGS`)
3. live `/object_info` filtered by `python_module` (handles dynamically-built mappings)
4. otherwise an actionable error naming exactly what to pass.

## 3. `move_queued_job` returned `queue_remaining: -17`
ComfyUI's `POST /prompt` `number` field is the queue's monotonic priority counter and is **negative** for `front:true` enqueues; it was leaking through as `queue_remaining`.

`move_queued_job` / `edit_queued_job` now report the real remaining count by reading the live `/queue` (running + pending), clamped `>= 0`, falling back to a clamped hint if the queue can't be re-read.

## Tests
Added/extended vitest coverage: extra-root model resolution (mocked `extra_model_paths`), the queue-count clamp, and the node-verify static + live inference paths. Full suite: build exit 0, 663 tests green.