### PR TITLE
Release 0.19.1 — live-tested tool/model/queue robustness, v3 API nodes, secret env propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.19.1] - 2026-06-25
+
+### Fixed
+
+- **Tool robustness** (live-tested): `convert_image` / `list_output_images` now honor
+  ComfyUI's `--output-directory` / `--base-directory` redirect (resolved from
+  `/system_stats` argv) instead of assuming `<COMFYUI_PATH>/output`;
+  `verify_workflow_lock` reports "no lock" gracefully instead of crashing; the whole
+  Manager snapshot family (`list`/`save`/`restore_node_snapshot`) degrades gracefully
+  on builds without the `/snapshot/*` endpoints; registry versions render as strings
+  (no more `[object Object]`); `generate_node_skill` works on a bare registry id.
+- **Models / queue**: `remove_model` resolves across `extra_model_paths` roots (e.g.
+  a model on another drive), with a cross-platform absolute-path guard (rejects
+  posix-absolute, Windows drive-letter `E:\`, and UNC paths on all hosts);
+  `verify_custom_node` infers class types for re-exporting packs; `move_queued_job`
+  reports a real (non-negative) queue count.
+- **v3 dynamic-combo API nodes** (e.g. Nano Banana 2) serialize their dotted
+  `model.<nested>` widgets into the API/prompt format, so `generate_with_api_node`
+  and the UI→API conversion no longer 400.
+- **`request_secret` reaches the built-in comfyui MCP server**: tool secrets
+  (`CIVITAI_API_TOKEN` / `HUGGINGFACE_TOKEN` / `HF_TOKEN`, allowlisted) persist to a
+  0600 store and inject into the server's spawn env on both backends, with an
+  in-process respawn so a saved token applies without fighting reloads (downloads no
+  longer stay 401).
+
 ## [0.19.0] - 2026-06-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "MCP server + autonomous AI agent for ComfyUI — drive your live graph in natural language from a sidebar agent on Claude OR ChatGPT (your own subscription, no API key). Generate images, video & audio, author and run workflows, manage models and custom nodes. Also a Claude Code plugin with skills, slash commands, and installer packs.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Patch release bundling 9 live-tested fixes (PRs #56–#60 + panel #15–#18). See CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)