### PR TITLE
feat(panel): install_panel tool + on-load auto-ensure of the sidebar panel

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+
+// Mock config so importing panel-installer doesn't trigger real port detection.
+// (We drive comfyuiPath via the injected deps, not the mocked config, but the
+// import graph still pulls config in.)
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: undefined as string | undefined },
+}));
+
+import {
+  detectPanelInstall,
+  ensurePanelInstalled,
+  panelStatus,
+  runPanelAction,
+  PanelInstallError,
+  PANEL_REGISTRY_ID,
+  PANEL_VERSION,
+  type PanelInstallerDeps,
+} from "../../services/panel-installer.js";
+
+const COMFY = "/fake/comfy";
+const CUSTOM_NODES = join(COMFY, "custom_nodes");
+
+function pyproject(name: string, version = "1.2.3"): string {
+  return `[project]\nname = "${name}"\nversion = "${version}"\n`;
+}
+
+interface Harness {
+  deps: PanelInstallerDeps;
+  installs: Array<{ id: string; version?: string }>;
+  updates: Array<{ id: string }>;
+  reinstalls: Array<{ id: string; version?: string }>;
+}
+
+function makeDeps(opts: {
+  comfyuiPath?: string;
+  env?: NodeJS.ProcessEnv;
+  files?: Record<string, string>; // path -> pyproject contents
+  dirs?: string[]; // custom_nodes subdir names
+  symlinks?: string[]; // absolute dir paths that are symlinks
+  reachable?: boolean;
+} = {}): Harness {
+  const files = opts.files ?? {};
+  const dirs = opts.dirs ?? [];
+  const symlinks = new Set(opts.symlinks ?? []);
+  const installs: Harness["installs"] = [];
+  const updates: Harness["updates"] = [];
+  const reinstalls: Harness["reinstalls"] = [];
+
+  const deps: PanelInstallerDeps = {
+    comfyuiPath: () => opts.comfyuiPath,
+    env: () => opts.env ?? {},
+    existsSync: (p) => p === CUSTOM_NODES || p in files,
+    isSymlink: (p) => symlinks.has(p),
+    readdir: (p) => (p === CUSTOM_NODES ? dirs : []),
+    readFile: (p) => files[p] ?? "",
+    isReachable: async () => opts.reachable ?? true,
+    install: async (o) => {
+      installs.push(o);
+      return { mechanism: "manager-http", message: "installed" };
+    },
+    update: async (o) => {
+      updates.push(o);
+      return { mechanism: "manager-http", message: "updated" };
+    },
+    reinstall: async (o) => {
+      reinstalls.push(o);
+      return { mechanism: "manager-http", message: "reinstalled" };
+    },
+  };
+  return { deps, installs, updates, reinstalls };
+}
+
+describe("detectPanelInstall", () => {
+  it("returns not-applicable when no local ComfyUI (remote/cloud mode)", async () => {
+    const { deps } = makeDeps({ comfyuiPath: undefined });
+    const d = await detectPanelInstall(deps);
+    expect(d.applicable).toBe(false);
+    expect(d.installed).toBe(false);
+    expect(d.isDevSymlink).toBe(false);
+  });
+
+  it("matches by pyproject name in the repo-named fast-path dir", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "2.0.0") },
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.installed).toBe(true);
+    expect(d.dir).toBe(dir);
+    expect(d.version).toBe("2.0.0");
+    expect(d.isDevSymlink).toBe(false);
+  });
+
+  it("matches by pyproject name even in an arbitrarily-named dir (scan)", async () => {
+    const dir = join(CUSTOM_NODES, "weird-folder-name");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["weird-folder-name", "some-other-node"],
+      files: {
+        [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "3.1.4"),
+        [join(CUSTOM_NODES, "some-other-node", "pyproject.toml")]: pyproject("other-pack"),
+      },
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.installed).toBe(true);
+    expect(d.dir).toBe(dir);
+    expect(d.version).toBe("3.1.4");
+  });
+
+  it("detects a dev symlink via lstat", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+      symlinks: [dir],
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.installed).toBe(true);
+    expect(d.isDevSymlink).toBe(true);
+  });
+
+  it("reports not-installed when no pyproject name matches", async () => {
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["unrelated"],
+      files: { [join(CUSTOM_NODES, "unrelated", "pyproject.toml")]: pyproject("unrelated") },
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.applicable).toBe(true);
+    expect(d.installed).toBe(false);
+  });
+});
+
+describe("ensurePanelInstalled policy matrix", () => {
+  it("missing → installs nightly (restart required)", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("installed");
+    expect(res.restartRequired).toBe(true);
+    expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("present → up-to-date (no churn on load, no install call)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "1.0.0") },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("up-to-date");
+    expect(res.installedVersion).toBe("1.0.0");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("dev symlink → skipped-dev (never touches it)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+      symlinks: [dir],
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("skipped-dev");
+    expect(h.installs).toEqual([]);
+    expect(h.updates).toEqual([]);
+  });
+
+  it("no COMFYUI_PATH → unavailable (local-only)", async () => {
+    const h = makeDeps({ comfyuiPath: undefined });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("not reachable → unavailable", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY, reachable: false });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("opt-out env (COMFYUI_MCP_PANEL_AUTOINSTALL=0) → skipped", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      env: { COMFYUI_MCP_PANEL_AUTOINSTALL: "0" },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("skipped");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("opt-out env 'false' → skipped", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      env: { COMFYUI_MCP_PANEL_AUTOINSTALL: "false" },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("skipped");
+  });
+
+  it("swallows errors and returns unavailable", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY });
+    h.deps.install = async () => {
+      throw new Error("manager down");
+    };
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(res.reason).toContain("manager down");
+  });
+});
+
+describe("runPanelAction", () => {
+  it("install targets nightly and flags restart required", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY });
+    const r = await runPanelAction("install", h.deps);
+    expect(r.action).toBe("install");
+    expect(r.restartRequired).toBe(true);
+    expect(r.message).toMatch(/RESTART ComfyUI/);
+    expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("update calls updateCustomNode for the panel", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(r.action).toBe("update");
+    expect(h.updates).toEqual([{ id: PANEL_REGISTRY_ID }]);
+  });
+
+  it("reinstall targets nightly", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY });
+    const r = await runPanelAction("reinstall", h.deps);
+    expect(h.reinstalls).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+    expect(r.message).toMatch(/RESTART ComfyUI/);
+  });
+
+  it("REFUSES on a dev symlink", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+      symlinks: [dir],
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.updates).toEqual([]);
+  });
+
+  it("REFUSES when no COMFYUI_PATH (local-only)", async () => {
+    const h = makeDeps({ comfyuiPath: undefined });
+    await expect(runPanelAction("install", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.installs).toEqual([]);
+  });
+});
+
+describe("panelStatus", () => {
+  it("never throws and reports not-applicable in remote/cloud mode", async () => {
+    const { deps } = makeDeps({ comfyuiPath: undefined });
+    const s = await panelStatus(deps);
+    expect(s.applicable).toBe(false);
+    expect(s.installed).toBe(false);
+    expect(s.note).toMatch(/local-only/i);
+  });
+
+  it("reports installed version and dev-symlink note", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "4.5.6") },
+      symlinks: [dir],
+    });
+    const s = await panelStatus(deps);
+    expect(s.installed).toBe(true);
+    expect(s.installedVersion).toBe("4.5.6");
+    expect(s.isDevSymlink).toBe(true);
+    expect(s.note).toMatch(/symlink/i);
+  });
+
+  it("notes install instructions when missing", async () => {
+    const { deps } = makeDeps({ comfyuiPath: COMFY });
+    const s = await panelStatus(deps);
+    expect(s.installed).toBe(false);
+    expect(s.targetVersion).toBe(PANEL_VERSION);
+    expect(s.note).toMatch(/install/i);
+  });
+});

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -35,6 +35,7 @@ interface Harness {
 
 function makeDeps(opts: {
   comfyuiPath?: string;
+  local?: boolean; // isLocalMode() — defaults to true
   env?: NodeJS.ProcessEnv;
   files?: Record<string, string>; // path -> pyproject contents
   dirs?: string[]; // custom_nodes subdir names
@@ -49,6 +50,7 @@ function makeDeps(opts: {
   const reinstalls: Harness["reinstalls"] = [];
 
   const deps: PanelInstallerDeps = {
+    isLocalMode: () => opts.local ?? true,
     comfyuiPath: () => opts.comfyuiPath,
     env: () => opts.env ?? {},
     existsSync: (p) => p === CUSTOM_NODES || p in files,
@@ -122,6 +124,41 @@ describe("detectPanelInstall", () => {
     expect(d.isDevSymlink).toBe(true);
   });
 
+  it("P1a: a known panel dir that is a junction with NO pyproject is still dev", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    // No pyproject file at all — only the symlink exists.
+    const { deps } = makeDeps({ comfyuiPath: COMFY, symlinks: [dir] });
+    const d = await detectPanelInstall(deps);
+    expect(d.installed).toBe(true);
+    expect(d.isDevSymlink).toBe(true);
+    expect(d.dir).toBe(dir);
+    expect(d.version).toBeUndefined();
+  });
+
+  it("P1a: a known panel dir that is a junction with CORRUPT pyproject is still dev", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-agent-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      symlinks: [dir],
+      files: { [join(dir, "pyproject.toml")]: "this is not valid toml {{{" },
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.installed).toBe(true);
+    expect(d.isDevSymlink).toBe(true);
+  });
+
+  it("P1b: not-applicable in remote mode even when COMFYUI_PATH is set", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      local: false,
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+    });
+    const d = await detectPanelInstall(deps);
+    expect(d.applicable).toBe(false);
+    expect(d.installed).toBe(false);
+  });
+
   it("reports not-installed when no pyproject name matches", async () => {
     const { deps } = makeDeps({
       comfyuiPath: COMFY,
@@ -172,6 +209,21 @@ describe("ensurePanelInstalled policy matrix", () => {
     const h = makeDeps({ comfyuiPath: undefined });
     const res = await ensurePanelInstalled({ deps: h.deps });
     expect(res.action).toBe("unavailable");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("P1b: remote mode with COMFYUI_PATH → unavailable (no mutation)", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY, local: false });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(h.installs).toEqual([]);
+  });
+
+  it("P1a: dev junction with NO pyproject → skipped-dev (no install)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({ comfyuiPath: COMFY, symlinks: [dir] });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("skipped-dev");
     expect(h.installs).toEqual([]);
   });
 
@@ -260,6 +312,32 @@ describe("runPanelAction", () => {
     );
     expect(h.installs).toEqual([]);
   });
+
+  it("P1a: REFUSES reinstall over a junction with NO pyproject (no clobber)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({ comfyuiPath: COMFY, symlinks: [dir] });
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.reinstalls).toEqual([]);
+    expect(h.installs).toEqual([]);
+  });
+
+  it("P1b: REFUSES mutation in remote mode even with COMFYUI_PATH set", async () => {
+    const h = makeDeps({ comfyuiPath: COMFY, local: false });
+    await expect(runPanelAction("install", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.installs).toEqual([]);
+    expect(h.updates).toEqual([]);
+    expect(h.reinstalls).toEqual([]);
+  });
 });
 
 describe("panelStatus", () => {
@@ -269,6 +347,13 @@ describe("panelStatus", () => {
     expect(s.applicable).toBe(false);
     expect(s.installed).toBe(false);
     expect(s.note).toMatch(/local-only/i);
+  });
+
+  it("P1b: remote mode note even with COMFYUI_PATH set (never errors)", async () => {
+    const { deps } = makeDeps({ comfyuiPath: COMFY, local: false });
+    const s = await panelStatus(deps);
+    expect(s.applicable).toBe(false);
+    expect(s.note).toMatch(/remote\/cloud mode/i);
   });
 
   it("reports installed version and dev-symlink note", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,44 @@ import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
 import { parseCliArgs } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
+import { isLocalMode } from "./config.js";
+import { ensurePanelInstalled } from "./services/panel-installer.js";
+
+/**
+ * Fire-and-forget: ensure the ComfyUI sidebar panel is installed (install-if-
+ * missing) on MCP load. LOCAL-only, hard-timed-out, and never throws — it must
+ * never block or crash startup. Opt out with COMFYUI_MCP_PANEL_AUTOINSTALL=0.
+ * The explicit `install_panel(action='update')` tool refreshes nightly on demand.
+ */
+function ensurePanelOnLoad(): void {
+  if (!isLocalMode()) return;
+  void ensurePanelInstalled()
+    .then((res) => {
+      switch (res.action) {
+        case "installed":
+          logger.info(
+            "Panel auto-install: installed the sidebar panel (nightly). RESTART ComfyUI to load it.",
+            res,
+          );
+          break;
+        case "up-to-date":
+          logger.info("Panel auto-install: panel already present.", res);
+          break;
+        case "skipped-dev":
+          logger.info(
+            "Panel auto-install: skipped — dev install (symlink), managed manually.",
+            res,
+          );
+          break;
+        case "skipped":
+          logger.debug("Panel auto-install: disabled via COMFYUI_MCP_PANEL_AUTOINSTALL.", res);
+          break;
+        default:
+          logger.debug("Panel auto-install: unavailable.", res);
+      }
+    })
+    .catch(() => {});
+}
 
 async function createConfiguredServer(): Promise<McpServer> {
   const server = new McpServer(
@@ -75,6 +113,9 @@ async function main() {
     await server.connect(transport);
     logger.info("ComfyUI MCP server running on stdio");
   }
+
+  // After the server is up: auto-ensure the sidebar panel (non-blocking).
+  ensurePanelOnLoad();
 }
 
 main().catch((err) => {

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -19,7 +19,7 @@
 
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { config } from "../config.js";
+import { config, isLocalMode } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { parsePyproject } from "./node-authoring.js";
 import {
@@ -59,6 +59,13 @@ export class PanelInstallError extends Error {
 // ---------------------------------------------------------------------------
 
 export interface PanelInstallerDeps {
+  /**
+   * True only in LOCAL mode. In remote (--comfyui-url) / cloud mode the Manager
+   * mutations target a REMOTE host, so panel install/update/reinstall must be
+   * refused even when COMFYUI_PATH happens to be set (the local FS scan would be
+   * the WRONG filesystem). The on-load ensure also no-ops.
+   */
+  isLocalMode: () => boolean;
   /** Resolved local ComfyUI root, or undefined in remote/cloud mode. */
   comfyuiPath: () => string | undefined;
   /** Process env (for the opt-out flag). */
@@ -76,6 +83,7 @@ export interface PanelInstallerDeps {
 }
 
 export const defaultDeps: PanelInstallerDeps = {
+  isLocalMode: () => isLocalMode(),
   comfyuiPath: () => config.comfyuiPath,
   env: () => process.env,
   existsSync,
@@ -126,11 +134,35 @@ export async function detectPanelInstall(
   deps: PanelInstallerDeps = defaultDeps,
 ): Promise<PanelDetection> {
   const comfyPath = deps.comfyuiPath();
-  if (!comfyPath) {
+  // LOCAL-only: in remote/cloud mode the local FS is the wrong filesystem to
+  // reason about, so detection is not applicable even if COMFYUI_PATH is set.
+  if (!deps.isLocalMode() || !comfyPath) {
     return { applicable: false, installed: false, isDevSymlink: false };
   }
 
   const customNodes = join(comfyPath, "custom_nodes");
+
+  // P1a — DEV-JUNCTION GUARD, FIRST and INDEPENDENT of pyproject parsing.
+  // lstat the KNOWN panel target dirs directly: if either is a symlink/junction
+  // it is a dev install and must be protected from any mutation, EVEN when its
+  // pyproject.toml is missing, corrupt, or unreadable. (A missing/bad pyproject
+  // must never downgrade a junction to "not installed" — that would let
+  // install/reinstall clobber the developer's working repo.)
+  for (const name of FAST_PATH_DIRS) {
+    const dir = join(customNodes, name);
+    if (deps.isSymlink(dir)) {
+      let version: string | undefined;
+      const pyproject = join(dir, "pyproject.toml");
+      if (deps.existsSync(pyproject)) {
+        try {
+          version = parsePyproject(deps.readFile(pyproject)).version;
+        } catch {
+          version = undefined;
+        }
+      }
+      return { applicable: true, installed: true, dir, version, isDevSymlink: true };
+    }
+  }
 
   // Candidate dirs: fast-path names first, then any other subdir.
   const candidates: string[] = FAST_PATH_DIRS.map((n) => join(customNodes, n));
@@ -226,6 +258,13 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
     };
   }
 
+  if (!deps.isLocalMode()) {
+    return {
+      action: "unavailable",
+      reason: "Panel auto-install is local-only (remote/cloud mode active).",
+    };
+  }
+
   if (!deps.comfyuiPath()) {
     return {
       action: "unavailable",
@@ -313,8 +352,9 @@ export async function panelStatus(
 
   let note: string;
   if (!detection.applicable) {
-    note =
-      "Panel management is local-only; no local ComfyUI (COMFYUI_PATH) is configured.";
+    note = !deps.isLocalMode()
+      ? "Remote/cloud mode — panel install is managed on the ComfyUI host, not from here."
+      : "Panel management is local-only; no local ComfyUI (COMFYUI_PATH) is configured.";
   } else if (detection.isDevSymlink) {
     note = "dev install (symlink) — managed manually; install/update/reinstall are refused.";
   } else if (!detection.installed) {
@@ -351,6 +391,17 @@ export async function runPanelAction(
   action: "install" | "update" | "reinstall",
   deps: PanelInstallerDeps = defaultDeps,
 ): Promise<PanelActionResult> {
+  // P1b — truly LOCAL-only. Refuse in remote/cloud mode even when COMFYUI_PATH
+  // is set: installCustomNode/reinstallCustomNode would queue Manager mutations
+  // against the REMOTE host while our symlink guard inspected the LOCAL disk —
+  // the wrong filesystem. The panel must be managed on the ComfyUI host itself.
+  if (!deps.isLocalMode()) {
+    throw new PanelInstallError(
+      `Panel ${action} is local-only and is refused in remote/cloud mode ` +
+        `(a remote COMFYUI_URL / Comfy Cloud is active). Install the panel on ` +
+        `the ComfyUI host itself.`,
+    );
+  }
   if (!deps.comfyuiPath()) {
     throw new PanelInstallError(
       `Panel ${action} is local-only and requires a local ComfyUI install. ` +

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -1,0 +1,386 @@
+// Installs / updates / reinstalls the ComfyUI sidebar panel
+// ("comfyui-agent-panel" on the Comfy Registry; repo comfyui-mcp-panel) into a
+// LOCAL ComfyUI's custom_nodes, and auto-ensures it on MCP load.
+//
+// Policy (decided by the user):
+//   - on load → install if MISSING (install-if-missing only, see ensurePanelInstalled).
+//   - explicit `update` action → pull the latest nightly on demand.
+//   - target version is always "nightly" (the registry git-HEAD channel) — there
+//     is no clean semver to diff, so we never churn an existing install on load.
+//
+// SAFETY:
+//   - LOCAL-only: no COMFYUI_PATH → no-op cleanly (remote/cloud modes).
+//   - NEVER touch a dev install: custom_nodes/comfyui-mcp-panel is often a
+//     SYMLINK/junction to the developer's working repo. lstat → skip/refuse.
+//   - on-load ensure is fire-and-forget, hard-timed-out, and never throws.
+//   - opt-out env COMFYUI_MCP_PANEL_AUTOINSTALL=0/false disables auto-ensure.
+//   - install/update/reinstall queue via ComfyUI-Manager; ComfyUI must be
+//     RESTARTED to load the new/updated node (we never auto-restart).
+
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "../config.js";
+import { logger } from "../utils/logger.js";
+import { parsePyproject } from "./node-authoring.js";
+import {
+  installCustomNode,
+  updateCustomNode,
+  reinstallCustomNode,
+  type NodeOpResult,
+} from "./node-management.js";
+import { getSystemStats } from "../comfyui/client.js";
+
+/** Comfy Registry id (also pyproject [project].name). Authoritative for detection. */
+export const PANEL_REGISTRY_ID = "comfyui-agent-panel";
+
+/** Always install/update/reinstall the panel from the registry git-HEAD channel. */
+export const PANEL_VERSION = "nightly";
+
+/**
+ * Fast-path directory names to probe first. The panel installs to a custom_nodes
+ * subdir named after the REPO ("comfyui-mcp-panel"), but the registry name is
+ * "comfyui-agent-panel" — so check both quickly, then fall back to a full scan.
+ * The pyproject `name == comfyui-agent-panel` match is always authoritative.
+ */
+const FAST_PATH_DIRS = ["comfyui-mcp-panel", "comfyui-agent-panel"];
+
+/** Hard cap so the on-load ensure can never block startup. */
+const ENSURE_TIMEOUT_MS = 20_000;
+
+export class PanelInstallError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PanelInstallError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Injectable deps (mirrors node-authoring's pattern for clean unit tests)
+// ---------------------------------------------------------------------------
+
+export interface PanelInstallerDeps {
+  /** Resolved local ComfyUI root, or undefined in remote/cloud mode. */
+  comfyuiPath: () => string | undefined;
+  /** Process env (for the opt-out flag). */
+  env: () => NodeJS.ProcessEnv;
+  existsSync: (p: string) => boolean;
+  /** True when `p` is a symlink/junction (dev install). Never throws. */
+  isSymlink: (p: string) => boolean;
+  readdir: (p: string) => string[];
+  readFile: (p: string) => string;
+  /** Is the target ComfyUI reachable right now? Never throws. */
+  isReachable: () => Promise<boolean>;
+  install: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
+  update: (opts: { id: string }) => Promise<NodeOpResult>;
+  reinstall: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
+}
+
+export const defaultDeps: PanelInstallerDeps = {
+  comfyuiPath: () => config.comfyuiPath,
+  env: () => process.env,
+  existsSync,
+  isSymlink: (p) => {
+    try {
+      return lstatSync(p).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  },
+  readdir: (p) => readdirSync(p),
+  readFile: (p) => readFileSync(p, "utf-8"),
+  isReachable: async () => {
+    try {
+      await getSystemStats();
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  install: (opts) => installCustomNode(opts),
+  update: (opts) => updateCustomNode(opts),
+  reinstall: (opts) => reinstallCustomNode(opts),
+};
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export interface PanelDetection {
+  /** Whether panel management even applies here (false in remote/cloud). */
+  applicable: boolean;
+  installed: boolean;
+  /** Matched custom_nodes subdir, if installed. */
+  dir?: string;
+  /** Installed version, read from the matched dir's pyproject.toml. */
+  version?: string;
+  /** The matched dir is a symlink/junction → dev install, manage manually. */
+  isDevSymlink: boolean;
+}
+
+/**
+ * Scan <COMFYUI_PATH>/custom_nodes for a subdir whose pyproject.toml
+ * `[project].name == "comfyui-agent-panel"`. LOCAL-only: with no comfyuiPath
+ * (remote/cloud) returns applicable:false / installed:false.
+ */
+export async function detectPanelInstall(
+  deps: PanelInstallerDeps = defaultDeps,
+): Promise<PanelDetection> {
+  const comfyPath = deps.comfyuiPath();
+  if (!comfyPath) {
+    return { applicable: false, installed: false, isDevSymlink: false };
+  }
+
+  const customNodes = join(comfyPath, "custom_nodes");
+
+  // Candidate dirs: fast-path names first, then any other subdir.
+  const candidates: string[] = FAST_PATH_DIRS.map((n) => join(customNodes, n));
+  if (deps.existsSync(customNodes)) {
+    let entries: string[] = [];
+    try {
+      entries = deps.readdir(customNodes);
+    } catch {
+      entries = [];
+    }
+    for (const e of entries) {
+      const full = join(customNodes, e);
+      if (!candidates.includes(full)) candidates.push(full);
+    }
+  }
+
+  for (const dir of candidates) {
+    const pyproject = join(dir, "pyproject.toml");
+    if (!deps.existsSync(pyproject)) continue;
+    let parsed: { projectName?: string; version?: string };
+    try {
+      parsed = parsePyproject(deps.readFile(pyproject));
+    } catch {
+      continue;
+    }
+    if (parsed.projectName === PANEL_REGISTRY_ID) {
+      return {
+        applicable: true,
+        installed: true,
+        dir,
+        version: parsed.version,
+        isDevSymlink: deps.isSymlink(dir),
+      };
+    }
+  }
+
+  return { applicable: true, installed: false, isDevSymlink: false };
+}
+
+// ---------------------------------------------------------------------------
+// On-load ensure (install-if-missing only)
+// ---------------------------------------------------------------------------
+
+export type EnsureAction =
+  | "installed"
+  | "up-to-date"
+  | "skipped-dev"
+  | "skipped"
+  | "unavailable";
+
+export interface EnsureResult {
+  action: EnsureAction;
+  reason?: string;
+  dir?: string;
+  installedVersion?: string;
+  restartRequired?: boolean;
+}
+
+export interface EnsureOptions {
+  deps?: PanelInstallerDeps;
+  timeoutMs?: number;
+}
+
+function isAutoInstallDisabled(env: NodeJS.ProcessEnv): boolean {
+  const v = (env.COMFYUI_MCP_PANEL_AUTOINSTALL ?? "").trim().toLowerCase();
+  return v === "0" || v === "false" || v === "no" || v === "off";
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(
+      () => reject(new Error(`panel ensure timed out after ${ms}ms`)),
+      ms,
+    );
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
+  if (isAutoInstallDisabled(deps.env())) {
+    return {
+      action: "skipped",
+      reason: "COMFYUI_MCP_PANEL_AUTOINSTALL disabled",
+    };
+  }
+
+  if (!deps.comfyuiPath()) {
+    return {
+      action: "unavailable",
+      reason: "No local ComfyUI (COMFYUI_PATH unset); panel auto-install is local-only.",
+    };
+  }
+
+  if (!(await deps.isReachable())) {
+    return { action: "unavailable", reason: "ComfyUI is not reachable." };
+  }
+
+  const detection = await detectPanelInstall(deps);
+
+  if (detection.isDevSymlink) {
+    return {
+      action: "skipped-dev",
+      reason: "dev install (symlink) — managed manually",
+      dir: detection.dir,
+      installedVersion: detection.version,
+    };
+  }
+
+  if (!detection.installed) {
+    await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+    return {
+      action: "installed",
+      reason: `Installed ${PANEL_REGISTRY_ID} (${PANEL_VERSION}).`,
+      restartRequired: true,
+    };
+  }
+
+  // Present already. We never diff nightly on load (no clean version), so we
+  // leave it untouched — the explicit `update` action refreshes on demand.
+  return {
+    action: "up-to-date",
+    dir: detection.dir,
+    installedVersion: detection.version,
+  };
+}
+
+/**
+ * The on-load policy engine. LOCAL + reachable only; install-if-missing.
+ * Hard-timed-out and swallows every error (returns `unavailable` on failure),
+ * so it can be fired-and-forgotten from startup without ever blocking/crashing.
+ */
+export async function ensurePanelInstalled(
+  opts: EnsureOptions = {},
+): Promise<EnsureResult> {
+  const deps = opts.deps ?? defaultDeps;
+  try {
+    return await withTimeout(ensureInner(deps), opts.timeoutMs ?? ENSURE_TIMEOUT_MS);
+  } catch (err) {
+    logger.debug("panel: ensure failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      action: "unavailable",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool-facing operations
+// ---------------------------------------------------------------------------
+
+export interface PanelStatus {
+  applicable: boolean;
+  installed: boolean;
+  dir?: string;
+  installedVersion?: string;
+  isDevSymlink: boolean;
+  targetVersion: string;
+  note: string;
+}
+
+/** status action — never throws. */
+export async function panelStatus(
+  deps: PanelInstallerDeps = defaultDeps,
+): Promise<PanelStatus> {
+  const detection = await detectPanelInstall(deps).catch(
+    () =>
+      ({ applicable: false, installed: false, isDevSymlink: false }) as PanelDetection,
+  );
+
+  let note: string;
+  if (!detection.applicable) {
+    note =
+      "Panel management is local-only; no local ComfyUI (COMFYUI_PATH) is configured.";
+  } else if (detection.isDevSymlink) {
+    note = "dev install (symlink) — managed manually; install/update/reinstall are refused.";
+  } else if (!detection.installed) {
+    note = `Not installed. Run install_panel(action='install') to add the panel (${PANEL_VERSION}). Restart ComfyUI afterwards.`;
+  } else {
+    note = `Installed${
+      detection.version ? ` (${detection.version})` : ""
+    }. Run install_panel(action='update') to pull the latest ${PANEL_VERSION}. Restart ComfyUI after updating.`;
+  }
+
+  return {
+    applicable: detection.applicable,
+    installed: detection.installed,
+    dir: detection.dir,
+    installedVersion: detection.version,
+    isDevSymlink: detection.isDevSymlink,
+    targetVersion: PANEL_VERSION,
+    note,
+  };
+}
+
+export interface PanelActionResult {
+  action: "install" | "update" | "reinstall";
+  result: NodeOpResult;
+  restartRequired: true;
+  message: string;
+}
+
+/**
+ * install/update/reinstall the panel. LOCAL-only and refuses dev symlinks.
+ * Targets version "nightly". Caller must RESTART ComfyUI to load the change.
+ */
+export async function runPanelAction(
+  action: "install" | "update" | "reinstall",
+  deps: PanelInstallerDeps = defaultDeps,
+): Promise<PanelActionResult> {
+  if (!deps.comfyuiPath()) {
+    throw new PanelInstallError(
+      `Panel ${action} is local-only and requires a local ComfyUI install. ` +
+        `Set COMFYUI_PATH (this is a no-op in remote/cloud mode).`,
+    );
+  }
+
+  const detection = await detectPanelInstall(deps);
+  if (detection.isDevSymlink) {
+    throw new PanelInstallError(
+      `Refusing to ${action} the panel: it is a dev install (symlink at ${detection.dir}) ` +
+        `— managed manually. Update it via your repo/git instead.`,
+    );
+  }
+
+  let result: NodeOpResult;
+  if (action === "install") {
+    result = await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+  } else if (action === "update") {
+    result = await deps.update({ id: PANEL_REGISTRY_ID });
+  } else {
+    result = await deps.reinstall({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+  }
+
+  return {
+    action,
+    result,
+    restartRequired: true,
+    message:
+      `Panel ${action} queued via ComfyUI-Manager (${PANEL_VERSION}). ` +
+      `RESTART ComfyUI to load the ${action === "update" ? "updated" : "new"} panel node.`,
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -40,6 +40,7 @@ import { registerStorageUploadTools } from "./storage-upload.js";
 import { registerHealthCheckTools } from "./health-check.js";
 import { registerWorkflowLockTools } from "./workflow-lock.js";
 import { registerSkillsAccessTools } from "./skills-access.js";
+import { registerInstallPanelTools } from "./install-panel.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -86,5 +87,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerHealthCheckTools(server);
   registerWorkflowLockTools(server);
   registerSkillsAccessTools(server);
+  registerInstallPanelTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  panelStatus,
+  runPanelAction,
+} from "../services/panel-installer.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerInstallPanelTools(server: McpServer): void {
+  server.tool(
+    "install_panel",
+    "Install, update, reinstall, or report status of the ComfyUI sidebar panel " +
+      "('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the " +
+      "LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as " +
+      "install_custom_node and always targets the 'nightly' (git-HEAD) channel. " +
+      "Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev " +
+      "install (a symlinked panel dir). After install/update/reinstall, ComfyUI must " +
+      "be RESTARTED to load the new/updated node — this tool does not auto-restart. " +
+      "The panel is also auto-installed-if-missing when the MCP server loads.",
+    {
+      action: z
+        .enum(["status", "install", "update", "reinstall"])
+        .default("status")
+        .describe(
+          "status: report installed/version/dev-symlink (never errors). " +
+            "install: add the panel (nightly). update: pull the latest nightly. " +
+            "reinstall: uninstall + reinstall (nightly). install/update/reinstall " +
+            "refuse on a dev symlink and require a local COMFYUI_PATH.",
+        ),
+    },
+    async ({ action }) => {
+      try {
+        if (action === "status") {
+          const status = await panelStatus();
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify(status, null, 2) },
+            ],
+          };
+        }
+        const result = await runPanelAction(action);
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## What

Adds an MCP tool (`install_panel`) and an on-load policy that programmatically **installs / updates / reinstalls** the ComfyUI sidebar panel (`comfyui-agent-panel` on the Comfy Registry; repo `comfyui-mcp-panel`) into a **local** ComfyUI's `custom_nodes`, reusing the existing ComfyUI-Manager v2 install path (`installCustomNode` / `updateCustomNode` / `reinstallCustomNode`).

Target channel is **`nightly`** (the registry git-HEAD channel) for all install/update/reinstall — there is no clean semver to diff, so we never compare versions.

## The `install_panel` tool

`action: status | install | update | reinstall` (default `status`).

- **status** — never errors. Reports applicable/installed/installedVersion/dev-symlink + a guidance note.
- **install** — installs the panel (nightly).
- **update** — pulls the latest nightly on demand.
- **reinstall** — uninstall + reinstall (nightly).
- install/update/reinstall **refuse** on a dev symlink, **refuse** in remote/cloud mode, and **require** a local `COMFYUI_PATH`. On success they report that **ComfyUI must be RESTARTED** to load the new/updated node (no auto-restart).

## On-load policy (install-if-missing only)

After `server.connect`, a **fire-and-forget**, hard-timed-out `ensurePanelInstalled()` runs (gated on local mode):

- **missing** → install nightly (logs "RESTART ComfyUI to load it").
- **present** → `up-to-date` (left untouched — no git-pull on every spawn).
- **dev symlink** → `skipped-dev`.
- **opt-out / no COMFYUI_PATH / remote / unreachable** → `skipped` / `unavailable`.

Rationale: nightly has no version number to diff, and pulling on every MCP spawn is too heavy. Install-if-missing is the on-load primary; the explicit `update` action covers refresh on demand.

## Detection

Scans `<COMFYUI_PATH>/custom_nodes` for a subdir whose `pyproject.toml` `[project].name == "comfyui-agent-panel"` (authoritative; robust to dir naming). Fast-paths the `comfyui-mcp-panel` / `comfyui-agent-panel` dirs, then full-scans. Installed version is read from that pyproject; dev installs are detected via `lstat().isSymbolicLink()`.

## Safety guards

- **LOCAL-only** (see P1b below): no-op/refuse in remote/cloud mode and when `COMFYUI_PATH` is unset.
- **Dev junction** (see P1a below): never install/update/reinstall over a symlinked panel dir.
- **Non-blocking startup**: on-load ensure is fire-and-forget, timed out (20s), swallows all errors.
- **Opt-out**: `COMFYUI_MCP_PANEL_AUTOINSTALL=0` (also `false`/`no`/`off`) disables auto-ensure.
- **No auto-restart**: results tell the agent to restart ComfyUI.

## Review follow-up — two P1 safety gaps fixed (commit 4c79225)

**P1a — dev-junction protection was pyproject-dependent.** The symlink check previously only ran *after* a readable, matching `pyproject.toml`. A junction whose pyproject was missing/corrupt/unreadable was reported as not-installed, so install/reinstall could clobber the dev junction. Fixed: `detectPanelInstall` now `lstat`s the KNOWN target dirs (`comfyui-mcp-panel` AND `comfyui-agent-panel`) FIRST and INDEPENDENTLY of pyproject parsing — a symlinked dir is treated as a dev install (`installed: true, isDevSymlink: true`) even with no/corrupt pyproject. All mutations (install/update/reinstall) and the on-load ensure refuse/skip it.

**P1b — actions weren't truly local-only.** With a remote `COMFYUI_URL` plus an explicit local `COMFYUI_PATH`, status/detect scanned the LOCAL disk while `installCustomNode`/`reinstallCustomNode` queued Manager mutations against the REMOTE host (symlink guard checking the wrong filesystem). Fixed: `runPanelAction`, `panelStatus`, and `detectPanelInstall` now honor the same `isLocalMode()` predicate the on-load path uses (injected dep). In remote/cloud mode mutations are refused even when `COMFYUI_PATH` is set; status reports "remote/cloud mode — managed on the ComfyUI host".

## Tests

29 cases (was 21): detection incl. symlink + arbitrary-dir scan; **junction without/with corrupt pyproject still protected**; the ensure policy matrix; tool refusals on dev-symlink, missing COMFYUI_PATH, and **remote mode**; status incl. **remote-mode note**. Build clean; full suite green (**740 passing**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)