### PR TITLE
feat(server): self-update check on MCP start

### DIFF
--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+
+import {
+  checkAndSelfUpdate,
+  compareSemver,
+  detectInstallMode,
+  isNewer,
+  runSelfUpdate,
+  selfUpdateStatus,
+  SelfUpdateError,
+  PACKAGE_NAME,
+  type SelfUpdateDeps,
+} from "../../services/self-update.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface Harness {
+  deps: SelfUpdateDeps;
+  npmCalls: Array<{ args: string[]; cwd?: string }>;
+}
+
+function pkgJson(version: string): string {
+  return JSON.stringify({ name: PACKAGE_NAME, version });
+}
+
+function makeDeps(opts: {
+  packageDir: string;
+  currentVersion?: string; // written into <packageDir>/package.json
+  latest?: string | undefined; // registry latest; undefined → offline
+  symlink?: boolean; // packageDir is a raw symlink
+  realpath?: string; // override realpath(packageDir)
+  env?: NodeJS.ProcessEnv;
+  existing?: string[]; // extra paths that exist (e.g. project package.json)
+  npmOk?: boolean; // result of runNpm
+  registryThrows?: boolean;
+}): Harness {
+  const realDir = opts.realpath ?? opts.packageDir;
+  const files: Record<string, string> = {};
+  if (opts.currentVersion) {
+    files[join(realDir, "package.json")] = pkgJson(opts.currentVersion);
+    files[join(opts.packageDir, "package.json")] = pkgJson(opts.currentVersion);
+  }
+  const existing = new Set(opts.existing ?? []);
+  const npmCalls: Harness["npmCalls"] = [];
+
+  const deps: SelfUpdateDeps = {
+    packageDir: () => opts.packageDir,
+    env: () => opts.env ?? {},
+    existsSync: (p) => p in files || existing.has(p),
+    isSymlink: () => opts.symlink ?? false,
+    realpath: () => realDir,
+    readFile: (p) => {
+      if (p in files) return files[p];
+      throw new Error(`ENOENT: ${p}`);
+    },
+    getLatestVersion: async () => {
+      if (opts.registryThrows) throw new Error("network down");
+      return opts.latest;
+    },
+    runNpm: async (args, cwd) => {
+      npmCalls.push({ args, cwd });
+      return { ok: opts.npmOk ?? true };
+    },
+  };
+  return { deps, npmCalls };
+}
+
+// Common install-dir fixtures (POSIX-style; detection normalizes separators).
+const GLOBAL_DIR = "/usr/lib/node_modules/comfyui-mcp";
+const LOCAL_PROJECT = "/home/me/proj";
+const LOCAL_DIR = join(LOCAL_PROJECT, "node_modules", "comfyui-mcp");
+const NPX_DIR = "/home/me/.npm/_npx/abc123/node_modules/comfyui-mcp";
+const DEV_DIR = "/home/me/code/comfyui-mcp";
+
+// ---------------------------------------------------------------------------
+// semver
+// ---------------------------------------------------------------------------
+
+describe("compareSemver / isNewer", () => {
+  it("orders core versions", () => {
+    expect(compareSemver("1.2.4", "1.2.3")).toBe(1);
+    expect(compareSemver("1.3.0", "1.2.9")).toBe(1);
+    expect(compareSemver("2.0.0", "1.9.9")).toBe(1);
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+    expect(compareSemver("1.2.3", "1.2.4")).toBe(-1);
+  });
+  it("treats a release as newer than its prerelease", () => {
+    expect(compareSemver("1.2.3", "1.2.3-beta.1")).toBe(1);
+    expect(compareSemver("1.2.3-beta.2", "1.2.3-beta.1")).toBe(1);
+  });
+  it("tolerates a leading v and bad input", () => {
+    expect(compareSemver("v1.2.4", "1.2.3")).toBe(1);
+    expect(compareSemver("garbage", "1.2.3")).toBe(0);
+  });
+  it("isNewer is strict", () => {
+    expect(isNewer("0.19.2", "0.19.1")).toBe(true);
+    expect(isNewer("0.19.1", "0.19.1")).toBe(false);
+    expect(isNewer("0.19.0", "0.19.1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInstallMode
+// ---------------------------------------------------------------------------
+
+describe("detectInstallMode", () => {
+  it("global: under node_modules with no project package.json above", () => {
+    const { deps } = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1" });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("global");
+    expect(info.isDevLink).toBe(false);
+    expect(info.currentVersion).toBe("0.19.1");
+  });
+
+  it("local: under a project's node_modules (project package.json present)", () => {
+    const { deps } = makeDeps({
+      packageDir: LOCAL_DIR,
+      currentVersion: "0.19.1",
+      existing: [join(LOCAL_PROJECT, "package.json")],
+    });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("local");
+    expect(info.projectRoot).toBe(LOCAL_PROJECT.replace(/\\/g, "/"));
+  });
+
+  it("npx: resolved inside an _npx cache dir", () => {
+    const { deps } = makeDeps({ packageDir: NPX_DIR, currentVersion: "0.19.1" });
+    expect(detectInstallMode(deps).mode).toBe("npx");
+  });
+
+  it("linked: not under node_modules → dev checkout", () => {
+    const { deps } = makeDeps({ packageDir: DEV_DIR, currentVersion: "0.19.1" });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("linked");
+    expect(info.isDevLink).toBe(true);
+  });
+
+  it("linked: npm link symlink resolved by realpath to a checkout", () => {
+    // Node resolves the symlink → realpath points at the dev checkout (no node_modules).
+    const { deps } = makeDeps({
+      packageDir: "/usr/lib/node_modules/comfyui-mcp",
+      realpath: DEV_DIR,
+      currentVersion: "0.19.1",
+    });
+    expect(detectInstallMode(deps).mode).toBe("linked");
+  });
+
+  it("linked: --preserve-symlinks (dir itself is a symlink) → dev", () => {
+    const { deps } = makeDeps({
+      packageDir: GLOBAL_DIR,
+      symlink: true,
+      currentVersion: "0.19.1",
+    });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("linked");
+    expect(info.isDevLink).toBe(true);
+  });
+
+  it("unknown: packageDir() throws", () => {
+    const { deps } = makeDeps({ packageDir: GLOBAL_DIR });
+    deps.packageDir = () => {
+      throw new Error("no url");
+    };
+    expect(detectInstallMode(deps).mode).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAndSelfUpdate policy matrix
+// ---------------------------------------------------------------------------
+
+describe("checkAndSelfUpdate policy", () => {
+  it("dev link → skipped-dev (NEVER runs npm)", async () => {
+    const h = makeDeps({ packageDir: DEV_DIR, currentVersion: "0.19.1", latest: "9.9.9" });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("skipped-dev");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("opt-out env → skipped-disabled (no npm)", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "9.9.9",
+      env: { COMFYUI_MCP_AUTOUPDATE: "0" },
+    });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("skipped-disabled");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("opt-out 'off' also disables", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "9.9.9",
+      env: { COMFYUI_MCP_AUTOUPDATE: "off" },
+    });
+    expect((await checkAndSelfUpdate({ deps: h.deps })).action).toBe("skipped-disabled");
+  });
+
+  it("up-to-date → no npm", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", latest: "0.19.1" });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("up-to-date");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("newer + global → runs `npm i -g comfyui-mcp@latest` and returns updated", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("updated");
+    expect(res.from).toBe("0.19.1");
+    expect(res.to).toBe("0.20.0");
+    expect(res.note).toMatch(/RECONNECT/i);
+    expect(h.npmCalls).toEqual([
+      { args: ["i", "-g", `${PACKAGE_NAME}@latest`], cwd: undefined },
+    ]);
+  });
+
+  it("newer + local → runs `npm i comfyui-mcp@latest` in the project root", async () => {
+    const h = makeDeps({
+      packageDir: LOCAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "0.20.0",
+      existing: [join(LOCAL_PROJECT, "package.json")],
+    });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("updated");
+    expect(h.npmCalls).toEqual([
+      { args: ["i", `${PACKAGE_NAME}@latest`], cwd: LOCAL_PROJECT.replace(/\\/g, "/") },
+    ]);
+  });
+
+  it("newer + global but npm fails → unavailable", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "0.20.0",
+      npmOk: false,
+    });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(res.to).toBe("0.20.0");
+  });
+
+  it("newer + npx → notify (no npm)", async () => {
+    const h = makeDeps({ packageDir: NPX_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("notify");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("offline / registry unreachable → unavailable", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", latest: undefined });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("never throws even if the registry probe throws", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      registryThrows: true,
+    });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+  });
+
+  it("never throws if runNpm throws", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
+    h.deps.runNpm = async () => {
+      throw new Error("spawn EACCES");
+    };
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSelfUpdate (explicit tool action)
+// ---------------------------------------------------------------------------
+
+describe("runSelfUpdate", () => {
+  it("REFUSES on a dev link", async () => {
+    const h = makeDeps({ packageDir: DEV_DIR, currentVersion: "0.19.1", latest: "9.9.9" });
+    await expect(runSelfUpdate(h.deps)).rejects.toBeInstanceOf(SelfUpdateError);
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("ignores the opt-out env (explicit request) and updates global", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "0.20.0",
+      env: { COMFYUI_MCP_AUTOUPDATE: "0" },
+    });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.action).toBe("updated");
+    expect(h.npmCalls).toEqual([
+      { args: ["i", "-g", `${PACKAGE_NAME}@latest`], cwd: undefined },
+    ]);
+  });
+
+  it("up-to-date is a no-op", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.20.0", latest: "0.20.0" });
+    const res = await runSelfUpdate(h.deps);
+    expect(res.action).toBe("up-to-date");
+    expect(h.npmCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selfUpdateStatus (never throws)
+// ---------------------------------------------------------------------------
+
+describe("selfUpdateStatus", () => {
+  it("reports update availability for a global install", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
+    const s = await selfUpdateStatus(h.deps);
+    expect(s.mode).toBe("global");
+    expect(s.currentVersion).toBe("0.19.1");
+    expect(s.latestVersion).toBe("0.20.0");
+    expect(s.updateAvailable).toBe(true);
+    expect(s.note).toMatch(/RECONNECT/i);
+  });
+
+  it("flags dev-link and never reports it as updatable", async () => {
+    const h = makeDeps({ packageDir: DEV_DIR, currentVersion: "0.19.1", latest: "9.9.9" });
+    const s = await selfUpdateStatus(h.deps);
+    expect(s.isDevLink).toBe(true);
+    expect(s.note).toMatch(/dev install/i);
+  });
+
+  it("never throws when the registry is unreachable", async () => {
+    const h = makeDeps({ packageDir: GLOBAL_DIR, currentVersion: "0.19.1", registryThrows: true });
+    const s = await selfUpdateStatus(h.deps);
+    expect(s.latestVersion).toBeUndefined();
+    expect(s.updateAvailable).toBe(false);
+  });
+});

--- a/src/__tests__/services/self-update.test.ts
+++ b/src/__tests__/services/self-update.test.ts
@@ -32,6 +32,7 @@ function makeDeps(opts: {
   latest?: string | undefined; // registry latest; undefined → offline
   symlink?: boolean; // packageDir is a raw symlink
   realpath?: string; // override realpath(packageDir)
+  realpathFails?: boolean; // realpath() returns undefined (resolution failed)
   env?: NodeJS.ProcessEnv;
   existing?: string[]; // extra paths that exist (e.g. project package.json)
   npmOk?: boolean; // result of runNpm
@@ -51,7 +52,7 @@ function makeDeps(opts: {
     env: () => opts.env ?? {},
     existsSync: (p) => p in files || existing.has(p),
     isSymlink: () => opts.symlink ?? false,
-    realpath: () => realDir,
+    realpath: () => (opts.realpathFails ? undefined : realDir),
     readFile: (p) => {
       if (p in files) return files[p];
       throw new Error(`ENOENT: ${p}`);
@@ -74,6 +75,20 @@ const LOCAL_PROJECT = "/home/me/proj";
 const LOCAL_DIR = join(LOCAL_PROJECT, "node_modules", "comfyui-mcp");
 const NPX_DIR = "/home/me/.npm/_npx/abc123/node_modules/comfyui-mcp";
 const DEV_DIR = "/home/me/code/comfyui-mcp";
+
+// pnpm virtual store: <proj>/node_modules/.pnpm/<pkg>@x/node_modules/<pkg>
+const PNPM_PROJECT = "/home/me/pnpmproj";
+const PNPM_DIR = join(
+  PNPM_PROJECT,
+  "node_modules",
+  ".pnpm",
+  "comfyui-mcp@0.19.1",
+  "node_modules",
+  "comfyui-mcp",
+);
+// yarn (un-hoisted nested dep-of-dep): <proj>/node_modules/<other>/node_modules/<pkg>
+const YARN_PROJECT = "/home/me/yarnproj";
+const YARN_DIR = join(YARN_PROJECT, "node_modules", "some-dep", "node_modules", "comfyui-mcp");
 
 // ---------------------------------------------------------------------------
 // semver
@@ -166,6 +181,61 @@ describe("detectInstallMode", () => {
     };
     expect(detectInstallMode(deps).mode).toBe("unknown");
   });
+
+  // --- P1: nested node_modules (pnpm / yarn) must be LOCAL, never global ------
+
+  it("local: pnpm virtual-store nested layout resolves to the project root", () => {
+    const { deps } = makeDeps({
+      packageDir: PNPM_DIR,
+      currentVersion: "0.19.1",
+      existing: [join(PNPM_PROJECT, "package.json")],
+    });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("local");
+    expect(info.projectRoot).toBe(PNPM_PROJECT.replace(/\\/g, "/"));
+  });
+
+  it("local: yarn un-hoisted nested dep resolves to the OUTERMOST project root", () => {
+    const { deps } = makeDeps({
+      packageDir: YARN_DIR,
+      currentVersion: "0.19.1",
+      existing: [join(YARN_PROJECT, "package.json")],
+    });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("local");
+    expect(info.projectRoot).toBe(YARN_PROJECT.replace(/\\/g, "/"));
+  });
+
+  it("unknown (NEVER global): nested node_modules with no identifiable project root", () => {
+    // Two node_modules segments, no package.json above either → ambiguous.
+    const { deps } = makeDeps({ packageDir: PNPM_DIR, currentVersion: "0.19.1" });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("unknown");
+    expect(info.mode).not.toBe("global");
+  });
+
+  // --- P2a: realpath failure must safe-fail to unknown ------------------------
+
+  it("unknown: realpath resolution fails while under node_modules", () => {
+    const { deps } = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      realpathFails: true,
+    });
+    const info = detectInstallMode(deps);
+    expect(info.mode).toBe("unknown");
+    // version still read from the raw path so status can report it
+    expect(info.currentVersion).toBe("0.19.1");
+  });
+
+  it("realpath failure still classifies a not-under-node_modules checkout as linked", () => {
+    const { deps } = makeDeps({
+      packageDir: DEV_DIR,
+      currentVersion: "0.19.1",
+      realpathFails: true,
+    });
+    expect(detectInstallMode(deps).mode).toBe("linked");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -217,7 +287,7 @@ describe("checkAndSelfUpdate policy", () => {
     expect(res.to).toBe("0.20.0");
     expect(res.note).toMatch(/RECONNECT/i);
     expect(h.npmCalls).toEqual([
-      { args: ["i", "-g", `${PACKAGE_NAME}@latest`], cwd: undefined },
+      { args: ["i", "-g", `${PACKAGE_NAME}@latest`, "--no-audit", "--no-fund"], cwd: undefined },
     ]);
   });
 
@@ -231,7 +301,10 @@ describe("checkAndSelfUpdate policy", () => {
     const res = await checkAndSelfUpdate({ deps: h.deps });
     expect(res.action).toBe("updated");
     expect(h.npmCalls).toEqual([
-      { args: ["i", `${PACKAGE_NAME}@latest`], cwd: LOCAL_PROJECT.replace(/\\/g, "/") },
+      {
+        args: ["i", `${PACKAGE_NAME}@latest`, "--no-audit", "--no-fund"],
+        cwd: LOCAL_PROJECT.replace(/\\/g, "/"),
+      },
     ]);
   });
 
@@ -251,6 +324,27 @@ describe("checkAndSelfUpdate policy", () => {
     const h = makeDeps({ packageDir: NPX_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
     const res = await checkAndSelfUpdate({ deps: h.deps });
     expect(res.action).toBe("notify");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("newer + unknown (ambiguous nested) → notify, NEVER an npm -g update", async () => {
+    const h = makeDeps({ packageDir: PNPM_DIR, currentVersion: "0.19.1", latest: "0.20.0" });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("notify");
+    expect(res.mode).toBe("unknown");
+    expect(h.npmCalls).toEqual([]);
+  });
+
+  it("newer + realpath-failure → notify (unknown), NEVER an npm update", async () => {
+    const h = makeDeps({
+      packageDir: GLOBAL_DIR,
+      currentVersion: "0.19.1",
+      latest: "0.20.0",
+      realpathFails: true,
+    });
+    const res = await checkAndSelfUpdate({ deps: h.deps });
+    expect(res.action).toBe("notify");
+    expect(res.mode).toBe("unknown");
     expect(h.npmCalls).toEqual([]);
   });
 
@@ -302,7 +396,7 @@ describe("runSelfUpdate", () => {
     const res = await runSelfUpdate(h.deps);
     expect(res.action).toBe("updated");
     expect(h.npmCalls).toEqual([
-      { args: ["i", "-g", `${PACKAGE_NAME}@latest`], cwd: undefined },
+      { args: ["i", "-g", `${PACKAGE_NAME}@latest`, "--no-audit", "--no-fund"], cwd: undefined },
     ]);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { parseCliArgs } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
+import { checkAndSelfUpdate } from "./services/self-update.js";
 
 /**
  * Fire-and-forget: ensure the ComfyUI sidebar panel is installed (install-if-
@@ -45,6 +46,42 @@ function ensurePanelOnLoad(): void {
           break;
         default:
           logger.debug("Panel auto-install: unavailable.", res);
+      }
+    })
+    .catch(() => {});
+}
+
+/**
+ * Fire-and-forget: on MCP load, check the npm registry and (for global/local
+ * installs) auto-update the package on disk, then surface a "reconnect to load
+ * vX" note — the running process can't hot-swap its own code. NEVER updates a
+ * dev (npm link) install, hard-timed-out, and never throws. Opt out with
+ * COMFYUI_MCP_AUTOUPDATE=0. Mirrors the panel auto-install ensure pattern.
+ */
+function selfUpdateOnLoad(): void {
+  void checkAndSelfUpdate()
+    .then((res) => {
+      switch (res.action) {
+        case "updated":
+          logger.info(
+            `Self-update: updated comfyui-mcp ${res.from} → ${res.to} (${res.mode}). ${res.note ?? ""}`,
+            res,
+          );
+          break;
+        case "notify":
+          logger.info(`Self-update: ${res.note ?? `v${res.to} available.`}`, res);
+          break;
+        case "up-to-date":
+          logger.debug("Self-update: already on the latest version.", res);
+          break;
+        case "skipped-dev":
+          logger.info("Self-update: skipped — dev install (npm link / checkout).", res);
+          break;
+        case "skipped-disabled":
+          logger.debug("Self-update: disabled via COMFYUI_MCP_AUTOUPDATE.", res);
+          break;
+        default:
+          logger.debug("Self-update: unavailable.", res);
       }
     })
     .catch(() => {});
@@ -116,6 +153,8 @@ async function main() {
 
   // After the server is up: auto-ensure the sidebar panel (non-blocking).
   ensurePanelOnLoad();
+  // ...and self-check the npm registry for a newer published version (non-blocking).
+  selfUpdateOnLoad();
 }
 
 main().catch((err) => {

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -75,8 +75,12 @@ export interface SelfUpdateDeps {
   existsSync: (p: string) => boolean;
   /** True when `p` is a symlink/junction. Never throws. */
   isSymlink: (p: string) => boolean;
-  /** fs.realpathSync, used to resolve `npm link` symlinks. Never throws. */
-  realpath: (p: string) => string;
+  /**
+   * fs.realpathSync, used to resolve `npm link` symlinks. Returns `undefined`
+   * when resolution FAILS — callers must safe-fail to "unknown" rather than
+   * trust the raw (unresolved) path for an updatable classification. Never throws.
+   */
+  realpath: (p: string) => string | undefined;
   /** Read a UTF-8 file. May throw; callers guard. */
   readFile: (p: string) => string;
   /** Fetch the latest published version from the npm registry, or undefined. */
@@ -144,7 +148,7 @@ export const defaultDeps: SelfUpdateDeps = {
     try {
       return realpathSync(p);
     } catch {
-      return p;
+      return undefined;
     }
   },
   readFile: (p) => readFileSync(p, "utf-8"),
@@ -214,9 +218,18 @@ function segmentsOf(p: string): string[] {
  *   - linked  → `npm link` / run-from-checkout (NOT under node_modules, or the
  *     dir is itself a symlink). DEV install — never auto-update.
  *   - npx     → resolved inside an `_npx` cache dir (npx -y comfyui-mcp).
- *   - local   → under a project's node_modules whose parent has a package.json.
- *   - global  → under a global node_modules (no project package.json above it).
- *   - unknown → couldn't classify confidently → caller must NOT auto-update.
+ *   - local   → under a project's node_modules; the OUTERMOST host dir with a
+ *     package.json is the project root (correctly handles pnpm/yarn nested
+ *     `node_modules/.pnpm/<pkg>/node_modules/<pkg>` virtual-store layouts).
+ *   - global  → the canonical single-`node_modules` global layout (package sits
+ *     directly inside node_modules, no project package.json above it).
+ *   - unknown → couldn't classify confidently → caller MUST NOT auto-update.
+ *
+ * SAFE-FAIL: any uncertainty (realpath resolution failed, nested/ambiguous
+ * virtual-store layout with no identifiable project root) returns "unknown"
+ * (notify only) — NEVER "global". The dangerous wrong-direction failure is
+ * classifying a local install as global and running `npm i -g` against it, so
+ * the classifier only ever errs toward "unknown".
  *
  * Uses realpath to follow an `npm link` symlink to the developer's checkout, and
  * lstat to catch the --preserve-symlinks case where the dir is the symlink.
@@ -233,35 +246,64 @@ export function detectInstallMode(deps: SelfUpdateDeps = defaultDeps): InstallIn
   const dirIsSymlink = deps.isSymlink(rawDir);
   // Default Node resolves symlinks for import.meta.url, so a linked package's
   // dir already points at the real checkout; realpath is a harmless no-op there.
-  const real = deps.realpath(rawDir);
+  // `undefined` means resolution FAILED — we must not trust the raw path for an
+  // updatable classification (safe-fail to "unknown" below).
+  const resolved = deps.realpath(rawDir);
+  const realpathFailed = resolved === undefined;
+  const real = resolved ?? rawDir;
   const currentVersion = readVersion(deps, real) ?? readVersion(deps, rawDir);
 
   const segs = segmentsOf(real);
   const lower = segs.map((s) => s.toLowerCase());
 
-  // npx cache (npm's `_npx` directory).
+  // npx cache (npm's `_npx` directory) — always notify-only, so realpath
+  // uncertainty is harmless here.
   if (lower.includes("_npx")) {
     return { mode: "npx", packageDir: real, currentVersion, isDevLink: false };
   }
 
-  // Last `node_modules` segment → the install lives under it.
-  const nmIdx = lower.lastIndexOf("node_modules");
+  // All `node_modules` segment indices (outermost → innermost).
+  const nmIndices: number[] = [];
+  for (let i = 0; i < lower.length; i++) {
+    if (lower[i] === "node_modules") nmIndices.push(i);
+  }
 
-  if (dirIsSymlink || nmIdx === -1) {
+  if (dirIsSymlink || nmIndices.length === 0) {
     // Not under node_modules (or it's a raw symlink): a working checkout, i.e.
     // `npm link` / `npm run dev` / a git clone. DEV — never auto-update.
     return { mode: "linked", packageDir: real, currentVersion, isDevLink: true };
   }
 
-  // Under node_modules. The dir CONTAINING node_modules is the install host:
-  // for a local dependency it's the project root (has its own package.json);
-  // for a global install it's the npm prefix (no package.json there).
-  const hostSegs = segs.slice(0, nmIdx);
-  const hostDir = hostSegs.join("/") || "/";
-  if (deps.existsSync(join(hostDir, "package.json"))) {
-    return { mode: "local", packageDir: real, currentVersion, isDevLink: false, projectRoot: hostDir };
+  // Under node_modules but realpath FAILED → we can't trust the on-disk
+  // location → safe-fail to unknown (notify only, never an update).
+  if (realpathFailed) {
+    return { mode: "unknown", packageDir: real, currentVersion, isDevLink: false };
   }
-  return { mode: "global", packageDir: real, currentVersion, isDevLink: false };
+
+  // LOCAL: walk OUTWARD — the outermost node_modules whose containing dir has a
+  // package.json is the real project root. This makes a pnpm/yarn nested path
+  //   <proj>/node_modules/.pnpm/<pkg>@x/node_modules/<pkg>
+  // resolve to <proj> (local), instead of the virtual-store folder (which has no
+  // package.json and would otherwise be misread as a global prefix).
+  for (const i of nmIndices) {
+    const host = segs.slice(0, i).join("/") || "/";
+    if (deps.existsSync(join(host, "package.json"))) {
+      return { mode: "local", packageDir: real, currentVersion, isDevLink: false, projectRoot: host };
+    }
+  }
+
+  // GLOBAL: only the canonical layout — a SINGLE node_modules with the package
+  // sitting directly inside it (`<prefix>/.../node_modules/comfyui-mcp`) and no
+  // project package.json above it (the npm prefix has none).
+  const lastNm = nmIndices[nmIndices.length - 1];
+  const packageIsDirectChild = lastNm === segs.length - 2;
+  if (nmIndices.length === 1 && packageIsDirectChild) {
+    return { mode: "global", packageDir: real, currentVersion, isDevLink: false };
+  }
+
+  // Ambiguous (nested/virtual-store layout with no identifiable project root)
+  // → safe-fail to unknown. NEVER "global".
+  return { mode: "unknown", packageDir: real, currentVersion, isDevLink: false };
 }
 
 /** Public, error-swallowing wrapper around the npm-registry probe. */
@@ -287,6 +329,20 @@ function isAutoUpdateDisabled(env: NodeJS.ProcessEnv): boolean {
 const RECONNECT_NOTE =
   "The running MCP server is still on the OLD code — RECONNECT (/mcp) or restart " +
   "the orchestrator to load the new version.";
+
+/**
+ * Build the `npm install` argv for a self-update. Every token is a CONSTANT —
+ * no user/dynamic value is ever interpolated into the command (the Windows path
+ * runs npm.cmd via shell:true, so injection-safety relies on this). `--no-audit
+ * --no-fund` keep it non-interactive and cut extra network/output.
+ */
+function npmInstallArgs(mode: "global" | "local"): string[] {
+  const base =
+    mode === "global"
+      ? ["i", "-g", `${PACKAGE_NAME}@latest`]
+      : ["i", `${PACKAGE_NAME}@latest`];
+  return [...base, "--no-audit", "--no-fund"];
+}
 
 export interface SelfUpdateOptions {
   deps?: SelfUpdateDeps;
@@ -339,10 +395,7 @@ async function checkInner(deps: SelfUpdateDeps): Promise<SelfUpdateResult> {
 
   // 5) Newer available. Only global/local can be safely self-replaced on disk.
   if (info.mode === "global" || info.mode === "local") {
-    const args =
-      info.mode === "global"
-        ? ["i", "-g", `${PACKAGE_NAME}@latest`]
-        : ["i", `${PACKAGE_NAME}@latest`];
+    const args = npmInstallArgs(info.mode);
     const { ok } = await deps.runNpm(args, info.mode === "local" ? info.projectRoot : undefined);
     if (!ok) {
       return {
@@ -500,10 +553,7 @@ export async function runSelfUpdate(
     return { action: "up-to-date", mode: info.mode, from: info.currentVersion, to: latest };
   }
   if (info.mode === "global" || info.mode === "local") {
-    const args =
-      info.mode === "global"
-        ? ["i", "-g", `${PACKAGE_NAME}@latest`]
-        : ["i", `${PACKAGE_NAME}@latest`];
+    const args = npmInstallArgs(info.mode);
     const { ok } = await deps.runNpm(args, info.mode === "local" ? info.projectRoot : undefined);
     return ok
       ? {

--- a/src/services/self-update.ts
+++ b/src/services/self-update.ts
@@ -1,0 +1,535 @@
+// Self-update for the comfyui-mcp npm package.
+//
+// On MCP server START we check the npm registry; if a newer version is
+// published we auto-update the on-disk package, then tell the agent/user to
+// RECONNECT — the running Node process cannot hot-swap its own code, so the new
+// version only takes effect after the MCP client reconnects (/mcp) or the
+// orchestrator restarts.
+//
+// This mirrors the SAFETY model of the panel on-load ensure
+// (src/services/panel-installer.ts):
+//   - NEVER mutate a dev install. `npm link` makes the package resolve to the
+//     developer's working checkout; updating it would clobber their repo. We
+//     detect that (install mode "linked") and refuse, exactly like the panel's
+//     dev-junction guard.
+//   - opt-out env COMFYUI_MCP_AUTOUPDATE=0/false/no/off disables auto-update.
+//   - every probe + the npm spawn is hard-timed-out, captures+swallows errors,
+//     and NEVER throws — it can be fired-and-forgotten from startup without ever
+//     blocking or crashing the server.
+//   - we NEVER kill/restart the running MCP process; we only surface a
+//     "reconnect to load vX" note.
+
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { logger } from "../utils/logger.js";
+
+/** npm package name — authoritative for the registry lookup and update command. */
+export const PACKAGE_NAME = "comfyui-mcp";
+
+/** Hard caps so nothing here can ever block startup. */
+const REGISTRY_TIMEOUT_MS = 5_000;
+const NPM_TIMEOUT_MS = 120_000;
+
+export type InstallMode = "linked" | "global" | "npx" | "local" | "unknown";
+
+export interface InstallInfo {
+  mode: InstallMode;
+  /** Resolved package root (the dir containing package.json). */
+  packageDir: string;
+  /** Version from the package's own package.json, if readable. */
+  currentVersion: string | undefined;
+  /** True for an `npm link` / run-from-checkout install — NEVER auto-update. */
+  isDevLink: boolean;
+  /** For a local project dependency: the project root to run `npm i` in. */
+  projectRoot?: string;
+}
+
+export type SelfUpdateAction =
+  | "updated"
+  | "up-to-date"
+  | "skipped-dev"
+  | "skipped-disabled"
+  | "notify"
+  | "unavailable";
+
+export interface SelfUpdateResult {
+  action: SelfUpdateAction;
+  mode: InstallMode;
+  from?: string;
+  to?: string;
+  /** Human-facing note (reconnect instruction, reason, etc.). */
+  note?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Injectable deps (mirrors panel-installer's pattern for clean unit tests)
+// ---------------------------------------------------------------------------
+
+export interface SelfUpdateDeps {
+  /** Raw package root, derived from import.meta.url (pre-realpath). */
+  packageDir: () => string;
+  /** Process env (opt-out flag). */
+  env: () => NodeJS.ProcessEnv;
+  existsSync: (p: string) => boolean;
+  /** True when `p` is a symlink/junction. Never throws. */
+  isSymlink: (p: string) => boolean;
+  /** fs.realpathSync, used to resolve `npm link` symlinks. Never throws. */
+  realpath: (p: string) => string;
+  /** Read a UTF-8 file. May throw; callers guard. */
+  readFile: (p: string) => string;
+  /** Fetch the latest published version from the npm registry, or undefined. */
+  getLatestVersion: () => Promise<string | undefined>;
+  /**
+   * Run an `npm` command (args are fixed constants — no user input).
+   * Resolves { ok } and NEVER throws.
+   */
+  runNpm: (args: string[], cwd?: string) => Promise<{ ok: boolean }>;
+}
+
+function defaultPackageDir(): string {
+  // dist/services/self-update.js → packageDir = dist/.. (the package root).
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "..");
+}
+
+async function defaultGetLatestVersion(): Promise<string | undefined> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return undefined;
+    const json = (await res.json()) as { version?: unknown };
+    return typeof json.version === "string" ? json.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultRunNpm(args: string[], cwd?: string): Promise<{ ok: boolean }> {
+  return new Promise((resolveP) => {
+    // `npm` is a .cmd shim on Windows; execFile needs shell:true to run it.
+    // SAFE: every arg is a hard-coded constant (no interpolation of user input),
+    // so there is no shell-injection surface.
+    const isWin = process.platform === "win32";
+    const cmd = isWin ? "npm.cmd" : "npm";
+    try {
+      const child = execFile(
+        cmd,
+        args,
+        { cwd, timeout: NPM_TIMEOUT_MS, windowsHide: true, shell: isWin },
+        (err) => resolveP({ ok: !err }),
+      );
+      child.on("error", () => resolveP({ ok: false }));
+    } catch {
+      resolveP({ ok: false });
+    }
+  });
+}
+
+export const defaultDeps: SelfUpdateDeps = {
+  packageDir: defaultPackageDir,
+  env: () => process.env,
+  existsSync,
+  isSymlink: (p) => {
+    try {
+      return lstatSync(p).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  },
+  realpath: (p) => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  },
+  readFile: (p) => readFileSync(p, "utf-8"),
+  getLatestVersion: defaultGetLatestVersion,
+  runNpm: defaultRunNpm,
+};
+
+// ---------------------------------------------------------------------------
+// semver compare (major.minor.patch with a basic prerelease ordering)
+// ---------------------------------------------------------------------------
+
+/** Compare two semver strings. Returns 1 if a>b, -1 if a<b, 0 if equal/unparseable. */
+export function compareSemver(a: string, b: string): number {
+  const parse = (v: string) => {
+    const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(v.trim());
+    if (!m) return undefined;
+    return {
+      nums: [Number(m[1]), Number(m[2]), Number(m[3])] as const,
+      pre: m[4] ?? "",
+    };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (pa.nums[i] > pb.nums[i]) return 1;
+    if (pa.nums[i] < pb.nums[i]) return -1;
+  }
+  // Equal core. A version WITHOUT a prerelease tag outranks one WITH it.
+  if (pa.pre === pb.pre) return 0;
+  if (pa.pre === "") return 1;
+  if (pb.pre === "") return -1;
+  return pa.pre > pb.pre ? 1 : -1;
+}
+
+/** True when `latest` is strictly newer than `current`. */
+export function isNewer(latest: string, current: string): boolean {
+  return compareSemver(latest, current) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Install-mode detection
+// ---------------------------------------------------------------------------
+
+function readVersion(deps: SelfUpdateDeps, dir: string): string | undefined {
+  try {
+    const pkg = JSON.parse(deps.readFile(join(dir, "package.json"))) as {
+      version?: unknown;
+    };
+    return typeof pkg.version === "string" ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Split a path into segments, tolerant of mixed separators / Windows drives.
+ * Empty segments are KEPT so a leading "/" (POSIX absolute root) survives
+ * reconstruction (segs[0] === "" → rejoin yields "/home/...").
+ */
+function segmentsOf(p: string): string[] {
+  return p.replace(/\\/g, "/").split("/");
+}
+
+/**
+ * Classify how this package is installed by inspecting the resolved package dir:
+ *   - linked  → `npm link` / run-from-checkout (NOT under node_modules, or the
+ *     dir is itself a symlink). DEV install — never auto-update.
+ *   - npx     → resolved inside an `_npx` cache dir (npx -y comfyui-mcp).
+ *   - local   → under a project's node_modules whose parent has a package.json.
+ *   - global  → under a global node_modules (no project package.json above it).
+ *   - unknown → couldn't classify confidently → caller must NOT auto-update.
+ *
+ * Uses realpath to follow an `npm link` symlink to the developer's checkout, and
+ * lstat to catch the --preserve-symlinks case where the dir is the symlink.
+ */
+export function detectInstallMode(deps: SelfUpdateDeps = defaultDeps): InstallInfo {
+  let rawDir: string;
+  try {
+    rawDir = deps.packageDir();
+  } catch {
+    return { mode: "unknown", packageDir: "", currentVersion: undefined, isDevLink: false };
+  }
+
+  // --preserve-symlinks: the dir we run from is itself the link → dev link.
+  const dirIsSymlink = deps.isSymlink(rawDir);
+  // Default Node resolves symlinks for import.meta.url, so a linked package's
+  // dir already points at the real checkout; realpath is a harmless no-op there.
+  const real = deps.realpath(rawDir);
+  const currentVersion = readVersion(deps, real) ?? readVersion(deps, rawDir);
+
+  const segs = segmentsOf(real);
+  const lower = segs.map((s) => s.toLowerCase());
+
+  // npx cache (npm's `_npx` directory).
+  if (lower.includes("_npx")) {
+    return { mode: "npx", packageDir: real, currentVersion, isDevLink: false };
+  }
+
+  // Last `node_modules` segment → the install lives under it.
+  const nmIdx = lower.lastIndexOf("node_modules");
+
+  if (dirIsSymlink || nmIdx === -1) {
+    // Not under node_modules (or it's a raw symlink): a working checkout, i.e.
+    // `npm link` / `npm run dev` / a git clone. DEV — never auto-update.
+    return { mode: "linked", packageDir: real, currentVersion, isDevLink: true };
+  }
+
+  // Under node_modules. The dir CONTAINING node_modules is the install host:
+  // for a local dependency it's the project root (has its own package.json);
+  // for a global install it's the npm prefix (no package.json there).
+  const hostSegs = segs.slice(0, nmIdx);
+  const hostDir = hostSegs.join("/") || "/";
+  if (deps.existsSync(join(hostDir, "package.json"))) {
+    return { mode: "local", packageDir: real, currentVersion, isDevLink: false, projectRoot: hostDir };
+  }
+  return { mode: "global", packageDir: real, currentVersion, isDevLink: false };
+}
+
+/** Public, error-swallowing wrapper around the npm-registry probe. */
+export async function getLatestPublishedVersion(
+  deps: SelfUpdateDeps = defaultDeps,
+): Promise<string | undefined> {
+  try {
+    return await deps.getLatestVersion();
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Policy engine
+// ---------------------------------------------------------------------------
+
+function isAutoUpdateDisabled(env: NodeJS.ProcessEnv): boolean {
+  const v = (env.COMFYUI_MCP_AUTOUPDATE ?? "").trim().toLowerCase();
+  return v === "0" || v === "false" || v === "no" || v === "off";
+}
+
+const RECONNECT_NOTE =
+  "The running MCP server is still on the OLD code — RECONNECT (/mcp) or restart " +
+  "the orchestrator to load the new version.";
+
+export interface SelfUpdateOptions {
+  deps?: SelfUpdateDeps;
+}
+
+async function checkInner(deps: SelfUpdateDeps): Promise<SelfUpdateResult> {
+  const info = detectInstallMode(deps);
+
+  // 1) DEV LINK — highest-priority safety guard. Never mutate a dev checkout,
+  //    even if the user did not set the opt-out env.
+  if (info.isDevLink || info.mode === "linked") {
+    return {
+      action: "skipped-dev",
+      mode: info.mode,
+      from: info.currentVersion,
+      note: "Dev install (npm link / checkout) — self-update is disabled; update via git.",
+    };
+  }
+
+  // 2) Opt-out.
+  if (isAutoUpdateDisabled(deps.env())) {
+    return {
+      action: "skipped-disabled",
+      mode: info.mode,
+      from: info.currentVersion,
+      note: "Self-update disabled via COMFYUI_MCP_AUTOUPDATE.",
+    };
+  }
+
+  // 3) Registry probe.
+  const latest = await deps.getLatestVersion();
+  if (!latest) {
+    return {
+      action: "unavailable",
+      mode: info.mode,
+      from: info.currentVersion,
+      note: "npm registry unreachable (offline or timed out).",
+    };
+  }
+
+  // 4) Up to date (also covers an unreadable current version → don't churn).
+  if (!info.currentVersion || !isNewer(latest, info.currentVersion)) {
+    return {
+      action: "up-to-date",
+      mode: info.mode,
+      from: info.currentVersion,
+      to: latest,
+    };
+  }
+
+  // 5) Newer available. Only global/local can be safely self-replaced on disk.
+  if (info.mode === "global" || info.mode === "local") {
+    const args =
+      info.mode === "global"
+        ? ["i", "-g", `${PACKAGE_NAME}@latest`]
+        : ["i", `${PACKAGE_NAME}@latest`];
+    const { ok } = await deps.runNpm(args, info.mode === "local" ? info.projectRoot : undefined);
+    if (!ok) {
+      return {
+        action: "unavailable",
+        mode: info.mode,
+        from: info.currentVersion,
+        to: latest,
+        note: `npm update to ${latest} failed; staying on ${info.currentVersion}.`,
+      };
+    }
+    return {
+      action: "updated",
+      mode: info.mode,
+      from: info.currentVersion,
+      to: latest,
+      note: `Updated ${PACKAGE_NAME} ${info.currentVersion} → ${latest}. ${RECONNECT_NOTE}`,
+    };
+  }
+
+  // 6) npx / unknown — can't safely self-replace; notify only.
+  const how =
+    info.mode === "npx"
+      ? "npx already fetches the latest on next run — restart to pick it up."
+      : "Could not classify the install; update manually.";
+  return {
+    action: "notify",
+    mode: info.mode,
+    from: info.currentVersion,
+    to: latest,
+    note: `${PACKAGE_NAME} ${latest} is available (current ${info.currentVersion}). ${how}`,
+  };
+}
+
+/**
+ * The on-load policy engine. Detects install mode, checks the registry, and (for
+ * global/local) self-updates on disk — then asks the user to RECONNECT. Swallows
+ * every error and NEVER throws, so it can be fired-and-forgotten from startup.
+ */
+export async function checkAndSelfUpdate(
+  opts: SelfUpdateOptions = {},
+): Promise<SelfUpdateResult> {
+  const deps = opts.deps ?? defaultDeps;
+  try {
+    return await checkInner(deps);
+  } catch (err) {
+    logger.debug("self-update: check failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    let mode: InstallMode = "unknown";
+    try {
+      mode = detectInstallMode(deps).mode;
+    } catch {
+      /* ignore */
+    }
+    return {
+      action: "unavailable",
+      mode,
+      note: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool-facing status (never throws)
+// ---------------------------------------------------------------------------
+
+export interface SelfUpdateStatus {
+  mode: InstallMode;
+  packageDir: string;
+  currentVersion: string | undefined;
+  latestVersion: string | undefined;
+  updateAvailable: boolean;
+  isDevLink: boolean;
+  autoUpdateDisabled: boolean;
+  note: string;
+}
+
+/** status action — never throws. Reports mode + current vs latest + notes. */
+export async function selfUpdateStatus(
+  deps: SelfUpdateDeps = defaultDeps,
+): Promise<SelfUpdateStatus> {
+  let info: InstallInfo;
+  try {
+    info = detectInstallMode(deps);
+  } catch {
+    info = { mode: "unknown", packageDir: "", currentVersion: undefined, isDevLink: false };
+  }
+  const latest = await getLatestPublishedVersion(deps);
+  const autoUpdateDisabled = isAutoUpdateDisabled(deps.env());
+  const updateAvailable =
+    !!latest && !!info.currentVersion && isNewer(latest, info.currentVersion);
+
+  let note: string;
+  if (info.isDevLink || info.mode === "linked") {
+    note = "Dev install (npm link / checkout) — self-update is disabled; update via git.";
+  } else if (!latest) {
+    note = "npm registry unreachable; cannot determine the latest version.";
+  } else if (!updateAvailable) {
+    note = `Up to date (${info.currentVersion}).`;
+  } else if (info.mode === "npx") {
+    note = `${latest} available — npx fetches the latest on next run; restart to pick it up.`;
+  } else if (info.mode === "unknown") {
+    note = `${latest} available — could not classify install; update manually.`;
+  } else {
+    note =
+      `${latest} available (current ${info.currentVersion}). ` +
+      `Run self_update(action='update')${autoUpdateDisabled ? "" : " (or it auto-updates on start)"}. ${RECONNECT_NOTE}`;
+  }
+
+  return {
+    mode: info.mode,
+    packageDir: info.packageDir,
+    currentVersion: info.currentVersion,
+    latestVersion: latest,
+    updateAvailable,
+    isDevLink: info.isDevLink || info.mode === "linked",
+    autoUpdateDisabled,
+    note,
+  };
+}
+
+export class SelfUpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SelfUpdateError";
+  }
+}
+
+/**
+ * Explicit `update` action. Refuses on a dev link. Returns the same result shape
+ * as the on-load check. Unlike the on-load path this IGNORES the opt-out env
+ * (the user explicitly asked), but still never updates a dev link, npx, or
+ * unknown install.
+ */
+export async function runSelfUpdate(
+  deps: SelfUpdateDeps = defaultDeps,
+): Promise<SelfUpdateResult> {
+  const info = detectInstallMode(deps);
+  if (info.isDevLink || info.mode === "linked") {
+    throw new SelfUpdateError(
+      "Refusing to self-update a dev install (npm link / checkout). Update via git instead.",
+    );
+  }
+
+  const latest = await getLatestPublishedVersion(deps);
+  if (!latest) {
+    return {
+      action: "unavailable",
+      mode: info.mode,
+      from: info.currentVersion,
+      note: "npm registry unreachable (offline or timed out).",
+    };
+  }
+  if (!info.currentVersion || !isNewer(latest, info.currentVersion)) {
+    return { action: "up-to-date", mode: info.mode, from: info.currentVersion, to: latest };
+  }
+  if (info.mode === "global" || info.mode === "local") {
+    const args =
+      info.mode === "global"
+        ? ["i", "-g", `${PACKAGE_NAME}@latest`]
+        : ["i", `${PACKAGE_NAME}@latest`];
+    const { ok } = await deps.runNpm(args, info.mode === "local" ? info.projectRoot : undefined);
+    return ok
+      ? {
+          action: "updated",
+          mode: info.mode,
+          from: info.currentVersion,
+          to: latest,
+          note: `Updated ${PACKAGE_NAME} ${info.currentVersion} → ${latest}. ${RECONNECT_NOTE}`,
+        }
+      : {
+          action: "unavailable",
+          mode: info.mode,
+          from: info.currentVersion,
+          to: latest,
+          note: `npm update to ${latest} failed; staying on ${info.currentVersion}.`,
+        };
+  }
+  // npx / unknown
+  return {
+    action: "notify",
+    mode: info.mode,
+    from: info.currentVersion,
+    to: latest,
+    note:
+      info.mode === "npx"
+        ? `${latest} available — npx fetches the latest on next run; restart to pick it up.`
+        : `${latest} available — could not classify install; update manually.`,
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -41,6 +41,7 @@ import { registerHealthCheckTools } from "./health-check.js";
 import { registerWorkflowLockTools } from "./workflow-lock.js";
 import { registerSkillsAccessTools } from "./skills-access.js";
 import { registerInstallPanelTools } from "./install-panel.js";
+import { registerSelfUpdateTools } from "./self-update.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 
 export async function registerAllTools(server: McpServer): Promise<void> {
@@ -88,5 +89,6 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerWorkflowLockTools(server);
   registerSkillsAccessTools(server);
   registerInstallPanelTools(server);
+  registerSelfUpdateTools(server);
   await registerAutoloadedWorkflows(server);
 }

--- a/src/tools/self-update.ts
+++ b/src/tools/self-update.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { runSelfUpdate, selfUpdateStatus } from "../services/self-update.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+export function registerSelfUpdateTools(server: McpServer): void {
+  server.tool(
+    "self_update",
+    "Check or apply a self-update of the comfyui-mcp npm package against the npm " +
+      "registry. The server also auto-checks on start (opt out with " +
+      "COMFYUI_MCP_AUTOUPDATE=0). Detects the install mode: a dev install (npm " +
+      "link / source checkout) is NEVER updated; global/local installs are updated " +
+      "via npm; npx fetches latest on next run. The running process cannot hot-swap " +
+      "its own code — after an update you must RECONNECT (/mcp) or restart the " +
+      "orchestrator to load the new version. This tool does not auto-restart.",
+    {
+      action: z
+        .enum(["status", "update"])
+        .default("status")
+        .describe(
+          "status: report install mode + current vs latest version + dev-link note " +
+            "(never errors). update: update to the latest published version " +
+            "(refuses on a dev link; no-op when already up to date or for npx).",
+        ),
+    },
+    async ({ action }) => {
+      try {
+        const result =
+          action === "status" ? await selfUpdateStatus() : await runSelfUpdate();
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(result, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

On MCP server **start**, self-check the npm registry; if a newer `comfyui-mcp` is published, auto-update the on-disk package, then tell the agent/user to **reconnect** — the running Node process can't hot-swap its own code. Mirrors the safety model of the panel on-load ensure (`ensurePanelInstalled` + the fire-and-forget hook in `main()`).

## Install-mode detection (`detectInstallMode`)

Classifies how the package is running from the resolved package dir (realpath of `import.meta.url` → package root), using realpath + lstat + `node_modules` path analysis. **The classifier only ever errs toward `unknown` (notify only) — never toward a wrong-direction update.**

- **linked** (dev) — the dir is a raw symlink (`--preserve-symlinks`) OR resolves to a checkout **not under `node_modules`** (`npm link` / `npm run dev` / git clone, after Node resolves the link). **Never auto-updated.**
- **npx** — resolved inside an `_npx` cache dir.
- **local** — under a project's `node_modules`; **walks OUTWARD to the outermost host dir that has a `package.json`** = the real project root. This correctly handles pnpm/yarn nested virtual-store layouts like `<proj>/node_modules/.pnpm/<pkg>@x/node_modules/<pkg>` and un-hoisted `<proj>/node_modules/<dep>/node_modules/<pkg>` → `local` with `<proj>`.
- **global** — only the **canonical** single-`node_modules` layout where the package sits directly inside `node_modules` and no project `package.json` is above it (the npm prefix).
- **unknown** — nested/ambiguous virtual-store layout with no identifiable project root, OR realpath resolution failed while under `node_modules`, OR couldn't classify. **Notify only — NEVER `global`.**

## Update policy per mode

| mode | newer available |
|------|-----------------|
| linked (dev) | `skipped-dev` — **never** touched |
| global | `npm i -g comfyui-mcp@latest --no-audit --no-fund` → `updated` |
| local | `npm i comfyui-mcp@latest --no-audit --no-fund` in the project root → `updated` |
| npx | `notify` (npx fetches latest on next run; restart) |
| unknown | `notify` (update manually) |

Plus: opt-out env → `skipped-disabled`; registry unreachable → `unavailable`; already current → `up-to-date`; npm spawn failure → `unavailable`.

## Safety guards

- **Dev link is never updated** (highest-priority check, even without the opt-out env), matching the panel's dev-junction guard.
- **Safe-fail classifier**: any uncertainty (nested/ambiguous node_modules, realpath failure) → `unknown`/notify, never `global`. Eliminates the dangerous case where a local pnpm/yarn install is misread as global and `npm i -g` is fired against it every start.
- Opt-out via `COMFYUI_MCP_AUTOUPDATE=0/false/no/off`.
- Registry probe is `AbortSignal.timeout`-bounded (5s); the npm spawn uses `execFile` with **array args built from constants only** (`npmInstallArgs()` — no dynamic interpolation; the Windows `npm.cmd` path uses `shell:true`, which stays injection-safe because nothing dynamic is ever concatenated into the command), `--no-audit --no-fund`, `windowsHide`, 120s timeout.
- **Fire-and-forget, swallows every error, never throws** — can't block or crash startup (wired after `server.connect`, alongside the panel ensure, independent of it).
- **Never auto-restarts** the running process; only surfaces a "RECONNECT (/mcp) or restart the orchestrator to load vX" note.

## `self_update` MCP tool

`action: status|update`. `status` never throws (reports mode + current vs latest + dev-link/opt-out notes); `update` refuses on a dev link, ignores the opt-out env (explicit request), no-ops when up to date / npx / unknown.

## Tests

`src/__tests__/services/self-update.test.ts` (35 tests): install-mode detection (global / local / npx / linked via realpath symlink + `--preserve-symlinks` + unknown), **pnpm & yarn nested layouts → local with the true root**, **nested-ambiguous → unknown (never global)**, **realpath-failure → unknown (still linked when not under node_modules)**, semver compare incl. prerelease, the `checkAndSelfUpdate` policy matrix (dev→skipped-dev, opt-out→skipped-disabled, up-to-date, newer+global/local→spawn with correct `--no-audit --no-fund` args, npm-fail→unavailable, npx/unknown/realpath-fail→notify, offline→unavailable), and never-throws on any failure. Full suite: **775 passing**, build clean.

## Codex review (PR #63) follow-up

- **P1** (nested node_modules misclassified as global) — fixed: outward walk to the real project root; ambiguous → `unknown`, never `global`.
- **P2a** (realpath failure weakened safe-fail) — fixed: `realpath` dep returns `undefined` on failure → `unknown` under node_modules.
- **P2b** (non-interactive npm) — fixed: `--no-audit --no-fund` on both update paths via a constant-only args helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)