### PR TITLE
docs(blog): add Krea 2 Turbo card to Model highlights

### DIFF
--- a/docs/blog/index.mdx
+++ b/docs/blog/index.mdx
@@ -54,6 +54,11 @@ open-weight champ, Ideogram 4.
   Fast GGUF video (T2V/I2V) and the LTX Director timeline editor inside ComfyUI.
 </Card>
 
+<Card title="Krea 2 Turbo" href="/blog/krea2-comfyui">
+  Krea.ai's 12B open-weight text-to-image — 8-step turbo speed, Qwen3-VL
+  prompting, and JSON area prompts.
+</Card>
+
 <Card title="Ideogram 4 — the finale" href="/blog/ideogram-4-comfyui">
   The 9.3B open-weight king of readable in-image text and design layout, with
   JSON area prompting.


### PR DESCRIPTION
The Krea 2 post (`docs/blog/krea2-comfyui.mdx`) existed but was unlinked from the blog index "Model highlights" CardGroup. This adds a card for it immediately before the Ideogram 4 finale card, so Ideogram stays the closing entry.

Single-file, insertion-only change — `href` is `/blog/krea2-comfyui`, matching the existing post file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)