### PR TITLE
fix(codex): advertise reasoning-effort metadata so the panel shows the effort dropdown for GPT-5.5

### DIFF
--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -91,6 +91,20 @@ export type AgentEvent =
 export interface ModelChoice {
   id: string;
   label?: string;
+  /**
+   * Whether this model exposes a reasoning-effort control. The panel's
+   * `normalizeModels` reads this (and/or `supportedEffortLevels`): if NEITHER is
+   * present it treats the model as having no effort control and hides the picker.
+   * Mirrors the Agent SDK `ModelInfo.supportsEffort` shape.
+   */
+  supportsEffort?: boolean;
+  /**
+   * The reasoning-effort levels this model accepts (provider-specific scale). The
+   * panel uses these to populate the effort dropdown. Mirrors the Agent SDK
+   * `ModelInfo.supportedEffortLevels` shape (kept as a plain `string[]` so the
+   * Codex scale — none|minimal|…|xhigh — fits, not just the Claude scale).
+   */
+  supportedEffortLevels?: string[];
 }
 
 export interface BackendStartOptions {

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -354,13 +354,26 @@ class AppServerClient {
   }
 }
 
+// ---- reasoning-effort scale (advertised + applied) ----
+// The authoritative Codex reasoning-effort scale (none < minimal < low < medium <
+// high < xhigh — the app-server `turn/start` `effort` field). Defined ONCE here
+// and reused by BOTH the model advertisement below (so every Codex ModelChoice
+// tells the panel it has an effort control — the panel's normalizeModels reads
+// `supportedEffortLevels`/`supportsEffort`, and hides the picker if neither is
+// present) AND toCodexEffort() further down (the validity check), to avoid drift.
+// The backend ALREADY applies effort to every turn via toCodexEffort regardless
+// of model, so advertising it for all Codex models matches current behavior.
+const CODEX_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+
 // ---- model fallback ----
 // config/read does not enumerate a model CATALOG (it reports the active provider
 // + model), so when we can't derive a list we fall back to the current Codex
-// model family. The panel picker degrades gracefully on an empty list.
+// model family. The panel picker degrades gracefully on an empty list. Each entry
+// advertises the Codex effort scale so the panel enables the reasoning-effort
+// dropdown for these models (the backend applies effort to every turn anyway).
 const CODEX_FALLBACK_MODELS: ModelChoice[] = [
-  { id: "gpt-5.5", label: "GPT-5.5" },
-  { id: "gpt-5.5-codex", label: "GPT-5.5 Codex" },
+  { id: "gpt-5.5", label: "GPT-5.5", supportsEffort: true, supportedEffortLevels: [...CODEX_EFFORT_LEVELS] },
+  { id: "gpt-5.5-codex", label: "GPT-5.5 Codex", supportsEffort: true, supportedEffortLevels: [...CODEX_EFFORT_LEVELS] },
 ];
 
 /** Does this id look like an OpenAI/Codex model (vs. a Claude panel model)? Used
@@ -380,7 +393,7 @@ function isCodexModel(id: string): boolean {
 // scale is low|medium|high|xhigh|max. The shared levels map 1:1; the only
 // off-scale source value is Claude "max", which has no Codex equivalent and maps
 // to the nearest valid level (xhigh). Unknown/empty → null (app-server default).
-const CODEX_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+const CODEX_EFFORTS = CODEX_EFFORT_LEVELS; // single source of truth (advertised == accepted)
 function toCodexEffort(effort: string | undefined): string | null {
   if (!effort) return null;
   const e = effort.toLowerCase();
@@ -1109,6 +1122,10 @@ export class CodexBackend implements AgentBackend {
    * family). Returns [] only if even that can't be determined.
    */
   async listModels(): Promise<ModelChoice[]> {
+    // Every Codex ModelChoice MUST carry CODEX_EFFORT_LEVELS so the panel enables
+    // the reasoning-effort dropdown (the backend applies effort to every turn).
+    // The fallback already does; if a future live config/read path builds its own
+    // ModelChoice(s) here, attach `supportedEffortLevels: [...CODEX_EFFORT_LEVELS]`.
     return CODEX_FALLBACK_MODELS;
   }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -625,7 +625,18 @@ export async function runPanelOrchestrator(): Promise<void> {
             .prepare()
             .then(() => probeBackend.listModels())
             .then((list) =>
-              list.map((m) => ({ value: m.id, displayName: m.label ?? m.id }) as unknown as ModelInfo),
+              // Carry the effort metadata through to the panel's ModelInfo — without
+              // this the supportsEffort/supportedEffortLevels the Codex backend
+              // advertises get dropped here and the panel hides the effort dropdown.
+              list.map(
+                (m) =>
+                  ({
+                    value: m.id,
+                    displayName: m.label ?? m.id,
+                    ...(m.supportsEffort != null ? { supportsEffort: m.supportsEffort } : {}),
+                    ...(m.supportedEffortLevels ? { supportedEffortLevels: m.supportedEffortLevels } : {}),
+                  }) as unknown as ModelInfo,
+              ),
             )
             .catch((err) => {
               logger.warn(`[panel-orchestrator] codex model probe failed: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Bug

In the panel, the reasoning-effort dropdown was **disabled** for Codex/ChatGPT models (e.g. GPT-5.5). The panel showed:

> "GPT-5.5 has no reasoning-effort control; effort cleared."

Yet the Codex backend **does** apply reasoning effort to every turn.

## Root cause

The metadata wasn't advertised, even though the backend applies effort.

- The panel's `normalizeModels` reads `supportsEffort` / `supportedEffortLevels` off each `ModelInfo`. If **neither** is present it treats the model as having no effort control and hides the picker.
- `CODEX_FALLBACK_MODELS` (`src/orchestrator/codex-backend.ts`) carried only `{id, label}` — no effort metadata.
- `toCodexEffort()` in the same file maps and applies effort (`none|minimal|low|medium|high|xhigh`) to `turn/start` for **every** turn regardless of model. So the backend supports effort, but the model list never said so.
- Even an advertised field would have been dropped: the `ModelChoice → ModelInfo` mapping in `src/orchestrator/index.ts` (`ensureModels`, Codex probe path) kept only `value`/`displayName`.

## Fix (advertise it everywhere it flows)

1. **`src/orchestrator/agent-backend.ts`** — `ModelChoice` gains optional `supportsEffort?: boolean` and `supportedEffortLevels?: string[]`, matching the exact Agent SDK `ModelInfo` field names the panel already reads (the Claude/panel path uses these).
2. **`src/orchestrator/codex-backend.ts`** — a single shared `CODEX_EFFORT_LEVELS` const (`["none","minimal","low","medium","high","xhigh"]`) is the source of truth, reused by both the model advertisement and `toCodexEffort()` (its validity check) to avoid drift. Both `CODEX_FALLBACK_MODELS` entries (`gpt-5.5` and `gpt-5.5-codex`) now set `supportsEffort: true` and `supportedEffortLevels: [...CODEX_EFFORT_LEVELS]`. `listModels()` returns the fallback, so the live path carries the metadata too (with a comment guarding any future `config/read`-built `ModelChoice`).
3. **`src/orchestrator/index.ts`** — the `ModelChoice → ModelInfo` mapping now propagates `supportsEffort` / `supportedEffortLevels` through to the panel (the actual drop site).

## Effort scale

The authoritative Codex scale already used by `toCodexEffort`: `none | minimal | low | medium | high | xhigh`.

## Per-model note

The backend already sends `effort` unconditionally for all Codex models via `toCodexEffort`, so advertising it for both `gpt-5.5` and `gpt-5.5-codex` is consistent with current behavior (no per-model guessing).

## Result

The panel will now show the reasoning-effort dropdown for GPT-5.5 / GPT-5.5 Codex.

## Verification

- `npm run build` (tsc) exits 0.
- Orchestrator tests green: 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)