### PR TITLE
fix(manifest): dedup model existence check across all model roots

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -23,6 +23,8 @@ const execFileSyncMock = vi.hoisted(() => vi.fn());
 const installCustomNodeMock = vi.hoisted(() => vi.fn());
 const listInstalledNodesMock = vi.hoisted(() => vi.fn());
 const downloadModelMock = vi.hoisted(() => vi.fn());
+const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
+const listLocalModelsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -68,6 +70,8 @@ vi.mock("../../services/model-resolver.js", () => ({
     "unet",
   ],
   downloadModel: (...a: unknown[]) => downloadModelMock(...a),
+  resolveExistingModelFile: (...a: unknown[]) => resolveExistingModelFileMock(...a),
+  listLocalModels: (...a: unknown[]) => listLocalModelsMock(...a),
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -92,6 +96,10 @@ beforeEach(() => {
   installCustomNodeMock.mockReset().mockResolvedValue({ message: "installed node" });
   listInstalledNodesMock.mockReset().mockResolvedValue([]);
   downloadModelMock.mockReset().mockResolvedValue("/fake/ComfyUI/models/checkpoints/m.safetensors");
+  // Default: the model is found in NO root (multi-root resolver rejects, HTTP
+  // listing is empty). Individual tests override to simulate an existing model.
+  resolveExistingModelFileMock.mockReset().mockRejectedValue(new Error("not found"));
+  listLocalModelsMock.mockReset().mockResolvedValue([]);
 });
 
 describe("loadManifestFile", () => {
@@ -189,6 +197,90 @@ describe("applyManifest", () => {
       "https://example.com/model.safetensors",
       "loras",
       "model.safetensors",
+    );
+  });
+
+  it("skips a model already present in an ALTERNATE model root (extra_model_paths)", async () => {
+    // The computed target under <COMFYUI_PATH>/models does NOT exist (statMock
+    // rejects by default), but the user already has the file under an extra root
+    // declared in extra_model_paths.yaml (e.g. another drive). The multi-root
+    // resolver finds it, so we must skip — not re-download.
+    const altPath = "E:/AImodels/checkpoints/big.safetensors";
+    resolveExistingModelFileMock.mockResolvedValueOnce({
+      path: altPath,
+      root: "E:/AImodels",
+      info: { isFile: () => true },
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/big.safetensors",
+            model_type: "checkpoints",
+            filename: "big.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 0, skipped: 1, failed: 0 });
+    expect(result.results).toMatchObject([
+      { action: "model", status: "skipped", item: "big.safetensors" },
+    ]);
+    expect(result.results[0].message).toContain(altPath);
+    expect(resolveExistingModelFileMock).toHaveBeenCalledWith(
+      "checkpoints/big.safetensors",
+    );
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a model found by filename in a nested/HTTP-served root (list_local_models)", async () => {
+    // Not at the computed path and not at the exact relative path in any root,
+    // but ComfyUI serves it from a nested subfolder within the category. The
+    // category listing finds it by filename, so we skip the download.
+    listLocalModelsMock.mockResolvedValueOnce([
+      { name: "sdxl/big.safetensors", path: "checkpoints/sdxl/big.safetensors", type: "checkpoints" },
+    ]);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/big.safetensors",
+            model_type: "checkpoints",
+            filename: "big.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 0, skipped: 1, failed: 0 });
+    expect(result.results[0].status).toBe("skipped");
+    expect(listLocalModelsMock).toHaveBeenCalledWith("checkpoints");
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("downloads when the model exists in NO root (multi-root check graceful miss)", async () => {
+    // resolveExistingModelFile rejects and listLocalModels is empty (defaults):
+    // the model is genuinely absent everywhere, so we must download it.
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/new.safetensors",
+            model_type: "loras",
+            filename: "new.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(downloadModelMock).toHaveBeenCalledWith(
+      "https://example.com/new.safetensors",
+      "loras",
+      "new.safetensors",
     );
   });
 

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -235,10 +235,10 @@ describe("applyManifest", () => {
     expect(downloadModelMock).not.toHaveBeenCalled();
   });
 
-  it("skips a model found by filename in a nested/HTTP-served root (list_local_models)", async () => {
-    // Not at the computed path and not at the exact relative path in any root,
-    // but ComfyUI serves it from a nested subfolder within the category. The
-    // category listing finds it by filename, so we skip the download.
+  it("skips a CATEGORY-ROOT target found by filename anywhere in the served category", async () => {
+    // model_type: checkpoints (category-root target). Not at the computed path
+    // nor the exact relative path in any root, but ComfyUI serves it from a
+    // nested subfolder within the category. Basename-anywhere match → skip.
     listLocalModelsMock.mockResolvedValueOnce([
       { name: "sdxl/big.safetensors", path: "checkpoints/sdxl/big.safetensors", type: "checkpoints" },
     ]);
@@ -259,6 +259,57 @@ describe("applyManifest", () => {
     expect(result.results[0].status).toBe("skipped");
     expect(listLocalModelsMock).toHaveBeenCalledWith("checkpoints");
     expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a NESTED local_path model present at the exact category-relative path", async () => {
+    // Nested target asks for checkpoints/foo/model.safetensors and ComfyUI
+    // serves exactly that (foo/model.safetensors within checkpoints) → skip.
+    listLocalModelsMock.mockResolvedValueOnce([
+      { name: "foo/model.safetensors", path: "checkpoints/foo/model.safetensors", type: "checkpoints" },
+    ]);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/model.safetensors",
+            local_path: "checkpoints/foo/model.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 0, skipped: 1, failed: 0 });
+    expect(result.results[0].status).toBe("skipped");
+    expect(listLocalModelsMock).toHaveBeenCalledWith("checkpoints");
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("downloads a NESTED local_path when only a same-named file in a DIFFERENT subfolder exists", async () => {
+    // Manifest wants checkpoints/foo/model.safetensors but only
+    // checkpoints/bar/model.safetensors exists. A basename match would
+    // false-skip and leave the requested file absent — must still download.
+    listLocalModelsMock.mockResolvedValueOnce([
+      { name: "bar/model.safetensors", path: "checkpoints/bar/model.safetensors", type: "checkpoints" },
+    ]);
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          {
+            url: "https://example.com/model.safetensors",
+            local_path: "checkpoints/foo/model.safetensors",
+          },
+        ],
+      },
+    });
+
+    expect(result.summary).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(downloadModelMock).toHaveBeenCalledWith(
+      "https://example.com/model.safetensors",
+      expect.stringMatching(/checkpoints[\\/]foo/),
+      "model.safetensors",
+    );
   });
 
   it("downloads when the model exists in NO root (multi-root check graceful miss)", async () => {

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -22,6 +22,8 @@ import {
 } from "./node-management.js";
 import {
   downloadModel,
+  listLocalModels,
+  resolveExistingModelFile,
   MODEL_SUBDIRS,
   type ModelType,
 } from "./model-resolver.js";
@@ -345,6 +347,71 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Decide whether a manifest model already exists locally, honoring EVERY model
+ * root ComfyUI loads from — not just the single computed target under
+ * `<COMFYUI_PATH>/models`. ComfyUI resolves models across the primary install
+ * PLUS the extra roots declared in extra_model_paths.yaml / extra_models_config
+ * (commonly on another drive, e.g. E:\). Checking only the computed path
+ * re-downloads a large model the user already has under an alternate root.
+ *
+ * Returns the path where the file was found (absolute for filesystem hits, or a
+ * ComfyUI-relative `category/name` for HTTP hits), or undefined if it exists in
+ * no root. Best-effort and NEVER throws: any resolver failure (ComfyUI
+ * unreachable, no extra roots, cloud mode) is swallowed and we fall back to the
+ * single-path check, so a legitimate install is never blocked.
+ *
+ * Reuses the existing multi-root machinery:
+ *  - `resolveExistingModelFile` (model-resolver, #58/#60) — exact relative-path
+ *    lookup across the primary root AND every extra_model_paths root, scoped per
+ *    category, with the project's containment/symlink guards.
+ *  - `listLocalModels` — the category listing ComfyUI actually serves over HTTP
+ *    (aggregates symlinked/extra roots and nested subfolders; also works in
+ *    remote mode), with a filesystem fallback.
+ */
+async function findExistingModel(target: {
+  targetSubfolder: string;
+  filename: string;
+  targetPath: string;
+}): Promise<string | undefined> {
+  // 1. Baseline single-path check (the original behavior). Always safe and is
+  //    the source of truth when no extra roots / HTTP are reachable.
+  if (await fileExists(target.targetPath)) return target.targetPath;
+
+  // 2. Exact relative-path lookup across the primary models/ root AND every
+  //    extra_model_paths root. The category scoping inside the resolver keeps a
+  //    `.safetensors` checkpoint from matching a same-named file under loras/.
+  const relativePath = (
+    target.targetSubfolder && target.targetSubfolder !== "."
+      ? `${target.targetSubfolder}/${target.filename}`
+      : target.filename
+  ).replace(/\\/g, "/");
+  try {
+    const found = await resolveExistingModelFile(relativePath);
+    if (found.info.isFile()) return found.path;
+  } catch {
+    // Not found in any root, comfyuiPath unset, or traversal — fall through.
+  }
+
+  // 3. Filename match within the category across all roots ComfyUI serves. This
+  //    catches a model stored in a nested subfolder (e.g. checkpoints/sdxl/foo)
+  //    and, when ComfyUI is running, the HTTP-aggregated view of extra/symlinked
+  //    roots (and remote setups). Category-scoped, so cross-category same-name
+  //    files are never mistaken for a match.
+  const category = target.targetSubfolder.split(/[/\\]+/).filter(Boolean)[0];
+  if (category && (MODEL_SUBDIRS as readonly string[]).includes(category)) {
+    try {
+      const local = await listLocalModels(category);
+      const hit = local.find((m) => basename(m.name) === target.filename);
+      if (hit) return hit.path;
+    } catch {
+      // Listing unavailable — fall through to download.
+    }
+  }
+
+  return undefined;
+}
+
 function report(
   action: ManifestAction,
   item: string,
@@ -428,8 +495,9 @@ export async function applyManifest(
     const item = model.local_path ?? model.filename ?? model.url;
     try {
       const target = await resolveLocalModelPath(comfyuiPath, model);
-      if (await fileExists(target.targetPath)) {
-        results.push(report("model", item, "skipped", `Model already exists at ${target.targetPath}.`));
+      const existing = await findExistingModel(target);
+      if (existing) {
+        results.push(report("model", item, "skipped", `Model already exists at ${existing}.`));
         continue;
       }
       const saved = await downloadModel(model.url, target.targetSubfolder, target.filename);

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -393,16 +393,36 @@ async function findExistingModel(target: {
     // Not found in any root, comfyuiPath unset, or traversal — fall through.
   }
 
-  // 3. Filename match within the category across all roots ComfyUI serves. This
-  //    catches a model stored in a nested subfolder (e.g. checkpoints/sdxl/foo)
-  //    and, when ComfyUI is running, the HTTP-aggregated view of extra/symlinked
-  //    roots (and remote setups). Category-scoped, so cross-category same-name
-  //    files are never mistaken for a match.
-  const category = target.targetSubfolder.split(/[/\\]+/).filter(Boolean)[0];
+  // 3. Match within the category across all roots ComfyUI serves (when running,
+  //    the HTTP-aggregated view of extra/symlinked roots; remote setups; and a
+  //    filesystem fallback). Category-scoped, so cross-category same-name files
+  //    are never mistaken for a match.
+  //
+  //    The match precision depends on where the target lives:
+  //    - CATEGORY ROOT target (e.g. model_type: checkpoints, or local_path
+  //      "checkpoints/foo.safetensors"): the intent is "do I already have this
+  //      file anywhere in the served category?", so match by basename anywhere
+  //      (also catches a model the user stored under a nested subfolder).
+  //    - NESTED target (e.g. local_path "checkpoints/foo/model.safetensors"):
+  //      the manifest asks for that EXACT relative location. Matching by
+  //      basename here would false-skip when only a same-named file under a
+  //      DIFFERENT subfolder exists, leaving the requested file absent. So
+  //      require an exact category-relative path match instead.
+  const subSegments = target.targetSubfolder.split(/[/\\]+/).filter(Boolean);
+  const category = subSegments[0];
   if (category && (MODEL_SUBDIRS as readonly string[]).includes(category)) {
+    const isCategoryRoot = subSegments.length === 1;
+    // The category-relative path implied by the target (strip the leading
+    // category segment), normalized to forward slashes for comparison.
+    const relWithinCategory = [...subSegments.slice(1), target.filename].join("/");
     try {
       const local = await listLocalModels(category);
-      const hit = local.find((m) => basename(m.name) === target.filename);
+      const hit = local.find((m) => {
+        const name = m.name.replace(/\\/g, "/");
+        return isCategoryRoot
+          ? basename(name) === target.filename
+          : name === relWithinCategory;
+      });
       if (hit) return hit.path;
     } catch {
       // Listing unavailable — fall through to download.


### PR DESCRIPTION
## Bug

`apply_manifest` (and the on-load pack install path that runs through it) **re-downloaded a model the user already had**. For a large model this wastes bandwidth and disk.

## Root cause

The "already exists, skip" check was a **single-path** check. `resolveLocalModelPath` computes ONE target under `<COMFYUI_PATH>/models/<subfolder>/<filename>` and the loop only `stat()`'d that one path:

```ts
const target = await resolveLocalModelPath(comfyuiPath, model);
if (await fileExists(target.targetPath)) { ...skip... }
```

But ComfyUI resolves models across **multiple roots** — the primary install plus every directory declared in `extra_model_paths.yaml` / `extra_models_config.yaml` (commonly another drive, e.g. `E:\`), and nested subfolders within a category. A model already present under an alternate root was missed, so it re-downloaded.

## Fix

Broaden only the **existence** check to honor every root ComfyUI loads from, via a new best-effort `findExistingModel()` helper. The download target logic (`resolveLocalModelPath`) is unchanged.

Reuses the project's existing multi-root machinery (no new resolution logic):

1. **Baseline single-path check** — original behavior, the source of truth when no extra roots / HTTP are reachable.
2. **`resolveExistingModelFile`** (from `model-resolver.ts`, the multi-root resolver added in #58/#60) — exact relative-path lookup across the primary `models/` root **and** every `extra_model_paths` root, scoped per category, with the project's existing containment/symlink guards.
3. **`listLocalModels(category)`** — the category listing ComfyUI actually serves over HTTP (aggregates symlinked/extra roots and nested subfolders, and works in remote mode), with a filesystem fallback. Match precision depends on the target:
   - **Category-root target** (`model_type`, or a `local_path` directly under the category): match by **basename anywhere** in the served category — the "do I already have this file somewhere in this category?" case, which also catches a model the user filed under a nested subfolder.
   - **Nested `local_path` target** (e.g. `checkpoints/foo/model.safetensors`): require an **exact category-relative path match** (separators normalized to forward slashes). Basename-anywhere here would false-skip when only a same-named file under a *different* subfolder exists, leaving the requested file absent.

If found in any root → reported `skipped` ("Model already exists at <path where it was found>"). Only if found in **no** root → download (to the same computed target as before).

### Graceful fallback

`findExistingModel()` **never throws**. Any resolver failure (ComfyUI unreachable, no extra roots, cloud/remote mode, traversal rejection) is swallowed and we fall back to the original single-path check, so a legitimate install is never blocked.

### Category scoping

Matching is category-scoped throughout, so a `.safetensors` checkpoint will never be mistaken for a same-named file under `loras/`. Symlinked roots resolve correctly (`resolveExistingModelFile` uses `stat`, which follows links; `listLocalModels` reflects ComfyUI's served view).

## Tests

`npm run build` exits 0; full suite green. Added to `src/__tests__/services/manifest.test.ts`:

- a model present in an **alternate extra root** (`extra_model_paths`) is reported `skipped`, not re-downloaded, and the skip message names the alternate path;
- a **category-root** target is `skipped` when found by basename anywhere in the served category (incl. a nested subfolder);
- a **nested `local_path`** present at the **exact** category-relative path is `skipped`;
- a **nested `local_path`** whose basename exists only under a **different** subfolder still **downloads** (no false-skip);
- a genuine **miss in all roots** still downloads (graceful-fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
