### PR TITLE
feat(panel): panel_set_node_mode tool + inspect-modes/verify-output guidance

### DIFF
--- a/plugin/skills/director/SKILL.md
+++ b/plugin/skills/director/SKILL.md
@@ -21,6 +21,13 @@ The Director skill orchestrates a complete short film production from a text sto
 - Each scene is independently retryable without affecting others
 - `clear_vram` between every model family switch
 
+## CRITICAL: Inspect modes + verify every output
+
+This pipeline drives the user's live canvas across many stages, so two habits are non-negotiable:
+
+- **Inspect node modes before each render.** After loading any pack/template/subgraph and before `panel_run`, call `panel_get_graph` and check each node's `mode`. A `bypass` node is skipped (passes input through); a `mute` node and everything downstream don't execute. If the path/branch/switch you need is bypassed or muted, enable it with `panel_set_node_mode` (set the wanted node `active`, the unwanted one `bypass`/`mute`). Never assume a switch or route is already active.
+- **Verify the output matches before moving on.** Every Phase-N render is a gate: actually LOOK at the produced frame/clip (view it) and confirm it matches the intent BEFORE advancing or reporting progress. If it's wrong, diagnose (wrong prompt path? a bypassed/muted builder or switch? wrong widget? wrong ref image?), fix, and rerun. Do NOT declare a phase done or report progress you haven't verified.
+
 ## CRITICAL: Character Consistency
 
 **Independent Z-Image generations per scene produce different-looking characters.** This was the #1 problem discovered during testing. The solution:

--- a/plugin/skills/krea2-txt2img/SKILL.md
+++ b/plugin/skills/krea2-txt2img/SKILL.md
@@ -55,9 +55,18 @@ adherence and structured-JSON prompts.
 ## JSON / area prompting
 
 Like Ideogram 4, Krea 2's Qwen3-VL encoder reads structured prompts (per-region
-desc + bounding boxes + palettes). To use it: **un-bypass `Ideogram4PromptBuilderKJ`
-(node 14) and bypass the manual prompt (node 143)** — the rgthree `Any Switch`
-feeds whichever is active into the encoder. Gotchas learned the hard way:
+desc + bounding boxes + palettes). The pack ships with BOTH a manual-prompt node
+and the JSON builder, picked by an rgthree `Any Switch` — and the JSON builder
+ships **bypassed**, so by default the manual prompt wins. To drive it from the
+JSON builder: **set `Ideogram4PromptBuilderKJ` (node 14) to mode 'active' and the
+manual prompt (node 143) to mode 'bypass'** — on the live canvas use
+`panel_set_node_mode` for both, then re-read with `panel_get_graph` to confirm the
+modes actually flipped (the `Any Switch` feeds whichever is active into the
+encoder). Do NOT assume the switch is already on the path you want — a stale
+bypass here silently renders the wrong (old manual) prompt. After the render,
+VERIFY the image matches the JSON you set (view it) BEFORE continuing; if it
+doesn't, the builder is probably still bypassed or a field is stale — fix and
+rerun. Gotchas learned the hard way:
 
 - **Set ALL the builder fields**, not just the prompt/boxes — `background`,
   `technical`, `style`, `lighting` (widgets 3/5/6/7). Leaving stale values leaks

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -113,6 +113,34 @@ describe("panel-tools: copy/paste + subgraph blueprints", () => {
   });
 });
 
+describe("panel-tools: panel_set_node_mode (bypass/mute/active)", () => {
+  it("is present in the shared def list", () => {
+    const names = buildPanelToolDefs().map((d) => d.name);
+    expect(names).toContain("panel_set_node_mode");
+  });
+
+  it("exposes a node_id + mode enum schema with exactly active/bypass/mute", () => {
+    const def = defByName("panel_set_node_mode");
+    expect(Object.keys(def.schema).sort()).toEqual(["mode", "node_id"]);
+    // The mode enum must match the executor contract EXACTLY.
+    const mode = def.schema.mode as { options: string[] };
+    expect([...mode.options].sort()).toEqual(["active", "bypass", "mute"]);
+    // node_id rejects non-numbers (typed like the other per-node tools).
+    const nodeId = def.schema.node_id as { safeParse: (v: unknown) => { success: boolean } };
+    expect(nodeId.safeParse(7).success).toBe(true);
+  });
+
+  it("forwards graph_set_node_mode with node_id + mode", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_set_node_mode").handler({ node_id: 143, mode: "bypass" }, ctx);
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_set_node_mode",
+      node_id: 143,
+      mode: "bypass",
+    });
+  });
+});
+
 describe("panel-tools: panel_load_workflow path (server-side disk read)", () => {
   it("reads an ABSOLUTE workflow .json off disk and fires graph_load with its graph", async () => {
     const dir = mkdtempSync(join(tmpdir(), "wf-load-"));

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -84,6 +84,10 @@ Adult / NSFW content is gated behind an explicit, persistent consent mode — qu
 
 SHOW / DISPLAY IMAGES AND VIDEOS — whenever the user asks to see, show, or display an image or video that you generated, composited, downloaded, or found — whether it is a file on disk (absolute path on the orchestrator host) or a ComfyUI output ref ({ filename, subfolder?, type? }) — call panel_show_media to render it as a media card directly in this chat. NEVER substitute emoji, text descriptions, or placeholder bullets for actual media; always call panel_show_media.
 
+INSPECT NODE MODES BEFORE YOU RUN. After loading a pack/template/workflow — and before any panel_run — call panel_get_graph and CHECK each node's mode. A node in 'bypass' is skipped (it just passes input through); a node in 'mute' does not execute and kills everything downstream. Packs and expert graphs ship with switches (a manual-prompt vs JSON/builder node, an rgthree Fast-Groups Bypasser/Muter, a prompt-source toggle) where the path you want is often BYPASSED/MUTED by default. NEVER assume a switch or route is active: if the path you intend to drive is bypassed/muted, enable it with panel_set_node_mode (set the wanted node 'active' and the unwanted one 'bypass'/'mute') BEFORE running. A wrong/stale mode is a top cause of renders that come out wrong.
+
+VERIFY THE OUTPUT MATCHES THE REQUEST. After a render completes, actually LOOK at the image/video the panel delivers and confirm it matches what was asked BEFORE you declare success or move to the next step. If it doesn't match, do NOT report progress — diagnose (wrong prompt path? a bypassed/muted builder or switch? wrong widget value?), fix it (often panel_set_node_mode or panel_set_widget), and rerun. Only claim something works once you've SEEN that it does — never report progress you haven't verified.
+
 AFTER PANEL_RUN — once you call panel_run to queue a render, you will be notified automatically with the output image(s)/video when it finishes. Do not poll get_queue, get_history, or list_output_images waiting for the result — just end your turn and the finished render will be delivered to you.`;
 
 /**

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -303,7 +303,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   return [
     def(
       "panel_get_graph",
-      "Read the workflow the user is CURRENTLY VIEWING on their canvas (root graph or an opened subgraph — 'viewing' says which): node ids, types, titles, widget values, and connections. Subgraph nodes are summarized shallowly — drill in with panel_get_subgraph. ALWAYS call this before your first edit so ids and slot names are accurate. This is the user's live graph — they watch your edits happen. Read-only.",
+      "Read the workflow the user is CURRENTLY VIEWING on their canvas (root graph or an opened subgraph — 'viewing' says which): node ids, types, titles, widget values, connections, and each node's MODE ('active', 'bypass', or 'mute'). Subgraph nodes are summarized shallowly — drill in with panel_get_subgraph. ALWAYS call this before your first edit so ids and slot names are accurate. CHECK THE MODE of every node on the path you care about: a node with mode 'bypass' is skipped (it just passes its input through) and one with mode 'mute' does not execute (and kills everything downstream) — so a BYPASSED/MUTED node means that part of the graph is OFF and may be why a render uses the wrong prompt/branch. If the path you intend to use is bypassed or muted, enable it with panel_set_node_mode before running. This is the user's live graph — they watch your edits happen. Read-only.",
       {},
       async (_args, ctx) => ctx.call({ cmd: "graph_get_state" }),
     ),
@@ -1063,6 +1063,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       },
       async (args: A, ctx) =>
         ctx.call({ cmd: "graph_set_node_collapsed", node_id: args.node_id, collapsed: args.collapsed }),
+    ),
+    def(
+      "panel_set_node_mode",
+      "Set a node's EXECUTION MODE on the user's open graph — active, bypass, or mute — and return { node_id, mode, previous_mode }. This is how you turn a node ON or OFF without deleting it. Modes:\n" +
+        "• 'active' — normal: the node executes.\n" +
+        "• 'bypass' — the node is SKIPPED and PASSES ITS INPUT THROUGH to its output (downstream still runs, just as if this node weren't there). Use to disable a single processing node (an upscaler, a LoRA, a detailer) while keeping the pipeline connected.\n" +
+        "• 'mute' — the node AND everything DOWNSTREAM of it do NOT execute (no pass-through). Use to fully switch off a branch/output.\n" +
+        "CRITICAL — modes silently change what a render produces, so they are a top cause of 'wrong output'. A BYPASSED node contributes nothing of its own and a MUTED node kills its branch. Use this tool to ENABLE the path you actually want and DISABLE the one you don't — e.g. to drive a workflow from its Ideogram/JSON prompt builder you must set the manual-prompt node to 'bypass' and the JSON-builder path to 'active' (or vice-versa); likewise to pick one branch of an rgthree 'Fast Groups Bypasser'/Muter or a prompt-source switch. ALWAYS read modes first with panel_get_graph: if the intended path is bypassed/muted, fix it HERE before running, and never assume a switch/route is already active. Undoable with Ctrl+Z.",
+      {
+        node_id: z.number().int().describe("Node id from panel_get_graph."),
+        mode: z
+          .enum(["active", "bypass", "mute"])
+          .describe(
+            "'active' = runs normally; 'bypass' = skipped, passes input through (downstream still runs); 'mute' = node and everything downstream do not execute.",
+          ),
+      },
+      async (args: A, ctx) =>
+        ctx.call({ cmd: "graph_set_node_mode", node_id: args.node_id, mode: args.mode }),
     ),
     def(
       "panel_set_node_color",


### PR DESCRIPTION
## Why

A live-canvas agent loaded a KREA pack, set the JSON-builder fields, but left those nodes **bypassed** and never verified — so the render used the stale manual prompt and produced the wrong image, yet the agent declared progress. Two root gaps: (1) no tool to bypass/un-bypass a node, and (2) the agent never inspected node modes or verified the output matched the request.

## What

**New tool — `panel_set_node_mode`** (matches the panel executor contract exactly):
- Dispatches bridge command `graph_set_node_mode` with args `{ node_id, mode }`, `mode ∈ "active" | "bypass" | "mute"`; executor returns `{ node_id, mode, previous_mode }`.
- `node_id`: `z.number().int()` (same typing as the other per-node panel tools); `mode`: `z.enum(["active","bypass","mute"])`.
- Strong description explaining bypass (skipped, passes input through) vs mute (node + downstream don't execute) vs active, and when to use it (enabling one path of an rgthree Fast-Groups Bypasser / a prompt-source switch / a JSON builder).
- Lives in the shared `buildPanelToolDefs` list, so BOTH transports pick it up automatically — the in-process Anthropic Agent SDK server (`createPanelMcpServer`) and the HTTP MCP server for Codex (`registerPanelTools` / `panel-mcp-http.ts`). No explicit per-tool lists to update.

**`panel_get_graph` surfaces mode:** description now states the response reports each node's `mode` and that bypassed/muted nodes must be checked. The handler forwards `graph_get_state` verbatim (no post-processing), so the new `mode` field passes straight through.

**Agent guidance:**
- System prompt (`PANEL_SYSTEM_APPEND`): inspect node modes after loading a pack/template and before any `panel_run` — fix a bypassed/muted intended path with `panel_set_node_mode`, never assume a switch is active; after a render, view the output and verify it matches before declaring success or advancing; don't report unverified progress.
- `krea2-txt2img` skill: the pack has both a manual prompt and an Ideogram-JSON builder behind an rgthree `Any Switch` (builder ships bypassed) — to drive from the builder, set node 14 `active` + node 143 `bypass` via `panel_set_node_mode`, re-read to confirm, then verify the rendered image before continuing.
- `director` skill: added a general inspect-modes + verify-every-output rule for the multi-stage live-canvas pipeline.

## Tests / build
- `npm run build` (tsc) exits 0.
- `panel-tools.test.ts`: added a case asserting `panel_set_node_mode` is present, its schema is `{ node_id, mode }` with the mode enum exactly `active/bypass/mute`, and it forwards `graph_set_node_mode`. All 15 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)