### PR TITLE
Add stage_output_as_input + resolveInputDir (honor custom ComfyUI input/output dirs)

### DIFF
--- a/plugin/skills/director/SKILL.md
+++ b/plugin/skills/director/SKILL.md
@@ -226,11 +226,15 @@ Show hero frame and all character refs. User approves or requests regeneration w
 
 Edits are **sequential** — each depends on the previous output:
 1. Run edit, wait for completion
-2. `upload_image` the output
-3. Use uploaded output as source for next edit
+2. **Stage the output as the next stage's input with `stage_output_as_input`** (pass the output's `{ filename, subfolder?, type? }`); it returns the registered input filename
+3. Use that returned filename as the `image` in the next edit's `LoadImage`
 4. Update state file after each edit
 
 Independent edits (both from hero) can run in parallel.
+
+### CRITICAL: feeding an output into the next loader (don't guess paths)
+
+To pipe ANY stage's output into the next stage's loader (`LoadImage` here, `VHS_LoadVideo` / `LoadAudio` in the video phases), call **`stage_output_as_input`** with the output's `{ filename, subfolder?, type? }` and drop the returned input filename into the loader's `image`/`video`/`audio` widget. For a file already on local disk, use `upload_image` / `upload_video` / `upload_audio`. **NEVER copy the output file into, or guess, a filesystem `input/` path** — ComfyUI's input and output directories may be CUSTOM (`--input-directory` / `--output-directory`), so a guessed path makes the loader reject the file (`Invalid image file`) and wastes the render. `stage_output_as_input` goes through the server API (`/view` → `/upload/image`), which resolves the real dirs correctly.
 
 ### Timing
 

--- a/plugin/skills/ltxv2-video/SKILL.md
+++ b/plugin/skills/ltxv2-video/SKILL.md
@@ -219,6 +219,18 @@ Dedicated sigma schedule for LTX-V2 latent space:
 
 Connect the optional `latent` input for latent-aware shift scaling.
 
+> **Feeding a prior stage's output into I2V (e.g. Krea2 image → LTX video).** The
+> `LoadImage` that feeds `LTXVImgToVideo.image` needs the source frame registered
+> as a ComfyUI INPUT. When that frame is an OUTPUT from an earlier stage, call
+> **`stage_output_as_input`** with its `{ filename, subfolder?, type? }` and drop
+> the returned input filename into `LoadImage`. (For a file already on local
+> disk, `upload_image`.) **NEVER copy the output file into, or guess, a
+> filesystem `input/` path** — ComfyUI's input/output dirs may be CUSTOM
+> (`--input-directory` / `--output-directory`), so a guessed path makes
+> `LoadImage` reject the file (`Invalid image file`) and wastes the render.
+> `stage_output_as_input` goes through the server API (`/view` → `/upload/image`)
+> and resolves the real dirs correctly.
+
 ### LTXVImgToVideo (For I2V)
 
 All-in-one node that encodes image, creates latent, and wraps conditioning:

--- a/plugin/skills/video-extend/SKILL.md
+++ b/plugin/skills/video-extend/SKILL.md
@@ -372,6 +372,15 @@ This also matters for **chaining** — color-match every new segment to the
 Pusa adds a bounded window (~4 s) per run. To go longer, **feed the output back
 in**:
 
+0. **Stage the output clip as the next run's input** with
+   **`stage_output_as_input`** (pass the rendered clip's
+   `{ filename, subfolder?, type? }`); use the returned input filename in
+   `VHS_LoadVideo`. **NEVER copy the output .mp4 into, or guess, a filesystem
+   `input/` path** — ComfyUI's input/output dirs may be CUSTOM
+   (`--input-directory` / `--output-directory`), so a guessed path makes
+   `VHS_LoadVideo` fail to find/decode the file and wastes the run. The tool
+   routes through the server API (`/view` → `/upload/image`), which resolves the
+   real dirs correctly. (For a clip already on local disk, `upload_video`.)
 1. Run the extension → decode → save (or keep the frames in-graph).
 2. Take the **tail of the *new* output** (the last ~13 frames) as the next
    `WanVideoEncode` input.

--- a/plugin/skills/wan-flf-video/SKILL.md
+++ b/plugin/skills/wan-flf-video/SKILL.md
@@ -521,7 +521,7 @@ When the start and end frames have different subject sizes (e.g., small cat → 
 1. **Generate anchor frame** with Z-Image/SDXL/Flux (portrait orientation for standing subjects)
 2. **Qwen Edit to create second frame** — the edit preserves scene context
 3. **Clear VRAM** between model families
-4. **Upload both frames** with `upload_image`
+4. **Stage both frames as inputs.** When the frames are ComfyUI OUTPUTS from a prior stage (the generated/edited frames above), use **`stage_output_as_input`** with each output's `{ filename, subfolder?, type? }` and feed the returned input filename into each `LoadImage`. (For a frame already on local disk, use `upload_image`.) **NEVER copy the output file into, or guess, a filesystem `input/` path** — ComfyUI's input/output dirs may be CUSTOM (`--input-directory` / `--output-directory`), so a guessed path makes `LoadImage` reject the file (`Invalid image file`) and wastes the render. `stage_output_as_input` routes through the server API (`/view` → `/upload/image`), which resolves the real dirs correctly.
 5. **Run dual hi-lo FLF** with morph LoRA if morphing is desired
 6. **Optionally upscale** with SeedVR2 to 1080p
 

--- a/src/__tests__/services/media-upload.test.ts
+++ b/src/__tests__/services/media-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { join } from "node:path";
+import { resolve } from "node:path";
 
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/comfy" as string | undefined },
@@ -27,6 +27,8 @@ import {
   uploadVideoLocal,
   uploadAudioAuto,
   uploadAudioLocal,
+  stageOutputAsInput,
+  inferMediaKind,
 } from "../../services/image-management.js";
 import { ValidationError } from "../../utils/errors.js";
 
@@ -93,11 +95,11 @@ describe("uploadVideoLocal / uploadAudioLocal (filesystem)", () => {
     const r = await uploadVideoLocal("/src/clip.mov");
     expect(copyFileMock).toHaveBeenCalledWith(
       "/src/clip.mov",
-      join("/comfy", "input", "clip.mov"),
+      resolve("/comfy", "input", "clip.mov"),
     );
     expect(r).toEqual({
       filename: "clip.mov",
-      path: join("/comfy", "input", "clip.mov"),
+      path: resolve("/comfy", "input", "clip.mov"),
     });
   });
 
@@ -114,5 +116,120 @@ describe("uploadVideoLocal / uploadAudioLocal (filesystem)", () => {
       ValidationError,
     );
     expect(copyFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("inferMediaKind", () => {
+  it("classifies image / video / audio by extension", () => {
+    expect(inferMediaKind("frame_00001_.png")).toBe("image");
+    expect(inferMediaKind("LTX_video_00001.mp4")).toBe("video");
+    expect(inferMediaKind("score.wav")).toBe("audio");
+  });
+
+  it("throws on an unknown extension", () => {
+    expect(() => inferMediaKind("notes.txt")).toThrow(ValidationError);
+  });
+});
+
+describe("stageOutputAsInput (output → input via server API)", () => {
+  beforeEach(() => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("bytes").toString("base64"),
+      mimeType: "application/octet-stream",
+    });
+  });
+
+  it("fetches the output via /view and re-uploads an image with the image mime", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "Krea2_00001_.png",
+      subfolder: "",
+      type: "input",
+    });
+    const r = await stageOutputAsInput({ filename: "Krea2_00001_.png" });
+    expect(fetchImageMock).toHaveBeenCalledWith("Krea2_00001_.png", "output", "");
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "Krea2_00001_.png",
+      expect.any(Buffer),
+      "image/png",
+    );
+    expect(r).toEqual({
+      filename: "Krea2_00001_.png",
+      subfolder: "",
+      type: "input",
+      kind: "image",
+    });
+  });
+
+  it("infers video and uploads with the video mime", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "LTX_00001.mp4",
+      subfolder: "",
+      type: "input",
+    });
+    const r = await stageOutputAsInput({ filename: "LTX_00001.mp4" });
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "LTX_00001.mp4",
+      expect.any(Buffer),
+      "video/mp4",
+    );
+    expect(r.kind).toBe("video");
+  });
+
+  it("infers audio and uploads with the audio mime", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "track.wav",
+      subfolder: "",
+      type: "input",
+    });
+    const r = await stageOutputAsInput({ filename: "track.wav" });
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "track.wav",
+      expect.any(Buffer),
+      "audio/wav",
+    );
+    expect(r.kind).toBe("audio");
+  });
+
+  it("honors type:temp and an as_filename override", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "staged.png",
+      subfolder: "",
+      type: "input",
+    });
+    await stageOutputAsInput({
+      filename: "preview.png",
+      type: "temp",
+      subfolder: "previews",
+      asFilename: "staged.png",
+    });
+    expect(fetchImageMock).toHaveBeenCalledWith("preview.png", "temp", "previews");
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "staged.png",
+      expect.any(Buffer),
+      "image/png",
+    );
+  });
+
+  it("respects an explicit kind override", async () => {
+    uploadImageHttpMock.mockResolvedValueOnce({
+      name: "clip.webm",
+      subfolder: "",
+      type: "input",
+    });
+    const r = await stageOutputAsInput({ filename: "clip.webm", kind: "video" });
+    expect(uploadImageHttpMock).toHaveBeenCalledWith(
+      "clip.webm",
+      expect.any(Buffer),
+      "video/webm",
+    );
+    expect(r.kind).toBe("video");
+  });
+
+  it("rejects an unknown extension before fetching", async () => {
+    await expect(stageOutputAsInput({ filename: "data.bin" })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    expect(fetchImageMock).not.toHaveBeenCalled();
+    expect(uploadImageHttpMock).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -14,6 +14,9 @@ import {
   parseOutputDirFromArgv,
   localOutputDirFallback,
   resolveOutputDir,
+  parseInputDirFromArgv,
+  localInputDirFallback,
+  resolveInputDir,
 } from "../../services/output-dir.js";
 import { config } from "../../config.js";
 
@@ -96,5 +99,78 @@ describe("resolveOutputDir", () => {
   it("falls back to <COMFYUI_PATH>/output when /system_stats is unreachable", async () => {
     getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
     expect(await resolveOutputDir()).toBe(resolve("/comfy", "output"));
+  });
+});
+
+describe("parseInputDirFromArgv", () => {
+  it("returns undefined when no relevant flags are present", () => {
+    expect(parseInputDirFromArgv(["python", "main.py", "--listen"])).toBeUndefined();
+    expect(parseInputDirFromArgv([])).toBeUndefined();
+    expect(parseInputDirFromArgv(undefined)).toBeUndefined();
+  });
+
+  it("parses --input-directory <value>", () => {
+    const abs = resolve("/shared/ComfyUI-Shared/input");
+    const got = parseInputDirFromArgv(["main.py", "--input-directory", abs]);
+    expect(got).toBe(abs);
+  });
+
+  it("parses --input-directory=<value>", () => {
+    const abs = resolve("/shared/in");
+    expect(parseInputDirFromArgv(["main.py", `--input-directory=${abs}`])).toBe(abs);
+  });
+
+  it("derives <base>/input from --base-directory", () => {
+    const base = resolve("/srv/comfy-base");
+    expect(parseInputDirFromArgv(["main.py", "--base-directory", base])).toBe(
+      join(base, "input"),
+    );
+  });
+
+  it("lets --input-directory win over --base-directory", () => {
+    const base = resolve("/srv/base");
+    const inp = resolve("/srv/explicit-in");
+    const got = parseInputDirFromArgv([
+      "main.py",
+      "--base-directory",
+      base,
+      "--input-directory",
+      inp,
+    ]);
+    expect(got).toBe(inp);
+  });
+});
+
+describe("localInputDirFallback", () => {
+  it("returns <COMFYUI_PATH>/input", () => {
+    expect(localInputDirFallback()).toBe(resolve("/comfy", "input"));
+  });
+
+  it("throws when COMFYUI_PATH is unset", () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    expect(() => localInputDirFallback()).toThrow(/COMFYUI_PATH/);
+  });
+});
+
+describe("resolveInputDir", () => {
+  it("uses the redirected dir reported by /system_stats argv", async () => {
+    const redirected = resolve("/shared/ComfyUI-Shared/input");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", "main.py", "--input-directory", redirected] },
+    });
+    const got = await resolveInputDir();
+    expect(got).toBe(redirected);
+    expect(got).not.toBe(resolve("/comfy", "input"));
+    expect(isAbsolute(got)).toBe(true);
+  });
+
+  it("falls back to <COMFYUI_PATH>/input when argv has no override", async () => {
+    getSystemStats.mockResolvedValue({ system: { argv: ["python", "main.py"] } });
+    expect(await resolveInputDir()).toBe(resolve("/comfy", "input"));
+  });
+
+  it("falls back to <COMFYUI_PATH>/input when /system_stats is unreachable", async () => {
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveInputDir()).toBe(resolve("/comfy", "input"));
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -88,7 +88,9 @@ INSPECT NODE MODES BEFORE YOU RUN. After loading a pack/template/workflow — an
 
 VERIFY THE OUTPUT MATCHES THE REQUEST. After a render completes, actually LOOK at the image/video the panel delivers and confirm it matches what was asked BEFORE you declare success or move to the next step. If it doesn't match, do NOT report progress — diagnose (wrong prompt path? a bypassed/muted builder or switch? wrong widget value?), fix it (often panel_set_node_mode or panel_set_widget), and rerun. Only claim something works once you've SEEN that it does — never report progress you haven't verified.
 
-AFTER PANEL_RUN — once you call panel_run to queue a render, you will be notified automatically with the output image(s)/video when it finishes. Do not poll get_queue, get_history, or list_output_images waiting for the result — just end your turn and the finished render will be delivered to you.`;
+AFTER PANEL_RUN — once you call panel_run to queue a render, you will be notified automatically with the output image(s)/video when it finishes. Do not poll get_queue, get_history, or list_output_images waiting for the result — just end your turn and the finished render will be delivered to you.
+
+CHAIN A STAGE'S OUTPUT INTO THE NEXT STAGE'S LOADER — when a multi-stage pipeline (e.g. Krea2 image → LTX video → WAN extend) needs one stage's OUTPUT fed into the next stage's loader (LoadImage / VHS_LoadVideo / LoadAudio), call stage_output_as_input with the output's { filename, subfolder?, type? } and drop the returned input filename into the loader's image/video/audio widget. (Or, for a file already on disk, upload_image / upload_video / upload_audio.) NEVER copy the output file into, or guess, a filesystem \`input/\` path: ComfyUI's input AND output directories may be CUSTOM (launched with --input-directory / --output-directory), so a guessed path makes LoadImage reject the file ("Invalid image file") and wastes the render. stage_output_as_input goes through the server API (/view → /upload/image), which resolves the real dirs correctly every time.`;
 
 /**
  * The panel auto-sends one of a few fixed "resume" nudges after ComfyUI restarts

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -3,15 +3,15 @@ import { join, basename, extname } from "node:path";
 import { config } from "../config.js";
 import { ValidationError, ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { resolveOutputDir } from "./output-dir.js";
+import { resolveOutputDir, resolveInputDir } from "./output-dir.js";
 
-function getInputDir(): string {
-  if (!config.comfyuiPath) {
-    throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
-    );
-  }
-  return join(config.comfyuiPath, "input");
+/**
+ * Resolve ComfyUI's REAL input directory (honors a custom --input-directory /
+ * --base-directory). Used only for genuine local filesystem copies; HTTP uploads
+ * go through the server API and don't need a path.
+ */
+async function getInputDir(): Promise<string> {
+  return resolveInputDir();
 }
 
 /**
@@ -22,7 +22,7 @@ export async function uploadImage(
   sourcePath: string,
   filename?: string,
 ): Promise<{ filename: string; path: string }> {
-  const inputDir = getInputDir();
+  const inputDir = await getInputDir();
   const resolvedFilename = filename ?? basename(sourcePath);
 
   // Validate extension
@@ -247,19 +247,13 @@ export async function uploadImageAuto(
 ): Promise<{ filename: string }> {
   const resolvedFilename = filename ?? basename(sourcePath);
   const ext = extname(resolvedFilename).toLowerCase();
-  const allowed = [".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif", ".tiff", ".tif"];
-  if (!allowed.includes(ext)) {
+  if (!(ext in IMAGE_MIME)) {
     throw new ValidationError(
-      `Unsupported image format "${ext}". Supported: ${allowed.join(", ")}`,
+      `Unsupported image format "${ext}". Supported: ${Object.keys(IMAGE_MIME).join(", ")}`,
     );
   }
   const data = await nodeReadFile(sourcePath);
-  const mimeMap: Record<string, string> = {
-    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
-    ".webp": "image/webp", ".bmp": "image/bmp", ".gif": "image/gif",
-    ".tiff": "image/tiff", ".tif": "image/tiff",
-  };
-  const mimeType = mimeMap[ext] ?? "application/octet-stream";
+  const mimeType = IMAGE_MIME[ext] ?? "application/octet-stream";
   logger.info("Uploading image to ComfyUI via HTTP", { sourcePath, resolvedFilename });
   const result = await uploadImageHttp(resolvedFilename, data, mimeType);
   return { filename: result.name };
@@ -270,6 +264,17 @@ export async function uploadImageAuto(
 // (and the input/ directory) accept arbitrary media, which video/audio loader
 // nodes (e.g. VHS_LoadVideo, LoadAudio) then read by filename.
 // ---------------------------------------------------------------------------
+
+const IMAGE_MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".gif": "image/gif",
+  ".tiff": "image/tiff",
+  ".tif": "image/tiff",
+};
 
 const VIDEO_MIME: Record<string, string> = {
   ".mp4": "video/mp4",
@@ -326,7 +331,7 @@ async function uploadMediaLocal(
   mimeMap: Record<string, string>,
   kind: "video" | "audio",
 ): Promise<{ filename: string; path: string }> {
-  const inputDir = getInputDir();
+  const inputDir = await getInputDir();
   const resolvedFilename = filename ?? basename(sourcePath);
   resolveMediaMime(resolvedFilename, mimeMap, kind);
   const targetPath = join(inputDir, resolvedFilename);
@@ -349,3 +354,113 @@ export const uploadAudioAuto = (sourcePath: string, filename?: string) =>
   uploadMediaHttp(sourcePath, filename, AUDIO_MIME, "audio");
 export const uploadAudioLocal = (sourcePath: string, filename?: string) =>
   uploadMediaLocal(sourcePath, filename, AUDIO_MIME, "audio");
+
+// ---------------------------------------------------------------------------
+// stage_output_as_input — pipe one pipeline stage's OUTPUT into the next stage's
+// loader (LoadImage / VHS_LoadVideo / LoadAudio) the CORRECT way: fetch the bytes
+// from the ComfyUI server (/view) and re-register them as an INPUT via the same
+// /upload/image endpoint the upload_* tools use. Because both legs go through the
+// server API, this works even when ComfyUI was launched with a CUSTOM
+// --input-directory / --output-directory — unlike copying or guessing a
+// filesystem input/ path, which the server then rejects ("Invalid image file").
+// ---------------------------------------------------------------------------
+
+export type MediaKind = "image" | "video" | "audio";
+
+const MIME_BY_KIND: Record<MediaKind, Record<string, string>> = {
+  image: IMAGE_MIME,
+  video: VIDEO_MIME,
+  audio: AUDIO_MIME,
+};
+
+/** Infer image/video/audio from a filename's extension. */
+export function inferMediaKind(filename: string): MediaKind {
+  const ext = extname(filename).toLowerCase();
+  if (ext in IMAGE_MIME) return "image";
+  if (ext in VIDEO_MIME) return "video";
+  if (ext in AUDIO_MIME) return "audio";
+  throw new ValidationError(
+    `Cannot infer media kind from extension "${ext}". ` +
+      `Pass an explicit kind ("image" | "video" | "audio").`,
+  );
+}
+
+/** Resolve the upload MIME type for a filename within a given media kind. */
+function mimeForKind(filename: string, kind: MediaKind): string {
+  const ext = extname(filename).toLowerCase();
+  const mime = MIME_BY_KIND[kind][ext];
+  if (!mime) {
+    throw new ValidationError(
+      `Extension "${ext}" is not a supported ${kind} format. ` +
+        `Supported: ${Object.keys(MIME_BY_KIND[kind]).join(", ")}`,
+    );
+  }
+  return mime;
+}
+
+export interface StageOutputAsInputArgs {
+  /** Filename of the existing output/temp asset (from get_history / list_output_images). */
+  filename: string;
+  /** Subfolder the asset lives in, if any. */
+  subfolder?: string;
+  /** Source directory the asset currently lives in. "output" (default) or "temp" (previews). */
+  type?: "output" | "temp";
+  /** Force the media kind instead of inferring from the extension. */
+  kind?: MediaKind;
+  /** Override the filename it is registered under in the input/ directory. */
+  asFilename?: string;
+}
+
+export interface StagedInput {
+  /** Filename to drop into the loader's image/video/audio widget. */
+  filename: string;
+  /** Subfolder ComfyUI stored it under (usually ""). */
+  subfolder: string;
+  /** ComfyUI directory it now lives in (always "input"). */
+  type: string;
+  /** Detected/forced media kind. */
+  kind: MediaKind;
+}
+
+/**
+ * Stage an EXISTING ComfyUI output (or temp preview) as an INPUT, ready to feed
+ * into the next stage's LoadImage / VHS_LoadVideo / LoadAudio loader.
+ *
+ * Fetches the bytes from the server via /view (the same path get_image uses) and
+ * re-registers them as an input via /upload/image (the same path upload_image /
+ * upload_video / upload_audio use). Goes entirely through the server API, so it
+ * is correct even when ComfyUI runs with a custom input/output directory.
+ */
+export async function stageOutputAsInput(
+  args: StageOutputAsInputArgs,
+): Promise<StagedInput> {
+  const sourceType = args.type ?? "output";
+  const kind = args.kind ?? inferMediaKind(args.filename);
+  const targetName = args.asFilename ?? basename(args.filename);
+  const mimeType = mimeForKind(targetName, kind);
+
+  // Fetch the existing asset's bytes via the same /view mechanism the asset
+  // tools use (fetchImage handles cloud vs local). Despite the name, /view
+  // returns raw bytes for any media type, not just images.
+  const { base64 } = await fetchImage(
+    args.filename,
+    sourceType,
+    args.subfolder ?? "",
+  );
+  const data = Buffer.from(base64, "base64");
+
+  logger.info("Staging ComfyUI output as input via server API", {
+    source: args.filename,
+    sourceType,
+    kind,
+    targetName,
+  });
+
+  const result = await uploadImageHttp(targetName, data, mimeType);
+  return {
+    filename: result.name,
+    subfolder: result.subfolder,
+    type: result.type,
+    kind,
+  };
+}

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -66,6 +66,72 @@ export function localOutputDirFallback(): string {
   return resolve(config.comfyuiPath, "output");
 }
 
+// ---------------------------------------------------------------------------
+// Resolve ComfyUI's REAL input directory — the exact mirror of the output-dir
+// logic above. ComfyUI can be launched with --input-directory (or
+// --base-directory) which redirects the LoadImage / VHS_LoadVideo / LoadAudio
+// search path away from the default <COMFYUI_PATH>/input. Filesystem-path tools
+// that write or check files in the input directory must therefore NOT assume
+// <COMFYUI_PATH>/input, or a server with a custom --input-directory rejects the
+// file ("Invalid image file") while the tool reports success. Prefer the server
+// API (/upload/image, see stage_output_as_input) when possible; use this only
+// for genuine local filesystem operations.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the configured input directory out of ComfyUI's launch argv.
+ * --input-directory wins; otherwise --base-directory implies <base>/input.
+ * Returns undefined when neither flag is present.
+ */
+export function parseInputDirFromArgv(argv: string[] | undefined): string | undefined {
+  if (!argv || argv.length === 0) return undefined;
+
+  let inputDir: string | undefined;
+  let baseDir: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    inputDir = flagValue(argv, i, "--input-directory") ?? inputDir;
+    baseDir = flagValue(argv, i, "--base-directory") ?? baseDir;
+  }
+
+  const resolvedBase = baseDir ? resolveDir(baseDir) : undefined;
+  if (inputDir) return resolveDir(inputDir, resolvedBase);
+  if (resolvedBase) return join(resolvedBase, "input");
+  return undefined;
+}
+
+/** <COMFYUI_PATH>/input fallback. Throws if COMFYUI_PATH is unset. */
+export function localInputDirFallback(): string {
+  if (!config.comfyuiPath) {
+    throw new ValidationError(
+      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
+    );
+  }
+  return resolve(config.comfyuiPath, "input");
+}
+
+/**
+ * Resolve the directory ComfyUI actually reads inputs from. Asks the running
+ * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/input.
+ */
+export async function resolveInputDir(): Promise<string> {
+  try {
+    const stats = await getSystemStats();
+    const fromArgv = parseInputDirFromArgv(stats.system?.argv);
+    if (fromArgv) {
+      logger.debug("Resolved ComfyUI input directory from launch argv", {
+        inputDir: fromArgv,
+      });
+      return fromArgv;
+    }
+  } catch (err) {
+    logger.debug(
+      "Could not resolve input dir from /system_stats; using COMFYUI_PATH/input",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+  return localInputDirFallback();
+}
+
 /**
  * Resolve the directory ComfyUI actually writes outputs to. Asks the running
  * ComfyUI (/system_stats argv) first; falls back to <COMFYUI_PATH>/output.

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -9,6 +9,7 @@ import {
   uploadImageAuto,
   uploadVideoAuto,
   uploadAudioAuto,
+  stageOutputAsInput,
 } from "../services/image-management.js";
 import { errorToToolResult } from "../utils/errors.js";
 
@@ -155,6 +156,92 @@ export function registerImageManagementTools(server: McpServer): void {
       "for images or upload_video for video.",
     uploadAudioAuto,
     "as the audio file input in LoadAudio (or similar) nodes",
+  );
+
+  // ── stage_output_as_input ─────────────────────────────────────────────────
+  // The correct, dir-agnostic way to pipe one pipeline stage's output into the
+  // next stage's loader. Fetches the output via /view and re-registers it as an
+  // input via /upload/image — never touches the filesystem, so it works with
+  // custom --input-directory / --output-directory.
+  server.tool(
+    "stage_output_as_input",
+    "Stage an EXISTING ComfyUI output (or temp/preview) as an INPUT so the next " +
+      "stage's loader (LoadImage / VHS_LoadVideo / LoadAudio) can read it. This " +
+      "is the CORRECT way to chain a multi-stage pipeline (e.g. Krea2 image → " +
+      "LTX video → WAN extend): it fetches the output's bytes from the server " +
+      "via /view and re-registers them as an input via /upload/image — the same " +
+      "endpoints get_image and upload_image use. Because it goes entirely " +
+      "through the server API, it works even when ComfyUI was launched with a " +
+      "CUSTOM input/output directory. Do NOT instead copy the output file or " +
+      "guess a filesystem `input/` path — the server's input dir may be custom " +
+      "and it will reject the file (\"Invalid image file\"), wasting the render. " +
+      "Pass an existing output reference ({ filename, subfolder?, type? }); the " +
+      "media kind (image/video/audio) is inferred from the extension unless you " +
+      "set `kind`. Returns the registered input { filename, subfolder, type: " +
+      "\"input\", kind } — drop the returned `filename` straight into the " +
+      "loader's image/video/audio widget.",
+    {
+      filename: z
+        .string()
+        .describe(
+          "Filename of the existing output/temp asset (from get_history or list_output_images), e.g. LTX_video_00001.mp4",
+        ),
+      subfolder: z
+        .string()
+        .optional()
+        .describe("Subfolder the asset currently lives in, if any"),
+      type: z
+        .enum(["output", "temp"])
+        .optional()
+        .default("output")
+        .describe(
+          "Source directory the asset lives in: output (default) or temp (previews)",
+        ),
+      kind: z
+        .enum(["image", "video", "audio"])
+        .optional()
+        .describe(
+          "Force the media kind instead of inferring it from the file extension",
+        ),
+      as_filename: z
+        .string()
+        .optional()
+        .describe(
+          "Override the filename it is registered under in the input/ directory (defaults to the source filename)",
+        ),
+    },
+    async (args) => {
+      try {
+        const staged = await stageOutputAsInput({
+          filename: args.filename,
+          subfolder: args.subfolder,
+          type: args.type ?? "output",
+          kind: args.kind,
+          asFilename: args.as_filename,
+        });
+        const loaderHint =
+          staged.kind === "video"
+            ? "the video file input in VHS_LoadVideo (or similar)"
+            : staged.kind === "audio"
+              ? "the audio input in LoadAudio (or similar)"
+              : "the `image` input in LoadImage";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Staged ${staged.kind} output as input via the server API.\n\n` +
+                `Input filename: ${staged.filename}\n` +
+                `subfolder: ${staged.subfolder || "(none)"}\n` +
+                `type: ${staged.type}\n\n` +
+                `Use "${staged.filename}" as ${loaderHint}.`,
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 
   // ── workflow_from_image ───────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In a multi-stage pipeline (Krea2 image → LTX video → WAN extend) the agent must feed each stage's OUTPUT into the next stage's loader (`LoadImage` / `VHS_LoadVideo` / `LoadAudio`). It fumbled this: it tried to COPY the output file to a guessed `input/` path, but ComfyUI's input dir was CUSTOM (`--input-directory`), so `LoadImage` rejected the file (`Invalid image file`) and wasted a render. Two gaps: no one-shot "stage an output as an input", and no `resolveInputDir` (path tools assumed the default input dir).

## PART A — `stage_output_as_input` tool

The correct, directory-agnostic way to pipe one stage's output into the next stage's loader.

- **Args:** `{ filename, subfolder?, type?("output"|"temp", default "output"), kind?("image"|"video"|"audio"), as_filename? }`
- **Behavior:** fetches the existing asset's bytes via the SAME `/view` mechanism the asset tools use (`fetchImage`), then re-registers them as an INPUT via the SAME `/upload/image` endpoint the `upload_*` tools use (`uploadImageHttp`). Media kind is inferred from the extension (or forced via `kind`).
- **Returns:** `{ filename, subfolder, type: "input", kind }` — drop `filename` straight into the loader's `image`/`video`/`audio` widget.
- Goes entirely through the server API, so it works even with custom input/output dirs — unlike copying files.

Service: `stageOutputAsInput` in `src/services/image-management.ts`; tool registered in `src/tools/image-management.ts`.

## PART B — `resolveInputDir`

`src/services/output-dir.ts` now exports `parseInputDirFromArgv`, `localInputDirFallback`, and `resolveInputDir()` — the exact mirror of the existing `resolveOutputDir`, parsing `--input-directory` (and `--base-directory` → `<base>/input`) from `/system_stats` argv, falling back to `<COMFYUI_PATH>/input`.

Wired in: `image-management.ts`'s `getInputDir()` (used by the local-filesystem copy paths `uploadImage` / `uploadMediaLocal`) now routes through `resolveInputDir()`, so filesystem uploads honor a custom input dir. (HTTP-based input fetches in view-image/storage-upload/image-convert already go through `/view` and need no path.)

## PART C — guidance

A tight rule added to:
- `PANEL_SYSTEM_APPEND` (`src/orchestrator/index.ts`)
- `plugin/skills/director/SKILL.md` (edit-chain step)
- `plugin/skills/video-extend/SKILL.md` (chaining extensions)
- `plugin/skills/ltxv2-video/SKILL.md` (I2V image input)
- `plugin/skills/wan-flf-video/SKILL.md` (start/end frame staging)

Rule: to feed a stage's output into the next `LoadImage`/`VHS_LoadVideo`/`LoadAudio`, use `stage_output_as_input` (or `upload_image`/`upload_video`/`upload_audio`) — NEVER copy or guess a filesystem `input/` path; only the server API resolves custom input/output dirs correctly.

## Tests

- `output-dir.test.ts`: `parseInputDirFromArgv`, `localInputDirFallback`, `resolveInputDir` (mirror the output-dir cases).
- `media-upload.test.ts`: `inferMediaKind` + `stageOutputAsInput` endpoint selection (image/video/audio mime), `type:temp` + `as_filename`, explicit `kind`, and unknown-extension rejection before any fetch.

`npm run build` exits 0; full suite green (801 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)