### PR TITLE
Investigate turn-gate drain P1: read-ahead deadlock NOT reproducible on real backends (+ regression guard)

### DIFF
--- a/src/__tests__/orchestrator/turn-gate-drain.test.ts
+++ b/src/__tests__/orchestrator/turn-gate-drain.test.ts
@@ -58,16 +58,69 @@ beforeAll(async () => {
  * produced on an independent queue — exactly how `streamInput` (input) and
  * `readMessages` (output) run as separate fire-and-forget tasks in the real SDK.
  *
- * Critically the pump reads the NEXT turn from the channel as soon as it has
- * written the current one (read-ahead), so when the current turn finishes the
- * channel is already parked inside the pump's pending `channel.next()`.
+ * Two properties make this a DETERMINISTIC guard (no wall-clock sleeps gate the
+ * ordering, so CI jitter can't make the assertion vacuous):
+ *
+ *  • READ-AHEAD: as soon as a turn is read the pump starts reading the NEXT turn
+ *    (`it.next()`) WITHOUT awaiting it before emitting the current turn's result —
+ *    so the panel channel is parked inside the pump's pending `channel.next()`
+ *    (i.e. at the turn gate) while the current turn is "in flight". If a future
+ *    change reintroduces a read-ahead/gate deadlock, that pending read never
+ *    resolves, the next turn never starts, and the test FAILS (times out).
+ *
+ *  • MANUAL RELEASE: each turn's terminal `result` is withheld until the test
+ *    calls `releaseTurn()`. So the test can prove a message was queued DURING the
+ *    turn (before its result) rather than racing a timer. `markStarted` lets the
+ *    test await "turn N has been read by the pump" deterministically.
  */
 class ConcurrentPumpBackend implements AgentBackend {
   readonly id = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
   turns: string[] = [];
   interrupted = 0;
-  private breakTurn: (() => void) | null = null;
+  /** One resolver per in-flight turn, FIFO — resolved by `releaseTurn()` to emit
+   *  that turn's `result`. */
+  private releaseResolvers: Array<() => void> = [];
+  /** How many turns the pump has READ so far (in flight), + waiters for a count. */
+  private startedCount = 0;
+  private startedWaiters: Array<{ n: number; resolve: () => void }> = [];
+
+  private markStarted(): void {
+    this.startedCount += 1;
+    this.startedWaiters = this.startedWaiters.filter((w) => {
+      if (this.startedCount >= w.n) {
+        w.resolve();
+        return false;
+      }
+      return true;
+    });
+  }
+
+  /** Resolve once the pump has READ at least `n` turns (each is then in flight,
+   *  with its result withheld). Rejects after `timeoutMs` so a reintroduced gate
+   *  deadlock — where the next turn never starts — fails the test fast instead of
+   *  hanging. No sleeps gate the happy path; the timeout is only a failure cap. */
+  waitStarted(n: number, timeoutMs = 2000): Promise<void> {
+    if (this.startedCount >= n) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`turn ${n} never started (gate did not drain) — ${this.turns.length} read`)),
+        timeoutMs,
+      );
+      this.startedWaiters.push({
+        n,
+        resolve: () => {
+          clearTimeout(timer);
+          resolve();
+        },
+      });
+    });
+  }
+
+  /** Release the OLDEST in-flight turn so its `result` is emitted (opens the gate). */
+  releaseTurn(): void {
+    this.releaseResolvers.shift()?.();
+  }
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     const out: AgentEvent[] = [];
@@ -79,22 +132,27 @@ class ConcurrentPumpBackend implements AgentBackend {
       wakeOut = null;
     };
 
-    // INPUT PUMP — concurrent, read-ahead. Mirrors SDK `streamInput`.
+    // INPUT PUMP — concurrent, read-ahead, manual per-turn result release.
     const pump = (async () => {
-      for await (const turn of opts.channel) {
-        this.turns.push(turn.text);
-        // The turn runs and finishes: emit its terminal events on the OUTPUT
-        // queue, decoupled from this pump. Then the for-await immediately reads
-        // the NEXT turn (read-ahead) — which parks at the panel's turn gate.
-        emit({ type: "assistant", text: `reply to: ${turn.text}` });
-        // Let the turn "hang" a tick so a second message can queue while busy,
-        // then finish it. The result is what must open the gate.
+      const it = opts.channel[Symbol.asyncIterator]();
+      let r = await it.next(); // read turn 1
+      while (!r.done) {
+        this.turns.push(r.value.text);
+        emit({ type: "assistant", text: `reply to: ${r.value.text}` });
+        // DECOUPLED read-ahead: begin reading the NEXT turn now, concurrently,
+        // WITHOUT awaiting it before this turn's result (mirrors the SDK, whose
+        // input pump and output reader are independent). This parks the panel
+        // channel at the turn gate while the current turn is in flight.
+        const readAhead = it.next();
+        // Withhold this turn's result until the test releases it.
         await new Promise<void>((resolve) => {
-          this.breakTurn = resolve;
-          setTimeout(resolve, 10);
+          this.releaseResolvers.push(resolve);
+          this.markStarted();
         });
-        this.breakTurn = null;
         emit({ type: "result", ok: true, subtype: "success" });
+        // Consume the read-ahead: resolves only once the gate opened and the next
+        // batch drained (or the channel closed on stop()).
+        r = await readAhead;
       }
       inputDone = true;
       wakeOut?.();
@@ -119,9 +177,11 @@ class ConcurrentPumpBackend implements AgentBackend {
 
   async interrupt(): Promise<void> {
     this.interrupted += 1;
-    const brk = this.breakTurn;
-    this.breakTurn = null;
-    brk?.();
+    // Release every still-held turn so the pump unblocks and the run loop can wind
+    // down (used by agent.stop() teardown — otherwise the pump parks forever).
+    const held = this.releaseResolvers;
+    this.releaseResolvers = [];
+    for (const r of held) r();
   }
   async listModels(): Promise<ModelChoice[]> {
     return [];
@@ -140,14 +200,6 @@ function makeDeps(turns: Array<"working" | "done">) {
   };
 }
 
-async function waitFor(cond: () => boolean, timeoutMs = 1500): Promise<void> {
-  const start = Date.now();
-  while (!cond()) {
-    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
-    await new Promise((r) => setTimeout(r, 5));
-  }
-}
-
 describe("turn gate drains the next queued batch when a turn ends (no read-ahead deadlock)", () => {
   it("delivers a message queued during turn N right after N's result — with NO later message arriving", async () => {
     const turns: Array<"working" | "done"> = [];
@@ -155,17 +207,22 @@ describe("turn gate drains the next queued batch when a turn ends (no read-ahead
     const agent = new PanelAgent("tab-drain", makeDeps(turns) as never, backend);
     void agent.start();
 
-    // Turn 1 starts.
+    // Turn 1 starts and is held in flight (its result withheld).
     agent.send("first message");
-    await waitFor(() => backend.turns.length === 1);
+    await backend.waitStarted(1);
+    expect(backend.turns).toEqual(["first message"]);
+    expect(agent.isBusy).toBe(true);
 
-    // While turn 1 is in flight, queue a second message. This is the message that
-    // must drain when turn 1 ends — and NOTHING else is ever sent afterwards.
+    // PROVABLY queued DURING turn 1: turn 1's result has not been emitted yet
+    // (we haven't released it), so this message lands behind the gate. Nothing
+    // else is ever sent afterwards.
     agent.send("second message queued behind the first");
 
-    // The invariant: turn 1 ends -> gate opens -> turn 2 is delivered promptly,
-    // with no dependency on a further user message.
-    await waitFor(() => backend.turns.length === 2, 1500);
+    // End turn 1. The invariant: the gate opens and turn 2 is delivered, with no
+    // dependency on any further user message. (If the gate deadlocks, turn 2 never
+    // starts and waitStarted(2) rejects → test fails.)
+    backend.releaseTurn();
+    await backend.waitStarted(2);
     expect(backend.turns[1]).toContain("second message");
 
     await agent.stop();
@@ -178,12 +235,13 @@ describe("turn gate drains the next queued batch when a turn ends (no read-ahead
     void agent.start();
 
     agent.send("A");
-    await waitFor(() => backend.turns.length === 1);
-    // Queue B and C while A is busy; they should batch into the next turn.
+    await backend.waitStarted(1);
+    // Queue B and C while A is held in flight; they must batch into the next turn.
     agent.send("B");
     agent.send("C");
 
-    await waitFor(() => backend.turns.length === 2, 1500);
+    backend.releaseTurn(); // end turn A
+    await backend.waitStarted(2);
     expect(backend.turns[1]).toContain("B");
     expect(backend.turns[1]).toContain("C");
 

--- a/src/__tests__/orchestrator/turn-gate-drain.test.ts
+++ b/src/__tests__/orchestrator/turn-gate-drain.test.ts
@@ -1,0 +1,192 @@
+// Reproduction harness for the turn-gate "stuck after a turn ends" P1.
+//
+// Symptom: after a turn ACTUALLY finishes, the agent stays busy/"thinking"
+// forever and NEVER drains the messages queued behind it — they sit PENDING and
+// only the slow freeze watchdog eventually breaks the logjam. Send-now (interrupt)
+// works; it's the NORMAL turn-end -> drain-next-queued path that's stuck.
+//
+// These fake backends model the REAL provider ordering where the agent runtime
+// reads the channel AHEAD of finishing the current turn (the Claude Agent SDK's
+// `streamInput` pump eagerly pulls the next user message while the current turn is
+// still producing output). The assertion is the invariant the panel must hold:
+//   a completed turn opens the gate and the next queued batch is delivered,
+//   EVEN IF no further user message ever arrives.
+//
+// INVESTIGATION NOTE (2026-06): the hypothesized "read-ahead deadlock" (the SDK
+// blocks on reading the next channel item before emitting turn N's `result`, while
+// the gate blocks the read until N's result → circular hang) was NOT reproducible
+// on the real backends:
+//   • The Claude Agent SDK runs its input pump (`streamInput`) and output reader
+//     (`readMessages`) as INDEPENDENT concurrent tasks, so turn N's `result` is
+//     enqueued to the output stream regardless of the input pump being parked at
+//     the gate (verified in node_modules/.../sdk.mjs).
+//   • A LIVE probe against the real `claude` CLI confirmed it emits turn 1's
+//     `result/success` with NO second user input ever sent — i.e. the result is
+//     NOT withheld pending the next stdin line. So the gate cannot deadlock it.
+//   • The Codex backend emits each turn's `result` (runTurn) BEFORE the outer
+//     `for await (const turn of opts.channel)` reads the next turn — sequential,
+//     not coupled.
+// The gate deadlocks ONLY under a COUPLED model (a backend that awaits the next
+// channel item before emitting the prior turn's result) — an ordering no current
+// backend exhibits, and one whose fix is fundamentally incompatible with the
+// send-now interrupt re-queue (which relies on the queue staying the source of
+// truth until a turn completes). So this file is a GREEN REGRESSION GUARD for the
+// drain invariant (it passes on current code), not a failing reproduction.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+// Keep the freeze watchdog FAR away so it can't mask a gate stall: the whole
+// point is that the gate must drain WITHOUT the watchdog's help.
+process.env.COMFYUI_MCP_TURN_IDLE_MS = String(60_000);
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/**
+ * Faithful model of the Claude Agent SDK transport: an INPUT PUMP task drains the
+ * channel concurrently (read-ahead) while OUTPUT (assistant/result events) is
+ * produced on an independent queue — exactly how `streamInput` (input) and
+ * `readMessages` (output) run as separate fire-and-forget tasks in the real SDK.
+ *
+ * Critically the pump reads the NEXT turn from the channel as soon as it has
+ * written the current one (read-ahead), so when the current turn finishes the
+ * channel is already parked inside the pump's pending `channel.next()`.
+ */
+class ConcurrentPumpBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  interrupted = 0;
+  private breakTurn: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    const out: AgentEvent[] = [];
+    let wakeOut: (() => void) | null = null;
+    let inputDone = false;
+    const emit = (ev: AgentEvent) => {
+      out.push(ev);
+      wakeOut?.();
+      wakeOut = null;
+    };
+
+    // INPUT PUMP — concurrent, read-ahead. Mirrors SDK `streamInput`.
+    const pump = (async () => {
+      for await (const turn of opts.channel) {
+        this.turns.push(turn.text);
+        // The turn runs and finishes: emit its terminal events on the OUTPUT
+        // queue, decoupled from this pump. Then the for-await immediately reads
+        // the NEXT turn (read-ahead) — which parks at the panel's turn gate.
+        emit({ type: "assistant", text: `reply to: ${turn.text}` });
+        // Let the turn "hang" a tick so a second message can queue while busy,
+        // then finish it. The result is what must open the gate.
+        await new Promise<void>((resolve) => {
+          this.breakTurn = resolve;
+          setTimeout(resolve, 10);
+        });
+        this.breakTurn = null;
+        emit({ type: "result", ok: true, subtype: "success" });
+      }
+      inputDone = true;
+      wakeOut?.();
+      wakeOut = null;
+    })();
+
+    emit({ type: "session", sessionId: "sess-pump" });
+    try {
+      while (!inputDone || out.length) {
+        if (!out.length) {
+          await new Promise<void>((resolve) => {
+            wakeOut = resolve;
+          });
+          continue;
+        }
+        yield out.shift()!;
+      }
+    } finally {
+      await pump.catch(() => {});
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    this.interrupted += 1;
+    const brk = this.breakTurn;
+    this.breakTurn = null;
+    brk?.();
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeDeps(turns: Array<"working" | "done">) {
+  return {
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: (_tab: string, state: "working" | "done") => {
+      turns.push(state);
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 1500): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("turn gate drains the next queued batch when a turn ends (no read-ahead deadlock)", () => {
+  it("delivers a message queued during turn N right after N's result — with NO later message arriving", async () => {
+    const turns: Array<"working" | "done"> = [];
+    const backend = new ConcurrentPumpBackend();
+    const agent = new PanelAgent("tab-drain", makeDeps(turns) as never, backend);
+    void agent.start();
+
+    // Turn 1 starts.
+    agent.send("first message");
+    await waitFor(() => backend.turns.length === 1);
+
+    // While turn 1 is in flight, queue a second message. This is the message that
+    // must drain when turn 1 ends — and NOTHING else is ever sent afterwards.
+    agent.send("second message queued behind the first");
+
+    // The invariant: turn 1 ends -> gate opens -> turn 2 is delivered promptly,
+    // with no dependency on a further user message.
+    await waitFor(() => backend.turns.length === 2, 1500);
+    expect(backend.turns[1]).toContain("second message");
+
+    await agent.stop();
+  });
+
+  it("drains several messages queued behind one busy turn, in order", async () => {
+    const turns: Array<"working" | "done"> = [];
+    const backend = new ConcurrentPumpBackend();
+    const agent = new PanelAgent("tab-drain2", makeDeps(turns) as never, backend);
+    void agent.start();
+
+    agent.send("A");
+    await waitFor(() => backend.turns.length === 1);
+    // Queue B and C while A is busy; they should batch into the next turn.
+    agent.send("B");
+    agent.send("C");
+
+    await waitFor(() => backend.turns.length === 2, 1500);
+    expect(backend.turns[1]).toContain("B");
+    expect(backend.turns[1]).toContain("C");
+
+    await agent.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Investigation of the reported P1 — *after a turn actually finishes, the panel agent stays busy/\"thinking\" forever and never drains its queued messages; only the 3.5-min freeze watchdog eventually breaks the logjam, while the send-now interrupt path works* — with the strong hypothesis being a **read-ahead/turn-gate deadlock** (the SDK blocks reading the next channel item to finalize turn N's `result`, while `channel()` parks waiting for that result → circular hang).

**Conclusion: the read-ahead deadlock is NOT reproducible on either real backend.** This PR ships **no behavior change** — only a green regression guard for the drain invariant plus the documented evidence. Per the task's instruction (*\"if you cannot reproduce a stuck gate, say so clearly — do NOT ship a speculative patch\"*), no gate rewrite was made.

## Evidence (reproduced, not guessed)

1. **The Claude Agent SDK decouples input and output.** In `node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs` the `Query` constructor starts the output reader and the streaming-input dispatch starts the input pump as **independent fire-and-forget tasks**:
   - `this.sdkMessages = this.readSdkMessages(); this.readMessages();` (output)
   - streaming-input dispatch: `e.streamInput(r).catch(n => o.abort(n))` (input pump)
   So turn N's `result` is enqueued to the output stream by `readMessages` **regardless** of the input pump (`streamInput`) being parked at the panel's turn gate. The gate cannot starve the result.

2. **Live probe against the real `claude` CLI.** Streaming ONE user message and never sending a second, the CLI emitted `result/success` at ~3.37s with `secondInputEverSent=false`. The CLI does **not** withhold a turn's result pending the next stdin line, so the gate cannot deadlock it.

3. **The Codex backend is sequential.** `runTurn` emits the turn's `result` (on `turn/completed` or via `emitTerminalError`) **before** the outer `for await (const turn of opts.channel)` reads the next turn — no read-ahead coupling.

4. **Faithful decoupled simulation drains correctly.** A fake backend modeling the real SDK (concurrent input pump with read-ahead + an independent output queue) delivers a message queued during turn N immediately after N's `result`, with no later message required — including a 60-message bursty stress run (no strands, no idle-reset race).

5. **The deadlock reproduces ONLY under a COUPLED model** — a backend that `await`s reading the next channel item *before* emitting the prior turn's `result`. No current backend does this, and a fix for that case is **fundamentally incompatible with the send-now interrupt re-queue**: the gate exists precisely so the queue stays the source of truth (a prematurely read-ahead message would overwrite `inFlight` and be unreorderable/lost on interrupt). Removing/loosening the gate to satisfy a coupled backend re-introduces the send-now message-loss bug the gate fixed.

## Why no patch

Because (a) neither real backend exhibits the coupling the deadlock requires, and (b) the only change that would break a coupled deadlock would regress the working send-now path, shipping a gate change here would trade a non-occurring bug for a real regression. The most likely real-world cause of the observed symptom is a genuine **mid-turn stall** (slow/hung tool, network/rate-limit pause) that the existing freeze watchdog correctly catches at `TURN_IDLE_MS` (default 210s) — the gate correctly holds queued messages behind it until then. Faster stall detection was previously considered and dropped by the user, and is out of scope.

## What this PR adds

`src/__tests__/orchestrator/turn-gate-drain.test.ts` — a **green** regression guard (passes on current code) that locks the invariant: *a completed turn opens the gate and the next queued batch is delivered even if no further user message ever arrives*, using a faithful decoupled concurrent-pump backend. It would catch any future regression that reintroduces a coupling or breaks the drain.

## Untouched

Send-now/interrupt re-queue, the freeze watchdog, the idle counter-reset, and rapid-fire batching are all unchanged. Existing suites stay green.

## Verification

- `npm run build` exits 0
- `npm test` → **810 passed** (incl. turn-watchdog, send-now-requeue, and the new drain guard); orchestrator subset 41/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)