### PR TITLE
fix(mcp): interrupt releases the gate on the aborted turn's result (no synchronous gate-open)

### DIFF
--- a/src/__tests__/orchestrator/send-now-requeue.test.ts
+++ b/src/__tests__/orchestrator/send-now-requeue.test.ts
@@ -21,10 +21,11 @@ beforeAll(async () => {
 
 /**
  * A backend that records the text of every turn it receives from the channel.
- * Each turn HANGS (emits a session then waits) until `interrupt()` is called,
- * which ends the in-flight run iteration and lets the channel release the next
- * batch — mirroring how a real interrupt breaks the live stream. After interrupt
- * the generator's for-await resumes and pulls the next turn.
+ * Each turn HANGS (emits a session then waits) until `interrupt()` is called.
+ * On interrupt the aborted turn emits a terminal `result` event — mirroring how
+ * the real Claude SDK emits a result message for an interrupted turn — which is
+ * what releases the turn gate (via completeTurn) at the right moment. The
+ * for-await then pulls the next (re-queued) batch.
  */
 class RecordingBackend implements AgentBackend {
   readonly id = "claude" as const;
@@ -34,6 +35,9 @@ class RecordingBackend implements AgentBackend {
   interrupted = 0;
   /** Resolver for the currently-hanging turn (called by interrupt()). */
   private breakTurn: (() => void) | null = null;
+  /** Set by interrupt() so the resumed turn knows to emit an interrupted result
+   *  (rather than a stop/teardown, where we just exit). */
+  private brokenByInterrupt = false;
   /** When true a turn completes cleanly (emits result) instead of hanging. */
   autoComplete = false;
 
@@ -51,6 +55,12 @@ class RecordingBackend implements AgentBackend {
         this.breakTurn = resolve;
       });
       this.breakTurn = null;
+      if (this.brokenByInterrupt) {
+        // The interrupted turn ends with a result (like the real SDK) — this is
+        // the signal that releases the turn gate for the next batch.
+        this.brokenByInterrupt = false;
+        yield { type: "result", ok: false, subtype: "interrupted" };
+      }
     }
   }
 
@@ -58,6 +68,7 @@ class RecordingBackend implements AgentBackend {
     this.interrupted += 1;
     const brk = this.breakTurn;
     this.breakTurn = null;
+    if (brk) this.brokenByInterrupt = true;
     brk?.();
   }
 
@@ -105,8 +116,10 @@ describe("send-now re-queues the interrupted message", () => {
     // second message. (A plain Stop would NOT re-queue — see the test below.)
     await agent.interrupt({ requeueInFlight: true });
 
-    // The next turn must combine BOTH, interrupted-first.
-    await waitFor(() => backend.turns.length === 2);
+    // The next turn must combine BOTH, interrupted-first — and arrive PROMPTLY
+    // (driven by the interrupted turn's result, not the slow release fallback or
+    // the multi-minute idle watchdog). 500ms guards against regressing to either.
+    await waitFor(() => backend.turns.length === 2, 500);
     const second = backend.turns[1];
     expect(second).toContain("first message"); // interrupted message NOT dropped
     expect(second).toContain("urgent second message"); // new message included

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -46,6 +46,14 @@ function msgOf(err: unknown): string {
  *  COMFYUI_MCP_TURN_IDLE_MS. Default 3.5 min. */
 const TURN_IDLE_MS = Number(process.env.COMFYUI_MCP_TURN_IDLE_MS) || 210_000;
 
+/** How long after an interrupt to wait for the aborted turn's `result` (which
+ *  releases the turn gate at the correct moment) before force-releasing it as a
+ *  fallback. Short enough to feel immediate if a result somehow never arrives;
+ *  in the normal case the result lands well within this and the gate opens then.
+ *  Overridable (tuning / tests) via COMFYUI_MCP_INTERRUPT_RELEASE_MS. */
+const INTERRUPT_RELEASE_FALLBACK_MS =
+  Number(process.env.COMFYUI_MCP_INTERRUPT_RELEASE_MS) || 1500;
+
 /** Reasoning effort levels. This is the PROVIDER-NEUTRAL union of every backend's
  *  scale so a value chosen for one provider survives a switch to another:
  *    • Claude scale: low | medium | high | xhigh | max
@@ -198,6 +206,14 @@ export class PanelAgent {
   private yieldedTurns = 0;
   private completedTurns = 0;
   private turnWaiter: (() => void) | null = null;
+  /** After an interrupt we DON'T force the turn gate open synchronously — that
+   *  fed the next batch into the backend before the aborted turn had settled, so
+   *  Claude took the message into the session but started no turn on it (wedged
+   *  until the slow idle watchdog or the next message). Instead the aborted
+   *  turn's `result` event drives completeTurn() at the right moment; this is a
+   *  short fallback that opens the gate anyway if no result ever arrives, so an
+   *  interrupt can never stop cold. */
+  private interruptReleaseTimer: ReturnType<typeof setTimeout> | null = null;
   /** Mutable so the model/effort picker can change them at runtime. */
   private model: string;
   private effort?: Effort;
@@ -437,6 +453,11 @@ export class PanelAgent {
     // both clear it and have us re-queue a stale copy.
     const interrupted = this.inFlight;
     this.inFlight = null;
+    // The turn that's in flight RIGHT NOW — the one we're aborting. Captured
+    // before the await so the release fallback below targets exactly this turn's
+    // gate (not a later one the channel may legitimately advance to if the
+    // aborted turn's result lands during the await).
+    const interruptedTurn = this.yieldedTurns;
     // Re-queue the interrupted turn ONLY for "send now" (requeueInFlight) — there
     // the user wants BOTH the interrupted message and the new one answered. A plain
     // Stop / Ctrl+C / Esc (requeueInFlight=false) must NOT re-queue, or it would
@@ -451,7 +472,47 @@ export class PanelAgent {
     } catch (err) {
       logger.debug(`[panel-agent ${this.short()}] interrupt: ${msgOf(err)}`);
     } finally {
-      this.releaseTurns();
+      // Do NOT force the gate open here. Synchronously releasing it fed the next
+      // batch (the re-queued turn + the "send now" message) into Claude before the
+      // aborted turn had settled — the SDK took the message into the session but
+      // started no turn on it, so it sat wedged until the slow idle watchdog (or
+      // the user's next message) nudged it. Instead let the aborted turn's
+      // `result` event drive completeTurn() — that fires once the SDK has finished
+      // tearing the turn down and is ready for the next prompt, so the re-queued
+      // batch is fed at the right moment and answered immediately. The fallback
+      // guarantees we still advance if no result ever arrives.
+      this.armInterruptReleaseFallback(interruptedTurn);
+    }
+  }
+
+  /** Bounded safety net for interrupt(): if the aborted turn's `result` (which
+   *  opens the gate via completeTurn) hasn't arrived shortly, force the gate so an
+   *  interrupt can't stop cold. `guardTurn` is the interrupted turn's number —
+   *  we only force-release while THAT turn is still the one the gate waits on, so
+   *  a result that lands during the await (advancing the channel to a new, legit
+   *  in-flight turn) can't be wrongly cut short. Cancelled by completeTurn(). */
+  private armInterruptReleaseFallback(guardTurn: number): void {
+    if (this.interruptReleaseTimer) clearTimeout(this.interruptReleaseTimer);
+    this.interruptReleaseTimer = setTimeout(() => {
+      this.interruptReleaseTimer = null;
+      if (this.closed) return;
+      // Fire only if the SAME interrupted turn still hasn't completed (no result
+      // arrived). If a result landed, completedTurns has reached guardTurn (and
+      // completeTurn already cleared this timer), so this is a no-op.
+      if (this.completedTurns < guardTurn) {
+        logger.debug(
+          `[panel-agent ${this.short()}] interrupt: no result within ${INTERRUPT_RELEASE_FALLBACK_MS}ms — releasing the gate`,
+        );
+        this.releaseTurns();
+      }
+    }, INTERRUPT_RELEASE_FALLBACK_MS);
+    this.interruptReleaseTimer.unref?.();
+  }
+
+  private clearInterruptReleaseFallback(): void {
+    if (this.interruptReleaseTimer) {
+      clearTimeout(this.interruptReleaseTimer);
+      this.interruptReleaseTimer = null;
     }
   }
 
@@ -484,15 +545,19 @@ export class PanelAgent {
    *  yieldedTurns so an interrupt + a late result for the same turn can't double-
    *  count and let the gate run ahead. */
   private completeTurn(): void {
+    // A real result settled the (interrupted or clean) turn — the post-interrupt
+    // fallback is no longer needed.
+    this.clearInterruptReleaseFallback();
     this.completedTurns = Math.min(this.completedTurns + 1, this.yieldedTurns);
     const w = this.turnWaiter;
     this.turnWaiter = null;
     w?.();
   }
 
-  /** Force the gate open regardless of results (interrupt / shutdown) so an
-   *  interrupt advances to the next pending batch instead of stopping cold. */
+  /** Force the gate open regardless of results (interrupt fallback / shutdown) so
+   *  an interrupt advances to the next pending batch instead of stopping cold. */
   private releaseTurns(): void {
+    this.clearInterruptReleaseFallback();
     this.completedTurns = this.yieldedTurns;
     const w = this.turnWaiter;
     this.turnWaiter = null;
@@ -622,10 +687,13 @@ export class PanelAgent {
         if (this.closed) break;
         logger.error(`[panel-agent ${this.short()}] stream error: ${msgOf(err)}`);
       }
-      // Session ended (cleanly or via error) — disarm any armed watchdog so a stale
-      // timer from the dead session can't fire into the restarted one. The gate
-      // counters are reset at the top of the next iteration.
+      // Session ended (cleanly or via error) — disarm any armed watchdog AND the
+      // interrupt-release fallback so a stale timer from the dead session can't fire
+      // into the restarted one (the restart resets the gate counters to 0, so a
+      // leftover fallback armed for old turn N would force-release the new session's
+      // first turn — gate run-ahead). The gate counters are reset next iteration.
       this.clearIdleWatchdog();
+      this.clearInterruptReleaseFallback();
       if (this.closed) break;
       // Session ended on its own — bound rapid failure loops so a persistently
       // broken SDK doesn't spin forever or black-hole each message.


### PR DESCRIPTION
On send-now/interrupt, synchronously force-opening the turn gate fed the next batch into Claude before the aborted turn settled → the SDK took the message but started no turn → wedged until the 3.5min watchdog. Now the aborted turn's `result` drives `completeTurn()`; a bounded fallback (1500ms, keyed to the interrupted turn) force-releases only if no result arrives — never stops cold, never runs the gate ahead. Cleared on completeTurn/releaseTurns + session restart (Codex P1: stale timer must not force-release the restarted session's first turn).

Build OK; 815 tests pass (incl. send-now-requeue + turn-gate-drain); live-smoked on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)