### PR TITLE
fix(mcp): list_output_images recurses into subfolders (video/ etc.)

### DIFF
--- a/src/__tests__/services/list-output-images.test.ts
+++ b/src/__tests__/services/list-output-images.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, writeFile, rm, utimes } from "node:fs/promises";
+import { mkdtemp, writeFile, rm, utimes, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,18 @@ import { listOutputImages } from "../../services/image-management.js";
 
 async function touch(name: string, when: Date, bytes = 1024): Promise<void> {
   const p = join(outputDir, name);
+  await writeFile(p, Buffer.alloc(bytes));
+  await utimes(p, when, when);
+}
+
+async function touchSub(
+  subfolder: string,
+  name: string,
+  when: Date,
+  bytes = 1024,
+): Promise<void> {
+  await mkdir(join(outputDir, subfolder), { recursive: true });
+  const p = join(outputDir, subfolder, name);
   await writeFile(p, Buffer.alloc(bytes));
   await utimes(p, when, when);
 }
@@ -91,5 +103,29 @@ describe("listOutputImages", () => {
 
     const results = await listOutputImages({ pattern: "LTX" });
     expect(results.map((r) => r.filename)).toEqual(["stage2_ltx_00003.mp4"]);
+  });
+
+  it("recurses into subfolders (SaveVideo writes to output/video/) and reports the subfolder", async () => {
+    const now = new Date("2026-06-26T12:00:00Z");
+    await touch("ComfyUI_00001_.png", now); // top-level still
+    await touchSub("video", "LTX_2.3_i2v_00004_.mp4", now); // the file a flat scan would miss
+
+    const results = await listOutputImages({ limit: 100 });
+    const vid = results.find((r) => r.filename === "LTX_2.3_i2v_00004_.mp4");
+    expect(vid).toBeDefined();
+    expect(vid?.kind).toBe("video");
+    expect(vid?.subfolder).toBe("video"); // forward-slash normalized, no leading sep
+    // top-level files carry an empty subfolder
+    expect(results.find((r) => r.filename === "ComfyUI_00001_.png")?.subfolder).toBe("");
+  });
+
+  it("matches the pattern against the subfolder-relative path", async () => {
+    const now = new Date("2026-06-26T12:00:00Z");
+    await touchSub("video", "clip_00001.mp4", now);
+    await touch("clip_00002.png", now);
+
+    // "video/" only matches the file under the video/ subfolder
+    const results = await listOutputImages({ pattern: "video/" });
+    expect(results.map((r) => r.filename)).toEqual(["clip_00001.mp4"]);
   });
 });

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -1,5 +1,5 @@
 import { readFile, copyFile, readdir, stat } from "node:fs/promises";
-import { join, basename, extname } from "node:path";
+import { join, basename, extname, relative, sep } from "node:path";
 import { config } from "../config.js";
 import { ValidationError, ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -172,6 +172,11 @@ export interface OutputImage {
   path: string;
   size: number;
   modified: string;
+  /** Subfolder relative to the output dir ("" for top level), forward-slash
+   *  normalized. ComfyUI writes to subfolders when a node's filename_prefix
+   *  contains a path (e.g. SaveVideo "video/clip" → output/video/clip_00001.mp4).
+   *  Pass { filename, subfolder } to get_image / stage_output_as_input. */
+  subfolder: string;
   /** Media kind derived from the file extension. */
   kind: "image" | "video";
 }
@@ -205,29 +210,40 @@ export async function listOutputImages(options?: {
   const limit = options?.limit ?? 20;
   const pattern = options?.pattern?.toLowerCase();
 
-  let entries: string[];
+  // RECURSIVE scan: ComfyUI writes to subfolders when a node's filename_prefix
+  // contains a path (SaveVideo / VHS / "video/clip" → output/video/clip_00001.mp4).
+  // A flat readdir of the top level silently misses those — so a finished video can
+  // look "not found" even though the dir resolved correctly. Walk the whole tree.
+  let dirents;
   try {
-    entries = await readdir(outputDir);
+    dirents = await readdir(outputDir, { recursive: true, withFileTypes: true });
   } catch {
     return [];
   }
 
   const images: OutputImage[] = [];
 
-  for (const entry of entries) {
-    const ext = extname(entry).toLowerCase();
+  for (const dirent of dirents) {
+    if (!dirent.isFile()) continue;
+    const ext = extname(dirent.name).toLowerCase();
     if (!MEDIA_EXTS.has(ext)) continue;
-    if (pattern && !entry.toLowerCase().includes(pattern)) continue;
 
-    const filePath = join(outputDir, entry);
+    // Dirent.parentPath (Node ≥20.12) is the absolute dir holding the entry.
+    const parent = dirent.parentPath ?? outputDir;
+    const subfolder = relative(outputDir, parent).split(sep).join("/"); // "" at top level
+    const relPath = subfolder ? `${subfolder}/${dirent.name}` : dirent.name;
+    // Match the pattern against the subfolder-relative path so "video/clip" works.
+    if (pattern && !relPath.toLowerCase().includes(pattern)) continue;
+
+    const filePath = join(parent, dirent.name);
     try {
       const info = await stat(filePath);
-      if (!info.isFile()) continue;
       images.push({
-        filename: entry,
+        filename: dirent.name,
         path: filePath,
         size: info.size,
         modified: info.mtime.toISOString(),
+        subfolder,
         kind: mediaKind(ext),
       });
     } catch {

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -290,7 +290,7 @@ export function registerImageManagementTools(server: McpServer): void {
   // ── list_output_images ────────────────────────────────────────────────────
   server.tool(
     "list_output_images",
-    "List recently generated image AND video files from ComfyUI's local output/ directory (filesystem scan), newest-first, with each file's kind ('image' | 'video'), size, and modification time. Covers stills (.png/.jpg/.jpeg/.bmp) and video/animation outputs (.mp4/.webm/.mov/.mkv/.m4v/.avi/.gif/.webp). Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the media bytes themselves. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the bytes. USE THIS TO CONFIRM A VIDEO RENDER (e.g. VHS_VideoCombine / LTX / WAN output) when get_history shows the prompt done but lists no output: VHS-style video nodes write the file but often do NOT register in ComfyUI's /history, so the filesystem scan is the reliable way to verify the .mp4 exists — then chain it with stage_output_as_input. Read-only.",
+    "List recently generated image AND video files from ComfyUI's local output/ directory (RECURSIVE filesystem scan — includes subfolders like video/ that VHS/SaveVideo write to), newest-first, with each file's kind ('image' | 'video'), subfolder, size, and modification time. Covers stills (.png/.jpg/.jpeg/.bmp) and video/animation outputs (.mp4/.webm/.mov/.mkv/.m4v/.avi/.gif/.webp). Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the media bytes themselves. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the bytes. USE THIS TO CONFIRM A VIDEO RENDER (e.g. VHS_VideoCombine / LTX / WAN output) when get_history shows the prompt done but lists no output: VHS-style video nodes write the file but often do NOT register in ComfyUI's /history, so the filesystem scan is the reliable way to verify the .mp4 exists — then chain it with stage_output_as_input. Read-only.",
     {
       limit: z
         .number()
@@ -325,7 +325,9 @@ export function registerImageManagementTools(server: McpServer): void {
         const lines = images.map((img, i) => {
           const sizeMB = (img.size / 1024 / 1024).toFixed(1);
           const date = new Date(img.modified).toLocaleString();
-          return `${i + 1}. **${img.filename}** [${img.kind}] (${sizeMB} MB) — ${date}`;
+          const loc = img.subfolder ? `${img.subfolder}/${img.filename}` : img.filename;
+          const sub = img.subfolder ? ` _(subfolder: ${img.subfolder})_` : "";
+          return `${i + 1}. **${loc}** [${img.kind}] (${sizeMB} MB) — ${date}${sub}`;
         });
         const videoCount = images.filter((img) => img.kind === "video").length;
         const summary =


### PR DESCRIPTION
**Found via live render-verify:** a finished LTX video at `output/video/LTX_2.3_i2v_00004_.mp4` was reported 'not found' by `list_output_images`. Root cause is **not** the output dir — `resolveOutputDir` correctly resolves `--output-directory` (`ComfyUI-Shared\output`) from `/system_stats`. The bug is a **flat `readdir`** that never descends into the `video/` subfolder ComfyUI writes to when `filename_prefix` contains a path. (The top-level stills it *did* return got mistaken for a wrong-dir/stale symptom.)

## Fix
- Recursive walk (`readdir` recursive + withFileTypes).
- `OutputImage` gains `subfolder` ('' at top level, forward-slash normalized); pass `{ filename, subfolder }` straight to `stage_output_as_input`/`get_image`.
- Pattern now matches the subfolder-relative path (`video/clip` works).
- Tool line shows the location; description notes the recursive scan.

Build OK; **817 tests pass** incl. 2 new subfolder regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)