### PR TITLE
fix(mcp): get_history newest-by-queue-number (#2/#4) + apply_manifest verifies installs (#3)

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -200,6 +200,54 @@ describe("applyManifest", () => {
     );
   });
 
+  it("reports a custom_node as FAILED when Manager queued it but it isn't present afterward", async () => {
+    // ComfyUI-Manager drains the queue "done" for a git URL not in its registry
+    // even though nothing was cloned. installCustomNode resolves, but the
+    // post-install verification (listInstalledNodes) must catch the no-op.
+    installCustomNodeMock.mockResolvedValueOnce({
+      message: "Queued + installed via ComfyUI-Manager.",
+    });
+    listInstalledNodesMock.mockResolvedValue([]); // never shows up — clone no-op'd
+
+    const result = await applyManifest({
+      manifest: {
+        custom_nodes: ["https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"],
+        models: [],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 0, failed: 1 });
+    expect(result.results[0]).toMatchObject({
+      action: "custom_node",
+      status: "failed",
+    });
+    expect(result.results[0].message).toMatch(/not present afterward/i);
+  });
+
+  it("reports a custom_node as APPLIED only after verifying it's actually installed", async () => {
+    installCustomNodeMock.mockResolvedValueOnce({
+      message: "Queued + installed via ComfyUI-Manager.",
+    });
+    listInstalledNodesMock
+      .mockResolvedValueOnce([]) // pre-install skip-check: not yet installed
+      .mockResolvedValueOnce([
+        { module: "comfyui-krea2t-enhancer", enabled: true },
+      ]); // verification: the freshly-cloned node now shows on disk
+
+    const result = await applyManifest({
+      manifest: {
+        custom_nodes: ["https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"],
+        models: [],
+      },
+    });
+
+    expect(result.summary).toMatchObject({ applied: 1, failed: 0 });
+    expect(result.results[0]).toMatchObject({
+      action: "custom_node",
+      status: "applied",
+    });
+  });
+
   it("skips a model already present in an ALTERNATE model root (extra_model_paths)", async () => {
     // The computed target under <COMFYUI_PATH>/models does NOT exist (statMock
     // rejects by default), but the user already has the file under an extra root

--- a/src/__tests__/tools/get-history-select.test.ts
+++ b/src/__tests__/tools/get-history-select.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Mock the client so the get_history tool is tested in isolation. We only care
+// about how it SELECTS "the most recent" entry when no prompt_id is given.
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getLogs: vi.fn(),
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+}));
+
+import { registerDiagnosticsTools } from "../../tools/diagnostics.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerDiagnosticsTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+const entry = (queueNumber: number, id: string) => ({
+  prompt: [queueNumber, id, {}, {}, []],
+  outputs: {},
+  status: { status_str: "success", completed: true, messages: [] },
+});
+
+beforeEach(() => {
+  getHistoryMock.mockReset();
+});
+
+describe("get_history (no prompt_id) selection", () => {
+  it("picks the entry with the highest queue number, NOT the dict-last entry", async () => {
+    // Dict order would pick "older-run" (inserted last), but its queue number is
+    // lower — the real newest is "newest-run" (queue 42). This is the off-by-one
+    // that made get_history / the panel's 'Run finished' card lag one render.
+    getHistoryMock.mockResolvedValue({
+      "newest-run": entry(42, "newest-run"),
+      "older-run": entry(41, "older-run"),
+    });
+
+    const handler = getHandler("get_history");
+    const res = await handler({});
+    expect(res.content[0].text).toContain("Execution: newest-run");
+    expect(res.content[0].text).not.toContain("Execution: older-run");
+  });
+
+  it("still returns the exact entry when a prompt_id is given", async () => {
+    getHistoryMock.mockResolvedValue({ "abc-123": entry(7, "abc-123") });
+    const handler = getHandler("get_history");
+    const res = await handler({ prompt_id: "abc-123" });
+    expect(res.content[0].text).toContain("Execution: abc-123");
+  });
+});

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -494,11 +494,28 @@ export async function applyManifest(
     }
     try {
       const res = await installCustomNode({ id });
-      installedNodes.push({
-        module: maybeGitModuleName(id) ?? id,
-        enabled: true,
-      });
-      results.push(report("custom_node", id, "applied", res.message));
+      // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it
+      // cloned NOTHING — e.g. a repo not in its registry resolves to nothing, no
+      // dir is created, but the queue still empties cleanly. So a successful
+      // installCustomNode() call is NOT proof of install. Re-query the installed
+      // list (it reflects on-disk custom_nodes via Manager's
+      // /v2/customnode/installed, so a freshly-cloned node shows up even before a
+      // reboot) and confirm the node is actually present before reporting success.
+      const verified = await installedNodesOrEmpty();
+      if (nodeAlreadyInstalled(id, verified)) {
+        installedNodes.length = 0;
+        installedNodes.push(...verified);
+        results.push(report("custom_node", id, "applied", res.message));
+      } else {
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "failed",
+            `ComfyUI-Manager reported the install as queued/done, but the node is not present afterward — the source likely resolved to nothing (a git URL that isn't in the Manager registry won't clone). Install it directly (git clone into custom_nodes) or use a registry id. ${res.message}`,
+          ),
+        );
+      }
     } catch (err) {
       results.push(
         report(

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -164,7 +164,7 @@ export function registerDiagnosticsTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Specific prompt ID to look up (returned by enqueue_workflow). If omitted, returns the most recent execution.",
+          "Specific prompt ID to look up (returned by enqueue_workflow). If omitted, returns the most recent COMMITTED execution (chosen by ComfyUI's queue number, not dict order). Note: immediately after a run finishes it can briefly lag by one until ComfyUI commits the new entry — pass the prompt_id from enqueue_workflow to get that exact run, and prefer the run-finished event for naming a just-produced output.",
         ),
     },
     async (args) => {
@@ -185,10 +185,20 @@ export function registerDiagnosticsTools(server: McpServer): void {
           };
         }
 
-        // If no prompt_id, return the most recent entry
+        // If no prompt_id, pick the newest by ComfyUI's MONOTONIC queue number
+        // (history[*].prompt[0]) rather than trusting object iteration order —
+        // /history is keyed by prompt_id and its order is not guaranteed
+        // newest-last, which made get_history return the PRIOR run (off-by-one,
+        // also surfaced as the panel's stale "Run finished" card). `prompt` is
+        // the array [queueNumber, promptId, graph, extra, outputs]; prompt[0] is
+        // the reliable order key.
+        const queueNumberOf = ([, e]: [string, HistoryEntry]): number => {
+          const p = e?.prompt as unknown;
+          return Array.isArray(p) ? Number(p[0]) || 0 : 0;
+        };
         const [promptId, entry] = args.prompt_id
           ? entries[0]
-          : entries[entries.length - 1];
+          : [...entries].sort((a, b) => queueNumberOf(b) - queueNumberOf(a))[0];
 
         const text = formatHistoryEntry(promptId, entry);
         return { content: [{ type: "text", text }] };


### PR DESCRIPTION
Both confirmed via the live render-verify audit.

## #2 / #4 — `get_history` returned the PRIOR run (off-by-one)
`diagnostics.ts` took `entries[length-1]` of `/history`, trusting dict order (not guaranteed newest-last) and reading before ComfyUI commits the just-finished prompt. Now selects by ComfyUI's **monotonic queue number** (`prompt[0]`); description steers callers to pass a `prompt_id` / use the run-finished event. The panel's stale 'Run finished' card (#2) is the **same** bug — the panel's own WS `executed`/`flushRunImages` path is correct; the lag only appeared when the agent resolved 'latest output' via `get_history`.

## #3 — `apply_manifest` false 'applied'
ComfyUI-Manager drains a git-URL task 'done' even when it cloned nothing (repo not in its registry). `apply_manifest` now **verifies** the node is actually present post-install (via `/v2/customnode/installed`, which reflects on-disk dirs even pre-reboot) and reports **failed** with a clear message otherwise.

Build OK; **821 tests pass** incl. 4 new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)