### PR TITLE
fix(mcp): clone fallback fails fast instead of hanging on a credential prompt

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -424,6 +424,11 @@ describe("node-management service", () => {
         "https://github.com/teskor-hub/comfyui-teskors-utils",
         NODE_DIR_UTILS,
       ]);
+      // The clone must run non-interactively so a missing/private repo fails fast
+      // instead of hanging on a credential prompt.
+      const cloneEnv = (cloneCall![2] as { env?: Record<string, string> })?.env;
+      expect(cloneEnv?.GIT_TERMINAL_PROMPT).toBe("0");
+      expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
     it("full-clones (no --depth) and checks out an explicit ref on fallback", async () => {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -257,6 +257,24 @@ async function queueManagerTask(
 // ---------------------------------------------------------------------------
 
 const CM_CLI_TIMEOUT = 600_000;
+// A real custom-node repo clones well under this; with prompts disabled a
+// missing/private repo fails in ~1s rather than blocking the whole timeout.
+const GIT_CLONE_TIMEOUT = 180_000;
+
+/** Env for git network ops that must NEVER block on an interactive credential
+ *  prompt. Without this, `git clone`/`fetch` of a missing or private repo waits
+ *  on a stdin username/password prompt and hangs until the timeout (observed as a
+ *  multi-minute "thinking" stall on a bad URL). GIT_ASKPASS=echo + the prompt
+ *  flags make git fail fast instead. GITHUB_TOKEN is passed through when set. */
+function nonInteractiveGitEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "echo",
+    GCM_INTERACTIVE: "never",
+    ...(config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}),
+  };
+}
 
 function resolveCmCliPath(): string {
   if (!config.comfyuiPath) {
@@ -497,12 +515,14 @@ function runGitCheckout(baseUrl: string, ref: string): void {
     execFileSync("git", ["-C", nodeDir, "fetch", "--all", "--tags"], {
       cwd: config.comfyuiPath,
       encoding: "utf-8",
-      timeout: CM_CLI_TIMEOUT,
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
     });
     execFileSync("git", ["-C", nodeDir, "checkout", "--detach", "--end-of-options", ref], {
       cwd: config.comfyuiPath,
       encoding: "utf-8",
-      timeout: CM_CLI_TIMEOUT,
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
     });
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
@@ -658,11 +678,8 @@ function cloneCustomNodeFallback(
       execFileSync("git", cloneArgs, {
         cwd: config.comfyuiPath,
         encoding: "utf-8",
-        timeout: CM_CLI_TIMEOUT,
-        env: {
-          ...process.env,
-          ...(config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}),
-        },
+        timeout: GIT_CLONE_TIMEOUT,
+        env: nonInteractiveGitEnv(),
       });
     } catch (err) {
       const e = err as NodeJS.ErrnoException & {


### PR DESCRIPTION
Live-testing 0.20.8 surfaced this: `install_custom_node` on a missing/private git URL hung for minutes — the fallback `git clone`/`fetch` inherited the terminal and blocked on a credential prompt until the timeout/watchdog. Now git network ops use `GIT_TERMINAL_PROMPT=0` + `GIT_ASKPASS=echo` + `GCM_INTERACTIVE=never` (`nonInteractiveGitEnv`) so a bad repo fails in ~1s, and the clone/fetch timeout is tightened to 180s. Test asserts the clone runs non-interactively. 827 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)