### PR TITLE
Release 0.20.9 — color-analysis, queue/render watchdog, live stall-threshold, hardened installs + full docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.20.9] - 2026-06-27
+
+### Added
+
+- **`analyze_color` tool** — palette / contrast / color statistics for a generated
+  image (dominant colors, average + luminance stats, contrast checks) so the agent
+  can reason about an image's color without a vision round-trip.
+- **Queue/render wedge watchdog** — three guards against the "stuck render + blind
+  re-queue" failure where a wedged high-res sampler step let the agent stack jobs
+  behind a zombie it couldn't see or kill:
+  - **`panel_run` backpressure** — appends a QUEUE WARNING to the tool result when a
+    render is already running, so the agent stops stacking behind it.
+  - **Passive `QueueMonitor`** — a best-effort WS to ComfyUI tracking the running
+    prompt / node / progress; a stuck step (the same progress value re-emitted) trips
+    a one-line STALL/BACKLOG note prepended to the agent's next turn, deduped per
+    episode. Threshold via `COMFYUI_MCP_STALL_S` (default 180s).
+  - **`cancel_job` escalation** — interrupt → verify it actually stopped → escalate to
+    `/free` → report WEDGED and suggest `restart_comfyui` if it still won't die. A new
+    `clear_pending` also drops all pending jobs in the same call.
+  All best-effort and fail-safe: if the watchdog WS never opens, nothing changes.
+
+### Changed
+
+- **Stall-warning threshold is now live-tunable.** A `set_config` bridge frame lets the
+  panel change the stall threshold without a reconnect (precedence: live value →
+  `COMFYUI_MCP_STALL_S` → 180s default; clamped 15–3600s).
+
+### Fixed
+
+- **Clone fallback fails fast instead of hanging on a credential prompt.** A custom-node
+  install of a missing/private git URL used to block for minutes on a username/password
+  prompt; git network ops now run non-interactively (`GIT_TERMINAL_PROMPT=0` +
+  `GIT_ASKPASS`), failing in ~1s, with a tightened 180s clone timeout.
+
 ## [0.20.8] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI installation and port.
 
-**89 MCP tools** | **22 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
+**108 MCP tools** | **22 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -180,7 +180,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-96 tools across workflow execution, generation, iteration, composition, models, and more:
+108 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 
@@ -201,6 +201,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 | Tool | Description |
 |------|-------------|
 | `view_image` | Return a generated asset's bytes as an inline image so the agent can see the result |
+| `analyze_color` | Palette / contrast / color statistics for a generated image (dominant colors, average + luminance stats, contrast checks) so the agent can reason about color without a vision round-trip |
 | `regenerate` | Re-run the workflow that produced an `asset_id`, with optional parameter overrides |
 | `list_assets` | Browse recently generated assets (newest-first) by `asset_id` |
 | `get_asset_metadata` | Full provenance for an asset, including the originating workflow |
@@ -222,7 +223,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 | `get_queued_workflow` | Inspect the full workflow payload for one pending queue item |
 | `move_queued_job` | Move a pending job to the front/back by requeueing it with a new prompt ID |
 | `edit_queued_job` | Patch or replace a pending queued workflow and requeue it with a new prompt ID |
-| `cancel_job` | Interrupt the currently running job |
+| `cancel_job` | Interrupt the currently running job — escalates (interrupt → verify → `/free`) and reports WEDGED if it won't die; `clear_pending: true` also drops all pending jobs in the same call |
 | `get_system_stats` | Get system info — GPU, VRAM, Python version, OS |
 
 ### Workflow Visualization
@@ -262,7 +263,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 |------|-------------|
 | `upload_image` | Copy a local image into ComfyUI's `input/` directory for img2img, inpaint, or ControlNet |
 | `workflow_from_image` | Extract embedded workflow metadata from a ComfyUI-generated PNG (reads `prompt` and `workflow` tEXt chunks) |
-| `list_output_images` | Browse recently generated images from the output directory, sorted newest-first |
+| `list_output_images` | Browse recently generated images **and videos** from the output directory, sorted newest-first — recurses into subfolders (e.g. SaveVideo's `output/video/…`) and returns each result's `subfolder` |
 
 ### Model Management
 
@@ -520,6 +521,8 @@ The server auto-detects your ComfyUI installation and port. Override with enviro
 | `COMFYUI_LRU_CACHE_SIZE_GB` | `0` | Cap the download cache in GB; `0` disables LRU eviction |
 | `COMFYUI_STARTUP_CHECK_INTERVAL_S` / `…_MAX_TRIES` | `1` / `20` | Readiness-probe interval + max tries when starting a local ComfyUI |
 | `COMFYUI_ALWAYS_RESTART` | `false` | Auto-restart a crashed local ComfyUI (bounded by `COMFYUI_RESTART_MAX_ATTEMPTS` / `COMFYUI_RESTART_WINDOW_S`) |
+| `COMFYUI_MCP_STALL_S` | `180` | Render-wedge watchdog: seconds a sampler step can re-emit the same progress before a STALL/BACKLOG note is prepended to the agent's next turn (clamped 15–3600s; live-tunable from the panel) |
+| `COMFYUI_MCP_INTERRUPT_S` | `30` | Seconds `cancel_job` waits for an interrupt to actually stop a job before escalating to `/free` and reporting it wedged |
 | `LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` |
 
 ### Transports

--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -33,6 +33,19 @@ Each provider authenticates with **your subscription**, not an API key:
 - **Claude** — `claude` (or `claude setup-token`) — claude.ai OAuth.
 - **ChatGPT** — `codex login` — ChatGPT login.
 
+### Connect-time readiness & onboarding
+
+The panel detects each provider's readiness at **Connect** time — the provider's CLI
+on your `PATH` plus a login on disk (the macOS Keychain is handled). You don't have to
+guess which provider is set up:
+
+- An **onboarding card** appears only when **neither** provider is signed in, pointing
+  you at the one-time `claude` / `codex login` step.
+- If your saved provider pick isn't usable, the panel **auto-switches to a ready
+  provider** (your saved preference is left untouched, so it's restored once you sign in).
+- A not-ready provider's row becomes a **"set up" action** that seeds a setup prompt to
+  the working agent.
+
 ## How each provider is driven
 
 The orchestrator depends on a provider-neutral **`AgentBackend`** port

--- a/docs/blog/self-healing-comfyui-agent.mdx
+++ b/docs/blog/self-healing-comfyui-agent.mdx
@@ -146,6 +146,31 @@ the only way past the guard is `force:true`, and only if you explicitly agree to
 kill the running job. Self-healing, but never at the cost of the work you've got
 in flight.
 
+## When the render doesn't crash — it just wedges
+
+A native crash is loud: the process dies and leaves a corpse to read. The quieter
+failure is a render that **wedges** — a high-res sampler step that stops advancing but
+never dies. ComfyUI only checks its interrupt flag *between* nodes, so a stuck
+multi-minute step ignores a polite cancel, and the agent, blind to it, does the worst
+thing again: it stacks more jobs behind the zombie.
+
+The same self-healing instinct handles this, with three best-effort guards:
+
+- **Backpressure.** `panel_run` notices a render is already running and appends a QUEUE
+  WARNING to its own result — so the agent stops piling on.
+- **Stall detection.** A passive WebSocket to ComfyUI watches the running prompt, node,
+  and progress. When a step re-emits the same progress past a threshold
+  (`COMFYUI_MCP_STALL_S`, default 180s — high, because video steps are legitimately
+  slow), a one-line STALL/BACKLOG note is prepended to the agent's next turn.
+- **Escalating cancel.** `cancel_job` doesn't trust the interrupt. It interrupts, then
+  **verifies** the job actually stopped (within `COMFYUI_MCP_INTERRUPT_S`, default 30s);
+  if it didn't, it escalates to `/free`, and if it *still* won't die it reports the render
+  WEDGED and points at `restart_comfyui`. `clear_pending` drops the queued backlog in the
+  same call.
+
+All of it is fail-safe — if the watchdog socket never opens, nothing changes. Same idea
+as the crash loop: see the real state, don't repeat the move that hung.
+
 ## Bonus: the agent can watch its own videos
 
 One more piece that makes the loop honest. An agent that makes video has a

--- a/docs/changelog/2026-06-27.mdx
+++ b/docs/changelog/2026-06-27.mdx
@@ -1,33 +1,123 @@
 ---
-title: "June 27: Krea 2 V2 — detail boost + two-pass combo"
-description: "The krea2 packs are re-sliced from the KREA2 ULTRA V2 workflow: a new Krea2T-Enhancer model detail-boost patch ships active in every pack, and a new krea2-combo pack adds a two-pass refine with the turbo LoRA (+ optional IdeoKrea LoRA)."
+title: "June 27: render-wedge watchdog, color analysis, provider onboarding"
+description: "A self-healing queue/render watchdog (backpressure + stall detection + escalating cancel), a new analyze_color tool, registry-first custom-node installs with a hardened clone fallback, and a wave of panel polish — provider onboarding, rich media metadata, code-block copy/wrap, and a background-tab streaming fix. Plus the Krea 2 ULTRA V2 re-slice."
 ---
 
 _June 27, 2026_
 
+A busy day across the MCP server (0.20.4 → 0.20.9) and the Agent Panel
+(0.4.3 → 0.4.4): the headline is a **self-healing queue/render watchdog**, joined by
+color analysis, much more reliable custom-node installs, and a round of panel polish.
+The krea2 packs were also re-sliced from the new KREA 2 ULTRA **V2** workflow.
+
+## Queue/render wedge watchdog
+
+The nastiest failure mode: a wedged high-res sampler step lets the agent stack jobs
+behind a zombie render it can't see or kill. Three best-effort, fail-safe guards close
+it (if the watchdog WebSocket never opens, nothing changes):
+
+- **`panel_run` backpressure** — appends a QUEUE WARNING to the tool result when a
+  render is already running, so the agent stops stacking behind it.
+- **Passive `QueueMonitor`** — a best-effort WS to ComfyUI tracks the running prompt /
+  node / progress; a stuck step (the same progress value re-emitted) trips a one-line
+  STALL/BACKLOG note prepended to the agent's next turn, deduped per episode. Threshold
+  via `COMFYUI_MCP_STALL_S` (default 180s, clamped 15–3600), and **live-tunable** from
+  the panel's **Render stall warning (seconds)** setting via a `set_config` frame — no
+  reconnect needed.
+- **`cancel_job` escalation** — interrupt → verify it actually stopped (within
+  `COMFYUI_MCP_INTERRUPT_S`, default 30s) → escalate to `/free` → report WEDGED and
+  suggest `restart_comfyui` if it still won't die. A new **`clear_pending`** drops all
+  pending jobs in the same call.
+
+See [How it works → the queue/render watchdog](/concepts#self-healing-the-queuerender-watchdog).
+
+## `analyze_color` — color stats without a vision round-trip
+
+A new **`analyze_color`** tool returns palette / contrast / color statistics for a
+generated image — dominant colors, average + luminance stats, contrast checks — so the
+agent can reason about an image's color without spending a vision turn on it.
+
+## Custom-node installs: registry-first, with a hardened clone fallback
+
+`install_custom_node` / `apply_manifest` used to pass the full git URL as the Manager's
+`id`, but ComfyUI-Manager keys its node DB by repo-name / CNR id (never a URL), so the
+lookup matched nothing and the queue reported "done" without cloning — a **false
+success**. Installs are now:
+
+- **Registry-first** — git URLs are resolved the way the Manager UI does (repo name,
+  `nightly` version, `dev` channel, `cache` mode).
+- **Verified** against `/v2/customnode/installed` (which reflects on-disk packs, so a
+  freshly-installed node is seen before a reboot); a non-URL id that doesn't install is
+  reported as a hard failure, not a false success. `apply_manifest` applies the same
+  verification.
+- **Clone fallback** — only when the Manager genuinely can't resolve the pack (an
+  unregistered repo) does it fall back to a direct `git clone` (+ best-effort
+  `pip install -r requirements.txt` via the ComfyUI venv). The fallback now **fails fast**
+  instead of hanging for minutes on a credential prompt — git network ops run
+  non-interactively (`GIT_TERMINAL_PROMPT=0` + `GIT_ASKPASS`) with a tightened 180s clone
+  timeout.
+
+The install path is also **hardened** against git-option injection (a URL starting with
+`-`) and path traversal (a repo name resolving outside `custom_nodes`): the URL is
+validated up front, every on-disk use is containment-checked, and `git clone`/`checkout`
+use `--end-of-options`. Separately, `update_all` now applies its `mode` (the Manager
+reads those params from the query string, where they're now sent).
+
+## Output discovery + correctness fixes
+
+- **`list_output_images` now recurses into subfolders** and lists **videos**, not just
+  images. SaveVideo / VHS write to paths like `output/video/clip_00001.mp4`; those used
+  to look "not found" on a flat scan. Each result carries its `subfolder` and a
+  `kind: "image" | "video"`, so you can pass `{ filename, subfolder }` straight to
+  `stage_output_as_input` / `get_image`. Verify a video render here, not via `/history`.
+- **`get_history` (no `prompt_id`) returns the newest run.** It now selects by ComfyUI's
+  monotonic queue number instead of object-iteration order, so it no longer lags one run
+  behind — pass a `prompt_id` when naming a just-produced output.
+- **"Send now" / interrupt no longer wedges the agent.** The aborted turn's `result`
+  event now drives the turn-gate release at the right moment (with a bounded fallback),
+  so an interrupt can never stop cold or run the gate ahead.
+
+## Panel: onboarding, rich media, code blocks, stall warning
+
+- **Provider onboarding.** Connect-time readiness detection per provider (CLI on PATH +
+  a login on disk; macOS Keychain handled). An onboarding card shows only when neither
+  provider is signed in; the panel auto-switches to a ready provider when the saved pick
+  isn't usable (the saved preference is kept), and a not-ready row becomes a "set up"
+  action. See [Backends → readiness & onboarding](/backends#connect-time-readiness--onboarding).
+- **Rich media metadata in agent pushes.** A render's executed-event note (and a
+  structured `metadata` field) now carry each output's path, file size, pixel dimensions,
+  asset-set grouping ("output K of N from this run" + siblings, or "single output"),
+  render duration, and completion time; video storyboards add format + real frame
+  count/fps.
+- **Code-block tools.** Rendered fenced code blocks get a Copy button + a persisted
+  global line-wrap toggle (off by default); inline code gets Copy.
+- **Render-stall warning setting** (General; default 180s, range 15–3600) — sent on
+  connect and pushed **live**, so changing it applies without a reconnect.
+- **Background-tab streaming fix.** Streamed replies now render even when the ComfyUI tab
+  is hidden — the reply commit finalizes synchronously in a background tab (and a
+  `visibilitychange` handler flushes on hide / resumes the typewriter on return), instead
+  of leaving an empty bubble with a stuck cursor that looked like the agent was "stuck
+  thinking."
+
+## Krea 2 ULTRA V2 — detail boost + two-pass combo
+
 Aitrepreneur shipped a **V2** of the KREA 2 ULTRA workflow. The krea2 packs are
 re-sliced from it, with a new detail-boost node and a new two-pass combo pack.
-
-## `Krea2T-Enhancer` — the V2 detail boost
 
 V2 adds the **`Krea2T-Enhancer`** node (`capitan01R/ComfyUI-Krea2T-Enhancer`), a
 MODEL→MODEL patch wired in the model path (Power Lora → Krea2T-Enhancer → sampler).
 It ships **active** in all three packs — bypass it to A/B against the un-boosted
 result. V2 also **drops** v1's `ConditioningKrea2Rebalance` node entirely.
 
-## `krea2-combo` — two-pass detail boost
+A new pack, **`krea2-combo`**, runs a two-pass detail boost: a first pass (8 steps,
+`er_sde`, denoise 1) → VAE roundtrip → a low-denoise **second pass** (4 steps, `euler`,
+denoise **0.3**), with the **krea2 turbo LoRA** @0.2 on both passes; it saves **both**
+passes so you can see the boost. The optional **IdeoKrea** LoRA
+(`Aitrepreneur/IdeoKrea`) — an Ideogram-4-style style/prompting LoRA — is downloaded but
+not wired by default; drop it into the Power Lora Loader's empty slot (start ~0.5–1.0)
+for the turbo + IdeoKrea combo.
 
-A new pack: a first pass (8 steps, `er_sde`, denoise 1) → VAE roundtrip → a
-low-denoise **second pass** (4 steps, `euler`, denoise **0.3**), with the
-**krea2 turbo LoRA** @0.2 on both passes. It saves **both** passes so you can see
-the boost. JSON/Ideogram-style prompting drives it.
-
-The optional **IdeoKrea** LoRA (`Aitrepreneur/IdeoKrea`) — an Ideogram-4-style
-style/prompting LoRA — is downloaded but not wired by default; drop it into the
-Power Lora Loader's empty slot (start ~0.5–1.0; it's a test LoRA) for the turbo +
-IdeoKrea combo.
-
-## The three packs
+The three packs:
 
 - **`krea2-txt2img-manual`** — prose prompt + detail boost.
 - **`krea2-txt2img-json`** — Ideogram-style JSON / area prompting + detail boost.

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -41,6 +41,27 @@ local, remote (`--comfyui-url`), or [Comfy Cloud](https://cloud.comfy.org) (`COM
   full feature-parity matrix is in [Configuration → Deployment modes](/configuration#deployment-modes).
 </Note>
 
+## Self-healing: the queue/render watchdog
+
+A wedged high-res sampler step used to let the agent stack jobs behind a zombie render
+it couldn't see or kill. Three best-effort guards close that gap, so the agent stops
+blindly re-queuing behind a stuck render:
+
+- **Backpressure** — `panel_run` appends a QUEUE WARNING to its result when a render is
+  already running, so the agent doesn't stack behind it.
+- **Stall detection** — a passive WebSocket to ComfyUI tracks the running prompt / node /
+  progress; a step that stops advancing past the threshold
+  ([`COMFYUI_MCP_STALL_S`](/configuration#panel-orchestrator--the-bridge), default 180s)
+  prepends a one-line STALL/BACKLOG note to the agent's next turn.
+- **Escalating cancel** — `cancel_job` interrupts, **verifies** the job actually stopped
+  (within [`COMFYUI_MCP_INTERRUPT_S`](/configuration#job-watching), default 30s), then
+  escalates to `/free` and reports the render WEDGED (suggesting `restart_comfyui`) if it
+  still won't die; `clear_pending` drops all pending jobs in the same call.
+
+It's all fail-safe: if the watchdog WebSocket never opens, nothing changes. The agent can
+also reason about an image's colors without a vision round-trip via `analyze_color`
+(dominant palette, average + luminance stats, contrast checks).
+
 ## Tool categories
 
 <CardGroup cols={2}>

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -176,6 +176,15 @@ npx -y comfyui-mcp --panel-orchestrator
   Loopback port for the panel WebSocket bridge that the **panel orchestrator**
   owns (default **9180**).
 </ParamField>
+<ParamField path="COMFYUI_MCP_STALL_S" type="number" default="180">
+  Render-stall threshold (seconds) for the orchestrator's queue/render watchdog: a
+  running job whose node/progress hasn't advanced for this long is flagged as stalled,
+  and a one-line STALL/BACKLOG note is prepended to the agent's next turn. Video steps
+  are legitimately slow, so the default is high. Clamped to **15–3600s**. The panel's
+  **Render stall warning (seconds)** setting (Settings → Comfy MCP Agent → General)
+  overrides this **live** via a `set_config` bridge frame — no reconnect needed —
+  taking precedence over this env value.
+</ParamField>
 
 ## Job watching
 
@@ -189,6 +198,12 @@ available, HTTP polling otherwise).
 </ParamField>
 <ParamField path="COMFYUI_JOB_POLL_INTERVAL_S" type="number" default="2">
   Seconds between HTTP history polls while a job is being watched.
+</ParamField>
+<ParamField path="COMFYUI_MCP_INTERRUPT_S" type="number" default="30">
+  Cancel honor window (seconds) for `cancel_job`: how long to wait for an interrupt to
+  actually stop the running job before escalating (to `/free`, then reporting the render
+  WEDGED). ComfyUI only checks the interrupt flag between nodes/steps, so a multi-minute
+  single step won't honor it immediately — this wait is what detects a true wedge.
 </ParamField>
 
 ## Transport

--- a/docs/panel.mdx
+++ b/docs/panel.mdx
@@ -62,6 +62,15 @@ above. To run an orchestrator yourself, set `COMFYUI_MCP_NO_AUTOSPAWN=1` and lau
 `npx -y comfyui-mcp --panel-orchestrator`, then click Connect; change the bridge
 port with `COMFYUI_MCP_BRIDGE_PORT`.
 
+<Note>
+  **Provider onboarding.** At Connect the panel checks each provider's readiness (its
+  CLI on your PATH + a login on disk; the macOS Keychain is handled). An onboarding card
+  appears only when **neither** provider is signed in. If your saved pick isn't usable
+  the panel **auto-switches to a ready provider** (your saved preference is kept), and a
+  not-ready provider's row offers a **"set up"** action that seeds the one-time
+  `claude` / `codex login` step. See [Backends → readiness & onboarding](/backends#connect-time-readiness--onboarding).
+</Note>
+
 ## What it can do
 
 The agent (Claude *or* ChatGPT) loads comfyui-mcp's model skills (IDEOGRAM, WAN,
@@ -253,6 +262,43 @@ Attach, drag-and-drop, or paste into the composer. Alongside images, the
 composer now accepts **video**, **workflow `.json`**, and **text** files, so you
 can hand the agent a reference clip, a workflow to adapt, or a notes file
 directly.
+
+## Rich media in agent replies
+
+When a run's media is fed back to the agent, the output isn't just an image block —
+it carries **metadata** the agent can reason about: each output's path
+(subfolder-relative), file size, pixel dimensions, and **asset-set grouping**
+("output K of N from this run" with its sibling filenames, or "single output"), plus
+render duration and completion time. Video storyboards add the format and the real
+frame count / fps when the payload carries them. So the agent names the actual saved
+result accurately and can talk about size, dimensions, and how many files a run
+produced.
+
+## Copy & wrap code blocks
+
+Rendered fenced code blocks get a hover **Copy** button and a persisted global
+**line-wrap** toggle (off by default — long lines scroll horizontally until you
+turn it on). Inline code gets its own Copy. Both are styled to match the panel.
+
+## Render-stall warning
+
+The orchestrator runs a passive watchdog over your ComfyUI queue: a render whose
+node/progress stops advancing is flagged as **stalled** and the agent is told (so it
+stops blindly stacking jobs behind a wedged one). The threshold is the
+**Render stall warning (seconds)** setting under **Settings → Comfy MCP Agent →
+General** (default 180s, range 15–3600). It's sent on Connect and pushed **live** —
+changing it applies without a reconnect. See
+[Configuration → `COMFYUI_MCP_STALL_S`](/configuration#panel-orchestrator--the-bridge).
+
+## Background-tab reliability
+
+Streamed replies now render even when the ComfyUI tab is in the **background**.
+Previously the reply typewriter ran on `requestAnimationFrame`, which the browser
+pauses in a hidden tab — so switching away during a long multi-stage run left the
+bubble empty with a stuck streaming cursor, looking like the agent was "stuck
+thinking" even though the turn had finished. The reply now finalizes synchronously
+when the tab is hidden, and a `visibilitychange` handler flushes any pending reply on
+hide and resumes the typewriter on return. Foreground animation is unchanged.
 
 ## See also
 

--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Assets & Images"
-description: "View, convert, and upload generated images; upload media inputs; browse outputs."
+description: "View, convert, and upload generated images; analyze colors; stage outputs as inputs; upload media inputs; browse outputs."
 icon: "images"
 ---
 
-<Info>10 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
+<Info>12 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
 ## view_image
 
@@ -40,10 +40,10 @@ Fetch a generated image from ComfyUI and return it as an inline image. Works wit
 <ParamField path="filename" type="string" required>
   Output image filename, e.g. PulID_Klein_00001_.png
 </ParamField>
-<ParamField path="type" type="enum" default="output">
+<ParamField path="type" type="enum" required default="output">
   Image directory: output (default), input, or temp Options: `output`, `input`, `temp`.
 </ParamField>
-<ParamField path="subfolder" type="string" default="">
+<ParamField path="subfolder" type="string" required default="">
   Subfolder within the directory, if any
 </ParamField>
 <ParamField path="save_dir" type="string">
@@ -58,7 +58,9 @@ Fetch a generated image from ComfyUI and return it as an inline image. Works wit
 {
   "tool": "get_image",
   "arguments": {
-    "filename": "<filename>"
+    "filename": "<filename>",
+    "type": "output",
+    "subfolder": "<subfolder>"
   }
 }
 ```
@@ -105,6 +107,85 @@ Re-encode a generated image to PNG, JPEG, or WebP and return it inline as an ima
   "tool": "convert_image",
   "arguments": {
     "format": "png"
+  }
+}
+```
+
+---
+
+## analyze_color
+
+Measure the color of a rendered image (not by eye): returns black/white points, contrast (luma std), saturation, per-channel means + cast, and clipping — plus heuristic flags (washedOut, lowContrast, liftedBlacks, dimHighlights, lowSaturation, colorCast) and a one-line verdict. Source = asset_id, a ComfyUI output ref (filename/subfolder/type), or an image path. Pass reference_path to shot-match against a known-good frame (target−reference deltas). Set histogram:true to also get an overlaid R/G/B/luma histogram PNG. Use this to diagnose 'washed out' objectively and decide a color fix; for a video, extract a frame to PNG first.
+
+### Parameters
+
+<ParamField path="asset_id" type="string">
+  Registered asset id from a completed job. Provide one source: asset_id, filename, or path.
+</ParamField>
+<ParamField path="filename" type="string">
+  A ComfyUI output ref filename (pair with subfolder/type). Provide one source: asset_id, filename, or path.
+</ParamField>
+<ParamField path="subfolder" type="string">
+  Subfolder for the output ref (default empty).
+</ParamField>
+<ParamField path="type" type="enum">
+  ComfyUI dir for the output ref (default 'output'). Options: `output`, `input`, `temp`.
+</ParamField>
+<ParamField path="path" type="string">
+  Absolute image path, or a path under the ComfyUI output dir. Provide one source: asset_id, filename, or path. (Videos: extract a frame to PNG first.)
+</ParamField>
+<ParamField path="reference_path" type="string">
+  Optional reference image to shot-match against; returns target−reference deltas for contrast, black/white points, saturation, and per-channel means.
+</ParamField>
+<ParamField path="histogram" type="boolean">
+  Also return an overlaid R/G/B/luma histogram PNG for visual confirmation (default false).
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "analyze_color",
+  "arguments": {}
+}
+```
+
+---
+
+## stage_output_as_input
+
+Stage an EXISTING ComfyUI output (or temp/preview) as an INPUT so the next stage's loader (LoadImage / VHS_LoadVideo / LoadAudio) can read it. This is the CORRECT way to chain a multi-stage pipeline (e.g. Krea2 image → LTX video → WAN extend): it fetches the output's bytes from the server via /view and re-registers them as an input via /upload/image — the same endpoints get_image and upload_image use. Because it goes entirely through the server API, it works even when ComfyUI was launched with a CUSTOM input/output directory. Do NOT instead copy the output file or guess a filesystem `input/` path — the server's input dir may be custom and it will reject the file ("Invalid image file"), wasting the render. Pass an existing output reference (&#123; filename, subfolder?, type? &#125;); the media kind (image/video/audio) is inferred from the extension unless you set `kind`. Returns the registered input &#123; filename, subfolder, type: "input", kind &#125; — drop the returned `filename` straight into the loader's image/video/audio widget.
+
+### Parameters
+
+<ParamField path="filename" type="string" required>
+  Filename of the existing output/temp asset (from get_history or list_output_images), e.g. LTX_video_00001.mp4
+</ParamField>
+<ParamField path="subfolder" type="string">
+  Subfolder the asset currently lives in, if any
+</ParamField>
+<ParamField path="type" type="enum" required default="output">
+  Source directory the asset lives in: output (default) or temp (previews) Options: `output`, `temp`.
+</ParamField>
+<ParamField path="kind" type="enum">
+  Force the media kind instead of inferring it from the file extension Options: `image`, `video`, `audio`.
+</ParamField>
+<ParamField path="as_filename" type="string">
+  Override the filename it is registered under in the input/ directory (defaults to the source filename)
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "stage_output_as_input",
+  "arguments": {
+    "filename": "<filename>",
+    "type": "output"
   }
 }
 ```
@@ -228,7 +309,7 @@ Upload a local audio file (.wav, .mp3, .flac, .ogg, .m4a, .aac) to the connected
 
 ## list_output_images
 
-List recently generated image files from ComfyUI's local output/ directory (filesystem scan), newest-first, with file size and modification time. Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the image data itself. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the actual bytes. Read-only.
+List recently generated image AND video files from ComfyUI's local output/ directory (RECURSIVE filesystem scan — includes subfolders like video/ that VHS/SaveVideo write to), newest-first, with each file's kind ('image' | 'video'), subfolder, size, and modification time. Covers stills (.png/.jpg/.jpeg/.bmp) and video/animation outputs (.mp4/.webm/.mov/.mkv/.m4v/.avi/.gif/.webp). Requires COMFYUI_PATH to be set (local installs only) — it does NOT return the media bytes themselves. For remote ComfyUI, use get_history to find filenames, then get_image to fetch the bytes. USE THIS TO CONFIRM A VIDEO RENDER (e.g. VHS_VideoCombine / LTX / WAN output) when get_history shows the prompt done but lists no output: VHS-style video nodes write the file but often do NOT register in ComfyUI's /history, so the filesystem scan is the reliable way to verify the .mp4 exists — then chain it with stage_output_as_input. Read-only.
 
 ### Parameters
 

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Install & Environment"
-description: "Install/update ComfyUI, apply a setup manifest, manage workspaces, inspect the environment, configure ComfyUI-Manager."
+description: "Install/update ComfyUI and the sidebar panel, self-update the MCP server, apply a setup manifest, manage workspaces, inspect the environment, configure ComfyUI-Manager, report issues."
 icon: "wrench"
 ---
 
-<Info>9 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
+<Info>12 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
 ## install_comfyui
 
@@ -73,6 +73,56 @@ Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues updat
 {
   "tool": "update_all",
   "arguments": {}
+}
+```
+
+---
+
+## install_panel
+
+Install, update, reinstall, or report status of the ComfyUI sidebar panel ('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as install_custom_node and always targets the 'nightly' (git-HEAD) channel. Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev install (a symlinked panel dir). After install/update/reinstall, ComfyUI must be RESTARTED to load the new/updated node — this tool does not auto-restart. The panel is also auto-installed-if-missing when the MCP server loads.
+
+### Parameters
+
+<ParamField path="action" type="enum" required default="status">
+  status: report installed/version/dev-symlink (never errors). install: add the panel (nightly). update: pull the latest nightly. reinstall: uninstall + reinstall (nightly). install/update/reinstall refuse on a dev symlink and require a local COMFYUI_PATH. Options: `status`, `install`, `update`, `reinstall`.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "install_panel",
+  "arguments": {
+    "action": "status"
+  }
+}
+```
+
+---
+
+## self_update
+
+Check or apply a self-update of the comfyui-mcp npm package against the npm registry. The server also auto-checks on start (opt out with COMFYUI_MCP_AUTOUPDATE=0). Detects the install mode: a dev install (npm link / source checkout) is NEVER updated; global/local installs are updated via npm; npx fetches latest on next run. The running process cannot hot-swap its own code — after an update you must RECONNECT (/mcp) or restart the orchestrator to load the new version. This tool does not auto-restart.
+
+### Parameters
+
+<ParamField path="action" type="enum" required default="status">
+  status: report install mode + current vs latest version + dev-link note (never errors). update: update to the latest published version (refuses on a dev link; no-op when already up to date or for npx). Options: `status`, `update`.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "self_update",
+  "arguments": {
+    "action": "status"
+  }
 }
 ```
 
@@ -208,6 +258,41 @@ Configure ComfyUI-Manager settings, mirroring `comfy-cli manager` subcommands. M
   "tool": "configure_manager",
   "arguments": {
     "action": "set_preview_method"
+  }
+}
+```
+
+---
+
+## report_issue
+
+Build a ready-to-open GitHub issue link for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp itself). Returns a URL with the title and body prefilled — SHARE it with the user so they can review and submit it in one click. It does NOT auto-file. Use it when you encounter an error you can't resolve so the user can report it upstream. For panel-specific bugs pass repo='artokun/comfyui-mcp-panel'.
+
+### Parameters
+
+<ParamField path="title" type="string" required>
+  Short, specific issue title.
+</ParamField>
+<ParamField path="body" type="string" required>
+  Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, OS) if known.
+</ParamField>
+<ParamField path="repo" type="string">
+  owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel).
+</ParamField>
+<ParamField path="labels" type="string[]">
+  Optional GitHub label names to prefill.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "report_issue",
+  "arguments": {
+    "title": "<title>",
+    "body": "<body>"
   }
 }
 ```

--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -39,15 +39,15 @@ Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, C
 
 ## download_model
 
-Download a model file to the ComfyUI models directory from a URL (HuggingFace, direct HTTP(S), s3://, or Azure Blob)
+Download a model file to the ComfyUI models directory from a URL (HuggingFace, direct HTTP(S), s3://, or Azure Blob). PREFER this over a raw shell download (curl/wget) for model weights: it lands the file in the right models/ subfolder and surfaces live progress in the panel download tray. target_subfolder accepts any relative subfolder (incl. nested, e.g. 'loras/&lt;subdir&gt;').
 
 ### Parameters
 
 <ParamField path="url" type="string" required>
   Direct download URL for the model file
 </ParamField>
-<ParamField path="target_subfolder" type="enum" required>
-  Target subfolder under ComfyUI models/ (e.g. 'checkpoints', 'loras', 'vae') Options: `checkpoints`, `loras`, `vae`, `upscale_models`, `controlnet`, `embeddings`, `clip`, `diffusers`, `diffusion_models`, `gligen`, `hypernetworks`, `photomaker`, `style_models`, `text_encoders`, `unet`.
+<ParamField path="target_subfolder" type="string" required>
+  Target subfolder under ComfyUI models/. Standard names: checkpoints, loras, vae, upscale_models, controlnet, embeddings, clip, diffusers, diffusion_models, gligen, hypernetworks, photomaker, style_models, text_encoders, unet. Any other relative subfolder (incl. nested like 'loras/&lt;subdir&gt;') is allowed; absolute paths and '..' escapes are rejected.
 </ParamField>
 <ParamField path="filename" type="string">
   Override filename (auto-detected from URL if omitted)
@@ -65,7 +65,7 @@ Download a model file to the ComfyUI models directory from a URL (HuggingFace, d
   "tool": "download_model",
   "arguments": {
     "url": "<url>",
-    "target_subfolder": "checkpoints"
+    "target_subfolder": "<target_subfolder>"
   }
 }
 ```
@@ -78,8 +78,8 @@ Download a model from CivitAI into the local ComfyUI models/ directory and retur
 
 ### Parameters
 
-<ParamField path="target_subfolder" type="enum" required>
-  Target subfolder under ComfyUI models/ (e.g. 'checkpoints', 'loras', 'vae'). Options: `checkpoints`, `loras`, `vae`, `upscale_models`, `controlnet`, `embeddings`, `clip`, `diffusers`, `diffusion_models`, `gligen`, `hypernetworks`, `photomaker`, `style_models`, `text_encoders`, `unet`.
+<ParamField path="target_subfolder" type="string" required>
+  Target subfolder under ComfyUI models/. Standard names: checkpoints, loras, vae, upscale_models, controlnet, embeddings, clip, diffusers, diffusion_models, gligen, hypernetworks, photomaker, style_models, text_encoders, unet. Any other relative subfolder (incl. nested like 'loras/&lt;subdir&gt;') is allowed; absolute paths and '..' escapes are rejected.
 </ParamField>
 <ParamField path="model_version_id" type="integer">
   CivitAI model-version id (from the URL ?modelVersionId=...). If both model_id and model_version_id are given, this selects the specific version of that model.
@@ -99,7 +99,7 @@ Download a model from CivitAI into the local ComfyUI models/ directory and retur
 {
   "tool": "download_civitai_model",
   "arguments": {
-    "target_subfolder": "checkpoints"
+    "target_subfolder": "<target_subfolder>"
   }
 }
 ```
@@ -131,12 +131,12 @@ List model files available to the connected ComfyUI, grouped by type. Read-only.
 
 ## remove_model
 
-Delete a model file from the local ComfyUI models directory. The path must stay within models/ (path traversal and absolute escapes are rejected).
+Delete a model file from the local ComfyUI models directories. Resolves the path across ALL configured roots — the primary &lt;COMFYUI_PATH&gt;/models AND every directory in extra_model_paths.yaml / extra_models_config.yaml (e.g. models stored on another drive like E:\) — the same roots ComfyUI loads from. The path must stay within a known root (path traversal and absolute escapes are rejected).
 
 ### Parameters
 
 <ParamField path="path" type="string" required>
-  Model file path relative to the ComfyUI models/ directory (e.g. 'checkpoints/sd_xl_base_1.0.safetensors').
+  Model file path relative to the ComfyUI models/ directory (e.g. 'checkpoints/sd_xl_base_1.0.safetensors'). The leading segment is the category used to locate the file in extra roots too.
 </ParamField>
 
 ### Example

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -15,7 +15,7 @@ Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2
 <ParamField path="template" type="enum" required>
   Template name: txt2img, img2img, upscale, or inpaint Options: `txt2img`, `img2img`, `upscale`, `inpaint`, `controlnet`, `ip_adapter`, `ace_step_15`, `stable_audio_3`.
 </ParamField>
-<ParamField path="params" type="object" default="[object Object]">
+<ParamField path="params" type="object" required default="[object Object]">
   Template parameters; recognized keys depend on the template. txt2img: checkpoint, positive_prompt, negative_prompt, width, height, steps, cfg, seed, sampler_name, scheduler. img2img/inpaint add image_path (and mask_path for inpaint) and denoise. upscale adds upscale_model. Unknown keys are ignored; omitted keys use template defaults.
 </ParamField>
 
@@ -27,7 +27,8 @@ Create a ready-to-run ComfyUI API-format workflow from a built-in template (txt2
 {
   "tool": "create_workflow",
   "arguments": {
-    "template": "txt2img"
+    "template": "txt2img",
+    "params": "<params>"
   }
 }
 ```
@@ -170,10 +171,10 @@ Convert a ComfyUI workflow JSON into a Mermaid flowchart diagram. Returns mermai
 <ParamField path="workflow" type="string | object" required>
   ComfyUI workflow JSON (as a JSON string or object)
 </ParamField>
-<ParamField path="show_values" type="boolean" default="true">
+<ParamField path="show_values" type="boolean" required default="true">
   Include widget values (seed, steps, cfg, etc.) in node labels
 </ParamField>
-<ParamField path="direction" type="enum" default="LR">
+<ParamField path="direction" type="enum" required default="LR">
   Flowchart direction: LR (left-to-right) or TB (top-to-bottom) Options: `LR`, `TB`.
 </ParamField>
 
@@ -185,7 +186,9 @@ Convert a ComfyUI workflow JSON into a Mermaid flowchart diagram. Returns mermai
 {
   "tool": "visualize_workflow",
   "arguments": {
-    "workflow": "<workflow>"
+    "workflow": "<workflow>",
+    "show_values": true,
+    "direction": "LR"
   }
 }
 ```
@@ -198,7 +201,7 @@ Visualize a large ComfyUI workflow as a hierarchical diagram. Detects logical se
 
 ### Parameters
 
-<ParamField path="view" type="enum" default="overview">
+<ParamField path="view" type="enum" required default="overview">
   overview: compact diagram with sections as summary nodes; detail: full diagram for one section; list: text summary of all sections; summary: structured text optimized for AI ingestion with node IDs, key settings, virtual wires, and full connection graph Options: `overview`, `detail`, `list`, `summary`.
 </ParamField>
 <ParamField path="section" type="string">
@@ -207,7 +210,7 @@ Visualize a large ComfyUI workflow as a hierarchical diagram. Detects logical se
 <ParamField path="workflow" type="string | object" required>
   ComfyUI workflow in API format or UI format (auto-detected)
 </ParamField>
-<ParamField path="show_values" type="boolean" default="true">
+<ParamField path="show_values" type="boolean" required default="true">
   Include widget values in node labels (detail view only)
 </ParamField>
 <ParamField path="direction" type="enum">
@@ -222,7 +225,9 @@ Visualize a large ComfyUI workflow as a hierarchical diagram. Detects logical se
 {
   "tool": "visualize_workflow_hierarchical",
   "arguments": {
-    "workflow": "<workflow>"
+    "view": "overview",
+    "workflow": "<workflow>",
+    "show_values": true
   }
 }
 ```

--- a/docs/tools/workflow-execution.mdx
+++ b/docs/tools/workflow-execution.mdx
@@ -191,12 +191,15 @@ Edit a PENDING ComfyUI queue item by removing it and re-enqueuing an updated wor
 
 ## cancel_job
 
-Interrupt the CURRENTLY RUNNING ComfyUI job, optionally only when its prompt_id matches. Stops in-progress execution — the partial result is discarded and not recoverable — and does NOT remove pending/queued jobs. Requires a reachable ComfyUI server. Use this for the job actively executing now; use cancel_queued_job to remove one specific PENDING job, or clear_queue to drop ALL pending jobs. Returns a confirmation (or a no-op status when nothing is running).
+Stop the CURRENTLY RUNNING ComfyUI job ROBUSTLY. Sends an interrupt, then WAITS and verifies the job actually stopped — ComfyUI only honors interrupts BETWEEN steps, so a long single step (e.g. a high-res video sampler) can ignore a plain cancel. If the interrupt isn't honored it escalates to freeing VRAM (POST /free) and re-checks; if it STILL won't die it reports the job as WEDGED and tells you to restart_comfyui (an HTTP cancel cannot kill a stuck step). Set clear_pending:true to also drop ALL pending jobs in the same call — the correct 'reset the queue' action, since cancelling alone leaves pending jobs that would run next. The partial result is discarded. Use cancel_queued_job to remove one specific PENDING job instead.
 
 ### Parameters
 
 <ParamField path="prompt_id" type="string">
   Optional. If given, only interrupts the running job when its prompt_id matches; omit to interrupt whatever is currently running.
+</ParamField>
+<ParamField path="clear_pending" type="boolean">
+  Also clear ALL pending jobs (recommended when resetting after a stuck/slow render, so a re-queue doesn't stack behind a backlog). Default false.
 </ParamField>
 
 ### Example
@@ -263,7 +266,7 @@ Get execution history for a ComfyUI prompt. Returns status, timing, cached nodes
 ### Parameters
 
 <ParamField path="prompt_id" type="string">
-  Specific prompt ID to look up (returned by enqueue_workflow). If omitted, returns the most recent execution.
+  Specific prompt ID to look up (returned by enqueue_workflow). If omitted, returns the most recent COMMITTED execution (chosen by ComfyUI's queue number, not dict order). Note: immediately after a run finishes it can briefly lag by one until ComfyUI commits the new entry — pass the prompt_id from enqueue_workflow to get that exact run, and prefer the run-finished event for naming a just-produced output.
 </ParamField>
 
 ### Example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.20.8",
+  "version": "0.20.9",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "MCP server + autonomous AI agent for ComfyUI — drive your live graph in natural language from a sidebar agent on Claude OR ChatGPT (your own subscription, no API key). Generate images, video & audio, author and run workflows, manage models and custom nodes. Also a Claude Code plugin with skills, slash commands, and installer packs.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/plugin/skills/color-correction/SKILL.md
+++ b/plugin/skills/color-correction/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: color-correction
+description: Diagnose and fix video/image color OBJECTIVELY with the analyze_color tool (scopes/stats — black/white points, contrast, saturation, clipping, cast) instead of eyeballing a contact sheet. Covers the "washed out" signature, why reference color-match (mkl/ColorMatch/ColorMatchAdobe) CAN'T add contrast a flat source lacks, the levels/contrast-stretch fix (core AdjustContrast / CurveEditor), the measure→fix→re-measure loop, the side-by-side sandbox pattern, and where to place the fix in a render graph (after decode, before save). Use when a render looks washed out / flat / dull / over-saturated / color-cast, or when deciding between a color-match and a contrast/levels fix.
+globs:
+  - "**/*.json"
+  - "**/packs/**"
+---
+
+# Color Correction (measure, don't eyeball)
+
+## The core principle
+
+**You cannot reliably judge color from a storyboard / contact sheet.** "Is it washed
+out?" flip-flops by eye, especially on AI-gen video. Make color **measurable** with the
+`analyze_color` MCP tool, read the numbers like a colorist reads scopes, then pick the
+fix the data points to — and re-measure to confirm. The whole skill is this loop:
+
+```
+extract a frame ─► analyze_color ─► read black/white points + contrast + saturation
+       ▲                                          │
+       │                                          ▼
+   re-measure  ◄──── apply fix (levels / contrast / match) ◄── diagnose from the numbers
+```
+
+> Origin: on a WAN-Animate render we argued for many turns over whether the clip was
+> "washed out." The instant we measured it, the answer was unambiguous and the *correct*
+> fix (a contrast stretch, NOT the color-match nodes we'd been adding) fell straight out.
+
+---
+
+## The `analyze_color` tool
+
+Read-only. Source = `asset_id`, a ComfyUI output ref (`filename`/`subfolder`/`type`), or
+an image `path` (absolute, or under the output dir). It returns per-image stats + heuristic
+flags + a one-line verdict, and (optional) an overlaid R/G/B/luma **histogram PNG**.
+
+```
+analyze_color({ filename: "render_00007_.png" })                 # absolute numbers
+analyze_color({ path: "frame.png", reference_path: "src.jpg" })  # + shot-match deltas
+analyze_color({ filename: "x.png", histogram: true })            # + histogram image
+```
+
+**Videos:** `analyze_color` is image-only (no ffmpeg dep). Extract a frame first with the
+ComfyUI venv's cv2:
+
+```bash
+"<comfy-venv>/python" -c "import cv2; c=cv2.VideoCapture(r'IN.mp4'); n=int(c.get(7)); \
+  c.set(1, n//2); _,f=c.read(); cv2.imwrite(r'frame.png', f)"
+```
+
+(grab the middle frame, or frame 0; for window-drift checks grab a frame from each window.)
+
+### What the numbers mean (8-bit)
+
+| Field | Reads like a scope | Healthy-ish |
+|---|---|---|
+| `luma.blackPoint` (1st pct) | where shadows bottom out | ~0–16 (lifted if >16) |
+| `luma.whitePoint` (99th pct) | where highlights top out | ~240–255 (dim if <235) |
+| `luma.contrast` (std) | overall punch | ~45+ (flat if <45) |
+| `luma.dynamicRange` | white−black | wide is good |
+| `saturation.meanSaturation` (HSV S) | vectorscope spread | ~0.25+ (dull if <0.22) |
+| `channels.{r,g,b}Mean` + `castHint` | RGB parade / white balance | spread <~12 = neutral |
+| `luma.clippedHighPct/LowPct` | blown / crushed pixels | keep low (<~2%) |
+
+Flags: `washedOut, lowContrast, liftedBlacks, dimHighlights, lowSaturation, colorCast`.
+
+---
+
+## The "washed out" signature
+
+Washed out = **compressed tonal range**, and it has an exact fingerprint:
+
+- `whitePoint` well below 255 (e.g. **191**) — highlights never reach white
+- `blackPoint` lifted off 0 (e.g. **45**) — milky shadows
+- `contrast` low (std < 45)
+- often *normal* saturation — **washout is usually NOT a saturation problem.**
+
+If you see that, the fix is a **levels / contrast stretch**, not a color match. (Real case:
+a WAN-Animate frame measured blackPoint 45 / whitePoint 191 / contrast 43 — clearly a range
+problem; saturation 0.25 was fine.)
+
+---
+
+## The load-bearing insight: a reference-match can't add contrast the source lacks
+
+The instinct is to "match the render to the input photo" with a color-match node
+(`ColorMatchV2` mkl/hm, `ImageColorMatchAdobe+`, easy `imageColorMatch`). **Measure the
+reference first.** If the reference is itself flat (e.g. a casual phone selfie:
+blackPoint 40, contrast 44), matching to it **cannot** produce punch — you'll match your way
+to the *same* flat numbers. In the real case, mkl and Adobe matches both left the frame
+flagged `washedOut` (whitePoint only crept 191→~218).
+
+So:
+
+- **Use a reference-match** (`ColorMatchV2`, `ImageColorMatchAdobe+`) when you want to *match
+  a known-good graded frame / shot-match across clips*, and the reference is actually good.
+- **Use a levels / contrast stretch** when the defect is compressed range (the washout case)
+  — it targets full range *regardless* of the reference. This is usually the real fix.
+
+---
+
+## The fix: contrast / levels stretch (core nodes, no install)
+
+`AdjustContrast` (core `comfy_extras.nodes_dataset`, category *image/adjustments*) — one
+`factor` (1.0 = none, >1 = more). Pivots around mid-gray, so it pushes the white point up
+and the black point down together. Tune it **by measurement**, not feel. Real measured sweep
+on the washout frame:
+
+| factor | blackPoint | whitePoint | contrast | sat | clippedHigh | verdict |
+|---|---|---|---|---|---|---|
+| 1.3 | 29 | 239 | 56 | 0.33 | **0%** | ✅ not washed (slightly soft) |
+| ~1.4 | ~20 | ~247 | ~60 | ~0.38 | ~1–2% | ✅ **sweet spot** |
+| 1.6 | 7 | 254 | 67 | 0.44 | **7.2%** ⚠️ | punchy but blows highlights |
+
+Pick the factor that lands **whitePoint ~248–255 with `clippedHighPct` < ~2%**. Going too far
+(1.6 here) blows highlights *and* over-warms (per-channel contrast drops blue more than red →
+`castHint` worsens). Sweet spot was ~1.4.
+
+Other levers when contrast alone isn't enough:
+- `CurveEditor` (core, *utilities*) → feeds a CURVE for precise black/white-point + gamma
+  control (a true levels curve) when you need more than a single contrast pivot.
+- `AdjustContrast` + a small saturation/brightness adjust (same *image/adjustments* family)
+  to fine-tune after the stretch.
+- A **mild** reference-match *after* the stretch only if you genuinely need to shot-match.
+
+---
+
+## The sandbox pattern (test corrections side by side, then measure)
+
+Don't tune blind on the full pipeline. Build a tiny separate workflow (`panel_new_workflow`)
+and let one run produce several candidates you then measure:
+
+```
+LoadImage (the washed frame, staged into input/)
+LoadImage (the reference, if shot-matching)
+        │
+        ├─► AdjustContrast factor 1.3 ─► SaveImage "contrast13"
+        ├─► AdjustContrast factor 1.6 ─► SaveImage "contrast16"
+        ├─► ColorMatchV2 (mkl, ref)   ─► SaveImage "balance_mkl"
+        └─► ImageColorMatchAdobe+(LAB)─► SaveImage "balance_adobe"
+```
+
+Run once, then `analyze_color` **every** output (+ the reference + the untouched frame) and
+compare blackPoint / whitePoint / contrast / saturation / clippedHigh. Whichever lands the
+numbers in range wins; interpolate the factor (1.3 vs 1.6 → 1.4) and confirm with one more
+pass. Stage the frame into the ComfyUI **input** dir first (cp the extracted PNG there) so
+`LoadImage` can see it — input/output dirs may be custom, so don't guess paths.
+
+---
+
+## Porting the fix into a render graph
+
+Place the chosen correction **after decode, before the save** — for a WAN/video graph that's
+right after `WanVideoDecode` (or the per-chunk color-match) and feeding the
+`VHS_VideoCombine`/save node. One `AdjustContrast` node is usually the whole fix; keep it as a
+single inline node (or a small bypassable group) so it's easy to toggle and re-tune. Re-render
+a clip, extract a frame, `analyze_color` it, and nudge the factor to hit whitePoint ~250.
+
+---
+
+## Video-specific gotchas
+
+- **Per-window drift (WAN long video):** WAN-Animate/long clips render in temporal windows and
+  can desaturate/dim across them. Measure a frame from the *first* window and a *late* window —
+  if they differ, that's drift, not a global grade issue (use the embeds' between-window
+  `colormatch`, not a final stretch).
+- **Relight LoRA ≠ levels:** a WanAnimate relight LoRA changes *lighting*, not black/white
+  points — it won't fix a compressed-range washout. Measure before and after to prove it.
+- **Don't over-stretch:** watch `clippedHighPct` — blown highlights are unrecoverable. Prefer
+  the lower factor that still clears `dimHighlights`.
+- **Cast is often inherited:** if the reference has the same warm/cool cast (festival/sunset
+  light), a matching cast on the render is *correct* — don't "fix" it.
+
+---
+
+## Quick reference — the decision tree
+
+```
+analyze_color the frame
+  ├─ washedOut / lowContrast / dimHighlights ........ contrast/levels stretch (AdjustContrast ~1.4 → measure)
+  ├─ lowSaturation only ............................. saturation boost (small)
+  ├─ colorCast (and reference is neutral) ........... white-balance / neutralization, or reference-match
+  ├─ want to MATCH a known-good graded frame ........ ColorMatchV2 / ImageColorMatchAdobe+ (ref must be good)
+  └─ blackPoint/whitePoint already 0/255, sat ok .... color is healthy — stop touching it
+```
+
+Always **re-measure after the fix.** If `analyze_color` still flags it, the fix was wrong —
+adjust and measure again. Numbers over vibes.

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -118,9 +118,10 @@ const CATEGORIES: Array<{
     group: "Assets & Images",
     slug: "assets-images",
     icon: "images",
-    description: "View, convert, and upload generated images; upload media inputs; browse outputs.",
+    description: "View, convert, and upload generated images; analyze colors; stage outputs as inputs; upload media inputs; browse outputs.",
     tools: [
-      "view_image", "get_image", "convert_image", "upload_output",
+      "view_image", "get_image", "convert_image", "analyze_color",
+      "stage_output_as_input", "upload_output",
       "upload_image", "upload_video", "upload_audio",
       "list_output_images", "list_assets", "get_asset_metadata",
     ],
@@ -161,10 +162,11 @@ const CATEGORIES: Array<{
     group: "Install & Environment",
     slug: "install-environment",
     icon: "wrench",
-    description: "Install/update ComfyUI, apply a setup manifest, manage workspaces, inspect the environment, configure ComfyUI-Manager.",
+    description: "Install/update ComfyUI and the sidebar panel, self-update the MCP server, apply a setup manifest, manage workspaces, inspect the environment, configure ComfyUI-Manager, report issues.",
     tools: [
-      "install_comfyui", "update_comfyui", "update_all", "apply_manifest", "get_workspace",
-      "set_default_workspace", "list_workspaces", "get_environment", "configure_manager",
+      "install_comfyui", "update_comfyui", "update_all", "install_panel", "self_update",
+      "apply_manifest", "get_workspace", "set_default_workspace", "list_workspaces",
+      "get_environment", "configure_manager", "report_issue",
     ],
   },
   {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -220,6 +220,24 @@ export async function interrupt(promptId?: string): Promise<void> {
 }
 
 /**
+ * POST /free — unload resident models and/or free cached memory. Used by
+ * clear_vram and by the cancel escalation (a wedged sampler step can ignore an
+ * interrupt; freeing VRAM under it sometimes shakes it loose). No-op on cloud.
+ */
+export async function freeMemory(opts: { unload_models?: boolean; free_memory?: boolean }): Promise<void> {
+  if (isCloudMode()) return;
+  const client = getClient();
+  await client.fetchApi("/free", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      unload_models: !!opts.unload_models,
+      free_memory: !!opts.free_memory,
+    }),
+  });
+}
+
+/**
  * Fire-and-forget: enqueue a prompt via HTTP POST (no WebSocket needed).
  * Returns prompt_id and queue position immediately.
  */

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -126,10 +126,21 @@ const injectedCrashes = new Set<string>();
  *  a fresh backlog) produces a new key and warns again. Process-scoped. */
 const injectedQueueNotes = new Set<string>();
 
+/** Live stall threshold (seconds) pushed from the panel setting via a `set_config`
+ *  frame — applies WITHOUT a reconnect. null = not set, fall back to env then the
+ *  built-in default. Process-global: one ComfyUI per orchestrator. */
+let liveStallSeconds: number | null = null;
+function setLiveStallSeconds(v: unknown): void {
+  const n = Number(v);
+  liveStallSeconds = Number.isFinite(n) && n > 0 ? Math.min(3600, Math.max(15, Math.round(n))) : null;
+}
+
 /** Stall threshold (ms): a running job with no node/progress advance for this long
- *  is treated as stalled. Video steps are legitimately slow, so default high (180s)
- *  and allow override via COMFYUI_MCP_STALL_S (seconds). */
+ *  is treated as stalled. Video steps are legitimately slow, so the DEFAULT is high
+ *  (180s). Precedence: live panel setting (set_config) → COMFYUI_MCP_STALL_S env
+ *  (spawn value) → 180s default. */
 function stallThresholdMs(): number {
+  if (liveStallSeconds != null) return liveStallSeconds * 1000;
   const s = Number(process.env.COMFYUI_MCP_STALL_S);
   return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 180000;
 }
@@ -808,6 +819,20 @@ export async function runPanelOrchestrator(): Promise<void> {
         });
       return;
     }
+    // Live panel config (currently just the render-stall threshold). Applied
+    // immediately, no reconnect — the next turn's watchdog check uses the new
+    // value. Sent by the panel on connect and whenever the setting changes.
+    if (event.type === "set_config" && event.tab_id) {
+      if ("stall_seconds" in event) {
+        setLiveStallSeconds((event as { stall_seconds?: unknown }).stall_seconds);
+        logger.info(
+          `[panel-orchestrator] live stall threshold → ${liveStallSeconds ?? "default"}s`,
+        );
+      }
+      bridge.push({ type: "ack", ok: true, kind: "config" }, event.tab_id);
+      return;
+    }
+
     // Model / effort picker: apply and confirm. Model switches live; an effort
     // change restarts the session (resumed) so the conversation carries over.
     if (event.type === "set_options" && event.tab_id) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -38,6 +38,7 @@ import { CodexBackend } from "./codex-backend.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
+import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
 import {
   gatherEnvCapabilities,
   buildPanelSystemAppend,
@@ -118,6 +119,45 @@ function isResumeNudge(text: string): boolean {
  *  out. We inject each distinct crash at most once per tab. Process-scoped — a fresh
  *  orchestrator (new session) starts clean. */
 const injectedCrashes = new Set<string>();
+
+/** Stall/backlog notes already surfaced, keyed `<tabId>:<promptId|backlog>:<kind>`.
+ *  Like injectedCrashes: warn the agent ONCE per stall episode so a long render
+ *  doesn't prepend the same warning to every message. A new running prompt id (or
+ *  a fresh backlog) produces a new key and warns again. Process-scoped. */
+const injectedQueueNotes = new Set<string>();
+
+/** Stall threshold (ms): a running job with no node/progress advance for this long
+ *  is treated as stalled. Video steps are legitimately slow, so default high (180s)
+ *  and allow override via COMFYUI_MCP_STALL_S (seconds). */
+function stallThresholdMs(): number {
+  const s = Number(process.env.COMFYUI_MCP_STALL_S);
+  return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 180000;
+}
+
+/** Build a one-line agent note from a stall/backlog report, or null when the
+ *  queue is healthy. Stall takes priority over a plain backlog. */
+function formatQueueNote(rep: StallReport): string | null {
+  if (rep.stalled) {
+    const secs = Math.round(rep.stalledForMs / 1000);
+    return (
+      `⚠️ The current ComfyUI render appears STALLED: ` +
+      `${rep.currentNode ? `node ${rep.currentNode} ` : ""}${rep.progress ? `(progress ${rep.progress}) ` : ""}` +
+      `on prompt ${rep.runningPromptId ?? "?"} has not advanced for ~${secs}s. ComfyUI only checks interrupts ` +
+      `BETWEEN steps, so a stuck step can ignore cancel_job. If it's wedged: call cancel_job with ` +
+      `clear_pending:true; if it reports the job still wedged, restart_comfyui / panel_restart_comfyui. ` +
+      `Do NOT queue another run on top.`
+    );
+  }
+  if (rep.backlog) {
+    const pending = Math.max(0, rep.queueDepth - 1);
+    return (
+      `⚠️ ComfyUI queue backlog: ${rep.queueDepth} tasks in flight (1 running + ${pending} pending). ` +
+      `You likely queued behind a slow/stuck job. Check get_queue; use cancel_job with clear_pending:true to ` +
+      `reset before re-queuing rather than stacking another run.`
+    );
+  }
+  return null;
+}
 
 /**
  * Lockfile path for a given bridge port. The orchestrator self-registers its
@@ -432,6 +472,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Build it before any agent could spawn. Guarded so a probe stall can't block
   // orchestrator startup beyond the probes' own (short) timeouts.
   await refreshEnvCapabilities();
+
+  // Render watchdog: a passive WS to ComfyUI that tracks live run progress so we
+  // can warn the agent about a stalled render or a queue backlog it can't see
+  // (panel_run queues through the browser). Best-effort — if the socket never
+  // opens, the watchdog stays inactive and nothing else changes.
+  QueueMonitor.start(comfyuiUrl);
   if (envCaps) {
     logger.info(
       `[panel-orchestrator] env: OS=${envCaps.os ?? "?"} GPU=${envCaps.gpu ?? "?"}${typeof envCaps.vramTotalGb === "number" ? ` ${envCaps.vramTotalGb}GB` : ""} torch=${envCaps.torch ?? "?"} cuda=${envCaps.cuda ?? "?"} py=${envCaps.python ?? "?"} comfyui=${envCaps.comfyui ?? "?"} (${envCaps.location ?? "?"}) triton=${envCaps.triton ?? "?"} sage=${envCaps.sageattention ?? "?"} backend=${envCaps.backend ?? "?"}`,
@@ -958,6 +1004,27 @@ export async function runPanelOrchestrator(): Promise<void> {
         );
       }
     }
+    // QUEUE WATCHDOG: surface a stalled render or a queue backlog the agent can't
+    // see (panel_run queues through the browser; the agent has no live view of
+    // ComfyUI's queue). Prepend ONCE per episode, the same way crash dumps inject.
+    try {
+      const rep = QueueMonitor.report(stallThresholdMs());
+      const qnote = formatQueueNote(rep);
+      if (qnote) {
+        const key = `${event.tab_id}:${rep.runningPromptId ?? "backlog"}:${rep.stalled ? "stall" : "backlog"}`;
+        if (!injectedQueueNotes.has(key)) {
+          injectedQueueNotes.add(key);
+          outText = `${qnote}\n\n${outText}`;
+          logger.warn(
+            `[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} queue note injected — ${rep.stalled ? "STALL" : "BACKLOG"} depth=${rep.queueDepth} node=${rep.currentNode ?? "?"} prompt=${rep.runningPromptId ?? "?"}`,
+          );
+        }
+      }
+    } catch (err) {
+      logger.debug(
+        `[panel-orchestrator] queue-note check failed (ignored): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     manager.send(event.tab_id, outText, {
       title: event.title,
       images: (event as { images?: Array<{ filename: string; subfolder?: string; type?: string }> }).images,
@@ -1031,6 +1098,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     shuttingDown = true;
     logger.info("[panel-orchestrator] shutting down — stopping agents…");
     clearInterval(downloadTimer);
+    QueueMonitor.stop();
     unsubscribeSecrets();
     await manager.stopAll();
     // Dispose the Codex readiness-probe backend (kills its app-server child).

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -40,6 +40,7 @@ import {
 } from "../services/user-mcp-config.js";
 import { setComfyuiSecret } from "../services/panel-secrets.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
+import { QueueMonitor } from "../services/queue-monitor.js";
 import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
@@ -591,15 +592,27 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .describe("Times to queue (default 1)."),
       },
       async (args: A, ctx) => {
+        // BACKPRESSURE: the agent can't see ComfyUI's queue, so re-queuing while a
+        // render is already running silently stacks behind it (this is how a stuck
+        // job once let three more pile up). Snapshot the watchdog BEFORE we queue.
+        const pre = QueueMonitor.snapshot();
         const res = await ctx.call({ cmd: "graph_run", batch_count: args.batch_count }, 20000);
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         const note =
           "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll get_queue, get_history, or list_output_images. Just end your turn now and wait for the result to be delivered to you.";
+        let warn = "";
+        if (pre.connected && pre.running) {
+          const morePending = pre.queueDepth > 1 ? ` plus ${pre.queueDepth - 1} already pending` : "";
+          warn =
+            `\n\n[QUEUE WARNING] A render is ALREADY RUNNING${pre.runningPromptId ? ` (prompt ${pre.runningPromptId})` : ""}${morePending} — ` +
+            `this new run is QUEUED BEHIND it and will not start until that finishes. If the running one looks stuck, do NOT keep queuing: ` +
+            `call cancel_job with clear_pending:true (it interrupts the running job AND drops pending), then escalate to restart_comfyui if it reports the job wedged.`;
+        }
         if (res.content?.[0]?.type === "text") {
           return {
             ...res,
-            content: [{ type: "text", text: res.content[0].text + note }, ...res.content.slice(1)],
+            content: [{ type: "text", text: res.content[0].text + warn + note }, ...res.content.slice(1)],
           };
         }
         return res;

--- a/src/services/color-analysis.ts
+++ b/src/services/color-analysis.ts
@@ -1,0 +1,375 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve, sep } from "node:path";
+import sharp from "sharp";
+import { AssetRegistry } from "./asset-registry.js";
+import { getOutputImage } from "./image-management.js";
+import { resolveOutputDir } from "./output-dir.js";
+import { ValidationError } from "../utils/errors.js";
+
+// ---------------------------------------------------------------------------
+// analyze_color — objective color scopes/stats for a rendered image.
+//
+// Motivation: judging "washed out" by eye off a contact sheet is unreliable.
+// This computes the numbers a colorist reads off scopes — black/white points,
+// contrast (luma std), saturation, per-channel means (cast), and clipping —
+// so the agent can diagnose color deterministically and pick a fix, plus an
+// optional reference comparison (shot match) for "how far from the source?".
+// ---------------------------------------------------------------------------
+
+export interface AnalyzeColorOptions {
+  asset_id?: string;
+  path?: string;
+  filename?: string;
+  subfolder?: string;
+  type?: "output" | "input" | "temp";
+  reference_path?: string;
+  histogram?: boolean;
+}
+
+export interface ColorStats {
+  width: number;
+  height: number;
+  luma: {
+    mean: number;
+    median: number;
+    contrast: number; // std-dev of luma (higher = punchier)
+    blackPoint: number; // 1st percentile
+    whitePoint: number; // 99th percentile
+    dynamicRange: number; // whitePoint - blackPoint
+    clippedLowPct: number; // % pixels at/near 0
+    clippedHighPct: number; // % pixels at/near 255
+  };
+  saturation: {
+    meanSaturation: number; // HSV S, 0..1
+    meanChroma: number; // max-min, 0..255
+  };
+  channels: {
+    rMean: number;
+    gMean: number;
+    bMean: number;
+    castHint: string;
+  };
+  flags: {
+    washedOut: boolean;
+    lowContrast: boolean;
+    liftedBlacks: boolean;
+    dimHighlights: boolean;
+    lowSaturation: boolean;
+    colorCast: boolean;
+  };
+  verdict: string;
+}
+
+export interface AnalyzeColorResult {
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string }
+  >;
+}
+
+// Heuristic thresholds (8-bit). Rough but practical; tuned for video frames.
+const TH = {
+  liftedBlack: 16, // blackPoint above this = blacks not reaching 0
+  dimWhite: 235, // whitePoint below this = highlights don't reach top
+  lowContrast: 45, // luma std below this = flat
+  lowSaturation: 0.22, // mean HSV saturation below this = desaturated
+  colorCast: 12, // spread between channel means above this = cast
+};
+
+interface RawPixels {
+  data: Buffer;
+  width: number;
+  height: number;
+  channels: number;
+}
+
+async function resolveBytes(opts: AnalyzeColorOptions): Promise<Buffer> {
+  if (opts.asset_id) {
+    const record = AssetRegistry.get(opts.asset_id);
+    if (!record) {
+      throw new ValidationError(
+        `No asset found for id "${opts.asset_id}". It may have expired or never been registered.`,
+      );
+    }
+    const validType =
+      record.type === "output" || record.type === "input" || record.type === "temp";
+    const fetchType: "output" | "input" | "temp" = validType
+      ? (record.type as "output" | "input" | "temp")
+      : "output";
+    const image = await getOutputImage(record.filename, fetchType, record.subfolder);
+    return Buffer.from(image.base64, "base64");
+  }
+
+  if (opts.filename) {
+    const image = await getOutputImage(
+      opts.filename,
+      opts.type ?? "output",
+      opts.subfolder ?? "",
+    );
+    return Buffer.from(image.base64, "base64");
+  }
+
+  if (opts.path) {
+    return readFile(await resolveSafePath(opts.path));
+  }
+
+  throw new ValidationError(
+    "analyze_color requires one of: asset_id, filename (+optional subfolder/type), or path.",
+  );
+}
+
+// Allow an absolute path anywhere readable, or a path under the ComfyUI output
+// dir. Reject parent-dir escapes on relative inputs.
+async function resolveSafePath(path: string): Promise<string> {
+  if (path.trim().length === 0) {
+    throw new ValidationError("path must be a non-empty string.");
+  }
+  if (isAbsolute(path)) return resolve(path);
+  const outputDir = await resolveOutputDir();
+  const resolved = resolve(outputDir, path);
+  if (resolved !== outputDir && !resolved.startsWith(outputDir + sep)) {
+    throw new ValidationError("relative path must stay within the ComfyUI output directory.");
+  }
+  return resolved;
+}
+
+async function toRaw(bytes: Buffer): Promise<RawPixels> {
+  const { data, info } = await sharp(bytes, { limitInputPixels: 100_000_000 })
+    .removeAlpha()
+    .toColourspace("srgb")
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return { data, width: info.width, height: info.height, channels: info.channels };
+}
+
+function percentile(hist: Float64Array, total: number, p: number): number {
+  if (total === 0) return 0;
+  const target = p * total;
+  let cum = 0;
+  for (let i = 0; i < 256; i++) {
+    cum += hist[i];
+    if (cum >= target) return i;
+  }
+  return 255;
+}
+
+export function computeStats(raw: RawPixels): ColorStats {
+  const { data, width, height, channels } = raw;
+  const stride = channels;
+  const pixelCount = width * height;
+
+  const lumaHist = new Float64Array(256);
+
+  let rSum = 0;
+  let gSum = 0;
+  let bSum = 0;
+  let satSum = 0;
+  let chromaSum = 0;
+
+  for (let i = 0; i < data.length; i += stride) {
+    const r = data[i];
+    const g = stride >= 3 ? data[i + 1] : r;
+    const b = stride >= 3 ? data[i + 2] : r;
+
+    rSum += r;
+    gSum += g;
+    bSum += b;
+
+    // Rec.709 luma
+    const luma = Math.round(0.2126 * r + 0.7152 * g + 0.0722 * b);
+    lumaHist[luma > 255 ? 255 : luma]++;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const chroma = max - min;
+    chromaSum += chroma;
+    satSum += max === 0 ? 0 : chroma / max;
+  }
+
+  // luma mean + std
+  let lumaSum = 0;
+  for (let v = 0; v < 256; v++) lumaSum += v * lumaHist[v];
+  const lumaMean = lumaSum / pixelCount;
+  let varSum = 0;
+  for (let v = 0; v < 256; v++) {
+    const d = v - lumaMean;
+    varSum += d * d * lumaHist[v];
+  }
+  const lumaStd = Math.sqrt(varSum / pixelCount);
+
+  const blackPoint = percentile(lumaHist, pixelCount, 0.01);
+  const whitePoint = percentile(lumaHist, pixelCount, 0.99);
+  const median = percentile(lumaHist, pixelCount, 0.5);
+
+  let clippedLow = 0;
+  let clippedHigh = 0;
+  for (let v = 0; v <= 2; v++) clippedLow += lumaHist[v];
+  for (let v = 253; v <= 255; v++) clippedHigh += lumaHist[v];
+
+  const rMean = rSum / pixelCount;
+  const gMean = gSum / pixelCount;
+  const bMean = bSum / pixelCount;
+  const meanSaturation = satSum / pixelCount;
+  const meanChroma = chromaSum / pixelCount;
+
+  const channelSpread =
+    Math.max(rMean, gMean, bMean) - Math.min(rMean, gMean, bMean);
+  let castHint = "neutral";
+  if (channelSpread > TH.colorCast) {
+    const top = Math.max(rMean, gMean, bMean);
+    castHint =
+      top === rMean ? "warm (red-heavy)" : top === bMean ? "cool (blue-heavy)" : "green-heavy";
+  }
+
+  const lowContrast = lumaStd < TH.lowContrast;
+  const liftedBlacks = blackPoint > TH.liftedBlack;
+  const dimHighlights = whitePoint < TH.dimWhite;
+  const lowSaturation = meanSaturation < TH.lowSaturation;
+  const colorCast = channelSpread > TH.colorCast;
+  const washedOut = lowContrast && (liftedBlacks || lowSaturation || dimHighlights);
+
+  const round = (n: number, d = 1) => Number(n.toFixed(d));
+
+  const issues: string[] = [];
+  if (lowContrast) issues.push(`low contrast (std ${round(lumaStd)})`);
+  if (liftedBlacks) issues.push(`lifted blacks (black point ${blackPoint})`);
+  if (dimHighlights) issues.push(`dim highlights (white point ${whitePoint})`);
+  if (lowSaturation) issues.push(`low saturation (${round(meanSaturation, 2)})`);
+  if (colorCast) issues.push(`${castHint} cast`);
+  const verdict = washedOut
+    ? `WASHED OUT — ${issues.join(", ")}`
+    : issues.length
+      ? `OK with notes: ${issues.join(", ")}`
+      : "Color looks healthy (good contrast, full range, saturated)";
+
+  return {
+    width,
+    height,
+    luma: {
+      mean: round(lumaMean),
+      median,
+      contrast: round(lumaStd),
+      blackPoint,
+      whitePoint,
+      dynamicRange: whitePoint - blackPoint,
+      clippedLowPct: round((clippedLow / pixelCount) * 100, 2),
+      clippedHighPct: round((clippedHigh / pixelCount) * 100, 2),
+    },
+    saturation: {
+      meanSaturation: round(meanSaturation, 3),
+      meanChroma: round(meanChroma),
+    },
+    channels: {
+      rMean: round(rMean),
+      gMean: round(gMean),
+      bMean: round(bMean),
+      castHint,
+    },
+    flags: {
+      washedOut,
+      lowContrast,
+      liftedBlacks,
+      dimHighlights,
+      lowSaturation,
+      colorCast,
+    },
+    verdict,
+  };
+}
+
+// Render a compact overlaid R/G/B/luma histogram PNG for visual confirmation.
+async function renderHistogram(raw: RawPixels): Promise<{ data: string; mimeType: string }> {
+  const { data, channels } = raw;
+  const stride = channels;
+  const W = 256;
+  const H = 200;
+  const rHist = new Float64Array(256);
+  const gHist = new Float64Array(256);
+  const bHist = new Float64Array(256);
+  const lHist = new Float64Array(256);
+  for (let i = 0; i < data.length; i += stride) {
+    const r = data[i];
+    const g = stride >= 3 ? data[i + 1] : r;
+    const b = stride >= 3 ? data[i + 2] : r;
+    rHist[r]++;
+    gHist[g]++;
+    bHist[b]++;
+    const luma = Math.min(255, Math.round(0.2126 * r + 0.7152 * g + 0.0722 * b));
+    lHist[luma]++;
+  }
+  const maxBin = Math.max(
+    1,
+    ...rHist,
+    ...gHist,
+    ...bHist,
+    ...lHist,
+  );
+  const buf = Buffer.alloc(W * H * 3);
+  // dark background
+  for (let i = 0; i < buf.length; i += 3) {
+    buf[i] = 18;
+    buf[i + 1] = 18;
+    buf[i + 2] = 26;
+  }
+  const draw = (hist: Float64Array, cr: number, cg: number, cb: number) => {
+    for (let x = 0; x < W; x++) {
+      const h = Math.round((hist[x] / maxBin) * (H - 1));
+      for (let y = H - 1; y >= H - h; y--) {
+        const idx = (y * W + x) * 3;
+        // max-blend so overlaid curves stay visible
+        buf[idx] = Math.max(buf[idx], cr);
+        buf[idx + 1] = Math.max(buf[idx + 1], cg);
+        buf[idx + 2] = Math.max(buf[idx + 2], cb);
+      }
+    }
+  };
+  draw(lHist, 120, 120, 130); // luma (gray, drawn first/behind)
+  draw(rHist, 220, 60, 60);
+  draw(gHist, 60, 200, 80);
+  draw(bHist, 80, 130, 240);
+  const png = await sharp(buf, { raw: { width: W, height: H, channels: 3 } })
+    .png()
+    .toBuffer();
+  return { data: png.toString("base64"), mimeType: "image/png" };
+}
+
+function deltaReport(target: ColorStats, ref: ColorStats): string {
+  const d = (a: number, b: number) => {
+    const v = Number((a - b).toFixed(1));
+    return v > 0 ? `+${v}` : `${v}`;
+  };
+  return [
+    "Shot-match delta (target − reference):",
+    `  contrast ${d(target.luma.contrast, ref.luma.contrast)} | ` +
+      `black point ${d(target.luma.blackPoint, ref.luma.blackPoint)} | ` +
+      `white point ${d(target.luma.whitePoint, ref.luma.whitePoint)}`,
+    `  saturation ${d(target.saturation.meanSaturation, ref.saturation.meanSaturation)} | ` +
+      `R ${d(target.channels.rMean, ref.channels.rMean)} ` +
+      `G ${d(target.channels.gMean, ref.channels.gMean)} ` +
+      `B ${d(target.channels.bMean, ref.channels.bMean)}`,
+  ].join("\n");
+}
+
+export async function analyzeColor(opts: AnalyzeColorOptions): Promise<AnalyzeColorResult> {
+  const raw = await toRaw(await resolveBytes(opts));
+  const stats = computeStats(raw);
+
+  const content: AnalyzeColorResult["content"] = [];
+  let summary = `analyze_color — ${stats.width}x${stats.height}\n${stats.verdict}\n\n` +
+    JSON.stringify(stats, null, 2);
+
+  if (opts.reference_path) {
+    const refRaw = await toRaw(await readFile(await resolveSafePath(opts.reference_path)));
+    const refStats = computeStats(refRaw);
+    summary += `\n\n${deltaReport(stats, refStats)}`;
+  }
+
+  content.push({ type: "text", text: summary });
+
+  if (opts.histogram) {
+    const hist = await renderHistogram(raw);
+    content.push({ type: "image", data: hist.data, mimeType: hist.mimeType });
+  }
+
+  return { content };
+}

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -6,6 +6,7 @@ import {
   deleteQueueItem as clientDeleteQueueItem,
   clearQueue as clientClearQueue,
   enqueuePrompt as clientEnqueuePrompt,
+  freeMemory as clientFreeMemory,
 } from "../comfyui/client.js";
 import * as cloudClient from "../comfyui/cloud-client.js";
 import { isCloudMode } from "../config.js";
@@ -299,6 +300,133 @@ export async function getJobStatus(
 export async function cancelRunningJob(promptId?: string): Promise<void> {
   await clientInterrupt(promptId);
   logger.info("Job interrupted", { prompt_id: promptId ?? "current" });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** How long to wait for an interrupt to actually stop the running job before
+ *  escalating. ComfyUI only checks the interrupt flag BETWEEN nodes/steps, so a
+ *  multi-minute single step won't honor it — that wait is what detects the wedge.
+ *  Tunable via COMFYUI_MCP_INTERRUPT_S (seconds); default 30. */
+function interruptHonorMs(): number {
+  const s = Number(process.env.COMFYUI_MCP_INTERRUPT_S);
+  return Number.isFinite(s) && s > 0 ? Math.round(s * 1000) : 30000;
+}
+
+/** Poll /queue until the target running job is gone (or any-running is gone when
+ *  no id given), or the timeout elapses. Returns true if it cleared. */
+async function waitForRunningCleared(promptId: string | undefined, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    await sleep(1500);
+    const q = await getQueueSummary().catch(() => null);
+    if (!q) continue;
+    if (q.running === 0) return true;
+    // A DIFFERENT job is now running → the one we targeted has cleared.
+    if (promptId && !q.running_jobs.some((j) => j.prompt_id === promptId)) return true;
+  }
+  return false;
+}
+
+export interface EscalatedCancelResult {
+  interrupted: boolean;
+  honored: boolean; // did the running job actually stop?
+  freed_vram: boolean; // did we escalate to POST /free?
+  wedged: boolean; // still running after interrupt + free → needs a restart
+  pending_cleared?: number; // how many pending jobs were dropped (if clear_pending)
+  running_prompt_id?: string;
+  message: string;
+}
+
+/**
+ * Cancel the running job ROBUSTLY: optionally clear all pending first (so a
+ * re-queue can't stack behind a backlog), interrupt, then WAIT and verify the
+ * job actually stopped. If the interrupt isn't honored within the window, escalate
+ * to POST /free and re-check; if it STILL won't die it's wedged inside a single
+ * step — HTTP can't kill that, so report that a ComfyUI restart is required rather
+ * than letting the agent re-queue on top of a zombie.
+ */
+export async function cancelRunningJobEscalating(opts: {
+  prompt_id?: string;
+  clear_pending?: boolean;
+}): Promise<EscalatedCancelResult> {
+  let pending_cleared: number | undefined;
+  if (opts.clear_pending) {
+    const before = await getQueueSummary().catch(() => null);
+    await clearAllQueued().catch((err) => logger.warn("clear_pending failed (continuing)", { err }));
+    pending_cleared = before?.pending;
+  }
+
+  // Identify the job we're trying to stop so we can verify it actually clears.
+  const pre = await getQueueSummary().catch(() => null);
+  const runningId = opts.prompt_id ?? pre?.running_jobs?.[0]?.prompt_id;
+
+  if (pre && pre.running === 0 && !opts.prompt_id) {
+    return {
+      interrupted: false,
+      honored: true,
+      freed_vram: false,
+      wedged: false,
+      pending_cleared,
+      message: `No job is running.${pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""}`,
+    };
+  }
+
+  await clientInterrupt(opts.prompt_id);
+  logger.info("Interrupt sent (escalating cancel)", { prompt_id: runningId ?? "current" });
+
+  if (await waitForRunningCleared(runningId, interruptHonorMs())) {
+    return {
+      interrupted: true,
+      honored: true,
+      freed_vram: false,
+      wedged: false,
+      pending_cleared,
+      running_prompt_id: runningId,
+      message: `Interrupted the running job${runningId ? ` (${runningId})` : ""}.${
+        pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""
+      }`,
+    };
+  }
+
+  // Not honored — the step is long-running. Free VRAM and re-check.
+  logger.warn("Interrupt not honored in window; escalating to /free", { prompt_id: runningId ?? "current" });
+  await clientFreeMemory({ unload_models: true, free_memory: true }).catch((err) =>
+    logger.warn("/free during cancel escalation failed (continuing)", { err }),
+  );
+
+  if (await waitForRunningCleared(runningId, Math.min(interruptHonorMs(), 12000))) {
+    return {
+      interrupted: true,
+      honored: true,
+      freed_vram: true,
+      wedged: false,
+      pending_cleared,
+      running_prompt_id: runningId,
+      message: `The job didn't stop on interrupt; freeing VRAM cleared it${runningId ? ` (${runningId})` : ""}.${
+        pending_cleared != null ? ` Cleared ${pending_cleared} pending.` : ""
+      }`,
+    };
+  }
+
+  return {
+    interrupted: true,
+    honored: false,
+    freed_vram: true,
+    wedged: true,
+    pending_cleared,
+    running_prompt_id: runningId,
+    message:
+      `⚠️ The running job${runningId ? ` (${runningId})` : ""} did NOT stop after interrupt + VRAM free within ` +
+      `~${Math.round(interruptHonorMs() / 1000)}s — it is wedged inside a single step (ComfyUI only honors interrupts ` +
+      `BETWEEN steps, so a multi-minute step ignores cancel). An HTTP cancel cannot kill this; restart ComfyUI ` +
+      `(panel_restart_comfyui, or restart_comfyui) to clear it. ` +
+      `${
+        opts.clear_pending
+          ? `Pending jobs were cleared (${pending_cleared ?? 0}).`
+          : "Pending jobs were NOT cleared — pass clear_pending:true or call clear_queue."
+      } Do NOT queue another run until this is gone.`,
+  };
 }
 
 export async function cancelQueuedJob(promptId: string): Promise<void> {

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -1,0 +1,253 @@
+// Passive ComfyUI render watchdog for the panel orchestrator.
+//
+// The orchestrator never sees live render progress on its own: panel_run queues
+// through the user's BROWSER, and the per-agent comfyui MCP only opens its WS for
+// its own generate calls. So a render that wedges (a single sampler step running
+// for minutes at high resolution) is invisible here — which is how a stalled job
+// once let the agent stack three more behind it before anyone noticed.
+//
+// This service opens its OWN lightweight WebSocket to COMFYUI_URL. ComfyUI
+// broadcasts execution events (status / executing / progress / execution_*) to
+// every connected client, so we receive the live stream for ANY job — including
+// the browser-queued ones — without touching the panel or the agent subprocess.
+// It holds the last-known run state and derives a stall/backlog report the
+// orchestrator surfaces to the agent as a turn-start note (the same channel as
+// the crash-dump injector).
+//
+// Everything here is BEST-EFFORT: if the socket can't open or drops, the report
+// is simply "inactive" and nothing in the orchestrator changes. It must never
+// throw into the main path.
+
+import WebSocket from "ws";
+import { logger } from "../utils/logger.js";
+
+interface MonitorState {
+  connected: boolean;
+  runningPromptId: string | null;
+  currentNode: string | null;
+  progressValue: number | null;
+  progressMax: number | null;
+  // ComfyUI's status.exec_info.queue_remaining — the total tasks the server still
+  // has (running + pending). Last-known value between status frames.
+  queueRemaining: number;
+  // Monotonic ms timestamp of the last FORWARD-progress signal (node advanced or
+  // progress value ticked up) while a job runs. A stuck step re-emits the same
+  // progress value, which must NOT refresh this — that's how we see the stall.
+  lastActivityTs: number | null;
+}
+
+export interface StallReport {
+  /** A job is running but its node + progress have not advanced for >= stallMs. */
+  stalled: boolean;
+  /** More than one task in flight (running + pending) — a backlog the agent may
+   *  not realize it created by re-queuing behind a slow job. */
+  backlog: boolean;
+  runningPromptId: string | null;
+  currentNode: string | null;
+  /** running + pending, from ComfyUI's own queue_remaining. */
+  queueDepth: number;
+  /** ms the running job has been idle (0 when not stalled). */
+  stalledForMs: number;
+  /** e.g. "0/4" when a progress frame has been seen, else null. */
+  progress: string | null;
+}
+
+export interface QueueSnapshot {
+  connected: boolean;
+  running: boolean;
+  runningPromptId: string | null;
+  queueDepth: number;
+}
+
+const RECONNECT_MS = 5000;
+
+class QueueMonitorImpl {
+  private ws: WebSocket | null = null;
+  private url: string | null = null;
+  private stopped = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private state: MonitorState = {
+    connected: false,
+    runningPromptId: null,
+    currentNode: null,
+    progressValue: null,
+    progressMax: null,
+    queueRemaining: 0,
+    lastActivityTs: null,
+  };
+
+  /** Open the watchdog WS to ComfyUI. Idempotent; best-effort (never throws). */
+  start(comfyuiUrl: string): void {
+    if (this.url) return; // already started
+    this.url = comfyuiUrl;
+    this.stopped = false;
+    this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore */
+    }
+    this.ws = null;
+  }
+
+  private wsUrl(): string {
+    // http(s)://host:port  →  ws(s)://host:port/ws?clientId=...
+    const base = (this.url ?? "http://127.0.0.1:8188").replace(/^http/, "ws").replace(/\/+$/, "");
+    return `${base}/ws?clientId=comfyui-mcp-watchdog`;
+  }
+
+  private connect(): void {
+    if (this.stopped) return;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(this.wsUrl());
+    } catch (err) {
+      logger.debug(`[queue-monitor] WS construct failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+    ws.on("open", () => {
+      this.state.connected = true;
+      logger.debug("[queue-monitor] watchdog WS connected");
+    });
+    ws.on("message", (raw: WebSocket.RawData, isBinary: boolean) => {
+      if (isBinary) return; // preview image frames — ignore
+      this.onMessage(raw.toString());
+    });
+    ws.on("close", () => {
+      this.state.connected = false;
+      this.ws = null;
+      this.scheduleReconnect();
+    });
+    ws.on("error", (err: Error) => {
+      logger.debug(`[queue-monitor] WS error: ${err.message}`);
+      try {
+        ws.close();
+      } catch {
+        /* close handler schedules the reconnect */
+      }
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, RECONNECT_MS);
+    // Don't keep the process alive solely for the watchdog reconnect.
+    this.reconnectTimer.unref?.();
+  }
+
+  private touchActivity(): void {
+    this.state.lastActivityTs = Date.now();
+  }
+
+  private clearRunning(): void {
+    this.state.runningPromptId = null;
+    this.state.currentNode = null;
+    this.state.progressValue = null;
+    this.state.progressMax = null;
+    this.state.lastActivityTs = null;
+  }
+
+  private onMessage(text: string): void {
+    let msg: { type?: string; data?: Record<string, unknown> };
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const data = (msg.data ?? {}) as Record<string, unknown>;
+    switch (msg.type) {
+      case "status": {
+        const status = data.status as Record<string, unknown> | undefined;
+        const execInfo = status?.exec_info as Record<string, unknown> | undefined;
+        const qr = execInfo?.queue_remaining;
+        if (typeof qr === "number") this.state.queueRemaining = qr;
+        break;
+      }
+      case "execution_start": {
+        this.state.runningPromptId = typeof data.prompt_id === "string" ? data.prompt_id : null;
+        this.state.currentNode = null;
+        this.state.progressValue = null;
+        this.state.progressMax = null;
+        this.touchActivity();
+        break;
+      }
+      case "executing": {
+        const node = data.node;
+        if (node === null || node === undefined) {
+          // ComfyUI sends node:null at the end of a prompt's execution.
+          this.clearRunning();
+        } else {
+          const n = String(node);
+          if (n !== this.state.currentNode) this.touchActivity(); // a new node = real progress
+          this.state.currentNode = n;
+          if (typeof data.prompt_id === "string") this.state.runningPromptId = data.prompt_id;
+        }
+        break;
+      }
+      case "progress": {
+        const value = typeof data.value === "number" ? data.value : null;
+        const max = typeof data.max === "number" ? data.max : null;
+        // ONLY treat an advancing value as activity — a wedged step re-emits the
+        // same value, and that must keep the stall clock running.
+        if (value !== null && value !== this.state.progressValue) this.touchActivity();
+        this.state.progressValue = value;
+        this.state.progressMax = max;
+        if (typeof data.node === "string") this.state.currentNode = data.node;
+        break;
+      }
+      case "execution_success":
+      case "execution_error":
+      case "execution_interrupted": {
+        this.clearRunning();
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** Cheap snapshot for backpressure (panel_run): is anything already in flight? */
+  snapshot(): QueueSnapshot {
+    return {
+      connected: this.state.connected,
+      running: this.state.runningPromptId !== null,
+      runningPromptId: this.state.runningPromptId,
+      queueDepth: Math.max(0, this.state.queueRemaining),
+    };
+  }
+
+  /** Stall/backlog report for the turn-start injector. */
+  report(stallMs: number): StallReport {
+    const running = this.state.runningPromptId !== null;
+    const queueDepth = Math.max(running ? 1 : 0, this.state.queueRemaining);
+    const idleFor = running && this.state.lastActivityTs ? Date.now() - this.state.lastActivityTs : 0;
+    const stalled = running && idleFor >= stallMs;
+    const progress =
+      this.state.progressValue !== null && this.state.progressMax !== null
+        ? `${this.state.progressValue}/${this.state.progressMax}`
+        : null;
+    return {
+      stalled,
+      backlog: queueDepth > 1,
+      runningPromptId: this.state.runningPromptId,
+      currentNode: this.state.currentNode,
+      queueDepth,
+      stalledForMs: stalled ? idleFor : 0,
+      progress,
+    };
+  }
+}
+
+/** Process-wide singleton (one ComfyUI per orchestrator). */
+export const QueueMonitor = new QueueMonitorImpl();

--- a/src/tools/color-analysis.ts
+++ b/src/tools/color-analysis.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { analyzeColor } from "../services/color-analysis.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+const analyzeColorSchema = {
+  asset_id: z
+    .string()
+    .optional()
+    .describe("Registered asset id from a completed job. Provide one source: asset_id, filename, or path."),
+  filename: z
+    .string()
+    .optional()
+    .describe("A ComfyUI output ref filename (pair with subfolder/type). Provide one source: asset_id, filename, or path."),
+  subfolder: z
+    .string()
+    .optional()
+    .describe("Subfolder for the output ref (default empty)."),
+  type: z
+    .enum(["output", "input", "temp"])
+    .optional()
+    .describe("ComfyUI dir for the output ref (default 'output')."),
+  path: z
+    .string()
+    .optional()
+    .describe("Absolute image path, or a path under the ComfyUI output dir. Provide one source: asset_id, filename, or path. (Videos: extract a frame to PNG first.)"),
+  reference_path: z
+    .string()
+    .optional()
+    .describe("Optional reference image to shot-match against; returns target−reference deltas for contrast, black/white points, saturation, and per-channel means."),
+  histogram: z
+    .boolean()
+    .optional()
+    .describe("Also return an overlaid R/G/B/luma histogram PNG for visual confirmation (default false)."),
+};
+
+export function registerColorAnalysisTools(server: McpServer): void {
+  server.tool(
+    "analyze_color",
+    "Measure the color of a rendered image (not by eye): returns black/white points, contrast (luma std), saturation, per-channel means + cast, and clipping — plus heuristic flags (washedOut, lowContrast, liftedBlacks, dimHighlights, lowSaturation, colorCast) and a one-line verdict. Source = asset_id, a ComfyUI output ref (filename/subfolder/type), or an image path. Pass reference_path to shot-match against a known-good frame (target−reference deltas). Set histogram:true to also get an overlaid R/G/B/luma histogram PNG. Use this to diagnose 'washed out' objectively and decide a color fix; for a video, extract a frame to PNG first.",
+    analyzeColorSchema,
+    async (args) => {
+      try {
+        const result = await analyzeColor(args);
+        return {
+          content: result.content.map((block) =>
+            block.type === "image"
+              ? { type: "image" as const, data: block.data, mimeType: block.mimeType }
+              : { type: "text" as const, text: block.text },
+          ),
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -36,6 +36,7 @@ import { registerApiNodesTools } from "./api-nodes.js";
 import { registerManagerConfigTools } from "./manager-config.js";
 import { registerManifestTools } from "./manifest.js";
 import { registerImageConvertTools } from "./image-convert.js";
+import { registerColorAnalysisTools } from "./color-analysis.js";
 import { registerStorageUploadTools } from "./storage-upload.js";
 import { registerHealthCheckTools } from "./health-check.js";
 import { registerWorkflowLockTools } from "./workflow-lock.js";
@@ -84,6 +85,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerNodeVerifyTools(server);
   registerManifestTools(server);
   registerImageConvertTools(server);
+  registerColorAnalysisTools(server);
   registerStorageUploadTools(server);
   registerHealthCheckTools(server);
   registerWorkflowLockTools(server);

--- a/src/tools/queue-management.ts
+++ b/src/tools/queue-management.ts
@@ -6,7 +6,7 @@ import {
   getQueuedWorkflow,
   moveQueuedJob,
   editQueuedJob,
-  cancelRunningJob,
+  cancelRunningJobEscalating,
   cancelQueuedJob,
   clearAllQueued,
 } from "../services/queue-manager.js";
@@ -137,7 +137,7 @@ export function registerQueueManagementTools(server: McpServer): void {
 
   server.tool(
     "cancel_job",
-    "Interrupt the CURRENTLY RUNNING ComfyUI job, optionally only when its prompt_id matches. Stops in-progress execution — the partial result is discarded and not recoverable — and does NOT remove pending/queued jobs. Requires a reachable ComfyUI server. Use this for the job actively executing now; use cancel_queued_job to remove one specific PENDING job, or clear_queue to drop ALL pending jobs. Returns a confirmation (or a no-op status when nothing is running).",
+    "Stop the CURRENTLY RUNNING ComfyUI job ROBUSTLY. Sends an interrupt, then WAITS and verifies the job actually stopped — ComfyUI only honors interrupts BETWEEN steps, so a long single step (e.g. a high-res video sampler) can ignore a plain cancel. If the interrupt isn't honored it escalates to freeing VRAM (POST /free) and re-checks; if it STILL won't die it reports the job as WEDGED and tells you to restart_comfyui (an HTTP cancel cannot kill a stuck step). Set clear_pending:true to also drop ALL pending jobs in the same call — the correct 'reset the queue' action, since cancelling alone leaves pending jobs that would run next. The partial result is discarded. Use cancel_queued_job to remove one specific PENDING job instead.",
     {
       prompt_id: z
         .string()
@@ -145,18 +145,22 @@ export function registerQueueManagementTools(server: McpServer): void {
         .describe(
           "Optional. If given, only interrupts the running job when its prompt_id matches; omit to interrupt whatever is currently running.",
         ),
+      clear_pending: z
+        .boolean()
+        .optional()
+        .describe(
+          "Also clear ALL pending jobs (recommended when resetting after a stuck/slow render, so a re-queue doesn't stack behind a backlog). Default false.",
+        ),
     },
     async (args) => {
       try {
-        await cancelRunningJob(args.prompt_id);
-        const target = args.prompt_id ?? "current";
+        const result = await cancelRunningJobEscalating({
+          prompt_id: args.prompt_id,
+          clear_pending: args.clear_pending,
+        });
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Job cancelled successfully (target: ${target}).`,
-            },
-          ],
+          content: [{ type: "text" as const, text: result.message }],
+          ...(result.wedged ? { isError: true } : {}),
         };
       } catch (err) {
         return errorToToolResult(err);


### PR DESCRIPTION
Consolidated session batch for `comfyui-mcp` 0.20.9.

## Features
- **`analyze_color` tool** + **color-correction skill** — objective palette/contrast/color stats so the agent measures instead of eyeballing.
- **Queue/render wedge watchdog** — `panel_run` backpressure, passive `QueueMonitor` stall detection, `cancel_job` escalation (interrupt→/free→WEDGED) + `clear_pending`. Env: `COMFYUI_MCP_STALL_S` / `COMFYUI_MCP_INTERRUPT_S`.
- **Live stall-threshold** via `set_config` (panel changes it without a reconnect).

## Fixes (earlier today, included)
- Registry-first custom-node install + clone fallback + **non-interactive git** (no credential-prompt hang) + security hardening.
- `get_history` newest-by-queue-number; `list_output_images` recurses subfolders + lists videos; `apply_manifest` install verification; interrupt/"send now" gate fix; subgraph I/O + unpack tools.

## Docs
- CHANGELOG 0.20.9; tool reference regenerated (**108/108 tools**, +`analyze_color`); guides (panel, configuration, concepts, backends), today's changelog page, self-healing blog; README (108-tool count + env vars).

**Smoke:** `tsc` clean, **827 tests pass**, `docs:gen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)