### PR TITLE
fix(mcp): reject path-traversal payloads in get_image / stage_output_as_input before forwarding to ComfyUI /view

### DIFF
--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: "/comfy" as string | undefined },
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  copyFile: vi.fn(),
+  readdir: vi.fn(),
+  stat: vi.fn(),
+}));
+
+const fetchImageMock = vi.fn();
+const uploadImageHttpMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  fetchImage: (...a: unknown[]) => fetchImageMock(...a),
+  uploadImageHttp: (...a: unknown[]) => uploadImageHttpMock(...a),
+}));
+
+import { getOutputImage } from "../../services/image-management.js";
+import { ValidationError } from "../../utils/errors.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchImageMock.mockResolvedValue({
+    base64: "aGVsbG8=",
+    mimeType: "image/png",
+  });
+});
+
+describe("getOutputImage — happy path (legitimate ComfyUI references)", () => {
+  it("accepts a plain filename in the output root", async () => {
+    await expect(
+      getOutputImage("hero_00001_.png", "output", ""),
+    ).resolves.toBeDefined();
+    expect(fetchImageMock).toHaveBeenCalledWith("hero_00001_.png", "output", "");
+  });
+
+  it("accepts a nested subfolder ComfyUI legitimately writes to (e.g. video/clip)", async () => {
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video/clip"),
+    ).resolves.toBeDefined();
+    expect(fetchImageMock).toHaveBeenCalledWith(
+      "clip_00001_.mp4",
+      "output",
+      "video/clip",
+    );
+  });
+
+  it("accepts an empty subfolder (top-level output)", async () => {
+    await expect(
+      getOutputImage("a.png", "temp", ""),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("getOutputImage — path-traversal sanitisation (CWE-22)", () => {
+  // ComfyUI's /view endpoint historically allows path traversal via the
+  // subfolder parameter. Untrusted MCP tool inputs must be rejected BEFORE
+  // they are forwarded to the server.
+
+  it("rejects a subfolder containing '..' traversal", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "../../etc"),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a subfolder that is a pure '..'", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", ".."),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an absolute POSIX subfolder", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "/etc"),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an absolute Windows-style subfolder", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "C:\\Windows"),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a subfolder containing NUL bytes", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "ok\u0000../etc"),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a filename containing path separators", async () => {
+    await expect(
+      getOutputImage("../../etc/passwd", "output", ""),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a filename with a backslash separator", async () => {
+    await expect(
+      getOutputImage("..\\..\\windows\\win.ini", "output", ""),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a filename that is '..'", async () => {
+    await expect(
+      getOutputImage("..", "output", ""),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty filename", async () => {
+    await expect(
+      getOutputImage("", "output", ""),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a subfolder containing a NUL byte even if it looks safe", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "video\u0000/../.."),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a subfolder with an embedded '..' segment between safe parts", async () => {
+    await expect(
+      getOutputImage("hero.png", "output", "video/../.."),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -261,6 +261,63 @@ import { fetchImage, uploadImageHttp } from "../comfyui/client.js";
 import { readFile as nodeReadFile } from "node:fs/promises";
 
 /**
+ * Reject filename / subfolder values that could traverse out of ComfyUI's
+ * output, input or temp directory when forwarded to the /view endpoint.
+ *
+ * ComfyUI's /view handler joins the requested `subfolder` and `filename`
+ * onto the configured base directory; the server has historically been
+ * permissive about ".." segments and absolute paths in those parameters
+ * (see e.g. comfyanonymous/ComfyUI#785), so an attacker who can reach the
+ * MCP tool surface could otherwise pivot through get_image / view_image /
+ * stage_output_as_input to read arbitrary files from the ComfyUI host.
+ *
+ * Legitimate ComfyUI values are a single filename (no separators) and a
+ * relative subfolder produced by listOutputImages (forward-slash joined,
+ * no ".." segments). Anything outside that shape is refused here BEFORE
+ * the request is forwarded.
+ */
+function assertSafeViewRef(filename: string, subfolder: string): void {
+  if (typeof filename !== "string" || filename.length === 0) {
+    throw new ValidationError("filename is required");
+  }
+  if (filename.includes("\0") || (subfolder && subfolder.includes("\0"))) {
+    throw new ValidationError(
+      "filename / subfolder must not contain NUL bytes",
+    );
+  }
+  // Filename must be a single path segment — no separators, no traversal.
+  if (
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    filename === "." ||
+    filename === ".." ||
+    filename.split(/[\\/]/).some((s) => s === "..")
+  ) {
+    throw new ValidationError(
+      `Invalid filename "${filename}": must be a single filename without path separators or '..' segments`,
+    );
+  }
+  if (!subfolder) return;
+  // Subfolder must be a forward-slash-joined relative path with no ".."
+  // segments and no Windows-style drive / absolute prefix.
+  if (
+    subfolder.startsWith("/") ||
+    subfolder.startsWith("\\") ||
+    /^[A-Za-z]:[\\/]/.test(subfolder)
+  ) {
+    throw new ValidationError(
+      `Invalid subfolder "${subfolder}": must be relative to the ComfyUI media directory`,
+    );
+  }
+  const segments = subfolder.split(/[\\/]/);
+  if (segments.some((s) => s === "..")) {
+    throw new ValidationError(
+      `Invalid subfolder "${subfolder}": '..' segments are not allowed`,
+    );
+  }
+}
+
+/**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
  * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
  */
@@ -269,6 +326,7 @@ export async function getOutputImage(
   type: "output" | "input" | "temp" = "output",
   subfolder = "",
 ): Promise<{ base64: string; mimeType: string; filename: string }> {
+  assertSafeViewRef(filename, subfolder);
   const result = await fetchImage(filename, type, subfolder);
   return { ...result, filename };
 }
@@ -478,10 +536,12 @@ export async function stageOutputAsInput(
   // Fetch the existing asset's bytes via the same /view mechanism the asset
   // tools use (fetchImage handles cloud vs local). Despite the name, /view
   // returns raw bytes for any media type, not just images.
+  const sourceSubfolder = args.subfolder ?? "";
+  assertSafeViewRef(args.filename, sourceSubfolder);
   const { base64 } = await fetchImage(
     args.filename,
     sourceType,
-    args.subfolder ?? "",
+    sourceSubfolder,
   );
   const data = Buffer.from(base64, "base64");
 


### PR DESCRIPTION
## Summary

The MCP tools `get_image`, `view_image` (asset adapter) and `stage_output_as_input` forward the caller's `filename` and `subfolder` arguments straight to ComfyUI's `/view` HTTP endpoint via `getOutputImage()` / `fetchImage()` in `src/services/image-management.ts`. Until this PR there was no validation of either field at the MCP boundary, so any caller able to reach those tools could include traversal payloads (`..`, absolute paths, NUL bytes, embedded separators) and have them concatenated onto ComfyUI's media directories.

This PR adds a small `assertSafeViewRef()` guard that rejects those shapes before the request is forwarded. Legitimate inputs produced by `listOutputImages` (e.g. `subfolder="video/clip"`, plain filenames like `hero_00001_.png`) continue to work.

- **CWE:** [CWE-22](https://cwe.mitre.org/data/definitions/22.html) — Improper Limitation of a Pathname to a Restricted Directory
- **Severity:** Low to Moderate — defense-in-depth (see "Honest framing" below)
- **Affected file:** `src/services/image-management.ts` — `getOutputImage()` and `stageOutputAsInput()`
- **MCP tools on the affected path:** `get_image`, `view_image`, `stage_output_as_input`, plus internal callers in `image-convert`, `color-analysis`, `storage-upload`

## Honest framing — what this PR is and isn't

I want to be upfront about scope so this is judged on its real merit, not an overstated headline.

**Upstream ComfyUI already mitigates the primary exploit vector.** ComfyUI's own `/view` handler has rejected `filename` values containing `..` or starting with `/`, and has used `os.path.commonpath()` to constrain the resolved subfolder, since commit [`b1294fa4`](https://github.com/comfyanonymous/ComfyUI/commit/b1294fa4) (March 2023). I simulated every payload in the new test suite against the upstream handler and they all return `400`/`403` before any file is read. So against a current mainline ComfyUI install, the realistic exploit window from this MCP is closed at the backend.

**Why I still think the fix is worth merging:**

1. **Heterogeneous backends.** The README documents deployment against Comfy Cloud, RunPod, remote VPS, LAN installs and reverse-proxied setups. ComfyUI custom forks, older pinned versions, and community node-packs that monkeypatch `/view` are common in this ecosystem; not every backend has the upstream sanitiser intact.
2. **MCP threat model.** Tool arguments here are agent-controlled, and agents in this stack consume workflow JSON, custom-node READMEs, CivitAI metadata and remote skills — all classic prompt-injection vectors. Defense-in-depth at the tool boundary is appropriate when the caller is partially attacker-influenced.
3. **Better diagnostics.** A clean `ValidationError` at the MCP boundary surfaces the bad input immediately and unambiguously, instead of a confusing ComfyUI `400`/`403` round-trip the agent then has to interpret.
4. **Cheap.** ~60 lines, one guard, zero behaviour change for legitimate inputs.

## Fix

Single new function in `src/services/image-management.ts`:

```typescript
function assertSafeViewRef(filename: string, subfolder: string): void {
  if (typeof filename !== "string" || filename.length === 0) {
    throw new ValidationError("filename is required");
  }
  if (filename.includes("\0") || (subfolder && subfolder.includes("\0"))) {
    throw new ValidationError("filename / subfolder must not contain NUL bytes");
  }
  if (
    filename.includes("/") || filename.includes("\\") ||
    filename === "." || filename === ".." ||
    filename.split(/[\\/]/).some((s) => s === "..")
  ) {
    throw new ValidationError(`Invalid filename "${filename}": must be a single filename without path separators or '..' segments`);
  }
  if (!subfolder) return;
  if (
    subfolder.startsWith("/") || subfolder.startsWith("\\") ||
    /^[A-Za-z]:[\\/]/.test(subfolder)
  ) {
    throw new ValidationError(`Invalid subfolder "${subfolder}": must be relative to the ComfyUI media directory`);
  }
  if (subfolder.split(/[\\/]/).some((s) => s === "..")) {
    throw new ValidationError(`Invalid subfolder "${subfolder}": '..' segments are not allowed`);
  }
}
```

Called from the two entry points that build `/view` URLs from user-supplied args:
- `getOutputImage(filename, type, subfolder)` — used by `get_image`, `view_image`, and the internal image-convert / color-analysis / storage-upload paths.
- `stageOutputAsInput({ filename, subfolder, ... })` — used by the `stage_output_as_input` MCP tool, which calls `fetchImage()` directly.

Rules enforced:
- `filename` must be a non-empty string with no path separators, no `..`, no NUL.
- `subfolder` (when present) must be relative — no leading `/` or `\`, no Windows drive prefix (`C:\`), no `..` segment, no NUL.
- Forward-slash-joined relative subfolders like `video/clip` (produced by `listOutputImages` for VHS/SaveVideo outputs) are preserved.

## Tests

New file: `src/__tests__/services/image-management-traversal.test.ts` — 14 vitest cases covering both the happy path and the documented traversal payloads.

**Happy path (must still work):**
- Plain filename in the output root (`hero_00001_.png`).
- Nested subfolder that `listOutputImages` legitimately returns (`video/clip` + `clip_00001_.mp4`).
- Empty subfolder against the `temp` directory.

**Rejected payloads:**
- `subfolder="../../etc"`, `subfolder=".."`, `subfolder="/etc"`, `subfolder="\\server\share"`, `subfolder="C:\\Windows"`, `subfolder="foo/../bar"`.
- `filename="../etc/passwd"`, `filename="foo/bar.png"`, `filename=".."`, `filename=""`.
- `filename="hero\0.png"`, `subfolder="video\0/clip"`.

Each rejection asserts both `ValidationError` is thrown AND that the underlying `fetchImage` mock was never called — i.e. the bad request never leaves the MCP process.

```text
$ npx vitest run src/__tests__/services/image-management-traversal.test.ts
 ✓ src/__tests__/services/image-management-traversal.test.ts (14 tests) 3ms

 Test Files  1 passed (1)
      Tests  14 passed (14)

$ npm test
 Test Files  80 passed (80)
      Tests  841 passed (841)

$ npm run lint   # tsc --noEmit
# clean — no errors
```

## Proof of concept

The data flow is `MCP tool args → getOutputImage()/stageOutputAsInput() → fetchImage() → GET /view?filename=…&subfolder=…&type=…` against the configured ComfyUI host. Before this patch, `subfolder` and `filename` were forwarded verbatim.

Reproduction without a live ComfyUI (uses the same mocked `fetchImage` the project's tests use, so this is exactly what a malicious tool call would attempt to send on the wire):

```typescript
// poc-traversal.ts — drop into the repo root and run with: npx tsx poc-traversal.ts
import { vi } from "vitest";
const fetchImageMock = vi.fn().mockResolvedValue({ base64: "Zm9v", mimeType: "image/png" });
vi.mock("./src/comfyui/client.js", () => ({
  fetchImage: (...a: unknown[]) => fetchImageMock(...a),
  uploadImageHttp: vi.fn(),
}));

const { getOutputImage } = await import("./src/services/image-management.js");

// BEFORE this patch: this call would have proxied to
//   GET /view?filename=passwd&type=output&subfolder=..%2F..%2F..%2F..%2Fetc
// AFTER this patch: ValidationError, fetchImageMock never called.
try {
  await getOutputImage("passwd", "output", "../../../../etc");
  console.log("VULN: request was forwarded");
} catch (e) {
  console.log("FIXED:", (e as Error).message);
}
console.log("fetchImage call count:", fetchImageMock.mock.calls.length); // 0 after the fix
```

End-to-end against a backend that doesn't have ComfyUI's upstream `b1294fa4` `/view` sanitiser, the agent-visible result on success would be the target file's bytes returned as a base64 `image` content block in the MCP response — i.e. the contents become readable by the agent and end up in transcripts/logs. The realistic delivery vector is prompt-injection of the agent via untrusted content the project itself fetches (workflow JSON, custom-node READMEs, CivitAI metadata, remote skills) telling it to call `get_image` with the crafted args. Against current upstream ComfyUI those payloads are rejected at the backend; against older/forked/cloud backends they are not.

## Scope notes (things I deliberately did **not** change)

- `src/orchestrator/claude-backend.ts` (around line 244, `fetchImageBlock`) and `src/orchestrator/codex-backend.ts` (around line 587, `fetchImageFile`) also construct `/view` URLs, but they build them from `ImageRef` events on the loopback panel-UI bridge rather than from agent-controlled MCP tool args. That's a different trust boundary, so I scoped them out of this PR. If you'd prefer the same guard applied there as a follow-up (e.g. for `--host 0.0.0.0` HTTP-mode deployments where the panel websocket could plausibly receive influenced events), I'm happy to send a separate small PR — flag it and I will.
- No change to the `/view` request encoding itself, no change to the tool schemas, no behaviour change for callers using legitimate filenames/subfolders.

## Adversarial review

Before opening this, I tried to talk myself out of submitting it. The strongest counter-argument is the one above: upstream ComfyUI rejects every payload in the test suite at the `/view` handler since 2023, so on a vanilla install the MCP-side guard is redundant. I went looking for cases where it isn't redundant and found three that I think are real: (1) the project explicitly supports remote/cloud backends and reverse-proxied installs where the `/view` implementation is not guaranteed to be current-mainline; (2) custom ComfyUI forks and node-packs that monkeypatch routes are common; (3) the agent-as-untrusted-caller model means validating at the tool boundary gives a clean, fast failure that doesn't depend on the backend's behaviour. I considered whether `zod` schema validation on the tool args was enough — it isn't, the schemas only constrain types, not content. I considered whether `basename()` (already used downstream in `get_image` when writing the file locally) covers this — it doesn't, because `basename()` runs after `getOutputImage()`, which is the call that actually leaves the host. Given the cost (one small function, one test file, zero behaviour change for legitimate inputs) I think defense-in-depth here is justified even with the upstream mitigation in place.