### PR TITLE
feat: Gemini agent backend (gemini --acp / Agent Client Protocol)

### DIFF
--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -1,0 +1,337 @@
+// Unit tests for the Gemini CLI ACP backend (gemini-backend.ts).
+//
+// We CANNOT run the real `gemini` CLI here, so we drive the REAL GeminiBackend /
+// AcpClient code end-to-end against a FAKE ACP server spoken over a mocked
+// child_process. `node:child_process` is mocked so `spawn()` returns an in-process
+// fake child whose stdin/stdout are wired to a tiny JSON-RPC-2.0 ACP server that
+// implements the handshake (initialize → session/new), one streamed prompt turn
+// (agent_thought_chunk + tool_call + tool_call_update + agent_message_chunk, then
+// a session/prompt response with stopReason), and session/cancel. This exercises
+// the line framing, the request/response correlation, the session/update →
+// AgentEvent mapping, the terminal-result invariant, and interrupt — all
+// deterministically, with no real binary.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type {
+  AgentEvent,
+  NeutralTurn,
+  BackendStartOptions,
+} from "../../orchestrator/agent-backend.js";
+
+// ---- shared state the mocked child_process writes into / the tests read ----
+const hoisted = vi.hoisted(() => ({
+  // The spawned fake procs (one per backend prepare()).
+  procs: [] as Array<Record<string, unknown>>,
+  // Every JSON-RPC message the client SENT to the server (requests + notifications).
+  received: [] as Array<Record<string, unknown>>,
+  // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
+  // "cancel" streams a bit then WAITS for session/cancel before resolving.
+  config: { mode: "complete" as "complete" | "cancel" },
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+
+  function makeFakeProc() {
+    const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    proc.pid = 4242;
+    proc.exitCode = null;
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    proc.stdin = stdin;
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.kill = () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+      return true;
+    };
+    // When the client ends stdin (close()), surface a clean child exit so
+    // AcpClient.exitPromise resolves and close() returns.
+    stdin.on("finish", () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+    });
+
+    const write = (obj: unknown) => stdout.write(`${JSON.stringify(obj)}\n`);
+    const notify = (sessionId: string, update: Record<string, unknown>) =>
+      write({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update } });
+
+    // Drive a streamed prompt turn, then resolve the request (or wait for cancel).
+    let pendingPromptId: number | string | null = null;
+    const SESSION_ID = "sess-test-1";
+
+    const streamTurn = (id: number | string, sessionId: string) => {
+      // Reasoning (thinking) chunk.
+      notify(sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "thinking..." },
+      });
+      // A tool call (start → completed).
+      notify(sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "panel_run",
+        kind: "other",
+        status: "pending",
+      });
+      notify(sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call_1",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "ran" } }],
+      });
+      // Reply message in two chunks (same messageId groups them).
+      notify(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "msg_1",
+        content: { type: "text", text: "Hello" },
+      });
+      notify(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "msg_1",
+        content: { type: "text", text: " there!" },
+      });
+      if (hoisted.config.mode === "complete") {
+        write({ jsonrpc: "2.0", id, result: { stopReason: "end_turn" } });
+      } else {
+        // Park the prompt; session/cancel will resolve it.
+        pendingPromptId = id;
+      }
+    };
+
+    // Read newline-framed JSON-RPC from the client's stdin.
+    let buf = "";
+    stdin.on("data", (chunk: Buffer) => {
+      buf += String(chunk);
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        hoisted.received.push(msg);
+        const method = msg.method as string | undefined;
+        const id = msg.id as number | string | undefined;
+        if (method === "initialize" && id !== undefined) {
+          write({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: 1,
+              agentCapabilities: {
+                loadSession: true,
+                promptCapabilities: { image: true, audio: false, embeddedContext: true },
+                mcpCapabilities: { http: true, sse: false },
+              },
+              agentInfo: { name: "gemini", title: "Gemini", version: "test" },
+              authMethods: [],
+            },
+          });
+        } else if (method === "session/new" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: { sessionId: SESSION_ID } });
+        } else if (method === "session/load" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: {} });
+        } else if (method === "authenticate" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: {} });
+        } else if (method === "session/prompt" && id !== undefined) {
+          // Stream on the next tick so the request is registered first.
+          setImmediate(() => streamTurn(id, (msg.params as { sessionId: string }).sessionId));
+        } else if (method === "session/cancel") {
+          if (pendingPromptId !== null) {
+            const pid = pendingPromptId;
+            pendingPromptId = null;
+            write({ jsonrpc: "2.0", id: pid, result: { stopReason: "cancelled" } });
+          }
+        }
+      }
+    });
+
+    hoisted.procs.push(proc);
+    return proc;
+  }
+
+  return {
+    ...actual,
+    spawn: () => makeFakeProc(),
+    // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
+    spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
+  };
+});
+
+let GeminiBackend: typeof import("../../orchestrator/gemini-backend.js").GeminiBackend;
+
+beforeEach(async () => {
+  hoisted.procs.length = 0;
+  hoisted.received.length = 0;
+  hoisted.config.mode = "complete";
+  ({ GeminiBackend } = await import("../../orchestrator/gemini-backend.js"));
+});
+
+/** A push-driven async channel of NeutralTurns (PanelAgent's "channel in" seam). */
+function makeChannel() {
+  const queue: NeutralTurn[] = [];
+  let resolveNext: ((r: IteratorResult<NeutralTurn>) => void) | null = null;
+  let closed = false;
+  const iterable: AsyncIterable<NeutralTurn> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<NeutralTurn>> {
+          if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+          if (closed) return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise((res) => {
+            resolveNext = res;
+          });
+        },
+      };
+    },
+  };
+  return {
+    iterable,
+    push(t: NeutralTurn) {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: t, done: false });
+      } else queue.push(t);
+    },
+    close() {
+      closed = true;
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: undefined as never, done: true });
+      }
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Start consuming a backend.run() generator into an events array. */
+function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<void> {
+  return (async () => {
+    for await (const ev of gen) events.push(ev);
+  })();
+}
+
+describe("GeminiBackend (ACP over stdio)", () => {
+  it("handshake → prompt → streamed updates → result maps to the canonical AgentEvent sequence", async () => {
+    const backend = new GeminiBackend({ cwd: process.cwd(), systemAppend: "BE NICE." });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const opts: BackendStartOptions = { channel: channel.iterable };
+    const run = consume(backend.run(opts), events);
+
+    channel.push({ text: "hi there" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // session event first, carrying the ACP sessionId.
+    expect(events[0]).toMatchObject({ type: "session", sessionId: "sess-test-1" });
+
+    // Thinking delta surfaced (agent_thought_chunk → assistant_delta thinking:true).
+    expect(events.some((e) => e.type === "assistant_delta" && e.thinking === true)).toBe(true);
+
+    // Reply deltas concatenate to the full message.
+    const replyDeltas = events
+      .filter((e): e is Extract<AgentEvent, { type: "assistant_delta" }> => e.type === "assistant_delta" && !e.thinking)
+      .map((e) => e.text)
+      .join("");
+    expect(replyDeltas).toBe("Hello there!");
+
+    // Tool call start + end both surfaced with the tool's title as the name.
+    const toolStart = events.find((e) => e.type === "tool_call" && e.phase === "start");
+    const toolEnd = events.find((e) => e.type === "tool_call" && e.phase === "end");
+    expect(toolStart).toMatchObject({ type: "tool_call", name: "panel_run", phase: "start" });
+    expect(toolEnd).toMatchObject({ type: "tool_call", name: "panel_run", phase: "end" });
+
+    // Exactly one committed assistant message with the full reply + its stream id.
+    const assistants = events.filter((e) => e.type === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]).toMatchObject({ type: "assistant", text: "Hello there!", id: "msg_1" });
+
+    // Exactly one terminal result (the "exactly one result" invariant), ok + subtype.
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: "result", ok: true, subtype: "end_turn" });
+
+    // Stream bubbles are balanced (every stream_start has a stream_end).
+    const starts = events.filter((e) => e.type === "stream_start").length;
+    const ends = events.filter((e) => e.type === "stream_end").length;
+    expect(starts).toBe(ends);
+    expect(starts).toBeGreaterThanOrEqual(2); // a thinking stream + a reply stream
+
+    // The handshake + session were established and the prompt carried the persona
+    // preamble (ACP session/new has no instructions field) as the first text block.
+    const methods = hoisted.received.map((m) => m.method);
+    expect(methods).toContain("initialize");
+    expect(methods).toContain("session/new");
+    const promptMsg = hoisted.received.find((m) => m.method === "session/prompt");
+    expect(promptMsg).toBeTruthy();
+    const promptBlocks = (promptMsg!.params as { prompt: Array<{ type: string; text?: string }> }).prompt;
+    expect(promptBlocks[0].type).toBe("text");
+    expect(promptBlocks[0].text).toContain("<system>");
+    expect(promptBlocks[0].text).toContain("BE NICE.");
+    expect(promptBlocks[0].text).toContain("hi there");
+
+    await backend.close();
+  });
+
+  it("interrupt() sends session/cancel and the turn ends with a single cancelled result", async () => {
+    hoisted.config.mode = "cancel";
+    const backend = new GeminiBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "do a long thing" });
+    // Wait until the stream has started (proves the turn is in flight) before cancelling.
+    await waitFor(() => events.some((e) => e.type === "assistant_delta"));
+
+    await backend.interrupt();
+
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // The client sent a session/cancel for the live session.
+    const cancel = hoisted.received.find((m) => m.method === "session/cancel");
+    expect(cancel).toBeTruthy();
+    expect((cancel!.params as { sessionId: string }).sessionId).toBe("sess-test-1");
+
+    // Exactly one terminal result, marked not-ok with the cancelled stopReason.
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: "result", ok: false, subtype: "cancelled" });
+
+    await backend.close();
+  });
+
+  it("listModels returns the static Gemini catalog (no effort metadata)", async () => {
+    const backend = new GeminiBackend();
+    const models = await backend.listModels();
+    expect(models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+    // Gemini has no discrete effort scale → no effort metadata (panel hides picker).
+    expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
+  });
+});

--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -22,6 +22,8 @@ import type {
 const hoisted = vi.hoisted(() => ({
   // The spawned fake procs (one per backend prepare()).
   procs: [] as Array<Record<string, unknown>>,
+  // The argv passed to spawn() for each spawned proc (to assert --model pinning).
+  spawnArgs: [] as string[][],
   // Every JSON-RPC message the client SENT to the server (requests + notifications).
   received: [] as Array<Record<string, unknown>>,
   // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
@@ -165,7 +167,10 @@ vi.mock("node:child_process", async (importOriginal) => {
 
   return {
     ...actual,
-    spawn: () => makeFakeProc(),
+    spawn: (_cmd: string, args: string[]) => {
+      hoisted.spawnArgs.push(Array.isArray(args) ? args : []);
+      return makeFakeProc();
+    },
     // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
     spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
   };
@@ -175,6 +180,7 @@ let GeminiBackend: typeof import("../../orchestrator/gemini-backend.js").GeminiB
 
 beforeEach(async () => {
   hoisted.procs.length = 0;
+  hoisted.spawnArgs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
   ({ GeminiBackend } = await import("../../orchestrator/gemini-backend.js"));
@@ -333,5 +339,84 @@ describe("GeminiBackend (ACP over stdio)", () => {
     expect(models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
     // Gemini has no discrete effort scale → no effort metadata (panel hides picker).
     expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
+  });
+
+  it("applies the panel-selected model to the FIRST spawn (--model) before prepare", async () => {
+    // No construction-time model; the panel-selected Gemini model arrives as
+    // opts.model and must pin the very first `gemini --acp` spawn (P1a).
+    const backend = new GeminiBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable, model: "gemini-2.5-flash" }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(hoisted.spawnArgs[0]).toContain("--acp");
+    expect(hoisted.spawnArgs[0]).toContain("--model");
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-2.5-flash");
+
+    await backend.close();
+  });
+
+  it("a live setModel() respawns the CLI with the new --model and a fresh session", async () => {
+    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-2.5-pro" });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    // First turn on the initial model.
+    channel.push({ text: "turn one" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 1);
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-2.5-pro");
+
+    // Live model switch (panel picker → PanelAgent.setOptions → agent.setModel).
+    await backend.setModel("gemini-2.5-flash");
+
+    // Next turn must transparently respawn with the new --model + a fresh session.
+    channel.push({ text: "turn two" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 2);
+    channel.close();
+    await run;
+
+    // A SECOND `gemini --acp` was spawned, pinned to the new model.
+    expect(hoisted.spawnArgs).toHaveLength(2);
+    expect(hoisted.spawnArgs[1]).toContain("--acp");
+    expect(hoisted.spawnArgs[1][hoisted.spawnArgs[1].indexOf("--model") + 1]).toBe("gemini-2.5-flash");
+
+    // The respawn opened a fresh session → a second `session` event was emitted.
+    expect(events.filter((e) => e.type === "session").length).toBe(2);
+    // Both turns completed cleanly.
+    expect(events.filter((e) => e.type === "result").every((r) => (r as { ok: boolean }).ok)).toBe(true);
+
+    await backend.close();
+  });
+
+  it("ignores a non-Gemini model id passed to setModel (e.g. the Claude panel model)", async () => {
+    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-2.5-pro" });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "turn one" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 1);
+
+    // PanelAgent may relay the Claude panel model — it must NOT respawn Gemini.
+    await backend.setModel("claude-opus-4-8");
+
+    channel.push({ text: "turn two" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 2);
+    channel.close();
+    await run;
+
+    // Still only one spawn (no respawn), and only one session.
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(events.filter((e) => e.type === "session").length).toBe(1);
+
+    await backend.close();
   });
 });

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -34,7 +34,7 @@ describe("formatEnvBlock", () => {
     expect(out).toContain("ComfyUI 0.26.1 (LOCAL)");
     expect(out).toContain("Triton: not installed");
     expect(out).toContain("SageAttention: not installed");
-    expect(out).toContain("Backend: Codex; Claude also available");
+    expect(out).toContain("Backend: Codex; other providers available");
     // The guidance tail (acceleration decision) is always appended.
     expect(out).toContain("default to sdpa + no");
     expect(out).toContain("triton-sageattention skill");

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -9,7 +9,7 @@
 
 import type { ImageRef } from "./panel-agent.js";
 
-export type BackendId = "claude" | "codex";
+export type BackendId = "claude" | "codex" | "gemini";
 
 /**
  * A user turn in PROVIDER-NEUTRAL form. PanelAgent owns the queue/turn-gate and
@@ -203,4 +203,21 @@ export const CODEX_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // gpt-5.5 sees images; delivered as `localImage` turn input items
+};
+
+/** Capability descriptor for the Gemini CLI ACP backend (Agent Client Protocol).
+ *  Mirrors the Codex posture: a persistent session over a JSON-RPC-over-stdio
+ *  client, streaming deltas + tool calls, interrupt via `session/cancel`, and
+ *  config-declared MCP servers (no in-process SDK MCP). forkAtAnchor is false —
+ *  ACP `session/load` is whole-session only, with no per-turn rewind anchor. */
+export const GEMINI_CAPABILITIES: AgentCapabilities = {
+  persistentChannel: true, // session/new + repeated session/prompt
+  streamingDeltas: true, // session/update agent_message_chunk / agent_thought_chunk
+  interruptMidTurn: true, // session/cancel
+  forkAtAnchor: false, // session/load is whole-session only (no anchor fork)
+  inProcessMcp: false, // ACP session/new declares config MCP servers only
+  modelEnumeration: true, // static catalog (gemini-2.5-pro / -flash) — ACP exposes no catalog
+  slashCommands: false,
+  hooks: false,
+  vision: true, // gemini-2.5 sees images; delivered as inline base64 image ContentBlocks
 };

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -501,6 +501,10 @@ export class GeminiBackend implements AgentBackend {
   private sessionId: string | null = null;
   /** The model requested for new sessions (applied at SPAWN via --model). */
   private model: string | undefined;
+  /** The model the LIVE `gemini --acp` child was actually spawned with. Gemini
+   *  pins the model at spawn, so when this drifts from `this.model` (a live
+   *  setModel) the run loop respawns the CLI before the next turn (P1). */
+  private spawnedModel: string | undefined;
   /** Capabilities the agent advertised at initialize (loadSession / image / http). */
   private agentCaps: AcpInitializeResult["agentCapabilities"] = undefined;
   private authMethods: AcpAuthMethod[] = [];
@@ -620,6 +624,9 @@ export class GeminiBackend implements AgentBackend {
       this.agentCaps = init.agentCapabilities;
       this.authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
       this.client = client;
+      // Record what the live child was spawned with so a later setModel can detect
+      // the model drifted and respawn (the model is spawn-pinned via --model) (P1).
+      this.spawnedModel = this.model;
       logger.info(
         `[gemini-backend] ACP ready (protocol ${init.protocolVersion ?? "?"}, agent ${init.agentInfo?.name ?? "gemini"}${this.authMethods.length ? `, ${this.authMethods.length} auth method(s)` : ""})`,
       );
@@ -699,21 +706,22 @@ export class GeminiBackend implements AgentBackend {
    * IS the turn-gate).
    */
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
-    await this.prepare();
-    const client = this.client;
-    if (!client) throw new Error("gemini --acp not initialized");
-    const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
-    // MODEL PRECEDENCE (P1-1): PanelAgent.start() always passes opts.model = the
-    // CLAUDE panel model, which is NOT a valid Gemini model. The Gemini model
-    // configured at construction (deps.model, from COMFYUI_MCP_GEMINI_MODEL) must
-    // win. Only honor opts.model if it actually looks like a Gemini model.
-    // (The model is applied at SPAWN via --model, so a change only takes effect on
-    // the next prepare()/process — see resolveSpawn; flagged in the PR body.)
+    // MODEL PRECEDENCE (P1): apply the panel-selected model BEFORE prepare() so the
+    // FIRST spawn uses it (the model is spawn-pinned via `--model`; preparing first
+    // would spawn the wrong model). PanelAgent.start() usually passes opts.model =
+    // the CLAUDE panel model, which is NOT a valid Gemini model — so the configured
+    // Gemini model (deps.model, from COMFYUI_MCP_GEMINI_MODEL) wins; only honor
+    // opts.model when it actually looks like a Gemini model (e.g. the user picked
+    // one in the panel, which arrives as opts.model on a fresh spawn).
     if (opts.model && isGeminiModel(opts.model)) this.model = opts.model;
+
+    await this.prepare();
+    if (!this.client) throw new Error("gemini --acp not initialized");
+    const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
 
     // forkAtAnchor is false → ignore opts.rewindAnchor; whole-session resume only.
     const resumeId = opts.resume ?? opts.sessionId ?? null;
-    const sessionId = await this.ensureSession(client, cwd, resumeId);
+    let sessionId = await this.ensureSession(this.client, cwd, resumeId);
 
     // The session id is our session id (PanelAgent persists it for resume).
     yield {
@@ -724,8 +732,41 @@ export class GeminiBackend implements AgentBackend {
 
     // Process the neutral channel one turn at a time.
     for await (const turn of opts.channel) {
-      yield* this.runTurn(client, turn, opts.onActivity);
+      // LIVE MODEL SWITCH (P1): PanelAgent treats setModel as live and does NOT
+      // restart run() for a model-only change, so the persistent loop adopts it
+      // here. The model is spawn-pinned, so a switch means respawning the CLI with
+      // the new --model — which necessarily starts a FRESH session (a model swap
+      // can't carry the old session forward). Done transparently before the turn;
+      // we emit a new `session` event so PanelAgent persists the new id.
+      if (this.spawnedModel !== this.model) {
+        await this.respawnForModelChange();
+        if (!this.client) throw new Error("gemini --acp respawn failed");
+        sessionId = await this.ensureSession(this.client, cwd, null);
+        yield {
+          type: "session",
+          sessionId,
+          ...(this.model ? { model: this.model } : {}),
+        };
+      }
+      yield* this.runTurn(this.client, turn, opts.onActivity);
     }
+  }
+
+  /** Tear down the live `gemini --acp` child (process-tree kill) and re-spawn it
+   *  with the current `this.model`'s `--model` flag, so a live setModel takes
+   *  effect. The model is spawn-pinned, so this is the only way to switch it. The
+   *  caller then opens a fresh session on the new child. */
+  private async respawnForModelChange(): Promise<void> {
+    const old = this.client;
+    this.client = null;
+    this.sessionId = null;
+    if (old) {
+      old.notificationHandler = null;
+      await old.close().catch(() => {});
+    }
+    this.spawnSpec = null; // force resolveSpawn to rebuild argv with the new --model
+    logger.info(`[gemini-backend] model switch → respawning gemini --acp with --model ${this.model ?? "(default)"}`);
+    await this.prepare(); // spawns with this.model; records spawnedModel
   }
 
   /** Run ONE turn: send session/prompt + stream its session/update notifications →
@@ -982,16 +1023,17 @@ export class GeminiBackend implements AgentBackend {
     }
   }
 
-  /** Switch the model for the NEXT session. ACP fixes the model at spawn (--model),
-   *  so this only takes effect on the next prepare()/process — the panel restarts
-   *  run() on a model change, but a live in-process switch would need a re-spawn.
-   *  Flagged in the PR body. */
+  /** Switch the model live. ACP pins the model at spawn (`--model`), so this can't
+   *  reconfigure a running child — instead it marks the model dirty (this.model !=
+   *  this.spawnedModel) and invalidates the cached spawn spec. The persistent run()
+   *  loop then RESPAWNS the `gemini --acp` CLI with the new --model (and a fresh
+   *  session) transparently before the next turn (see run()'s live-switch branch).
+   *  If the backend hasn't spawned yet, the first prepare() simply uses the new
+   *  model. Ignores non-Gemini ids (PanelAgent may pass the Claude panel model). */
   async setModel(model: string): Promise<void> {
-    if (isGeminiModel(model)) {
-      this.model = model;
-      // Invalidate the cached spawn spec so the next prepare() picks up --model.
-      this.spawnSpec = null;
-    }
+    if (!isGeminiModel(model)) return;
+    this.model = model;
+    this.spawnSpec = null; // next spawn rebuilds argv with the new --model
   }
 
   /**

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -1,0 +1,1031 @@
+// Google Gemini backend — the provider-specific adapter behind the AgentBackend
+// port, driving the Gemini CLI over its **ACP (Agent Client Protocol)** mode
+// (`gemini --acp`), a JSON-RPC 2.0 client over stdio. This is a faithful MIRROR
+// of codex-backend.ts (the Codex app-server adapter): same self-contained
+// line-framed JSON-RPC client, same per-turn event-queue bridge, same
+// terminal-result invariant, same Windows/POSIX process-tree kill. Only the
+// wire protocol differs (ACP instead of the codex app-server protocol).
+//
+// PanelAgent keeps all provider-agnostic orchestration (queue, turn-gate, bridge
+// push, self-restart) and drives this backend via
+// `for await (const ev of backend.run({...}))`. See
+// docs/design/agent-backend-injection.md.
+//
+// PROTOCOL MAPPING (AgentBackend ↔ ACP, per agentclientprotocol.com + the
+// Gemini CLI docs/cli/acp-mode.md):
+//   - prepare()           = spawn `gemini --acp` + `initialize` handshake
+//   - session             = an ACP SESSION (`session/new` new | `session/load` resume)
+//   - run() loop turn     = `session/prompt` (ONE request per neutral channel batch);
+//                           the request RESOLVES with a `stopReason` at turn end
+//                           (unlike Codex, where turn/start returns immediately
+//                           and a separate turn/completed notification ends it).
+//                           Images ride inline as base64 `image` ContentBlocks.
+//   - assistant_delta     ← `session/update` { update.sessionUpdate:"agent_message_chunk",
+//                            content:{type:"text",text} }
+//   - assistant_delta(th) ← `session/update` { ...:"agent_thought_chunk", ... } (thinking)
+//   - assistant (commit)  ← the accumulated agent_message_chunk text, emitted once
+//                            when the session/prompt request resolves (ACP has no
+//                            separate "final message" notification — the chunks ARE
+//                            the message; the prompt response is the turn boundary)
+//   - tool_call(start)    ← `session/update` { ...:"tool_call", toolCallId, title, kind }
+//   - tool_call(end)      ← `session/update` { ...:"tool_call_update", status:
+//                            "completed"|"failed" }
+//   - result              ← the `session/prompt` response { stopReason }
+//   - error               ← a failed `session/prompt` / the child dying mid-turn
+//   - interrupt()         → `session/cancel` (notification); the in-flight prompt
+//                            then resolves with stopReason:"cancelled"
+//   - listModels()        ← a static catalog (gemini-2.5-pro / -flash) — ACP exposes
+//                            no model enumeration; the model is selected at SPAWN via
+//                            the CLI `--model` flag (see resolveBin/spawn below)
+//
+// AUTH (NO API KEY — the CLI owns auth): Gemini CLI authenticates itself via
+// Google OAuth / Code Assist (the user runs `gemini` once to sign in). This
+// backend NEVER passes an API key; it just spawns the already-authenticated CLI.
+// If the CLI is signed out, `session/new` returns an `auth_required` error — we
+// attempt one `authenticate` with the first advertised auth method, then surface
+// a clear "run `gemini` and sign in" message (the OAuth browser flow itself is
+// owned by the CLI and cannot be completed headlessly).
+//
+// PARITY with Codex/Claude: the Gemini backend gets the SAME tool surface — the
+// headless `comfyui` stdio MCP plus the `panel` HTTP MCP for live-graph panel_*
+// tools — declared to `session/new` as ACP McpServers. The panel system prompt
+// is prepended to the FIRST turn's prompt (ACP `session/new` has no system /
+// instructions field, mirroring the Codex app-server's thread/start).
+//
+// ASSUMPTIONS we could NOT verify without the live `gemini` CLI (flagged inline,
+// see also the PR body): the exact ACP McpServer http variant shape, the
+// session/load resume semantics, the auth_required retry, and live model
+// switching (we set the model at spawn via --model since ACP exposes no standard
+// per-session model setter). Each is the closest faithful mapping to the
+// documented ACP spec.
+
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createRequire } from "node:module";
+import readline from "node:readline";
+import { logger } from "../utils/logger.js";
+import {
+  type AgentBackend,
+  type AgentEvent,
+  type BackendStartOptions,
+  type ModelChoice,
+  type NeutralTurn,
+  GEMINI_CAPABILITIES,
+} from "./agent-backend.js";
+import type { ImageRef } from "./panel-agent.js";
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Kill an entire process tree, not just the direct child. On the Windows
+ * PATH/shell fallback the direct child is a cmd.exe/`.cmd` shim whose grandchild
+ * is the real `gemini` node process — killing only the shell leaves the tree
+ * alive. Use `taskkill /T /F`. On POSIX, signal the process group (negative pid)
+ * so a shell + its child both die, falling back to the single pid. Best-effort +
+ * swallows errors: it runs during teardown and must never throw into the host.
+ * (Identical to codex-backend's killProcessTree — same spawn posture.)
+ */
+function killProcessTree(pid: number | undefined): void {
+  if (!Number.isFinite(pid)) return;
+  const p = pid as number;
+  if (process.platform === "win32") {
+    try {
+      spawnSync("taskkill", ["/PID", String(p), "/T", "/F"], { windowsHide: true });
+    } catch {
+      try {
+        process.kill(p);
+      } catch {
+        // already gone
+      }
+    }
+    return;
+  }
+  try {
+    process.kill(-p, "SIGTERM"); // process group (we spawn detached on POSIX)
+  } catch {
+    try {
+      process.kill(p, "SIGTERM");
+    } catch {
+      // already gone
+    }
+  }
+}
+
+// ---- minimal JSON-RPC-2.0-over-stdio client for `gemini --acp` ----
+// A self-contained line-framed (newline-delimited) JSON-RPC 2.0 client, modeled
+// 1:1 on codex-backend's AppServerClient. The only wire differences from the
+// codex app-server client are: (1) we stamp `jsonrpc:"2.0"` on every outbound
+// message (ACP is strict JSON-RPC 2.0), and (2) the server→client request set we
+// auto-approve is the ACP one (session/request_permission).
+
+interface RpcMessage {
+  jsonrpc?: string;
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code?: number; message?: string; data?: unknown };
+}
+
+type NotificationHandler = (msg: RpcMessage) => void;
+
+/** An Error carrying the JSON-RPC error `data` so the auth_required reason
+ *  survives the request rejection (used to drive the authenticate retry). */
+class RpcError extends Error {
+  code?: number;
+  data?: unknown;
+  constructor(message: string, code?: number, data?: unknown) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+class AcpClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private rl: readline.Interface | null = null;
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void; method: string }
+  >();
+  private nextId = 1;
+  private closed = false;
+  private exitResolved = false;
+  /** The error that ended the connection (null = clean exit). */
+  exitError: Error | null = null;
+  stderr = "";
+  notificationHandler: NotificationHandler | null = null;
+  private resolveExit!: () => void;
+  /** Resolves when the `gemini` process exits or errors — runTurn() races its
+   *  per-turn drain against this so a child that dies mid-prompt never deadlocks
+   *  the turn forever (mirrors codex P0-2). */
+  readonly exitPromise: Promise<void>;
+
+  constructor(
+    private readonly cmd: string,
+    private readonly args: string[],
+    private readonly cwd: string,
+    private readonly env: NodeJS.ProcessEnv,
+    private readonly useShell: boolean,
+  ) {
+    this.exitPromise = new Promise<void>((resolve) => {
+      this.resolveExit = resolve;
+    });
+  }
+
+  /** Spawn `gemini --acp` and perform the ACP `initialize` handshake. Returns the
+   *  agent's initialize result (capabilities + authMethods). NOTE: ACP has NO
+   *  `initialized` notification (that's MCP, not ACP) — initialize is a plain
+   *  request/response, after which we go straight to session/new. */
+  async initialize(clientInfo: {
+    name: string;
+    title: string;
+    version: string;
+  }): Promise<AcpInitializeResult> {
+    this.proc = spawn(this.cmd, this.args, {
+      cwd: this.cwd,
+      env: this.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      shell: this.useShell,
+      // POSIX: own process group so close() can kill the whole tree with one
+      // negative-pid signal. Windows uses taskkill /T instead.
+      detached: process.platform !== "win32",
+    }) as ChildProcessWithoutNullStreams;
+
+    this.proc.stdout.setEncoding("utf8");
+    this.proc.stderr.setEncoding("utf8");
+    this.proc.stderr.on("data", (chunk: string) => {
+      this.stderr += chunk;
+    });
+    // Route pipe errors (EPIPE when the child dies mid-turn) through handleExit so
+    // the turn rejects cleanly instead of crashing the host as an uncaught error.
+    this.proc.stdin.on("error", (error) => this.handleExit(error));
+    this.proc.stdout.on("error", (error) => this.handleExit(error));
+    this.proc.on("error", (error) => this.handleExit(error));
+    this.proc.on("exit", (code, signal) => {
+      const detail =
+        code === 0
+          ? null
+          : new Error(
+              `gemini --acp exited unexpectedly (${signal ? `signal ${signal}` : `exit ${code}`}).${this.stderr ? ` ${this.stderr.trim().split(/\r?\n/).slice(-2).join(" ")}` : ""}`,
+            );
+      this.handleExit(detail);
+    });
+
+    this.rl = readline.createInterface({ input: this.proc.stdout });
+    this.rl.on("line", (line) => this.handleLine(line));
+
+    // ACP initialize: negotiate protocol version + advertise client capabilities.
+    // We do NOT implement the client fs/terminal methods, so advertise them false
+    // (the agent then won't issue fs/read_text_file, terminal/*, etc.).
+    const result = await this.request<AcpInitializeResult>("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+      clientInfo,
+    });
+    return result;
+  }
+
+  request<T = unknown>(method: string, params: unknown): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("gemini --acp client is closed."));
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, method });
+      this.send({ id, method, params });
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    if (this.closed) return;
+    // Fire-and-forget: a write failure (dead child) must not throw into the caller.
+    try {
+      this.send({ method, params });
+    } catch {
+      // connection gone; pending requests already rejected via handleExit
+    }
+  }
+
+  private send(message: RpcMessage): void {
+    const stdin = this.proc?.stdin;
+    if (!stdin || stdin.destroyed || stdin.writableEnded) {
+      this.handleExit(this.exitError ?? new Error("gemini --acp stdin is not available."));
+      throw this.exitError ?? new Error("gemini --acp stdin is not available.");
+    }
+    // ACP is strict JSON-RPC 2.0 — every outbound frame carries `jsonrpc:"2.0"`.
+    const framed: RpcMessage = { jsonrpc: "2.0", ...message };
+    try {
+      stdin.write(`${JSON.stringify(framed)}\n`);
+    } catch (err) {
+      this.handleExit(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
+  }
+
+  /**
+   * The auto-approve RESULT for a server→client request, or null if it isn't one
+   * we should auto-grant. The panel agent is an ISOLATED background agent (same
+   * posture as Claude's bypassPermissions / Codex's auto-approve), so we grant
+   * tool-permission requests to keep the live-graph work flowing.
+   *
+   * ACP permission flow: the agent sends `session/request_permission`
+   * ({ sessionId, toolCall, options:[{ optionId, name, kind }] }) and expects
+   * { outcome: { outcome:"selected", optionId } }. We pick the most-permissive
+   * "allow" option (allow_always > allow_once); if none is offered we cancel.
+   */
+  private autoApproveResult(msg: RpcMessage): Record<string, unknown> | null {
+    if (msg.method !== "session/request_permission") return null;
+    const params = (msg.params ?? {}) as { options?: Array<{ optionId?: string; kind?: string }> };
+    const options = Array.isArray(params.options) ? params.options : [];
+    const pick =
+      options.find((o) => o.kind === "allow_always") ??
+      options.find((o) => o.kind === "allow_once") ??
+      // Fall back to any option whose id/kind reads as an allow.
+      options.find((o) => /allow/i.test(o.kind ?? "") || /allow/i.test(o.optionId ?? ""));
+    if (pick?.optionId) {
+      return { outcome: { outcome: "selected", optionId: pick.optionId } };
+    }
+    // No allow option offered → decline gracefully so the agent moves on.
+    return { outcome: { outcome: "cancelled" } };
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+    let message: RpcMessage;
+    try {
+      message = JSON.parse(line) as RpcMessage;
+    } catch (error) {
+      this.handleExit(new Error(`Failed to parse gemini --acp JSONL: ${msgOf(error)}`));
+      return;
+    }
+    // Server→client request (id + method). Auto-approve permission prompts; reply
+    // method-not-found to anything else so the protocol keeps moving (we declared
+    // no fs/terminal client capabilities, so those shouldn't arrive).
+    if (message.id !== undefined && message.method) {
+      const result = this.autoApproveResult(message);
+      if (result) {
+        logger.debug(`[gemini-backend] auto-approving server request ${message.method}`);
+        this.send({ id: message.id, result });
+      } else {
+        logger.debug(
+          `[gemini-backend] unsupported server request ${message.method} — replying method-not-found`,
+        );
+        this.send({
+          id: message.id,
+          error: { code: -32601, message: `Unsupported server request: ${message.method}` },
+        });
+      }
+      return;
+    }
+    // Response to one of our requests.
+    if (message.id !== undefined) {
+      const p = this.pending.get(message.id as number);
+      if (!p) return;
+      this.pending.delete(message.id as number);
+      if (message.error) {
+        p.reject(
+          new RpcError(
+            message.error.message ?? `gemini --acp ${p.method} failed.`,
+            message.error.code,
+            message.error.data,
+          ),
+        );
+      } else {
+        p.resolve(message.result ?? {});
+      }
+      return;
+    }
+    // Notification.
+    if (message.method) this.notificationHandler?.(message);
+  }
+
+  private handleExit(error: Error | null): void {
+    if (this.exitResolved) return;
+    this.exitResolved = true;
+    this.exitError = error;
+    for (const p of this.pending.values())
+      p.reject(error ?? new Error("gemini --acp connection closed."));
+    this.pending.clear();
+    this.resolveExit();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      await this.exitPromise;
+      return;
+    }
+    this.closed = true;
+    this.notificationHandler = null;
+    this.rl?.close();
+    this.rl = null;
+    if (this.proc && this.proc.exitCode === null) {
+      try {
+        this.proc.stdin.end();
+      } catch {
+        // already gone
+      }
+      const proc = this.proc;
+      // Give a graceful stdin-EOF shutdown a beat, then KILL THE WHOLE TREE — on
+      // the Windows shell fallback the direct child is a shim whose grandchild is
+      // the real gemini node process, so proc.kill() alone would orphan it.
+      setTimeout(() => {
+        if (proc.exitCode === null) killProcessTree(proc.pid);
+      }, 50).unref?.();
+    }
+    await this.exitPromise;
+    this.proc = null;
+  }
+}
+
+// ---- ACP type shapes (the subset we read; best-effort, defensive) ----
+
+interface AcpAuthMethod {
+  id?: string;
+  name?: string;
+  description?: string;
+}
+
+interface AcpInitializeResult {
+  protocolVersion?: number;
+  agentCapabilities?: {
+    loadSession?: boolean;
+    promptCapabilities?: { image?: boolean; audio?: boolean; embeddedContext?: boolean };
+    mcpCapabilities?: { http?: boolean; sse?: boolean };
+  };
+  authMethods?: AcpAuthMethod[];
+  agentInfo?: { name?: string; title?: string; version?: string };
+}
+
+// ---- model catalog ----
+// ACP exposes no model enumeration, and the model is fixed at SPAWN via the CLI
+// `--model` flag — so we surface a static catalog of the current Gemini family.
+// Gemini's "thinking" is a token BUDGET, not a discrete effort scale, so we do
+// NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
+// then hides the effort dropdown (omission is the documented "no effort control"
+// signal). gemini-2.5-pro is the default.
+const GEMINI_MODELS: ModelChoice[] = [
+  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+];
+const GEMINI_DEFAULT_MODEL = "gemini-2.5-pro";
+
+/** Does this id look like a Gemini model (vs. the Claude panel model PanelAgent
+ *  unconditionally passes as opts.model)? Used so the configured Gemini model
+ *  wins — mirrors codex-backend's isCodexModel guard (P1-1). */
+function isGeminiModel(id: string): boolean {
+  return /^gemini[-/]/i.test(id) || id.toLowerCase().startsWith("models/gemini");
+}
+
+/** A declared MCP server for the ACP session. Either a stdio command (the headless
+ *  comfyui MCP) or a streamable-HTTP url (the panel_* loopback server). Identical
+ *  shape to codex-backend's CodexMcpServerSpec so the orchestrator can build one
+ *  config for both. */
+export type GeminiMcpServerSpec =
+  | { transport: "stdio"; command: string; args?: string[]; env?: Record<string, string> }
+  | { transport: "http"; url: string };
+
+/**
+ * Convert our MCP server specs into the ACP `session/new` `mcpServers` array.
+ * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. The HTTP
+ * variant ({ type:"http", name, url }) is the closest faithful mapping to the ACP
+ * spec's HTTP transport (gated by the agent's mcpCapabilities.http) — FLAGGED as
+ * unverified against the live gemini CLI. Empty env is the required `[]`.
+ */
+export function buildAcpMcpServers(
+  servers: Record<string, GeminiMcpServerSpec>,
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const [name, spec] of Object.entries(servers)) {
+    if (spec.transport === "stdio") {
+      out.push({
+        name,
+        command: spec.command,
+        args: spec.args ?? [],
+        env: Object.entries(spec.env ?? {}).map(([k, v]) => ({ name: k, value: v })),
+      });
+    } else {
+      // ASSUMPTION (unverified w/o live CLI): ACP HTTP McpServer variant.
+      out.push({ type: "http", name, url: spec.url });
+    }
+  }
+  return out;
+}
+
+/** Provider config the Gemini backend needs. Mirrors CodexBackendDeps. */
+export interface GeminiBackendDeps {
+  /** Working directory for the ACP session (defaults to opts.cwd / process cwd). */
+  cwd?: string;
+  /** Default model for new sessions (e.g. gemini-2.5-pro); set at SPAWN via --model. */
+  model?: string;
+  /**
+   * Base URL of the ComfyUI instance, for fetching image bytes (/view). When set,
+   * NeutralTurn image refs are fetched and delivered inline as base64 `image`
+   * ContentBlocks on the prompt (vision parity with the Claude path).
+   */
+  comfyuiUrl?: string;
+  /**
+   * MCP servers to declare to the ACP `session/new` — the headless `comfyui`
+   * stdio MCP + the `panel` HTTP MCP for live-graph tools (full tool parity).
+   */
+  mcpServers?: Record<string, GeminiMcpServerSpec>;
+  /**
+   * Panel system prompt (persona). ACP `session/new` has no instructions field,
+   * so this is PREPENDED to the first turn's prompt as a clearly-marked
+   * system/context preamble; later turns send plain text.
+   */
+  systemAppend?: string;
+}
+
+/**
+ * The Gemini CLI ACP adapter. One instance per PanelAgent; it holds the live ACP
+ * client + current session id and re-opens on each `run()`.
+ */
+export class GeminiBackend implements AgentBackend {
+  readonly id = "gemini" as const;
+  readonly capabilities = GEMINI_CAPABILITIES;
+  private deps: GeminiBackendDeps;
+  private client: AcpClient | null = null;
+  /** The client an in-flight prepare() is spinning up, tracked so a concurrent
+   *  close() can tear it down before it's published (P0-A). */
+  private preparingClient: AcpClient | null = null;
+  /** Set once close() runs — a tripwire so an in-flight prepare() disposes its
+   *  local client instead of publishing it (P0-A). */
+  private disposed = false;
+  /** Cached resolved spawn command/args/shell (set in prepare()). */
+  private spawnSpec: { cmd: string; args: string[]; useShell: boolean } | null = null;
+  /** The live ACP session id — used for session/prompt + session/cancel. */
+  private sessionId: string | null = null;
+  /** The model requested for new sessions (applied at SPAWN via --model). */
+  private model: string | undefined;
+  /** Capabilities the agent advertised at initialize (loadSession / image / http). */
+  private agentCaps: AcpInitializeResult["agentCapabilities"] = undefined;
+  private authMethods: AcpAuthMethod[] = [];
+  /** True until the panel system prompt has been prepended to a turn. Reset
+   *  whenever a NEW session starts (run()). */
+  private needsSystemPreamble = false;
+
+  constructor(deps: GeminiBackendDeps = {}) {
+    this.deps = deps;
+    this.model = deps.model;
+  }
+
+  /**
+   * Resolve how to spawn `gemini --acp`. Prefer the bundled `@google/gemini-cli`
+   * launcher (via require.resolve of its package bin) so no separate install is
+   * needed; fall back to a `gemini` on PATH. The `--model` flag pins the model at
+   * spawn (ACP has no standard per-session model setter). Mirrors codex-backend's
+   * resolveBin + the Windows `.cmd`/`.ps1` shim handling.
+   */
+  private resolveSpawn(): { cmd: string; args: string[]; useShell: boolean } {
+    if (this.spawnSpec) return this.spawnSpec;
+    let bin: string | null = null;
+    try {
+      const require = createRequire(import.meta.url);
+      const pkgPath = require.resolve("@google/gemini-cli/package.json");
+      const pkg = require("@google/gemini-cli/package.json") as {
+        bin?: Record<string, string> | string;
+      };
+      const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.gemini;
+      if (binRel) {
+        const sep = pkgPath.includes("\\") ? "\\" : "/";
+        const pkgDir = pkgPath.replace(/[\\/]package\.json$/, "");
+        bin = `${pkgDir}${sep}${binRel.replace(/^\.[\\/]/, "")}`;
+      }
+    } catch {
+      // bundled package not installed — fall through to PATH.
+    }
+    const isJs = !!bin && /\.(c|m)?js$/i.test(bin);
+    // The bundled bin is a node launcher script → run it via the current node so
+    // we don't depend on a `gemini` shim being on PATH. A PATH `gemini` on Windows
+    // resolves to a `.cmd`/`.ps1` shim, which spawn can't find without a shell.
+    const cmd = isJs ? process.execPath : bin ?? "gemini";
+    const modelArgs = this.model ? ["--model", this.model] : [];
+    const args = isJs ? [bin as string, "--acp", ...modelArgs] : ["--acp", ...modelArgs];
+    const useShell = !isJs && process.platform === "win32";
+    this.spawnSpec = { cmd, args, useShell };
+    return this.spawnSpec;
+  }
+
+  /**
+   * Fetch a ComfyUI image (/view) and return it as an ACP base64 `image`
+   * ContentBlock ({ type:"image", mimeType, data }) — or null on any failure (the
+   * text reference still names the image as a fallback). Unlike Codex (which
+   * spills to a temp file for its path-based localImage item), ACP takes inline
+   * base64, so this mirrors ClaudeBackend.fetchImageBlock exactly (only the key
+   * names differ: ACP uses `mimeType`/`data`).
+   */
+  private async fetchImageBlock(ref: ImageRef): Promise<Record<string, unknown> | null> {
+    if (!this.deps.comfyuiUrl || !ref?.filename) return null;
+    try {
+      const u = new URL("/view", this.deps.comfyuiUrl);
+      u.searchParams.set("filename", ref.filename);
+      u.searchParams.set("type", ref.type || "input");
+      if (ref.subfolder) u.searchParams.set("subfolder", ref.subfolder);
+      const res = await fetch(u, { signal: AbortSignal.timeout(15000) });
+      if (!res.ok) return null;
+      let mt = (res.headers.get("content-type") || "").split(";")[0].trim().toLowerCase();
+      if (!["image/png", "image/jpeg", "image/gif", "image/webp"].includes(mt)) {
+        mt = "image/png"; // ComfyUI outputs are PNG by default
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length > 12 * 1024 * 1024) return null; // keep context sane (parity with Claude)
+      return { type: "image", mimeType: mt, data: buf.toString("base64") };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Preflight: resolve + spawn `gemini --acp` and perform the ACP `initialize`
+   * handshake. Fails fast with a clear reject so a missing binary surfaces
+   * immediately instead of being retried as a dropped session. Idempotent —
+   * reuses the live client. NOTE: the actual login (Google OAuth) is verified
+   * lazily at `session/new` (ACP returns auth_required there) — see run() — since
+   * ACP has no pre-session account probe; flagged in the PR body.
+   */
+  async prepare(): Promise<void> {
+    if (this.disposed) throw new Error("gemini backend is closed.");
+    if (this.client) return;
+    const { cmd, args, useShell } = this.resolveSpawn();
+    const cwd = this.deps.cwd ?? process.cwd();
+    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // Publish the in-flight client BEFORE the startup awaits so a concurrent
+    // close() can find and kill it (P0-A).
+    this.preparingClient = client;
+    const abortIfDisposed = async (): Promise<void> => {
+      if (!this.disposed) return;
+      if (this.preparingClient === client) this.preparingClient = null;
+      await client.close().catch(() => {});
+      throw new Error("gemini backend was closed during prepare().");
+    };
+    try {
+      let init: AcpInitializeResult;
+      try {
+        init = await client.initialize({
+          name: "comfyui-mcp",
+          title: "comfyui-mcp panel",
+          version: "0.16.0",
+        });
+      } catch (err) {
+        await client.close().catch(() => {});
+        throw new Error(
+          `Could not start the Gemini CLI in ACP mode (gemini backend). Install the Gemini CLI (npm i -g @google/gemini-cli, or ensure \`gemini\` is on PATH) and sign in with \`gemini\`. Details: ${msgOf(err)}`,
+        );
+      }
+      await abortIfDisposed();
+      this.agentCaps = init.agentCapabilities;
+      this.authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
+      this.client = client;
+      logger.info(
+        `[gemini-backend] ACP ready (protocol ${init.protocolVersion ?? "?"}, agent ${init.agentInfo?.name ?? "gemini"}${this.authMethods.length ? `, ${this.authMethods.length} auth method(s)` : ""})`,
+      );
+    } finally {
+      if (this.preparingClient === client) this.preparingClient = null;
+    }
+  }
+
+  /** Ensure a live ACP session exists, creating (session/new) or resuming
+   *  (session/load) one. Handles an `auth_required` error from session/new by
+   *  attempting a single `authenticate` with the first advertised method, then
+   *  retrying — surfacing a clear sign-in message if it still fails. Returns the
+   *  session id. */
+  private async ensureSession(client: AcpClient, cwd: string, resumeId: string | null): Promise<string> {
+    const mcpServers = this.deps.mcpServers ? buildAcpMcpServers(this.deps.mcpServers) : [];
+    const canLoad = this.agentCaps?.loadSession === true;
+    // RESUME (session/load) — whole-session only (forkAtAnchor=false). Only if the
+    // agent advertised loadSession; otherwise fall through to a fresh session.
+    if (resumeId && canLoad) {
+      try {
+        await client.request("session/load", { sessionId: resumeId, cwd, mcpServers });
+        this.sessionId = resumeId;
+        this.needsSystemPreamble = false; // persona already delivered on the original first turn
+        return resumeId;
+      } catch (err) {
+        logger.warn(`[gemini-backend] session/load failed (${msgOf(err)}) — starting a fresh session`);
+      }
+    }
+    // NEW session, with one auth_required retry.
+    const createNew = async (): Promise<string> => {
+      const res = await client.request<{ sessionId?: string }>("session/new", { cwd, mcpServers });
+      if (!res?.sessionId) throw new Error("gemini --acp session/new returned no sessionId.");
+      return res.sessionId;
+    };
+    try {
+      this.sessionId = await createNew();
+    } catch (err) {
+      if (this.isAuthRequired(err) && this.authMethods[0]?.id) {
+        // The CLI owns auth (Google OAuth). Try the first advertised method once;
+        // if the CLI isn't already signed in this cannot complete headlessly.
+        try {
+          await client.request("authenticate", { methodId: this.authMethods[0].id });
+          this.sessionId = await createNew();
+        } catch {
+          throw new Error(
+            "Gemini CLI is not signed in. Run `gemini` once and complete the Google sign-in, then reconnect.",
+          );
+        }
+      } else if (this.isAuthRequired(err)) {
+        throw new Error(
+          "Gemini CLI is not signed in. Run `gemini` once and complete the Google sign-in, then reconnect.",
+        );
+      } else {
+        throw err;
+      }
+    }
+    this.needsSystemPreamble = !!this.deps.systemAppend; // fresh session → persona on first turn
+    return this.sessionId!;
+  }
+
+  /** Does this error look like an ACP `auth_required`? Reads the JSON-RPC error
+   *  data.reason carried by RpcError, falling back to the message text. */
+  private isAuthRequired(err: unknown): boolean {
+    if (err instanceof RpcError) {
+      const data = err.data as { reason?: string } | undefined;
+      if (data?.reason === "auth_required") return true;
+    }
+    return /auth.?required|authenticat|not.*(logged|signed).*in/i.test(msgOf(err));
+  }
+
+  /**
+   * Open/continue an ACP session and yield canonical AgentEvents. The user
+   * channel (PanelAgent's gated queue) is consumed ONE turn at a time: each
+   * neutral batch becomes a `session/prompt`, whose streamed session/update
+   * notifications are normalized to AgentEvents, and only after the prompt
+   * resolves (stopReason) do we read the next batch (the channel async-iteration
+   * IS the turn-gate).
+   */
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    await this.prepare();
+    const client = this.client;
+    if (!client) throw new Error("gemini --acp not initialized");
+    const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
+    // MODEL PRECEDENCE (P1-1): PanelAgent.start() always passes opts.model = the
+    // CLAUDE panel model, which is NOT a valid Gemini model. The Gemini model
+    // configured at construction (deps.model, from COMFYUI_MCP_GEMINI_MODEL) must
+    // win. Only honor opts.model if it actually looks like a Gemini model.
+    // (The model is applied at SPAWN via --model, so a change only takes effect on
+    // the next prepare()/process — see resolveSpawn; flagged in the PR body.)
+    if (opts.model && isGeminiModel(opts.model)) this.model = opts.model;
+
+    // forkAtAnchor is false → ignore opts.rewindAnchor; whole-session resume only.
+    const resumeId = opts.resume ?? opts.sessionId ?? null;
+    const sessionId = await this.ensureSession(client, cwd, resumeId);
+
+    // The session id is our session id (PanelAgent persists it for resume).
+    yield {
+      type: "session",
+      sessionId,
+      ...(this.model ? { model: this.model } : {}),
+    };
+
+    // Process the neutral channel one turn at a time.
+    for await (const turn of opts.channel) {
+      yield* this.runTurn(client, turn, opts.onActivity);
+    }
+  }
+
+  /** Run ONE turn: send session/prompt + stream its session/update notifications →
+   *  AgentEvents, resolving when the prompt request returns a stopReason, OR when
+   *  the child exits mid-turn (never deadlock). ACP's prompt request IS the turn
+   *  boundary, so — unlike Codex — there is no separate completion notification and
+   *  no turn-id buffering: the sessionId is known before the prompt is sent. */
+  private async *runTurn(
+    client: AcpClient,
+    turn: NeutralTurn,
+    onActivity?: () => void,
+  ): AsyncGenerator<AgentEvent> {
+    const sessionId = this.sessionId!;
+    // Event queue bridging the push-based notification handler to this pull-based
+    // async generator (identical pattern to codex-backend).
+    const queue: AgentEvent[] = [];
+    let wake: (() => void) | null = null;
+    let done = false;
+    const push = (ev: AgentEvent) => {
+      queue.push(ev);
+      wake?.();
+      wake = null;
+    };
+    const finish = () => {
+      done = true;
+      wake?.();
+      wake = null;
+    };
+
+    // Accumulate the assistant reply text across agent_message_chunk so we can emit
+    // ONE authoritative `assistant` commit when the turn ends (ACP has no separate
+    // final-message notification). messageId (when present) groups the deltas + the
+    // commit under one bubble id, mirroring the Claude/Codex stream reconciliation.
+    let assistantText = "";
+    let messageId: string | null = null;
+
+    // Stream bubble state (reasoning vs reply each open/close their own stream).
+    let streamOpen = false;
+    let streamKind: "text" | "thinking" | null = null;
+    const openStream = (id: string | null, kind: "text" | "thinking") => {
+      if (streamOpen && streamKind === kind) return;
+      if (streamOpen) push({ type: "stream_end" }); // switch kinds → close the old one
+      streamOpen = true;
+      streamKind = kind;
+      push({ type: "stream_start", id });
+    };
+    const closeStream = () => {
+      if (streamOpen) {
+        push({ type: "stream_end" });
+        streamOpen = false;
+        streamKind = null;
+      }
+    };
+
+    // EXACTLY ONE terminal `result` (PanelAgent's turn-gate only advances on a
+    // result; a missing one parks the channel forever). This idempotent helper
+    // emits an `error` + `{result, ok:false}` and finishes; no-op once a result
+    // has fired (so the prompt rejection AND the exit watcher can both call it).
+    let finishedResult = false;
+    const emitTerminalError = (message: string) => {
+      if (finishedResult) return;
+      finishedResult = true;
+      closeStream();
+      push({ type: "error", message });
+      push({ type: "result", ok: false, subtype: "error" });
+      finish();
+    };
+
+    let interrupted = false;
+
+    // tool_call carries the title/kind; tool_call_update (ACP) repeats only the
+    // toolCallId — so remember each call's display name to label its end event.
+    const toolNames = new Map<string, string>();
+
+    // Normalize ONE session/update notification into canonical AgentEvents.
+    const apply = (msg: RpcMessage) => {
+      if (finishedResult) return;
+      const params = (msg.params ?? {}) as Record<string, unknown>;
+      // Only our session's updates.
+      if (params.sessionId && params.sessionId !== sessionId) return;
+      const update = (params.update ?? {}) as Record<string, unknown>;
+      const kind = update.sessionUpdate as string | undefined;
+      switch (kind) {
+        case "agent_message_chunk": {
+          const content = update.content as { type?: string; text?: string } | undefined;
+          const text = content?.type === "text" ? content.text : undefined;
+          const id = (update.messageId as string | undefined) ?? null;
+          if (typeof text === "string" && text) {
+            if (id) messageId = id;
+            openStream(messageId, "text");
+            assistantText += text;
+            push({ type: "assistant_delta", text });
+          }
+          break;
+        }
+        case "agent_thought_chunk": {
+          // Extended-thinking streaming. Open a reasoning stream on the FIRST delta
+          // so PanelAgent (which drops assistant_delta when no stream is open)
+          // renders early thinking, mirroring codex P2-1.
+          const content = update.content as { type?: string; text?: string } | undefined;
+          const text = content?.type === "text" ? content.text : undefined;
+          if (typeof text === "string" && text) {
+            openStream(messageId, "thinking");
+            push({ type: "assistant_delta", text, thinking: true });
+          }
+          break;
+        }
+        case "tool_call": {
+          // A tool call was requested — emit tool_call(start) for panel visibility.
+          const id = update.toolCallId as string | undefined;
+          const name =
+            (update.title as string | undefined) ||
+            (update.kind as string | undefined) ||
+            id ||
+            "tool";
+          if (id) toolNames.set(id, name);
+          push({ type: "tool_call", name, phase: "start", detail: update });
+          break;
+        }
+        case "tool_call_update": {
+          // Progress + completion of a tool call. Emit tool_call(end) only on a
+          // TERMINAL status; intermediate in_progress updates just keep the
+          // watchdog armed (onActivity already fired for them). ACP's update
+          // repeats only the toolCallId, so reuse the remembered title for the name.
+          const status = update.status as string | undefined;
+          if (status === "completed" || status === "failed") {
+            const id = update.toolCallId as string | undefined;
+            const name =
+              (update.title as string | undefined) ||
+              (id ? toolNames.get(id) : undefined) ||
+              (update.kind as string | undefined) ||
+              id ||
+              "tool";
+            push({ type: "tool_call", name, phase: "end", detail: update });
+          }
+          break;
+        }
+        // plan / available_commands_update / session_info_update / current_mode_update
+        // carry no AgentEvent — onActivity (below) already re-armed the watchdog.
+        default:
+          break;
+      }
+    };
+
+    const prev = client.notificationHandler;
+    client.notificationHandler = (msg: RpcMessage) => {
+      // LIVENESS: ANY notification while this turn is in flight means the agent is
+      // alive — fire onActivity BEFORE filtering/translating so even updates that
+      // produce no AgentEvent (a long MCP tool call mid-generation) keep
+      // PanelAgent's idle watchdog armed. A genuine zero-event freeze never
+      // reaches here, so the real freeze-catch is preserved.
+      try {
+        onActivity?.();
+      } catch {
+        // a watchdog bump must never break the protocol reader
+      }
+      if (msg.method === "session/update") apply(msg);
+      else prev?.(msg); // anything else (other methods) → pass through
+    };
+
+    // Watch for the child dying mid-turn: end the turn with a terminal result so
+    // the local drain is woken instead of waiting forever. emitTerminalError is a
+    // no-op if a result already fired, so it's safe alongside the prompt rejection.
+    void client.exitPromise.then(() => {
+      if (done) return;
+      emitTerminalError(
+        client.exitError ? msgOf(client.exitError) : "gemini --acp connection closed.",
+      );
+    });
+
+    // FIRST-TURN PERSONA: ACP session/new has no instructions field, so the panel
+    // system prompt is prepended to the first turn's prompt as a clearly-marked
+    // system/context preamble (later turns send plain text). Mirrors codex.
+    let turnText = turn.text;
+    if (this.needsSystemPreamble && this.deps.systemAppend) {
+      turnText =
+        `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
+        `The user's first message follows.\n\n${turn.text}`;
+      this.needsSystemPreamble = false;
+    }
+
+    // Build the prompt ContentBlock[]: the text block first (preserves prompt
+    // context), then any resolved inline base64 image blocks (vision parity).
+    // Images are only attached when the agent advertised promptCapabilities.image
+    // (default-allow when the capability is unknown).
+    const prompt: Array<Record<string, unknown>> = [{ type: "text", text: turnText }];
+    const imagesAllowed = this.agentCaps?.promptCapabilities?.image !== false;
+    if (imagesAllowed) {
+      for (const ref of turn.images ?? []) {
+        const block = await this.fetchImageBlock(ref);
+        if (block) prompt.push(block);
+      }
+    }
+
+    try {
+      // session/prompt is a REQUEST that RESOLVES with a stopReason at turn end.
+      client
+        .request<{ stopReason?: string }>("session/prompt", { sessionId, prompt })
+        .then((res) => {
+          if (finishedResult) return;
+          finishedResult = true;
+          closeStream();
+          const stop = res?.stopReason;
+          // Commit the accumulated assistant text (if any) as the authoritative
+          // turn-ending message — no per-turn rewind anchor (forkAtAnchor=false).
+          const text = assistantText.trim();
+          if (text) push({ type: "assistant", text, ...(messageId ? { id: messageId } : {}) });
+          // end_turn / max_tokens / max_turn_requests = a real completion; cancelled
+          // (user interrupt) and refusal are not "ok".
+          const ok = !!stop && stop !== "cancelled" && stop !== "refusal";
+          push({ type: "result", ok, ...(stop ? { subtype: stop } : {}) });
+          finish();
+        })
+        .catch((err) => {
+          // A failed prompt ends the turn. When the child dies mid-turn handleExit
+          // rejects this BEFORE exitPromise resolves, so this .catch runs first —
+          // it MUST end with a terminal result (the idempotent helper guarantees
+          // exactly one), or the exit watcher then sees done and hangs the gate.
+          if (interrupted) emitTerminalError("gemini turn interrupted.");
+          else emitTerminalError(msgOf(err));
+        });
+
+      // Drain the bridged queue until the turn completes.
+      while (true) {
+        while (queue.length) {
+          yield queue.shift()!;
+        }
+        if (done) break;
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      while (queue.length) yield queue.shift()!;
+    } finally {
+      // Mark interrupted so a late prompt rejection doesn't surface a spurious
+      // error after teardown.
+      interrupted = true;
+      // Restore the prior handler ONLY if it's still ours (close() may have nulled
+      // it during shutdown — don't resurrect a stale handler onto a dead client).
+      if (client.notificationHandler && !client.exitError) client.notificationHandler = prev ?? null;
+    }
+  }
+
+  /** Stop the current turn without ending the session → `session/cancel`
+   *  (notification). The in-flight session/prompt then resolves with
+   *  stopReason:"cancelled", which the run-turn path turns into a terminal result. */
+  async interrupt(): Promise<void> {
+    const client = this.client;
+    if (!client || !this.sessionId) return;
+    try {
+      client.notify("session/cancel", { sessionId: this.sessionId });
+    } catch (err) {
+      logger.debug(`[gemini-backend] interrupt: ${msgOf(err)}`);
+    }
+  }
+
+  /** Switch the model for the NEXT session. ACP fixes the model at spawn (--model),
+   *  so this only takes effect on the next prepare()/process — the panel restarts
+   *  run() on a model change, but a live in-process switch would need a re-spawn.
+   *  Flagged in the PR body. */
+  async setModel(model: string): Promise<void> {
+    if (isGeminiModel(model)) {
+      this.model = model;
+      // Invalidate the cached spawn spec so the next prepare() picks up --model.
+      this.spawnSpec = null;
+    }
+  }
+
+  /**
+   * Gemini model enumeration. ACP exposes no model catalog, so we surface a static
+   * set (the current Gemini family); the panel picker degrades gracefully on an
+   * empty list. No effort metadata (Gemini uses a thinking BUDGET, not a discrete
+   * effort scale) → the panel hides the effort dropdown.
+   */
+  async listModels(): Promise<ModelChoice[]> {
+    return GEMINI_MODELS;
+  }
+
+  /** Permanently dispose of the backend (AgentBackend.close): kill the gemini
+   *  process TREE (Windows shell-fallback grandchild included), remove listeners,
+   *  null the client. Idempotent + safe when never prepared. Mirrors codex (P0-1):
+   *  interrupt() is a no-op when idle, so without this the child is orphaned. */
+  async close(): Promise<void> {
+    this.disposed = true; // tripwire FIRST (an in-flight prepare() bails) (P0-A)
+    const client = this.client;
+    const preparing = this.preparingClient;
+    this.client = null;
+    this.preparingClient = null;
+    this.sessionId = null;
+    if (client) {
+      client.notificationHandler = null;
+      await client.close().catch(() => {});
+    }
+    if (preparing && preparing !== client) {
+      preparing.notificationHandler = null;
+      await preparing.close().catch(() => {});
+    }
+  }
+}
+
+// Expose the default model id for the orchestrator wiring (COMFYUI_MCP_GEMINI_MODEL
+// fallback) without duplicating the literal.
+export { GEMINI_DEFAULT_MODEL };

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -35,6 +35,7 @@ import {
   onComfyuiSecretsChanged,
 } from "../services/panel-secrets.js";
 import { CodexBackend } from "./codex-backend.js";
+import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
@@ -386,6 +387,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   const model = process.env.COMFYUI_MCP_PANEL_MODEL ?? "claude-opus-4-8";
   const envEffort = process.env.COMFYUI_MCP_PANEL_EFFORT;
   const effort: Effort | undefined = isEffort(envEffort) ? envEffort : undefined;
+  // Each backend runs its OWN orchestrator on its OWN loopback bridge port so the
+  // providers never share a session or fight for a port. The launcher (panel pack)
+  // sets COMFYUI_MCP_BRIDGE_PORT per the selected backend; the convention is
+  // 9180 = claude (default), 9181 = codex, 9182 = gemini.
   const bridgePort = Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180;
 
   // Cross-process download-progress channel: each tab's comfyui MCP subprocess
@@ -447,7 +452,16 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Codex model — so for codex we only pass a model when COMFYUI_MCP_CODEX_MODEL
   // is set explicitly; otherwise Codex uses the account's default (e.g. gpt-5.5).
   const codexModel = process.env.COMFYUI_MCP_CODEX_MODEL;
+  // Gemini likewise: the panel model is a Claude id, so the Gemini model comes from
+  // COMFYUI_MCP_GEMINI_MODEL (default gemini-2.5-pro). The model is applied at spawn
+  // via the CLI `--model` flag (ACP exposes no per-session model setter).
+  const geminiModel = process.env.COMFYUI_MCP_GEMINI_MODEL ?? GEMINI_DEFAULT_MODEL;
   const isCodex = backendId === "codex";
+  const isGemini = backendId === "gemini";
+  // Codex + Gemini both drive the live canvas through the loopback HTTP panel MCP
+  // (neither can host an in-process SDK MCP server like Claude does), so several
+  // branches below treat them together.
+  const isHttpPanelBackend = isCodex || isGemini;
 
   // ---- live ENVIRONMENT-CAPABILITIES block ----
   // Gather the machine's facts ONCE at startup (CACHED) — OS/CPU/RAM from node,
@@ -512,20 +526,40 @@ export async function runPanelOrchestrator(): Promise<void> {
     ...(process.env.COMFYUI_MCP_TOOL_TRACE ? { COMFYUI_MCP_TOOL_TRACE: process.env.COMFYUI_MCP_TOOL_TRACE } : {}),
   };
 
-  // The orchestrator-hosted loopback HTTP MCP for panel_* tools (Codex). Started
-  // only in codex mode (Claude uses the in-process server). Port:
-  // COMFYUI_MCP_PANEL_MCP_PORT, default bridgePort+1 (loopback only).
+  // The orchestrator-hosted loopback HTTP MCP for panel_* tools. Started for the
+  // non-Claude backends (Codex + Gemini), which can't host an in-process SDK MCP
+  // server the way Claude does. Port: COMFYUI_MCP_PANEL_MCP_PORT, default
+  // bridgePort+1 (loopback only).
   let panelMcpHttp: PanelMcpHttpServer | null = null;
-  if (isCodex) {
+  if (isHttpPanelBackend) {
     const panelMcpPort = Number(process.env.COMFYUI_MCP_PANEL_MCP_PORT) || bridgePort + 1;
     try {
       panelMcpHttp = await startPanelMcpHttpServer(bridge, panelMcpPort);
     } catch (err) {
       logger.error(
-        `[panel-orchestrator] could not start the panel HTTP MCP on :${panelMcpPort} — Codex will lack live-graph tools: ${err instanceof Error ? err.message : String(err)}`,
+        `[panel-orchestrator] could not start the panel HTTP MCP on :${panelMcpPort} — ${backendId} will lack live-graph tools: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
+
+  // Shared MCP server config for BOTH the Codex and Gemini backends — they take an
+  // identical { transport } spec (the headless comfyui stdio MCP + the panel HTTP
+  // MCP for this tab). Claude keeps its own in-process server set unchanged.
+  const makeHttpBackendMcpServers = (tabId: string) => ({
+    // Headless comfyui MCP (this build) over stdio — same as Claude.
+    comfyui: {
+      transport: "stdio" as const,
+      command: process.execPath, // node
+      args: [mcpEntry], // dist/index.js
+      // Merge persisted tool secrets at SPAWN time so a respawn picks up a
+      // just-saved CIVITAI_API_TOKEN / HF_TOKEN without a process restart.
+      env: buildComfyuiMcpEnv(comfyuiBaseEnv),
+    },
+    // Live-graph panel_* tools for THIS tab over the loopback HTTP MCP.
+    ...(panelMcpHttp
+      ? { panel: { transport: "http" as const, url: panelMcpHttp.urlFor(tabId) } }
+      : {}),
+  });
 
   const makeBackend: ((tabId: string) => AgentBackend) | undefined = isCodex
     ? (tabId: string) =>
@@ -536,37 +570,40 @@ export async function runPanelOrchestrator(): Promise<void> {
           // Base ComfyUI URL so the backend can fetch image bytes from /view and
           // deliver them to a turn as `localImage` input items (vision parity).
           comfyuiUrl,
-          mcpServers: {
-            // Headless comfyui MCP (this build) over stdio — same as Claude.
-            comfyui: {
-              transport: "stdio",
-              command: process.execPath, // node
-              args: [mcpEntry], // dist/index.js
-              // Merge persisted tool secrets at SPAWN time so a respawn picks up
-              // a just-saved CIVITAI_API_TOKEN / HF_TOKEN without a process restart.
-              env: buildComfyuiMcpEnv(comfyuiBaseEnv),
-            },
-            // Live-graph panel_* tools for THIS tab over the loopback HTTP MCP.
-            ...(panelMcpHttp
-              ? { panel: { transport: "http" as const, url: panelMcpHttp.urlFor(tabId) } }
-              : {}),
-          },
+          mcpServers: makeHttpBackendMcpServers(tabId),
         })
-    : undefined;
+    : isGemini
+      ? (tabId: string) =>
+          new GeminiBackend({
+            cwd: comfyuiPath ?? process.cwd(),
+            model: geminiModel,
+            systemAppend: panelSystemAppend,
+            // Base ComfyUI URL so the backend can fetch image bytes from /view and
+            // deliver them inline as base64 image ContentBlocks (vision parity).
+            comfyuiUrl,
+            mcpServers: makeHttpBackendMcpServers(tabId),
+          })
+      : undefined;
   if (isCodex) {
     logger.info(
       `[panel-orchestrator] agent backend = codex (codex app-server); panel_* live-graph tools via loopback HTTP MCP${panelMcpHttp ? ` on :${panelMcpHttp.port}` : " UNAVAILABLE"} + headless comfyui MCP`,
     );
+  } else if (isGemini) {
+    logger.info(
+      `[panel-orchestrator] agent backend = gemini (gemini --acp); model=${geminiModel}; panel_* live-graph tools via loopback HTTP MCP${panelMcpHttp ? ` on :${panelMcpHttp.port}` : " UNAVAILABLE"} + headless comfyui MCP`,
+    );
   } else if (backendId !== "claude") {
     logger.warn(`[panel-orchestrator] unknown PANEL_AGENT_BACKEND "${backendId}" — defaulting to claude`);
   }
-  // Readiness/model probing must route through the SELECTED backend (P1-2): in
-  // Codex mode the panel's "ready" must NOT depend on Claude SDK/login health.
-  // A dedicated probe backend (not tied to a tab) supplies the Codex model list
-  // and proves the app-server can start; Claude mode keeps its SDK probes.
-  const probeBackend: CodexBackend | null = isCodex
+  // Readiness/model probing must route through the SELECTED backend (P1-2): in a
+  // non-Claude mode the panel's "ready" must NOT depend on Claude SDK/login health.
+  // A dedicated probe backend (not tied to a tab) supplies the model list and
+  // proves the CLI can start; Claude mode keeps its SDK probes.
+  const probeBackend: AgentBackend | null = isCodex
     ? new CodexBackend({ cwd: comfyuiPath ?? process.cwd(), model: codexModel })
-    : null;
+    : isGemini
+      ? new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel })
+      : null;
 
   // Durable per-tab session ids (keyed by our bridge port), so a tab's agent
   // resumes its conversation even after the orchestrator PROCESS is killed and
@@ -684,12 +721,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   let modelsPromise: Promise<ModelInfo[]> | null = null;
   function ensureModels(): Promise<ModelInfo[]> {
     if (!modelsPromise) {
-      // Codex mode (P1-2): enumerate via the Codex backend (which also proves the
-      // app-server can start = readiness) — NEVER the Claude SDK probe. Shape the
-      // Codex ModelChoice[] into the panel's ModelInfo[] form (value/displayName).
+      // Non-Claude mode (P1-2): enumerate via the selected backend (which also
+      // proves the CLI can start = readiness) — NEVER the Claude SDK probe. Shape
+      // the backend's ModelChoice[] into the panel's ModelInfo[] form.
       const probe: Promise<ModelInfo[]> = probeBackend
-        ? probeBackend
-            .prepare()
+        ? Promise.resolve(probeBackend.prepare?.())
             .then(() => probeBackend.listModels())
             .then((list) =>
               // Carry the effort metadata through to the panel's ModelInfo — without
@@ -749,9 +785,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the built-ins that make sense inside the ComfyUI panel chat.
   const PANEL_SLASH_ALLOWLIST = new Set(["compact", "context", "usage", "loop", "goal", "clear"]);
   function pushCommands(tabId: string): void {
-    // Codex mode (P1-2): no Claude slash-commands — skip the Claude SDK probe
-    // entirely (CODEX_CAPABILITIES.slashCommands === false).
-    if (isCodex) return;
+    // Non-Claude mode (P1-2): no Claude slash-commands — skip the Claude SDK probe
+    // entirely (CODEX/GEMINI_CAPABILITIES.slashCommands === false).
+    if (isHttpPanelBackend) return;
     void ensureCommands()
       .then((commands) => {
         const useful = commands.filter((c) => PANEL_SLASH_ALLOWLIST.has(c.name));
@@ -1126,9 +1162,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     QueueMonitor.stop();
     unsubscribeSecrets();
     await manager.stopAll();
-    // Dispose the Codex readiness-probe backend (kills its app-server child).
-    if (probeBackend) await probeBackend.close().catch(() => {});
-    // Tear down the loopback panel HTTP MCP (codex mode only).
+    // Dispose the readiness-probe backend (kills its Codex/Gemini CLI child).
+    if (probeBackend?.close) await probeBackend.close().catch(() => {});
+    // Tear down the loopback panel HTTP MCP (codex/gemini mode only).
     if (panelMcpHttp) await panelMcpHttp.stop().catch(() => {});
     await bridge.stop();
     // Only remove the lockfile if it still names us — avoid clobbering a fresh

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -724,6 +724,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // Non-Claude mode (P1-2): enumerate via the selected backend (which also
       // proves the CLI can start = readiness) — NEVER the Claude SDK probe. Shape
       // the backend's ModelChoice[] into the panel's ModelInfo[] form.
+      // NOTE (gemini): the Gemini probe is prepare()+listModels, which proves the
+      // CLI launches + the ACP handshake works but does NOT verify Google sign-in
+      // (ACP reports auth only at session/new), so the "ready" ack is PROVISIONAL
+      // for Gemini — a signed-out CLI still acks green here and surfaces a clear
+      // one-shot sign-in error on the first turn (no loop). The panel separately
+      // gates the UI via oauth_creds detection, so this is acceptable.
       const probe: Promise<ModelInfo[]> = probeBackend
         ? Promise.resolve(probeBackend.prepare?.())
             .then(() => probeBackend.listModels())
@@ -829,14 +835,20 @@ export async function runPanelOrchestrator(): Promise<void> {
             // Greet only on a FRESH session. On a reconnect/resume — a panel swap,
             // a WS blip, or a real restart (all carry `resume`) — the user already
             // has their thread, so re-greeting is just noise. The ack still fires.
-            // Backend-appropriate messaging (P1-2): Codex mode must not claim a
-            // Claude subscription, and the agent label is the Codex model (or the
-            // account default when COMFYUI_MCP_CODEX_MODEL is unset).
-            const agentLabel = isCodex ? (codexModel ?? (models[0] as { value?: string }).value ?? "Codex") : model;
+            // Backend-appropriate messaging (P1-2): each provider must name its own
+            // account/auth, and the agent label is that provider's model (Codex/
+            // Gemini account default when the env override is unset).
+            const agentLabel = isCodex
+              ? (codexModel ?? (models[0] as { value?: string }).value ?? "Codex")
+              : isGemini
+                ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
+                : model;
             if (!resume) {
               const readyText = isCodex
                 ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Codex (ChatGPT) account. Ask away.`
-                : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
+                : isGemini
+                  ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
+                  : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
               bridge.push({ type: "say", text: readyText }, tabId);
             }
             bridge.push({ type: "ack", ok: true, kind: "ready", agent: agentLabel, backend: backendId }, tabId);
@@ -844,7 +856,9 @@ export async function runPanelOrchestrator(): Promise<void> {
           } else {
             const degradedText = isCodex
               ? "⚠️ The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry."
-              : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
+              : isGemini
+                ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
+                : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
             bridge.push({ type: "say", text: degradedText }, tabId);
             bridge.push({ type: "ack", ok: false, kind: "degraded" }, tabId);
             logger.warn(`[panel-orchestrator] tab ${tabId.slice(0, 8)} connected but model probe empty — sent degraded ack`);

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -42,7 +42,7 @@ export interface EnvCapabilities {
   location?: "LOCAL" | "REMOTE"; // from COMFYUI_URL host
   triton?: TriState;
   sageattention?: TriState;
-  backend?: "Claude" | "Codex"; // active provider (human label)
+  backend?: "Claude" | "Codex" | "Gemini"; // active provider (human label)
   otherBackendAvailable?: boolean; // is the OTHER provider resolvable?
 }
 
@@ -312,22 +312,29 @@ function canResolve(specifier: string): boolean {
 }
 
 /**
- * Determine the active backend label and whether the other provider is available.
- * activeBackendId is "claude" | "codex" (from PANEL_AGENT_BACKEND).
+ * Determine the active backend label and whether ANY other provider is available.
+ * activeBackendId is "claude" | "codex" | "gemini" (from PANEL_AGENT_BACKEND).
  */
 export function resolveBackends(activeBackendId: string): {
-  backend: "Claude" | "Codex";
+  backend: "Claude" | "Codex" | "Gemini";
   otherBackendAvailable: boolean;
 } {
-  const isCodex = activeBackendId.toLowerCase() === "codex";
+  const id = activeBackendId.toLowerCase();
   const claudeAvailable = canResolve("@anthropic-ai/claude-agent-sdk");
-  // Codex can be the @openai/codex package OR a `codex` CLI on PATH; resolving
-  // the package is the cheap, synchronous signal we use here.
+  // Codex can be the @openai/codex package OR a `codex` CLI on PATH; Gemini the
+  // @google/gemini-cli package OR a `gemini` CLI on PATH. Resolving the package is
+  // the cheap, synchronous signal we use here (a PATH-only CLI reads as absent).
   const codexAvailable = canResolve("@openai/codex");
-  return {
-    backend: isCodex ? "Codex" : "Claude",
-    otherBackendAvailable: isCodex ? claudeAvailable : codexAvailable,
-  };
+  const geminiAvailable = canResolve("@google/gemini-cli");
+  const backend = id === "codex" ? "Codex" : id === "gemini" ? "Gemini" : "Claude";
+  // "Other available" = any provider other than the active one is resolvable.
+  const otherBackendAvailable =
+    backend === "Claude"
+      ? codexAvailable || geminiAvailable
+      : backend === "Codex"
+        ? claudeAvailable || geminiAvailable
+        : claudeAvailable || codexAvailable;
+  return { backend, otherBackendAvailable };
 }
 
 // ---------------------------------------------------------------------------
@@ -459,9 +466,9 @@ export function formatEnvBlock(caps: EnvCapabilities): string {
   if (sage) parts.push(`SageAttention: ${sage}`);
 
   if (caps.backend) {
-    const other =
-      caps.backend === "Claude" ? "Codex" : "Claude";
-    const otherClause = caps.otherBackendAvailable ? `; ${other} also available` : "";
+    // With three providers the specific "other" isn't single-valued, so name them
+    // generically when an alternative is resolvable.
+    const otherClause = caps.otherBackendAvailable ? "; other providers available" : "";
     parts.push(`Backend: ${caps.backend}${otherClause}`);
   }
 


### PR DESCRIPTION
## Summary

Adds a **Gemini agent backend** for the panel orchestrator, mirroring the existing Codex backend. It drives the **Gemini CLI in ACP (Agent Client Protocol) mode** (`gemini --acp`) as a JSON-RPC 2.0 client over stdio. Default backend (unset / `claude` / `codex`) behavior is 100% unchanged — everything is gated behind `PANEL_AGENT_BACKEND=gemini`.

> Note: the `gemini` CLI is **not installed** in the dev environment, so this could not be live-tested. Correctness rests on faithfully mirroring the Codex pattern + the documented ACP protocol (researched via context7: `/google-gemini/gemini-cli` + `/agentclientprotocol/agent-client-protocol`), a clean build, and a deterministic unit test driving a fake ACP server over stdio. **Unverified ACP assumptions are listed at the bottom.**

## ACP ↔ AgentEvent mapping

| ACP (wire) | AgentEvent |
|---|---|
| spawn `gemini --acp` + `initialize` handshake | `prepare()` |
| `session/new` (new) / `session/load` (resume) → `{ sessionId }` | `{ type: "session", sessionId }` |
| `session/prompt` request (one per channel turn; **resolves with `stopReason`** = turn boundary) | drives the turn |
| `session/update` `agent_message_chunk` `{content:{type:"text",text}}` | `assistant_delta` (+ `stream_start`/`stream_end`, grouped by `messageId`) |
| `session/update` `agent_thought_chunk` | `assistant_delta { thinking:true }` |
| `session/update` `tool_call` `{toolCallId,title,kind}` | `tool_call { phase:"start" }` |
| `session/update` `tool_call_update` `{status:"completed"|"failed"}` | `tool_call { phase:"end" }` (title remembered by id) |
| accumulated `agent_message_chunk` text, on prompt resolve | `assistant` (one commit; ACP has no separate final-message notification) |
| `session/prompt` response `{ stopReason }` | `result { ok, subtype:stopReason }` |
| failed prompt / child dies mid-turn | `error` + `result { ok:false }` |
| `interrupt()` → `session/cancel` (notification) → prompt resolves `cancelled` | `result { ok:false, subtype:"cancelled" }` |

Mirrors Codex exactly on: the line-framed JSON-RPC client, the push→pull event-queue bridge, the **exactly-one terminal-result invariant** (PanelAgent's turn-gate parks forever without it), the `onActivity` liveness re-arm, the Windows `taskkill /T /F` + POSIX process-group kill, the Windows `.cmd`/`.ps1` shim spawn fallback, and the close()/prepare() race guards (P0-A/P0-B/P0-2).

**Auth (no API key):** the CLI owns auth (Google OAuth / Code Assist). The backend just spawns the already-signed-in CLI and never passes a key. If `session/new` returns `auth_required`, it attempts one `authenticate` with the first advertised method, then surfaces a clear "run `gemini` and sign in" message.

**Vision:** images are delivered inline as base64 `image` ContentBlocks on the prompt (like Claude), not temp files (Codex). **Tool parity:** the headless `comfyui` stdio MCP + the `panel` loopback-HTTP MCP are declared to `session/new` as ACP McpServers. **Persona:** prepended to the first turn's prompt (ACP `session/new` has no instructions field, same as Codex's thread/start).

## Models + port

- Static catalog (ACP exposes no enumeration): **`gemini-2.5-pro` (default)** and `gemini-2.5-flash`. Model is pinned at spawn via the CLI `--model` flag.
- **No effort metadata** advertised — Gemini uses a thinking *budget*, not a discrete effort scale, so the panel hides the effort picker.
- `COMFYUI_MCP_GEMINI_MODEL` env (mirrors `COMFYUI_MCP_CODEX_MODEL`), default `gemini-2.5-pro`.
- Per-backend loopback **bridge port = 9182** (9180 claude / 9181 codex / 9182 gemini), set by the launcher via `COMFYUI_MCP_BRIDGE_PORT`; documented at the port default in `index.ts`.

## Files changed

- `src/orchestrator/gemini-backend.ts` — **new**: `GeminiBackend` + `AcpClient`.
- `src/orchestrator/agent-backend.ts` — `BackendId += "gemini"`; `GEMINI_CAPABILITIES`.
- `src/orchestrator/index.ts` — `isGemini` branch: `makeBackend`/`probeBackend`, loopback HTTP panel MCP for both non-Claude backends, model list, env, port note. Codex config refactored into a shared `makeHttpBackendMcpServers` (identical output).
- `src/services/env-capabilities.ts` — `resolveBackends` handles gemini; env-block backend clause now generic across 3 providers.
- `src/__tests__/orchestrator/gemini-backend.test.ts` — **new**: fake ACP server over a mocked `child_process` driving handshake → streamed turn → result, plus interrupt and the model catalog.
- `src/__tests__/services/env-capabilities.test.ts` — updated the backend-clause assertion.

## Build / test

- `npm run build` → exit 0 (clean `tsc`).
- New test: 3/3 green.
- `npm test` → **830/830 green** (80 files). Claude/Codex paths unchanged.

## ACP assumptions I could NOT verify without the live `gemini` CLI

(flagged inline in `gemini-backend.ts`; closest faithful mapping to the documented ACP spec)

1. **`--acp` flag + bin name.** Docs say `gemini --acp` (deprecated `--experimental-acp`); bin resolved from `@google/gemini-cli` package `bin.gemini`, else `gemini` on PATH.
2. **HTTP MCP McpServer variant** in `session/new` — used `{ type:"http", name, url }` (gated by the agent's `mcpCapabilities.http`); the exact discriminator wasn't in the docs. Stdio form (`{name,command,args,env:[{name,value}]}`) follows the v1 schema.
3. **`session/load` resume** — assumed `{ sessionId, cwd, mcpServers }` reusing the same id, gated on `agentCapabilities.loadSession`; falls back to a fresh session on failure.
4. **`auth_required` retry** — reads `error.data.reason==="auth_required"`; the OAuth flow itself is interactive and CLI-owned, so a true signed-out state yields a clear instruction rather than a headless login.
5. **Live model switching** — none in standard ACP, so the model is set at spawn (`--model`); `setModel()` invalidates the cached spawn spec so the next process picks it up. The panel restarts run() on a model change.
6. **Permission auto-approve** — `session/request_permission` answered by selecting an `allow_always`/`allow_once` option (isolated background-agent posture, like Codex's auto-approve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
