### PR TITLE
feat: hosted/remote MCP connector — HTTP auth + one-command tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ Claude will find (or download) a checkpoint, build a workflow, execute it, and r
 
 For **Comfy Cloud** users, [Comfy-Org ships an official Comfy Cloud MCP](https://docs.comfy.org/development/cloud/mcp-server) (currently invite-only beta) which is cloud-exclusive and maintained by the Comfy team. `comfyui-mcp` *also* includes a community cloud-mode (set `COMFYUI_API_KEY` — see [Deployment modes](#deployment-modes)) so a single MCP can target all three deployment shapes from one config; pick whichever fits your workflow.
 
+### Remote / hosted connector (one command)
+
+Want to use `comfyui-mcp` from **Claude Desktop's Custom Connectors** or any remote
+client — like Comfy's own `cloud.comfy.org/mcp` connector? Run it as an
+authenticated, publicly-reachable Streamable-HTTP server with one flag:
+
+```bash
+npx -y comfyui-mcp --tunnel
+```
+
+This forces the HTTP transport, generates an auth token, opens a
+[cloudflared](https://github.com/cloudflare/cloudflared) quick tunnel, and prints
+a ready-to-paste `https://…/mcp` URL + token + Claude Desktop connector snippet.
+Auth accepts `Authorization: Bearer <token>` **or** `X-API-Key: <token>` (matching
+Comfy Cloud's convention). See the
+[Remote / hosted connector guide](https://comfyui-mcp.artokun.io/docs/remote-connector)
+for the full walkthrough and headless usage.
+
+> Auth is opt-in: with no `COMFYUI_MCP_HTTP_TOKEN` set and no `--tunnel`, the
+> default stdio (and plain `--http` on loopback) behavior is unchanged — open and
+> local. OAuth (Comfy's browser sign-in flow) is a planned follow-up.
+
 ---
 
 ## Claude Code Plugin

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,6 +51,7 @@
             "group": "Configuration",
             "pages": [
               "configuration",
+              "remote-connector",
               "concepts",
               "plugin",
               "panel",

--- a/docs/remote-connector.mdx
+++ b/docs/remote-connector.mdx
@@ -1,0 +1,141 @@
+---
+title: "Remote / hosted connector"
+description: "Expose comfyui-mcp as an authenticated, publicly-reachable Streamable-HTTP MCP server — add it to Claude Desktop's Custom Connectors or any remote client, one command."
+icon: "globe"
+---
+
+`comfyui-mcp` speaks the same **Streamable-HTTP** MCP transport that hosted
+connectors use (for example Comfy's own `cloud.comfy.org/mcp` Custom Connector).
+With one command it runs as a token-authenticated server behind a public HTTPS
+tunnel, so you can add it to **Claude Desktop → Connectors** or call it
+headlessly from anywhere.
+
+<Note>
+This is opt-in. The default `stdio` transport (and plain `--http` on loopback)
+behaves exactly as before — open and local. Auth and the tunnel only activate
+when you set a token or pass `--tunnel`.
+</Note>
+
+## One-command tunnel
+
+```bash
+npx -y comfyui-mcp --tunnel
+```
+
+This does four things:
+
+1. Forces the HTTP transport (`MCP_TRANSPORT=http`).
+2. Generates a strong random auth token if you haven't set one.
+3. Starts a [cloudflared](https://github.com/cloudflare/cloudflared) quick tunnel
+   to the local MCP port.
+4. Prints a ready-to-paste block: the public `https://…/mcp` URL, the token, and
+   a Claude Desktop connector snippet.
+
+The output looks like:
+
+```text
+════════════════════════════════════════════════════════════════════
+ ComfyUI MCP — Remote / Hosted Connector is LIVE
+════════════════════════════════════════════════════════════════════
+ Public MCP URL : https://shiny-otter-1234.trycloudflare.com/mcp
+ Auth token     : 9f2c…<redacted>
+ ...
+════════════════════════════════════════════════════════════════════
+```
+
+<Warning>
+Keep the terminal open. A cloudflared **quick tunnel** is ephemeral — its URL
+changes on every run and it closes when the process exits. For a stable hostname,
+run your own [named cloudflared tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+pointed at the local HTTP port instead.
+</Warning>
+
+### cloudflared not installed?
+
+`cloudflared` ships as an optional dependency. If the binary can't be found, the
+server keeps running locally and prints install guidance:
+
+```bash
+npm install -g cloudflared          # cross-platform
+brew install cloudflared            # macOS
+winget install cloudflare.cloudflared  # Windows
+```
+
+Then re-run with `--tunnel`.
+
+## Add it to Claude Desktop
+
+Open **Claude Desktop → Settings → Connectors → Add custom connector** and fill in:
+
+| Field  | Value |
+|--------|-------|
+| Name   | `ComfyUI` |
+| URL    | the printed `https://…/mcp` URL |
+| Header | `X-API-Key: <token>` (or `Authorization: Bearer <token>`) |
+
+Save, then enable the connector in a chat. The ComfyUI tools appear just like
+they do for the local stdio server.
+
+## Headless / programmatic config
+
+Any MCP client that supports a remote Streamable-HTTP server works. Provide the
+URL and the auth header:
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "url": "https://shiny-otter-1234.trycloudflare.com/mcp",
+      "headers": { "X-API-Key": "<token>" }
+    }
+  }
+}
+```
+
+Both header forms are accepted on **every** request to `/mcp`:
+
+```bash
+# X-API-Key (matches Comfy Cloud's convention)
+curl -H "X-API-Key: <token>" https://…/mcp
+
+# Authorization: Bearer
+curl -H "Authorization: Bearer <token>" https://…/mcp
+```
+
+## Manual setup (bring your own tunnel / proxy)
+
+If you'd rather manage the public endpoint yourself, run the HTTP transport with
+a fixed token and put it behind your own reverse proxy, tunnel, or VPN:
+
+```bash
+COMFYUI_MCP_HTTP_TOKEN=my-long-random-secret \
+  npx -y comfyui-mcp --http --host 0.0.0.0 --port 9100
+```
+
+Then point your tunnel/proxy at `http://127.0.0.1:9100/mcp`.
+
+<Warning>
+Binding to a non-loopback host (e.g. `0.0.0.0`) **without** a token logs a
+warning and leaves the endpoint open. Always set `COMFYUI_MCP_HTTP_TOKEN` before
+exposing the server off-box.
+</Warning>
+
+## Auth reference
+
+| Setting | Effect |
+|---------|--------|
+| `COMFYUI_MCP_HTTP_TOKEN` | Shared-secret token required on `/mcp`. Unset → endpoint is open. |
+| `--token <value>` | Same as the env var; CLI flag wins over the env var. |
+| `--tunnel` / `MCP_TUNNEL=1` | Force HTTP, auto-generate a token if unset, open a cloudflared tunnel. |
+| `--http` / `MCP_TRANSPORT=http` | HTTP transport without a tunnel (auth still applies if a token is set). |
+| `--host`, `--port` | Bind address (default `127.0.0.1:9100`). |
+
+Tokens are compared in constant time, and the gate is enforced on every HTTP
+method (`POST`/`GET`/`DELETE`) at the MCP endpoint.
+
+## Roadmap: OAuth
+
+Today's auth is a **manual shared-secret token** (Bearer / `X-API-Key`), which
+covers both the headless and the Claude Desktop Custom Connector paths. A full
+browser-based **OAuth** sign-in flow (like Comfy's hosted connector) is a planned
+follow-up — it's a heavier change and isn't required to connect manually.

--- a/docs/remote-connector.mdx
+++ b/docs/remote-connector.mdx
@@ -115,9 +115,13 @@ COMFYUI_MCP_HTTP_TOKEN=my-long-random-secret \
 Then point your tunnel/proxy at `http://127.0.0.1:9100/mcp`.
 
 <Warning>
-Binding to a non-loopback host (e.g. `0.0.0.0`) **without** a token logs a
-warning and leaves the endpoint open. Always set `COMFYUI_MCP_HTTP_TOKEN` before
-exposing the server off-box.
+Binding to a non-loopback host (e.g. `0.0.0.0`) **without** a token is a **hard
+failure** — the server refuses to start rather than expose an open `/mcp`
+endpoint off-box. Set `COMFYUI_MCP_HTTP_TOKEN` (recommended), use `--tunnel`, or
+bind a loopback host. If you genuinely want an open endpoint (e.g. behind your
+own authenticating proxy), opt in explicitly with
+`--allow-unauthenticated-non-loopback` (env `COMFYUI_MCP_ALLOW_UNAUTH=1`), which
+downgrades the failure to a warning.
 </Warning>
 
 ## Auth reference
@@ -129,9 +133,11 @@ exposing the server off-box.
 | `--tunnel` / `MCP_TUNNEL=1` | Force HTTP, auto-generate a token if unset, open a cloudflared tunnel. |
 | `--http` / `MCP_TRANSPORT=http` | HTTP transport without a tunnel (auth still applies if a token is set). |
 | `--host`, `--port` | Bind address (default `127.0.0.1:9100`). |
+| `--allow-unauthenticated-non-loopback` / `COMFYUI_MCP_ALLOW_UNAUTH=1` | Opt into an OPEN `/mcp` on a non-loopback host. Without it, that combination is a hard startup failure. |
 
 Tokens are compared in constant time, and the gate is enforced on every HTTP
-method (`POST`/`GET`/`DELETE`) at the MCP endpoint.
+method (`POST`/`GET`/`DELETE`) at the MCP endpoint. Binding a non-loopback host
+with no token is refused at startup unless the escape hatch above is set.
 
 ## Roadmap: OAuth
 

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -10,6 +10,8 @@ describe("parseCliArgs", () => {
       host: "127.0.0.1",
       port: 9100,
       panelOrchestrator: false,
+      token: undefined,
+      tunnel: false,
     });
   });
 
@@ -23,23 +25,45 @@ describe("parseCliArgs", () => {
 
   it("supports --port value and --host value", () => {
     const o = parseCliArgs([...base, "--http", "--host", "0.0.0.0", "--port", "8080"], {});
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 8080, panelOrchestrator: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false });
   });
 
   it("supports --flag=value form", () => {
     const o = parseCliArgs([...base, "--transport=http", "--port=3000", "--host=0.0.0.0"], {});
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 3000, panelOrchestrator: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false });
   });
 
   it("reads env defaults", () => {
     const o = parseCliArgs(base, { MCP_TRANSPORT: "http", MCP_HOST: "0.0.0.0", MCP_PORT: "5000" });
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 5000, panelOrchestrator: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false });
+  });
+
+  it("reads token from COMFYUI_MCP_HTTP_TOKEN env and --token flag (flag wins)", () => {
+    expect(parseCliArgs(base, { COMFYUI_MCP_HTTP_TOKEN: "envtok" }).token).toBe("envtok");
+    expect(parseCliArgs([...base, "--token", "flagtok"], { COMFYUI_MCP_HTTP_TOKEN: "envtok" }).token).toBe(
+      "flagtok",
+    );
+    expect(parseCliArgs([...base, "--token=eq"], {}).token).toBe("eq");
+  });
+
+  it("--tunnel forces http transport and sets tunnel=true; MCP_TUNNEL env works too", () => {
+    const o = parseCliArgs([...base, "--tunnel"], {});
+    expect(o.tunnel).toBe(true);
+    expect(o.transport).toBe("http");
+    const e = parseCliArgs(base, { MCP_TUNNEL: "1" });
+    expect(e.tunnel).toBe(true);
+    expect(e.transport).toBe("http");
   });
 
   it("--panel-orchestrator enables orchestrator mode; env works too", () => {
     expect(parseCliArgs(base, {}).panelOrchestrator).toBe(false);
     expect(parseCliArgs([...base, "--panel-orchestrator"], {}).panelOrchestrator).toBe(true);
     expect(parseCliArgs(base, { COMFYUI_MCP_PANEL_ORCHESTRATOR: "1" }).panelOrchestrator).toBe(true);
+    expect(parseCliArgs([...base, "--panel-orchestrator"], {})).toMatchObject({
+      panelOrchestrator: true,
+      token: undefined,
+      tunnel: false,
+    });
   });
 
   it("explicit --stdio flag overrides MCP_TRANSPORT=http env", () => {

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -12,6 +12,7 @@ describe("parseCliArgs", () => {
       panelOrchestrator: false,
       token: undefined,
       tunnel: false,
+      allowUnauthenticated: false,
     });
   });
 
@@ -25,17 +26,17 @@ describe("parseCliArgs", () => {
 
   it("supports --port value and --host value", () => {
     const o = parseCliArgs([...base, "--http", "--host", "0.0.0.0", "--port", "8080"], {});
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false });
   });
 
   it("supports --flag=value form", () => {
     const o = parseCliArgs([...base, "--transport=http", "--port=3000", "--host=0.0.0.0"], {});
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false });
   });
 
   it("reads env defaults", () => {
     const o = parseCliArgs(base, { MCP_TRANSPORT: "http", MCP_HOST: "0.0.0.0", MCP_PORT: "5000" });
-    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false });
+    expect(o).toEqual({ transport: "http", host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false });
   });
 
   it("reads token from COMFYUI_MCP_HTTP_TOKEN env and --token flag (flag wins)", () => {
@@ -53,6 +54,14 @@ describe("parseCliArgs", () => {
     const e = parseCliArgs(base, { MCP_TUNNEL: "1" });
     expect(e.tunnel).toBe(true);
     expect(e.transport).toBe("http");
+  });
+
+  it("reads the unauthenticated escape hatch from flag and env", () => {
+    expect(parseCliArgs(base, {}).allowUnauthenticated).toBe(false);
+    expect(
+      parseCliArgs([...base, "--allow-unauthenticated-non-loopback"], {}).allowUnauthenticated,
+    ).toBe(true);
+    expect(parseCliArgs(base, { COMFYUI_MCP_ALLOW_UNAUTH: "1" }).allowUnauthenticated).toBe(true);
   });
 
   it("--panel-orchestrator enables orchestrator mode; env works too", () => {

--- a/src/__tests__/transport/http.test.ts
+++ b/src/__tests__/transport/http.test.ts
@@ -89,4 +89,84 @@ describe("startHttpServer (streamable-HTTP)", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it("stays OPEN (no auth required) when no token is configured", async () => {
+    // Same as the happy path — proves the default behavior is unchanged.
+    const { client } = await connectClient();
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name).sort()).toEqual(["echo", "ping"]);
+  });
+});
+
+const TOKEN = "s3cr3t-token";
+
+async function startTokenServer(): Promise<number> {
+  httpServer = await startHttpServer({
+    host: "127.0.0.1",
+    port: 0,
+    token: TOKEN,
+    createServer: stubServerFactory,
+  });
+  return (httpServer.address() as AddressInfo).port;
+}
+
+const INIT_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "raw", version: "0.0.0" },
+  },
+});
+
+async function connectAuthedClient(headers: Record<string, string>): Promise<Client> {
+  const port = await startTokenServer();
+  const c = new Client({ name: "test-client", version: "0.0.0" });
+  await c.connect(
+    new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+      requestInit: { headers },
+    }),
+  );
+  client = c;
+  return c;
+}
+
+describe("startHttpServer auth (token configured)", () => {
+  it("returns 401 for a request with no credentials", async () => {
+    const port = await startTokenServer();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: INIT_BODY,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for a wrong token", async () => {
+    const port = await startTokenServer();
+    const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer nope",
+      },
+      body: INIT_BODY,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("completes the handshake with a correct Authorization: Bearer token", async () => {
+    const client = await connectAuthedClient({ Authorization: `Bearer ${TOKEN}` });
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name).sort()).toEqual(["echo", "ping"]);
+  });
+
+  it("completes the handshake with a correct X-API-Key token", async () => {
+    const client = await connectAuthedClient({ "X-API-Key": TOKEN });
+    const tools = await client.listTools();
+    expect(tools.tools.map((t) => t.name).sort()).toEqual(["echo", "ping"]);
+  });
 });

--- a/src/__tests__/transport/http.test.ts
+++ b/src/__tests__/transport/http.test.ts
@@ -30,7 +30,13 @@ let client: Client | undefined;
 afterEach(async () => {
   await client?.close();
   client = undefined;
-  await new Promise<void>((resolve) => httpServer?.close(() => resolve()));
+  // Guard: when a test never started a server (e.g. startHttpServer rejected),
+  // httpServer is undefined and `?.close(cb)` would short-circuit without ever
+  // invoking the callback — leaving the promise (and the hook) hanging forever.
+  await new Promise<void>((resolve) => {
+    if (httpServer) httpServer.close(() => resolve());
+    else resolve();
+  });
   httpServer = undefined;
 });
 
@@ -168,5 +174,37 @@ describe("startHttpServer auth (token configured)", () => {
     const client = await connectAuthedClient({ "X-API-Key": TOKEN });
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name).sort()).toEqual(["echo", "ping"]);
+  });
+});
+
+describe("startHttpServer non-loopback safety gate", () => {
+  it("refuses to start on a non-loopback host with no token and no escape hatch", async () => {
+    await expect(
+      startHttpServer({
+        host: "0.0.0.0",
+        port: 0,
+        createServer: stubServerFactory,
+      }),
+    ).rejects.toThrow(/Refusing to start/);
+  });
+
+  it("starts on a non-loopback host with no token when the escape hatch is set", async () => {
+    httpServer = await startHttpServer({
+      host: "0.0.0.0",
+      port: 0,
+      allowUnauthenticated: true,
+      createServer: stubServerFactory,
+    });
+    expect((httpServer.address() as AddressInfo).port).toBeGreaterThan(0);
+  });
+
+  it("starts on a non-loopback host with a token (no escape hatch needed)", async () => {
+    httpServer = await startHttpServer({
+      host: "0.0.0.0",
+      port: 0,
+      token: TOKEN,
+      createServer: stubServerFactory,
+    });
+    expect((httpServer.address() as AddressInfo).port).toBeGreaterThan(0);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { randomBytes } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -124,6 +125,75 @@ async function createConfiguredServer(): Promise<McpServer> {
   return server;
 }
 
+/**
+ * Open a cloudflared quick tunnel to the local HTTP MCP port and print a clear,
+ * ready-to-paste Claude Desktop Custom Connector block (public https://…/mcp
+ * URL + token + headless X-API-Key usage). Resilient: a missing cloudflared
+ * binary (or any tunnel error) surfaces install guidance and leaves the local
+ * server running instead of crashing.
+ */
+async function openTunnelAndAnnounce(
+  host: string,
+  port: number,
+  token: string,
+): Promise<void> {
+  const { startQuickTunnel } = await import("./services/tunnel.js");
+  logger.info("[tunnel] starting cloudflared quick tunnel…");
+  let publicUrl: string;
+  try {
+    const tunnel = await startQuickTunnel(port);
+    publicUrl = tunnel.url;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      `[tunnel] could not start cloudflared: ${message}\n` +
+        `  Install it, then re-run with --tunnel:\n` +
+        `    npm install -g cloudflared      # or: brew install cloudflared / winget install cloudflare.cloudflared\n` +
+        `  The local server is still running at http://${host}:${port}/mcp (token auth active).`,
+    );
+    return;
+  }
+
+  const mcpUrl = `${publicUrl}/mcp`;
+  const snippet = JSON.stringify(
+    {
+      mcpServers: {
+        comfyui: {
+          url: mcpUrl,
+          headers: { "X-API-Key": token },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  // Single multi-line block to stderr so it survives MCP stdio framing and is
+  // easy to copy from the terminal.
+  process.stderr.write(
+    [
+      "",
+      "════════════════════════════════════════════════════════════════════",
+      " ComfyUI MCP — Remote / Hosted Connector is LIVE",
+      "════════════════════════════════════════════════════════════════════",
+      ` Public MCP URL : ${mcpUrl}`,
+      ` Auth token     : ${token}`,
+      "",
+      " Claude Desktop → Settings → Connectors → Add custom connector:",
+      `   • Name : ComfyUI`,
+      `   • URL  : ${mcpUrl}`,
+      `   • Header: X-API-Key: ${token}   (or Authorization: Bearer ${token})`,
+      "",
+      " Headless / programmatic config snippet:",
+      snippet,
+      "",
+      " Keep this terminal open — the tunnel closes when the process exits.",
+      "════════════════════════════════════════════════════════════════════",
+      "",
+    ].join("\n"),
+  );
+}
+
 async function main() {
   const cli = parseCliArgs(process.argv);
 
@@ -138,12 +208,27 @@ async function main() {
   await JobWatcher.cleanupOldFiles();
 
   if (cli.transport === "http") {
+    // In tunnel mode, require a token even if none was configured: the endpoint
+    // is about to be exposed publicly, so generate a strong one on the fly.
+    const token =
+      cli.token ?? (cli.tunnel ? randomBytes(24).toString("hex") : undefined);
+
     await startHttpServer({
       host: cli.host,
       port: cli.port,
+      token,
       createServer: () => createConfiguredServer(),
     });
     logger.info(`ComfyUI MCP server running on http://${cli.host}:${cli.port}/mcp`);
+    if (token) {
+      logger.info(
+        `HTTP MCP auth ENABLED — send 'Authorization: Bearer <token>' or 'X-API-Key: <token>'.`,
+      );
+    }
+
+    if (cli.tunnel) {
+      await openTunnelAndAnnounce(cli.host, cli.port, token!);
+    }
   } else {
     const server = await createConfiguredServer();
     const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ async function main() {
       host: cli.host,
       port: cli.port,
       token,
+      allowUnauthenticated: cli.allowUnauthenticated,
       createServer: () => createConfiguredServer(),
     });
     logger.info(`ComfyUI MCP server running on http://${cli.host}:${cli.port}/mcp`);

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -8,6 +8,13 @@ export interface CliOptions {
    *  the UI bridge and drives the panel with autonomous Agent SDK sessions
    *  (subscription auth, no API key). Mutually exclusive with the MCP server. */
   panelOrchestrator: boolean;
+  /** Shared-secret token required on the HTTP /mcp endpoint when set
+   *  (COMFYUI_MCP_HTTP_TOKEN). Undefined → endpoint is open (local default). */
+  token?: string;
+  /** --tunnel / MCP_TUNNEL=1: force http transport, auto-generate a token if
+   *  none set, and open a cloudflared quick tunnel to the local port so the
+   *  /mcp endpoint is reachable as a hosted/remote Custom Connector. */
+  tunnel: boolean;
 }
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -32,6 +39,8 @@ export function parseCliArgs(
   let panelOrchestrator =
     env.COMFYUI_MCP_PANEL_ORCHESTRATOR === "1" ||
     env.COMFYUI_MCP_PANEL_ORCHESTRATOR === "true";
+  let token = env.COMFYUI_MCP_HTTP_TOKEN?.trim() || undefined;
+  let tunnel = env.MCP_TUNNEL === "1" || env.MCP_TUNNEL === "true";
 
   const valueOf = (current: string, inline: string, i: number): [string, number] => {
     if (current.includes("=")) return [current.slice(current.indexOf("=") + 1), i];
@@ -58,8 +67,19 @@ export function parseCliArgs(
       i = ni;
     } else if (a === "--panel-orchestrator") {
       panelOrchestrator = true;
+    } else if (a === "--token" || a.startsWith("--token=")) {
+      const [v, ni] = valueOf(a, "--token", i);
+      if (v) token = v;
+      i = ni;
+    } else if (a === "--tunnel") {
+      tunnel = true;
     }
   }
 
-  return { transport, host, port, panelOrchestrator };
+  // --tunnel implies the HTTP transport: a cloudflared quick tunnel needs an
+  // HTTP origin to point at. (Token auto-generation happens at startup, not
+  // here, to keep this parser pure/side-effect-free.)
+  if (tunnel) transport = "http";
+
+  return { transport, host, port, panelOrchestrator, token, tunnel };
 }

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -15,6 +15,9 @@ export interface CliOptions {
    *  none set, and open a cloudflared quick tunnel to the local port so the
    *  /mcp endpoint is reachable as a hosted/remote Custom Connector. */
   tunnel: boolean;
+  /** --allow-unauthenticated-non-loopback / COMFYUI_MCP_ALLOW_UNAUTH=1: opt into
+   *  an OPEN /mcp endpoint on a non-loopback host (otherwise a hard fail). */
+  allowUnauthenticated: boolean;
 }
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -41,6 +44,8 @@ export function parseCliArgs(
     env.COMFYUI_MCP_PANEL_ORCHESTRATOR === "true";
   let token = env.COMFYUI_MCP_HTTP_TOKEN?.trim() || undefined;
   let tunnel = env.MCP_TUNNEL === "1" || env.MCP_TUNNEL === "true";
+  let allowUnauthenticated =
+    env.COMFYUI_MCP_ALLOW_UNAUTH === "1" || env.COMFYUI_MCP_ALLOW_UNAUTH === "true";
 
   const valueOf = (current: string, inline: string, i: number): [string, number] => {
     if (current.includes("=")) return [current.slice(current.indexOf("=") + 1), i];
@@ -73,6 +78,8 @@ export function parseCliArgs(
       i = ni;
     } else if (a === "--tunnel") {
       tunnel = true;
+    } else if (a === "--allow-unauthenticated-non-loopback") {
+      allowUnauthenticated = true;
     }
   }
 
@@ -81,5 +88,5 @@ export function parseCliArgs(
   // here, to keep this parser pure/side-effect-free.)
   if (tunnel) transport = "http";
 
-  return { transport, host, port, panelOrchestrator, token, tunnel };
+  return { transport, host, port, panelOrchestrator, token, tunnel, allowUnauthenticated };
 }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -12,6 +12,48 @@ export interface HttpServerOptions {
   createServer: () => Promise<McpServer> | McpServer;
   /** Path the MCP endpoint is served on (default /mcp). */
   path?: string;
+  /**
+   * Optional shared-secret token. When set, EVERY request to the MCP endpoint
+   * must present it as `Authorization: Bearer <token>` OR `X-API-Key: <token>`
+   * (the latter matches Comfy Cloud's convention); missing/wrong → 401. When
+   * unset, the endpoint is open (preserves the existing local stdio/http use).
+   */
+  token?: string;
+}
+
+// Hostnames that keep traffic on the local machine. Anything else (including
+// 0.0.0.0, which binds all interfaces) is reachable off-box, so an unset token
+// there is worth a one-line warning.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost", "::ffff:127.0.0.1"]);
+
+/**
+ * Constant-time comparison of the presented credential against the configured
+ * token. Reads `Authorization: Bearer <token>` first, then `X-API-Key`. Returns
+ * true iff exactly one matches; the length-guard keeps timingSafeEqual from
+ * throwing on mismatched lengths while staying constant-time per-comparison.
+ */
+function isAuthorized(req: http.IncomingMessage, token: string): boolean {
+  const expected = Buffer.from(token);
+  const candidates: string[] = [];
+
+  const authHeader = req.headers["authorization"];
+  const auth = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (auth) {
+    const m = /^Bearer\s+(.+)$/i.exec(auth.trim());
+    if (m) candidates.push(m[1].trim());
+  }
+
+  const apiKeyHeader = req.headers["x-api-key"];
+  const apiKey = Array.isArray(apiKeyHeader) ? apiKeyHeader[0] : apiKeyHeader;
+  if (apiKey) candidates.push(apiKey.trim());
+
+  for (const candidate of candidates) {
+    const provided = Buffer.from(candidate);
+    if (provided.length === expected.length && timingSafeEqual(provided, expected)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function readBody(req: http.IncomingMessage): Promise<unknown> {
@@ -49,13 +91,29 @@ function sendJsonError(res: http.ServerResponse, status: number, message: string
  */
 export async function startHttpServer(opts: HttpServerOptions): Promise<http.Server> {
   const path = opts.path ?? "/mcp";
+  const token = opts.token?.trim() || undefined;
   const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  if (!token && !LOOPBACK_HOSTS.has(opts.host.toLowerCase())) {
+    logger.warn(
+      `HTTP MCP transport bound on non-loopback host ${opts.host} WITHOUT an auth token — ` +
+        `the /mcp endpoint is OPEN to anyone who can reach this host. ` +
+        `Set COMFYUI_MCP_HTTP_TOKEN (or use --tunnel) to require a token.`,
+    );
+  }
 
   const httpServer = http.createServer(async (req, res) => {
     try {
       const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
       if (url.pathname !== path) {
         sendJsonError(res, 404, `Not found. MCP endpoint is ${path}`);
+        return;
+      }
+
+      // Auth gate: only enforced when a token is configured. Unset → open
+      // (unchanged legacy behavior). Applies to every method on the endpoint.
+      if (token && !isAuthorized(req, token)) {
+        sendJsonError(res, 401, "Unauthorized: missing or invalid token");
         return;
       }
 

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -19,11 +19,20 @@ export interface HttpServerOptions {
    * unset, the endpoint is open (preserves the existing local stdio/http use).
    */
   token?: string;
+  /**
+   * Escape hatch for the "non-loopback host without a token" safety gate. By
+   * default, binding a non-loopback host (anything but 127.0.0.1/::1/localhost)
+   * with NO token is a HARD FAIL — an open MCP endpoint reachable off-box is a
+   * footgun next to the tunnel/hosted path. Set this (via
+   * `--allow-unauthenticated-non-loopback` / `COMFYUI_MCP_ALLOW_UNAUTH=1`) to
+   * downgrade the failure to a warning and start anyway.
+   */
+  allowUnauthenticated?: boolean;
 }
 
 // Hostnames that keep traffic on the local machine. Anything else (including
 // 0.0.0.0, which binds all interfaces) is reachable off-box, so an unset token
-// there is worth a one-line warning.
+// there is a hard failure unless explicitly allowed.
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost", "::ffff:127.0.0.1"]);
 
 /**
@@ -95,10 +104,22 @@ export async function startHttpServer(opts: HttpServerOptions): Promise<http.Ser
   const transports = new Map<string, StreamableHTTPServerTransport>();
 
   if (!token && !LOOPBACK_HOSTS.has(opts.host.toLowerCase())) {
+    if (!opts.allowUnauthenticated) {
+      throw new Error(
+        `Refusing to start: HTTP MCP transport bound on non-loopback host ${opts.host} ` +
+          `WITHOUT an auth token — the /mcp endpoint would be OPEN to anyone who can reach ` +
+          `this host. Fix one of:\n` +
+          `  • set COMFYUI_MCP_HTTP_TOKEN=<secret> (recommended), or\n` +
+          `  • use --tunnel (auto-generates a token), or\n` +
+          `  • bind a loopback host (--host 127.0.0.1), or\n` +
+          `  • explicitly opt into an open endpoint with ` +
+          `--allow-unauthenticated-non-loopback (env COMFYUI_MCP_ALLOW_UNAUTH=1).`,
+      );
+    }
     logger.warn(
       `HTTP MCP transport bound on non-loopback host ${opts.host} WITHOUT an auth token — ` +
-        `the /mcp endpoint is OPEN to anyone who can reach this host. ` +
-        `Set COMFYUI_MCP_HTTP_TOKEN (or use --tunnel) to require a token.`,
+        `the /mcp endpoint is OPEN to anyone who can reach this host ` +
+        `(allowed via --allow-unauthenticated-non-loopback / COMFYUI_MCP_ALLOW_UNAUTH).`,
     );
   }
 


### PR DESCRIPTION
## Summary

Enables a **hosted/remote MCP connector** for `comfyui-mcp` — parity with Comfy's `cloud.comfy.org/mcp` Custom Connector — by adding **token auth** to the existing Streamable-HTTP transport and a **one-command public tunnel**. The default `stdio` (and plain loopback `--http`) behavior is 100% unchanged.

## Auth model

- New optional token: `COMFYUI_MCP_HTTP_TOKEN` env or `--token <value>` (flag wins).
- When set, **every** request to `/mcp` must present it as either:
  - `Authorization: Bearer <token>`, or
  - `X-API-Key: <token>` (matches Comfy Cloud's convention).
- Constant-time comparison (`crypto.timingSafeEqual`); missing/wrong → **401**.
- When **unset**, the endpoint is open exactly as today (preserves local stdio/http use).
- A one-line **warning** is logged if the HTTP transport binds a non-loopback host without a token.

## Tunnel command

```bash
npx -y comfyui-mcp --tunnel        # or MCP_TUNNEL=1
```

`--tunnel` (a) forces `MCP_TRANSPORT=http`, (b) auto-generates a token if none is set, (c) opens a cloudflared quick tunnel to the local port (reusing the existing `src/services/tunnel.ts` helper from the experimental agent POC), and (d) prints the public `https://…/mcp` URL + token + a paste-ready Claude Desktop Custom Connector snippet. If `cloudflared` is missing it prints install guidance and keeps the local server running instead of crashing.

## Reused code

- `src/services/tunnel.ts` — existing cloudflared quick-tunnel helper (`startQuickTunnel`), originally built for the experimental embedded-agent panel POC (`src/experimental/agent-poc.ts`), now also driven by `--tunnel`. No changes needed to it.
- `cloudflared` is already in `optionalDependencies`; loaded lazily via `requireOptionalDep`.

## Docs

- New `docs/remote-connector.mdx` (Mintlify) mirroring Comfy's cloud connector setup docs: tunnel command, Claude Desktop Custom Connector steps, headless `X-API-Key` usage, manual bring-your-own-tunnel path, auth reference table.
- `docs.json` nav entry under **Configuration**.
- README "Remote / hosted connector" section.

## Security notes

- Auth is opt-in; the public path (`--tunnel`) always requires a token (auto-generated if absent).
- Token compared in constant time; 401 returned for missing/invalid on all HTTP methods.
- Quick tunnels are ephemeral (URL rotates per run); docs recommend a named cloudflared tunnel for stable hosting.

## Future enhancement (not in this PR)

Full **OAuth** browser sign-in (like Comfy's hosted connector) is a heavier follow-up. Bearer / `X-API-Key` + a manual Custom Connector token covers the headless and manual paths now. Noted in the docs and tracked as future work.

## Verification

- `npm run build` → exit 0.
- New transport tests: 401 (no token / wrong token), 200 (Bearer + X-API-Key), open-when-unset, token/tunnel CLI parsing.
- Full suite: **854 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
