### PR TITLE
feat(tools): run_workflow_url + rerun_generation (Comfy-MCP parity)

### DIFF
--- a/src/__tests__/tools/rerun-generation.test.ts
+++ b/src/__tests__/tools/rerun-generation.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Mock history retrieval + enqueue; keep applyOverrides + the queue-number
+// selection helper real so we test the actual "pick newest + re-enqueue" path.
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+}));
+
+const enqueueWorkflowMock = vi.fn(async () => ({
+  prompt_id: "rerun-prompt-1",
+  queue_remaining: 1,
+}));
+const getSystemInfoMock = vi.fn();
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
+  getSystemInfo: (...a: unknown[]) => getSystemInfoMock(...a),
+}));
+
+// generation-tracker is imported by workflow-execute (used by enqueue_workflow);
+// stub it so registering the tools doesn't pull in real tracker state.
+vi.mock("../../services/generation-tracker.js", () => ({
+  getTracker: () => ({
+    fileHasher: {},
+    logGeneration: () => ({ settingsHash: "x", reuseCount: 0 }),
+  }),
+}));
+vi.mock("../../services/workflow-settings-extractor.js", () => ({
+  extractSettings: async () => null,
+}));
+
+import { registerWorkflowExecuteTools } from "../../tools/workflow-execute.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowExecuteTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+// history entry: prompt tuple is [queueNumber, promptId, graph, extra, outputs].
+const entry = (queueNumber: number, id: string, graph: Record<string, unknown>) => ({
+  prompt: [queueNumber, id, graph, {}, []],
+  outputs: {},
+  status: { status_str: "success", completed: true, messages: [] },
+});
+
+const GRAPH_A = { "1": { class_type: "KSampler", inputs: { seed: 1, cfg: 7 } } };
+const GRAPH_B = { "1": { class_type: "KSampler", inputs: { seed: 2, cfg: 8 } } };
+
+beforeEach(() => {
+  getHistoryMock.mockReset();
+  enqueueWorkflowMock.mockClear();
+});
+
+describe("rerun_generation", () => {
+  it("picks the newest run (by queue number) and re-enqueues its graph", async () => {
+    getHistoryMock.mockResolvedValue({
+      "old-run": entry(41, "old-run", GRAPH_A),
+      "new-run": entry(42, "new-run", GRAPH_B),
+    });
+    const handler = getHandler("rerun_generation");
+
+    const res = await handler({});
+
+    expect(res.isError).toBeFalsy();
+    expect(enqueueWorkflowMock).toHaveBeenCalledTimes(1);
+    // Re-enqueued GRAPH_B (the newest), not GRAPH_A.
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof GRAPH_B;
+    expect(enqueued["1"].inputs.seed).toBe(2);
+    const out = JSON.parse(res.content[0].text);
+    expect(out.prompt_id).toBe("rerun-prompt-1");
+    expect(out.source_prompt_id).toBe("new-run");
+  });
+
+  it("re-runs a specific prompt_id when given", async () => {
+    getHistoryMock.mockResolvedValue({ "abc-123": entry(7, "abc-123", GRAPH_A) });
+    const handler = getHandler("rerun_generation");
+
+    const res = await handler({ prompt_id: "abc-123" });
+
+    expect(getHistoryMock).toHaveBeenCalledWith("abc-123");
+    const out = JSON.parse(res.content[0].text);
+    expect(out.source_prompt_id).toBe("abc-123");
+  });
+
+  it("applies overrides to the re-enqueued workflow", async () => {
+    getHistoryMock.mockResolvedValue({ "abc-123": entry(7, "abc-123", GRAPH_A) });
+    const handler = getHandler("rerun_generation");
+
+    await handler({ prompt_id: "abc-123", inputs: { cfg: 12 } });
+
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof GRAPH_A;
+    expect(enqueued["1"].inputs.cfg).toBe(12);
+  });
+
+  it("errors clearly when there is no history", async () => {
+    getHistoryMock.mockResolvedValue({});
+    const handler = getHandler("rerun_generation");
+
+    const res = await handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/No execution history/i);
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("errors when the history entry has no usable graph", async () => {
+    getHistoryMock.mockResolvedValue({
+      "abc-123": {
+        prompt: [7, "abc-123"], // truncated tuple — no graph at index 2
+        outputs: {},
+        status: { status_str: "success", completed: true, messages: [] },
+      },
+    });
+    const handler = getHandler("rerun_generation");
+
+    const res = await handler({ prompt_id: "abc-123" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/no usable prompt graph/i);
+  });
+});

--- a/src/__tests__/tools/run-workflow-url.test.ts
+++ b/src/__tests__/tools/run-workflow-url.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+// --- Mock the server-touching dependencies; keep applyOverrides + the SSRF
+// guard + isApiFormat real so we exercise real format/override logic. ---
+const getObjectInfoMock = vi.fn(async () => ({}));
+const backfillObjectInfoMock = vi.fn(async (oi: unknown) => oi);
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+  backfillObjectInfo: (...a: unknown[]) => backfillObjectInfoMock(...a),
+}));
+
+vi.mock("../../services/workflow-converter.js", () => ({
+  isUiFormat: (o: unknown) =>
+    !!o &&
+    typeof o === "object" &&
+    Array.isArray((o as { nodes?: unknown }).nodes) &&
+    Array.isArray((o as { links?: unknown }).links),
+  collectNodeTypes: () => ["KSampler"],
+  convertUiToApi: () => ({
+    workflow: { "1": { class_type: "KSampler", inputs: { seed: 1, cfg: 7 } } },
+    warnings: ["converted from UI"],
+  }),
+}));
+
+const validateWorkflowMock = vi.fn(async () => ({
+  valid: true,
+  issues: [] as unknown[],
+  summary: "0 issues",
+}));
+vi.mock("../../services/workflow-validator.js", () => ({
+  validateWorkflow: (...a: unknown[]) => validateWorkflowMock(...a),
+}));
+
+const enqueueWorkflowMock = vi.fn(async () => ({
+  prompt_id: "new-prompt-1",
+  queue_remaining: 0,
+}));
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
+}));
+
+import { registerWorkflowUrlTools } from "../../tools/workflow-url.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowUrlTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  getObjectInfoMock.mockClear();
+  backfillObjectInfoMock.mockClear();
+  validateWorkflowMock.mockClear();
+  enqueueWorkflowMock.mockClear();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const API_WF = {
+  "1": { class_type: "KSampler", inputs: { seed: 1, cfg: 7 } },
+  "2": { class_type: "SaveImage", inputs: { images: ["1", 0] } },
+};
+
+describe("run_workflow_url", () => {
+  it("loads a raw API-format JSON URL (run=false, read-only)", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(API_WF));
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({
+      url: "https://example.com/wf.json",
+      run: false,
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain("Workflow loaded");
+    expect(res.content[0].text).toContain("Node count: 2");
+    // The full workflow JSON is returned as a second content block.
+    expect(res.content[1].text).toContain("KSampler");
+  });
+
+  it("converts a UI-format export via the converter", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [{ id: 1, type: "KSampler" }], links: [] }));
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({ url: "https://example.com/ui.json" });
+
+    expect(res.isError).toBeFalsy();
+    expect(getObjectInfoMock).toHaveBeenCalled();
+    expect(res.content[0].text).toContain("converted from UI");
+    expect(res.content[0].text).toContain("Node count: 1");
+  });
+
+  it("normalizes a GitHub blob URL to raw.githubusercontent.com", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(API_WF));
+    const handler = getHandler("run_workflow_url");
+
+    await handler({
+      url: "https://github.com/owner/repo/blob/main/wf.json",
+    });
+
+    const fetchedUrl = String((fetchMock.mock.calls[0][0] as URL).toString());
+    expect(fetchedUrl).toBe("https://raw.githubusercontent.com/owner/repo/main/wf.json");
+  });
+
+  it("rejects an SSRF attempt (loopback/metadata host) without fetching", async () => {
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({ url: "http://169.254.169.254/latest/meta-data/" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/SSRF|internal\/loopback/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-http(s) schemes (file://)", async () => {
+    const handler = getHandler("run_workflow_url");
+    const res = await handler({ url: "file:///etc/passwd" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/http\/https/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error for an unsupported share host", async () => {
+    const handler = getHandler("run_workflow_url");
+    const res = await handler({ url: "https://comfyworkflows.com/workflows/abc123" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Unsupported share host/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("errors clearly on invalid JSON", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const handler = getHandler("run_workflow_url");
+    const res = await handler({ url: "https://example.com/page.html" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/did not return valid JSON/i);
+  });
+
+  it("rejects JSON that is not a recognized workflow", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ hello: "world" }));
+    const handler = getHandler("run_workflow_url");
+    const res = await handler({ url: "https://example.com/other.json" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/not a recognized ComfyUI workflow/i);
+  });
+
+  it("enqueues and applies overrides when run=true", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(API_WF));
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({
+      url: "https://example.com/wf.json",
+      run: true,
+      inputs: { cfg: 9.5 },
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(enqueueWorkflowMock).toHaveBeenCalledTimes(1);
+    // Override applied to the node that has a `cfg` input.
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof API_WF;
+    expect(enqueued["1"].inputs.cfg).toBe(9.5);
+    const out = JSON.parse(res.content[0].text);
+    expect(out.status).toBe("enqueued");
+    expect(out.prompt_id).toBe("new-prompt-1");
+  });
+});

--- a/src/__tests__/tools/run-workflow-url.test.ts
+++ b/src/__tests__/tools/run-workflow-url.test.ts
@@ -39,6 +39,12 @@ vi.mock("../../services/workflow-executor.js", () => ({
   enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
 }));
 
+// Mock DNS so resolution is deterministic + offline. Default: a public IP.
+const lookupMock = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]);
+vi.mock("node:dns/promises", () => ({
+  lookup: (...a: unknown[]) => lookupMock(...a),
+}));
+
 import { registerWorkflowUrlTools } from "../../tools/workflow-url.js";
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{
@@ -73,6 +79,8 @@ beforeEach(() => {
   validateWorkflowMock.mockClear();
   enqueueWorkflowMock.mockClear();
   fetchMock.mockReset();
+  lookupMock.mockReset();
+  lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   vi.stubGlobal("fetch", fetchMock);
 });
 
@@ -143,6 +151,43 @@ describe("run_workflow_url", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/http\/https/i);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks a hostname that DNS-resolves to a private IP (rebinding)", async () => {
+    // Host passes the literal check, but resolves to an internal address.
+    lookupMock.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    fetchMock.mockResolvedValue(jsonResponse(API_WF));
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({ url: "https://evil.example.com/wf.json" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/resolves to internal\/private|DNS-rebinding/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks an IPv6 ULA resolution too", async () => {
+    lookupMock.mockResolvedValue([{ address: "fd00::1", family: 6 }]);
+    const handler = getHandler("run_workflow_url");
+    const res = await handler({ url: "https://evil6.example.com/wf.json" });
+    expect(res.isError).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a redirect response instead of following it", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      }),
+    );
+    const handler = getHandler("run_workflow_url");
+
+    const res = await handler({ url: "https://example.com/redirector" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/redirect/i);
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
   });
 
   it("returns a clear error for an unsupported share host", async () => {

--- a/src/services/history-select.ts
+++ b/src/services/history-select.ts
@@ -1,0 +1,44 @@
+import type { HistoryEntry } from "../comfyui/client.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+
+/**
+ * Pick "the most recent" execution from a /history response.
+ *
+ * When `promptId` is given, /history is already scoped to that prompt, so we just
+ * take the single entry. Otherwise we choose by ComfyUI's MONOTONIC queue number
+ * (`history[*].prompt[0]`) rather than object iteration order — /history is keyed
+ * by prompt_id and its order is not guaranteed newest-last, which otherwise made
+ * callers return the PRIOR run (off-by-one). `prompt` is the tuple
+ * `[queueNumber, promptId, graph, extra, outputs]`; `prompt[0]` is the order key.
+ *
+ * Shared by get_history and rerun_generation so both agree on "the latest run".
+ */
+export function selectNewestHistoryEntry(
+  history: Record<string, HistoryEntry>,
+  promptId?: string,
+): [string, HistoryEntry] | undefined {
+  const entries = Object.entries(history);
+  if (entries.length === 0) return undefined;
+  if (promptId) return entries[0];
+
+  const queueNumberOf = ([, e]: [string, HistoryEntry]): number => {
+    const p = e?.prompt as unknown;
+    return Array.isArray(p) ? Number(p[0]) || 0 : 0;
+  };
+  return [...entries].sort((a, b) => queueNumberOf(b) - queueNumberOf(a))[0];
+}
+
+/**
+ * Extract the API-format prompt graph that produced a history entry.
+ * `entry.prompt` is the tuple `[queueNumber, promptId, graph, extra, outputs]`;
+ * the graph at index 2 is the node dict we can re-enqueue. Returns null when the
+ * entry has no usable graph.
+ */
+export function extractWorkflowGraph(entry: HistoryEntry): WorkflowJSON | null {
+  const p = entry?.prompt as unknown;
+  if (!Array.isArray(p) || p.length < 3) return null;
+  const graph = p[2];
+  if (!graph || typeof graph !== "object" || Array.isArray(graph)) return null;
+  if (Object.keys(graph as Record<string, unknown>).length === 0) return null;
+  return graph as WorkflowJSON;
+}

--- a/src/services/workflow-url.ts
+++ b/src/services/workflow-url.ts
@@ -1,0 +1,235 @@
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+/** Default cap on how long we wait for a workflow URL to respond. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+/** Default cap on the workflow payload size (workflows are JSON, rarely > a few MB). */
+const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Known "share" hosts that serve an HTML page (or require an authenticated API
+ * call) rather than raw workflow JSON. We can't resolve these to a graph, so we
+ * fail fast with a clear instruction instead of fetching a web page and choking
+ * on the HTML.
+ */
+const UNSUPPORTED_SHARE_HOSTS = [
+  "comfyworkflows.com",
+  "openart.ai",
+  "civitai.com",
+  "comfy.icu",
+  "pixfor.us",
+];
+
+export interface FetchWorkflowResult {
+  /** Parsed JSON payload (unknown shape — caller validates it's a workflow). */
+  json: unknown;
+  /** The final URL actually fetched (after blob→raw normalization). */
+  finalUrl: string;
+}
+
+/**
+ * Normalize well-known workflow URLs to their raw-JSON equivalent, and reject
+ * share hosts we can't resolve.
+ *
+ * - GitHub blob pages (`github.com/o/r/blob/ref/path.json`) → the raw file on
+ *   `raw.githubusercontent.com`.
+ * - GitHub `?raw=true` blob links → raw host too.
+ * - Known share hosts (comfyworkflows, openart, civitai, …) → throw with a hint
+ *   to paste the raw `.json` URL.
+ *
+ * Anything else is returned unchanged.
+ */
+export function normalizeWorkflowUrl(rawUrl: string): string {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    // Leave parsing/validation errors to assertSafeUrl, which gives a better message.
+    return rawUrl;
+  }
+
+  const host = u.hostname.toLowerCase();
+
+  // github.com/<owner>/<repo>/blob/<ref>/<path...> → raw.githubusercontent.com
+  if (host === "github.com" || host === "www.github.com") {
+    const parts = u.pathname.split("/").filter(Boolean);
+    const blobIdx = parts.indexOf("blob");
+    if (blobIdx >= 2 && blobIdx < parts.length - 1) {
+      const owner = parts[0];
+      const repo = parts[1];
+      const rest = parts.slice(blobIdx + 1).join("/");
+      return `https://raw.githubusercontent.com/${owner}/${repo}/${rest}`;
+    }
+  }
+
+  // Refuse share hosts that don't serve raw JSON.
+  if (
+    UNSUPPORTED_SHARE_HOSTS.some((h) => host === h || host.endsWith("." + h))
+  ) {
+    throw new ValidationError(
+      `Unsupported share host "${host}" — it serves a web page, not raw workflow JSON, ` +
+        `and we can't resolve it without that site's API. Open the workflow there, then paste ` +
+        `the direct raw .json URL (e.g. a raw.githubusercontent.com link or a "Save (API Format)" ` +
+        `export hosted as a .json file).`,
+    );
+  }
+
+  return rawUrl;
+}
+
+/**
+ * Reject any URL that isn't a plain http(s) request to a public host. Blocks
+ * file:// and other schemes, loopback, link-local, private, and CGNAT ranges to
+ * avoid SSRF (e.g. tricking the server into fetching its own /admin or the cloud
+ * metadata endpoint at 169.254.169.254).
+ *
+ * Note: this checks the literal host/IP in the URL. It does not resolve DNS, so
+ * a public hostname that resolves to a private IP (DNS rebinding) is not caught
+ * here — redirects are followed by fetch and are likewise not re-validated.
+ */
+export function assertSafeUrl(rawUrl: string): URL {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    throw new ValidationError(`Invalid URL: ${rawUrl}`);
+  }
+
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new ValidationError(
+      `Only http/https URLs are supported (got "${u.protocol}"). ` +
+        `file://, data:, and other schemes are rejected.`,
+    );
+  }
+
+  const host = u.hostname.toLowerCase();
+  if (isBlockedHost(host)) {
+    throw new ValidationError(
+      `Refusing to fetch from internal/loopback host "${host}" (SSRF guard). ` +
+        `Only public http/https hosts are allowed.`,
+    );
+  }
+
+  return u;
+}
+
+/**
+ * True for hostnames/IPs that point at the local machine or a private network.
+ * Exported for unit testing.
+ */
+export function isBlockedHost(host: string): boolean {
+  if (!host) return true;
+
+  // Hostname-based internal names.
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host.endsWith(".local") || host.endsWith(".internal")) return true;
+
+  // IPv6 (URL.hostname strips the surrounding brackets).
+  if (host.includes(":")) {
+    const h = host.replace(/^\[|\]$/g, "");
+    if (h === "::1" || h === "::") return true; // loopback / unspecified
+    const low = h.toLowerCase();
+    // Unique-local fc00::/7 (fc.. / fd..) and link-local fe80::/10 (fe8/fe9/fea/feb).
+    if (/^f[cd]/.test(low)) return true;
+    if (/^fe[89ab]/.test(low)) return true;
+    // IPv4-mapped IPv6 (::ffff:127.0.0.1) — extract the trailing v4 literal.
+    const v4 = low.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (v4) return isBlockedIpv4(v4[1]);
+    return false;
+  }
+
+  // IPv4 literal.
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) {
+    return isBlockedIpv4(host);
+  }
+
+  return false;
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n > 255)) {
+    return true; // malformed → reject
+  }
+  const [a, b] = parts;
+  if (a === 0 || a === 127 || a === 10) return true; // this-host / loopback / private
+  if (a === 169 && b === 254) return true; // link-local + cloud metadata (169.254.169.254)
+  if (a === 192 && b === 168) return true; // private
+  if (a === 172 && b >= 16 && b <= 31) return true; // private
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  return false;
+}
+
+/**
+ * Fetch and JSON-parse a workflow from a remote URL with SSRF, timeout, and
+ * size guards. Throws ValidationError (never a raw fetch error) on any failure
+ * so callers can surface a clean message via errorToToolResult.
+ */
+export async function fetchWorkflowFromUrl(
+  rawUrl: string,
+  opts?: { timeoutMs?: number; maxBytes?: number },
+): Promise<FetchWorkflowResult> {
+  const normalized = normalizeWorkflowUrl(rawUrl);
+  const u = assertSafeUrl(normalized);
+
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = opts?.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetch(u, {
+      signal: controller.signal,
+      redirect: "follow",
+      headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.5" },
+    });
+  } catch (err) {
+    const e = err as Error;
+    if (e?.name === "AbortError") {
+      throw new ValidationError(
+        `Timed out after ${timeoutMs}ms fetching workflow from "${u.hostname}".`,
+      );
+    }
+    throw new ValidationError(`Failed to fetch workflow URL: ${e?.message ?? err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!res.ok) {
+    throw new ValidationError(
+      `Workflow URL returned ${res.status} ${res.statusText}. ` +
+        `Check the link points at a public raw .json file.`,
+    );
+  }
+
+  // Pre-flight size check via Content-Length when present.
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (declared && declared > maxBytes) {
+    throw new ValidationError(
+      `Workflow payload too large (${declared} bytes > ${maxBytes} byte limit).`,
+    );
+  }
+
+  const text = await res.text();
+  if (text.length > maxBytes) {
+    throw new ValidationError(
+      `Workflow payload too large (${text.length} bytes > ${maxBytes} byte limit).`,
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    const preview = text.slice(0, 120).replace(/\s+/g, " ").trim();
+    throw new ValidationError(
+      `URL did not return valid JSON (got: "${preview}…"). ` +
+        `If this is a share/preview page, paste the raw workflow JSON URL instead.`,
+    );
+  }
+
+  logger.info("Fetched workflow from URL", { finalUrl: u.toString(), bytes: text.length });
+  return { json, finalUrl: u.toString() };
+}

--- a/src/services/workflow-url.ts
+++ b/src/services/workflow-url.ts
@@ -1,3 +1,4 @@
+import { lookup } from "node:dns/promises";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -5,6 +6,8 @@ import { logger } from "../utils/logger.js";
 const DEFAULT_TIMEOUT_MS = 15_000;
 /** Default cap on the workflow payload size (workflows are JSON, rarely > a few MB). */
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
+/** Default cap on the DNS lookup so a slow/hanging resolver can't stall the tool. */
+const DEFAULT_DNS_TIMEOUT_MS = 5_000;
 
 /**
  * Known "share" hosts that serve an HTML page (or require an authenticated API
@@ -83,9 +86,9 @@ export function normalizeWorkflowUrl(rawUrl: string): string {
  * avoid SSRF (e.g. tricking the server into fetching its own /admin or the cloud
  * metadata endpoint at 169.254.169.254).
  *
- * Note: this checks the literal host/IP in the URL. It does not resolve DNS, so
- * a public hostname that resolves to a private IP (DNS rebinding) is not caught
- * here — redirects are followed by fetch and are likewise not re-validated.
+ * This is the LITERAL-host check; `fetchWorkflowFromUrl` additionally resolves
+ * the hostname via DNS and re-runs these checks against every resolved address
+ * (defeating DNS-rebinding) and refuses to follow redirects.
  */
 export function assertSafeUrl(rawUrl: string): URL {
   let u: URL;
@@ -160,17 +163,82 @@ function isBlockedIpv4(ip: string): boolean {
   return false;
 }
 
+/** Reject a promise that doesn't settle within `ms`, with a clear label. */
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+/**
+ * Resolve a hostname and reject if ANY resolved address is internal/private.
+ * This defeats DNS-rebinding: a hostname that passes the literal-host check but
+ * resolves to loopback/RFC1918/link-local/metadata/CGNAT/IPv6-ULA is blocked.
+ * IP literals resolve to themselves, so this is a no-op-but-safe for those.
+ * Bounded so a slow resolver can't hang the tool. Exported for testing.
+ */
+export async function assertHostResolvesSafe(
+  host: string,
+  timeoutMs: number = DEFAULT_DNS_TIMEOUT_MS,
+): Promise<void> {
+  let results: Array<{ address: string }>;
+  try {
+    results = await withTimeout(
+      lookup(host, { all: true }),
+      timeoutMs,
+      `DNS lookup for "${host}"`,
+    );
+  } catch (err) {
+    const e = err as Error;
+    throw new ValidationError(
+      `Could not resolve host "${host}": ${e?.message ?? err}`,
+    );
+  }
+
+  if (!results || results.length === 0) {
+    throw new ValidationError(`Host "${host}" did not resolve to any address.`);
+  }
+
+  for (const r of results) {
+    if (isBlockedHost(r.address)) {
+      throw new ValidationError(
+        `Refusing to fetch "${host}" — it resolves to internal/private address ` +
+          `${r.address} (SSRF guard / DNS-rebinding protection).`,
+      );
+    }
+  }
+}
+
 /**
  * Fetch and JSON-parse a workflow from a remote URL with SSRF, timeout, and
  * size guards. Throws ValidationError (never a raw fetch error) on any failure
  * so callers can surface a clean message via errorToToolResult.
+ *
+ * SSRF defenses: http/https only; literal-host check; DNS resolution with every
+ * resolved address re-checked against the private/internal ranges; and redirects
+ * are NOT followed (a 30x to an internal target is rejected — raw workflow-JSON
+ * hosts don't need redirects, and GitHub blob→raw is normalized up front).
  */
 export async function fetchWorkflowFromUrl(
   rawUrl: string,
-  opts?: { timeoutMs?: number; maxBytes?: number },
+  opts?: { timeoutMs?: number; maxBytes?: number; dnsTimeoutMs?: number },
 ): Promise<FetchWorkflowResult> {
   const normalized = normalizeWorkflowUrl(rawUrl);
   const u = assertSafeUrl(normalized);
+  await assertHostResolvesSafe(u.hostname, opts?.dnsTimeoutMs ?? DEFAULT_DNS_TIMEOUT_MS);
 
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxBytes = opts?.maxBytes ?? DEFAULT_MAX_BYTES;
@@ -182,7 +250,9 @@ export async function fetchWorkflowFromUrl(
   try {
     res = await fetch(u, {
       signal: controller.signal,
-      redirect: "follow",
+      // Do NOT auto-follow redirects — a public URL could 30x to an internal
+      // target that bypasses the DNS/host checks above.
+      redirect: "manual",
       headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.5" },
     });
   } catch (err) {
@@ -195,6 +265,20 @@ export async function fetchWorkflowFromUrl(
     throw new ValidationError(`Failed to fetch workflow URL: ${e?.message ?? err}`);
   } finally {
     clearTimeout(timer);
+  }
+
+  // redirect:"manual" surfaces redirects as an opaqueredirect response (status 0
+  // in Node/undici) or, in test doubles, a literal 3xx. Reject either rather
+  // than following into a possibly-internal Location.
+  if (
+    res.type === "opaqueredirect" ||
+    res.status === 0 ||
+    (res.status >= 300 && res.status < 400)
+  ) {
+    throw new ValidationError(
+      `Workflow URL responded with a redirect (status ${res.status}) — redirects are ` +
+        `not followed (SSRF guard). Use the final direct .json URL instead.`,
+    );
   }
 
   if (!res.ok) {

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -5,6 +5,7 @@ import {
   getHistory,
   type HistoryEntry,
 } from "../comfyui/client.js";
+import { selectNewestHistoryEntry } from "../services/history-select.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 function formatHistoryEntry(
@@ -170,9 +171,9 @@ export function registerDiagnosticsTools(server: McpServer): void {
     async (args) => {
       try {
         const history = await getHistory(args.prompt_id);
-        const entries = Object.entries(history);
+        const selected = selectNewestHistoryEntry(history, args.prompt_id);
 
-        if (entries.length === 0) {
+        if (!selected) {
           return {
             content: [
               {
@@ -185,21 +186,7 @@ export function registerDiagnosticsTools(server: McpServer): void {
           };
         }
 
-        // If no prompt_id, pick the newest by ComfyUI's MONOTONIC queue number
-        // (history[*].prompt[0]) rather than trusting object iteration order —
-        // /history is keyed by prompt_id and its order is not guaranteed
-        // newest-last, which made get_history return the PRIOR run (off-by-one,
-        // also surfaced as the panel's stale "Run finished" card). `prompt` is
-        // the array [queueNumber, promptId, graph, extra, outputs]; prompt[0] is
-        // the reliable order key.
-        const queueNumberOf = ([, e]: [string, HistoryEntry]): number => {
-          const p = e?.prompt as unknown;
-          return Array.isArray(p) ? Number(p[0]) || 0 : 0;
-        };
-        const [promptId, entry] = args.prompt_id
-          ? entries[0]
-          : [...entries].sort((a, b) => queueNumberOf(b) - queueNumberOf(a))[0];
-
+        const [promptId, entry] = selected;
         const text = formatHistoryEntry(promptId, entry);
         return { content: [{ type: "text", text }] };
       } catch (err) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@ import { registerExtraPathsTools } from "./extra-paths.js";
 import { registerSkillGeneratorTools } from "./skill-generator.js";
 import { registerDiagnosticsTools } from "./diagnostics.js";
 import { registerWorkflowLibraryTools } from "./workflow-library.js";
+import { registerWorkflowUrlTools } from "./workflow-url.js";
 import { registerProcessControlTools } from "./process-control.js";
 import { registerImageManagementTools } from "./image-management.js";
 import { registerMemoryManagementTools } from "./memory-management.js";
@@ -59,6 +60,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   registerSkillGeneratorTools(server);
   registerDiagnosticsTools(server);
   registerWorkflowLibraryTools(server);
+  registerWorkflowUrlTools(server);
   registerProcessControlTools(server);
   registerImageManagementTools(server);
   registerMemoryManagementTools(server);

--- a/src/tools/workflow-execute.ts
+++ b/src/tools/workflow-execute.ts
@@ -4,7 +4,13 @@ import {
   enqueueWorkflow,
   getSystemInfo,
 } from "../services/workflow-executor.js";
-import { errorToToolResult } from "../utils/errors.js";
+import { getHistory } from "../comfyui/client.js";
+import {
+  selectNewestHistoryEntry,
+  extractWorkflowGraph,
+} from "../services/history-select.js";
+import { applyOverrides } from "../services/asset-registry.js";
+import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { getTracker } from "../services/generation-tracker.js";
 import { extractSettings } from "../services/workflow-settings-extractor.js";
 import { logger } from "../utils/logger.js";
@@ -51,6 +57,82 @@ export function registerWorkflowExecuteTools(server: McpServer): void {
                   status: "enqueued",
                   prompt_id: result.prompt_id,
                   queue_remaining: result.queue_remaining,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "rerun_generation",
+    "Re-run the workflow behind a previous generation. Retrieves the prompt graph from " +
+      "execution history (by prompt_id, or the most recent run when omitted — chosen by " +
+      "ComfyUI's queue number, same logic as get_history) and re-enqueues it, optionally " +
+      "applying `inputs` overrides. Seeds are re-randomized unless disable_random_seed is set. " +
+      "Returns the new prompt_id and the source prompt_id it came from. Clear error if no " +
+      "matching history exists.",
+    {
+      prompt_id: z
+        .string()
+        .optional()
+        .describe(
+          "Prompt ID of the generation to re-run. If omitted, uses the most recent execution.",
+        ),
+      inputs: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          "Optional overrides applied to every node with a matching input name " +
+            "(e.g. cfg, steps, sampler_name, seed, text).",
+        ),
+      disable_random_seed: z
+        .boolean()
+        .optional()
+        .describe("If true, do not randomize seed fields (combine with inputs.seed to reproduce exactly)."),
+    },
+    async (args) => {
+      try {
+        const history = await getHistory(args.prompt_id);
+        const selected = selectNewestHistoryEntry(history, args.prompt_id);
+        if (!selected) {
+          throw new ValidationError(
+            args.prompt_id
+              ? `No execution history found for prompt ${args.prompt_id}.`
+              : "No execution history available to re-run.",
+          );
+        }
+
+        const [sourcePromptId, entry] = selected;
+        const workflow = extractWorkflowGraph(entry);
+        if (!workflow) {
+          throw new ValidationError(
+            `History entry ${sourcePromptId} has no usable prompt graph to re-run.`,
+          );
+        }
+
+        const next = applyOverrides(workflow, args.inputs);
+        const result = await enqueueWorkflow(next, {
+          disable_random_seed: args.disable_random_seed,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  status: "enqueued",
+                  prompt_id: result.prompt_id,
+                  queue_remaining: result.queue_remaining,
+                  source_prompt_id: sourcePromptId,
+                  overrides_applied: args.inputs ?? {},
                 },
                 null,
                 2,

--- a/src/tools/workflow-url.ts
+++ b/src/tools/workflow-url.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+import {
+  getObjectInfo,
+  backfillObjectInfo,
+} from "../comfyui/client.js";
+import {
+  isUiFormat,
+  convertUiToApi,
+  collectNodeTypes,
+} from "../services/workflow-converter.js";
+import { validateWorkflow } from "../services/workflow-validator.js";
+import { enqueueWorkflow } from "../services/workflow-executor.js";
+import { applyOverrides } from "../services/asset-registry.js";
+import { fetchWorkflowFromUrl } from "../services/workflow-url.js";
+import { errorToToolResult, ValidationError } from "../utils/errors.js";
+
+/**
+ * Detect a ComfyUI API-format prompt graph: a plain object whose values all look
+ * like nodes ({ class_type, inputs }). Some shares wrap the graph as
+ * `{ prompt: {...} }` (a raw /prompt request body) — `unwrapApiWorkflow` handles
+ * that before this check.
+ */
+function isApiFormat(obj: unknown): obj is WorkflowJSON {
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return false;
+  const values = Object.values(obj as Record<string, unknown>);
+  if (values.length === 0) return false;
+  return values.every(
+    (v) =>
+      v != null &&
+      typeof v === "object" &&
+      !Array.isArray(v) &&
+      "class_type" in (v as Record<string, unknown>),
+  );
+}
+
+/** Unwrap `{ prompt: {...} }` /prompt-request bodies to the bare node graph. */
+function unwrapApiWorkflow(json: unknown): unknown {
+  if (
+    json != null &&
+    typeof json === "object" &&
+    !Array.isArray(json) &&
+    "prompt" in (json as Record<string, unknown>) &&
+    isApiFormat((json as Record<string, unknown>).prompt)
+  ) {
+    return (json as Record<string, unknown>).prompt;
+  }
+  return json;
+}
+
+/** Class-type fragments that identify the structurally important nodes. */
+const KEY_NODE_PATTERNS =
+  /(checkpoint|unet|diffusionmodel|sampler|saveimage|savevideo|vaedecode|cliptextencode|loraloader|controlnet)/i;
+
+function summarizeWorkflow(workflow: WorkflowJSON): string {
+  const histogram: Record<string, number> = {};
+  const keyNodes: string[] = [];
+  for (const [id, node] of Object.entries(workflow)) {
+    const t = node.class_type ?? "?";
+    histogram[t] = (histogram[t] ?? 0) + 1;
+    if (KEY_NODE_PATTERNS.test(t)) keyNodes.push(`${id}:${t}`);
+  }
+  const types = Object.entries(histogram)
+    .sort((a, b) => b[1] - a[1])
+    .map(([t, c]) => `${c}× ${t}`)
+    .join(", ");
+  const lines = [
+    `Node count: ${Object.keys(workflow).length}`,
+    `Node types: ${types}`,
+  ];
+  if (keyNodes.length > 0) {
+    lines.push(`Key nodes: ${keyNodes.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+export function registerWorkflowUrlTools(server: McpServer): void {
+  server.tool(
+    "run_workflow_url",
+    "Read (and optionally execute) a shared ComfyUI workflow from a URL. " +
+      "Fetches the workflow JSON, accepts API-format prompt graphs or UI-format exports " +
+      "(UI is auto-converted via the same converter as get_workflow), validates it, and " +
+      "summarizes it. Supports raw .json links and GitHub blob/raw URLs (blob is normalized " +
+      "to raw); other share hosts that need a site API return a clear 'paste the raw JSON URL' " +
+      "error. The fetch is bounded (http/https only, timeout + size cap, loopback/private/" +
+      "metadata IPs rejected to prevent SSRF). " +
+      "READ-ONLY unless run=true; when run=true it enqueues the workflow (applying optional " +
+      "`inputs` overrides) and returns the prompt_id.",
+    {
+      url: z
+        .string()
+        .describe(
+          "URL of the workflow JSON. Raw .json links and GitHub blob/raw URLs work directly.",
+        ),
+      run: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, enqueue the workflow for execution and return the prompt_id. " +
+            "Default false: only fetch, validate, and summarize (read-only).",
+        ),
+      inputs: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          "Optional parameter overrides applied (only when run=true) to every node that " +
+            "already has a matching input name. Common keys: cfg, steps, sampler_name, seed, text.",
+        ),
+    },
+    async ({ url, run, inputs }) => {
+      try {
+        const { json, finalUrl } = await fetchWorkflowFromUrl(url);
+
+        // Resolve to an API-format graph: convert UI exports, unwrap /prompt bodies.
+        let workflow: WorkflowJSON;
+        const warnings: string[] = [];
+        if (isUiFormat(json)) {
+          const bulk = await getObjectInfo();
+          const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(json));
+          const converted = convertUiToApi(json, objectInfo);
+          workflow = converted.workflow;
+          warnings.push(...converted.warnings);
+        } else {
+          const candidate = unwrapApiWorkflow(json);
+          if (!isApiFormat(candidate)) {
+            throw new ValidationError(
+              "The URL returned JSON that is not a recognized ComfyUI workflow " +
+                "(neither an API-format prompt graph of {class_type, inputs} nodes, " +
+                "nor a UI-format export with nodes[]/links[]).",
+            );
+          }
+          workflow = candidate;
+        }
+
+        if (Object.keys(workflow).length === 0) {
+          throw new ValidationError("The workflow contains no nodes.");
+        }
+
+        // Validate (best-effort — never throws; reports 'cannot reach ComfyUI' as an issue).
+        const validation = await validateWorkflow(workflow);
+
+        if (!run) {
+          const lines: string[] = [];
+          lines.push(`# Workflow loaded from ${finalUrl}`);
+          if (warnings.length > 0) {
+            lines.push("");
+            lines.push(`**Conversion warnings (${warnings.length}):**`);
+            lines.push(...warnings.map((w) => `- ${w}`));
+          }
+          lines.push("");
+          lines.push(summarizeWorkflow(workflow));
+          lines.push("");
+          lines.push(`Validation: ${validation.summary}`);
+          for (const issue of validation.issues) {
+            const loc = issue.node_id
+              ? `${issue.node_id} (${issue.node_type})`
+              : "workflow";
+            lines.push(`- [${issue.severity}] ${loc}: ${issue.message}`);
+          }
+          lines.push("");
+          lines.push("Re-call with run=true to enqueue this workflow.");
+          return {
+            content: [
+              { type: "text" as const, text: lines.join("\n") },
+              { type: "text" as const, text: JSON.stringify(workflow, null, 2) },
+            ],
+          };
+        }
+
+        // run=true → apply overrides and enqueue.
+        const next = applyOverrides(workflow, inputs);
+        const result = await enqueueWorkflow(next);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  status: "enqueued",
+                  prompt_id: result.prompt_id,
+                  queue_remaining: result.queue_remaining,
+                  source_url: finalUrl,
+                  overrides_applied: inputs ?? {},
+                  conversion_warnings: warnings,
+                  validation: validation.summary,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds two MCP tools for parity with Comfy MCP's shared-workflow features.

### `run_workflow_url`
- **Input:** `{ url, run? (default false), inputs? }`
- Fetches workflow JSON from a URL. Normalizes GitHub **blob → raw** (`raw.githubusercontent.com`); accepts raw `.json` links.
- Accepts **API-format** prompt graphs (and unwraps `{prompt:{...}}` request bodies) or **UI-format** exports — UI is auto-converted via the existing `convertUiToApi` (with `object_info` backfill), same path as `get_workflow`.
- Validates via the existing `validateWorkflow`.
- `run=false` (default, read-only): returns a summary (node count, node-type histogram, key nodes), validation results, and the resolved API workflow JSON.
- `run=true`: applies `inputs` overrides (reuses `applyOverrides`) and enqueues, returning `prompt_id`.
- Registered in `tools/index.ts`.

### `rerun_generation`
- **Input:** `{ prompt_id? (default = most recent), inputs? }`
- Retrieves the prompt graph from `get_history` and re-enqueues it, applying optional overrides. Returns the new `prompt_id` and the `source_prompt_id`.
- Reuses the newest-by-queue-number selection logic, now extracted to a shared `selectNewestHistoryEntry` helper that `get_history` also uses.

## Fetch / validation / SSRF guards (`services/workflow-url.ts`)
- **http/https only** — rejects `file://`, `data:`, etc.
- **Literal-host SSRF guard** — blocks loopback, `0.0.0.0`, RFC1918 private, link-local + cloud metadata (`169.254.169.254`), CGNAT `100.64/10`, IPv6 `::1`/ULA/link-local/IPv4-mapped, and `localhost`/`.local`/`.internal` hosts.
- **DNS-rebinding protection** — resolves the hostname (`dns.lookup`, all addresses, bounded by a 5s timeout) and re-runs the private-range checks against **every** resolved IPv4/IPv6 address; rejects if any is internal.
- **Redirects not followed** — `redirect: "manual"`; any redirect (opaqueredirect/status 0 or a 3xx) is rejected rather than followed into a possibly-internal `Location`. (Raw workflow-JSON hosts don't need redirects, and GitHub blob→raw is normalized up front.)
- **Bounded fetch** — 15s request timeout (AbortController) and 25 MB size cap (Content-Length pre-check + body length).
- **Known share hosts** (comfyworkflows.com, openart.ai, civitai.com, comfy.icu, pixfor.us) return a clear "unsupported share host — paste the raw workflow JSON URL" error instead of choking on HTML.
- All failures (incl. DNS errors / blocked addresses / redirects) surface via `errorToToolResult` (never a raw throw).

## Test coverage
- `run-workflow-url.test.ts` (12): raw JSON load, UI→convert, GitHub blob normalization, literal SSRF reject (no fetch), `file://` reject, **DNS-rebinding to private IPv4 reject**, **DNS-rebinding to IPv6 ULA reject**, **redirect reject**, share-host reject, invalid-JSON, non-workflow-JSON reject, run=true enqueue + override applied. DNS mocked for determinism/offline.
- `rerun-generation.test.ts` (6): newest-by-queue-number pick, specific prompt_id, override applied, no-history error, missing-graph error.
- Existing `get-history-select.test.ts` still green after the helper refactor.

Build exit 0 (`tsc`); full suite **864 passed**.

## Share hosts not resolvable
comfyworkflows.com, openart.ai, civitai.com, comfy.icu, pixfor.us serve HTML/API pages, not raw JSON — they are explicitly rejected with guidance to paste the raw `.json` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)