### PR TITLE
fix: generation tools — live-render widget fixes (generate_video, remove_background)

### DIFF
--- a/src/__tests__/services/generate-video.test.ts
+++ b/src/__tests__/services/generate-video.test.ts
@@ -80,6 +80,9 @@ describe("generateVideo", () => {
     expect(node(wf, "LTXAVTextEncoderLoader")!.inputs.text_encoder).toBe(
       "gemma_3_12B_it_fp8_scaled.safetensors",
     );
+    // `device` is a REQUIRED widget on the installed comfy_extras node — omitting
+    // it 400s at submit (regression guard for the live-render fix).
+    expect(node(wf, "LTXAVTextEncoderLoader")!.inputs.device).toBe("default");
     // Both LoRAs present (abliterated on CLIP, distilled on model).
     expect(node(wf, "LoraLoader")).toBeDefined();
     expect(node(wf, "LoraLoaderModelOnly")!.inputs.strength_model).toBe(0.5);
@@ -89,7 +92,11 @@ describe("generateVideo", () => {
     expect(node(wf, "LTXVImgToVideo")).toBeUndefined();
     // The distilled sampler tail + video output.
     expect(node(wf, "SamplerCustomAdvanced")).toBeDefined();
-    expect(node(wf, "SaveVideo")).toBeDefined();
+    // SaveVideo's `format` + `codec` are REQUIRED widgets — omitting them 400s at
+    // submit (regression guard for the live-render fix).
+    const save = node(wf, "SaveVideo")!;
+    expect(save.inputs.format).toBe("auto");
+    expect(save.inputs.codec).toBe("auto");
     // Positive prompt wired in.
     const pos = Object.values(wf).find(
       (n) => n.class_type === "CLIPTextEncode" && n._meta?.title === "Positive Prompt",

--- a/src/__tests__/services/remove-background.test.ts
+++ b/src/__tests__/services/remove-background.test.ts
@@ -40,6 +40,15 @@ describe("removeBackground", () => {
     const rembg = node(wf, REMBG_NODE)!;
     expect(rembg.inputs.image).toEqual(["1", 0]);
     expect(rembg.inputs.model).toBe("BiRefNet_toonout");
+    // background=Alpha gives a transparent cutout; the other widgets are "optional"
+    // in the node schema but ComfyUI-RMBG reads them by key, so they MUST be passed
+    // explicitly or the node KeyErrors at runtime over the API (regression guard).
+    expect(rembg.inputs.background).toBe("Alpha");
+    expect(rembg.inputs.mask_blur).toBe(0);
+    expect(rembg.inputs.mask_offset).toBe(0);
+    expect(rembg.inputs.invert_output).toBe(false);
+    expect(rembg.inputs.refine_foreground).toBe(false);
+    expect(rembg.inputs.background_color).toBe("#222222");
     const save = node(wf, "SaveImage")!;
     expect(save.inputs.images).toEqual(["2", 0]);
   });

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -255,10 +255,21 @@ function buildRemoveBackground(p: RemoveBackgroundParams): WorkflowJSON {
     },
     "2": {
       class_type: "BiRefNetRMBG",
-      // `background: "Alpha"` forces a transparent RGBA cutout regardless of the
-      // node version's default (matches packs/wan-transparent). The remaining
-      // widgets (mask blur/offset, invert, refine) keep their defaults.
-      inputs: { image: conn("1", 0), model, background: "Alpha" },
+      // `background: "Alpha"` forces a transparent RGBA cutout (matches
+      // packs/wan-transparent). The other widgets are declared "optional" in the
+      // node schema but ComfyUI-RMBG's process_image reads them by key, so omitting
+      // them KeyErrors at runtime over the API (defaults are only injected by the
+      // UI). Pass every one explicitly with the node's documented defaults.
+      inputs: {
+        image: conn("1", 0),
+        model,
+        mask_blur: 0,
+        mask_offset: 0,
+        invert_output: false,
+        refine_foreground: false,
+        background: "Alpha",
+        background_color: "#222222",
+      },
     },
     "3": {
       class_type: "SaveImage",

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -330,7 +330,8 @@ function buildLtxVideo(p: LtxVideoParams): WorkflowJSON {
     "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: ckpt } },
     "2": {
       class_type: "LTXAVTextEncoderLoader",
-      inputs: { text_encoder: textEncoder, ckpt_name: ckpt },
+      // `device` is a required widget (default = load on the compute device).
+      inputs: { text_encoder: textEncoder, ckpt_name: ckpt, device: "default" },
     },
     // distilled speed LoRA on the checkpoint model @0.5 (this is the model the
     // guider samples with — matches the pack's LoraLoaderModelOnly placement).
@@ -435,7 +436,8 @@ function buildLtxVideo(p: LtxVideoParams): WorkflowJSON {
   wf["26"] = { class_type: "CreateVideo", inputs: { images: conn("25", 0), fps } };
   wf["27"] = {
     class_type: "SaveVideo",
-    inputs: { video: conn("26", 0), filename_prefix: prefix },
+    // `format` and `codec` are required widgets ("auto" lets ComfyUI pick mp4/h264).
+    inputs: { video: conn("26", 0), filename_prefix: prefix, format: "auto", codec: "auto" },
   };
   return wf;
 }


### PR DESCRIPTION
## Live-render verification of the 0.21.0 parity generation tools (RTX 4090, ComfyUI 0.26.2)

Ran all five new tools against a real ComfyUI on hardware. Three passed as-is; two needed graph fixes that **only** surface against the installed node schemas (unit tests don't validate against live nodes).

### Fixes
1. **`generate_video`** — the composed LTX-2.3 graph 400'd at submit: three required widgets were missing for the installed `comfy_extras` versions —
   - `LTXAVTextEncoderLoader.device` (`"default"`)
   - `SaveVideo.format` / `SaveVideo.codec` (`"auto"`)

   Matches the render-verified `packs/ltx-2.3-img2vid/workflow.json`. Corrected graph renders (8 steps, 768×512×49 → `output/video/*.mp4`, ~51s).
2. **`remove_background`** — `BiRefNetRMBG` raised a runtime `'mask_blur'`: ComfyUI-RMBG declares `mask_blur`/`mask_offset`/`invert_output`/`refine_foreground`/`background_color` as *optional* but reads them by key, so over the API (no UI default injection) it KeyErrors. Now passes every optional widget explicitly with the node's documented defaults. Cutout renders (1280×1648 → RGBA transparent PNG, ~0.8s).

### Regression guards
Added unit assertions for exactly the widgets that failed on hardware, so they can't silently drop again.

### Verified on hardware
| Tool | Result |
|---|---|
| `generate_video` | ✅ renders (after fix) — `video/ltx-livetest_00001_.mp4` |
| `remove_background` | ✅ RGBA cutout (after fix) — color-type 6, 1280×1648 |
| `upscale_image` | ✅ 1280×1648 → 2560×3296 (exact 2×), no fix needed |
| `run_workflow_url` | ✅ blob→raw normalize + UI→API convert + validate |
| `rerun_generation` | ✅ history retrieve + re-enqueue + source-id tracking |

900 unit tests green (+ new guards). No `package.json` version bump — these ride on 0.21.0 (already merged via #89, unpublished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)