### PR TITLE
feat(cli): one-command `connect <comfyui-url>` to drive a remote ComfyUI locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ on demand by the panel's **Connect** button:
 npx -y comfyui-mcp --panel-orchestrator
 ```
 
+### Drive a REMOTE ComfyUI from your own machine (`connect`)
+
+When ComfyUI runs somewhere with **no Node/agent** (a RunPod pod, a cloud box) you
+can still run the agent on **your** machine and drive that remote ComfyUI — no
+agent login on the box, no tunnel:
+
+```bash
+npx -y comfyui-mcp connect https://abcd1234-8188.proxy.runpod.net
+```
+
+This is sugar for `--panel-orchestrator` with `COMFYUI_URL` set from the URL: the
+orchestrator runs locally on your Claude/ChatGPT login and reaches the remote
+ComfyUI over its public proxy URL. The agent bridge stays on
+`ws://127.0.0.1:9180`. Because the panel JS runs in **your local browser** (even
+when served by the remote ComfyUI), that bridge is already on your machine — so
+nothing needs to be installed remotely.
+
+To finish: open the remote ComfyUI in your browser, turn on **Settings → General →
+"Use external/local orchestrator (advanced)"** in the Agent panel, then click
+**Connect**. (In that mode the panel connects straight to the local bridge instead
+of asking the ComfyUI host to spawn an orchestrator it can't run.)
+
 **Multi-provider, full parity.** The orchestrator depends on a provider-neutral
 **`AgentBackend`** port (dependency injection), with two adapters:
 

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -75,6 +75,37 @@ describe("parseCliArgs", () => {
     });
   });
 
+  it("`connect <url>` implies panelOrchestrator and captures comfyuiUrl", () => {
+    const o = parseCliArgs([...base, "connect", "https://abcd-8188.proxy.runpod.net"], {});
+    expect(o.panelOrchestrator).toBe(true);
+    expect(o.comfyuiUrl).toBe("https://abcd-8188.proxy.runpod.net");
+    expect(o.transport).toBe("stdio");
+  });
+
+  it("`connect` with no URL is sugar for --panel-orchestrator (no comfyuiUrl)", () => {
+    const o = parseCliArgs([...base, "connect"], {});
+    expect(o.panelOrchestrator).toBe(true);
+    expect(o.comfyuiUrl).toBeUndefined();
+  });
+
+  it("`connect` followed by a flag does not swallow the flag as a URL", () => {
+    const o = parseCliArgs([...base, "connect", "--port", "9999"], {});
+    expect(o.panelOrchestrator).toBe(true);
+    expect(o.comfyuiUrl).toBeUndefined();
+    expect(o.port).toBe(9999);
+  });
+
+  it("`connect <url>` still parses trailing flags", () => {
+    const o = parseCliArgs([...base, "connect", "http://10.0.0.5:8188", "--port=9181"], {});
+    expect(o.comfyuiUrl).toBe("http://10.0.0.5:8188");
+    expect(o.port).toBe(9181);
+  });
+
+  it("no `connect` subcommand leaves comfyuiUrl undefined", () => {
+    expect(parseCliArgs(base, {}).comfyuiUrl).toBeUndefined();
+    expect(parseCliArgs([...base, "--panel-orchestrator"], {}).comfyuiUrl).toBeUndefined();
+  });
+
   it("explicit --stdio flag overrides MCP_TRANSPORT=http env", () => {
     expect(parseCliArgs([...base, "--stdio"], { MCP_TRANSPORT: "http" }).transport).toBe("stdio");
   });

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCliArgs } from "../../transport/cli.js";
+import { parseCliArgs, validateConnectUrl } from "../../transport/cli.js";
 
 const base = ["node", "comfyui-mcp"];
 
@@ -113,5 +113,29 @@ describe("parseCliArgs", () => {
   it("explicit flags override env values", () => {
     const o = parseCliArgs([...base, "--port", "7000"], { MCP_PORT: "5000" });
     expect(o.port).toBe(7000);
+  });
+});
+
+describe("validateConnectUrl", () => {
+  it("accepts a full http(s) URL (returns null)", () => {
+    expect(validateConnectUrl("https://abcd-8188.proxy.runpod.net")).toBeNull();
+    expect(validateConnectUrl("http://127.0.0.1:8188")).toBeNull();
+    expect(validateConnectUrl("https://comfy.example.com/comfyapi")).toBeNull();
+  });
+
+  it("rejects a non-URL token with a clear, actionable error", () => {
+    const err = validateConnectUrl("not-a-url");
+    expect(err).not.toBeNull();
+    expect(err).toContain("not-a-url");
+    expect(err).toMatch(/http\(s\) URL/);
+  });
+
+  it("rejects a non-http(s) protocol", () => {
+    expect(validateConnectUrl("ftp://example.com")).not.toBeNull();
+    expect(validateConnectUrl("ws://127.0.0.1:8188")).not.toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(validateConnectUrl("")).not.toBeNull();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { registerAllTools } from "./tools/index.js";
 import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
-import { parseCliArgs } from "./transport/cli.js";
+import { parseCliArgs, validateConnectUrl } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
@@ -207,6 +207,13 @@ async function main() {
     // still runs in the user's local browser, so its bridge (ws://127.0.0.1:9180)
     // already reaches this process — no tunnel needed.
     if (cli.comfyuiUrl) {
+      // Hard-fail on a bad `connect <url>` instead of silently falling back to the
+      // local ComfyUI (which would make the banner below lie about what it drives).
+      const urlError = validateConnectUrl(cli.comfyuiUrl);
+      if (urlError) {
+        process.stderr.write(`\nComfyUI MCP — cannot start: ${urlError}\n\n`);
+        process.exit(1);
+      }
       process.env.COMFYUI_URL = cli.comfyuiUrl;
       // Default panel bridge port is 9180 (claude); COMFYUI_MCP_BRIDGE_PORT overrides.
       const bridgePort = Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180;

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,39 @@ async function main() {
   // Standalone background orchestrator: owns the UI bridge and drives the panel
   // with autonomous Agent SDK sessions. Not an MCP server — it never returns.
   if (cli.panelOrchestrator) {
+    // `connect <comfyui-url>`: drive a (possibly REMOTE) ComfyUI from an agent on
+    // THIS machine. Export the URL as COMFYUI_URL so the orchestrator and the
+    // comfyui MCP it spawns target that server — the same remote-URL mechanism the
+    // panel's "Remote ComfyUI URL" setting uses, just from the CLI. The panel JS
+    // still runs in the user's local browser, so its bridge (ws://127.0.0.1:9180)
+    // already reaches this process — no tunnel needed.
+    if (cli.comfyuiUrl) {
+      process.env.COMFYUI_URL = cli.comfyuiUrl;
+      // Default panel bridge port is 9180 (claude); COMFYUI_MCP_BRIDGE_PORT overrides.
+      const bridgePort = Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180;
+      const bridge = `ws://127.0.0.1:${bridgePort}`;
+      process.stderr.write(
+        [
+          "",
+          "════════════════════════════════════════════════════════════════════",
+          " ComfyUI MCP — local agent bridge is starting",
+          "════════════════════════════════════════════════════════════════════",
+          ` Agent bridge : ${bridge}`,
+          ` Driving      : ${cli.comfyuiUrl}`,
+          "",
+          " Next steps:",
+          `   1. Open that ComfyUI in your browser: ${cli.comfyuiUrl}`,
+          "   2. In the Agent panel's Settings → General, turn ON",
+          "      'Use external/local orchestrator (advanced)'.",
+          "   3. Click Connect in the panel.",
+          "",
+          " The agent runs HERE on your Claude/Codex login — nothing is installed",
+          " on the ComfyUI box. Keep this terminal open.",
+          "════════════════════════════════════════════════════════════════════",
+          "",
+        ].join("\n"),
+      );
+    }
     const { runPanelOrchestrator } = await import("./orchestrator/index.js");
     await runPanelOrchestrator();
     return;

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -18,6 +18,12 @@ export interface CliOptions {
   /** --allow-unauthenticated-non-loopback / COMFYUI_MCP_ALLOW_UNAUTH=1: opt into
    *  an OPEN /mcp endpoint on a non-loopback host (otherwise a hard fail). */
   allowUnauthenticated: boolean;
+  /** ComfyUI target URL captured from the `connect <comfyui-url>` subcommand.
+   *  When set, startup exports it as COMFYUI_URL so the panel orchestrator drives
+   *  that (possibly REMOTE, e.g. RunPod) ComfyUI from the agent running on THIS
+   *  machine — no Node/agent needed on the ComfyUI box. Undefined when `connect`
+   *  wasn't used (or used without a URL). `connect` also implies panelOrchestrator. */
+  comfyuiUrl?: string;
 }
 
 const DEFAULT_HOST = "127.0.0.1";
@@ -46,6 +52,7 @@ export function parseCliArgs(
   let tunnel = env.MCP_TUNNEL === "1" || env.MCP_TUNNEL === "true";
   let allowUnauthenticated =
     env.COMFYUI_MCP_ALLOW_UNAUTH === "1" || env.COMFYUI_MCP_ALLOW_UNAUTH === "true";
+  let comfyuiUrl: string | undefined;
 
   const valueOf = (current: string, inline: string, i: number): [string, number] => {
     if (current.includes("=")) return [current.slice(current.indexOf("=") + 1), i];
@@ -54,7 +61,19 @@ export function parseCliArgs(
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === "--http") {
+    if (a === "connect") {
+      // `comfyui-mcp connect <comfyui-url>` — one-command local connect: run the
+      // panel orchestrator (subscription auth, no API key) and point it at the
+      // given ComfyUI via COMFYUI_URL. The URL is the next positional token (a
+      // following "--flag" is left to be parsed normally). With no URL it's just
+      // sugar for --panel-orchestrator (local default / inherited COMFYUI_URL).
+      panelOrchestrator = true;
+      const next = args[i + 1];
+      if (next && !next.startsWith("-")) {
+        comfyuiUrl = next;
+        i += 1; // consume the URL token
+      }
+    } else if (a === "--http") {
       transport = "http";
     } else if (a === "--stdio") {
       transport = "stdio";
@@ -88,5 +107,5 @@ export function parseCliArgs(
   // here, to keep this parser pure/side-effect-free.)
   if (tunnel) transport = "http";
 
-  return { transport, host, port, panelOrchestrator, token, tunnel, allowUnauthenticated };
+  return { transport, host, port, panelOrchestrator, token, tunnel, allowUnauthenticated, comfyuiUrl };
 }

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -1,3 +1,5 @@
+import { parseComfyUIUrl } from "./comfyui-url.js";
+
 export type TransportMode = "stdio" | "http";
 
 export interface CliOptions {
@@ -108,4 +110,28 @@ export function parseCliArgs(
   if (tunnel) transport = "http";
 
   return { transport, host, port, panelOrchestrator, token, tunnel, allowUnauthenticated, comfyuiUrl };
+}
+
+/**
+ * Validate the `connect <comfyui-url>` positional before the orchestrator starts.
+ * The URL is exported as COMFYUI_URL and used to drive a (possibly remote)
+ * ComfyUI, so a bad value (e.g. `connect not-a-url`) must hard-fail instead of
+ * silently falling back to the local default — which would leave the startup
+ * banner claiming it's "Driving <bad url>" while actually targeting localhost.
+ *
+ * Reuses parseComfyUIUrl (the same parser COMFYUI_URL / --comfyui-url use) so the
+ * accept/reject rules stay identical. Returns a clear, actionable error message
+ * when the URL is invalid, or null when it parses cleanly.
+ */
+export function validateConnectUrl(url: string): string | null {
+  try {
+    parseComfyUIUrl(url);
+    return null;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return (
+      `Invalid ComfyUI URL passed to \`connect\`: "${url}" (${reason}). ` +
+      `Pass a full http(s) URL, e.g. https://abcd-8188.proxy.runpod.net or http://127.0.0.1:8188.`
+    );
+  }
 }


### PR DESCRIPTION
## What

Adds a `connect <comfyui-url>` CLI subcommand:

```bash
npx -y comfyui-mcp connect https://abcd1234-8188.proxy.runpod.net
```

It is sugar for `--panel-orchestrator` with `COMFYUI_URL` exported from the positional argument, plus a friendly startup banner. The orchestrator runs locally on the user's on-disk Claude/Codex login and reaches the (possibly remote) ComfyUI over `COMFYUI_URL` — the same remote-URL mechanism as **PR #42 (remote URL)**.

## The external-orchestrator flow (why this exists)

When ComfyUI runs somewhere with **no Node/agent** (a RunPod pod, a cloud box), the user can still drive it with an agent on **their own machine** — no agent login on the box, no tunnel:

1. The panel JS runs in the user's **local browser** even when served by the remote ComfyUI, so the panel↔orchestrator bridge (`ws://127.0.0.1:9180`) is already on the user's machine.
2. `comfyui-mcp connect <remote-url>` starts the orchestrator locally with `COMFYUI_URL=<remote pod>`; it reaches the remote ComfyUI over its public proxy URL.
3. In the panel, the user turns on **"Use external/local orchestrator (advanced)"** and clicks Connect — the panel then dials the local bridge directly instead of asking the remote ComfyUI host to spawn anything (which it can't).

This PR is the **comfyui-mcp half**; it pairs with the panel PR (`comfyui-mcp-panel`) that adds the toggle.

## Changes

- `src/transport/cli.ts` — parse `connect [url]` → `panelOrchestrator=true` + `comfyuiUrl` (a trailing `--flag` is not swallowed as a URL).
- `src/index.ts` — when `comfyuiUrl` is set, export it as `COMFYUI_URL` and print a startup banner naming the local bridge + remote target + the panel steps.
- `src/__tests__/transport/cli.test.ts` — 5 new cases for the subcommand parsing.
- `README.md` — a "Drive a REMOTE ComfyUI from your own machine" note.

## Tests / build

- `npm run build` (tsc) clean.
- `npm test` — full suite green (**915 passed**), including the 5 new CLI cases.

## Notes

- Built **unattended** by an agent. The **UX / wording** of the startup banner and the README note **need owner review**.
- Pairs with **PR #42 (remote URL)** and the panel's external-orchestrator toggle.
- Codex review was requested but Codex CLI is not installed in this environment (needs an interactive `codex login`), so a manual self-review was done instead (it caught + fixed a wrong env var name in the banner: `COMFYUI_MCP_BRIDGE_PORT`, not `..._BRIDGE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)