### PR TITLE
feat(skills): comfyui-launch-flags — VRAM/attention/cache/perf launch-flag matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI installation and port.
 
-**108 MCP tools** | **31 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
+**108 MCP tools** | **32 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -115,7 +115,7 @@ This package also ships as a **Claude Code plugin**, providing slash commands, s
 
 ### Built-in skills
 
-31 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, the **launch/performance-flags** matrix, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
+32 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, the **launch/performance-flags** matrix, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
 
 > **Installer packs.** [`packs/`](packs/) bundles 13 one-command ComfyUI setups — ANIMA, Ideogram 4, LTX-2.3, ERNIE, WAN (animate / longer-videos / transparent), Qwen (image / image-edit), Z-Image (turbo / base / xy-plot) and artokun-flow (WAN Animate — replace / animate). Each is a manifest of custom nodes + model URLs + workflow that drives both `apply_manifest` and generated `install-windows.bat` / `install-runpod.sh`, with CI that validates every model link + payload size. See [`packs/README.md`](packs/README.md).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI installation and port.
 
-**108 MCP tools** | **29 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
+**108 MCP tools** | **31 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -115,7 +115,7 @@ This package also ships as a **Claude Code plugin**, providing slash commands, s
 
 ### Built-in skills
 
-29 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
+31 skills total — model-family guides (Flux, WAN, LTX 2.3, Qwen, Z-Image, Ideogram 4, ERNIE, ANIMA + anime / WAN / Z-Image LoRA training), the **model-registry** (curated download URLs), the **civitai** pairing skill, node authoring, the **launch/performance-flags** matrix, and the core four below. Full list on the [plugin docs page](https://comfyui-mcp.artokun.io/docs/plugin).
 
 > **Installer packs.** [`packs/`](packs/) bundles 13 one-command ComfyUI setups — ANIMA, Ideogram 4, LTX-2.3, ERNIE, WAN (animate / longer-videos / transparent), Qwen (image / image-edit), Z-Image (turbo / base / xy-plot) and artokun-flow (WAN Animate — replace / animate). Each is a manifest of custom nodes + model URLs + workflow that drives both `apply_manifest` and generated `install-windows.bat` / `install-runpod.sh`, with CI that validates every model link + payload size. See [`packs/README.md`](packs/README.md).
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 29 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 108 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 31 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 108 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 29 AI skills — and growing
+## 31 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,
@@ -43,6 +43,7 @@ and failure-mode guidance:
 | `director` | Multi-shot scene direction for video pipelines |
 | `prompt-engineering` | Architecture-specific prompting (natural language vs tags) |
 | `troubleshooting` | OOM, missing nodes, version drift — diagnosis trees |
+| `comfyui-launch-flags` | The VRAM/attention/cache/perf launch-flag matrix — `--reserve-vram`, `--novram`+`--cache-none`, `--use-sage-attention` vs `--use-pytorch-cross-attention` (Z-Image), plus Blackwell/RTX 5000 accel-stack notes |
 
 New skills land with each release — generated from popular registry packs via
 the built-in `generate_node_skill` tool, then human-curated.

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 31 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 108 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 32 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 108 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 31 AI skills — and growing
+## 32 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,

--- a/plugin/skills/comfyui-launch-flags/SKILL.md
+++ b/plugin/skills/comfyui-launch-flags/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: comfyui-launch-flags
+description: Pick the right ComfyUI startup flags for VRAM, attention, caching, and speed — the full decision matrix for OOM (--novram / --cache-none / --disable-smart-memory), shared-VRAM creep on Windows (--reserve-vram N), model-switching with big text encoders (--cache-none), high-VRAM throughput (--gpu-only / --highvram), and attention-backend selection (--use-sage-attention for speed, --use-pytorch-cross-attention as the highest-quality / Z-Image-safe fallback). Also the acceleration-stack + Blackwell/RTX 5000 (sm_120) notes. Use when a graph OOMs (especially long video like LTX 2 / WAN), when the GPU spills into shared VRAM and slows to a crawl, when switching between models eats all RAM, when Z-Image produces black/garbled output under Sage, or when deciding which attention backend to launch with. Flag names verified against upstream comfy/cli_args.py — see Sources.
+globs:
+  - "**/*.json"
+  - "**/packs/**"
+---
+
+# ComfyUI launch/performance flags
+
+## Overview
+
+ComfyUI's runtime behavior is controlled by CLI flags passed to `main.py`
+(e.g. `python main.py --reserve-vram 2 --use-sage-attention`). The three that
+matter most for making a graph *run* — rather than OOM or crawl — are the
+**VRAM strategy**, the **attention backend**, and the **cache mode**. This skill
+is the decision matrix for choosing them.
+
+> ⚠️ **Verification note (June 2026).** Every flag below was checked against
+> upstream [`comfy/cli_args.py`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/cli_args.py).
+> ComfyUI adds/renames flags often — when in doubt run `python main.py --help`
+> in the target install and prefer that over this list. One common non-upstream
+> flag: **`--enable-triton-backend` is a SwarmUI backend flag, NOT a ComfyUI
+> `main.py` flag** — don't pass it to ComfyUI directly.
+
+> ℹ️ **How to apply today.** The MCP's `start_comfyui` currently *replays the
+> exact argv of the previous run* — it does not compose fresh flags. So set
+> these when you launch ComfyUI yourself (the `python main.py …` line, a
+> `run.bat`/shell alias, or the SwarmUI backend args box), then `start_comfyui`
+> will preserve them on restart. (Injecting flags through the tool is a tracked
+> follow-up.)
+
+---
+
+## Decide first: which flag do you need?
+
+```
+Symptom                                             ▶ Flag(s) to try
+─────────────────────────────────────────────────────────────────────────────
+CUDA out of memory, long video (LTX 2 / WAN)        ▶ --novram  (+ --cache-none)
+OOM, still want models resident when they fit       ▶ --reserve-vram N  then --disable-smart-memory
+GPU slows to a crawl, spills into "shared GPU        ▶ --reserve-vram 2..4
+  memory" (Windows WDDM) mid-run
+RAM blows up switching between models, or a huge     ▶ --cache-none
+  text encoder (FLUX 2 / Mistral) won't unload
+Plenty of VRAM (48GB+), want max throughput         ▶ --gpu-only  or  --highvram
+Want faster sampling on NVIDIA                       ▶ --use-sage-attention   (see caveats)
+Z-Image produces BLACK / wrong output               ▶ --use-pytorch-cross-attention (NOT sage)
+Sage gives black output on some models              ▶ --use-pytorch-cross-attention (or fix dtype)
+```
+
+VRAM strategy and attention backend are each **mutually exclusive groups** —
+pass at most one from each. You can combine one VRAM flag + one attention flag +
+one cache flag (e.g. `--novram --use-sage-attention --cache-none`).
+
+---
+
+## VRAM strategy (mutually exclusive)
+
+| Flag | What it does | Use when |
+|------|--------------|----------|
+| `--gpu-only` | Keep everything (incl. text encoders) on GPU | 48GB+ card, single model, max speed |
+| `--highvram` | Keep models resident in VRAM after use | High-VRAM card, repeated runs of one model |
+| *(default)* | ComfyUI's smart offload | Most setups — try this first |
+| `--lowvram` | Offload text encoders / parts to CPU | Mid card OOMing on load |
+| `--novram` | Extreme offload — minimal VRAM footprint | OOM on long video / huge models; pair with `--cache-none` |
+| `--cpu` | Everything on CPU (very slow) | No usable CUDA GPU only |
+
+Modifiers (combine with the above):
+
+- **`--reserve-vram N`** — reserve N GB for the OS / other apps. The fix for the
+  Windows failure mode where the GPU quietly starts using **shared** VRAM and
+  throughput collapses. Typical `2`–`4`; bump to `10` for heavy video decode.
+- **`--disable-smart-memory`** — force aggressive offload to regular RAM instead
+  of keeping models cached in VRAM. Reach for this when a run gets *stuck* or
+  OOMs intermittently. Slightly slower, much more robust.
+- **`--async-offload`** — async weight offload streams (default on where
+  supported); `--disable-async-offload` to turn off if it misbehaves.
+
+---
+
+## Attention backend (mutually exclusive)
+
+| Flag | Notes |
+|------|-------|
+| `--use-sage-attention` | Quantized SageAttention kernel, ~20–40% faster sampling. Needs the `sageattention` package installed and version-matched — see [`triton-sageattention`](../triton-sageattention/SKILL.md). |
+| `--use-flash-attention` | FlashAttention kernels. Needs `flash-attn` built for your torch/CUDA. |
+| `--use-pytorch-cross-attention` | PyTorch SDPA. **Highest quality, always available, no extra deps.** The safe default and the correct fallback. |
+| `--use-split-cross-attention` / `--use-quad-cross-attention` | Memory-optimized math attention for older/low-VRAM cards. |
+
+**Two gotchas worth memorizing:**
+
+1. **Z-Image + Sage = broken.** Z-Image (Turbo/Base) does **not** sample
+   correctly under `--use-sage-attention` — you get black or garbled output.
+   Launch Z-Image with **`--use-pytorch-cross-attention`** instead. See
+   [`z-image-txt2img`](../z-image-txt2img/SKILL.md).
+2. **Sage black output on other models.** If a model outputs black *only* with
+   Sage, either switch to `--use-pytorch-cross-attention`, or (SwarmUI) set
+   Advanced Sampling → Preferred DType = Default (16-bit). Sage-on vs Sage-off
+   also produces *slightly different* images — expect non-identical seeds.
+
+> When a graph hard-crashes with `No module named 'sageattention'` /
+> `triton: unavailable`, the fix is the sdpa / no-compile fallback in
+> [`triton-sageattention`](../triton-sageattention/SKILL.md), not this flag.
+
+---
+
+## Cache mode (mutually exclusive)
+
+| Flag | Effect |
+|------|--------|
+| *(default `--cache-ram`)* | Cache results under RAM pressure |
+| `--cache-classic` | Aggressive result caching |
+| `--cache-lru N` | Keep at most N node results (LRU) |
+| `--cache-none` | Cache nothing — re-executes every node; **lowest RAM/VRAM**. Essential when switching between dual models or when a giant text encoder (FLUX 2's Mistral) must fully unload. |
+
+---
+
+## Speed / precision
+
+- **`--fast`** — enables experimental, potentially quality-degrading
+  optimizations. Accepts specific `PerformanceFeature` values:
+  `fp16_accumulation`, `fp8_matrix_mult`, `cublas_ops`, `autotune`. Bare `--fast`
+  turns them all on. Test output quality before committing to it.
+- **UNet/VAE/text-encoder dtype casts** exist too
+  (`--fp8_e4m3fn-unet`, `--fp16-unet`, `--bf16-unet`, `--fp32-unet`, …) for
+  forcing a compute precision; usually the model/loader picks the right one, so
+  only reach for these to work around a specific dtype error.
+
+---
+
+## Recommended combos (recipes)
+
+```
+Long video OOM (LTX 2 / WAN, 24GB):   --novram --cache-none
+                                      (add --disable-smart-memory if it stalls)
+Windows shared-VRAM creep:            --reserve-vram 3
+FLUX 2 / huge text-encoder swaps:     --cache-none
+High-VRAM throughput (48GB+):         --gpu-only        (or --highvram)
+Fast NVIDIA sampling (most models):   --use-sage-attention
+Z-Image (any):                        --use-pytorch-cross-attention
+```
+
+Cross-refs: video OOM specifics in
+[`ltxv2-video`](../ltxv2-video/SKILL.md) / [`wan-t2v-video`](../wan-t2v-video/SKILL.md);
+per-model VRAM math in [`troubleshooting`](../troubleshooting/SKILL.md) and
+[`model-compatibility`](../model-compatibility/SKILL.md).
+
+---
+
+## Acceleration stack & GPU coverage (context)
+
+The attention/compile accelerators are **version-locked to your exact
+torch + CUDA + Python**. A mismatched wheel doesn't just fail to import — it can
+break the torch install. A known-good, mutually-compatible stack for late-2025 /
+2026 NVIDIA (including **Blackwell / RTX 5000, `sm_120`**) looks like:
+
+| Component | Role | Notes |
+|-----------|------|-------|
+| Torch + CUDA | base | e.g. Torch 2.9.x on CUDA 12.8/13; use the wheel index matching your driver |
+| Triton | `torch.compile` / inductor | Windows: `triton-windows` (woct0rdho) |
+| SageAttention | `--use-sage-attention` | wheel matched to torch/CUDA/python |
+| FlashAttention | `--use-flash-attention` | built per torch/CUDA/python |
+| xFormers | memory-efficient attention | optional |
+| InsightFace | FaceID / IP-Adapter / ReActor | `onnxruntime-gpu` alongside |
+
+Operational facts worth carrying:
+
+- **No system-wide CUDA toolkit is required** to *run* ComfyUI — an up-to-date
+  NVIDIA driver + prebuilt wheels are enough. A full CUDA/MSVC/cuDNN toolchain is
+  only needed to *compile* kernels yourself.
+- **Broad arch coverage** when building wheels:
+  `TORCH_CUDA_ARCH_LIST=7.5;8.0;8.6;8.9;9.0;10.0;12.0+PTX` spans RTX 20xx→50xx
+  and datacenter (A100/H100/B200). `+PTX` lets newer archs JIT.
+- **DeepSpeed has no wheels for Python 3.13**; several accel wheels lag the
+  newest Python — 3.10–3.12 is the safe range for the full stack.
+- **Clear the Triton cache** (`~/.triton` / `%USERPROFILE%\.triton` and temp)
+  when you hit stale-kernel Triton errors after an upgrade.
+- Prefer **`uv pip install`** over pip for the venv — dramatically faster
+  resolves/downloads. `install_comfyui` already supports this via `preferUv`.
+- **A single bad custom node can crash all of ComfyUI at startup.** Install/test
+  acceleration and new node packs on a fresh/known-good install, not before a
+  deadline. See [`troubleshooting`](../troubleshooting/SKILL.md).
+
+## Quantization quick take
+
+- **FP8-*scaled*** (per-tensor scaled) is markedly higher quality than plain
+  base FP8, ~half the size of BF16, and usually faster.
+- **Prefer FP8-scaled over GGUF when you have enough system RAM** — ComfyUI's
+  block-swap streams from RAM, so BF16/FP8 can run on 24GB GPUs given ample RAM.
+  Fall back to GGUF (Q8→Q4) only when RAM is the constraint.
+- **NVFP4 / NVFP8** are markedly faster on Blackwell (RTX 5000) at near-BF16
+  quality for supported models; LoRA support on NVFP4 is still partial.
+
+---
+
+## Sources
+
+- ComfyUI CLI args (authoritative): <https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/cli_args.py>
+- ComfyUI startup flags docs: <https://docs.comfy.org/development/comfyui-server/startup-flags>
+- Operational flag/stack guidance distilled from community ComfyUI auto-installer
+  changelogs (SECourses) — flags cross-checked against upstream above; no
+  third-party scripts, presets, or model files are reproduced here.

--- a/plugin/skills/triton-sageattention/SKILL.md
+++ b/plugin/skills/triton-sageattention/SKILL.md
@@ -8,6 +8,11 @@ globs:
 
 # Triton + SageAttention (ComfyUI acceleration)
 
+> See also [`comfyui-launch-flags`](../comfyui-launch-flags/SKILL.md) for the full
+> attention / VRAM / cache flag matrix. Note the **Z-Image exception**: Z-Image is
+> broken under `--use-sage-attention` → launch it with
+> `--use-pytorch-cross-attention` instead.
+
 ## Overview
 
 Two **optional accelerators** that many modern video graphs (especially kijai's

--- a/plugin/skills/troubleshooting/SKILL.md
+++ b/plugin/skills/troubleshooting/SKILL.md
@@ -52,7 +52,13 @@ The GPU does not have enough VRAM to hold the model weights, intermediate tensor
 1. **Reduce resolution**: Drop to the model's native resolution (512 for SD 1.5, 1024 for SDXL/Flux)
 2. **Use FP8/FP16 quantized models**: FP8 Flux models use ~8GB vs ~24GB for FP16
    - Search for FP8 variants: `search_models("flux fp8")` or `search_models("sdxl fp8")`
-3. **Use `--lowvram` flag**: ComfyUI CLI flag that offloads model parts to CPU during inference
+3. **Launch flags (the VRAM ladder)**: offload aggressively via ComfyUI CLI flags —
+   - `--lowvram` — offload text encoders / model parts to CPU
+   - `--novram` — extreme offload; the go-to for long video (LTX 2 / WAN) OOM
+   - `--cache-none` — cache nothing (lowest RAM/VRAM); combine with `--novram`
+   - `--reserve-vram N` — reserve N GB so the GPU stops spilling into slow *shared* VRAM (Windows); typical `2`–`4`
+   - `--disable-smart-memory` — force offload to RAM when a run gets stuck / intermittently OOMs
+   - Full matrix + recipes: [`comfyui-launch-flags`](../comfyui-launch-flags/SKILL.md)
 4. **Free VRAM between generations**: ComfyUI should auto-manage, but restarting clears leaked memory
 5. **Use tiled VAE decoding**: For high-resolution images, tile the VAE decode step
    - Node: `VAEDecodeTiled` instead of `VAEDecode`
@@ -416,7 +422,7 @@ list_local_models(model_type="controlnet")        # Installed ControlNets
 
 | Error Message (partial) | Most Likely Fix |
 |--------------------------|----------------|
-| `CUDA out of memory` | Reduce resolution, use FP8 model, `--lowvram` |
+| `CUDA out of memory` | Reduce resolution, use FP8 model; VRAM ladder `--lowvram` → `--novram --cache-none` → `--reserve-vram N` ([launch flags](../comfyui-launch-flags/SKILL.md)) |
 | `Expected all tensors on same device` | Update custom node, restart ComfyUI |
 | `Cannot find node class` | Install the node pack, restart ComfyUI |
 | `Input contains NaN` | Lower CFG, use FP32 VAE, remove LoRAs |

--- a/plugin/skills/z-image-txt2img/SKILL.md
+++ b/plugin/skills/z-image-txt2img/SKILL.md
@@ -7,6 +7,11 @@ globs:
 
 # Z-Image Text-to-Image Workflows
 
+> ⚠️ **Launch flag:** Z-Image does **not** sample correctly under
+> `--use-sage-attention` (black / garbled output). Launch ComfyUI with
+> **`--use-pytorch-cross-attention`** for Z-Image. See
+> [`comfyui-launch-flags`](../comfyui-launch-flags/SKILL.md).
+
 ## Overview
 
 Z-Image is a 6B-parameter image generation model from Alibaba's Tongyi Lab using a Scalable Single-Stream DiT (S3-DiT) architecture. It uses a Qwen text encoder (not CLIP-L/T5). Its VAE shares the Flux VAE *architecture* (same tensor shapes, so the file is the same 320MB size) but ships **different weights** — it is NOT byte-identical to Flux's `ae.safetensors` and must be kept as a separate file (`z-image-ae.safetensors`) to avoid clobbering the Flux VAE. Two variants:


### PR DESCRIPTION
## Why

Distills the **transferable, upstream-verifiable** learnings from two SECourses (Furkan Gözükara) Patreon posts — the ComfyUI auto-installer and the SwarmUI model-downloader — into the repo's skills, which is comfyui-mcp's differentiator. The single biggest gap those posts exposed: operators need to know **which launch flags to pass** for OOM / shared-VRAM / model-switching / long-video / attention selection, and that knowledge was scattered across a few blog docs and partially in `triton-sageattention` / `troubleshooting`.

**Licensing/ethics:** none of SECourses' paid `.bat`/`.sh`/zip scripts, preset JSONs, or self-quantized model files are reproduced. Every flag is cross-checked against upstream [`comfy/cli_args.py`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/cli_args.py).

## What's in it (markdown-only — no TS, no build impact)

- **New skill `comfyui-launch-flags`** — the decision matrix for VRAM strategy (`--gpu-only`/`--highvram`/`--lowvram`/`--novram` + `--reserve-vram N` + `--disable-smart-memory`), attention backend (`--use-sage-attention` vs `--use-pytorch-cross-attention` vs flash/split/quad), cache mode (`--cache-none`/`--cache-lru`), `--fast`/PerformanceFeature, plus copy-paste recipes and the acceleration-stack + Blackwell/RTX 5000 (`sm_120`) / no-system-CUDA / DeepSpeed-no-py3.13 / Triton-cache context.
- **Cross-links:** `triton-sageattention` (Z-Image sage exception), `z-image-txt2img` (`--use-pytorch-cross-attention`), `troubleshooting` (OOM → full VRAM ladder + quick-ref row).
- Skill count **30 → 31** in README + `docs/plugin.mdx` (base main had already drifted to 30 via a new `debug-render` skill; corrected here).

## Two accuracy notes
- **`--enable-triton-backend`** (used in SECourses' bat files) is a **SwarmUI** backend flag, **not** upstream ComfyUI `main.py` — called out in-skill so agents don't pass it to ComfyUI.
- The MCP's `start_comfyui` currently only *replays the prior run's argv*, so it can't inject these flags yet — the skill says so and points to the fast-follow.

## Fast-follows (filed as beads, not in this PR)
- **(B)** optional launch-flag params on `start_comfyui` (`vramMode`/`attention`/`reserveVramGb`/raw args) so the agent can *act* on this knowledge.
- **(C)** SHA256-verified, resumable multi-connection model downloads (from post 2's downloader).

Draft for your review of the skill copy before it goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)