### PR TITLE
perf(runpod): seed the volume from ONE archive + completion marker (no re-copy)

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -130,11 +130,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #    cron   — replicate the aitrepreneur service set
 #    nodejs — runtime for the copied /app-manager Node app (:8000)
 #    zstd   — pack/extract the seed as ONE archive (first-boot seed to the volume)
+#    pv     — clean, low-frequency extract progress (percent per interval, no spam)
 #    rsync  — general file ops (no longer the seed path; kept for manual/debug use)
 #    git/curl/ca-certificates — clone/pull + code-server install
 # -----------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git cron rsync zstd ca-certificates curl nodejs \
+      git cron rsync zstd pv ca-certificates curl nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------

--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -99,9 +99,13 @@ ARG PANEL_REF=
 # regardless of what the base ships (no cu121 leftovers). See README for the
 # leaner "reuse the base's cu128 torch" alternative.
 ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
-# SEED path (IMAGE): the pristine ComfyUI tree baked into the image. Copied to
-# the volume on first boot; never run from directly.
+# SEED path (IMAGE): the pristine ComfyUI tree baked into the image. Packed into
+# a single archive (below) and extracted to the volume on first boot.
 ARG SEED_HOME=/opt/ComfyUI-seed
+# SEED archive (IMAGE): the built seed, tar+zstd into ONE file. First boot extracts
+# this single stream — far faster than rsyncing tens of thousands of small files
+# over a network volume. The raw ${SEED_HOME} tree is removed after packing.
+ARG SEED_ARCHIVE=/opt/ComfyUI-seed.tar.zst
 # RUNTIME path (VOLUME): where ComfyUI actually lives + runs after first boot.
 ARG COMFY_HOME=/workspace/ComfyUI
 # Baked spotcheck-model dir (NOT under the ComfyUI seed — copied to
@@ -115,6 +119,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONUNBUFFERED=1 \
     SEED_HOME=${SEED_HOME} \
+    SEED_ARCHIVE=${SEED_ARCHIVE} \
     COMFY_HOME=${COMFY_HOME} \
     SEED_MODELS=${SEED_MODELS} \
     COMFY_NETWORK_MODE=${COMFY_NETWORK_MODE} \
@@ -124,11 +129,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # 0. OS deps the lean base may not ship.
 #    cron   — replicate the aitrepreneur service set
 #    nodejs — runtime for the copied /app-manager Node app (:8000)
-#    rsync  — first-boot seed copy + idempotent resume of an interrupted copy
+#    zstd   — pack/extract the seed as ONE archive (first-boot seed to the volume)
+#    rsync  — general file ops (no longer the seed path; kept for manual/debug use)
 #    git/curl/ca-certificates — clone/pull + code-server install
 # -----------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git cron rsync ca-certificates curl nodejs \
+      git cron rsync zstd ca-certificates curl nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 # -----------------------------------------------------------------------------
@@ -198,6 +204,18 @@ RUN git clone --depth 1 ${PANEL_REF:+--branch "${PANEL_REF}"} \
 #    ${COMFY_HOME}/custom_nodes on the volume (ComfyUI's default), so they persist.
 # -----------------------------------------------------------------------------
 COPY extra_model_paths.yaml ${SEED_HOME}/extra_model_paths.yaml
+
+# -----------------------------------------------------------------------------
+# 5b. PACK the finished seed into ONE compressed archive, then drop the raw tree.
+#     First boot extracts this single stream to the volume — dramatically faster
+#     than rsyncing tens of thousands of small files over the network volume's
+#     poor per-file IOPS. `--use-compress-program` (not a shell pipe) keeps tar's
+#     exit status authoritative; `zstd -T0` packs multi-threaded and decompresses
+#     near-free at boot. The raw ${SEED_HOME} is removed so the image ships only
+#     the archive (no size doubling). Level is tunable (higher = smaller/slower build).
+# -----------------------------------------------------------------------------
+RUN tar -C "${SEED_HOME}" --use-compress-program='zstd -T0 -6' -cf "${SEED_ARCHIVE}" . \
+ && rm -rf "${SEED_HOME}"
 
 # -----------------------------------------------------------------------------
 # 6. Manager config TEMPLATE (remote-install gate). Kept at a STABLE image path

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -7,9 +7,10 @@ live ComfyUI graph from your Claude/ChatGPT subscription.
 
 Everything durable lives **on the network volume** and is **run from there**.
 The image ships a pristine **seed** of the whole ComfyUI tree — ComfyUI + its
-venv + `comfyui_manager` v2 + the Agent Panel custom node — at
-`/opt/ComfyUI-seed`. On the **first** boot the entrypoint copies that seed to
-`/workspace/ComfyUI` (a slow, one-time, multi-GB `rsync` to the network drive).
+venv + `comfyui_manager` v2 + the Agent Panel custom node — baked as a single
+archive at `/opt/ComfyUI-seed.tar.zst`. On the **first** boot the entrypoint
+extracts that seed to `/workspace/ComfyUI` (a one-time, multi-GB archive extract
+to the network drive, gated by a completion marker so restarts never re-copy).
 On **every boot after** there is **no copy**: it `git pull`s ComfyUI + the panel,
 re-`pip install`s only when a requirements file actually changed, and launches
 ComfyUI **from the volume venv** (warm restart ~**20-40s**).
@@ -63,12 +64,17 @@ there.
 | `input/` | **volume** `/workspace/input` | **Yes** |
 | `output/` | **volume** `/workspace/output` | **Yes** |
 | Caches (HF / pip / torch) | **container** ephemeral disk | No — ephemeral |
-| pristine **seed** of the ComfyUI tree | **image** `/opt/ComfyUI-seed` | n/a (re-pulled with the image; only used to seed an empty volume) |
+| pristine **seed** of the ComfyUI tree | **image** `/opt/ComfyUI-seed.tar.zst` | n/a (re-pulled with the image; only used to seed an empty volume) |
 
-* **FIRST boot (empty volume):** the entrypoint `rsync`s the seed
-  `/opt/ComfyUI-seed` → `/workspace/ComfyUI` (the app + venv + custom_nodes).
-  Slow, one-time, multi-GB to the network drive. `rsync` resumes a partial copy
-  idempotently, so an interrupted first boot just continues where it left off.
+* **FIRST boot (empty volume):** the entrypoint extracts the seed archive
+  `/opt/ComfyUI-seed.tar.zst` → `/workspace/ComfyUI` (the app + venv +
+  custom_nodes) — **one** compressed stream, not tens of thousands of small files,
+  so it's far faster over the network volume's poor per-file IOPS. Completion is
+  keyed off a marker `/workspace/ComfyUI/.seed-complete` written only after a
+  fully-successful extract: a restart with the marker present **never re-copies**
+  (your later model/node installs are safe), while an interrupted/killed copy
+  leaves no marker and safely re-extracts (tar overwrites the partial tree) next
+  boot.
 * **EVERY boot after:** **no copy.** `git pull --ff-only` on `/workspace/ComfyUI`
   (ComfyUI) and on `/workspace/ComfyUI/custom_nodes/comfyui-mcp-panel` (the
   panel), re-`pip install` **only** when a requirements file's sha256 changed
@@ -81,8 +87,9 @@ Custom nodes the agent/Manager install at runtime **DO persist**, together with
 their pip dependencies in the venv, and ComfyUI/Manager/panel **auto-update in
 place**. The price you pay for that:
 
-* **Slower first boot.** The one-time seed copy is a multi-GB `rsync` to the
-  network drive.
+* **Slower first boot.** The one-time seed is a multi-GB archive extract to the
+  network drive (one `tar -I zstd -x` stream — much faster than the old per-file
+  `rsync`, but still a large write to a network volume).
 * **Slower warm restart (~20-40s)** vs. the old ~7s baked boot. ComfyUI now runs
   off the network drive, and each boot does a fast (usually no-op) `git pull` +
   sha-checked pip step before launch.
@@ -108,7 +115,7 @@ ARG RUNPOD_SRC_IMAGE = aitrepreneur/comfyui:2.3.5                  (donor only)
 │  spotcheck-1 = ADD sd_xl_base_1.0.safetensors ; spotcheck-0 = empty  │
 └─────────────────────────────────────────────────────────────────────┘
 ┌─ FINAL: FROM ${BASE_IMAGE} ─────────────────────────────────────────┐
-│  apt: git cron rsync nodejs … ; install code-server                 │
+│  apt: git cron rsync zstd nodejs … ; install code-server            │
 │  git clone ComfyUI (master) -> /opt/ComfyUI-seed   (SEED, not run)  │
 │  python -m venv --copies /opt/ComfyUI-seed/venv                     │
 │    pip cu128 torch/vision/audio  (NO xformers)                      │
@@ -116,6 +123,7 @@ ARG RUNPOD_SRC_IMAGE = aitrepreneur/comfyui:2.3.5                  (donor only)
 │    rm classic custom_nodes/ComfyUI-Manager                          │
 │  git clone comfyui-mcp-panel -> /opt/ComfyUI-seed/custom_nodes/…    │
 │  COPY extra_model_paths.yaml -> /opt/ComfyUI-seed/…                  │
+│  tar+zstd /opt/ComfyUI-seed -> /opt/ComfyUI-seed.tar.zst ; rm tree  │
 │  COPY config.ini -> /opt/config.ini.seed   (Manager gate template)  │
 │  COPY --from=spotcheck-src  -> /opt/ComfyUI-seed-models             │
 │  COPY --from=runpod-src  runpod-uploader, croc, /app-manager        │
@@ -124,8 +132,8 @@ ARG RUNPOD_SRC_IMAGE = aitrepreneur/comfyui:2.3.5                  (donor only)
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-The seed at `/opt/ComfyUI-seed` is **never run from directly** — it exists only
-to populate `/workspace/ComfyUI` on the first boot.
+The seed archive at `/opt/ComfyUI-seed.tar.zst` is **never run from directly** —
+it exists only to populate `/workspace/ComfyUI` on the first boot.
 
 ### Boot sequence (what runs, in order)
 
@@ -137,17 +145,20 @@ The base image's `CMD` is **`/start.sh`** (from `runpod/containers`). On boot it
 3. `setup_ssh` — injects RunPod's `$PUBLIC_KEY` and starts sshd.
 4. `start_jupyter` — starts JupyterLab on **:8888** if `$JUPYTER_PASSWORD` is set.
 5. runs **our `/post_start.sh`** — `mkdir` the volume data dirs; **first-boot**
-   `rsync` of the seed onto the volume (skipped on later boots); **auto-update**
+   extract of the seed archive onto the volume (skipped on later boots); **auto-update**
    (git pull + sha-checked pip) on later boots; assert the Manager gate; start the
    ancillary services; and **launch ComfyUI from the volume venv**.
 6. `sleep infinity` — keeps the pod alive.
 
 So SSH + Jupyter + nginx come from the base; **our hook adds everything else**.
 
-`/post_start.sh` keys "first boot" off the **volume venv python**: if
-`/workspace/ComfyUI/venv/bin/python` is missing or non-executable, the volume copy
-is absent or incomplete, so it (re-)runs the `rsync`. On later boots that python
-exists, so it skips straight to the auto-update + launch path. The script is
+`/post_start.sh` keys "first boot" off a **completion marker**
+(`/workspace/ComfyUI/.seed-complete`), NOT the presence of any single file: if the
+marker is absent (fresh volume, or a killed/interrupted copy) it extracts the seed
+archive `/opt/ComfyUI-seed.tar.zst` → the volume (`tar -I zstd -x`, overwriting any
+partial tree), verifies the venv, then writes the marker. If the marker is present
+it skips straight to auto-update + launch — so a restart never re-copies and never
+clobbers models/nodes you installed later. The script is
 best-effort throughout (`set +e` semantics) and ends by `exec tail -F`-ing the
 ComfyUI log to hold the pod open regardless of later crashes.
 

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -127,16 +127,33 @@ if [ ! -f "${SEED_DONE}" ]; then
     log "FIRST BOOT: extracting seed ${SEED_ARCHIVE} -> ${COMFY_HOME} (one-time; multi-GB)…"
   fi
   mkdir -p "${COMFY_HOME}"
-  if tar -I zstd -xf "${SEED_ARCHIVE}" -C "${COMFY_HOME}"; then
-    if [ -x "${VPY}" ]; then
-      # Stamp the marker LAST, only once the tree is verifiably complete, so a
-      # future restart trusts it and skips the copy.
-      { date -u +%FT%TZ; echo "seed=${SEED_ARCHIVE}"; } > "${SEED_DONE}" 2>/dev/null || true
-      log "seed extraction complete."
-    else
-      log "FATAL: ${VPY} missing after extract — seed incomplete. Holding pod for debug."
-      exec sleep infinity
+  # Progress WITHOUT log spam: pipe the archive through `pv -n`, which emits ONE
+  # integer percent per interval to stderr (NOT a carriage-return bar, which a
+  # non-TTY container log would explode into thousands of lines). We read the archive
+  # (the cheap side — not an expensive `du` walk of the network volume) so progress
+  # is monotonic and near-free. One clean "seeding… N%" line every ~20s.
+  ARCHIVE_SIZE="$(stat -c%s "${SEED_ARCHIVE}" 2>/dev/null || echo 0)"
+  EXTRACT_OK=0
+  if command -v pv >/dev/null 2>&1 && [ "${ARCHIVE_SIZE}" -gt 0 ]; then
+    if pv -n -i 20 -s "${ARCHIVE_SIZE}" "${SEED_ARCHIVE}" \
+         2> >(while read -r pct; do log "  seeding… ${pct}% (of $(( ARCHIVE_SIZE / 1024 / 1024 ))MB archive)"; done) \
+         | zstd -dc | tar -xf - -C "${COMFY_HOME}"; then
+      EXTRACT_OK=1
     fi
+  else
+    # pv unavailable / size unknown — plain quiet extract (no per-file spam either).
+    if tar -I zstd -xf "${SEED_ARCHIVE}" -C "${COMFY_HOME}"; then
+      EXTRACT_OK=1
+    fi
+  fi
+  if [ "${EXTRACT_OK}" = "1" ] && [ -x "${VPY}" ]; then
+    # Stamp the marker LAST, only once the tree is verifiably complete, so a
+    # future restart trusts it and skips the copy.
+    { date -u +%FT%TZ; echo "seed=${SEED_ARCHIVE}"; } > "${SEED_DONE}" 2>/dev/null || true
+    log "seed extraction complete."
+  elif [ "${EXTRACT_OK}" = "1" ]; then
+    log "FATAL: ${VPY} missing after extract — seed incomplete. Holding pod for debug."
+    exec sleep infinity
   else
     # No marker written -> next boot retries from scratch (tar overwrites partials).
     log "FATAL: seed extraction failed — NOT marking complete; restart to retry. Holding pod for debug."

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -37,7 +37,13 @@ log() { echo "[comfyui-mcp/post_start] $*"; }
 
 # ---- Config (override via pod Environment) ----------------------------------
 SEED_HOME="${SEED_HOME:-/opt/ComfyUI-seed}"            # baked pristine tree (image)
+SEED_ARCHIVE="${SEED_ARCHIVE:-/opt/ComfyUI-seed.tar.zst}" # baked seed as ONE archive
 COMFY_HOME="${COMFY_HOME:-/workspace/ComfyUI}"         # runtime tree (VOLUME)
+# Completion marker on the VOLUME: written ONLY after a fully-successful seed
+# extract. Its presence means "already seeded" — so a restart NEVER re-copies
+# (protecting user data), while an interrupted extract leaves no marker and safely
+# retries next boot.
+SEED_DONE="${SEED_DONE:-${COMFY_HOME}/.seed-complete}"
 SEED_MODELS="${SEED_MODELS:-/opt/ComfyUI-seed-models}" # baked spotcheck model(s)
 WORKSPACE="${WORKSPACE:-/workspace}"                   # network volume
 COMFY_PORT="${COMFY_PORT:-3001}"                        # nginx :3000 -> here
@@ -86,27 +92,45 @@ for sub in checkpoints configs loras vae text_encoders clip diffusion_models \
 done
 
 # -----------------------------------------------------------------------------
-# 2. FIRST BOOT: seed ComfyUI onto the volume. We key off the venv python: if
-#    it's missing/non-executable the volume copy is absent or incomplete, so
-#    rsync the seed (rsync resumes a partial copy idempotently).
+# 2. FIRST BOOT: seed ComfyUI onto the volume, ONCE.
+#    The seed ships as a SINGLE compressed archive (${SEED_ARCHIVE}); we extract
+#    that one stream to the volume — far faster than rsyncing tens of thousands of
+#    small files over the network volume's poor per-file IOPS.
+#    Idempotency is keyed off a COMPLETION MARKER (${SEED_DONE}) written only after
+#    a fully-successful extract — NOT off the presence of any single file. So:
+#      • marker present  -> already seeded; skip (a restart never re-copies, and a
+#                           user's later model/node installs are never clobbered).
+#      • marker absent    -> never finished (fresh volume, or an interrupted/killed
+#                           copy); (re)extract — tar overwrites a partial tree and
+#                           completes it — then write the marker.
 # -----------------------------------------------------------------------------
 FIRST_BOOT=0
-if [ ! -x "${VPY}" ]; then
+if [ ! -f "${SEED_DONE}" ]; then
   FIRST_BOOT=1
-  if [ ! -x "${SEED_HOME}/venv/bin/python" ]; then
-    log "FATAL: seed venv missing at ${SEED_HOME}/venv — image build problem."
+  if [ ! -f "${SEED_ARCHIVE}" ]; then
+    log "FATAL: seed archive missing at ${SEED_ARCHIVE} — image build problem."
     log "       Holding pod open for debug."
     exec sleep infinity
   fi
-  log "FIRST BOOT: copying seed ${SEED_HOME} -> ${COMFY_HOME} (one-time; multi-GB)…"
-  mkdir -p "${COMFY_HOME}"
-  if rsync -a --info=progress2 "${SEED_HOME}/" "${COMFY_HOME}/"; then
-    log "seed copy complete."
+  if [ -d "${COMFY_HOME}" ] && [ -n "$(ls -A "${COMFY_HOME}" 2>/dev/null)" ]; then
+    log "resuming an interrupted seed into ${COMFY_HOME} (no completion marker)…"
   else
-    log "WARN: rsync returned non-zero — verifying venv anyway."
+    log "FIRST BOOT: extracting seed ${SEED_ARCHIVE} -> ${COMFY_HOME} (one-time; multi-GB)…"
   fi
-  if [ ! -x "${VPY}" ]; then
-    log "FATAL: ${VPY} still missing after seed copy — holding pod open for debug."
+  mkdir -p "${COMFY_HOME}"
+  if tar -I zstd -xf "${SEED_ARCHIVE}" -C "${COMFY_HOME}"; then
+    if [ -x "${VPY}" ]; then
+      # Stamp the marker LAST, only once the tree is verifiably complete, so a
+      # future restart trusts it and skips the copy.
+      { date -u +%FT%TZ; echo "seed=${SEED_ARCHIVE}"; } > "${SEED_DONE}" 2>/dev/null || true
+      log "seed extraction complete."
+    else
+      log "FATAL: ${VPY} missing after extract — seed incomplete. Holding pod for debug."
+      exec sleep infinity
+    fi
+  else
+    # No marker written -> next boot retries from scratch (tar overwrites partials).
+    log "FATAL: seed extraction failed — NOT marking complete; restart to retry. Holding pod for debug."
     exec sleep infinity
   fi
 fi

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -100,11 +100,20 @@ done
 #    a fully-successful extract — NOT off the presence of any single file. So:
 #      • marker present  -> already seeded; skip (a restart never re-copies, and a
 #                           user's later model/node installs are never clobbered).
-#      • marker absent    -> never finished (fresh volume, or an interrupted/killed
-#                           copy); (re)extract — tar overwrites a partial tree and
-#                           completes it — then write the marker.
+#      • marker absent BUT venv already present -> a volume seeded by a PRE-marker
+#                           (old rsync) image, or a prior boot: ADOPT it (stamp the
+#                           marker, DON'T re-extract — never clobber a live volume).
+#      • marker absent AND no venv -> fresh volume, or an interrupted/killed copy;
+#                           (re)extract — tar overwrites a partial tree and completes
+#                           it — then write the marker.
 # -----------------------------------------------------------------------------
 FIRST_BOOT=0
+if [ ! -f "${SEED_DONE}" ] && [ -x "${VPY}" ]; then
+  # Migration / already-seeded: a complete volume with no marker (e.g. seeded by an
+  # older image). Adopt it so we never re-extract over the user's models/nodes.
+  log "existing seeded volume detected (no completion marker) — adopting; NOT re-copying."
+  { date -u +%FT%TZ; echo "seed=adopted"; } > "${SEED_DONE}" 2>/dev/null || true
+fi
 if [ ! -f "${SEED_DONE}" ]; then
   FIRST_BOOT=1
   if [ ! -f "${SEED_ARCHIVE}" ]; then


### PR DESCRIPTION
First boot rsync'd tens of thousands of small files to the network volume — brutal on its per-file IOPS (multi-GB, minutes), and keyed "already seeded" off the venv python so an interrupted copy could look done-but-partial.

- **Build**: pack the finished seed into ONE `tar+zstd` archive (`/opt/ComfyUI-seed.tar.zst`) and drop the raw tree (no image-size double). `zstd` + `pv` added to apt.
- **First boot**: extract that single stream (`tar -I zstd -x`) — far faster than per-file rsync. Idempotency keys off a **completion marker** (`/workspace/ComfyUI/.seed-complete`) written only after a verified-complete extract:
  - marker present → skip (a restart NEVER re-copies, never clobbers user-installed models/nodes)
  - marker absent **but venv present** → adopt an old-image volume (stamp marker, no extract) — migration safety
  - marker absent AND no venv → fresh/interrupted → (re)extract, then stamp
- **Progress without log spam**: `pv -n` emits one "seeding… N%" line every ~20s (no carriage-return bar that a non-TTY log explodes).

`bash -n` clean. Takes effect on the next image rebuild + push. README updated.