### PR TITLE
feat(runpod): GPU driver preflight — fail fast on a too-old host driver

### DIFF
--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -75,6 +75,40 @@ MARKERS="${COMFY_HOME}/.autoupdate"   # sha markers for conditional pip
 LOG_DIR="${COMFY_LOG_DIR:-/var/log/comfyui-mcp}"
 mkdir -p "${LOG_DIR}"
 
+# Minimum host NVIDIA driver for this image. It ships CUDA 12.8 (cu128 torch), and a
+# Blackwell GPU (RTX 50xx / sm_120) additionally needs a Blackwell-aware driver —
+# both require driver >= ~570. Override for a different image/GPU with MIN_DRIVER=0
+# to disable the check.
+MIN_DRIVER="${MIN_DRIVER:-570}"
+
+# -----------------------------------------------------------------------------
+# 0. GPU DRIVER PREFLIGHT. The host NVIDIA driver is NOT upgradable from inside the
+#    container, so a too-old driver (common when the scheduler drops a new GPU on a
+#    stale host) makes torch fail to init CUDA and ComfyUI crash-loops with a cryptic
+#    error. Detect it UP FRONT (before the multi-GB seed) and hold the pod open with a
+#    clear "redeploy on a newer host" message instead of looping.
+# -----------------------------------------------------------------------------
+if [ "${MIN_DRIVER}" != "0" ] && command -v nvidia-smi >/dev/null 2>&1; then
+  GPU_NAME="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
+  DRV="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)"
+  DRV_MAJOR="${DRV%%.*}"
+  log "GPU: ${GPU_NAME:-unknown} | driver: ${DRV:-unknown} (this CUDA 12.8 image needs driver >= ${MIN_DRIVER})"
+  if [ -n "${DRV_MAJOR}" ] && [ "${DRV_MAJOR}" -lt "${MIN_DRIVER}" ] 2>/dev/null; then
+    log "============================================================================"
+    log "FATAL: host NVIDIA driver ${DRV} is TOO OLD for this image (needs >= ${MIN_DRIVER})."
+    log "  Your ${GPU_NAME:-GPU} (esp. RTX 50xx / Blackwell) needs a newer driver, and the"
+    log "  HOST driver CANNOT be upgraded from inside a pod — torch would fail to init CUDA."
+    log "  FIX: TERMINATE this pod and REDEPLOY on a host with CUDA >= 12.8 / driver >= ${MIN_DRIVER}"
+    log "       (filter by 'CUDA Version' on the RunPod deploy screen). Verify with: nvidia-smi"
+    log "  Holding the pod open (no crash-loop) so you can inspect it. Set MIN_DRIVER=0 to bypass."
+    log "============================================================================"
+    exec sleep infinity
+  fi
+else
+  [ "${MIN_DRIVER}" = "0" ] && log "driver preflight disabled (MIN_DRIVER=0)." \
+    || log "WARNING: nvidia-smi not found — skipping GPU driver preflight."
+fi
+
 # -----------------------------------------------------------------------------
 # 1. Volume user-data dirs (fast, idempotent). ComfyUI runs FROM ${COMFY_HOME}
 #    but its user/models/input/output are pointed at the volume root via launch


### PR DESCRIPTION
A new GPU (esp. RTX 50xx / Blackwell, sm_120) dropped by the scheduler onto a host with a stale NVIDIA driver makes torch fail to init CUDA → ComfyUI **crash-loops with a cryptic error** (the exact "my 5090 has an old driver" case). The host driver can't be upgraded from inside a pod.

`post_start.sh` now runs `nvidia-smi` **up front** (before the multi-GB seed) and, if the driver major is below the image's minimum (CUDA 12.8 / Blackwell need ≥ ~570), prints a loud **"terminate + redeploy on a CUDA ≥ 12.8 host"** message and holds the pod open for inspection instead of looping. Tunable via `MIN_DRIVER` (`0` disables).

`bash -n` clean; threshold logic verified (535/550 block, 570/575 pass). Takes effect on the next image rebuild.