### PR TITLE
fix(orchestrator): real provider readiness over the bridge + Sonnet 5 (SDK bump)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.20.5",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.20.5",
+      "version": "0.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -38,7 +38,7 @@
         "@ai-sdk/anthropic": "^3.0.79",
         "@ai-sdk/google": "^3.0.79",
         "@ai-sdk/openai": "^3.0.65",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.179",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.197",
         "@aws-sdk/client-s3": "^3.1053.0",
         "@azure/storage-blob": "^12.31.0",
         "@openai/codex": "~0.141.0",
@@ -147,23 +147,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.179.tgz",
-      "integrity": "sha512-BlZULVW61ZCcho6mb026QoOQbGZnfxbsEtcoNaW5lF0sIEu7D+/nnQjHSMK8buS/h7HVmIx2RtGbHVX1y4V0uQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
+      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
       "license": "SEE LICENSE IN README.md",
       "optional": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.179",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.179"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.179.tgz",
-      "integrity": "sha512-2QoEl7p+RTkF4ARZ40N9OWWi+at8Iy9ZZg3UeP6sWoGrM0GL6NJSv8pbYUdoSRySbNeZshqWar5DF41265J5Sg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
+      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
       "cpu": [
         "arm64"
       ],
@@ -185,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.179.tgz",
-      "integrity": "sha512-U5683Hi4uP5Wkg9IhHayqx8co9rgeZaAJcutLAgJiAN9ZnL128+WT0K4DKaBVuMbeeoORodVs9IJgM38lBxUxg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
+      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
       "cpu": [
         "x64"
       ],
@@ -198,9 +198,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.179.tgz",
-      "integrity": "sha512-Io9X2xF5J3cHR20b0oflLe0sLHyT/KFMCA7sVJhwuSvcqeCHqXTxn6sG+4lArD9wNf+RtLVKgSvOt5Oz4j7mew==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
+      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
       "cpu": [
         "arm64"
       ],
@@ -214,9 +214,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.179.tgz",
-      "integrity": "sha512-ehqWR9bV0dJONkoKleKg/LJIGDVevLGLPVIQpol+Bqrgyv05DE1hx68g6mBnfp9IEKo2BMZCba3aHKhkHlZvnQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
+      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +230,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.179.tgz",
-      "integrity": "sha512-Ck2pLG2GJ5lYULK0Rb6FvAUhkLSvIFgJ77MsbVhvBJHG3C31Fuk6FnkXEL614WSZZdI1ST0Y7s7wc9yLI2kmiQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
+      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
       "cpu": [
         "x64"
       ],
@@ -246,9 +246,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.179.tgz",
-      "integrity": "sha512-Q+clijh01m+Gg/tSNjHQWfPFRvXSVMIQJZqu6v28vFduaucL7ZL+p6o6VOSdlgLjhqtIFFjOO37aL+VkvEu9MQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
+      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
       "cpu": [
         "x64"
       ],
@@ -262,9 +262,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.179.tgz",
-      "integrity": "sha512-7wc4j3vDE/TiuiCEPV024U/TDNKXUJ89V0N9WteYJ57YrIUm0RA51WiKCrEmSxSqstQ7Slq26e0gWGHRf7ljDQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
+      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
       "cpu": [
         "arm64"
       ],
@@ -275,9 +275,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.179",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.179.tgz",
-      "integrity": "sha512-gFad1AVUZOXbEyS9lf3Pr0LDXrLuO6limZoZoUZQmjhjy0LnudnTU8P/VbCY0AHmT46YMZ/ieisFzeq8X5jTcg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
+      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "zod": "^4.0.0"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.179",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
     "@openai/codex": "~0.141.0",
     "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/google": "^3.0.79",

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -1,0 +1,105 @@
+// Readiness is computed on the machine that RUNS the agents (this orchestrator),
+// not the ComfyUI host — so a remote pod no longer false-flags "CLI not installed".
+//
+// Claude is the SDK host (no CLI): always usable here. Codex/Gemini need their CLI
+// on PATH AND a cached login. These tests drive PATH + a fake HOME so the on-disk
+// probes are deterministic across platforms.
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join, delimiter } from "node:path";
+import { backendReadiness, allBackendReadiness } from "../../orchestrator/backend-readiness.js";
+
+const REAL_PATH = process.env.PATH;
+const REAL_GEMINI_HOME = process.env.GEMINI_CLI_HOME;
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "readiness-"));
+  // Empty PATH by default so nothing resolves unless a test adds it.
+  process.env.PATH = "";
+  delete process.env.GEMINI_CLI_HOME;
+});
+
+afterEach(() => {
+  process.env.PATH = REAL_PATH;
+  if (REAL_GEMINI_HOME === undefined) delete process.env.GEMINI_CLI_HOME;
+  else process.env.GEMINI_CLI_HOME = REAL_GEMINI_HOME;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Create a fake CLI binary on a dir and add that dir to PATH. */
+function putOnPath(name: string): void {
+  const dir = join(tmp, "bin");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), "#!/bin/sh\n");
+  process.env.PATH = [dir, process.env.PATH].filter(Boolean).join(delimiter);
+}
+
+describe("backendReadiness", () => {
+  it("reports Claude ready unconditionally (SDK host, no CLI)", () => {
+    const r = backendReadiness("claude");
+    expect(r).toEqual({ backend: "claude", cli: true, auth: true, ready: true });
+  });
+
+  it("is case-insensitive", () => {
+    expect(backendReadiness("CLAUDE").ready).toBe(true);
+  });
+
+  it("codex: not ready with neither CLI nor login", () => {
+    const r = backendReadiness("codex", { home: tmp });
+    expect(r.cli).toBe(false);
+    expect(r.ready).toBe(false);
+  });
+
+  it("codex: CLI on PATH but no login → cli true, not ready", () => {
+    putOnPath(process.platform === "win32" ? "codex.cmd" : "codex");
+    const r = backendReadiness("codex", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(false);
+    expect(r.ready).toBe(false);
+  });
+
+  it("codex: CLI on PATH AND login on disk → ready", () => {
+    putOnPath(process.platform === "win32" ? "codex.cmd" : "codex");
+    mkdirSync(join(tmp, ".codex"), { recursive: true });
+    writeFileSync(join(tmp, ".codex", "auth.json"), "{}");
+    const r = backendReadiness("codex", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
+  it("gemini: honors GEMINI_CLI_HOME for the oauth creds path", () => {
+    putOnPath(process.platform === "win32" ? "gemini.cmd" : "gemini");
+    const gh = join(tmp, "geminihome");
+    mkdirSync(join(gh, ".gemini"), { recursive: true });
+    writeFileSync(join(gh, ".gemini", "oauth_creds.json"), "{}");
+    process.env.GEMINI_CLI_HOME = gh;
+    const r = backendReadiness("gemini", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
+  it("unknown backend is never ready", () => {
+    expect(backendReadiness("bogus").ready).toBe(false);
+  });
+});
+
+describe("allBackendReadiness", () => {
+  it("rolls up any_ready (Claude alone makes it true)", () => {
+    const { backends, any_ready } = allBackendReadiness(["claude", "codex", "gemini"]);
+    expect(backends).toHaveLength(3);
+    expect(any_ready).toBe(true);
+    expect(backends.find((b) => b.backend === "claude")?.ready).toBe(true);
+  });
+
+  it("real homedir stays untouched by the probe", () => {
+    // Sanity: the function must not throw on a real environment.
+    process.env.PATH = REAL_PATH ?? "";
+    expect(() => allBackendReadiness(["claude", "codex", "gemini"])).not.toThrow();
+    expect(typeof homedir()).toBe("string");
+  });
+});

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -1,0 +1,98 @@
+// Per-provider readiness, computed on the machine that actually RUNS the agents
+// (this orchestrator = the user's laptop) — NOT on the ComfyUI host.
+//
+// The panel's ComfyUI-side Python (comfyui-mcp-panel/__init__.py) also probes
+// readiness, but it runs wherever ComfyUI runs. In the "remote ComfyUI, local
+// agent" model that's the POD, which has no provider CLIs and no logins, so it
+// always reports "CLI not installed" even though the agent is happily running on
+// the laptop. This module lets the orchestrator report the TRUTH over the bridge,
+// which the panel then prefers (see comfyui-mcp-panel: applyReadiness on a
+// {type:"backends"} bridge frame).
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type BackendReadiness = {
+  backend: string;
+  /** The provider's runtime is present (a CLI on PATH, or — for Claude — the SDK). */
+  cli: boolean;
+  /** A usable login exists. null = unknown (don't nag). */
+  auth: boolean | null;
+  /** cli && auth-not-false. */
+  ready: boolean;
+};
+
+// CLI binary names per provider (Windows resolves .cmd/.exe via PATHEXT, but we
+// probe the common variants explicitly to match the panel's Python).
+const CLI_NAMES: Record<string, string[]> = {
+  codex: ["codex", "codex.cmd", "codex.exe"],
+  gemini: ["gemini", "gemini.cmd", "gemini.exe"],
+};
+
+/** True if any of `names` resolves on the local PATH. */
+function onPath(names: string[]): boolean {
+  const sep = process.platform === "win32" ? ";" : ":";
+  const dirs = (process.env.PATH || "").split(sep).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      try {
+        if (existsSync(join(dir, name))) return true;
+      } catch {
+        // unreadable PATH entry — skip
+      }
+    }
+  }
+  return false;
+}
+
+function fileExists(...parts: string[]): boolean {
+  try {
+    return existsSync(join(...parts));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Readiness for one backend, evaluated locally.
+ *
+ * - claude: the orchestrator IS the Claude Agent SDK host — no separate CLI. If
+ *   this process is running we can attempt Claude; a genuinely dead/unsigned
+ *   Claude still surfaces via the connect ack's model probe (degraded). So we
+ *   report it usable here rather than false-flagging "CLI not installed".
+ * - codex/gemini: the CLI must be on PATH AND a login cached on disk.
+ */
+export function backendReadiness(backend: string, opts?: { home?: string }): BackendReadiness {
+  const b = (backend || "").toLowerCase();
+  const home = opts?.home ?? homedir();
+  if (b === "claude") {
+    return { backend: "claude", cli: true, auth: true, ready: true };
+  }
+  if (b === "codex") {
+    const cli = onPath(CLI_NAMES.codex);
+    const auth = fileExists(home, ".codex", "auth.json");
+    return { backend: "codex", cli, auth, ready: cli && auth };
+  }
+  if (b === "gemini") {
+    const cli = onPath(CLI_NAMES.gemini);
+    // The gemini CLI caches its Google OAuth at <home>/.gemini/oauth_creds.json
+    // (or GEMINI_CLI_HOME when set).
+    const geminiHome = process.env.GEMINI_CLI_HOME || home;
+    const auth = fileExists(geminiHome, ".gemini", "oauth_creds.json");
+    return { backend: "gemini", cli, auth, ready: cli && auth };
+  }
+  return { backend: b, cli: false, auth: false, ready: false };
+}
+
+/** Readiness for every known backend, plus a rolled-up any_ready. */
+export function allBackendReadiness(
+  backends: Iterable<string>,
+  opts?: { home?: string },
+): {
+  backends: BackendReadiness[];
+  any_ready: boolean;
+} {
+  const list = [...backends].map((b) => backendReadiness(b, opts));
+  return { backends: list, any_ready: list.some((r) => r.ready) };
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -36,6 +36,7 @@ import {
 } from "../services/panel-secrets.js";
 import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
+import { allBackendReadiness } from "./backend-readiness.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
@@ -917,6 +918,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       });
   }
 
+  // Real per-provider readiness, computed HERE (the machine running the agents)
+  // and pushed over the bridge so the panel's provider switcher reflects the
+  // truth — not the ComfyUI host's probe, which is blind to the laptop in the
+  // "remote ComfyUI, local agent" model (and never sees Claude's SDK, which has
+  // no CLI). The panel prefers this frame over its GET /backends probe.
+  function pushReadiness(tabId: string): void {
+    try {
+      const { backends, any_ready } = allBackendReadiness(KNOWN_BACKENDS);
+      bridge.push({ type: "backends", backends, any_ready }, tabId);
+    } catch (err) {
+      logger.warn(`[panel-orchestrator] readiness probe failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   bridge.onPanelMessage = (event) => {
     // Connect ack: the instant a panel tab connects, the orchestrator announces
     // itself so "connected" means "a real agent is attending" — not merely "a
@@ -953,6 +968,9 @@ export async function runPanelOrchestrator(): Promise<void> {
 
       // Live model list for the picker; SDK slash commands are Claude-only.
       pushModels(panelTab);
+      // Truthful provider readiness (this machine runs the agents), so the
+      // switcher stops falsely showing "CLI not installed" behind a remote pod.
+      pushReadiness(panelTab);
       if (backend === "claude") pushCommands(panelTab);
       // Re-push the last usage so the context meter isn't blank after a reload.
       const lastStatus = manager.lastStatusFor(key);


### PR DESCRIPTION
Fixes two provider-picker bugs surfaced when driving a **remote** ComfyUI pod from the local agent.

### 1. Switcher showed "CLI not installed" for every provider (even the connected one)
Readiness was probed only by the panel's **ComfyUI-side Python** (`shutil.which` + on-disk logins), which runs wherever ComfyUI runs — the **pod**, which has no provider CLIs, no logins, and never sees Claude's SDK (no CLI at all). The orchestrator runs the agents on the user's own machine, so it's the real source of truth. It now computes readiness locally (`backend-readiness.ts`) and pushes a `{type:"backends"}` frame on hello. Pairs with panel #50, which prefers this over the pod probe.

### 2. Sonnet 5 missing from the model list
`supportedModels()` reads the SDK's bundled catalog; `0.3.179` predates Sonnet 5. Bump `@anthropic-ai/claude-agent-sdk` `^0.3.179 → ^0.3.197` (adds `claude-sonnet-5`).

### Tests
+9 `backend-readiness` unit tests; full suite **948 pass**; tsc clean.

### Pairs with
- comfyui-mcp-panel #50 (panel applies the readiness frame)

🤖 Generated with [Claude Code](https://claude.com/claude-code)