### PR TITLE
feat(validate): match the frontend — out-of-list combo values are errors

### DIFF
--- a/src/__tests__/services/workflow-validator.test.ts
+++ b/src/__tests__/services/workflow-validator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// validateWorkflow reaches ComfyUI only through getObjectInfo — mock it to feed a
+// deterministic node catalog so we can exercise the combo (value_not_in_list) logic.
+const getObjectInfoMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+}));
+
+import { validateWorkflow } from "../../services/workflow-validator.js";
+import type { WorkflowJSON } from "../../comfyui/types.js";
+
+// Minimal /object_info: a CLIPLoader with a MODEL combo + a non-model `type` combo,
+// a UNETLoader whose model list is EMPTY (nothing installed), and a SaveImage output.
+const OBJECT_INFO = {
+  CLIPLoader: {
+    input: {
+      required: {
+        clip_name: [["good_clip.safetensors", "other.safetensors"], {}],
+        type: [["qwen_image", "lumina2", "sdxl"], {}],
+      },
+    },
+    output: ["CLIP"],
+  },
+  UNETLoader: {
+    input: { required: { unet_name: [[], {}], weight_dtype: [["default", "fp8"], {}] } },
+    output: ["MODEL"],
+  },
+  SaveImage: { input: { required: {} }, output: [], output_node: true },
+} as const;
+
+beforeEach(() => {
+  getObjectInfoMock.mockReset();
+  getObjectInfoMock.mockResolvedValue(OBJECT_INFO);
+});
+
+const wf = (nodes: Record<string, { class_type: string; inputs: Record<string, unknown> }>) =>
+  nodes as unknown as WorkflowJSON;
+
+describe("validateWorkflow — combo value_not_in_list parity with the ComfyUI frontend", () => {
+  it("flags a non-model combo value that isn't in the list as an ERROR (with valid options)", async () => {
+    const r = await validateWorkflow(
+      wf({
+        "1": { class_type: "CLIPLoader", inputs: { clip_name: "good_clip.safetensors", type: "gemma" } },
+        "9": { class_type: "SaveImage", inputs: {} },
+      }),
+    );
+    const typeErr = r.issues.find((i) => i.node_id === "1" && /"type"/.test(i.message));
+    expect(typeErr?.severity).toBe("error");
+    expect(typeErr?.message).toMatch(/value_not_in_list/);
+    expect(typeErr?.message).toMatch(/qwen_image/); // surfaces the valid options
+    expect(r.valid).toBe(false);
+  });
+
+  it("flags a missing MODEL as an error with a download hint (not just a warning)", async () => {
+    const r = await validateWorkflow(
+      wf({
+        "1": { class_type: "CLIPLoader", inputs: { clip_name: "missing.safetensors", type: "qwen_image" } },
+        "9": { class_type: "SaveImage", inputs: {} },
+      }),
+    );
+    const err = r.issues.find((i) => i.node_id === "1" && /clip_name/.test(i.message));
+    expect(err?.severity).toBe("error");
+    expect(err?.message).toMatch(/isn't installed|download/i);
+  });
+
+  it("flags any value against an EMPTY option list (the 'nothing installed → not in []' case)", async () => {
+    const r = await validateWorkflow(
+      wf({
+        "2": { class_type: "UNETLoader", inputs: { unet_name: "z_image_turbo_bf16.safetensors", weight_dtype: "default" } },
+        "9": { class_type: "SaveImage", inputs: {} },
+      }),
+    );
+    const err = r.issues.find((i) => i.node_id === "2" && /unet_name/.test(i.message));
+    expect(err?.severity).toBe("error");
+    expect(err?.message).toMatch(/value_not_in_list/);
+  });
+
+  it("passes a fully valid combo graph (no value_not_in_list issues)", async () => {
+    const r = await validateWorkflow(
+      wf({
+        "1": { class_type: "CLIPLoader", inputs: { clip_name: "good_clip.safetensors", type: "qwen_image" } },
+        "9": { class_type: "SaveImage", inputs: {} },
+      }),
+    );
+    expect(r.issues.filter((i) => /value_not_in_list/.test(i.message))).toHaveLength(0);
+    expect(r.valid).toBe(true);
+  });
+
+  it("skips a combo fed by a CONNECTION (can't validate a linked value statically)", async () => {
+    const r = await validateWorkflow(
+      wf({
+        "1": { class_type: "CLIPLoader", inputs: { clip_name: ["3", 0], type: "qwen_image" } },
+        "3": { class_type: "CLIPLoader", inputs: { clip_name: "good_clip.safetensors", type: "qwen_image" } },
+        "9": { class_type: "SaveImage", inputs: {} },
+      }),
+    );
+    expect(r.issues.find((i) => i.node_id === "1" && /clip_name/.test(i.message))).toBeUndefined();
+  });
+});

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -110,8 +110,8 @@ export async function validateWorkflow(
       }
     }
 
-    // 2d. Check for model references using objectInfo dropdown values
-    checkModelReferences(nodeId, classType, node.inputs, issues, objectInfo);
+    // 2d. Check every combo (dropdown) value against objectInfo's valid options
+    checkComboValues(nodeId, classType, node.inputs, issues, objectInfo);
   }
 
   // 3. Check for cycles (basic: no self-references)
@@ -167,12 +167,19 @@ export async function validateWorkflow(
 }
 
 /**
- * Check if model file references in node inputs exist in ComfyUI's known models.
- * Uses /object_info dropdown values (ComfyUI's authoritative model list) instead of
- * scanning the filesystem directly. This correctly handles all model search paths,
- * subdirectories, and custom loaders without hardcoded mappings.
+ * Check that every combo (dropdown) widget value is one ComfyUI actually offers —
+ * mirroring ComfyUI's OWN frontend validator, which rejects an out-of-list value
+ * with `value_not_in_list` (the "N ERRORS" the user sees in the error panel). This
+ * catches BOTH classes the frontend flags as errors:
+ *   - missing models (a `*.safetensors`/`*.gguf`/… value not in the loader's list,
+ *     incl. the empty-list case when nothing is installed), and
+ *   - any other invalid dropdown value (a wrong `type`, `sampler_name`, `scheduler`,
+ *     an uploaded-file name that isn't present, etc.).
+ * Uses /object_info's authoritative option lists (all model search paths, subdirs,
+ * and custom loaders — no hardcoded mappings). A value fed by a CONNECTION (not a
+ * literal widget value) is skipped: it can't be validated statically.
  */
-function checkModelReferences(
+function checkComboValues(
   nodeId: string,
   classType: string,
   inputs: Record<string, unknown>,
@@ -188,24 +195,36 @@ function checkModelReferences(
   };
 
   for (const [inputName, inputSpec] of Object.entries(allInputDefs)) {
-    const value = inputs[inputName];
-    if (typeof value !== "string") continue;
-
-    // Only check combo inputs (dropdowns) that have an array of valid values
+    // A combo input's spec is `[ [...options], {config?} ]`. Non-combos (INT/FLOAT/
+    // STRING/BOOLEAN, or a linked node-type string) have a non-array first element.
     if (!Array.isArray(inputSpec) || !Array.isArray(inputSpec[0])) continue;
 
-    const validValues = inputSpec[0] as string[];
+    const value = inputs[inputName];
+    // Only a literal widget value is checkable; a connection is `[nodeId, outIdx]`.
+    if (typeof value !== "string") continue;
 
-    // Only check values that look like model files (by extension)
-    if (!/\.(safetensors|gguf|ckpt|pt|pth|bin|sft)$/i.test(value)) continue;
+    const validValues = inputSpec[0] as unknown[];
+    // Only validate string option lists (model names, types, samplers, schedulers…).
+    // A non-empty non-string/mixed list (rare) is skipped to avoid false positives;
+    // an EMPTY list is validated (that's the "nothing installed" → not in [] case).
+    if (validValues.length > 0 && !validValues.every((v) => typeof v === "string")) continue;
+    if (validValues.includes(value)) continue;
 
-    if (!validValues.includes(value)) {
-      issues.push({
-        severity: "warning",
-        node_id: nodeId,
-        node_type: classType,
-        message: `Model "${value}" not found in ${classType}'s "${inputName}" options (${validValues.length} available). The model may need to be downloaded or ComfyUI restarted.`,
-      });
-    }
+    const isModel = /\.(safetensors|gguf|ckpt|pt|pth|bin|sft)$/i.test(value);
+    const hint = isModel
+      ? " This model file isn't installed here (or ComfyUI needs a restart to see it) — download it or fix the path/filename."
+      : validValues.length
+        ? ` Valid options: ${(validValues as string[])
+            .slice(0, 8)
+            .map((v) => `"${v}"`)
+            .join(", ")}${validValues.length > 8 ? ", …" : ""}.`
+        : ` No options are available for "${inputName}" on this ComfyUI (the source list is empty).`;
+
+    issues.push({
+      severity: "error",
+      node_id: nodeId,
+      node_type: classType,
+      message: `"${inputName}" = "${value}" is not in the list of valid options (value_not_in_list).${hint}`,
+    });
   }
 }


### PR DESCRIPTION
## Why
`validate_workflow` under-reported vs ComfyUI's own frontend validator. It only checked combo values that *looked like model files*, and only as **warnings** — so a wrong `type` / `sampler_name` / `scheduler` slipped through, and missing models read as soft warnings even though the frontend rejects all of these as **errors** (the "N ERRORS" / `value_not_in_list` the user sees).

## What
Generalize `checkModelReferences` → `checkComboValues`: validate **every** string combo (dropdown) value against `/object_info`'s option list and report an out-of-list value as an **error** — including the empty-list "nothing installed → not in `[]`" case. Model files keep a download/restart hint; other combos list the valid options. Connection-fed inputs and non-string option lists are skipped (no false positives).

Now an on-demand `validate_workflow` / `panel_get_errors` reads **identically** to the `⚠️ GRAPH VALIDATION` block injected at turn start (panel #51).

## Tests
+5 focused unit tests (non-model combo, missing model, empty list, valid graph, connection-fed). Full suite **953 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)