### PR TITLE
docs: sync README + cloud-deployment for wss bridge (0.23.4) + custom_nodes persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ npx -y comfyui-mcp@latest connect
 
 When ComfyUI runs somewhere with **no Node/agent** (a RunPod pod, a cloud box) you
 can still run the agent on **your** machine and drive that remote ComfyUI — no
-agent login on the box, no tunnel:
+agent login on the box, nothing to install or configure remotely:
 
 ```bash
 npx -y comfyui-mcp@latest connect https://abcd1234-8188.proxy.runpod.net
@@ -176,10 +176,16 @@ npx -y comfyui-mcp@latest connect https://abcd1234-8188.proxy.runpod.net
 
 This is sugar for `--panel-orchestrator` with `COMFYUI_URL` set from the URL: the
 orchestrator runs locally on your Claude/ChatGPT login and reaches the remote
-ComfyUI over its public proxy URL. The agent bridge stays on
-`ws://127.0.0.1:9180`. Because the panel JS runs in **your local browser** (even
-when served by the remote ComfyUI), that bridge is already on your machine — so
-nothing needs to be installed remotely.
+ComfyUI over its public proxy URL. For a **remote HTTPS pod**, `connect`
+automatically opens a secure, token-gated **`wss://` tunnel** (via Cloudflare) to
+the local agent bridge and hands the pod's panel that URL — so the pod's HTTPS page
+reaches your machine with **no browser prompt, in any browser** (a secure page
+can't open a plain `ws://` socket to your box — mixed content / Private Network
+Access). A **local** ComfyUI uses the plain `ws://127.0.0.1:9180` loopback bridge;
+add **`--insecure-bridge`** to force that loopback for a remote pod (then arrange
+your own path to it, e.g. an SSH port-forward). Either way the panel JS runs in
+**your local browser** and the agent — and your login — run only on **your**
+machine, so nothing is installed remotely.
 
 To finish: open the remote ComfyUI in your browser, turn on **Settings → General →
 "Use external/local orchestrator (advanced)"** in the Agent panel, then click

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -50,30 +50,39 @@ This design **inverts** that:
 | Concern | Where it lives | Persists a restart? |
 |---------|----------------|---------------------|
 | ComfyUI install + venv | **image** `/opt/ComfyUI` (immutable) | n/a (re-pulled with the image) |
-| `custom_nodes` (incl. Agent Panel, Manager) | **image** `/opt/ComfyUI/custom_nodes` | **No** — ephemeral |
-| Caches (HF / pip / torch / npm) | **container** ephemeral disk | **No** — ephemeral |
+| `custom_nodes` (Agent Panel + your installs) | **volume** `/workspace/custom_nodes` (symlinked; image nodes seeded each boot) | **Yes** |
+| ComfyUI-Manager | **image** venv (pip package) | n/a (in the image) |
+| Custom-node pip cache | **volume** `/workspace/.cache/pip` | **Yes** |
+| Other caches (HF / torch / npm) | **container** ephemeral disk | **No** — ephemeral |
 | `user/` (workflows + settings + Manager config) | **volume** `/workspace/user` | **Yes** |
 | `models/` (incl. Manager downloads) | **volume** `/workspace/models` | **Yes** |
 | `input/` | **volume** `/workspace/input` | **Yes** |
 | `output/` | **volume** `/workspace/output` | **Yes** |
 
-**Result:** restart is just `mkdir -p /workspace/{user,models,input,output}` (plus
-model subdirs) and `launch ComfyUI from the baked venv`. No install/sync/seed.
+**Result:** the base ComfyUI + venv boot fast from the immutable image; only your
+data **and your custom nodes** live on the volume. A restart is `mkdir -p` the
+user-data dirs, symlink + seed `custom_nodes`, reinstall node deps from the
+persistent cache, and launch from the baked venv. No full install/sync/seed.
 
-### ⚠️ The custom_nodes tradeoff (read this)
+### Custom nodes persist on the volume
 
-Because `custom_nodes` are **baked into the immutable image**, **custom nodes the
-agent or Manager install at runtime do NOT survive a restart** — they live on the
-container's ephemeral disk and are gone on the next start. This is the deliberate
-cost of fast restart.
+`custom_nodes` is **symlinked to `/workspace/custom_nodes`**, so **custom nodes the
+agent or Manager install at runtime survive a restart** — while the base ComfyUI +
+venv still boot fast from the immutable image.
 
+* **How it works (each boot).** The entrypoint symlinks
+  `/opt/ComfyUI/custom_nodes` → `/workspace/custom_nodes`, seeds/refreshes the
+  image's baked nodes (Agent Panel + ComfyUI builtins) into it — so an image
+  upgrade always ships a current panel while **your** installed nodes are preserved
+  — then reinstalls each node's `requirements.txt` into the venv from a
+  **persistent pip cache** on the volume (fast after the first time).
 * **Models DO persist** — Manager's install-model writes to `/workspace/models`
-  (see [Model paths](#model-paths-extra_model_pathsyaml)), so downloaded models
-  survive restarts.
-* **Nodes do NOT persist.** To add a custom node **permanently**, add it to the
-  `Dockerfile` (a `git clone` into `/opt/ComfyUI/custom_nodes` + its
-  `pip install`) and **rebuild the image**. Within a single pod session,
-  Manager-installed nodes work until the next restart.
+  (see [Model paths](#model-paths-extra_model_pathsyaml)).
+* **First install of a node** downloads its Python deps into the persistent cache;
+  every restart after re-materializes them from cache (the venv lives in the image,
+  so its packages are refreshed on boot). Compiled/CUDA-linked deps may rebuild
+  rather than unpack. To bake a node so it needs **zero** boot-time work, still add
+  it to the `Dockerfile` and rebuild.
 
 ---
 
@@ -414,9 +423,15 @@ Once the pod is up and you have its proxy URL, on your laptop:
 npx -y comfyui-mcp@latest connect https://<pod-id>-3000.proxy.runpod.net
 ```
 
-This starts the comfyui-mcp panel orchestrator pointed at the pod. Then open the
-pod's ComfyUI, open the **Agent Panel**, enable the **external-orchestrator**
-toggle, and click **Connect**.
+This starts the comfyui-mcp panel orchestrator pointed at the pod. Because the pod
+page is served over `https://`, `connect` automatically opens a secure, token-gated
+**`wss://` tunnel** (via Cloudflare) to the agent bridge on your machine and hands
+the pod's panel that URL — so the HTTPS page reaches your local agent with **no
+browser prompt, in any browser** (a secure page can't open a plain `ws://` socket
+to your box). Then open the pod's ComfyUI, open the **Agent Panel**, enable the
+**external-orchestrator** toggle, and click **Connect**. (Add **`--insecure-bridge`**
+to force the plain `ws://127.0.0.1:9180` loopback instead — e.g. when you reach the
+pod via an SSH port-forward.)
 
 If you're on a build that predates the `connect` subcommand, the equivalents are:
 

--- a/docs/cloud-deployment.mdx
+++ b/docs/cloud-deployment.mdx
@@ -103,25 +103,28 @@ local Agent Panel uses, just with ComfyUI on a cloud GPU instead of localhost.
 
 ## What persists (and what doesn't)
 
-The image is optimized for **fast stop/start**. All software — ComfyUI, its venv,
-Manager v2, the Agent Panel — is baked into the immutable image and run from
-`/opt/ComfyUI`. The `/workspace` network volume holds **only your data**, so a warm
-restart does no install/sync/seed and just relaunches ComfyUI.
+The image is optimized for **fast stop/start**. The heavy software — ComfyUI, its
+venv, Manager v2 — is baked into the immutable image and run from `/opt/ComfyUI`,
+while `custom_nodes` lives on the `/workspace` volume (symlinked) so your installs
+persist. A warm restart does no full install/sync/seed and just relaunches ComfyUI.
 
 | What | Where it lives | Survives a restart? |
 |------|----------------|---------------------|
 | Models (incl. Manager downloads) | volume `/workspace/models` | **Yes** |
 | Workflows + ComfyUI settings + Manager config | volume `/workspace/user` | **Yes** |
 | Inputs / outputs | volume `/workspace/input`, `/output` | **Yes** |
-| ComfyUI install + venv + baked custom nodes | image `/opt/ComfyUI` | Re-pulled with the image |
-| **Custom nodes installed at runtime** (agent/Manager) | container ephemeral disk | **No** |
+| **Custom nodes** (agent/Manager installs) | volume `/workspace/custom_nodes` (symlinked) | **Yes** |
+| ComfyUI install + venv + Manager | image `/opt/ComfyUI` | Re-pulled with the image |
 
-<Warning>
-**Custom nodes the agent or Manager installs at runtime do NOT survive a restart**
-— that's the deliberate cost of fast restart. Models *do* persist. To add a custom
-node **permanently**, add it to the `Dockerfile` and rebuild the image (below).
-Within a single pod session, Manager-installed nodes work until the next restart.
-</Warning>
+<Note>
+**Custom nodes installed at runtime survive a restart.** `custom_nodes` is
+symlinked to `/workspace/custom_nodes`; on each boot the image's baked nodes (Agent
+Panel + builtins) are seeded/refreshed into it (so an image upgrade ships a current
+panel while your own nodes are kept), and each node's Python deps are reinstalled
+into the venv from a **persistent pip cache** on the volume — fast after the first
+time. Models persist too. To bake a node so it needs zero boot-time work, add it to
+the `Dockerfile` and rebuild the image (below).
+</Note>
 
 ## Build & deploy your own image
 


### PR DESCRIPTION
Brings the docs current with two recently-shipped changes that had left stale wording:

### Secure `wss://` bridge (0.23.4)
`connect` to a remote **HTTPS** pod now auto-opens a token-gated `wss://` Cloudflare tunnel to the local bridge — no browser prompt / mixed-content block; `--insecure-bridge` forces the plain `ws://127.0.0.1:9180` loopback.
- **README.md** — reworked the remote-connect section (dropped the now-wrong "no tunnel" and "bridge stays on `ws://`" wording).
- **docker/runpod/README.md** — added the wss-tunnel + `--insecure-bridge` note to the connect section.
- `docs/cloud-deployment.mdx` already covered the wss part (Mac's 0.23.4 commit).

### custom_nodes persistence (#111)
`custom_nodes` is symlinked to `/workspace/custom_nodes`, so runtime-installed nodes **survive a restart** (baked nodes seeded/refreshed each boot; deps reinstalled from a persistent pip cache).
- **docker/runpod/README.md** + **docs/cloud-deployment.mdx** — replaced the now-wrong "custom nodes do NOT survive a restart" tables/warnings with the persistence behavior.

Docs-only; no code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)