### PR TITLE
fix(runpod): default image to cu128 (driver >=570); cu130 SageAttention stack becomes opt-in variant

### DIFF
--- a/.github/workflows/build-runpod-image.yml
+++ b/.github/workflows/build-runpod-image.yml
@@ -1,7 +1,7 @@
 name: Build RunPod image
 
 # Builds docker/runpod's image on GitHub-hosted runners with a BuildKit registry
-# cache, so unchanged layers (cu130 torch, ComfyUI, the base OS) are reused
+# cache, so unchanged layers (the pinned torch, ComfyUI, the base OS) are reused
 # across runs instead of a full from-scratch build every time — this is what
 # removes the "needs a local Docker daemon on a manual build machine" step.
 #
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Standard GitHub-hosted runners ship ~20-25 GB free under /, which is
-      # tight even for the lean build (base image + cu130 torch + ComfyUI).
+      # tight even for the lean build (base image + the pinned torch + ComfyUI).
       # Drop preinstalled toolchains this build doesn't use to buy headroom.
       - name: Free up runner disk space
         run: |

--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -110,19 +110,35 @@ ARG COMFYUI_MANAGER_VERSION=4.2.2
 ARG PANEL_REPO=https://github.com/artokun/comfyui-mcp-panel.git
 # Optional panel tag/branch for reproducible images (empty = default branch).
 ARG PANEL_REF=
-# cu128 PyTorch wheels (sm_120 kernels). The fresh venv gets a clean cu128 torch
-# regardless of what the base ships (no cu121 leftovers). See README for the
-# leaner "reuse the base's cu128 torch" alternative.
-# PERF stack (mirrors the proven SECourses "CU13" 5090 setup): CUDA 13 / cu130 +
-# torch 2.9.1 + prebuilt SageAttention + xformers wheels. Launch uses
-# --use-sage-attention + --enable-triton-backend. We KEEP the base's Python 3.12
-# and use the `abi3` (py3.9+) sage/xformers wheels — flash_attn's wheel is cp310
-# only (would force py3.10 via deadsnakes) and is redundant with SageAttention, so
-# it's omitted. All wheels require torch 2.9.1 + cuda13.1 at runtime.
-ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu130
+# Torch pin — DEFAULT = BROAD COMPATIBILITY (cu128). cu128 has sm_120 kernels
+# (Blackwell / RTX 5090) AND runs on host driver >= 570 — the same CUDA 12.8 bar
+# the runpod/pytorch base already advertises via NVIDIA_REQUIRE_CUDA, so any host
+# that can START the container can also RUN torch. The cu130 stack we shipped
+# briefly raised the real bar to driver >= 580 (CUDA 13), which almost no RunPod
+# host meets — pods scheduled fine and then died in the driver preflight (#118).
+# The fresh venv gets a clean pinned torch regardless of what the base ships.
+#
+# No prebuilt SageAttention/xformers in the default build: no linux cu128 wheels
+# exist for this torch line, so WHEEL_SAGE/WHEEL_XFORMERS default EMPTY (the perf-
+# wheel step below skips itself) and post_start.sh detects the absence and
+# launches with --use-pytorch-cross-attention.
+#
+# CU13 PERF VARIANT (the SECourses 5090 recipe: SageAttention + xformers, abi3
+# wheels, fine on the base's py3.12; flash_attn omitted — cp310-only + redundant
+# with Sage). Needs host driver >= 580 — RARE on the fleet; tag it separately
+# (e.g. :cu130), never :latest. Build with:
+#   --build-arg TORCH_INDEX_URL=https://download.pytorch.org/whl/cu130 \
+#   --build-arg WHEEL_SAGE=https://huggingface.co/MonsterMMORPG/Wan_GGUF/resolve/main/sageattention-2.2.0+torch2.9.1.cuda13.1-cp39-abi3-linux_x86_64.whl \
+#   --build-arg WHEEL_XFORMERS=https://huggingface.co/MonsterMMORPG/Wan_GGUF/resolve/main/xformers-0.0.34+41531cee.d20260109-cp39-abi3-linux_x86_64.whl \
+#   --build-arg MIN_DRIVER_DEFAULT=580
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
 ARG TORCH_SPEC="torch==2.9.1 torchvision torchaudio==2.9.1"
-ARG WHEEL_SAGE=https://huggingface.co/MonsterMMORPG/Wan_GGUF/resolve/main/sageattention-2.2.0+torch2.9.1.cuda13.1-cp39-abi3-linux_x86_64.whl
-ARG WHEEL_XFORMERS=https://huggingface.co/MonsterMMORPG/Wan_GGUF/resolve/main/xformers-0.0.34+41531cee.d20260109-cp39-abi3-linux_x86_64.whl
+ARG WHEEL_SAGE=
+ARG WHEEL_XFORMERS=
+# Host-driver floor enforced by post_start.sh's preflight (override at runtime
+# with MIN_DRIVER; 0 disables). 570 == CUDA 12.8 (matches the cu128 default and
+# the base's own container-start gate); the cu130 variant passes 580.
+ARG MIN_DRIVER_DEFAULT=570
 # Fixed IMAGE path for the baked ComfyUI + its venv. RUN FROM HERE — never copied
 # to the volume. Immutable software.
 ARG COMFY_HOME=/opt/ComfyUI
@@ -139,7 +155,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     COMFY_HOME=${COMFY_HOME} \
     SEED_MODELS=${SEED_MODELS} \
     COMFY_NETWORK_MODE=${COMFY_NETWORK_MODE} \
-    COMFY_SECURITY_LEVEL=${COMFY_SECURITY_LEVEL}
+    COMFY_SECURITY_LEVEL=${COMFY_SECURITY_LEVEL} \
+    MIN_DRIVER_DEFAULT=${MIN_DRIVER_DEFAULT}
 
 # -----------------------------------------------------------------------------
 # 0. OS deps the lean base may not ship.
@@ -169,7 +186,7 @@ RUN git clone https://github.com/comfyanonymous/ComfyUI.git "${COMFY_HOME}" \
  && git --no-pager log -1 --format='ComfyUI baked at %h %ci'
 
 # -----------------------------------------------------------------------------
-# 3. Dedicated venv + cu128 torch + ComfyUI requirements + Manager v2.
+# 3. Dedicated venv + pinned torch (default cu128) + ComfyUI requirements + Manager v2.
 #    The venv lives at ${COMFY_HOME}/venv and is invoked by absolute path. It is
 #    NEVER copied to the volume — ComfyUI runs straight from the image, so import
 #    is a fast local read and boot does zero sync.
@@ -180,14 +197,13 @@ ENV VPY=${VENV}/bin/python
 RUN python3 -m venv "${VENV}" \
  && "${VPY}" -m pip install --no-cache-dir --upgrade pip wheel
 
-# cu130 torch 2.9.1 FIRST (pinned) so the requirements resolver below can't pull a
-# different torch and break the SageAttention/xformers wheel ABI. This is the
-# CUDA-13 build the RTX 5090 (Blackwell) wants for optimized ops.
+# Pinned torch FIRST so the requirements resolver below can't pull a different
+# torch (and, on the cu130 perf variant, break the sage/xformers wheel ABI).
 # shellcheck disable=SC2086
 RUN "${VPIP}" install --no-cache-dir \
       ${TORCH_SPEC} --index-url "${TORCH_INDEX_URL}"
 
-# ComfyUI runtime requirements (cu128 index passed as a safety net so nothing
+# ComfyUI runtime requirements (the torch index passed as a safety net so nothing
 # re-resolves torch off PyPI).
 RUN "${VPIP}" install --no-cache-dir --extra-index-url "${TORCH_INDEX_URL}" \
       -r "${COMFY_HOME}/requirements.txt"
@@ -198,14 +214,19 @@ RUN "${VPIP}" install --no-cache-dir "comfyui_manager==${COMFYUI_MANAGER_VERSION
  && rm -rf "${COMFY_HOME}/custom_nodes/ComfyUI-Manager" \
            "${COMFY_HOME}/custom_nodes/comfyui-manager"
 
-# PERF wheels: SageAttention 2.2.0 (used via --use-sage-attention) + xformers,
-# both prebuilt for torch2.9.1+cuda13.1 (abi3 → fine on py3.12). Uninstall any
-# requirements-pulled xformers first (SECourses does the same) so the pinned wheel
-# wins. A failure here must NOT break the image — Sage is a speedup, not required
-# (launch falls back to pytorch attention if the flag can't load).
-RUN "${VPIP}" uninstall -y xformers >/dev/null 2>&1 || true; \
-    "${VPIP}" install --no-cache-dir "${WHEEL_XFORMERS}" "${WHEEL_SAGE}" \
-      || echo "WARN: perf wheels (sage/xformers) failed to install — will run without SageAttention"
+# PERF wheels (cu130 variant only — see the ARG block above): SageAttention
+# (used via --use-sage-attention) + xformers. The DEFAULT build pins neither, so
+# this step is a no-op and post_start launches with PyTorch cross-attention.
+# When set: uninstall any requirements-pulled xformers first (SECourses does the
+# same) so the pinned wheel wins. A failure here must NOT break the image — Sage
+# is a speedup, not required (post_start detects whether it actually imports).
+RUN if [ -n "${WHEEL_SAGE}${WHEEL_XFORMERS}" ]; then \
+      "${VPIP}" uninstall -y xformers >/dev/null 2>&1 || true; \
+      "${VPIP}" install --no-cache-dir ${WHEEL_XFORMERS} ${WHEEL_SAGE} \
+        || echo "WARN: perf wheels (sage/xformers) failed to install — will run without SageAttention"; \
+    else \
+      echo "broad-compat build: no perf wheels pinned — PyTorch cross-attention at launch"; \
+    fi
 
 # -----------------------------------------------------------------------------
 # 4. comfyui-mcp Agent Panel custom node (registry id: comfyui-agent-panel).

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -366,6 +366,7 @@ Create a **Pod template** (or fill these on a one-off GPU pod):
 | **Expose HTTP ports** | **`3000`** (nginx → ComfyUI). Optionally `8081` (code-server), `8001` (app-manager), `8888` (Jupyter). |
 | **Expose TCP ports** | `22` (SSH) |
 | **GPU** | RTX 5090 / any Blackwell or Ada card (cu128 covers both) |
+| **Host driver** | >= 570 (CUDA 12.8) for the default image; >= 580 (CUDA 13) for the `:cu130` perf variant. The entrypoint preflights this (`MIN_DRIVER`) and holds the pod open with a clear message instead of crash-looping. |
 
 **Environment variables** (Pod → Environment):
 

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -70,11 +70,12 @@ OUTPUT_DIR="${WORKSPACE}/output"
 LOG_DIR="${COMFY_LOG_DIR:-/var/log/comfyui-mcp}"
 mkdir -p "${LOG_DIR}"
 
-# Minimum host NVIDIA driver for this image. It ships the CUDA 13 stack (cu130
-# torch 2.9.1), and a Blackwell GPU (RTX 50xx / sm_120) additionally needs a
-# Blackwell-aware driver — CUDA 13.0 requires driver >= ~580. Override for a
-# different image/GPU, or set MIN_DRIVER=0 to disable the check.
-MIN_DRIVER="${MIN_DRIVER:-580}"
+# Minimum host NVIDIA driver. Baked per image variant by the Dockerfile
+# (MIN_DRIVER_DEFAULT env: 570 for the default cu128 build — the same CUDA 12.8
+# bar the runpod/pytorch base's container-start gate already enforces — 580 for
+# the cu130 perf variant, which needs CUDA 13). Override at runtime with
+# MIN_DRIVER, or set MIN_DRIVER=0 to disable the check.
+MIN_DRIVER="${MIN_DRIVER:-${MIN_DRIVER_DEFAULT:-570}}"
 
 # -----------------------------------------------------------------------------
 # 0. GPU DRIVER PREFLIGHT. The host NVIDIA driver is NOT upgradable from inside the
@@ -87,13 +88,13 @@ if [ "${MIN_DRIVER}" != "0" ] && command -v nvidia-smi >/dev/null 2>&1; then
   GPU_NAME="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)"
   DRV="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)"
   DRV_MAJOR="${DRV%%.*}"
-  log "GPU: ${GPU_NAME:-unknown} | driver: ${DRV:-unknown} (this CUDA 13 image needs driver >= ${MIN_DRIVER})"
+  log "GPU: ${GPU_NAME:-unknown} | driver: ${DRV:-unknown} (this image needs driver >= ${MIN_DRIVER})"
   if [ -n "${DRV_MAJOR}" ] && [ "${DRV_MAJOR}" -lt "${MIN_DRIVER}" ] 2>/dev/null; then
     log "============================================================================"
     log "FATAL: host NVIDIA driver ${DRV} is TOO OLD for this image (needs >= ${MIN_DRIVER})."
     log "  Your ${GPU_NAME:-GPU} (esp. RTX 50xx / Blackwell) needs a newer driver, and the"
     log "  HOST driver CANNOT be upgraded from inside a pod — torch would fail to init CUDA."
-    log "  FIX: TERMINATE this pod and REDEPLOY on a host with CUDA >= 13 / driver >= ${MIN_DRIVER}"
+    log "  FIX: TERMINATE this pod and REDEPLOY on a host with driver >= ${MIN_DRIVER}"
     log "       (filter by 'CUDA Version' on the RunPod deploy screen). Verify with: nvidia-smi"
     log "  Holding the pod open (no crash-loop) so you can inspect it. Set MIN_DRIVER=0 to bypass."
     log "============================================================================"
@@ -361,12 +362,21 @@ mkdir -p "${COMFY_HOME}/user"
 # the whole UI ("won't render") even though curl (no Sec-Fetch headers) works.
 # --enable-cors-header swaps that middleware for the CORS one, letting the
 # proxied browser through.
-# PERF: --use-sage-attention (SageAttention 2.2, baked) + --enable-triton-backend
-# (comfy-kitchen Triton, available in the image). The RTX 5090 wants these on cu130.
-# Override via COMFY_EXTRA_ARGS / edit here to fall back to --use-pytorch-cross-attention.
+# PERF: attention backend PROBED, not assumed — the cu130 perf variant bakes
+# SageAttention 2.2 (+ triton backend) but the default cu128 build ships neither
+# (no linux cu128 wheels exist for this torch line). Passing --use-sage-attention
+# without the package would crash ComfyUI at startup, so import-check the venv
+# and pick the matching flags. Override either way via COMFY_EXTRA_ARGS.
+if "${COMFY_HOME}/venv/bin/python" -c "import sageattention" >/dev/null 2>&1; then
+  ATTN_ARGS=(--use-sage-attention --enable-triton-backend)
+  log "SageAttention baked in this image — launching with --use-sage-attention"
+else
+  ATTN_ARGS=(--use-pytorch-cross-attention)
+  log "no SageAttention in this image (cu128 broad-compat build) — using PyTorch cross-attention"
+fi
 ARGS=(--listen 0.0.0.0 --port "${COMFY_PORT}"
       --enable-manager --enable-cors-header
-      --use-sage-attention --enable-triton-backend
+      "${ATTN_ARGS[@]}"
       --user-directory  "${USER_DIR}"
       --input-directory "${INPUT_DIR}"
       --output-directory "${OUTPUT_DIR}")


### PR DESCRIPTION
Fixes #118 — the Agent Panel RunPod template is currently effectively undeployable: the cu130 torch + cuda13.1 sage/xformers pins hard-require host driver >=580 (CUDA 13), which almost no fleet host meets, while all docs and the base image's scheduler-visible gate say cu128. Pods scheduled onto 570-driver hosts and died in the driver preflight.

## Changes
- **Dockerfile**: `TORCH_INDEX_URL` defaults back to **cu128** (Blackwell sm_120 fully covered; runs on driver >=570 — the same bar as the base's `NVIDIA_REQUIRE_CUDA`, so scheduler placement and runtime reality agree). `WHEEL_SAGE`/`WHEEL_XFORMERS` default empty (no linux cu128 wheels exist for this torch line) and the perf-wheel step self-skips. New `MIN_DRIVER_DEFAULT` ARG→ENV bakes the per-variant driver floor (570 default / 580 for cu130). The CU13 perf stack remains available as documented build-args (tag `:cu130`, never `:latest`).
- **post_start.sh**: preflight floor now comes from `MIN_DRIVER_DEFAULT`; launch **import-probes sageattention** and picks `--use-sage-attention` vs `--use-pytorch-cross-attention` — hardcoded sage flags would crash the cu128 build.
- **README**: CUDA-variants section, host-driver requirement row, cu130 build recipe.
- **workflow**: comment accuracy (the lean CI tag `cu128-lean` is now truthful again).

## Deploy plan
After merge: local full build (donor extras + spotcheck) → push `artokun/comfyui-mcp-runpod:1.5` + `:latest` → template `bnqtkvcer3` picks it up automatically (it references `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)