### PR TITLE
release: v0.25.0 — OpenRouter provider + panel key settings + COMFYUI_PATH auto-detect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.24.5",
+  "version": "0.25.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI Ã¢â‚¬â€ MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/plugin/skills/ideogram-ultra/SKILL.md
+++ b/plugin/skills/ideogram-ultra/SKILL.md
@@ -153,6 +153,22 @@ Generation uses the modular sampler stack, not `KSampler`:
 
 A KJNodes node that outputs the structured caption JSON string (see "Prompt Style" below). On the canvas you draw bounding boxes for objects/text, set descriptions, a color palette, and background/style. Its string output feeds `CLIPTextEncode`. Source widget values include `width 1920`, `height 1080`, a high-level prompt, a background description, a `color_palette` array, and an `elements` array.
 
+#### ⚠️ Editing this node programmatically (panel_set_widget WILL NOT STICK)
+
+**This is the single most important thing to know about this node.** Its `elements_data` / `style_palette_data` widgets are **NOT the source of truth** — they are serialized *from* a live in-browser array (`node._boxes`) inside the KJNodes editor JS. Two mechanisms defeat any external widget edit:
+
+- **Queue-time re-serialization.** In `web/js/ideogram4_prompt_builder.js`, `elementsWidget.serializeValue()` regenerates the value from `node._boxes` *every time the graph is queued*. So `panel_set_widget(14, "elements_data", ...)` sets the value, but ComfyUI overwrites it with the stale editor boxes the instant you run. **The edit silently reverts on every run.**
+- **You can't reach `node._boxes`.** It lives in the browser tab; no panel/MCP tool can touch it. Editing `elements_data`, `ideo_editor`, or forcing `import_mode` alone does nothing durable. `node._boxes` is only ever re-seeded from `elements_data` on workflow *load* (`onConfigure`), and even then the saved `o.ideo.boxes` blob wins over the widget — so a stale saved workflow reloads stale.
+
+**The symptom:** you edit the JSON, the panel confirms the new value, but the render (and the visible builder JSON) still shows the OLD prompt — e.g. old subject/region text that "won't go away."
+
+**The correct, node-designed fix — drive it via `import_json`:**
+1. Add a `PrimitiveStringMultiline` node containing the FULL caption JSON (the `high_level_description` + `style_description` + `compositional_deconstruction` shape from "Prompt Style" below).
+2. Wire it into node 14's **`import_json`** input.
+3. Set **`import_mode = "always"`**.
+
+The Python `execute()` then does `used_import = imported is not None and (import_mode == "always" or not boxes)` → the caption is built **entirely** from `import_json`; the poisoned `elements_data`/`node._boxes` are ignored. Bonus: running once in this mode pushes the caption back into the editor via `ui`, which re-seeds `node._boxes` and flushes the stale boxes for good. From then on, edit the prompt in the wired string node, **not** the builder's visual editor. (`import_mode = "when empty"` only seeds the editor when it has no regions, then the editor wins again — so for programmatic control it MUST be `"always"`.)
+
 ### ImageSharpenKJ (post-process)
 
 The source applies a light RCAS sharpen after decode: `sharpen_mode = rcas`, `strength = 0.55`.
@@ -327,6 +343,7 @@ Optional upstream: Ideogram4PromptBuilderKJ  OR  TextGenerate(gemma4) ─► CLI
 
 ## Troubleshooting
 
+- **Prompt edits to `Ideogram4PromptBuilderKJ` won't stick / stale prompt keeps coming back** — `elements_data` is re-serialized from the browser editor's `node._boxes` at queue time, so `panel_set_widget` reverts on every run and you can't reach `node._boxes` externally. Fix: wire a `PrimitiveStringMultiline` (full caption JSON) into the node's `import_json` input and set `import_mode = "always"`. See "Editing this node programmatically" under Key Nodes. This is the ONLY reliable way to drive the prompt from outside the browser.
 - **"NOT A VALID IDEOGRAM 4 CAPTION JSON"** — JSON is malformed. Use double quotes, no trailing commas, exact key `compositional_deconstruction`, matched brackets. Validate in any JSON linter.
 - **Garbled / overlapping text in the image** — text bboxes overlap or text is too long. Increase spacing, shorten text, remove boxes.
 - **Style drift (anime when you wanted photo, etc.)** — add explicit style-lock language in the element/style description.

--- a/src/__tests__/services/model-resolver-roots.test.ts
+++ b/src/__tests__/services/model-resolver-roots.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { resolve } from "node:path";
 
-// Control config (comfyuiPath) per test.
+// Control config (comfyuiPath) per test. isRemoteMode is a controllable mock:
+// resolveComfyUIBase() consults it only when comfyuiPath is unset, to decide
+// whether a local default-workspace fallback is allowed (never in remote mode).
 vi.mock("../../config.js", () => ({
   config: {
     comfyuiPath: "/comfy" as string | undefined,
     huggingfaceToken: undefined as string | undefined,
     civitaiApiToken: undefined as string | undefined,
   },
+  isRemoteMode: vi.fn(() => false),
+}));
+
+// Saved default workspace (set via set_default_workspace) — the local fallback
+// resolveComfyUIBase() uses when COMFYUI_PATH is unset and we're not remote.
+const getSavedDefaultWorkspaceSyncMock = vi.fn<() => string | undefined>();
+vi.mock("../../services/workspace-env.js", () => ({
+  getSavedDefaultWorkspaceSync: () => getSavedDefaultWorkspaceSyncMock(),
 }));
 
 // node:fs/promises is mocked so stat answers per-path from a fixture map.
@@ -30,7 +40,7 @@ vi.mock("../../services/extra-paths.js", () => ({
   getExtraModelRoots: (...a: unknown[]) => getExtraModelRootsMock(...a),
 }));
 
-import { config } from "../../config.js";
+import { config, isRemoteMode } from "../../config.js";
 import { resolveExistingModelFile } from "../../services/model-resolver.js";
 import { ModelError, ValidationError } from "../../utils/errors.js";
 
@@ -54,6 +64,9 @@ beforeEach(() => {
   getExtraModelRootsMock.mockReset();
   getExtraModelRootsMock.mockResolvedValue([]);
   config.comfyuiPath = "/comfy";
+  vi.mocked(isRemoteMode).mockReturnValue(false);
+  getSavedDefaultWorkspaceSyncMock.mockReset();
+  getSavedDefaultWorkspaceSyncMock.mockReturnValue(undefined);
 });
 
 describe("resolveExistingModelFile — multi-root resolution", () => {
@@ -128,9 +141,34 @@ describe("resolveExistingModelFile — multi-root resolution", () => {
 
   it("errors clearly when COMFYUI_PATH is unset (remote mode)", async () => {
     config.comfyuiPath = undefined;
+    vi.mocked(isRemoteMode).mockReturnValue(true);
+    // Remote mode never falls back to a local workspace, even if one is saved.
+    getSavedDefaultWorkspaceSyncMock.mockReturnValue("/saved-ws");
     await expect(
       resolveExistingModelFile("loras/x.safetensors"),
     ).rejects.toThrow(/COMFYUI_PATH/);
+  });
+
+  it("falls back to the saved default workspace when COMFYUI_PATH is unset (local mode)", async () => {
+    config.comfyuiPath = undefined;
+    vi.mocked(isRemoteMode).mockReturnValue(false);
+    getSavedDefaultWorkspaceSyncMock.mockReturnValue("/saved-ws");
+    const savedRoot = resolve("/saved-ws", "models");
+    fsFixture([resolve(savedRoot, "loras/x.safetensors")]);
+
+    const res = await resolveExistingModelFile("loras/x.safetensors");
+
+    expect(res.path).toBe(resolve(savedRoot, "loras/x.safetensors"));
+    expect(res.root).toBe(savedRoot);
+  });
+
+  it("errors with set_default_workspace hint when unset and no saved workspace (local mode)", async () => {
+    config.comfyuiPath = undefined;
+    vi.mocked(isRemoteMode).mockReturnValue(false);
+    getSavedDefaultWorkspaceSyncMock.mockReturnValue(undefined);
+    await expect(
+      resolveExistingModelFile("loras/x.safetensors"),
+    ).rejects.toThrow(/set_default_workspace/);
   });
 
   it("returns a directory match so callers can report 'not a file'", async () => {

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getNsfwConsent, setNsfwConsent } from "../../services/panel-settings.js";
+import {
+  getAgentSettings,
+  getNsfwConsent,
+  setAgentSettings,
+  setNsfwConsent,
+} from "../../services/panel-settings.js";
 
 let dir: string;
 let settingsPath: string;
@@ -50,5 +55,45 @@ describe("panel-settings nsfw consent", () => {
     const after = JSON.parse(readFileSync(settingsPath, "utf-8"));
     expect(after.someOtherSetting).toBe(42);
     expect(after.nsfwConsent.allowed).toBe(false);
+  });
+});
+
+describe("panel-settings agent model preferences", () => {
+  it("defaults to {} when never set", () => {
+    expect(getAgentSettings()).toEqual({});
+  });
+
+  it("persists preferred models, deduped and trimmed", () => {
+    setAgentSettings({ preferredModels: [" gemma4:12b ", "xiaomi/mimo-v2.5", "gemma4:12b", ""] });
+    expect(getAgentSettings().preferredModels).toEqual(["gemma4:12b", "xiaomi/mimo-v2.5"]);
+  });
+
+  it("replaces the whole preferred list on update", () => {
+    setAgentSettings({ preferredModels: ["a:1", "b:2"] });
+    setAgentSettings({ preferredModels: ["c:3"] });
+    expect(getAgentSettings().preferredModels).toEqual(["c:3"]);
+  });
+
+  it("merges ollama config per-key", () => {
+    setAgentSettings({ ollama: { api: "openai", baseUrl: "https://openrouter.ai/api/v1" } });
+    setAgentSettings({ ollama: { model: "xiaomi/mimo-v2.5" } });
+    expect(getAgentSettings().ollama).toEqual({
+      api: "openai",
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "xiaomi/mimo-v2.5",
+    });
+  });
+
+  it("leaves ollama config untouched when only preferred models change", () => {
+    setAgentSettings({ ollama: { model: "gemma4:e4b" } });
+    setAgentSettings({ preferredModels: ["x/y"] });
+    expect(getAgentSettings().ollama).toEqual({ model: "gemma4:e4b" });
+  });
+
+  it("coexists with nsfw consent in the same file", () => {
+    setNsfwConsent(true);
+    setAgentSettings({ preferredModels: ["m:1"] });
+    expect(getNsfwConsent().allowed).toBe(true);
+    expect(getAgentSettings().preferredModels).toEqual(["m:1"]);
   });
 });

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -9,7 +9,7 @@
 
 import type { ImageRef } from "./panel-agent.js";
 
-export type BackendId = "claude" | "codex" | "gemini" | "ollama";
+export type BackendId = "claude" | "codex" | "gemini" | "ollama" | "openrouter";
 
 /**
  * A user turn in PROVIDER-NEUTRAL form. PanelAgent owns the queue/turn-gate and

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -102,6 +102,13 @@ export function backendReadiness(backend: string, opts?: { home?: string }): Bac
     const cli = ollamaInstalled(home);
     return { backend: "ollama", cli, auth: cli ? true : null, ready: cli };
   }
+  if (b === "openrouter") {
+    // Hosted — no CLI. Readiness = an OpenRouter API key in the orchestrator's
+    // env (OPENROUTER_API_KEY, or the shared COMFYUI_MCP_OLLAMA_API_KEY). A bad
+    // key still surfaces via the connect ack's model probe (degraded).
+    const key = !!(process.env.OPENROUTER_API_KEY || process.env.COMFYUI_MCP_OLLAMA_API_KEY);
+    return { backend: "openrouter", cli: key, auth: key ? true : false, ready: key };
+  }
   return { backend: b, cli: false, auth: false, ready: false };
 }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -38,6 +38,9 @@ import {
   buildComfyuiMcpEnv,
   comfyuiSecretKeys,
   onComfyuiSecretsChanged,
+  hydrateAgentSecretsIntoEnv,
+  onAgentSecretsChanged,
+  setAgentSecret,
 } from "../services/panel-secrets.js";
 import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
@@ -47,6 +50,7 @@ import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-ht
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
+import { getAgentSettings, setAgentSettings } from "../services/panel-settings.js";
 import {
   gatherEnvCapabilities,
   buildPanelSystemAppend,
@@ -691,19 +695,56 @@ export async function runPanelOrchestrator(): Promise<void> {
   // applied PER REQUEST — switching live is free. Default = the LLM Arena's best
   // performer (scripts/llm-arena.mjs): gemma4:e4b, 9/10 with the cleanest runs
   // (first-try tool dispatch, no nudges) and multimodal headroom for vision.
-  const ollamaModel = process.env.COMFYUI_MCP_OLLAMA_MODEL ?? "gemma4:e4b";
+  //
+  // Config precedence: env (escape hatch, always wins) → persisted user settings
+  // (~/.comfyui-mcp/panel-settings.json, edited from the panel Settings dialog
+  // via set_config) → built-in default. Mutable (`let`) because set_config can
+  // retarget them live; API keys stay env-only and never touch the settings file.
+  // Copy any panel-stored provider keys (OPENROUTER_API_KEY) into env BEFORE we
+  // read them below, so a key set on a prior run enables its provider on boot.
+  const hydratedSecrets = hydrateAgentSecretsIntoEnv();
+  if (hydratedSecrets.length) {
+    logger.info(`[panel-orchestrator] hydrated agent secrets from store: ${hydratedSecrets.join(", ")}`);
+  }
+  const persistedAgent = getAgentSettings();
+  let ollamaModel =
+    process.env.COMFYUI_MCP_OLLAMA_MODEL ?? persistedAgent.ollama?.model ?? "gemma4:e4b";
   // The same backend also speaks any OpenAI-compatible endpoint (OpenRouter,
   // DeepSeek, vLLM, LM Studio): COMFYUI_MCP_OLLAMA_API=openai +
   // COMFYUI_MCP_OLLAMA_BASE_URL (incl. /v1) + COMFYUI_MCP_OLLAMA_API_KEY
   // (falls back to OPENROUTER_API_KEY). The chip stays "Ollama (local)".
-  const ollamaApi = process.env.COMFYUI_MCP_OLLAMA_API === "openai" ? ("openai" as const) : ("ollama" as const);
-  const ollamaBaseUrl = process.env.COMFYUI_MCP_OLLAMA_BASE_URL;
+  let ollamaApi: "openai" | "ollama" =
+    (process.env.COMFYUI_MCP_OLLAMA_API
+      ? process.env.COMFYUI_MCP_OLLAMA_API === "openai"
+      : persistedAgent.ollama?.api === "openai")
+      ? "openai"
+      : "ollama";
+  let ollamaBaseUrl = process.env.COMFYUI_MCP_OLLAMA_BASE_URL ?? persistedAgent.ollama?.baseUrl;
   const ollamaApiKey = process.env.COMFYUI_MCP_OLLAMA_API_KEY || process.env.OPENROUTER_API_KEY;
   const ollamaDeps = () => ({
     api: ollamaApi,
     ...(ollamaBaseUrl ? { host: ollamaBaseUrl } : {}),
     ...(ollamaApi === "openai" && ollamaApiKey ? { apiKey: ollamaApiKey } : {}),
   });
+  // OpenRouter is a first-class provider = the Ollama backend hard-wired to
+  // OpenRouter's OpenAI-compatible endpoint, so its picker leads with the
+  // curated arena-winning models (RECOMMENDED_OPENROUTER_MODELS, MiMo/MiniMax
+  // tagged 1M · SOTA). Key comes from OPENROUTER_API_KEY (or the shared ollama
+  // key). Default model = the arena's top open-weight, MiMo v2.5.
+  const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+  let openrouterModel = process.env.COMFYUI_MCP_OPENROUTER_MODEL ?? "xiaomi/mimo-v2.5";
+  // Read the key FRESH each call (not a startup const) so a key the user sets
+  // later via the panel — setAgentSecret hydrates it into env — takes effect on
+  // the next backend build without an orchestrator restart.
+  const openrouterApiKey = () => process.env.OPENROUTER_API_KEY || process.env.COMFYUI_MCP_OLLAMA_API_KEY;
+  const openrouterDeps = () => {
+    const key = openrouterApiKey();
+    return {
+      api: "openai" as const,
+      host: OPENROUTER_BASE_URL,
+      ...(key ? { apiKey: key } : {}),
+    };
+  };
   // ── Per-tab backend (single-port multi-provider) ──────────────────────────
   // ONE orchestrator on ONE bridge port serves ALL providers; the panel picks a
   // provider per tab via the `hello`/`set_backend` handshake, instead of the node
@@ -713,7 +754,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // provider (the panel replays the transcript to seed it) while a same-provider
   // reconnect RESUMES. `backendId`/`codexModel`/`geminiModel` above are the
   // DEFAULT + per-provider model config; the process is no longer pinned to one.
-  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "ollama"]);
+  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "ollama", "openrouter"]);
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
@@ -871,6 +912,16 @@ export async function runPanelOrchestrator(): Promise<void> {
         ...ollamaDeps(),
       });
     }
+    if (backend === "openrouter") {
+      return new OllamaBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: openrouterModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+        ...openrouterDeps(),
+      });
+    }
     return undefined; // claude → built-in ClaudeBackend
   };
   logger.info(
@@ -892,7 +943,9 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? new CodexBackend({ cwd: comfyuiPath ?? process.cwd(), model: codexModel })
           : backend === "ollama"
             ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: ollamaModel, ...ollamaDeps() })
-            : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
+            : backend === "openrouter"
+              ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: openrouterModel, ...openrouterDeps() })
+              : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
       probeBackends.set(backend, pb);
     }
     return pb;
@@ -1052,6 +1105,24 @@ export async function runPanelOrchestrator(): Promise<void> {
     );
   });
 
+  // An agent-provider secret changed (e.g. the OpenRouter API key set from the
+  // panel). Hydrate it into env, drop the cached openrouter probe/model list so
+  // the next probe uses the new key, and re-push readiness + models to every
+  // live tab so the OpenRouter provider flips to "ready" and lists its models
+  // without a reconnect.
+  const unsubscribeAgentSecrets = onAgentSecretsChanged(() => {
+    hydrateAgentSecretsIntoEnv();
+    modelsByBackend.delete("openrouter");
+    const pb = probeBackends.get("openrouter");
+    if (pb?.close) void pb.close().catch(() => {});
+    probeBackends.delete("openrouter");
+    for (const tabId of tabBackends.keys()) {
+      pushReadiness(tabId);
+      pushModels(tabId);
+    }
+    logger.info("[panel-orchestrator] OpenRouter key saved → provider readiness + models refreshed");
+  });
+
   // Debounce the connect ack: the panel re-sends `hello` on reconnect and on
   // workflow-title changes, which would otherwise stack duplicate greetings.
   const lastAckAt = new Map<string, number>();
@@ -1093,7 +1164,26 @@ export async function runPanelOrchestrator(): Promise<void> {
             })
         : fetchSupportedModels(model);
       p = probe.then((list) => {
-        if (!list.length) modelsByBackend.delete(backend); // don't cache a failure
+        if (!list.length) modelsByBackend.delete(backend); // don't cache a failed probe
+        // User-curated preferred models (panel Settings → set_config) pin to the
+        // top of the ollama picker, ahead of the discovered catalog. Read fresh
+        // on every probe; set_config evicts the cache so edits apply live.
+        if (backend === "ollama") {
+          const preferred = getAgentSettings().preferredModels ?? [];
+          if (preferred.length) {
+            const discovered = new Map(list.map((m) => [m.value, m] as const));
+            list = [
+              ...preferred.map(
+                (id) =>
+                  (discovered.get(id) ?? {
+                    value: id,
+                    displayName: `${id} ★`,
+                  }) as unknown as ModelInfo,
+              ),
+              ...list.filter((m) => !preferred.includes(m.value as string)),
+            ];
+          }
+        }
         return list;
       });
       modelsByBackend.set(backend, p);
@@ -1107,6 +1197,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "codex") return codexModel;
     if (backend === "gemini") return geminiModel;
     if (backend === "ollama") return ollamaModel;
+    if (backend === "openrouter") return openrouterModel;
     return model;
   }
   function pushModels(panelTabId: string): void {
@@ -1229,9 +1320,28 @@ export async function runPanelOrchestrator(): Promise<void> {
       const isCx = backend === "codex";
       const isGm = backend === "gemini";
       const isOl = backend === "ollama";
+      const isOr = backend === "openrouter";
       // TRUTHFUL "connected": only claim ready after PROVING the SELECTED backend
       // can run, by probing its model list. If the probe fails — the "connected
       // but dead" wedge — send a degraded ack so the panel shows the real state.
+      // OpenRouter needs an explicit key check FIRST: its /models endpoint is
+      // PUBLIC, so the probe "succeeds" keyless and the tab would greet ready —
+      // then 401 on the first real message. Degrade up front instead.
+      if (isOr && !openrouterApiKey()) {
+        bridge.push(
+          {
+            type: "say",
+            text:
+              "⚠️ OpenRouter has no API key — the connection would fail on your first message. " +
+              "Set it in Settings → OpenRouter → “Set API key…” (masked, stored by the orchestrator — takes effect immediately, no reconnect needed), " +
+              "or set the OPENROUTER_API_KEY environment variable and restart the orchestrator. Keys: https://openrouter.ai/keys",
+          },
+          panelTab,
+        );
+        bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
+        logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (openrouter) but no API key — degraded ack`);
+        return;
+      }
       void ensureModels(backend)
         .then((models) => {
           if (models.length) {
@@ -1241,7 +1351,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
                 : isOl
                   ? (ollamaModel ?? (models[0] as { value?: string }).value ?? "Ollama")
-                  : model;
+                  : isOr
+                    ? (openrouterModel ?? (models[0] as { value?: string }).value ?? "OpenRouter")
+                    : model;
             // Greet only on a FRESH session (a resume/reconnect already has the thread).
             if (!resume) {
               const readyText = isCx
@@ -1250,7 +1362,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                   ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
                   : isOl
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
-                    : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
+                    : isOr
+                      ? `🟢 comfyui-mcp agent ready — ${agentLabel} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`
+                      : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
               bridge.push({ type: "say", text: readyText }, panelTab);
             }
             bridge.push({ type: "ack", ok: true, kind: "ready", agent: agentLabel, backend }, panelTab);
@@ -1297,9 +1411,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       logger.info(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} switched backend ${prev} → ${reqBackend}`);
       return;
     }
-    // Live panel config (currently just the render-stall threshold). Applied
-    // immediately, no reconnect — the next turn's watchdog check uses the new
-    // value. Sent by the panel on connect and whenever the setting changes.
+    // Live panel config: render-stall threshold, plus the user's agent-model
+    // preferences (preferred_models list + ollama endpoint config), persisted to
+    // ~/.comfyui-mcp/panel-settings.json. Sent by the panel on connect and
+    // whenever a setting changes. Model-list changes apply live (cache evicted,
+    // fresh `models` frame pushed); an endpoint change retargets NEW sessions —
+    // live ollama sessions keep their connection until restarted.
     if (event.type === "set_config" && event.tab_id) {
       if ("stall_seconds" in event) {
         setLiveStallSeconds((event as { stall_seconds?: unknown }).stall_seconds);
@@ -1307,7 +1424,75 @@ export async function runPanelOrchestrator(): Promise<void> {
           `[panel-orchestrator] live stall threshold → ${liveStallSeconds ?? "default"}s`,
         );
       }
+      const cfg = event as { preferred_models?: unknown; ollama?: unknown };
+      let ollamaChanged = false;
+      if (Array.isArray(cfg.preferred_models)) {
+        const ids = cfg.preferred_models.filter((m): m is string => typeof m === "string");
+        setAgentSettings({ preferredModels: ids });
+        ollamaChanged = true;
+        logger.info(`[panel-orchestrator] preferred models → [${ids.join(", ")}]`);
+      }
+      if (cfg.ollama && typeof cfg.ollama === "object") {
+        const o = cfg.ollama as { model?: unknown; api?: unknown; base_url?: unknown };
+        const patch: { model?: string; api?: "ollama" | "openai"; baseUrl?: string } = {};
+        if (typeof o.model === "string" && o.model.trim()) {
+          patch.model = o.model.trim();
+          if (!process.env.COMFYUI_MCP_OLLAMA_MODEL) ollamaModel = patch.model;
+        }
+        if (o.api === "openai" || o.api === "ollama") {
+          patch.api = o.api;
+          if (!process.env.COMFYUI_MCP_OLLAMA_API) ollamaApi = o.api;
+        }
+        if (typeof o.base_url === "string") {
+          patch.baseUrl = o.base_url.trim();
+          if (!process.env.COMFYUI_MCP_OLLAMA_BASE_URL) ollamaBaseUrl = patch.baseUrl || undefined;
+        }
+        if (Object.keys(patch).length) {
+          setAgentSettings({ ollama: patch });
+          ollamaChanged = true;
+          // Endpoint may have moved — drop the cached probe backend so the next
+          // readiness/model probe hits the NEW host/api with fresh deps.
+          const pb = probeBackends.get("ollama");
+          if (pb?.close) void pb.close().catch(() => {});
+          probeBackends.delete("ollama");
+          logger.info(
+            `[panel-orchestrator] ollama config → model=${ollamaModel} api=${ollamaApi} host=${ollamaBaseUrl ?? "(default)"}`,
+          );
+        }
+      }
+      if (ollamaChanged) {
+        modelsByBackend.delete("ollama");
+        pushModels(event.tab_id);
+      }
       bridge.push({ type: "ack", ok: true, kind: "config" }, event.tab_id);
+      return;
+    }
+
+    // Panel-initiated provider secret (Settings › "Set API key…") — NO agent, no
+    // chat: the panel paints its own masked input and ships the value here
+    // directly, over the same loopback/token-gated bridge the agent-initiated
+    // request_secret reply already rides. setAgentSecret enforces the allowlist
+    // (OPENROUTER_API_KEY), persists 0600, and hydrates process.env immediately,
+    // so the refreshed readiness frame flips the provider picker live — a user
+    // can enable OpenRouter before ANY backend is ready (no chicken-and-egg).
+    if (event.type === "set_secret" && event.tab_id) {
+      const rawKey = (event as { key?: unknown }).key;
+      const rawValue = (event as { value?: unknown }).value;
+      const key = typeof rawKey === "string" ? rawKey : "";
+      const value = typeof rawValue === "string" ? rawValue : "";
+      let error: string | undefined;
+      try {
+        if (!value.trim()) throw new Error("No token entered — nothing was saved.");
+        setAgentSecret(key, value.trim());
+        logger.info(`[panel-orchestrator] provider secret set from panel Settings: ${key} (redacted)`);
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+      bridge.push(
+        { type: "secret_saved", key, ok: !error, ...(error ? { error } : {}) },
+        event.tab_id,
+      );
+      if (!error) pushReadiness(event.tab_id);
       return;
     }
 
@@ -1614,6 +1799,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     clearInterval(downloadTimer);
     QueueMonitor.stop();
     unsubscribeSecrets();
+    unsubscribeAgentSecrets();
     await manager.stopAll();
     // Dispose the readiness-probe backends (kills each Codex/Gemini CLI child).
     for (const pb of probeBackends.values()) {

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -13,6 +13,8 @@
 //   panel_list_tools / panel_describe_tool / panel_call_tool — synthesized
 //     here over the orchestrator's loopback panel HTTP MCP (live-graph tools)
 import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { logger } from "../utils/logger.js";
 import type {
   AgentBackend,
@@ -130,6 +132,27 @@ const OLLAMA_SYSTEM_PROMPT = [
   "- To see or show any generated image/video, run the panel_show_media tool via panel_call_tool.",
   "- Workflows with API nodes cost the user PAID credits; local-GPU workflows are free. Ask before anything that might spend credits.",
 ].join("\n");
+
+/**
+ * Curated OpenRouter models that top the comfyui-mcp LLM Arena on the full tool
+ * surface — surfaced at the TOP of the openai-mode picker so users don't have
+ * to dig them out of OpenRouter's 300+ catalog. ToS-open where noted (these are
+ * also the fine-tune teachers). The label carries context-window and tier hints
+ * the picker shows verbatim; `context1m` marks the 1M-context models that get
+ * the full tool surface + SOTA prompt with room to spare.
+ */
+export interface RecommendedModel {
+  id: string;
+  label: string;
+  context1m?: boolean;
+}
+export const RECOMMENDED_OPENROUTER_MODELS: readonly RecommendedModel[] = [
+  { id: "xiaomi/mimo-v2.5", label: "MiMo v2.5 (1M · SOTA · open)", context1m: true },
+  { id: "minimax/minimax-m3", label: "MiniMax M3 (1M · SOTA · open)", context1m: true },
+  { id: "moonshotai/kimi-k2.5", label: "Kimi K2.5 (SOTA · open)" },
+  { id: "z-ai/glm-5.1", label: "GLM 5.1 (SOTA · open)" },
+  { id: "deepseek/deepseek-v3.2", label: "DeepSeek v3.2 (open)" },
+];
 
 function msgOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -663,6 +686,10 @@ export class OllamaBackend implements AgentBackend {
         }
 
         if (!toolCalls.length) {
+          // Record the final answer in history too — without this, the NEXT
+          // turn's context is missing the model's own previous replies (and
+          // the transcript dump ends mid-conversation on a tool message).
+          this.history.push({ role: "assistant", content });
           yield { type: "assistant", text: content, id: streamId ?? undefined, usage };
           yield { type: "result", ok: true, usage };
           resultEmitted = true;
@@ -709,6 +736,27 @@ export class OllamaBackend implements AgentBackend {
       }
     } finally {
       if (this.turnAbort === abort) this.turnAbort = null;
+      this.dumpTranscript();
+    }
+  }
+
+  /**
+   * Fine-tune datagen hook: when COMFYUI_MCP_TRANSCRIPT_DIR is set, snapshot
+   * the session's OpenAI-shaped message history after every turn (overwrite —
+   * the last write holds the whole conversation). Off in normal operation;
+   * consumed by scripts/panel-arena.mjs to harvest training trajectories.
+   */
+  private dumpTranscript(): void {
+    const dir = process.env.COMFYUI_MCP_TRANSCRIPT_DIR;
+    if (!dir) return;
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, `${this.sessionId ?? "session"}.json`),
+        JSON.stringify({ model: this.model, messages: this.history }, null, 2),
+      );
+    } catch (err) {
+      logger.warn(`[ollama-backend] transcript dump failed: ${msgOf(err)}`);
     }
   }
 
@@ -731,10 +779,17 @@ export class OllamaBackend implements AgentBackend {
         if (!res.ok) return [{ id: this.model, label: this.model }];
         const data = (await res.json()) as { data?: Array<{ id?: string }> };
         const ids = (data.data ?? []).map((m) => m.id).filter((n): n is string => !!n);
-        // Hosted catalogs can be huge (OpenRouter: 300+). Surface the configured
-        // model first, then a bounded slice — the panel picker isn't a browser.
-        const rest = ids.filter((id) => id !== this.model).slice(0, 40);
-        return [this.model, ...rest].map((id) => ({ id, label: id }));
+        const available = new Set(ids);
+        // Curated arena winners first (only those the endpoint actually serves),
+        // with their context/tier labels; then the configured model; then a
+        // bounded slice of the rest — OpenRouter's 300+ catalog isn't a browser.
+        const recommended = RECOMMENDED_OPENROUTER_MODELS.filter((m) => available.has(m.id));
+        const recIds = new Set(recommended.map((m) => m.id));
+        const rest = ids.filter((id) => id !== this.model && !recIds.has(id)).slice(0, 40);
+        const out: ModelChoice[] = recommended.map((m) => ({ id: m.id, label: m.label }));
+        if (!recIds.has(this.model)) out.push({ id: this.model, label: this.model });
+        for (const id of rest) out.push({ id, label: id });
+        return out;
       }
       const res = await fetch(`${this.host}/api/tags`, { signal: AbortSignal.timeout(5000) });
       if (!res.ok) return [];

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -38,7 +38,7 @@ import {
   removeUserMcpServer,
   setUserMcpServerSecret,
 } from "../services/user-mcp-config.js";
-import { setComfyuiSecret } from "../services/panel-secrets.js";
+import { setComfyuiSecret, setAgentSecret, isAllowedAgentSecretKey } from "../services/panel-secrets.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
@@ -797,7 +797,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       {
         label: z.string().describe("Prompt shown above the masked input, e.g. 'Paste your CivitAI API token'."),
         target_kind: z.enum(["header", "env"]).describe("'header' for http/sse servers (e.g. Authorization); 'env' for stdio servers and the built-in comfyui server."),
-        mcp_server: z.string().describe("MCP server to attach the secret to: 'comfyui' for the built-in tools (download_civitai_model etc.), or a user-added server name like 'civitai'."),
+        mcp_server: z.string().describe("MCP server to attach the secret to: 'comfyui' for the built-in tools (download_civitai_model etc.), 'orchestrator' for orchestrator-level provider keys (OPENROUTER_API_KEY), or a user-added server name like 'civitai'."),
         key: z.string().describe("For 'comfyui': one of CIVITAI_API_TOKEN, HUGGINGFACE_TOKEN, HF_TOKEN (others rejected). For a user-added server: env var name or header name (e.g. 'Authorization')."),
         value_prefix: z.string().optional().describe("Optional string prepended to the token, e.g. 'Bearer '. Usually empty for env vars."),
         hint: z.string().optional().describe("Optional reassurance/help text shown under the input."),
@@ -812,6 +812,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             return ok("No token entered — nothing was saved.");
           }
           const server = (args.mcp_server as string) ?? "";
+          // An ORCHESTRATOR provider secret (OpenRouter API key) — stored in the
+          // agent-secret slice of the 0600 config and hydrated into the
+          // orchestrator's OWN env, which flips the OpenRouter provider to ready
+          // and lists its models. NOT injected into the comfyui child.
+          if (server.toLowerCase() === "orchestrator" || isAllowedAgentSecretKey(args.key as string)) {
+            setAgentSecret(args.key as string, secret);
+            return ok(
+              `🔒 ${args.key} saved to your ~/.comfyui-mcp config. The OpenRouter provider is now enabled — pick it in the provider list.`,
+            );
+          }
           // The BUILT-IN comfyui server is NOT in the user's ~/.claude.json — the
           // orchestrator spawns it with its own env. Route its secrets to the
           // dedicated store, which injects them into that env and RESPAWNS the

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -5,6 +5,7 @@ import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
+import { getSavedDefaultWorkspaceSync } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -113,11 +114,30 @@ export interface LocalModel {
   type: string;
 }
 
+/**
+ * Resolve the local ComfyUI base directory for filesystem operations. Prefers
+ * COMFYUI_PATH / auto-detection (config.comfyuiPath); when that's unset and we're
+ * NOT targeting a remote ComfyUI, falls back to the saved default workspace (set
+ * via set_default_workspace) so local downloads and model lookups work without
+ * COMFYUI_PATH — matching what get_environment / get_workspace already report.
+ * Never falls back to a local workspace in remote mode (that dir isn't the remote
+ * target). Returns undefined when no usable local path exists.
+ */
+function resolveComfyUIBase(): string | undefined {
+  if (config.comfyuiPath) return config.comfyuiPath;
+  if (isRemoteMode()) return undefined;
+  return getSavedDefaultWorkspaceSync();
+}
+
 function getModelsRoot(): string {
-  if (!config.comfyuiPath) {
-    throw new ModelError("COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.");
+  const base = resolveComfyUIBase();
+  if (!base) {
+    throw new ModelError(
+      "No local ComfyUI path configured. Set the COMFYUI_PATH environment variable, " +
+        "or save a default workspace with set_default_workspace.",
+    );
   }
-  return join(config.comfyuiPath, "models");
+  return join(base, "models");
 }
 
 export async function searchHuggingFaceModels(
@@ -333,11 +353,12 @@ export interface ResolvedModelFile {
 export async function resolveExistingModelFile(
   relativePath: string,
 ): Promise<ResolvedModelFile> {
-  if (!config.comfyuiPath) {
+  if (!resolveComfyUIBase()) {
     throw new ModelError(
-      "COMFYUI_PATH is not configured. Locating/removing a local model operates on " +
+      "No local ComfyUI path configured. Locating/removing a local model operates on " +
         "the local filesystem and is unavailable when targeting a remote ComfyUI. " +
-        "Set the COMFYUI_PATH environment variable.",
+        "Set the COMFYUI_PATH environment variable, or save a default workspace with " +
+        "set_default_workspace.",
     );
   }
   const raw = (relativePath ?? "").trim();

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -25,6 +25,11 @@ import { logger } from "../utils/logger.js";
 interface PanelSecrets {
   /** Env vars injected into the built-in comfyui MCP server's spawn env. */
   comfyuiEnv?: Record<string, string>;
+  /** Env vars the ORCHESTRATOR reads in-process (not the comfyui child) — e.g.
+   *  the OpenRouter API key for the OpenRouter provider backend. Kept SEPARATE
+   *  from comfyuiEnv (different allowlist) so a provider key is never injected
+   *  into the tool subprocess and a tool token never reaches the LLM backend. */
+  agentEnv?: Record<string, string>;
 }
 
 // STRICT ALLOWLIST of env keys a panel-collected secret may set on the comfyui
@@ -47,6 +52,19 @@ const ALLOWLIST_SET = new Set<string>(COMFYUI_SECRET_ENV_ALLOWLIST);
 /** Is `key` a permitted comfyui tool-secret env var? */
 export function isAllowedComfyuiSecretKey(key: string): boolean {
   return ALLOWLIST_SET.has(key);
+}
+
+// STRICT ALLOWLIST of env keys the ORCHESTRATOR itself may read from the store.
+// These configure the agent provider backends in-process (never a subprocess),
+// so the injection surface is different from the comfyui child's — but we keep
+// the same allowlist discipline so a corrupt file can't set arbitrary env.
+//   OPENROUTER_API_KEY → the OpenRouter provider backend (OllamaBackend openai)
+export const AGENT_SECRET_ENV_ALLOWLIST = ["OPENROUTER_API_KEY"] as const;
+const AGENT_ALLOWLIST_SET = new Set<string>(AGENT_SECRET_ENV_ALLOWLIST);
+
+/** Is `key` a permitted orchestrator agent-secret env var? */
+export function isAllowedAgentSecretKey(key: string): boolean {
+  return AGENT_ALLOWLIST_SET.has(key);
 }
 
 /** Secrets file path. Overridable for tests. */
@@ -149,6 +167,65 @@ export function removeComfyuiSecret(key: string): boolean {
   write(secrets);
   emitter.emit("change");
   return true;
+}
+
+/** The persisted agent-provider secrets (e.g. OPENROUTER_API_KEY), filtered
+ *  through the agent allowlist. Never logged. */
+export function loadAgentSecretEnv(): Record<string, string> {
+  const env = read().agentEnv;
+  if (!env || typeof env !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (isAllowedAgentSecretKey(k) && typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Copy stored agent secrets into process.env so every in-process reader
+ * (openrouterDeps, backendReadiness, the ollama key fallback) sees one source
+ * of truth. An EXPLICIT env value WINS — the shell/.env stays the escape hatch;
+ * the store only fills what env didn't provide. Called at orchestrator startup
+ * and whenever an agent secret changes. Returns the keys it hydrated.
+ */
+export function hydrateAgentSecretsIntoEnv(): string[] {
+  const hydrated: string[] = [];
+  for (const [k, v] of Object.entries(loadAgentSecretEnv())) {
+    if (!process.env[k]) {
+      process.env[k] = v;
+      hydrated.push(k);
+    }
+  }
+  return hydrated;
+}
+
+/** Subscribe to "an agent provider secret changed". Returns an unsubscribe fn. */
+export function onAgentSecretsChanged(cb: () => void): () => void {
+  emitter.on("agentChange", cb);
+  return () => {
+    emitter.off("agentChange", cb);
+  };
+}
+
+/**
+ * Persist an agent-provider secret (e.g. OPENROUTER_API_KEY) to the 0600 store
+ * and hydrate it into process.env immediately, then emit so the orchestrator
+ * re-probes readiness / re-pushes the model list. Rejects non-allowlisted keys.
+ */
+export function setAgentSecret(key: string, value: string): void {
+  const trimmed = key.trim();
+  if (!isAllowedAgentSecretKey(trimmed)) {
+    throw new Error(
+      `Env var "${trimmed}" is not an accepted agent secret. Allowed: ${AGENT_SECRET_ENV_ALLOWLIST.join(", ")}.`,
+    );
+  }
+  const secrets = read();
+  const env = secrets.agentEnv && typeof secrets.agentEnv === "object" ? secrets.agentEnv : {};
+  env[trimmed] = value;
+  secrets.agentEnv = env;
+  write(secrets);
+  process.env[trimmed] = value; // a freshly-set key must take effect now (env wins)
+  emitter.emit("agentChange");
 }
 
 /**

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -21,8 +21,26 @@ export interface NsfwConsent {
   decidedAt?: string;
 }
 
+/** Non-secret connection config for the Ollama/OpenAI-compatible backend.
+ *  API keys never live here — they stay in env (OPENROUTER_API_KEY etc.). */
+export interface OllamaAgentConfig {
+  /** Default model tag/id (e.g. "gemma4:12b", "xiaomi/mimo-v2.5"). */
+  model?: string;
+  /** "ollama" (local /api/chat) or "openai" (any OpenAI-compatible endpoint). */
+  api?: "ollama" | "openai";
+  /** Endpoint base URL (e.g. https://openrouter.ai/api/v1, incl. /v1). */
+  baseUrl?: string;
+}
+
+export interface AgentSettings {
+  /** User-curated model ids pinned to the top of the panel's model picker. */
+  preferredModels?: string[];
+  ollama?: OllamaAgentConfig;
+}
+
 export interface PanelSettings {
   nsfwConsent?: NsfwConsent;
+  agent?: AgentSettings;
 }
 
 /** Settings file path. Overridable for tests. */
@@ -66,4 +84,31 @@ export function setNsfwConsent(allowed: boolean): NsfwConsent {
   settings.nsfwConsent = { allowed, decidedAt };
   write(settings);
   return settings.nsfwConsent;
+}
+
+/** Persisted agent backend/model preferences ({} when never set). */
+export function getAgentSettings(): AgentSettings {
+  return read().agent ?? {};
+}
+
+/**
+ * Merge a partial update into the persisted agent settings. `preferredModels`
+ * replaces the whole list (the panel sends the full edited list); `ollama`
+ * fields merge per-key so e.g. a model change doesn't clobber the base URL.
+ */
+export function setAgentSettings(patch: AgentSettings): AgentSettings {
+  const settings = read();
+  const prev = settings.agent ?? {};
+  const next: AgentSettings = { ...prev };
+  if (patch.preferredModels !== undefined) {
+    next.preferredModels = [
+      ...new Set(patch.preferredModels.map((m) => m.trim()).filter(Boolean)),
+    ].slice(0, 50);
+  }
+  if (patch.ollama !== undefined) {
+    next.ollama = { ...prev.ollama, ...patch.ollama };
+  }
+  settings.agent = next;
+  write(settings);
+  return next;
 }

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
@@ -43,6 +43,30 @@ export function resetWorkspaceConfig(): void {
 
 function workspaceConfigPath(): string {
   return configPathOverride ?? defaultWorkspaceConfigPath();
+}
+
+/**
+ * Synchronous read of the saved default workspace (set via set_default_workspace).
+ * Mirrors readWorkspaceConfig()'s validation but is sync, so sync filesystem-path
+ * resolvers (e.g. model-resolver.getModelsRoot) can consult the saved default
+ * workspace without going async — this is what lets local downloads / model
+ * lookups work when COMFYUI_PATH isn't set but a default workspace is saved.
+ * Returns undefined when unset, invalid, or unreadable.
+ */
+export function getSavedDefaultWorkspaceSync(): string | undefined {
+  const path = workspaceConfigPath();
+  try {
+    if (!existsSync(path)) return undefined;
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const dw = (parsed as Record<string, unknown>).defaultWorkspace;
+    if (typeof dw === "string" && dw.trim().length > 0) return dw;
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function readWorkspaceConfig(): Promise<WorkspaceConfig> {


### PR DESCRIPTION
Focused release carved out of #121 so shippable product value lands **now**, without waiting on the gemma4 fine-tune.

## What ships
- **OpenRouter** as a first-class panel provider — key-gated, curated arena-winner models pinned atop the picker, provider keys set from Settings (bridge-level `set_secret`), wired through `BackendId` + readiness probe.
- **User-configurable preferred models** + persisted Ollama/OpenRouter endpoint config.
- **COMFYUI_PATH auto-detect** — local model ops fall back to the saved default workspace (`set_default_workspace`) when `COMFYUI_PATH` is unset (never in remote mode).
- **ollama-backend fix** — record the final assistant turn in history (the next turn was losing the model's own prior replies); env-gated transcript dump hook (off unless set).
- Ideogram4PromptBuilderKJ `import_json` edit-path docs.

## Deliberately excluded
- The WIP `finetune/` pipeline + training data (not user-facing; never in the npm `files` list) — stays in #121.
- The panel-agent resume **self-heal fix (#120)** — pending the attribution decision (cherry-pick MDC's `2ff5032` vs ship the duplicate). Fast-follow as v0.25.1 once decided.

## Gates (all green locally, mirrors `release.yml`)
- ✅ `tsc` build
- ✅ 1028 tests
- ✅ pack/install smoke (tarball installs + boots)

## ⚠️ Publishing
Merging + pushing a `v0.25.0` tag auto-triggers `release.yml` → **`npm publish`**. Holding that for maintainer go.

> Note: the OpenRouter **panel UI** (dropdown/settings) lives in the separate `comfyui-mcp-panel` repo — that repo needs a matching release for the dropdown to appear; the orchestrator-side support here works via config/env meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)