### PR TITLE
release: v0.25.1 — panel agent self-heals a dead resume session (#120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI Ã¢â‚¬â€ MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -650,6 +650,9 @@ export class PanelAgent {
       // this also suppresses the resumeSessionId fallback.)
       const resume = rewind?.anchor === null ? undefined : (this.sessionId ?? resumeSessionId);
       const startedAt = Date.now();
+      // Set below if the backend fails because the resume target is gone; keeps a
+      // recoverable resume-miss from counting toward the give-up threshold.
+      let resumeMiss = false;
       // Fresh channel → reset the turn-gate counters so a restart/resume never
       // inherits a stale offset that would mis-gate the first batch.
       this.yieldedTurns = 0;
@@ -685,7 +688,23 @@ export class PanelAgent {
         }
       } catch (err) {
         if (this.closed) break;
-        logger.error(`[panel-agent ${this.short()}] stream error: ${msgOf(err)}`);
+        const emsg = msgOf(err);
+        logger.error(`[panel-agent ${this.short()}] stream error: ${emsg}`);
+        // A resume whose target session no longer exists — e.g. the orchestrator was
+        // relaunched from a different cwd, or the session transcript was pruned —
+        // fails with "No conversation found with session ID: <id>". Retrying the SAME
+        // resume just loops until the give-up threshold trips and self-exits the whole
+        // orchestrator (a live bridge left serving a permanently-dead agent). Drop the
+        // dead resume target so the NEXT iteration starts a FRESH session and
+        // self-heals; queued messages (this.queue) survive and replay.
+        if (/No conversation found with session ID/i.test(emsg)) {
+          logger.warn(
+            `[panel-agent ${this.short()}] resume target is gone — starting a fresh session`,
+          );
+          this.sessionId = null;
+          resumeSessionId = undefined;
+          resumeMiss = true;
+        }
       }
       // Session ended (cleanly or via error) — disarm any armed watchdog AND the
       // interrupt-release fallback so a stale timer from the dead session can't fire
@@ -697,7 +716,9 @@ export class PanelAgent {
       if (this.closed) break;
       // Session ended on its own — bound rapid failure loops so a persistently
       // broken SDK doesn't spin forever or black-hole each message.
-      quickRestarts = Date.now() - startedAt < 5000 ? quickRestarts + 1 : 0;
+      // A recoverable resume-miss (handled above by dropping the dead session) must
+      // NOT count toward the give-up threshold — the next iteration starts fresh.
+      quickRestarts = !resumeMiss && Date.now() - startedAt < 5000 ? quickRestarts + 1 : 0;
       if (quickRestarts >= 4) {
         logger.error(`[panel-agent ${this.short()}] session keeps ending immediately — giving up`);
         this.sessionId = null; // don't resume a session that won't stay up


### PR DESCRIPTION
Bundles @MichaelDanCurtis's fix (`2ff5032`, **attribution preserved**) for #120: when a resumed panel session no longer exists on the backend, the agent now drops the dead resume id and starts fresh instead of looping the "No conversation found" error and self-exiting — which was killing all panel tabs (the "can't run two tabs at once" crash).

## Gates (all green locally, mirrors `release.yml`)
- ✅ `tsc` build
- ✅ 1028 tests
- ✅ pack/install smoke

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)