### PR TITLE
fix(gemini): ACP mcpServers — live CLI rejects type 'http'; use the SSE variant

### DIFF
--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -420,3 +420,18 @@ describe("GeminiBackend (ACP over stdio)", () => {
     await backend.close();
   });
 });
+
+describe("buildAcpMcpServers", () => {
+  it("maps http specs to the ACP SSE variant (live CLIs reject type 'http')", async () => {
+    const { buildAcpMcpServers } = await import("../../orchestrator/gemini-backend.js");
+    const out = buildAcpMcpServers({
+      panel: { transport: "http", url: "http://127.0.0.1:9181/tab1" },
+      comfy: { transport: "stdio", command: "node", args: ["x.js"], env: { A: "1" } },
+    });
+    expect(out).toContainEqual({ type: "sse", name: "panel", url: "http://127.0.0.1:9181/tab1", headers: [] });
+    // stdio mapping unchanged
+    expect(out).toContainEqual({ name: "comfy", command: "node", args: ["x.js"], env: [{ name: "A", value: "1" }] });
+    // the rejected variant must NOT appear
+    expect(out.some((s) => s.type === "http")).toBe(false);
+  });
+});

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -430,10 +430,11 @@ export type GeminiMcpServerSpec =
 
 /**
  * Convert our MCP server specs into the ACP `session/new` `mcpServers` array.
- * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. The HTTP
- * variant ({ type:"http", name, url }) is the closest faithful mapping to the ACP
- * spec's HTTP transport (gated by the agent's mcpCapabilities.http) — FLAGGED as
- * unverified against the live gemini CLI. Empty env is the required `[]`.
+ * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. Streamable
+ * HTTP MCP rides the SSE variant ({ type:"sse", name, url, headers:[] }) — the
+ * live Gemini (and Grok) CLIs reject { type:"http" } with Invalid params on the
+ * FIRST user message, after a successful connect ack, so the old "http" mapping
+ * made a panel-MCP-attached tab look connected but fail on first use.
  */
 export function buildAcpMcpServers(
   servers: Record<string, GeminiMcpServerSpec>,
@@ -448,8 +449,7 @@ export function buildAcpMcpServers(
         env: Object.entries(spec.env ?? {}).map(([k, v]) => ({ name: k, value: v })),
       });
     } else {
-      // ASSUMPTION (unverified w/o live CLI): ACP HTTP McpServer variant.
-      out.push({ type: "http", name, url: spec.url });
+      out.push({ type: "sse", name, url: spec.url, headers: [] });
     }
   }
   return out;


### PR DESCRIPTION
Harvested from `MichaelDanCurtis/comfyui-mcp` commit `3dcc692` (fork sweep) — co-author credit preserved.

Our `buildAcpMcpServers` mapped streamable-HTTP MCP specs to `{ type: 'http' }`, with a comment flagging the mapping as unverified against the live gemini CLI. It's now verified: the live CLI **accepts the connect ack, then rejects the first user message with Invalid params** when an `http`-typed server is present — so a gemini tab with the loopback panel MCP attached looked connected but died on first use. The accepted shape is the SSE variant `{ type: 'sse', name, url, headers: [] }`.

- 3-line mapping change + updated comment
- new regression test asserting the SSE shape and that `type:'http'` never appears
- `npm run build` clean; gemini backend suite 7/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)