### PR TITLE
fix(save_workflow): warn when saving API format — the canvas can't open it

### DIFF
--- a/docs/tools/workflow-library.mdx
+++ b/docs/tools/workflow-library.mdx
@@ -156,7 +156,7 @@ Slice ONE pipeline out of a toggle-template workflow — the kind built with rgt
 
 ## save_workflow
 
-Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. Accepts API-format or UI-format JSON. Returns a confirmation message, or the HTTP status and error text on failure.
+Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. **For a workflow that should be readable and editable in the ComfyUI canvas, pass Web UI format (`{ nodes: [], links: [] }`).** API-format graphs are accepted but the frontend cannot open them — the tool warns in its response when it happens. Returns a confirmation message, or the HTTP status and error text on failure.
 
 ### Parameters
 
@@ -164,7 +164,7 @@ Save a workflow JSON to the connected ComfyUI server's user library so it appear
   Filename to save as (e.g. 'my_workflow.json'). Will overwrite if it already exists.
 </ParamField>
 <ParamField path="workflow" type="object" required>
-  Workflow JSON to save (API or UI format). Stored verbatim; not validated before saving.
+  Workflow JSON to save. **Prefer Web UI format** (`{ nodes: [], links: [] }`) so it opens in ComfyUI's canvas; API format is accepted but not editable in the frontend. Stored verbatim; not validated before saving.
 </ParamField>
 
 ### Example

--- a/plugin/skills/comfyui-core/SKILL.md
+++ b/plugin/skills/comfyui-core/SKILL.md
@@ -49,10 +49,11 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 
 ### Important: API Format vs Web UI Format
 
-- **API format** (what we use): `{ "1": { class_type, inputs }, "2": { ... } }`
-- **Web UI format** (saved workflows): `{ "nodes": [...], "links": [...] }` — includes layout positions, visual metadata
-- All MCP tools expect and return API format
-- `get_workflow` defaults to `format="api"` which auto-converts saved UI-format workflows to compact API format
+- **API format** (for execution/analysis): `{ "1": { class_type, inputs }, "2": { ... } }` — compact, used by `enqueue_workflow`, `validate_workflow`, `modify_workflow`, etc.
+- **Web UI format** (for saving and frontend editing): `{ "nodes": [...], "links": [...] }` — includes layout positions, sizes, groups, and visual metadata so ComfyUI's canvas can open and edit it
+- Execution tools expect and return **API format**
+- **Saving tools must use Web UI format** so saved workflows stay readable and editable in the ComfyUI frontend — an API-format save "exists" in the library but loads blank in the canvas, which strands users (and tempts agents into creating yet another new workflow instead of reopening the old one)
+- `get_workflow` defaults to `format="api"` for analysis/execution; use `format="ui"` when loading a workflow to re-save or edit in the canvas
 - Muted/bypassed nodes are preserved with `_meta.mode: "muted"` — these are inactive but visible for understanding the workflow
 - Get/Set virtual wire nodes are preserved with `_meta.title` and `Constant` key for tracing data flow
 
@@ -60,8 +61,8 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 
 - **`analyze_workflow(filename)`** — **use this first** to understand any saved workflow. Returns a structured text summary with sections, node IDs, key settings, virtual wires, and connection graph. No raw JSON — just what you need to reason about the workflow. Supports views: summary (default), overview (mermaid), detail (section mermaid), list, flat.
 - **`list_workflows`** — list all saved workflows in ComfyUI's user library
-- **`get_workflow(filename)`** — load raw workflow JSON. Only use when you need the actual JSON for `enqueue_workflow`, `modify_workflow`, or `save_workflow`. Use `analyze_workflow` instead for understanding.
-- **`save_workflow(filename, workflow)`** — save a workflow to the user library
+- **`get_workflow(filename)`** — load raw workflow JSON. Only use when you need the actual JSON for `enqueue_workflow`, `modify_workflow`, or `save_workflow`. Use `analyze_workflow` instead for understanding. **For `save_workflow`, request `format="ui"`** so the workflow stays editable in the frontend.
+- **`save_workflow(filename, workflow)`** — save a workflow to the user library. **Pass Web UI format (`{ nodes, links }`)** so it can be opened and edited in ComfyUI's canvas; API-format graphs are accepted but the frontend cannot open them.
 
 ## Data Types
 

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -290,7 +290,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
 
   server.tool(
     "save_workflow",
-    "Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. Accepts API-format or UI-format JSON. Returns a confirmation message, or the HTTP status and error text on failure.",
+    "Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. IMPORTANT: pass Web-UI-format JSON ({ nodes: [], links: [] }) so the saved workflow opens and edits in the ComfyUI canvas — when re-saving an existing workflow, load it with get_workflow format='ui' and modify THAT. API-format graphs are accepted and stored verbatim, but the canvas CANNOT open them (users see a broken/blank load), so only save API format for headless re-queueing. Returns a confirmation message (with a warning when the input was API format), or the HTTP status and error text on failure.",
     {
       filename: z
         .string()
@@ -299,7 +299,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         ),
       workflow: z
         .record(z.string(), z.any())
-        .describe("Workflow JSON to save (API or UI format). Stored verbatim; not validated before saving."),
+        .describe("Workflow JSON to save. Prefer Web UI format ({ nodes: [], links: [] }) so it stays editable in ComfyUI's canvas; API format is accepted but the frontend cannot open it. Stored verbatim; not validated before saving."),
     },
     async (args) => {
       try {
@@ -327,11 +327,21 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           };
         }
 
+        // API-format saves are legal (headless re-queue) but the canvas can't
+        // open them — the #1 way agents strand users with workflows that "exist"
+        // in the library yet load blank, so they keep creating new ones instead
+        // of navigating back. Warn loudly until auto-conversion ships.
+        const apiFormatWarning = isUiFormat(args.workflow)
+          ? ""
+          : `\n\n⚠️ This was saved in API format — the ComfyUI canvas CANNOT open or edit it. ` +
+            `If this workflow is meant to be reopened in the UI, rebuild it in Web UI format ` +
+            `({ nodes: [], links: [] }) — e.g. load the on-canvas graph or an existing file via ` +
+            `get_workflow format="ui", apply your changes to that, and save again.`;
         return {
           content: [
             {
               type: "text",
-              text: `Workflow saved as "${args.filename}" in the ComfyUI user library.`,
+              text: `Workflow saved as "${args.filename}" in the ComfyUI user library.${apiFormatWarning}`,
             },
           ],
         };


### PR DESCRIPTION
Fixes the day-to-day symptom where the agent saves a workflow, the file exists in the library, but the canvas loads it blank — so the agent can't navigate back to it and keeps creating new workflows instead. Independently caught by `1696762169/comfyui-mcp` (`3da56c9`); guidance wording adapted from their patch with credit.

- `save_workflow` now detects API-format input via `isUiFormat` and appends a loud ⚠️ warning to the success response with the recovery path (`get_workflow format='ui'` → edit that → re-save). Tool + param descriptions steer to Web UI format up front.
- `comfyui-core` skill + docs split the format story: API for execution/analysis, **UI for anything that must reopen in the canvas**.
- Full suite green.

The real fix — API→UI auto-conversion with generated layout — is a feature (no API→UI converter exists today, only `convertUiToApi`); tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)