### PR TITLE
fix(docs): un-mangle the topbar star — double-encoded UTF-8 rendered as 'â­'

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,7 +20,7 @@
   "navbar": {
     "primary": {
       "type": "button",
-      "label": "â­ Star on GitHub",
+      "label": "\u2b50 Star on GitHub",
       "href": "https://github.com/artokun/comfyui-mcp"
     },
     "links": [


### PR DESCRIPTION
The docs topbar's `⭐ Star on GitHub` label was committed with the emoji's UTF-8 bytes re-encoded through Latin-1 (`C3 A2 C2 AD C2 90`), so the live Mintlify site renders **"â­ Star on GitHub"**. Replaced with the JSON escape `\u2b50` — same star when parsed, pure-ASCII file bytes, immune to any future encoding round-trip.

Repo-wide sweep for double-encoded sequences (all md/mdx/json/ts/js/yml/html) found **no other instances**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)