### PR TITLE
release: v0.25.2 — gemini SSE fix + save_workflow warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Ships shipped-quality fixes sitting on main since v0.25.1.

- **#124** `fix(gemini)` — ACP mcpServers: live Gemini CLI rejects `type: 'http'`; use the SSE variant. **Fixes gemini tabs dying on the first message** with panel tools in the released build.
- **#125** `fix(save_workflow)` — warn when saving API format (canvas can't reopen it).
- **#128** repo declutter (finetune → HF).
- **#129** docs star fix.

Build + 1029 tests + pack/install smoke green locally (mirrors `release.yml`).
Merging + tagging `v0.25.2` publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)