### PR TITLE
fix(runpod): 0-byte panel/custom-nodes on full volumes — self-heal + integrity gates

### DIFF
--- a/.github/workflows/build-runpod-image.yml
+++ b/.github/workflows/build-runpod-image.yml
@@ -71,3 +71,12 @@ jobs:
             BAKE_SPOTCHECK_MODEL=${{ github.event.inputs.bake_spotcheck_model == 'true' && '1' || '0' }}
           cache-from: type=registry,ref=ghcr.io/artokun/comfyui-mcp-runpod:buildcache
           cache-to: type=registry,ref=ghcr.io/artokun/comfyui-mcp-runpod:buildcache,mode=max
+
+      # Post-push integrity check of what the registry ACTUALLY serves (manifest
+      # + the custom_nodes_seed layer only — a few MB, not the whole image). The
+      # Dockerfile's build-time gate catches a broken build; this catches a build
+      # that went stale/mangled through the registry cache or the push itself.
+      # A red run here means: do NOT retag this build for Docker Hub / the
+      # RunPod template.
+      - name: Verify pushed image (registry-side integrity)
+        run: python3 docker/runpod/verify_image_remote.py ghcr.io/artokun/comfyui-mcp-runpod:cu128-lean

--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -9,19 +9,21 @@
 # just `mkdir -p` the user-data dirs and launches ComfyUI from the baked venv
 # (~30-60s ComfyUI init).
 #
-# The /workspace NETWORK VOLUME holds ONLY USER DATA:
-#     /workspace/user     workflows + ComfyUI settings + Manager config
-#     /workspace/models   all model categories (Manager downloads land here)
-#     /workspace/input    input images
-#     /workspace/output   generated images
-# Nothing else lives on the volume — no venv, no custom_nodes, no caches.
+# The /workspace NETWORK VOLUME holds USER DATA (everything that must persist):
+#     /workspace/user          workflows + ComfyUI settings + Manager config
+#     /workspace/models        all model categories (Manager downloads land here)
+#     /workspace/input         input images
+#     /workspace/output        generated images
+#     /workspace/custom_nodes  ALL custom nodes (symlinked from the image at boot;
+#                              runtime installs SURVIVE restarts — see post_start
+#                              §4.5). The image's baked nodes live in
+#                              custom_nodes_seed and are refreshed onto the volume
+#                              each boot; node PYTHON DEPS are re-installed into
+#                              the (ephemeral) venv from /workspace/.cache/pip.
+# No venv and no other caches live on the volume.
 #
-# TRADEOFF (documented in README): because custom_nodes are baked into the
-# (immutable) image, custom nodes the agent / Manager install at runtime do NOT
-# survive a restart — they live on the container's ephemeral disk. MODELS the
-# agent / Manager download DO persist (they land on /workspace/models via
-# extra_model_paths.yaml `is_default`). To add a node permanently, add it to this
-# Dockerfile and rebuild.
+# MODELS the agent / Manager download persist too (they land on /workspace/models
+# via extra_model_paths.yaml `is_default`).
 #
 # TOPOLOGY (why the image is lean): the panel ORCHESTRATOR (the autonomous agent
 # loop — Claude/Codex Agent SDK, on YOUR subscription) runs on the USER's laptop,
@@ -29,8 +31,10 @@
 # Node.js for the agent, the Agent SDK and any LLM client are deliberately ABSENT.
 # See ./README.md.
 #
-# DRAFT — NOT build-tested (no Docker in the authoring env). The owner builds +
-# pushes + tests. Pins that must be confirmed at build are flagged in README.md.
+# TESTING: a build-time integrity gate (§9.5) fails the build on empty/missing
+# artifacts, and ./test_image.sh runs a deeper post-build suite (including a
+# real boot cycle against a scratch volume) — run it before ANY registry push;
+# ./deploy-dockerhub.sh wires it in front of the Docker Hub push.
 # =============================================================================
 
 # ---- Global ARGs (used in FROM lines; must precede the first FROM) -----------
@@ -146,6 +150,9 @@ ARG COMFY_HOME=/opt/ComfyUI
 # checkpoint from here into /workspace/models/checkpoints on first boot.
 ARG SEED_MODELS=/opt/ComfyUI-seed-models
 # Manager remote-install gate (required for the agent to install models/nodes).
+# NOTE: COMFY_SECURITY_LEVEL's EFFECTIVE default is overridden to "weak" in the
+# late runtime-ENV block (§10) — changing it there doesn't bust the expensive
+# torch/ComfyUI layers the way editing this early block would.
 ARG COMFY_NETWORK_MODE=personal_cloud
 ARG COMFY_SECURITY_LEVEL=normal-
 
@@ -316,6 +323,29 @@ RUN curl -fsSL "https://github.com/filebrowser/filebrowser/releases/download/${F
 RUN mv "${COMFY_HOME}/custom_nodes" "${COMFY_HOME}/custom_nodes_seed"
 
 # -----------------------------------------------------------------------------
+# 9.5 BUILD-TIME INTEGRITY GATE — fail the BUILD, not the user's pod. Asserts the
+#     load-bearing artifacts actually have CONTENT (a report from the field was a
+#     panel whose whole file tree existed with 0 bytes — a silently-degraded copy
+#     is worse than a red build). test_image.sh re-runs these against the built
+#     image before any registry push; this layer is the last line of defense.
+# -----------------------------------------------------------------------------
+RUN set -e; \
+    for f in "${COMFY_HOME}/custom_nodes_seed/comfyui-mcp-panel/__init__.py" \
+             "${COMFY_HOME}/custom_nodes_seed/comfyui-mcp-panel/pyproject.toml" \
+             "${COMFY_HOME}/custom_nodes_seed/comfyui-mcp-panel/web/js/comfyui-mcp-panel.js" \
+             "${COMFY_HOME}/extra_model_paths.yaml" \
+             "${COMFY_HOME}/config.ini.seed" \
+             /post_start.sh; do \
+      [ -s "$f" ] || { echo "INTEGRITY GATE FAILED: $f is missing or 0 bytes"; exit 1; }; \
+    done; \
+    EMPTY="$(find "${COMFY_HOME}/custom_nodes_seed" -type f -size 0 | head -20)"; \
+    [ -z "$EMPTY" ] || { echo "INTEGRITY GATE FAILED: 0-byte files in custom_nodes_seed:"; echo "$EMPTY"; exit 1; }; \
+    bash -n /post_start.sh || { echo "INTEGRITY GATE FAILED: /post_start.sh has syntax errors"; exit 1; }; \
+    "${COMFY_HOME}/venv/bin/python" -c "import torch; import importlib.metadata as m; m.version('comfyui-manager')" \
+      || { echo "INTEGRITY GATE FAILED: venv torch import / comfyui-manager package"; exit 1; }; \
+    echo "integrity gate passed: panel seed + configs + entrypoint + venv all sane"
+
+# -----------------------------------------------------------------------------
 # 10. Volume hygiene (LAST so it doesn't bust the expensive build-layer cache).
 #     The runpod/pytorch base points these caches at /workspace so they "persist"
 #     across restarts. With the fast-restart design ALL software is baked in the
@@ -329,6 +359,20 @@ ENV PIP_CACHE_DIR=/root/.cache/pip \
     UV_CACHE_DIR=/root/.cache/uv \
     VIRTUALENV_OVERRIDE_APP_DATA=/root/.cache/virtualenv \
     XDG_CACHE_HOME=/root/.cache
+
+# Runtime-only env overrides (late on purpose — they never affect build steps,
+# so tweaking them must not bust the torch/ComfyUI layer cache above):
+#   COMFY_SECURITY_LEVEL=weak — at "normal-" Manager silently SKIPS git-URL node
+#     installs (a confusing half-working state on a single-user pod whose whole
+#     premise is agent-driven installs). The early ENV baked "normal-", which
+#     overrode post_start.sh's `:-weak` default and defeated that fix. Set
+#     COMFY_SECURITY_LEVEL=normal- on the pod to restore the guardrails.
+#   PANEL_REPO / PANEL_REF — where post_start.sh §4.5(b.2) re-clones the Agent
+#     Panel from when the copy on the volume is broken (0-byte/missing files);
+#     PANEL_REF keeps a ref-pinned build pinned even through a self-heal.
+ENV COMFY_SECURITY_LEVEL=weak \
+    PANEL_REPO=${PANEL_REPO} \
+    PANEL_REF=${PANEL_REF}
 
 # The runpod/pytorch base bakes a ~1.1GB pip cache at /workspace/.cache. Docker
 # SEEDS a fresh named/network volume from the image's mount-point contents, so

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -393,7 +393,7 @@ Create a **Pod template** (or fill these on a one-off GPU pod):
 |-----|---------|---------|
 | `JUPYTER_PASSWORD` | *(unset)* | set to enable JupyterLab on :8888 (base behavior) |
 | `PUBLIC_KEY` | *(RunPod injects)* | SSH public key (base behavior) |
-| `COMFY_SECURITY_LEVEL` | `normal-` | Manager security level (`weak` = most permissive) |
+| `COMFY_SECURITY_LEVEL` | `weak` | Manager security level — `weak` lets the agent install nodes from git URLs (single-user pod); set `normal-` to restore Manager's guardrails |
 | `COMFY_NETWORK_MODE` | `personal_cloud` | must stay `personal_cloud` for remote installs |
 | `COMFY_EXTRA_ARGS` | *(empty)* | extra ComfyUI flags appended verbatim by the entrypoint |
 | `COMFY_HOME` | `/opt/ComfyUI` | baked ComfyUI path (rarely overridden) |
@@ -500,7 +500,7 @@ To shave that:
   (`python -c "import torch;print(torch.__version__, torch.version.cuda)"`) —
   some older `cu1281` tags shipped a cu-default torch.
 
-> **DRAFT — not build-tested.** Build once locally and watch for: (a) the base's
+> **First build on a new base tag?** Watch for: (a) the base's
 > `/start.sh` actually invokes `/post_start.sh` (it does in `runpod/containers`,
 > but confirm for your exact tag); (b) `main.py --help` lists `--user-directory`,
 > `--input-directory`, `--output-directory`, `--extra-model-paths-config`,

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -1,4 +1,4 @@
-# comfyui-mcp RunPod image — FAST RESTART (image-immutable software) (DRAFT)
+# comfyui-mcp RunPod image — FAST RESTART (image-immutable software)
 
 A RunPod image that boots **ready to be driven by the
 [comfyui-mcp](https://github.com/artokun/comfyui-mcp) Agent Panel**. Deploy on
@@ -12,10 +12,10 @@ It is optimized for **fast stop/start**. All the software — ComfyUI + its venv
 `input/`, `output/`). A warm restart does **no install, no sync, no seed** — it
 just `mkdir -p` the data dirs and launches ComfyUI (~**30-60s** ComfyUI init).
 
-> **Status: DRAFT for owner review.** Authored to be correct and well-documented,
-> but **not** build-tested (no Docker in the authoring env). A few pins still need
-> confirmation — see [Owner confirmations needed](#owner-confirmations-needed).
-> The owner builds + pushes + tests next.
+> **Testing:** every build ends in an in-Dockerfile integrity gate, and
+> [`test_image.sh`](#test-before-you-push-post-build-gate) runs a full boot
+> suite (fresh volume → redeploy → corruption self-heal) before any push;
+> `deploy-dockerhub.sh` makes that gate mandatory for the official image.
 
 ---
 
@@ -83,6 +83,25 @@ venv still boot fast from the immutable image.
   so its packages are refreshed on boot). Compiled/CUDA-linked deps may rebuild
   rather than unpack. To bake a node so it needs **zero** boot-time work, still add
   it to the `Dockerfile` and rebuild.
+
+### If the panel (or a node) shows up EMPTY — 0-byte files
+
+A **full network volume** is the classic cause: on ENOSPC, `cp`/`git` still
+*create* every file but write 0 bytes into them, so the node's whole file tree
+exists as empty husks — ComfyUI lists the node, but nothing loads. Because the
+volume persists, this used to survive every redeploy.
+
+The entrypoint now defends itself:
+
+* logs the volume's **free space** at boot and prints a loud warning under 500 MB;
+* **skips the ~7 GB spotcheck-model copy** when the volume can't hold it;
+* **verifies the Agent Panel** on the volume every boot and **self-heals** a
+  broken copy (re-clone from GitHub, or restore from the image seed offline);
+* names any other custom node whose `__init__.py` is 0 bytes in the boot log
+  (`WARN: custom nodes with 0-byte __init__.py …`) — reinstall those via Manager.
+
+If you see the ENOSPC warning: free or grow the volume, restart the pod, and the
+panel repairs itself on the next boot.
 
 ---
 
@@ -403,6 +422,36 @@ docker push     <your-registry>/comfyui-mcp-runpod:cu128
 docker build --build-arg BAKE_SPOTCHECK_MODEL=0 \
   -t <your-registry>/comfyui-mcp-runpod:cu128-noseed .
 ```
+
+### Test before you push (post-build gate)
+
+The build itself ends in an **integrity gate** (Dockerfile §9.5) that fails on
+missing/0-byte panel files, a broken venv, or a `post_start.sh` syntax error.
+Before any registry push, run the deeper suite:
+
+```bash
+# static checks + a real 2-boot volume test + the ENOSPC self-heal test:
+./test_image.sh <image-ref>
+
+# static checks only (~seconds):
+./test_image.sh <image-ref> --static
+```
+
+For the official Docker Hub image use the gated deploy script — it refuses to
+push an image that fails `test_image.sh`, then re-verifies **what the registry
+actually serves** after the push:
+
+```bash
+docker build -t artokun/comfyui-mcp-runpod:build .
+./deploy-dockerhub.sh 1.6        # pushes :1.6 + :latest, verifies both ends
+```
+
+CI does the same for `ghcr.io/...:cu128-lean` (`verify_image_remote.py`
+inspects the pushed manifest + seed layer without pulling the 20 GB image).
+
+> **Pin the RunPod template to the VERSION tag** (`:1.6`), not `:latest`.
+> RunPod hosts cache images per-tag — a template on `:latest` can silently
+> serve a stale build from a host's cache; a fresh version tag can't.
 
 Override pins as needed:
 

--- a/docker/runpod/deploy-dockerhub.sh
+++ b/docker/runpod/deploy-dockerhub.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# deploy-dockerhub.sh — gated Docker Hub release for the comfyui-mcp RunPod
+# image. Refuses to push anything that hasn't passed test_image.sh (static +
+# boot suite), then verifies what the registry ACTUALLY serves post-push.
+#
+#   ./deploy-dockerhub.sh <version> [<local-image-ref>]
+#
+#   <version>          e.g. 1.6  (also moves :latest)
+#   <local-image-ref>  default: artokun/comfyui-mcp-runpod:build
+#
+# Typical flow:
+#   docker build -t artokun/comfyui-mcp-runpod:build docker/runpod
+#   docker/runpod/deploy-dockerhub.sh 1.6
+#
+# After pushing, PIN THE RUNPOD TEMPLATE to the new VERSION tag (not :latest):
+# RunPod hosts cache images per-tag, so a template on :latest can silently serve
+# a stale build — a version tag forces every new pod onto the bits you tested.
+set -euo pipefail
+
+VERSION="${1:?usage: deploy-dockerhub.sh <version> [<local-image-ref>]}"
+SRC="${2:-artokun/comfyui-mcp-runpod:build}"
+REPO="artokun/comfyui-mcp-runpod"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[deploy] gate 1/2: test_image.sh (static + boot suite) on ${SRC}…"
+"${HERE}/test_image.sh" "${SRC}"
+
+echo "[deploy] tagging ${SRC} -> ${REPO}:${VERSION} + ${REPO}:latest"
+docker tag "${SRC}" "${REPO}:${VERSION}"
+docker tag "${SRC}" "${REPO}:latest"
+
+echo "[deploy] pushing ${REPO}:${VERSION}…"
+docker push "${REPO}:${VERSION}"
+echo "[deploy] pushing ${REPO}:latest…"
+docker push "${REPO}:latest"
+
+echo "[deploy] gate 2/2: verifying what the registry actually serves…"
+python3 "${HERE}/verify_image_remote.py" "docker.io/${REPO}:${VERSION}"
+
+cat <<EOF
+[deploy] DONE: ${REPO}:${VERSION} (+ :latest) pushed and registry-verified.
+[deploy] NEXT: pin the RunPod template image to  ${REPO}:${VERSION}
+[deploy]       (console.runpod.io -> Templates; do NOT leave it on :latest).
+EOF

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -57,6 +57,11 @@ EXTRA_MODEL_PATHS="${EXTRA_MODEL_PATHS:-${COMFY_HOME}/extra_model_paths.yaml}"
 # Automatically a no-op for a PANEL_REF-pinned build (detached HEAD — pinning
 # means the user wants reproducibility, not drift). Set to 0 to disable outright.
 PANEL_AUTO_UPDATE="${PANEL_AUTO_UPDATE:-1}"
+# Where the §4.5(b.2) self-heal re-clones the Agent Panel from if the copy on the
+# volume is broken (0-byte/missing files). Baked as ENV by the Dockerfile;
+# PANEL_REF (optional tag/branch) keeps a ref-pinned build pinned through a heal.
+PANEL_REPO="${PANEL_REPO:-https://github.com/artokun/comfyui-mcp-panel.git}"
+PANEL_REF="${PANEL_REF:-}"
 
 # Volume user-data dirs (the ONLY things on /workspace).
 USER_DIR="${WORKSPACE}/user"
@@ -113,6 +118,22 @@ fi
 #    guarantees Manager has a place to download into).
 #    NO caches, NO venv, NO custom_nodes are placed on the volume.
 # -----------------------------------------------------------------------------
+# Free-space preflight. A FULL volume is the nastiest failure mode on this pod:
+# every `cp`/`git checkout` still CREATES its files but writes 0 bytes into them
+# (ENOSPC), so the panel + custom nodes turn into a correct-looking tree of empty
+# husks that PERSISTS across redeploys. Detect it up front and say so in plain
+# words instead of letting the boot "succeed".
+free_mb() { df -Pm "$1" 2>/dev/null | awk 'NR==2 {print $4}'; }
+WS_FREE_MB="$(free_mb "${WORKSPACE}")"
+log "volume free space: ${WS_FREE_MB:-unknown} MB on ${WORKSPACE}"
+if [ -n "${WS_FREE_MB}" ] && [ "${WS_FREE_MB}" -lt 500 ] 2>/dev/null; then
+  log "============================================================================"
+  log "WARNING: ${WORKSPACE} has only ${WS_FREE_MB} MB free. Writes will fail with"
+  log "  ENOSPC and leave 0-BYTE files (empty panel, broken custom nodes, failed"
+  log "  model downloads). Free up space or grow the network volume, then restart."
+  log "============================================================================"
+fi
+
 log "preparing /workspace user-data dirs (mkdir -p; no sync)…"
 mkdir -p "${USER_DIR}" "${INPUT_DIR}" "${OUTPUT_DIR}"
 for sub in checkpoints configs loras vae text_encoders clip diffusion_models \
@@ -131,10 +152,20 @@ done
 # -----------------------------------------------------------------------------
 if [ ! -f "${MODELS_DIR}/checkpoints/sd_xl_base_1.0.safetensors" ] \
    && ls "${SEED_MODELS}"/*.safetensors >/dev/null 2>&1; then
-  log "first boot: copying baked spotcheck model(s) into models/checkpoints…"
-  cp -n "${SEED_MODELS}"/*.safetensors "${MODELS_DIR}/checkpoints/" \
-    && log "spotcheck model in place." \
-    || log "WARN: spotcheck copy failed (continuing)."
+  # Guard: the copy is ~7 GB. On a small/nearly-full volume it fills the disk and
+  # everything AFTER it (panel seed, node installs) degrades into 0-byte files.
+  # The spotcheck model is a convenience — skip it rather than poison the volume.
+  SEED_MODELS_MB="$(du -sm "${SEED_MODELS}" 2>/dev/null | awk '{print $1}')"
+  WS_FREE_MB="$(free_mb "${WORKSPACE}")"
+  if [ -n "${WS_FREE_MB}" ] && [ -n "${SEED_MODELS_MB}" ] \
+     && [ "${WS_FREE_MB}" -lt "$((SEED_MODELS_MB + 2048))" ] 2>/dev/null; then
+    log "SKIP spotcheck model: needs ~${SEED_MODELS_MB} MB (+2 GB headroom) but only ${WS_FREE_MB} MB free on ${WORKSPACE}."
+  else
+    log "first boot: copying baked spotcheck model(s) into models/checkpoints…"
+    cp -n "${SEED_MODELS}"/*.safetensors "${MODELS_DIR}/checkpoints/" \
+      && log "spotcheck model in place." \
+      || log "WARN: spotcheck copy failed (continuing)."
+  fi
 fi
 
 # -----------------------------------------------------------------------------
@@ -270,11 +301,17 @@ fi
 
 # (b) Seed/refresh the baked nodes (panel + builtins) onto the volume. cp -rf
 #     overwrites the image-owned copies (keeps them current on an image upgrade)
-#     but never deletes the user's OWN nodes already on the volume.
+#     but never deletes the user's OWN nodes already on the volume. Errors go to
+#     a LOG, not /dev/null — a swallowed ENOSPC here once shipped a panel whose
+#     every file existed with 0 bytes, and nothing in the console said why.
 if [ -d "${CN_SEED}" ]; then
-  cp -rf "${CN_SEED}/." "${CN_VOL}/" 2>/dev/null \
-    && log "seeded/refreshed baked custom_nodes (panel + builtins) onto the volume" \
-    || log "WARN: custom_nodes seed refresh had errors (continuing)"
+  if cp -rf "${CN_SEED}/." "${CN_VOL}/" 2>>"${LOG_DIR}/custom-nodes-seed.log"; then
+    log "seeded/refreshed baked custom_nodes (panel + builtins) onto the volume"
+  else
+    log "WARN: custom_nodes seed refresh had errors — first lines:"
+    head -3 "${LOG_DIR}/custom-nodes-seed.log" 2>/dev/null | while IFS= read -r l; do log "  cp: ${l}"; done
+    log "  (full log: ${LOG_DIR}/custom-nodes-seed.log; free space: $(free_mb "${WORKSPACE}") MB)"
+  fi
 fi
 
 # (b.1) PANEL AUTO-UPDATE — decouples "get the latest Agent Panel" from "wait for
@@ -308,6 +345,45 @@ if [ "${PANEL_AUTO_UPDATE}" = "1" ] && [ -d "${PANEL_DIR}/.git" ]; then
   fi
 elif [ "${PANEL_AUTO_UPDATE}" != "1" ]; then
   log "Agent Panel auto-update disabled (PANEL_AUTO_UPDATE=${PANEL_AUTO_UPDATE})"
+fi
+
+# (b.2) PANEL INTEGRITY CHECK + SELF-HEAL. A past ENOSPC (or any interrupted
+#     copy) can leave the panel on the volume as a full file tree of 0-BYTE
+#     files — ComfyUI then lists the node but the panel tab never loads, and
+#     because the volume PERSISTS, every later redeploy looks just as broken.
+#     Verify the three load-bearing files; on failure re-clone from scratch.
+panel_ok() {  # $1 = panel dir
+  [ -s "$1/__init__.py" ] && [ -s "$1/pyproject.toml" ] \
+    && [ -s "$1/web/js/comfyui-mcp-panel.js" ]
+}
+if ! panel_ok "${PANEL_DIR}"; then
+  log "Agent Panel on the volume is BROKEN (missing/0-byte files) — self-healing…"
+  rm -rf "${PANEL_DIR}"
+  if git clone --depth 1 ${PANEL_REF:+--branch "${PANEL_REF}"} "${PANEL_REPO}" "${PANEL_DIR}" \
+       >>"${LOG_DIR}/panel-update.log" 2>&1 && panel_ok "${PANEL_DIR}"; then
+    log "Agent Panel re-cloned OK: $(git -C "${PANEL_DIR}" rev-parse --short HEAD 2>/dev/null)"
+  elif [ -d "${CN_SEED}/comfyui-mcp-panel" ] \
+       && rm -rf "${PANEL_DIR}" \
+       && cp -rf "${CN_SEED}/comfyui-mcp-panel" "${PANEL_DIR}" 2>>"${LOG_DIR}/panel-update.log" \
+       && panel_ok "${PANEL_DIR}"; then
+    log "Agent Panel restored from the image seed (offline fallback)."
+  else
+    log "============================================================================"
+    log "ERROR: could not repair the Agent Panel on ${CN_VOL}. Most common cause: the"
+    log "  network volume is FULL ($(free_mb "${WORKSPACE}") MB free) — writes create"
+    log "  0-byte files. Free/grow the volume and restart the pod; the panel will"
+    log "  self-heal on the next boot. Details: ${LOG_DIR}/panel-update.log"
+    log "============================================================================"
+  fi
+fi
+
+# Zero-byte sweep across ALL nodes on the volume — the same ENOSPC event that
+# empties the panel empties user-installed nodes too. We can't safely re-clone
+# arbitrary nodes (unknown sources), but we CAN say exactly which are broken.
+BROKEN_NODES="$(find "${CN_VOL}" -mindepth 2 -maxdepth 2 -name '__init__.py' -size 0 2>/dev/null \
+  | sed 's|.*/custom_nodes/||; s|/__init__.py$||' | sort -u | tr '\n' ' ')"
+if [ -n "${BROKEN_NODES// /}" ]; then
+  log "WARN: custom nodes with 0-byte __init__.py (broken; reinstall via Manager): ${BROKEN_NODES}"
 fi
 
 # (c) Reinstall custom-node Python deps into the venv from the persistent cache.

--- a/docker/runpod/test_image.sh
+++ b/docker/runpod/test_image.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# test_image.sh — post-build integrity + boot test for the comfyui-mcp RunPod
+# image. Run this against a LOCALLY BUILT (or pulled) image BEFORE pushing it
+# to any registry; deploy-dockerhub.sh refuses to push unless this passes.
+#
+#   ./test_image.sh <image-ref>            # static checks + 2-boot volume test
+#   ./test_image.sh <image-ref> --static   # static checks only (~seconds)
+#
+# What it catches (all real, all shipped at least once):
+#   * 0-byte / missing panel or config files in the image  (field report: an
+#     entire panel file tree of empty husks)
+#   * post_start.sh syntax errors or a broken venv
+#   * custom_nodes NOT persisting across a redeploy (symlink regression)
+#   * the ENOSPC self-heal failing to repair a corrupted volume
+#
+# Needs: docker. No GPU required — everything under test runs before ComfyUI
+# needs CUDA (the boot test only asserts volume/panel state, not inference).
+set -euo pipefail
+# Git Bash (Windows) rewrites /container/paths in args into C:/... host paths,
+# silently breaking -v/--tmpfs mounts. Disabling conversion is a no-op elsewhere.
+export MSYS_NO_PATHCONV=1
+
+IMAGE="${1:?usage: test_image.sh <image-ref> [--static]}"
+MODE="${2:-full}"
+FAILURES=0
+
+say()  { echo "[test_image] $*"; }
+pass() { echo "[test_image]   PASS: $*"; }
+fail() { echo "[test_image]   FAIL: $*"; FAILURES=$((FAILURES + 1)); }
+
+drun() { MSYS_NO_PATHCONV=1 docker run --rm --entrypoint bash "$IMAGE" -c "$1"; }
+
+# -----------------------------------------------------------------------------
+# 1. STATIC CHECKS — file presence, non-emptiness, syntax, venv imports.
+# -----------------------------------------------------------------------------
+say "static checks on ${IMAGE}…"
+
+if drun '
+  set -e
+  CH="${COMFY_HOME:-/opt/ComfyUI}"
+  for f in "$CH/custom_nodes_seed/comfyui-mcp-panel/__init__.py" \
+           "$CH/custom_nodes_seed/comfyui-mcp-panel/pyproject.toml" \
+           "$CH/custom_nodes_seed/comfyui-mcp-panel/web/js/comfyui-mcp-panel.js" \
+           "$CH/extra_model_paths.yaml" \
+           "$CH/config.ini.seed" \
+           "$CH/main.py" \
+           /post_start.sh /etc/nginx/nginx.conf; do
+    [ -s "$f" ] || { echo "MISSING/EMPTY: $f"; exit 1; }
+  done
+  EMPTY="$(find "$CH/custom_nodes_seed" -type f -size 0 | head -20)"
+  [ -z "$EMPTY" ] || { echo "0-BYTE FILES IN SEED:"; echo "$EMPTY"; exit 1; }
+  [ -x /post_start.sh ] || { echo "/post_start.sh not executable"; exit 1; }
+  bash -n /post_start.sh
+  "$CH/venv/bin/python" -c "import torch; import importlib.metadata as m; m.version(\"comfyui-manager\")"
+  grep -q "^security_level" "$CH/config.ini.seed" || { echo "config.ini.seed lacks security_level"; exit 1; }
+'; then
+  pass "baked files present + non-empty, post_start.sh parses, venv imports torch/comfyui_manager"
+else
+  fail "static checks (see output above)"
+fi
+
+if [ "$MODE" = "--static" ]; then
+  [ "$FAILURES" -eq 0 ] && { say "STATIC OK"; exit 0; } || { say "FAILED"; exit 1; }
+fi
+
+# -----------------------------------------------------------------------------
+# 2. BOOT TEST — the pod lifecycle against a scratch volume:
+#      boot 1 (fresh volume)  -> panel healthy on the volume, symlink correct
+#      simulated user install -> a marker "custom node" written via the symlink
+#      boot 2 (fresh CONTAINER, same volume == RunPod redeploy)
+#                             -> user node still there, panel still healthy
+#      corruption + boot 3    -> 0-byte panel (the ENOSPC aftermath) self-heals
+# -----------------------------------------------------------------------------
+VOL="cmcp-test-$$"
+CN="/workspace/custom_nodes"
+PANEL="$CN/comfyui-mcp-panel"
+cleanup() { docker rm -f "cmcp-t1-$$" "cmcp-t2-$$" "cmcp-t3-$$" >/dev/null 2>&1 || true
+            docker volume rm "$VOL" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+docker volume create "$VOL" >/dev/null
+
+boot() {  # $1 = container name — waits until post_start reaches the ComfyUI launch
+  docker run -d --name "$1" -v "$VOL:/workspace" -e MIN_DRIVER=0 "$IMAGE" >/dev/null
+  for _ in $(seq 1 60); do
+    if docker logs "$1" 2>&1 | grep -q 'launching ComfyUI:'; then return 0; fi
+    if docker logs "$1" 2>&1 | grep -q 'FATAL'; then docker logs "$1" 2>&1 | tail -20; return 1; fi
+    sleep 5
+  done
+  echo "timed out waiting for post_start"; docker logs "$1" 2>&1 | tail -20; return 1
+}
+
+panel_check() {  # $1 = container name, $2 = label
+  if docker exec "$1" bash -c "
+      set -e
+      [ \"\$(readlink -f \${COMFY_HOME:-/opt/ComfyUI}/custom_nodes)\" = \"$CN\" ]
+      [ -s $PANEL/__init__.py ] && [ -s $PANEL/pyproject.toml ] && [ -s $PANEL/web/js/comfyui-mcp-panel.js ]
+      [ -z \"\$(find $CN -type f -size 0 -not -path '*/.git/*' | head -1)\" ]
+    "; then pass "$2"; else fail "$2"; fi
+}
+
+say "boot 1: fresh volume…"
+if boot "cmcp-t1-$$"; then
+  panel_check "cmcp-t1-$$" "boot 1: symlink -> volume, panel non-empty, no 0-byte files"
+  docker exec "cmcp-t1-$$" bash -c "mkdir -p /opt/ComfyUI/custom_nodes/user-test-node && echo 'MARKER = 1' > /opt/ComfyUI/custom_nodes/user-test-node/__init__.py"
+else
+  fail "boot 1 did not reach ComfyUI launch"
+fi
+docker rm -f "cmcp-t1-$$" >/dev/null
+
+say "boot 2: redeploy (fresh container, same volume)…"
+if boot "cmcp-t2-$$"; then
+  panel_check "cmcp-t2-$$" "boot 2: panel still healthy after redeploy"
+  if docker exec "cmcp-t2-$$" bash -c "grep -q 'MARKER = 1' $CN/user-test-node/__init__.py"; then
+    pass "boot 2: user-installed node SURVIVED the redeploy"
+  else
+    fail "boot 2: user-installed node LOST on redeploy (persistence regression)"
+  fi
+else
+  fail "boot 2 did not reach ComfyUI launch"
+fi
+docker rm -f "cmcp-t2-$$" >/dev/null
+
+say "boot 3: self-heal after simulated ENOSPC corruption (0-byte panel)…"
+# Truncate EVERY panel file (worktree AND .git — exactly what a full volume
+# leaves behind), and hide the image seed behind an empty bind-mount so the
+# routine seed refresh can't repair it — this forces the §4.5(b.2) last-resort
+# re-clone, the path that saves a pod whose volume corrupted while the image
+# seed is stale/unavailable.
+docker run --rm -v "$VOL:/workspace" --entrypoint bash "$IMAGE" -c \
+  "find $PANEL -type f -exec truncate -s 0 {} +" >/dev/null
+boot3() {
+  docker run -d --name "cmcp-t3-$$" -v "$VOL:/workspace" -e MIN_DRIVER=0 \
+    --tmpfs /opt/ComfyUI/custom_nodes_seed "$IMAGE" >/dev/null
+  for _ in $(seq 1 60); do
+    if docker logs "cmcp-t3-$$" 2>&1 | grep -q 'launching ComfyUI:'; then return 0; fi
+    sleep 5
+  done
+  echo "timed out"; docker logs "cmcp-t3-$$" 2>&1 | tail -20; return 1
+}
+if boot3; then
+  panel_check "cmcp-t3-$$" "boot 3: 0-byte panel was self-healed at boot"
+  docker logs "cmcp-t3-$$" 2>&1 | grep -q 'self-healing' \
+    && pass "boot 3: §4.5(b.2) self-heal path was taken and logged" \
+    || fail "boot 3: self-heal log line missing"
+else
+  fail "boot 3 did not reach ComfyUI launch"
+fi
+docker rm -f "cmcp-t3-$$" >/dev/null
+
+if [ "$FAILURES" -eq 0 ]; then
+  say "ALL CHECKS PASSED — image is safe to push"
+else
+  say "FAILED: $FAILURES check(s) — DO NOT PUSH THIS IMAGE"
+  exit 1
+fi

--- a/docker/runpod/verify_image_remote.py
+++ b/docker/runpod/verify_image_remote.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Verify a PUSHED comfyui-mcp RunPod image straight from its registry.
+
+Downloads only the manifest, config, and the one layer produced by the
+`mv custom_nodes -> custom_nodes_seed` build step (a few MB — not the 20 GB
+image) and asserts the load-bearing files are present with real contents.
+This checks what the registry ACTUALLY serves, after any build cache,
+compression, or push step had a chance to mangle it.
+
+    python3 verify_image_remote.py ghcr.io/artokun/comfyui-mcp-runpod:cu128-lean
+    python3 verify_image_remote.py docker.io/artokun/comfyui-mcp-runpod:1.6
+
+Exit 0 = verified; exit 1 = FAILED (do not point the RunPod template at it).
+Anonymous pull only — works for public repos, no credentials needed.
+"""
+import io
+import json
+import gzip
+import sys
+import tarfile
+import urllib.request
+
+KEY_FILES = [
+    "opt/ComfyUI/custom_nodes_seed/comfyui-mcp-panel/__init__.py",
+    "opt/ComfyUI/custom_nodes_seed/comfyui-mcp-panel/pyproject.toml",
+    "opt/ComfyUI/custom_nodes_seed/comfyui-mcp-panel/web/js/comfyui-mcp-panel.js",
+]
+ACCEPT = ", ".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+])
+
+
+def fetch(url, token=None, accept=None, raw=False):
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if accept:
+        req.add_header("Accept", accept)
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = r.read()
+    return data if raw else json.loads(data)
+
+
+def registry_parts(ref):
+    host, _, rest = ref.partition("/")
+    if host in ("docker.io", "index.docker.io"):
+        host = "registry-1.docker.io"
+    repo, _, tag = rest.rpartition(":")
+    if not repo:  # no tag given
+        repo, tag = rest, "latest"
+    return host, repo, tag
+
+
+def get_token(host, repo):
+    if host == "registry-1.docker.io":
+        url = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"
+    elif host == "ghcr.io":
+        url = f"https://ghcr.io/token?scope=repository:{repo}:pull"
+    else:
+        return None
+    return fetch(url)["token"]
+
+
+def main(ref):
+    host, repo, tag = registry_parts(ref)
+    token = get_token(host, repo)
+    base = f"https://{host}/v2/{repo}"
+
+    manifest = fetch(f"{base}/manifests/{tag}", token, ACCEPT)
+    if "manifests" in manifest:  # index/manifest-list -> pick linux/amd64
+        digest = next(
+            m["digest"] for m in manifest["manifests"]
+            if m.get("platform", {}).get("architecture") == "amd64"
+        )
+        manifest = fetch(f"{base}/manifests/{digest}", token, ACCEPT)
+
+    config = fetch(f"{base}/blobs/{manifest['config']['digest']}", token)
+
+    # Map non-empty history entries onto layers; find the mv-seed step's layer.
+    layers = manifest["layers"]
+    idx, seed_layer = 0, None
+    for entry in config.get("history", []):
+        if entry.get("empty_layer"):
+            continue
+        created_by = entry.get("created_by", "")
+        if "custom_nodes_seed" in created_by and " mv " in f" {created_by} ":
+            seed_layer = layers[idx]
+        idx += 1
+    if seed_layer is None:
+        print("FAIL: no layer matches the `mv custom_nodes -> custom_nodes_seed` step")
+        return 1
+
+    print(f"seed layer: {seed_layer['digest']} ({seed_layer['size'] / 1e6:.1f} MB) — downloading…")
+    blob = fetch(f"{base}/blobs/{seed_layer['digest']}", token, raw=True)
+    tf = tarfile.open(fileobj=io.BytesIO(gzip.decompress(blob)))
+
+    sizes = {m.name: m.size for m in tf if m.isfile()}
+    failures = []
+    for f in KEY_FILES:
+        size = sizes.get(f)
+        if not size:
+            failures.append(f"{f}: {'MISSING' if size is None else '0 BYTES'}")
+        else:
+            print(f"  ok: {f} ({size} bytes)")
+    empty = [n for n, s in sizes.items()
+             if s == 0 and "/.git/" not in n and not n.split("/")[-1].startswith(".wh.")]
+    if empty:
+        failures.append(f"{len(empty)} zero-byte files in seed, e.g. {empty[:5]}")
+
+    if failures:
+        print("FAIL: the registry is serving a broken image:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print(f"VERIFIED: {ref} serves a healthy custom_nodes_seed ({len(sizes)} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -55,9 +55,31 @@ allow_git_url_install = True   ; Manager 3.x: additionally required
 ```
 
 Restart ComfyUI afterward. On the RunPod image this is the default as of
-image `1.4` (`COMFY_SECURITY_LEVEL` env overrides it; the level is re-asserted
-on every boot). Only relax this on a machine you control — it removes
-Manager's install guardrails.
+image `1.6` (`COMFY_SECURITY_LEVEL` env overrides it; the level is re-asserted
+on every boot). Images `1.4`/`1.5` *intended* this but a baked
+`COMFY_SECURITY_LEVEL=normal-` env var overrode the boot script's default —
+on those images set `COMFY_SECURITY_LEVEL=weak` in the pod's environment.
+Only relax this on a machine you control — it removes Manager's install
+guardrails.
+
+## RunPod: Agent Panel tab is empty — its files exist but are all 0 bytes
+
+ComfyUI lists `comfyui-mcp-panel` but the sidebar tab never loads;
+`ls -la /workspace/custom_nodes/comfyui-mcp-panel` shows every file at **0
+bytes**. User-installed nodes may be empty the same way.
+
+**Cause:** the network volume ran **out of space** at some point (often the
+first-boot ~7 GB spotcheck-model copy on a small volume, or a big model
+download). On ENOSPC, `cp`/`git` still *create* each file but write nothing
+into it — and since the volume persists, the husks survive every redeploy.
+
+**Fix:** free or grow the volume, then restart the pod. As of image `1.6` the
+boot script warns when the volume is low/full, skips the spotcheck-model copy
+when it wouldn't fit, and **self-heals** a 0-byte panel automatically (re-clone
+from GitHub, or the image seed when offline). It also logs
+`WARN: custom nodes with 0-byte __init__.py` naming any other broken nodes —
+reinstall those via Manager. On images `<= 1.5`, delete the panel folder and
+restart: `rm -rf /workspace/custom_nodes/comfyui-mcp-panel`.
 
 ## Panel says "No agent is listening on the bridge (ws://127.0.0.1:9180)"
 


### PR DESCRIPTION
## The field report (tester: KeepYourWord)

1. **Agent Panel ships "completely empty"** — `init.py`, `pyproject.toml`, and the JS bundle all 0 bytes on a fresh deploy.
2. **Custom nodes appear not to persist** across redeploys on the same volume.

## Root cause (reproduced)

Registry-layer forensics show **every published image is healthy** (hub `1.0`–`1.5`, ghcr `cu128-lean` — panel seed fully populated, symlink boot logic present). The corruption is **runtime ENOSPC**: when `/workspace` fills up, `cp`/`git` still *create* every file but write 0 bytes, the boot script swallowed the errors (`2>/dev/null`), and because the volume persists the husks survive every redeploy. Reproduced byte-for-byte with a small volume: **69/69 seeded files at 0 bytes**, boot "succeeds", panel tab never loads. Likely trigger: the first-boot ~7 GB spotcheck-model copy on the template's 60 GB default volume + a few video models.

A second real bug rode along: the baked `COMFY_SECURITY_LEVEL=normal-` ENV has been overriding `post_start.sh`'s `weak` default since 1.4, so git-URL node installs were **silently skipped** (defeated 613f8c7).

## Fixes

* **Boot self-heal** (`post_start.sh`): free-space preflight + loud ENOSPC warning · spotcheck copy skipped when it won't fit · seed-copy errors logged · panel integrity check with re-clone (PANEL_REF-aware) and offline image-seed fallback · 0-byte sweep names any other broken node.
* **Build-time integrity gate** (Dockerfile §9.5): a build with empty/missing artifacts now fails red instead of shipping.
* **Post-build test gate**: `test_image.sh` (static + fresh-volume boot + redeploy-persistence + corruption self-heal — all green against a local build), `deploy-dockerhub.sh` (gated push), `verify_image_remote.py` (verifies what the registry actually serves; wired into CI post-push).
* `COMFY_SECURITY_LEVEL=weak` baked via the late runtime-ENV block (cache-friendly); stale pre-#111 docs corrected; troubleshooting entry added.

## Verified

* All 5 boot-path behaviors exercised against the real image (ENOSPC warning, spotcheck skip, seed refresh, online re-clone, offline seed restore).
* Full `test_image.sh` suite green on a locally built image; the integrity gate caught a real mistake during development (wrong import check), proving it fails builds.

Ship plan: merge → CI rebuilds + verifies `ghcr:cu128-lean` → push hub `1.6` via the gated deploy script → pin the RunPod template to `:1.6` (`:latest` is a stale-host-cache hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)