### PR TITLE
feat(save_workflow): auto-convert API-format graphs to Web UI format (#126)

### DIFF
--- a/src/__tests__/services/workflow-converter-api-to-ui.test.ts
+++ b/src/__tests__/services/workflow-converter-api-to-ui.test.ts
@@ -294,10 +294,27 @@ describe("convertApiToUi — structure and round-trip", () => {
       save: { class_type: "SaveImage", inputs: { images: ["latent", 0], filename_prefix: "x" } },
     } as never;
     const { workflow: ui, warnings } = convertApiToUi(api, T2I_INFO);
-    expect(warnings.some((w) => w.includes("not a positive integer"))).toBe(true);
+    expect(warnings.some((w) => w.includes("not a usable unique positive integer"))).toBe(true);
     expect(ui.links).toHaveLength(1);
     const save = ui.nodes.find((n) => n.type === "SaveImage")!;
     expect(save.inputs!.find((i) => i.name === "images")!.link).toBe(ui.links[0][0]);
+  });
+
+  it('remaps colliding numeric keys ("1" vs "01") to unique ids, keeping wiring', () => {
+    const api = {
+      "1": { class_type: "EmptyLatentImage", inputs: { width: 512, height: 512, batch_size: 1 } },
+      "01": { class_type: "EmptyLatentImage", inputs: { width: 256, height: 256, batch_size: 1 } },
+      "2": { class_type: "SaveImage", inputs: { images: ["01", 0], filename_prefix: "x" } },
+    } as never;
+    const { workflow: ui, warnings } = convertApiToUi(api, T2I_INFO);
+    expect(warnings.some((w) => w.includes('"01"'))).toBe(true);
+    const ids = ui.nodes.map((n) => n.id);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicate node ids
+    // The link still points at the REMAPPED "01" node, not the "1" node.
+    const save = ui.nodes.find((n) => n.type === "SaveImage")!;
+    const link = ui.links.find((l) => l[0] === save.inputs![0].link)!;
+    const src = ui.nodes.find((n) => n.id === link[1])!;
+    expect(src.widgets_values![0]).toBe(256);
   });
 
   it("warns on a literal value stuck on a connection-only input and drops it", () => {

--- a/src/__tests__/services/workflow-converter-api-to-ui.test.ts
+++ b/src/__tests__/services/workflow-converter-api-to-ui.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertApiToUi,
+  convertUiToApi,
+  isApiFormat,
+  isUiFormat,
+} from "../../services/workflow-converter.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// convertApiToUi — API → UI with generated layout (issue #126)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Realistic txt2img object_info subset with outputs + input_order (widget order
+// is definitional — the round-trip depends on it).
+const T2I_INFO = {
+  CheckpointLoaderSimple: {
+    input: { required: { ckpt_name: [["model_a.safetensors", "model_b.safetensors"]] } },
+    input_order: { required: ["ckpt_name"] },
+    output: ["MODEL", "CLIP", "VAE"],
+    output_name: ["MODEL", "CLIP", "VAE"],
+  },
+  CLIPTextEncode: {
+    input: { required: { text: ["STRING", { multiline: true }], clip: ["CLIP"] } },
+    input_order: { required: ["text", "clip"] },
+    output: ["CONDITIONING"],
+    output_name: ["CONDITIONING"],
+  },
+  EmptyLatentImage: {
+    input: {
+      required: {
+        width: ["INT", { default: 512 }],
+        height: ["INT", { default: 512 }],
+        batch_size: ["INT", { default: 1 }],
+      },
+    },
+    input_order: { required: ["width", "height", "batch_size"] },
+    output: ["LATENT"],
+    output_name: ["LATENT"],
+  },
+  KSampler: {
+    input: {
+      required: {
+        model: ["MODEL"],
+        seed: ["INT", { default: 0, control_after_generate: true }],
+        steps: ["INT", { default: 20 }],
+        cfg: ["FLOAT", { default: 8.0 }],
+        sampler_name: [["euler", "dpmpp_2m"]],
+        scheduler: [["normal", "karras"]],
+        positive: ["CONDITIONING"],
+        negative: ["CONDITIONING"],
+        latent_image: ["LATENT"],
+        denoise: ["FLOAT", { default: 1.0 }],
+      },
+    },
+    input_order: {
+      required: [
+        "model", "seed", "steps", "cfg", "sampler_name", "scheduler",
+        "positive", "negative", "latent_image", "denoise",
+      ],
+    },
+    output: ["LATENT"],
+    output_name: ["LATENT"],
+  },
+  VAEDecode: {
+    input: { required: { samples: ["LATENT"], vae: ["VAE"] } },
+    input_order: { required: ["samples", "vae"] },
+    output: ["IMAGE"],
+    output_name: ["IMAGE"],
+  },
+  SaveImage: {
+    input: {
+      required: { images: ["IMAGE"], filename_prefix: ["STRING", { default: "ComfyUI" }] },
+    },
+    input_order: { required: ["images", "filename_prefix"] },
+    output: [],
+    output_name: [],
+  },
+} as never;
+
+const T2I_API = {
+  "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "model_a.safetensors" } },
+  "2": {
+    class_type: "CLIPTextEncode",
+    inputs: { text: "a cat in a hat", clip: ["1", 1] },
+    _meta: { title: "Positive" },
+  },
+  "3": {
+    class_type: "CLIPTextEncode",
+    inputs: { text: "blurry, low quality", clip: ["1", 1] },
+    _meta: { title: "Negative" },
+  },
+  "4": { class_type: "EmptyLatentImage", inputs: { width: 768, height: 512, batch_size: 1 } },
+  "5": {
+    class_type: "KSampler",
+    inputs: {
+      model: ["1", 0], seed: 42, steps: 25, cfg: 7.5,
+      sampler_name: "euler", scheduler: "karras",
+      positive: ["2", 0], negative: ["3", 0], latent_image: ["4", 0], denoise: 1.0,
+    },
+  },
+  "6": { class_type: "VAEDecode", inputs: { samples: ["5", 0], vae: ["1", 2] } },
+  "7": { class_type: "SaveImage", inputs: { images: ["6", 0], filename_prefix: "roundtrip" } },
+} as never;
+
+describe("convertApiToUi — structure and round-trip", () => {
+  it("round-trips a full txt2img graph: convertUiToApi(convertApiToUi(x)) === x", () => {
+    const { workflow: ui, warnings } = convertApiToUi(T2I_API, T2I_INFO);
+    expect(warnings).toEqual([]);
+    const back = convertUiToApi(ui as never, T2I_INFO);
+    expect(back.workflow).toEqual(T2I_API);
+  });
+
+  it("emits canvas-loadable structure: nodes, links, slots, and workflow ids", () => {
+    const { workflow: ui } = convertApiToUi(T2I_API, T2I_INFO);
+    expect(ui.nodes).toHaveLength(7);
+    expect(ui.links).toHaveLength(9); // clip×2, model, pos, neg, latent, samples, vae, images
+    expect(ui.last_node_id).toBe(7);
+    expect(ui.last_link_id).toBe(9);
+
+    const ks = ui.nodes.find((n) => n.type === "KSampler")!;
+    // control_after_generate seed carries the phantom widget slot.
+    expect(ks.widgets_values).toEqual([42, "fixed", 25, 7.5, "euler", "karras", 1.0]);
+    // Link inputs appear as slots in definition order with wired link ids.
+    expect(ks.inputs!.map((i) => i.name)).toEqual([
+      "model", "positive", "negative", "latent_image",
+    ]);
+    for (const inp of ks.inputs!) expect(inp.link).toBeTypeOf("number");
+
+    const ckpt = ui.nodes.find((n) => n.type === "CheckpointLoaderSimple")!;
+    expect(ckpt.outputs!.map((o) => o.name)).toEqual(["MODEL", "CLIP", "VAE"]);
+    expect(ckpt.outputs![1].links).toHaveLength(2); // CLIP feeds both encoders
+
+    // Every link's target slot index matches the target node's inputs array.
+    for (const [id, , , tgtId, tgtSlot] of ui.links) {
+      const tgt = ui.nodes.find((n) => n.id === tgtId)!;
+      expect(tgt.inputs![tgtSlot].link).toBe(id);
+    }
+  });
+
+  it("preserves _meta.title as node title and _meta.mode muted/bypassed as mode 2/4", () => {
+    const api = {
+      "1": { class_type: "EmptyLatentImage", inputs: { width: 512, height: 512, batch_size: 1 } },
+      "2": {
+        class_type: "SaveImage",
+        inputs: { filename_prefix: "x" },
+        _meta: { title: "Final Save", mode: "muted" },
+      },
+      "3": {
+        class_type: "VAEDecode",
+        inputs: {},
+        _meta: { mode: "bypassed" },
+      },
+    } as never;
+    const { workflow: ui } = convertApiToUi(api, T2I_INFO);
+    const save = ui.nodes.find((n) => n.type === "SaveImage")!;
+    expect(save.title).toBe("Final Save");
+    expect(save.mode).toBe(2);
+    expect(ui.nodes.find((n) => n.type === "VAEDecode")!.mode).toBe(4);
+    expect(ui.nodes.find((n) => n.type === "EmptyLatentImage")!.mode).toBe(0);
+  });
+
+  it("generates a left-to-right topological layout with no overlapping positions", () => {
+    const { workflow: ui } = convertApiToUi(T2I_API, T2I_INFO);
+    const x = (type: string) =>
+      (ui.nodes.find((n) => n.type === type)!.pos as [number, number])[0];
+    expect(x("CLIPTextEncode")).toBeGreaterThan(x("CheckpointLoaderSimple"));
+    expect(x("KSampler")).toBeGreaterThan(x("CLIPTextEncode"));
+    expect(x("VAEDecode")).toBeGreaterThan(x("KSampler"));
+    expect(x("SaveImage")).toBeGreaterThan(x("VAEDecode"));
+    const seen = new Set(ui.nodes.map((n) => String(n.pos)));
+    expect(seen.size).toBe(ui.nodes.length); // all positions distinct
+    for (const n of ui.nodes) {
+      const [w, h] = n.size as [number, number];
+      expect(w).toBeGreaterThan(0);
+      expect(h).toBeGreaterThan(0);
+    }
+  });
+
+  it("represents a link-fed widget input as a converted slot and round-trips it", () => {
+    const info = {
+      MyInt: {
+        input: { required: { value: ["INT", { default: 0 }] } },
+        input_order: { required: ["value"] },
+        output: ["INT"],
+        output_name: ["INT"],
+      },
+      Blur: {
+        input: { required: { image: ["IMAGE"], blur_radius: ["INT", { default: 5 }] } },
+        input_order: { required: ["image", "blur_radius"] },
+        output: ["IMAGE"],
+        output_name: ["IMAGE"],
+      },
+      SolidColor: {
+        input: { required: { width: ["INT", { default: 64 }], height: ["INT", { default: 64 }] } },
+        input_order: { required: ["width", "height"] },
+        output: ["IMAGE"],
+        output_name: ["IMAGE"],
+      },
+    } as never;
+    const api = {
+      "1": { class_type: "MyInt", inputs: { value: 9 } },
+      "2": { class_type: "SolidColor", inputs: { width: 64, height: 64 } },
+      "3": { class_type: "Blur", inputs: { image: ["2", 0], blur_radius: ["1", 0] } },
+    } as never;
+    const { workflow: ui } = convertApiToUi(api, info);
+    const blur = ui.nodes.find((n) => n.type === "Blur")!;
+    const widgetSlot = blur.inputs!.find((i) => i.name === "blur_radius")!;
+    expect(widgetSlot.widget).toEqual({ name: "blur_radius" });
+    expect(widgetSlot.link).toBeTypeOf("number");
+    expect(blur.widgets_values).toHaveLength(1); // positional placeholder kept
+
+    const back = convertUiToApi(ui as never, info);
+    expect(back.workflow).toEqual(api);
+  });
+
+  it("round-trips V3 dynamic-combo nested dotted keys", () => {
+    const info = {
+      GeminiNanoBanana2V2: {
+        input: {
+          required: {
+            prompt: ["STRING", { multiline: true }],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                        resolution: ["COMBO", { options: ["1K", "2K", "4K"] }],
+                        thinking_level: ["COMBO", { options: ["MINIMAL", "HIGH"] }],
+                        images: ["COMFY_AUTOGROW_V3", { min: 0 }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT", { default: 42, control_after_generate: true }],
+            response_modalities: ["COMBO", { options: ["IMAGE", "IMAGE+TEXT"] }],
+          },
+        },
+        output: ["IMAGE"],
+        output_name: ["IMAGE"],
+      },
+    } as never;
+    const api = {
+      "1": {
+        class_type: "GeminiNanoBanana2V2",
+        inputs: {
+          prompt: "a red cube",
+          model: "Nano Banana 2 (Gemini 3.1 Flash Image)",
+          "model.aspect_ratio": "16:9",
+          "model.resolution": "2K",
+          "model.thinking_level": "HIGH",
+          seed: 7,
+          response_modalities: "IMAGE",
+        },
+      },
+    } as never;
+    const { workflow: ui, warnings } = convertApiToUi(api, info);
+    expect(warnings).toEqual([]);
+    expect(ui.nodes[0].widgets_values).toEqual([
+      "a red cube",
+      "Nano Banana 2 (Gemini 3.1 Flash Image)",
+      "16:9", "2K", "HIGH",
+      7, "fixed",
+      "IMAGE",
+    ]);
+    const back = convertUiToApi(ui as never, info);
+    expect(back.workflow).toEqual(api);
+  });
+
+  it("keeps connections for unknown node types (best-effort) and warns", () => {
+    const api = {
+      "1": { class_type: "EmptyLatentImage", inputs: { width: 512, height: 512, batch_size: 1 } },
+      "2": { class_type: "TotallyUnknownNode", inputs: { latent: ["1", 0], strength: 0.5 } },
+    } as never;
+    const { workflow: ui, warnings } = convertApiToUi(api, T2I_INFO);
+    expect(warnings.some((w) => w.includes("TotallyUnknownNode"))).toBe(true);
+    const unk = ui.nodes.find((n) => n.type === "TotallyUnknownNode")!;
+    expect(unk.inputs![0].link).toBeTypeOf("number");
+    expect(unk.widgets_values).toEqual([0.5]);
+    expect(ui.links).toHaveLength(1);
+  });
+
+  it("remaps non-numeric node keys with a warning, preserving connections", () => {
+    const api = {
+      latent: {
+        class_type: "EmptyLatentImage",
+        inputs: { width: 512, height: 512, batch_size: 1 },
+      },
+      save: { class_type: "SaveImage", inputs: { images: ["latent", 0], filename_prefix: "x" } },
+    } as never;
+    const { workflow: ui, warnings } = convertApiToUi(api, T2I_INFO);
+    expect(warnings.some((w) => w.includes("not a positive integer"))).toBe(true);
+    expect(ui.links).toHaveLength(1);
+    const save = ui.nodes.find((n) => n.type === "SaveImage")!;
+    expect(save.inputs!.find((i) => i.name === "images")!.link).toBe(ui.links[0][0]);
+  });
+
+  it("warns on a literal value stuck on a connection-only input and drops it", () => {
+    const api = {
+      "1": { class_type: "VAEDecode", inputs: { samples: "not-a-link" } },
+    } as never;
+    const { warnings } = convertApiToUi(api, T2I_INFO);
+    expect(warnings.some((w) => w.includes('"samples"') && w.includes("literal"))).toBe(true);
+  });
+
+  it("fills omitted widgets with object_info defaults so positions stay aligned", () => {
+    const api = {
+      "1": { class_type: "EmptyLatentImage", inputs: { width: 768 } }, // height/batch omitted
+    } as never;
+    const { workflow: ui } = convertApiToUi(api, T2I_INFO);
+    expect(ui.nodes[0].widgets_values).toEqual([768, 512, 1]);
+  });
+});
+
+describe("isApiFormat / isUiFormat detection", () => {
+  it("classifies API format", () => {
+    expect(isApiFormat(T2I_API)).toBe(true);
+    expect(isUiFormat(T2I_API)).toBe(false);
+  });
+  it("classifies UI format", () => {
+    const ui = { nodes: [], links: [] };
+    expect(isUiFormat(ui)).toBe(true);
+    expect(isApiFormat(ui)).toBe(false);
+  });
+  it("rejects empty objects, arrays, and junk", () => {
+    expect(isApiFormat({})).toBe(false);
+    expect(isApiFormat([])).toBe(false);
+    expect(isApiFormat(null)).toBe(false);
+    expect(isApiFormat({ a: { inputs: {} } })).toBe(false); // no class_type
+  });
+});

--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -172,6 +172,8 @@ export type UiLink = [number, number, number, number, number, string];
 export interface UiWorkflow {
   nodes: UiNode[];
   links: UiLink[];
+  last_node_id?: number;
+  last_link_id?: number;
   version?: number;
   extra?: Record<string, unknown>;
   config?: Record<string, unknown>;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -726,7 +726,12 @@ interface PendingLink {
  * Convert an API-format workflow to UI (canvas) format with a generated
  * layout. The inverse of convertUiToApi for well-formed graphs:
  * `convertUiToApi(convertApiToUi(x).workflow)` reproduces `x` (modulo layout,
- * string-normalized link refs, and filled-in defaults for omitted widgets).
+ * string-normalized link refs, and filled-in defaults for omitted widgets —
+ * both deliberate: the canvas itself materializes every widget when queueing).
+ * One knowing asymmetry: `_meta.mode` muted/bypassed becomes UI mode 2/4 and
+ * the node is PRESERVED on canvas, but convertUiToApi excludes mode-2/4 nodes
+ * from the executable prompt (correct queue semantics), so those nodes don't
+ * survive a UI→API round-trip.
  *
  * objectInfo is definitional: widget ORDER in widgets_values comes from
  * input_order (the same order convertUiToApi consumes), including the phantom

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -717,7 +717,7 @@ function widgetDefaultValue(spec: NodeInputSpec): unknown {
 interface PendingLink {
   srcKey: string;
   srcSlot: number;
-  tgtId: number;
+  tgtKey: string;
   tgtSlotIdx: number;
   expectedType: string;
 }
@@ -741,21 +741,26 @@ export function convertApiToUi(
   const keys = Object.keys(api);
   const keySet = new Set(keys);
 
-  // Numeric node ids; non-numeric API keys (rare, hand-written) get remapped.
+  // Numeric node ids; non-numeric API keys (rare, hand-written) get remapped,
+  // as does a key whose numeric value another key already claimed ("1" vs
+  // "01" both Number() to 1 — duplicate node ids would corrupt the canvas).
   let maxId = 0;
   for (const k of keys) {
     const n = Number(k);
     if (Number.isInteger(n) && n > 0) maxId = Math.max(maxId, n);
   }
   const idFor = new Map<string, number>();
+  const usedIds = new Set<number>();
   for (const k of keys) {
     const n = Number(k);
-    if (Number.isInteger(n) && n > 0 && !idFor.has(k)) {
+    if (Number.isInteger(n) && n > 0 && !usedIds.has(n)) {
       idFor.set(k, n);
+      usedIds.add(n);
     } else {
       idFor.set(k, ++maxId);
+      usedIds.add(maxId);
       warnings.push(
-        `Node key "${k}" is not a positive integer — remapped to id ${maxId} (connections preserved).`,
+        `Node key "${k}" is not a usable unique positive integer — remapped to id ${maxId} (connections preserved).`,
       );
     }
   }
@@ -787,7 +792,7 @@ export function convertApiToUi(
           pending.push({
             srcKey: String(val[0]),
             srcSlot: val[1],
-            tgtId: id,
+            tgtKey: key,
             tgtSlotIdx: uiInputs.length - 1,
             expectedType: "*",
           });
@@ -821,7 +826,7 @@ export function convertApiToUi(
             pending.push({
               srcKey: String(raw[0]),
               srcSlot: raw[1],
-              tgtId: id,
+              tgtKey: key,
               tgtSlotIdx: uiInputs.length - 1,
               expectedType: widgetSlotType(spec),
             });
@@ -864,7 +869,7 @@ export function convertApiToUi(
             pending.push({
               srcKey: String(raw[0]),
               srcSlot: raw[1],
-              tgtId: id,
+              tgtKey: key,
               tgtSlotIdx: uiInputs.length - 1,
               expectedType: slotType,
             });
@@ -899,7 +904,7 @@ export function convertApiToUi(
           pending.push({
             srcKey: String(val[0]),
             srcSlot: val[1],
-            tgtId: id,
+            tgtKey: key,
             tgtSlotIdx: uiInputs.length - 1,
             expectedType: "*",
           });
@@ -944,7 +949,7 @@ export function convertApiToUi(
   let lastLinkId = 0;
   for (const p of pending) {
     const src = uiNodes.get(p.srcKey);
-    const tgt = [...uiNodes.values()].find((n) => n.id === p.tgtId)!;
+    const tgt = uiNodes.get(p.tgtKey)!;
     if (!src) continue; // ref to a key we never materialized (can't happen: keySet-gated)
     // Ensure the source has a slot at srcSlot even if its def was unknown.
     while ((src.outputs ??= []).length <= p.srcSlot) {
@@ -961,10 +966,7 @@ export function convertApiToUi(
   // ── Generated layout: topological layers, left → right ──────────────────
   const layerByKey = new Map<string, number>(keys.map((k) => [k, 0]));
   const edges = pending
-    .map((p) => {
-      const tgtKey = keys.find((k) => uiNodes.get(k)!.id === p.tgtId)!;
-      return [p.srcKey, tgtKey] as const;
-    })
+    .map((p) => [p.srcKey, p.tgtKey] as const)
     .filter(([s, t]) => s !== t);
   // Bounded relaxation — cycle-safe and plenty for real graph depths.
   for (let pass = 0; pass < keys.length; pass++) {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -2,8 +2,11 @@ import type {
   WorkflowJSON,
   ObjectInfo,
   ComfyUINodeDef,
+  NodeInputSpec,
   UiWorkflow,
   UiNode,
+  UiNodeInput,
+  UiNodeOutput,
   UiLink,
   SubgraphDefinition,
   SubgraphLink,
@@ -642,6 +645,380 @@ function findWidgetIndex(node: UiNode, widgetName: string): number | null {
   // it may be at a fixed position. Search widgets_values if we can match by name.
   // For now, return null — the widget is likely at its default value.
   return null;
+}
+
+// ── API → UI conversion ─────────────────────────────────────────────────────
+
+/**
+ * Detect an API-format workflow: a non-empty record whose every value is a
+ * node object with a string `class_type`. (`inputs` may be absent on
+ * degenerate nodes; class_type is the discriminator.)
+ */
+export function isApiFormat(obj: unknown): obj is WorkflowJSON {
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return false;
+  const values = Object.values(obj as Record<string, unknown>);
+  if (values.length === 0) return false;
+  return values.every(
+    (v) =>
+      typeof v === "object" &&
+      v !== null &&
+      !Array.isArray(v) &&
+      typeof (v as { class_type?: unknown }).class_type === "string",
+  );
+}
+
+/** An API-format connection reference: ["<nodeId>", <outputSlot>]. */
+function isLinkRef(v: unknown, nodeKeys: Set<string>): v is [string | number, number] {
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    (typeof v[0] === "string" || typeof v[0] === "number") &&
+    typeof v[1] === "number" &&
+    nodeKeys.has(String(v[0]))
+  );
+}
+
+/** The UI slot `type` string for a widget input spec. */
+function widgetSlotType(spec: NodeInputSpec): string {
+  const t = spec[0];
+  return Array.isArray(t) ? "COMBO" : t;
+}
+
+/**
+ * A sensible widgets_values entry for a widget the API graph didn't provide:
+ * the spec default, else the first combo option, else a type-appropriate zero.
+ * Used both for omitted widgets (ComfyUI would apply the same default) and as
+ * the positional placeholder under a link-fed widget input.
+ */
+function widgetDefaultValue(spec: NodeInputSpec): unknown {
+  const [type, cfg] = spec;
+  const c = cfg as
+    | { default?: unknown; options?: Array<{ key?: unknown } | string> }
+    | undefined;
+  if (c?.default !== undefined) return c.default;
+  if (Array.isArray(type)) return type[0];
+  if (Array.isArray(c?.options)) {
+    const first = c.options[0];
+    return typeof first === "object" && first !== null ? first.key : first;
+  }
+  switch (type) {
+    case "INT":
+    case "FLOAT":
+      return 0;
+    case "STRING":
+      return "";
+    case "BOOLEAN":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+interface PendingLink {
+  srcKey: string;
+  srcSlot: number;
+  tgtId: number;
+  tgtSlotIdx: number;
+  expectedType: string;
+}
+
+/**
+ * Convert an API-format workflow to UI (canvas) format with a generated
+ * layout. The inverse of convertUiToApi for well-formed graphs:
+ * `convertUiToApi(convertApiToUi(x).workflow)` reproduces `x` (modulo layout,
+ * string-normalized link refs, and filled-in defaults for omitted widgets).
+ *
+ * objectInfo is definitional: widget ORDER in widgets_values comes from
+ * input_order (the same order convertUiToApi consumes), including the phantom
+ * control_after_generate slot after seed-type widgets and V3 dynamic-combo
+ * nested values ("combo.nested" dotted keys) after their combo.
+ */
+export function convertApiToUi(
+  api: WorkflowJSON,
+  objectInfo: ObjectInfo,
+): { workflow: UiWorkflow; warnings: string[] } {
+  const warnings: string[] = [];
+  const keys = Object.keys(api);
+  const keySet = new Set(keys);
+
+  // Numeric node ids; non-numeric API keys (rare, hand-written) get remapped.
+  let maxId = 0;
+  for (const k of keys) {
+    const n = Number(k);
+    if (Number.isInteger(n) && n > 0) maxId = Math.max(maxId, n);
+  }
+  const idFor = new Map<string, number>();
+  for (const k of keys) {
+    const n = Number(k);
+    if (Number.isInteger(n) && n > 0 && !idFor.has(k)) {
+      idFor.set(k, n);
+    } else {
+      idFor.set(k, ++maxId);
+      warnings.push(
+        `Node key "${k}" is not a positive integer — remapped to id ${maxId} (connections preserved).`,
+      );
+    }
+  }
+
+  const uiNodes = new Map<string, UiNode>();
+  const pending: PendingLink[] = [];
+
+  for (const key of keys) {
+    const apiNode = api[key];
+    const classType = apiNode.class_type;
+    const apiInputs = (apiNode.inputs ?? {}) as Record<string, unknown>;
+    const def = objectInfo[classType];
+    const id = idFor.get(key)!;
+
+    const uiInputs: UiNodeInput[] = [];
+    const widgetsValues: unknown[] = [];
+    const consumed = new Set<string>();
+
+    if (!def) {
+      // Best-effort: keep connections; carry literals as positional widgets in
+      // key order. convertUiToApi will skip this node too (same warning), so
+      // the graph degrades symmetrically instead of silently losing wiring.
+      warnings.push(
+        `Node ${key} (${classType}): not found in object_info — custom node may not be installed. Slot layout is best-effort.`,
+      );
+      for (const [name, val] of Object.entries(apiInputs)) {
+        if (isLinkRef(val, keySet)) {
+          uiInputs.push({ name, type: "*", link: null });
+          pending.push({
+            srcKey: String(val[0]),
+            srcSlot: val[1],
+            tgtId: id,
+            tgtSlotIdx: uiInputs.length - 1,
+            expectedType: "*",
+          });
+        } else {
+          widgetsValues.push(val);
+        }
+      }
+    } else {
+      const orderedNames = getOrderedInputNames(def);
+      for (const name of orderedNames) {
+        const spec = def.input.required?.[name] ?? def.input.optional?.[name];
+        if (!spec) continue;
+        consumed.add(name);
+        const raw = apiInputs[name];
+
+        if (isWidgetInput(name, def)) {
+          // A widget input fed by a link is a "converted widget" in the UI:
+          // an inputs[] slot carrying widget:{name}, with a positional
+          // placeholder kept in widgets_values so downstream widget indices
+          // stay aligned (convertUiToApi assigns the placeholder, then the
+          // link overrides it by name).
+          let effective: unknown;
+          if (isLinkRef(raw, keySet)) {
+            effective = widgetDefaultValue(spec);
+            uiInputs.push({
+              name,
+              type: widgetSlotType(spec),
+              link: null,
+              widget: { name },
+            });
+            pending.push({
+              srcKey: String(raw[0]),
+              srcSlot: raw[1],
+              tgtId: id,
+              tgtSlotIdx: uiInputs.length - 1,
+              expectedType: widgetSlotType(spec),
+            });
+          } else {
+            effective = raw !== undefined ? raw : widgetDefaultValue(spec);
+          }
+          widgetsValues.push(effective);
+
+          // Phantom "fixed"/"randomize" widget after control_after_generate
+          // seeds — convertUiToApi skips exactly one entry here.
+          if (hasControlAfterGenerate(name, def)) widgetsValues.push("fixed");
+
+          // V3 dynamic combo: the selected option's nested POSITIONAL widgets
+          // follow the combo value in widgets_values; their API values arrive
+          // as dotted "combo.nested" keys.
+          const opts = (
+            spec[1] as
+              | { options?: Array<{ key?: unknown; inputs?: { required?: Record<string, unknown> } }> }
+              | undefined
+          )?.options;
+          const nested = Array.isArray(opts)
+            ? opts.find((o) => o?.key === effective)?.inputs?.required
+            : undefined;
+          if (nested) {
+            for (const [nName, nSpec] of Object.entries(nested)) {
+              if (!isPositionalWidgetSpec(nSpec)) continue;
+              const dotted = `${name}.${nName}`;
+              consumed.add(dotted);
+              const nRaw = apiInputs[dotted];
+              widgetsValues.push(
+                nRaw !== undefined ? nRaw : widgetDefaultValue(nSpec as NodeInputSpec),
+              );
+            }
+          }
+        } else {
+          // Link (connection) input — always present as a slot, wired or not.
+          const slotType = typeof spec[0] === "string" ? spec[0] : "COMBO";
+          uiInputs.push({ name, type: slotType, link: null });
+          if (isLinkRef(raw, keySet)) {
+            pending.push({
+              srcKey: String(raw[0]),
+              srcSlot: raw[1],
+              tgtId: id,
+              tgtSlotIdx: uiInputs.length - 1,
+              expectedType: slotType,
+            });
+          } else if (raw !== undefined) {
+            warnings.push(
+              `Node ${key} (${classType}): input "${name}" expects a connection but got a literal value — dropped (wire it or use a Primitive node).`,
+            );
+          }
+        }
+      }
+
+      // rgthree Power Lora Loader: loras arrive as lora_1..lora_N input objects
+      // (the shape convertUiToApi emits); in the UI they live in widgets_values.
+      if (/Power Lora Loader/.test(classType)) {
+        const loraKeys = Object.keys(apiInputs)
+          .filter((k) => /^lora_\d+$/.test(k))
+          .sort((a, b) => Number(a.slice(5)) - Number(b.slice(5)));
+        for (const lk of loraKeys) {
+          consumed.add(lk);
+          const v = apiInputs[lk];
+          if (v && typeof v === "object" && !Array.isArray(v)) widgetsValues.push(v);
+        }
+      }
+
+      // Anything left is either a stray link (wire it anyway, extra slot) or a
+      // literal on an input the node definition doesn't declare (warn — it
+      // would be silently lost on a UI round-trip).
+      for (const [name, val] of Object.entries(apiInputs)) {
+        if (consumed.has(name)) continue;
+        if (isLinkRef(val, keySet)) {
+          uiInputs.push({ name, type: "*", link: null });
+          pending.push({
+            srcKey: String(val[0]),
+            srcSlot: val[1],
+            tgtId: id,
+            tgtSlotIdx: uiInputs.length - 1,
+            expectedType: "*",
+          });
+        } else {
+          warnings.push(
+            `Node ${key} (${classType}): input "${name}" is not declared by the node definition — value carried nowhere in UI format and will not round-trip.`,
+          );
+        }
+      }
+    }
+
+    // Output slots straight from the definition. (COMBO outputs appear as
+    // option arrays in some defs — normalize to a "COMBO" slot type.)
+    const outputs: UiNodeOutput[] = ((def?.output ?? []) as unknown[]).map((t, i) => ({
+      name: def?.output_name?.[i] ?? (typeof t === "string" ? t : "COMBO"),
+      type: typeof t === "string" ? t : "COMBO",
+      links: [],
+    }));
+
+    const meta = apiNode._meta as { title?: string; mode?: string } | undefined;
+    const mode = meta?.mode === "muted" ? 2 : meta?.mode === "bypassed" ? 4 : 0;
+
+    const uiNode: UiNode = {
+      id,
+      type: classType,
+      pos: [0, 0],
+      size: [280, 100], // finalized by the layout pass
+      flags: {},
+      order: 0,
+      mode,
+      inputs: uiInputs,
+      outputs,
+      properties: { "Node name for S&R": classType },
+      widgets_values: widgetsValues,
+    };
+    if (meta?.title && meta.title !== classType) uiNode.title = meta.title;
+    uiNodes.set(key, uiNode);
+  }
+
+  // ── Materialize links ────────────────────────────────────────────────────
+  const links: UiLink[] = [];
+  let lastLinkId = 0;
+  for (const p of pending) {
+    const src = uiNodes.get(p.srcKey);
+    const tgt = [...uiNodes.values()].find((n) => n.id === p.tgtId)!;
+    if (!src) continue; // ref to a key we never materialized (can't happen: keySet-gated)
+    // Ensure the source has a slot at srcSlot even if its def was unknown.
+    while ((src.outputs ??= []).length <= p.srcSlot) {
+      src.outputs.push({ name: `out_${src.outputs.length}`, type: "*", links: [] });
+    }
+    const srcOut = src.outputs[p.srcSlot];
+    const linkType = srcOut.type !== "*" ? srcOut.type : p.expectedType;
+    const linkId = ++lastLinkId;
+    (srcOut.links ??= []).push(linkId);
+    tgt.inputs![p.tgtSlotIdx].link = linkId;
+    links.push([linkId, src.id, p.srcSlot, tgt.id, p.tgtSlotIdx, linkType]);
+  }
+
+  // ── Generated layout: topological layers, left → right ──────────────────
+  const layerByKey = new Map<string, number>(keys.map((k) => [k, 0]));
+  const edges = pending
+    .map((p) => {
+      const tgtKey = keys.find((k) => uiNodes.get(k)!.id === p.tgtId)!;
+      return [p.srcKey, tgtKey] as const;
+    })
+    .filter(([s, t]) => s !== t);
+  // Bounded relaxation — cycle-safe and plenty for real graph depths.
+  for (let pass = 0; pass < keys.length; pass++) {
+    let changed = false;
+    for (const [s, t] of edges) {
+      const want = layerByKey.get(s)! + 1;
+      if (want > layerByKey.get(t)!) {
+        layerByKey.set(t, want);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  const byLayer = new Map<number, string[]>();
+  for (const k of keys) {
+    const l = layerByKey.get(k)!;
+    if (!byLayer.has(l)) byLayer.set(l, []);
+    byLayer.get(l)!.push(k);
+  }
+  const X_START = 40;
+  const X_STEP = 380;
+  const Y_START = 60;
+  const Y_GAP = 60;
+  let order = 0;
+  for (const layer of [...byLayer.keys()].sort((a, b) => a - b)) {
+    let y = Y_START;
+    for (const k of byLayer.get(layer)!) {
+      const n = uiNodes.get(k)!;
+      const slots = Math.max(n.inputs?.length ?? 0, n.outputs?.length ?? 0);
+      const widgets = Array.isArray(n.widgets_values) ? n.widgets_values.length : 0;
+      const height = Math.max(60, 36 + 22 * slots + 26 * widgets);
+      n.pos = [X_START + layer * X_STEP, y];
+      n.size = [280, height];
+      n.order = order++;
+      y += height + Y_GAP;
+    }
+  }
+
+  const nodes = keys.map((k) => uiNodes.get(k)!);
+  const workflow: UiWorkflow = {
+    last_node_id: Math.max(0, ...nodes.map((n) => n.id)),
+    last_link_id: lastLinkId,
+    nodes,
+    links,
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4,
+  };
+
+  logger.info(
+    `Converted API workflow to UI format: ${nodes.length} nodes, ${links.length} links`,
+  );
+  return { workflow, warnings };
 }
 
 /**

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -5,7 +5,13 @@ import type { WorkflowJSON } from "../comfyui/types.js";
 import { getClient, getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { isUiFormat, convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
+import {
+  isUiFormat,
+  isApiFormat,
+  convertUiToApi,
+  convertApiToUi,
+  collectNodeTypes,
+} from "../services/workflow-converter.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import { detectSections } from "../services/workflow-sections.js";
 import {
@@ -290,7 +296,7 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
 
   server.tool(
     "save_workflow",
-    "Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. IMPORTANT: pass Web-UI-format JSON ({ nodes: [], links: [] }) so the saved workflow opens and edits in the ComfyUI canvas — when re-saving an existing workflow, load it with get_workflow format='ui' and modify THAT. API-format graphs are accepted and stored verbatim, but the canvas CANNOT open them (users see a broken/blank load), so only save API format for headless re-queueing. Returns a confirmation message (with a warning when the input was API format), or the HTTP status and error text on failure.",
+    "Save a workflow JSON to the connected ComfyUI server's user library so it appears in the ComfyUI web UI. Requires a running ComfyUI server; this writes to that server's userdata and overwrites any existing file with the same filename without confirmation. Web-UI-format JSON ({ nodes: [], links: [] }) is saved as-is and is the preferred input — when re-saving an existing workflow, load it with get_workflow format='ui' and modify THAT. API-format graphs ({ '1': { class_type, inputs } }) are AUTO-CONVERTED to Web UI format with a generated layout so the saved file always opens in the ComfyUI canvas (the canvas cannot open raw API format). Returns a confirmation message (noting the conversion and any warnings), or the HTTP status and error text on failure.",
     {
       filename: z
         .string()
@@ -299,19 +305,57 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
         ),
       workflow: z
         .record(z.string(), z.any())
-        .describe("Workflow JSON to save. Prefer Web UI format ({ nodes: [], links: [] }) so it stays editable in ComfyUI's canvas; API format is accepted but the frontend cannot open it. Stored verbatim; not validated before saving."),
+        .describe("Workflow JSON to save. Web UI format ({ nodes: [], links: [] }) is stored verbatim; API format ({ '1': { class_type, inputs } }) is auto-converted to Web UI format (generated layout) so it stays openable in ComfyUI's canvas. Not validated against the server before saving."),
     },
     async (args) => {
       try {
         const client = getClient();
         const encoded = encodeURIComponent(`workflows/${args.filename}`);
-        const body = JSON.stringify(args.workflow);
+
+        // API-format graphs can't be opened by the canvas — the #1 way agents
+        // strand users with workflows that "exist" in the library yet load
+        // blank. Auto-convert them to UI format with a generated layout; fall
+        // back to a verbatim save (with the loud warning) only if conversion
+        // itself fails.
+        let toSave: unknown = args.workflow;
+        let note = "";
+        if (!isUiFormat(args.workflow) && isApiFormat(args.workflow)) {
+          try {
+            const apiGraph = args.workflow as WorkflowJSON;
+            const bulk = await getObjectInfo();
+            const objectInfo = await backfillObjectInfo(
+              bulk,
+              Object.values(apiGraph).map((n) => n.class_type),
+            );
+            const { workflow: ui, warnings } = convertApiToUi(apiGraph, objectInfo);
+            toSave = ui;
+            note =
+              `\n\nℹ️ Input was API format — auto-converted to Web UI format (generated layout) ` +
+              `so it opens in the ComfyUI canvas.`;
+            if (warnings.length > 0) {
+              note += `\nConversion warnings (${warnings.length}):\n${warnings.map((w) => `- ${w}`).join("\n")}`;
+            }
+          } catch (convErr) {
+            note =
+              `\n\n⚠️ Input was API format and auto-conversion to Web UI format failed ` +
+              `(${convErr instanceof Error ? convErr.message : String(convErr)}) — saved verbatim. ` +
+              `The ComfyUI canvas CANNOT open or edit this file. If it is meant to be reopened in ` +
+              `the UI, rebuild it in Web UI format ({ nodes: [], links: [] }) — e.g. load the ` +
+              `on-canvas graph or an existing file via get_workflow format="ui", apply your ` +
+              `changes to that, and save again.`;
+          }
+        } else if (!isUiFormat(args.workflow)) {
+          note =
+            `\n\n⚠️ This JSON is neither Web UI format ({ nodes: [], links: [] }) nor API format ` +
+            `({ '1': { class_type, inputs } }) — saved verbatim, but the ComfyUI canvas likely ` +
+            `cannot open it.`;
+        }
 
         const res = await client.fetchApi(
           `/api/userdata/${encoded}`,
           {
             method: "POST",
-            body,
+            body: JSON.stringify(toSave),
           },
         );
 
@@ -327,21 +371,11 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           };
         }
 
-        // API-format saves are legal (headless re-queue) but the canvas can't
-        // open them — the #1 way agents strand users with workflows that "exist"
-        // in the library yet load blank, so they keep creating new ones instead
-        // of navigating back. Warn loudly until auto-conversion ships.
-        const apiFormatWarning = isUiFormat(args.workflow)
-          ? ""
-          : `\n\n⚠️ This was saved in API format — the ComfyUI canvas CANNOT open or edit it. ` +
-            `If this workflow is meant to be reopened in the UI, rebuild it in Web UI format ` +
-            `({ nodes: [], links: [] }) — e.g. load the on-canvas graph or an existing file via ` +
-            `get_workflow format="ui", apply your changes to that, and save again.`;
         return {
           content: [
             {
               type: "text",
-              text: `Workflow saved as "${args.filename}" in the ComfyUI user library.${apiFormatWarning}`,
+              text: `Workflow saved as "${args.filename}" in the ComfyUI user library.${note}`,
             },
           ],
         };


### PR DESCRIPTION
Closes #126.

## What

`save_workflow` now auto-converts API-format graphs (`{ "1": { class_type, inputs } }`) to Web-UI format (`{ nodes, links }`) with a generated layout before saving, so every saved workflow opens in the ComfyUI canvas. Previously an API-format save was stored verbatim and loaded blank — the agent couldn't navigate back to the workflow it just made and kept creating new ones (#125 only warned about this).

## How

New `convertApiToUi` in `workflow-converter.ts`, the inverse of `convertUiToApi`, mirroring its consumption order exactly so round-trips hold:

- **nodes[]/links[]** from the API graph, with per-node input/output slots from `object_info` (backfilled for types missing from the bulk response)
- **widgets_values order is definitional**: `input_order`, the phantom `control_after_generate` slot after seed-type widgets, and V3 dynamic-combo nested values (dotted `combo.nested` keys) after their combo
- **link-fed widget inputs** become converted slots (`widget: {name}` + positional placeholder) so downstream widget indices stay aligned
- **generated layout**: topological layering left→right (cycle-safe bounded relaxation), per-node height from slot/widget counts — sane, not beautiful, per the issue
- `_meta.title` → node title; `_meta.mode` muted/bypassed → mode 2/4
- graceful degradation: best-effort nodes for unknown `class_type` (connections preserved, symmetric with the forward converter's skip), non-numeric key remapping, rgthree Power Lora Loader `lora_N` reversal, omitted widgets filled from spec defaults
- fallback: if conversion throws, the graph is saved verbatim with the pre-existing loud warning

## Round-trip guard

`convertUiToApi(convertApiToUi(x)) === x` (exact `toEqual`, modulo layout) asserted for a full txt2img graph (multi-output CheckpointLoader, seed with `control_after_generate`, titles), a converted-widget graph, and a V3 dynamic-combo graph with dotted keys. 13 new tests; full suite 1042/1042 green, `tsc` clean.

## Not verified live

ComfyUI wasn't running on the dev box, so canvas-open verification of a converted save is pending — the emitted JSON is the standard litegraph schema (`last_node_id`/`last_link_id`/`version: 0.4`, slot-indexed links verified invariant in tests). Worth one manual open-in-canvas check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)