### PR TITLE
fix(path-detect): find Desktop-recorded installs + auto-detect in the orchestrator

### DIFF
--- a/src/__tests__/config-desktop-detect.test.ts
+++ b/src/__tests__/config-desktop-detect.test.ts
@@ -89,6 +89,20 @@ describe("Desktop-recorded install detection (installations.json)", () => {
     expect(mod.detectLocalComfyUIPath()).toBe(alive);
   });
 
+  it("skips recorded dirs that still exist but are no longer installs (no root markers)", async () => {
+    // Uninstalled/moved: the dir remains (logs, leftovers) but has no main.py/
+    // output/custom_nodes/models and no nested ComfyUI root.
+    const dead = join(FAKE_HOME, "installs", "uninstalled");
+    mkdirSync(join(dead, "logs"), { recursive: true });
+    const alive = makeRoot(join(FAKE_HOME, "installs", "still-real"));
+    writeInstallations([
+      { id: "dead", installPath: dead, lastLaunchedAt: 999 },
+      { id: "ok", installPath: alive, lastLaunchedAt: 1 },
+    ]);
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBe(alive);
+  });
+
   it("skips remote entries by sourceId even when they carry a stale local path", async () => {
     const stale = makeRoot(join(FAKE_HOME, "installs", "stale-remote"));
     const local = makeRoot(join(FAKE_HOME, "installs", "local"));

--- a/src/__tests__/config-desktop-detect.test.ts
+++ b/src/__tests__/config-desktop-detect.test.ts
@@ -89,6 +89,17 @@ describe("Desktop-recorded install detection (installations.json)", () => {
     expect(mod.detectLocalComfyUIPath()).toBe(alive);
   });
 
+  it("skips remote entries by sourceId even when they carry a stale local path", async () => {
+    const stale = makeRoot(join(FAKE_HOME, "installs", "stale-remote"));
+    const local = makeRoot(join(FAKE_HOME, "installs", "local"));
+    writeInstallations([
+      { id: "r", installPath: stale, sourceId: "remote", lastLaunchedAt: 999 },
+      { id: "l", installPath: local, sourceId: "standalone", lastLaunchedAt: 1 },
+    ]);
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBe(local);
+  });
+
   it("malformed installations.json is ignored without throwing", async () => {
     writeInstallations("{not json[");
     const mod = await import("../config.js");

--- a/src/__tests__/config-desktop-detect.test.ts
+++ b/src/__tests__/config-desktop-detect.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Desktop-recorded install detection (installations.json) — the fix for local
+// installs at custom locations (e.g. ~/ComfyUI-Installs/ComfyUI) that the
+// common-directory heuristics can never find. homedir() is mocked so the
+// detector reads a fabricated "Comfy Desktop" config dir.
+
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "cfg-desktop-home-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+const OLD_ENV = process.env;
+const OLD_ARGV = process.argv;
+
+const DESKTOP_DIR = join(FAKE_HOME, "AppData", "Roaming", "Comfy Desktop");
+
+function makeRoot(dir: string): string {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "main.py"), "# fake comfyui entrypoint\n");
+  mkdirSync(join(dir, "output"), { recursive: true });
+  return dir;
+}
+
+function writeInstallations(entries: unknown): void {
+  mkdirSync(DESKTOP_DIR, { recursive: true });
+  writeFileSync(
+    join(DESKTOP_DIR, "installations.json"),
+    typeof entries === "string" ? entries : JSON.stringify(entries),
+  );
+}
+
+describe("Desktop-recorded install detection (installations.json)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_URL = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_PORT = "8188"; // skip port auto-detect
+    rmSync(DESKTOP_DIR, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+  });
+
+  it("finds a custom-location install from installations.json and descends the wrapper", async () => {
+    // Layout mirrors a real Desktop standalone install:
+    //   <wrapper>/            (logs, outputs — NOT a root)
+    //   <wrapper>/ComfyUI/    (main.py — the real root)
+    const wrapper = join(FAKE_HOME, "ComfyUI-Installs", "ComfyUI");
+    mkdirSync(wrapper, { recursive: true });
+    const nested = makeRoot(join(wrapper, "ComfyUI"));
+    writeInstallations([
+      { id: "r", installPath: "", sourceId: "remote", remoteUrl: "https://x" },
+      { id: "l", installPath: wrapper, sourceId: "standalone", lastLaunchedAt: 5 },
+    ]);
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBe(nested);
+  });
+
+  it("prefers the most recently launched install when several are recorded", async () => {
+    const older = makeRoot(join(FAKE_HOME, "installs", "old"));
+    const newer = makeRoot(join(FAKE_HOME, "installs", "new"));
+    writeInstallations([
+      { id: "a", installPath: older, lastLaunchedAt: 100 },
+      { id: "b", installPath: newer, lastLaunchedAt: 200 },
+    ]);
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBe(newer);
+  });
+
+  it("skips recorded paths that no longer exist on disk", async () => {
+    const alive = makeRoot(join(FAKE_HOME, "installs", "alive"));
+    writeInstallations([
+      { id: "gone", installPath: join(FAKE_HOME, "installs", "deleted"), lastLaunchedAt: 999 },
+      { id: "ok", installPath: alive, lastLaunchedAt: 1 },
+    ]);
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBe(alive);
+  });
+
+  it("malformed installations.json is ignored without throwing", async () => {
+    writeInstallations("{not json[");
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBeUndefined();
+  });
+
+  it("no Desktop config at all → undefined (heuristics find nothing in a bare home)", async () => {
+    const mod = await import("../config.js");
+    expect(mod.detectLocalComfyUIPath()).toBeUndefined();
+  });
+
+  it("an explicit COMFYUI_PATH env var still outranks Desktop-recorded installs", async () => {
+    const envRoot = makeRoot(join(FAKE_HOME, "env-root"));
+    const recorded = makeRoot(join(FAKE_HOME, "installs", "recorded"));
+    writeInstallations([{ id: "x", installPath: recorded, lastLaunchedAt: 1 }]);
+    process.env.COMFYUI_PATH = envRoot;
+    const mod = await import("../config.js");
+    expect(mod.config.comfyuiPath).toBe(envRoot);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,18 @@ function desktopRecordedInstallPaths(): string[] {
       // Unreadable/malformed — the heuristic scan below still applies.
     }
   }
-  return entries.sort((a, b) => b.launched - a.launched).map((e) => e.path);
+  return (
+    entries
+      .sort((a, b) => b.launched - a.launched)
+      .map((e) => e.path)
+      // An entry can point at a directory that still EXISTS but is no longer
+      // an install (uninstalled/moved — only logs/outputs left). The shared
+      // detect filter trusts non-Documents paths without a marker check, so a
+      // dead recorded root would win over a real install — require real-root
+      // markers here (directly, or one level down for the Desktop-installer
+      // wrapper layout that descendToNestedRoot heals).
+      .filter((p) => looksLikeComfyUIRoot(p) || looksLikeComfyUIRoot(join(p, "ComfyUI")))
+  );
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, resolve, join } from "path";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { parseComfyUIUrl, type ComfyUITarget } from "./transport/comfyui-url.js";
 
@@ -56,13 +56,53 @@ export function descendToNestedRoot(p: string, label = "COMFYUI_PATH"): string {
 }
 
 /**
+ * Local install paths the ComfyUI Desktop app itself recorded in its
+ * installations.json — the authoritative source for Desktop users, who pick an
+ * arbitrary install location at setup (e.g. ~/ComfyUI-Installs/ComfyUI) that no
+ * directory heuristic can guess. Entries are sorted most-recently-launched
+ * first; remote connections (empty installPath) are skipped. Best-effort: any
+ * read/parse failure just falls through to the heuristic scan.
+ */
+function desktopRecordedInstallPaths(): string[] {
+  const home = homedir();
+  const configDirs = [
+    join(home, "AppData", "Roaming", "Comfy Desktop"), // Windows
+    join(home, "Library", "Application Support", "Comfy Desktop"), // macOS
+    join(home, ".config", "Comfy Desktop"), // Linux
+  ];
+  const entries: Array<{ path: string; launched: number }> = [];
+  for (const dir of configDirs) {
+    try {
+      const file = join(dir, "installations.json");
+      if (!existsSync(file)) continue;
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      if (!Array.isArray(parsed)) continue;
+      for (const inst of parsed) {
+        if (!inst || typeof inst !== "object") continue;
+        const rec = inst as Record<string, unknown>;
+        if (typeof rec.installPath !== "string" || !rec.installPath.trim()) continue;
+        entries.push({
+          path: rec.installPath,
+          launched: typeof rec.lastLaunchedAt === "number" ? rec.lastLaunchedAt : 0,
+        });
+      }
+    } catch {
+      // Unreadable/malformed — the heuristic scan below still applies.
+    }
+  }
+  return entries.sort((a, b) => b.launched - a.launched).map((e) => e.path);
+}
+
+/**
  * Auto-detect ComfyUI installation directories.
- * Checks common locations on macOS, Linux, and Windows.
+ * Checks the Desktop app's own installation records first, then common
+ * locations on macOS, Linux, and Windows.
  * Returns all found paths sorted by preference.
  */
 function detectComfyUIPaths(): string[] {
   const home = homedir();
-  const candidates: string[] = [];
+  // Desktop-recorded installs outrank every guessed location.
+  const candidates: string[] = [...desktopRecordedInstallPaths()];
 
   // macOS: ComfyUI Desktop app stores data here
   candidates.push(join(home, "Documents", "ComfyUI"));
@@ -195,6 +235,20 @@ function resolveComfyUIPath(
 
   // detectComfyUIPaths() already descends wrapper hits; this is a defensive
   // no-op so the selected path is guaranteed to be a real root.
+  return descendToNestedRoot(detected[0], "Detected ComfyUI path");
+}
+
+/**
+ * Best local ComfyUI install path by auto-detection alone (no env var, no
+ * remote/cloud gating — the CALLER decides whether a local path applies to its
+ * target). Used by the panel orchestrator so a loopback session without
+ * COMFYUI_PATH still resolves the local install (Desktop-recorded installs
+ * first) and keeps local install/pack tools enabled. Returns undefined when
+ * nothing is found.
+ */
+export function detectLocalComfyUIPath(): string | undefined {
+  const detected = detectComfyUIPaths();
+  if (detected.length === 0) return undefined;
   return descendToNestedRoot(detected[0], "Detected ComfyUI path");
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,8 +60,10 @@ export function descendToNestedRoot(p: string, label = "COMFYUI_PATH"): string {
  * installations.json — the authoritative source for Desktop users, who pick an
  * arbitrary install location at setup (e.g. ~/ComfyUI-Installs/ComfyUI) that no
  * directory heuristic can guess. Entries are sorted most-recently-launched
- * first; remote connections (empty installPath) are skipped. Best-effort: any
- * read/parse failure just falls through to the heuristic scan.
+ * first; remote connections are skipped (by sourceId, and by the empty
+ * installPath they normally carry — a stale local path on a remote entry must
+ * not win). Best-effort: any read/parse failure just falls through to the
+ * heuristic scan.
  */
 function desktopRecordedInstallPaths(): string[] {
   const home = homedir();
@@ -80,6 +82,7 @@ function desktopRecordedInstallPaths(): string[] {
       for (const inst of parsed) {
         if (!inst || typeof inst !== "object") continue;
         const rec = inst as Record<string, unknown>;
+        if (rec.sourceId === "remote") continue;
         if (typeof rec.installPath !== "string" || !rec.installPath.trim()) continue;
         entries.push({
           path: rec.installPath,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -592,7 +592,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // COMFYUI_PATH always landed in "local install/pack tools limited" even with
   // a local install the MCP itself could find.
   const envComfyuiPath = process.env.COMFYUI_PATH;
-  const localComfyuiPath = envComfyuiPath ?? detectLocalComfyUIPath();
+  // `||` not `??`: a set-but-empty COMFYUI_PATH= means "unset" (the headless
+  // MCP's config truthy-checks it the same way) — it must not block detection.
+  const localComfyuiPath = envComfyuiPath || detectLocalComfyUIPath();
   const isLoopbackUrl = (u: string): boolean => {
     try {
       return isLoopbackHost(new URL(u).hostname);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -602,7 +602,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       return true;
     }
   };
-  let comfyuiPath = isLoopbackUrl(comfyuiUrl) ? localComfyuiPath : undefined;
+  // --force-remote drops the local path too: a loopback URL that is really a
+  // port-forward to a pod (e.g. RunPod/dstack) must not hand spawned agents a
+  // local install — the spawn env builders prefer COMFYUI_PATH over the
+  // force-remote flag, so a leaked path would silently defeat --force-remote.
+  const localPathForTarget = (url: string): string | undefined =>
+    !isForceRemoteFlagSet() && isLoopbackUrl(url) ? localComfyuiPath : undefined;
+  let comfyuiPath = localPathForTarget(comfyuiUrl);
   // Force the child remote only when opted in (--force-remote) or the target is
   // non-loopback; a default loopback panel user with no COMFYUI_PATH is left to
   // auto-detect its local install (keeps download_model/apply_manifest/scans).
@@ -1071,7 +1077,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (!host || next === comfyuiUrl) return false;
     const prev = comfyuiUrl;
     comfyuiUrl = next;
-    comfyuiPath = isLoopbackUrl(next) ? localComfyuiPath : undefined;
+    comfyuiPath = localPathForTarget(next);
     // Point every provider at the new target: Claude via its rebuilt MCP env, the
     // manager's image-fetch URL, then respawn active agents so the live comfyui MCP
     // subprocess is recreated with the new COMFYUI_URL (no-op if none are running —

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -33,7 +33,7 @@ import {
 } from "./panel-agent.js";
 import { createPanelMcpServer } from "./panel-tools.js";
 import { readUserMcpServers } from "../services/user-mcp-config.js";
-import { isForceRemoteFlagSet, isLoopbackHost } from "../config.js";
+import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath } from "../config.js";
 import {
   buildComfyuiMcpEnv,
   comfyuiSecretKeys,
@@ -586,7 +586,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // model-scan tools). A REMOTE target (non-loopback) forces remote-only, so we
   // drop the path. `envComfyuiPath` is the orchestrator's own env value; the live
   // `comfyuiPath` is derived from it + the current target.
+  // env > auto-detected. The detection (Desktop-recorded installs first, then
+  // common directories) is the same one the headless MCP's config uses — the
+  // orchestrator previously read ONLY the env var, so a Desktop user without
+  // COMFYUI_PATH always landed in "local install/pack tools limited" even with
+  // a local install the MCP itself could find.
   const envComfyuiPath = process.env.COMFYUI_PATH;
+  const localComfyuiPath = envComfyuiPath ?? detectLocalComfyUIPath();
   const isLoopbackUrl = (u: string): boolean => {
     try {
       return isLoopbackHost(new URL(u).hostname);
@@ -594,7 +600,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       return true;
     }
   };
-  let comfyuiPath = isLoopbackUrl(comfyuiUrl) ? envComfyuiPath : undefined;
+  let comfyuiPath = isLoopbackUrl(comfyuiUrl) ? localComfyuiPath : undefined;
   // Force the child remote only when opted in (--force-remote) or the target is
   // non-loopback; a default loopback panel user with no COMFYUI_PATH is left to
   // auto-detect its local install (keeps download_model/apply_manifest/scans).
@@ -1063,7 +1069,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (!host || next === comfyuiUrl) return false;
     const prev = comfyuiUrl;
     comfyuiUrl = next;
-    comfyuiPath = isLoopbackUrl(next) ? envComfyuiPath : undefined;
+    comfyuiPath = isLoopbackUrl(next) ? localComfyuiPath : undefined;
     // Point every provider at the new target: Claude via its rebuilt MCP env, the
     // manager's image-fetch URL, then respawn active agents so the live comfyui MCP
     // subprocess is recreated with the new COMFYUI_URL (no-op if none are running —

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -128,25 +128,33 @@ function findPidByPort(port: number): number | null {
 }
 
 /**
- * Find PIDs of the Desktop app's Electron shell (ComfyUI.exe on Windows).
- * The Python backend is a child of the Electron app, so we need to kill
- * the parent to fully stop the Desktop app.
+ * Find PIDs of the Desktop app's Electron shell — current branding
+ * ("Comfy Desktop.exe" / "Comfy Desktop.app") and legacy ("ComfyUI.exe" /
+ * "ComfyUI.app"). The Python backend is a child of the Electron app, so we
+ * need to kill the parent to fully stop the Desktop app.
  */
 function findDesktopAppPids(): number[] {
   const pids: number[] = [];
-  try {
-    if (IS_WIN) {
-      const out = execSync(
-        `tasklist /FI "IMAGENAME eq ComfyUI.exe" /FO CSV /NH`,
-        { encoding: "utf-8", timeout: 5000 },
-      ).trim();
-      for (const line of out.split("\n")) {
-        // CSV format: "ComfyUI.exe","12345","Console","1","206,248 K"
-        const match = line.match(/"ComfyUI\.exe","(\d+)"/i);
-        if (match) pids.push(parseInt(match[1], 10));
+  if (IS_WIN) {
+    for (const exe of ["ComfyUI.exe", "Comfy Desktop.exe"]) {
+      try {
+        const out = execSync(
+          `tasklist /FI "IMAGENAME eq ${exe}" /FO CSV /NH`,
+          { encoding: "utf-8", timeout: 5000 },
+        ).trim();
+        for (const line of out.split("\n")) {
+          // CSV format: "ComfyUI.exe","12345","Console","1","206,248 K"
+          // (the image name is already filtered — match any first column)
+          const match = line.match(/^"[^"]+","(\d+)"/);
+          if (match) pids.push(parseInt(match[1], 10));
+        }
+      } catch {
+        // No processes with this image name
       }
-    } else {
-      const out = execSync(`pgrep -f "ComfyUI.app"`, {
+    }
+  } else {
+    try {
+      const out = execSync(`pgrep -f "ComfyUI.app|Comfy Desktop.app"`, {
         encoding: "utf-8",
         timeout: 5000,
       }).trim();
@@ -154,9 +162,9 @@ function findDesktopAppPids(): number[] {
         const pid = parseInt(line, 10);
         if (!isNaN(pid) && pid > 0) pids.push(pid);
       }
+    } catch {
+      // No Desktop app processes found
     }
-  } catch {
-    // No Desktop app processes found
   }
   return pids;
 }
@@ -216,7 +224,11 @@ function isDesktopApp(argv: string[]): boolean {
   return (
     joined.includes("programs/comfyui/resources") ||
     joined.includes("programs\\comfyui\\resources") ||
-    joined.includes("comfyui.app")
+    joined.includes("comfyui.app") ||
+    // Current branding ("Comfy Desktop\Comfy Desktop.exe", "Comfy Desktop.app")
+    // and the electron-era install dir.
+    joined.includes("comfy desktop") ||
+    joined.includes("@comfyorgcomfyui-electron")
   );
 }
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -228,6 +228,12 @@ function findDesktopExeFromCommonPaths(): string | undefined {
   if (IS_WIN) {
     const home = process.env.LOCALAPPDATA || process.env.USERPROFILE || "";
     const candidates = [
+      // Current branding: "Comfy Desktop" (per-machine and per-user installs)
+      `C:\\Program Files\\Comfy Desktop\\Comfy Desktop.exe`,
+      `${process.env.LOCALAPPDATA}\\Programs\\Comfy Desktop\\Comfy Desktop.exe`,
+      // Electron-era install dir
+      `${process.env.LOCALAPPDATA}\\Programs\\@comfyorgcomfyui-electron\\ComfyUI.exe`,
+      // Legacy names
       `${home}\\Programs\\ComfyUI\\ComfyUI.exe`,
       `${process.env.LOCALAPPDATA}\\Programs\\ComfyUI\\ComfyUI.exe`,
       `C:\\Program Files\\ComfyUI\\ComfyUI.exe`,
@@ -243,6 +249,8 @@ function findDesktopExeFromCommonPaths(): string | undefined {
   } else {
     // macOS
     const candidates = [
+      "/Applications/Comfy Desktop.app",
+      `${process.env.HOME}/Applications/Comfy Desktop.app`,
       "/Applications/ComfyUI.app",
       `${process.env.HOME}/Applications/ComfyUI.app`,
     ];


### PR DESCRIPTION
## Symptom

`connect` on a box with a local Comfy Desktop install still logs:

> ready — … comfyui=http://127.0.0.1:8188 — **no COMFYUI_PATH, local install/pack tools limited**

and `start_comfyui` reports *"could not find ComfyUI Desktop app"* with the app installed.

## Root causes (three stale-assumption gaps, one theme)

1. **`detectComfyUIPaths()` only guessed directories** (`~/ComfyUI`, Documents, `AppData\Local\Programs\ComfyUI`, …). Comfy Desktop lets the user pick any install location at setup — here `~\ComfyUI-Installs\ComfyUI` — and no heuristic can find that. But Desktop **records every install in its own `installations.json`**. That file is now the first-priority source (Windows `Roaming`, macOS `Application Support`, Linux `.config`), entries sorted by `lastLaunchedAt`, remote connections skipped, wrapper layouts healed by the existing `descendToNestedRoot`.
2. **The panel orchestrator never ran any detection** — it read the raw `COMFYUI_PATH` env var only (`src/orchestrator/index.ts`), so every env-less loopback session spawned agents remote-limited even when the headless MCP could resolve the path. It now falls back to the new exported `detectLocalComfyUIPath()`; env still wins, non-loopback targets still drop the path (including on `applyComfyuiUrl` retarget).
3. **`start_comfyui`'s Desktop-app search only knew legacy `ComfyUI.exe` names.** Added current branding — `C:\Program Files\Comfy Desktop\Comfy Desktop.exe`, per-user `Programs\Comfy Desktop`, the electron-era `@comfyorgcomfyui-electron` dir, and `Comfy Desktop.app` on macOS.

## Verification

- **Live on the affected box:** `detectLocalComfyUIPath()` resolves `C:\Users\Artokun\ComfyUI-Installs\ComfyUI\ComfyUI` (wrapper → nested root descent logged as designed); the Desktop exe exists at the newly-added `Program Files\Comfy Desktop` path.
- **6 new tests** (`config-desktop-detect.test.ts`, mocked homedir): custom-location resolution + wrapper descent, most-recent-launch preference, dead-path skipping, malformed-JSON tolerance, bare-home undefined, env-var precedence. Full suite 1035/1035, `tsc` clean.

Side benefit: `config.comfyuiPath` resolves at module load, so the headless MCP (get_environment, model download/scan tools) gains the Desktop-recorded source too — the v0.25.0 auto-detect now actually works for Desktop users with custom install locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)