### PR TITLE
fix(runpod): aria2 download sidecar — Manager's built-in downloader ran at <1-4 MB/s

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -331,6 +331,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends aria2 \
  && rm -rf /var/lib/apt/lists/* \
  && "${VPIP}" install --no-cache-dir aria2p
 
+# hf_transfer — Rust parallel downloader for the OTHER model-fetch path: aria2
+# only covers Manager's install-model; many custom nodes (Impact, WAS, …) and
+# ComfyUI internals download via huggingface_hub, which stays single-stream
+# unless HF_HUB_ENABLE_HF_TRANSFER=1 (env set in §10) AND the hf_transfer
+# package is importable — the hub RAISES at download time if the flag is set
+# without the package, so they ship together. hf_xet accelerates Xet-backed
+# repos the same way (hub uses it automatically when present).
+RUN "${VPIP}" install --no-cache-dir hf_transfer hf_xet
+
 # -----------------------------------------------------------------------------
 # custom_nodes PERSISTENCE seed. Move the image's baked custom_nodes (the Agent
 # Panel + ComfyUI's builtins) to a SEED dir. At boot, post_start.sh symlinks
@@ -366,7 +375,9 @@ RUN set -e; \
       || { echo "INTEGRITY GATE FAILED: aria2c missing (fast model downloads)"; exit 1; }; \
     "${COMFY_HOME}/venv/bin/python" -c "import aria2p" \
       || { echo "INTEGRITY GATE FAILED: aria2p not importable in venv (Manager would crash at startup with COMFYUI_MANAGER_ARIA2_SERVER set)"; exit 1; }; \
-    echo "integrity gate passed: panel seed + configs + entrypoint + venv + aria2 all sane"
+    "${COMFY_HOME}/venv/bin/python" -c "import hf_transfer" \
+      || { echo "INTEGRITY GATE FAILED: hf_transfer not importable in venv (HF_HUB_ENABLE_HF_TRANSFER=1 is baked — huggingface_hub downloads would raise at runtime)"; exit 1; }; \
+    echo "integrity gate passed: panel seed + configs + entrypoint + venv + aria2 + hf_transfer all sane"
 
 # -----------------------------------------------------------------------------
 # 10. Volume hygiene (LAST so it doesn't bust the expensive build-layer cache).
@@ -381,7 +392,8 @@ ENV PIP_CACHE_DIR=/root/.cache/pip \
     HF_HOME=/root/.cache/huggingface \
     UV_CACHE_DIR=/root/.cache/uv \
     VIRTUALENV_OVERRIDE_APP_DATA=/root/.cache/virtualenv \
-    XDG_CACHE_HOME=/root/.cache
+    XDG_CACHE_HOME=/root/.cache \
+    HF_HUB_ENABLE_HF_TRANSFER=1
 
 # Runtime-only env overrides (late on purpose — they never affect build steps,
 # so tweaking them must not bust the torch/ComfyUI layer cache above):

--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -313,6 +313,25 @@ RUN curl -fsSL "https://github.com/filebrowser/filebrowser/releases/download/${F
  || echo "WARN: filebrowser install failed — it will be skipped at boot"
 
 # -----------------------------------------------------------------------------
+# aria2 model-download sidecar — REQUIRED, not best-effort. ComfyUI-Manager's
+# built-in model downloader (manager_downloader.py fallback via torchvision) is
+# single-stream with tiny chunks and collapses to <1-4 MB/s against the pod's
+# MooseFS network volume — a 13 GB model then takes HOURS and the serial Manager
+# queue wedges everything behind it, which users experience as "downloads don't
+# work" (field report 2026-07-07: 792 kB/s while curl on the same pod pulled the
+# SAME HuggingFace file at 15-80 MB/s). Manager natively switches to an aria2
+# RPC daemon when COMFYUI_MANAGER_ARIA2_SERVER is set: multi-connection,
+# big-block writes, full pipe speed. post_start.sh §4.7 starts the daemon and
+# exports the env. aria2p must be importable in the VENV — Manager does
+# `import aria2p` at module import whenever the env var is set, so a missing
+# package would crash Manager at ComfyUI startup (post_start also guards this).
+# Placed LATE so it doesn't bust the torch/ComfyUI layer cache.
+# -----------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends aria2 \
+ && rm -rf /var/lib/apt/lists/* \
+ && "${VPIP}" install --no-cache-dir aria2p
+
+# -----------------------------------------------------------------------------
 # custom_nodes PERSISTENCE seed. Move the image's baked custom_nodes (the Agent
 # Panel + ComfyUI's builtins) to a SEED dir. At boot, post_start.sh symlinks
 # ${COMFY_HOME}/custom_nodes -> /workspace/custom_nodes and copies this seed into
@@ -343,7 +362,11 @@ RUN set -e; \
     bash -n /post_start.sh || { echo "INTEGRITY GATE FAILED: /post_start.sh has syntax errors"; exit 1; }; \
     "${COMFY_HOME}/venv/bin/python" -c "import torch; import importlib.metadata as m; m.version('comfyui-manager')" \
       || { echo "INTEGRITY GATE FAILED: venv torch import / comfyui-manager package"; exit 1; }; \
-    echo "integrity gate passed: panel seed + configs + entrypoint + venv all sane"
+    command -v aria2c >/dev/null \
+      || { echo "INTEGRITY GATE FAILED: aria2c missing (fast model downloads)"; exit 1; }; \
+    "${COMFY_HOME}/venv/bin/python" -c "import aria2p" \
+      || { echo "INTEGRITY GATE FAILED: aria2p not importable in venv (Manager would crash at startup with COMFYUI_MANAGER_ARIA2_SERVER set)"; exit 1; }; \
+    echo "integrity gate passed: panel seed + configs + entrypoint + venv + aria2 all sane"
 
 # -----------------------------------------------------------------------------
 # 10. Volume hygiene (LAST so it doesn't bust the expensive build-layer cache).

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -423,6 +423,14 @@ Manager's aria2 path (like its built-in one) does not attach `HF_TOKEN` to
 download requests — gated-model fetches need a token-authenticated URL either
 way.
 
+aria2 only covers Manager's install-model route. The **other** fetch path —
+custom nodes (Impact, WAS, …) and ComfyUI internals downloading via
+`huggingface_hub` — is accelerated separately: the image bakes `hf_transfer`
+(HF's Rust parallel downloader) + `hf_xet` and sets
+`HF_HUB_ENABLE_HF_TRANSFER=1`. The two ship together deliberately: with the
+flag set and the package missing, `huggingface_hub` raises at download time
+(the integrity gate asserts the import for exactly that reason).
+
 > **First boot vs warm restart:** both are fast. First boot additionally creates
 > the volume data dirs and copies the spotcheck model (if baked); warm restart
 > skips even those. Watch the pod log / the "starting" page; ComfyUI init is

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -399,6 +399,29 @@ Create a **Pod template** (or fill these on a one-off GPU pod):
 | `COMFY_HOME` | `/opt/ComfyUI` | baked ComfyUI path (rarely overridden) |
 | `WORKSPACE` | `/workspace` | network-volume mount (rarely overridden) |
 | `PANEL_AUTO_UPDATE` | `1` | fast-forward the Agent Panel to its latest release on every boot (git fetch + reset --hard, before ComfyUI launches) — reaches pods without a new image build. Automatically a no-op on a `PANEL_REF`-pinned build (detached HEAD). Set `0` to disable. |
+| `HF_TOKEN` (or `HUGGINGFACE_TOKEN`) | *(unset)* | HuggingFace token for gated model downloads (exported to ComfyUI + Manager) |
+| `ARIA2_DISABLE` | `0` | set `1` to skip the aria2 download sidecar (Manager then uses its slow built-in downloader) |
+| `ARIA2_RPC_PORT` | `6800` | loopback port for the aria2 RPC daemon |
+| `ARIA2_RPC_SECRET` | *(random per boot)* | RPC secret for the aria2 daemon (auto-generated; set only if you need a fixed one) |
+
+### Fast model downloads (aria2 sidecar)
+
+ComfyUI-Manager's built-in model downloader is single-stream with tiny chunks
+and collapses to **<1–4 MB/s** against the MooseFS network volume — a 13 GB
+model then takes hours, and because Manager's install queue is serial,
+everything behind it looks wedged ("downloads don't work"). Measured on a live
+pod (2026-07-07): Manager at 792 kB/s while `curl` on the same pod pulled the
+same HuggingFace file at 15–80 MB/s and wrote the volume at 60–300 MB/s.
+
+The image therefore bakes **aria2** and starts a loopback, secret-gated RPC
+daemon at boot (post_start §4.4). Manager natively switches to it when
+`COMFYUI_MANAGER_ARIA2_SERVER` is set — multi-connection segmented downloads at
+full pipe speed. The env is only exported when the daemon is confirmed up AND
+`aria2p` imports in the venv (Manager `import aria2p`s at startup when the env
+var is set — exporting it without the package would crash ComfyUI). Note
+Manager's aria2 path (like its built-in one) does not attach `HF_TOKEN` to
+download requests — gated-model fetches need a token-authenticated URL either
+way.
 
 > **First boot vs warm restart:** both are fast. First boot additionally creates
 > the volume data dirs and copies the spotcheck model (if baked); warm restart

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -269,6 +269,40 @@ export HF_TOKEN="${HF_TOKEN:-${HUGGINGFACE_TOKEN:-}}"
 [ -n "${HF_TOKEN}" ] && log "HF_TOKEN present — gated HuggingFace downloads authenticated."
 
 # -----------------------------------------------------------------------------
+# 4.4 aria2 RPC sidecar — FAST model downloads. Manager's built-in downloader
+#     (single stream, tiny chunks) collapses to <1-4 MB/s against the MooseFS
+#     network volume, wedging the serial install queue for hours per model;
+#     with COMFYUI_MANAGER_ARIA2_SERVER set, Manager hands downloads to this
+#     local aria2 daemon instead (multi-connection → full pipe speed; the same
+#     pod measured 792 kB/s built-in vs 15-80 MB/s for aria2-class fetches).
+#     GUARD: Manager `import aria2p`s at startup whenever the env var is set, so
+#     the env is only exported when the daemon started AND aria2p imports —
+#     otherwise ComfyUI would crash at boot. Set ARIA2_DISABLE=1 to opt out.
+#     The daemon is loopback-only, secret-gated, and ephemeral (per boot).
+# -----------------------------------------------------------------------------
+ARIA2_RPC_PORT="${ARIA2_RPC_PORT:-6800}"
+if [ "${ARIA2_DISABLE:-0}" = "1" ]; then
+  log "aria2 sidecar disabled (ARIA2_DISABLE=1) — Manager uses its built-in downloader"
+elif command -v aria2c >/dev/null 2>&1 \
+     && "${COMFY_HOME}/venv/bin/python" -c "import aria2p" >/dev/null 2>&1; then
+  ARIA2_RPC_SECRET="${ARIA2_RPC_SECRET:-$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')}"
+  if aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port="${ARIA2_RPC_PORT}" \
+       --rpc-secret="${ARIA2_RPC_SECRET}" --daemon=true \
+       --max-connection-per-server=16 --split=16 --min-split-size=8M \
+       --file-allocation=none --continue=true \
+       --allow-overwrite=true --auto-file-renaming=false \
+       --console-log-level=warn --log-level=notice --log="${LOG_DIR}/aria2.log"; then
+    export COMFYUI_MANAGER_ARIA2_SERVER="http://127.0.0.1:${ARIA2_RPC_PORT}"
+    export COMFYUI_MANAGER_ARIA2_SECRET="${ARIA2_RPC_SECRET}"
+    log "aria2 RPC sidecar up (127.0.0.1:${ARIA2_RPC_PORT}) — Manager model downloads now multi-connection"
+  else
+    log "WARN: aria2c failed to start — Manager falls back to its built-in (slow) downloader"
+  fi
+else
+  log "aria2c/aria2p not baked in this image — Manager uses its built-in downloader"
+fi
+
+# -----------------------------------------------------------------------------
 # 4.5 CUSTOM NODES → the VOLUME (so runtime-installed nodes SURVIVE a restart).
 #     The base ComfyUI + venv stay in the image (fast boot), but custom_nodes live
 #     on /workspace — the #1 user complaint with a pure image-baked custom_nodes

--- a/docker/runpod/test_image.sh
+++ b/docker/runpod/test_image.sh
@@ -53,9 +53,11 @@ if drun '
   [ -x /post_start.sh ] || { echo "/post_start.sh not executable"; exit 1; }
   bash -n /post_start.sh
   "$CH/venv/bin/python" -c "import torch; import importlib.metadata as m; m.version(\"comfyui-manager\")"
+  command -v aria2c >/dev/null || { echo "aria2c missing (fast model downloads)"; exit 1; }
+  "$CH/venv/bin/python" -c "import aria2p" || { echo "aria2p not importable in venv"; exit 1; }
   grep -q "^security_level" "$CH/config.ini.seed" || { echo "config.ini.seed lacks security_level"; exit 1; }
 '; then
-  pass "baked files present + non-empty, post_start.sh parses, venv imports torch/comfyui_manager"
+  pass "baked files present + non-empty, post_start.sh parses, venv imports torch/comfyui_manager, aria2 baked"
 else
   fail "static checks (see output above)"
 fi
@@ -102,6 +104,14 @@ panel_check() {  # $1 = container name, $2 = label
 say "boot 1: fresh volume…"
 if boot "cmcp-t1-$$"; then
   panel_check "cmcp-t1-$$" "boot 1: symlink -> volume, panel non-empty, no 0-byte files"
+  # aria2 sidecar: the daemon must be up and the launch env wired, or Manager
+  # model downloads silently fall back to the <1-4 MB/s built-in downloader.
+  if docker logs "cmcp-t1-$$" 2>&1 | grep -q 'aria2 RPC sidecar up' \
+     && docker exec "cmcp-t1-$$" bash -c "pgrep -x aria2c >/dev/null"; then
+    pass "boot 1: aria2 RPC sidecar running (fast model downloads)"
+  else
+    fail "boot 1: aria2 sidecar not running — Manager would use the slow built-in downloader"
+  fi
   docker exec "cmcp-t1-$$" bash -c "mkdir -p /opt/ComfyUI/custom_nodes/user-test-node && echo 'MARKER = 1' > /opt/ComfyUI/custom_nodes/user-test-node/__init__.py"
 else
   fail "boot 1 did not reach ComfyUI launch"

--- a/docker/runpod/test_image.sh
+++ b/docker/runpod/test_image.sh
@@ -55,6 +55,7 @@ if drun '
   "$CH/venv/bin/python" -c "import torch; import importlib.metadata as m; m.version(\"comfyui-manager\")"
   command -v aria2c >/dev/null || { echo "aria2c missing (fast model downloads)"; exit 1; }
   "$CH/venv/bin/python" -c "import aria2p" || { echo "aria2p not importable in venv"; exit 1; }
+  "$CH/venv/bin/python" -c "import hf_transfer" || { echo "hf_transfer not importable in venv (HF_HUB_ENABLE_HF_TRANSFER=1 baked)"; exit 1; }
   grep -q "^security_level" "$CH/config.ini.seed" || { echo "config.ini.seed lacks security_level"; exit 1; }
 '; then
   pass "baked files present + non-empty, post_start.sh parses, venv imports torch/comfyui_manager, aria2 baked"


### PR DESCRIPTION
## Symptom (live pod b0ndoon4j7tcto, image 1.6, 2026-07-07)

"The pod cannot download models." Reality: a 12.9 GB `krea2_turbo_fp8.safetensors` install had been running for 40+ minutes at **792 kB/s – 3.5 MB/s** with 2 more tasks wedged behind it (Manager's install queue is serial), so every subsequent install looked dead.

## Root cause

Measured on the affected pod (via its Jupyter kernel):

| Path | Speed |
|---|---|
| Manager's built-in download of the file | **0.8–3.5 MB/s** |
| `curl` of the **same HF file**, same pod | **14.7 MB/s** |
| `curl` of another HF repo | **83 MB/s** |
| `curl` → `/workspace` (write path) | **62 MB/s** |
| `dd` 4 MB blocks → `/workspace` | **309 MB/s** |

Not HuggingFace, not the volume: ComfyUI-Manager's fallback downloader (`manager_downloader.py` → torchvision `download_url`, single stream, tiny chunks) collapses against the MooseFS network volume.

## Fix

Manager **natively** hands model downloads to an aria2 RPC daemon when `COMFYUI_MANAGER_ARIA2_SERVER` is set (multi-connection segmented fetch). This PR bakes that sidecar into the image:

- **Dockerfile**: `apt aria2` + venv `aria2p` as a required late layer; integrity gate asserts both. (Manager `import aria2p`s at startup whenever the env var is set — a missing package would crash ComfyUI at boot, hence hard-required and double-guarded.)
- **post_start.sh §4.4**: loopback, secret-gated `aria2c` RPC daemon (`--split=16 --max-connection-per-server=16 --min-split-size=8M`, `--file-allocation=none` for MooseFS, `--allow-overwrite`/`--auto-file-renaming=false` so a partial file from the old downloader can't cause a `.1` rename mismatch). Env exported **only** when the daemon started and `aria2p` imports; `ARIA2_DISABLE=1` opts out.
- **test_image.sh**: static aria2c/aria2p assertions + boot-1 assertion that the sidecar is actually running (a silent fallback to the slow path is exactly the bug).
- **README**: env-var table additions (incl. the already-honored `HF_TOKEN`/`HUGGINGFACE_TOKEN` alias) and a "Fast model downloads" section with the field numbers.

Manager's aria2 dir handling was verified against its source: it passes the absolute `/workspace/models/<cat>` dir + filename straight to the daemon, which runs in the same container — no path mapping needed.

## Rollout

Needs an image release (**1.7**) via `deploy-dockerhub.sh` (runs `test_image.sh` as the gate). Existing pods can't pick this up without the new image — the env must be exported before ComfyUI launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)