### PR TITLE
fix(runpod): harden the aria2 sidecar per codex review

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -321,7 +321,7 @@ RUN curl -fsSL "https://github.com/filebrowser/filebrowser/releases/download/${F
 # work" (field report 2026-07-07: 792 kB/s while curl on the same pod pulled the
 # SAME HuggingFace file at 15-80 MB/s). Manager natively switches to an aria2
 # RPC daemon when COMFYUI_MANAGER_ARIA2_SERVER is set: multi-connection,
-# big-block writes, full pipe speed. post_start.sh §4.7 starts the daemon and
+# big-block writes, full pipe speed. post_start.sh §4.4 starts the daemon and
 # exports the env. aria2p must be importable in the VENV — Manager does
 # `import aria2p` at module import whenever the env var is set, so a missing
 # package would crash Manager at ComfyUI startup (post_start also guards this).
@@ -334,10 +334,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends aria2 \
 # hf_transfer — Rust parallel downloader for the OTHER model-fetch path: aria2
 # only covers Manager's install-model; many custom nodes (Impact, WAS, …) and
 # ComfyUI internals download via huggingface_hub, which stays single-stream
-# unless HF_HUB_ENABLE_HF_TRANSFER=1 (env set in §10) AND the hf_transfer
-# package is importable — the hub RAISES at download time if the flag is set
-# without the package, so they ship together. hf_xet accelerates Xet-backed
-# repos the same way (hub uses it automatically when present).
+# unless HF_HUB_ENABLE_HF_TRANSFER=1. The flag is NOT baked as image ENV:
+# post_start.sh §4.4 defaults it on ONLY after verifying hf_transfer imports
+# (the hub RAISES at download time if the flag is set without the package) and
+# a pod env of 0 opts out. hf_xet accelerates Xet-backed repos the same way
+# (hub uses it automatically when present).
 RUN "${VPIP}" install --no-cache-dir hf_transfer hf_xet
 
 # -----------------------------------------------------------------------------
@@ -392,8 +393,7 @@ ENV PIP_CACHE_DIR=/root/.cache/pip \
     HF_HOME=/root/.cache/huggingface \
     UV_CACHE_DIR=/root/.cache/uv \
     VIRTUALENV_OVERRIDE_APP_DATA=/root/.cache/virtualenv \
-    XDG_CACHE_HOME=/root/.cache \
-    HF_HUB_ENABLE_HF_TRANSFER=1
+    XDG_CACHE_HOME=/root/.cache
 
 # Runtime-only env overrides (late on purpose — they never affect build steps,
 # so tweaking them must not bust the torch/ComfyUI layer cache above):

--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -403,6 +403,8 @@ Create a **Pod template** (or fill these on a one-off GPU pod):
 | `ARIA2_DISABLE` | `0` | set `1` to skip the aria2 download sidecar (Manager then uses its slow built-in downloader) |
 | `ARIA2_RPC_PORT` | `6800` | loopback port for the aria2 RPC daemon |
 | `ARIA2_RPC_SECRET` | *(random per boot)* | RPC secret for the aria2 daemon (auto-generated; set only if you need a fixed one) |
+| `HF_HUB_ENABLE_HF_TRANSFER` | `1` (set at boot) | Rust parallel downloader for `huggingface_hub` fetches. **Set `0` as the FIRST troubleshooting step if an HF download fails** — hf_transfer trades resume robustness/proxy support for speed |
+| `HF_XET_HIGH_PERFORMANCE` | `1` (set at boot) | high-performance mode for Xet-backed HF repos (newer hub versions) |
 
 ### Fast model downloads (aria2 sidecar)
 
@@ -413,23 +415,37 @@ everything behind it looks wedged ("downloads don't work"). Measured on a live
 pod (2026-07-07): Manager at 792 kB/s while `curl` on the same pod pulled the
 same HuggingFace file at 15–80 MB/s and wrote the volume at 60–300 MB/s.
 
-The image therefore bakes **aria2** and starts a loopback, secret-gated RPC
-daemon at boot (post_start §4.4). Manager natively switches to it when
-`COMFYUI_MANAGER_ARIA2_SERVER` is set — multi-connection segmented downloads at
-full pipe speed. The env is only exported when the daemon is confirmed up AND
-`aria2p` imports in the venv (Manager `import aria2p`s at startup when the env
-var is set — exporting it without the package would crash ComfyUI). Note
-Manager's aria2 path (like its built-in one) does not attach `HF_TOKEN` to
-download requests — gated-model fetches need a token-authenticated URL either
-way.
+The image therefore bakes **aria2** and runs a loopback, secret-gated RPC
+daemon at boot (post_start §4.4), hardened per review:
+
+- **Supervised**: aria2c runs under a respawn loop — a crashed daemon would
+  otherwise leave Manager hard-failing with *no* fallback (Manager commits to
+  the aria2 path at import time).
+- **Readiness-probed**: `COMFYUI_MANAGER_ARIA2_SERVER`/`SECRET` are exported
+  only after a real `aria2.getVersion` RPC answers (daemonizing successfully
+  says nothing about the listener). On probe failure the sidecar is torn down
+  and Manager keeps its built-in downloader.
+- **`/models` → `/workspace/models` symlink**: Manager's aria2 path joins
+  *relative* model dirs onto `/models` — without the link an edge case would
+  write models onto the ephemeral container fs and lose them on restart.
+- The RPC secret lives in a `0600` conf file (not the process cmdline) and is
+  length-checked; the live server+secret are written to
+  `/var/lib/comfyui-mcp/aria2-rpc.env` (root-only) so `test_image.sh` and a
+  debugging human can make a real RPC call.
+
+Note Manager's aria2 path (like its built-in one) does not attach `HF_TOKEN`
+to download requests — gated-model fetches need a token-authenticated URL
+either way.
 
 aria2 only covers Manager's install-model route. The **other** fetch path —
 custom nodes (Impact, WAS, …) and ComfyUI internals downloading via
 `huggingface_hub` — is accelerated separately: the image bakes `hf_transfer`
-(HF's Rust parallel downloader) + `hf_xet` and sets
-`HF_HUB_ENABLE_HF_TRANSFER=1`. The two ship together deliberately: with the
-flag set and the package missing, `huggingface_hub` raises at download time
-(the integrity gate asserts the import for exactly that reason).
+(HF's Rust parallel downloader) + `hf_xet`, and boot defaults
+`HF_HUB_ENABLE_HF_TRANSFER=1` + `HF_XET_HIGH_PERFORMANCE=1` **only after
+verifying `hf_transfer` imports** (with the flag set and the package missing,
+`huggingface_hub` raises at download time — the integrity gate asserts the
+import for the same reason). Both are plain pod env opt-outs (`=0`); flip
+`HF_HUB_ENABLE_HF_TRANSFER=0` first when debugging a failing HF download.
 
 > **First boot vs warm restart:** both are fast. First boot additionally creates
 > the volume data dirs and copies the spotcheck model (if baked); warm restart

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -269,34 +269,95 @@ export HF_TOKEN="${HF_TOKEN:-${HUGGINGFACE_TOKEN:-}}"
 [ -n "${HF_TOKEN}" ] && log "HF_TOKEN present — gated HuggingFace downloads authenticated."
 
 # -----------------------------------------------------------------------------
-# 4.4 aria2 RPC sidecar — FAST model downloads. Manager's built-in downloader
-#     (single stream, tiny chunks) collapses to <1-4 MB/s against the MooseFS
-#     network volume, wedging the serial install queue for hours per model;
-#     with COMFYUI_MANAGER_ARIA2_SERVER set, Manager hands downloads to this
-#     local aria2 daemon instead (multi-connection → full pipe speed; the same
-#     pod measured 792 kB/s built-in vs 15-80 MB/s for aria2-class fetches).
-#     GUARD: Manager `import aria2p`s at startup whenever the env var is set, so
-#     the env is only exported when the daemon started AND aria2p imports —
-#     otherwise ComfyUI would crash at boot. Set ARIA2_DISABLE=1 to opt out.
-#     The daemon is loopback-only, secret-gated, and ephemeral (per boot).
+# 4.4 FAST DOWNLOADS — two independent paths:
+#     (a) huggingface_hub fetches (custom nodes, ComfyUI internals): hf_transfer
+#         (Rust, parallel) + xet high-performance mode, DEFAULT ON for pod use
+#         (datacenter pipe, no proxies) — set either var to 0 on the pod to opt
+#         out (that is also the first troubleshooting step for a failing HF
+#         download: hf_transfer trades resume robustness for speed).
+#     (b) Manager install-model: an aria2 RPC sidecar. Manager's built-in
+#         downloader (single stream, tiny chunks) collapses to <1-4 MB/s
+#         against the MooseFS network volume, wedging the serial install queue
+#         for hours per model; with COMFYUI_MANAGER_ARIA2_SERVER set, Manager
+#         hands downloads to local aria2 instead (multi-connection → full pipe
+#         speed; the same pod measured 792 kB/s built-in vs 15-80 MB/s for
+#         aria2-class fetches). Set ARIA2_DISABLE=1 to opt out.
+#     GUARDS (review findings, 2026-07-08):
+#       - the flag/env is only set when the matching package imports — both the
+#         hub (HF_HUB_ENABLE_HF_TRANSFER) and Manager (import aria2p at startup
+#         when COMFYUI_MANAGER_ARIA2_SERVER is set) RAISE/CRASH otherwise;
+#       - aria2 runs under a respawn loop (a --daemon'd process that crashes
+#         mid-session would leave Manager hard-failing with NO fallback);
+#       - the Manager env is exported ONLY after a real RPC answer (daemonizing
+#         successfully says nothing about the listener being ready);
+#       - /models → volume symlink: Manager's aria2 path joins RELATIVE model
+#         dirs onto '/models' (container-ephemeral!) — the symlink turns that
+#         silent-loss edge case into a persistent write;
+#       - the RPC secret lives in a 600 conf file (not the process cmdline) and
+#         is length-checked (an empty --rpc-secret must never ship).
 # -----------------------------------------------------------------------------
+if "${COMFY_HOME}/venv/bin/python" -c "import hf_transfer" >/dev/null 2>&1; then
+  export HF_HUB_ENABLE_HF_TRANSFER="${HF_HUB_ENABLE_HF_TRANSFER:-1}"
+  export HF_XET_HIGH_PERFORMANCE="${HF_XET_HIGH_PERFORMANCE:-1}"
+  log "HF fast downloads: HF_HUB_ENABLE_HF_TRANSFER=${HF_HUB_ENABLE_HF_TRANSFER} HF_XET_HIGH_PERFORMANCE=${HF_XET_HIGH_PERFORMANCE} (set 0 on the pod to opt out)"
+else
+  log "hf_transfer not importable — HF hub downloads use the default backend"
+fi
+
 ARIA2_RPC_PORT="${ARIA2_RPC_PORT:-6800}"
+RUNSTATE_DIR=/var/lib/comfyui-mcp
 if [ "${ARIA2_DISABLE:-0}" = "1" ]; then
   log "aria2 sidecar disabled (ARIA2_DISABLE=1) — Manager uses its built-in downloader"
 elif command -v aria2c >/dev/null 2>&1 \
      && "${COMFY_HOME}/venv/bin/python" -c "import aria2p" >/dev/null 2>&1; then
-  ARIA2_RPC_SECRET="${ARIA2_RPC_SECRET:-$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')}"
-  if aria2c --enable-rpc --rpc-listen-all=false --rpc-listen-port="${ARIA2_RPC_PORT}" \
-       --rpc-secret="${ARIA2_RPC_SECRET}" --daemon=true \
-       --max-connection-per-server=16 --split=16 --min-split-size=8M \
-       --file-allocation=none --continue=true \
-       --allow-overwrite=true --auto-file-renaming=false \
-       --console-log-level=warn --log-level=notice --log="${LOG_DIR}/aria2.log"; then
-    export COMFYUI_MANAGER_ARIA2_SERVER="http://127.0.0.1:${ARIA2_RPC_PORT}"
-    export COMFYUI_MANAGER_ARIA2_SECRET="${ARIA2_RPC_SECRET}"
-    log "aria2 RPC sidecar up (127.0.0.1:${ARIA2_RPC_PORT}) — Manager model downloads now multi-connection"
+  ARIA2_RPC_SECRET="${ARIA2_RPC_SECRET:-$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')}"
+  if [ "${#ARIA2_RPC_SECRET}" -lt 8 ]; then
+    log "WARN: could not generate an aria2 RPC secret — sidecar skipped (built-in downloader)"
   else
-    log "WARN: aria2c failed to start — Manager falls back to its built-in (slow) downloader"
+    mkdir -p "${RUNSTATE_DIR}"
+    ARIA2_CONF="${RUNSTATE_DIR}/aria2.conf"
+    ( umask 077; printf 'rpc-secret=%s\n' "${ARIA2_RPC_SECRET}" > "${ARIA2_CONF}" )
+    # /models guard — see GUARDS above. ln, not mkdir: an existing real /models
+    # (never shipped by this image) is left alone.
+    [ -e /models ] || ln -s "${MODELS_DIR}" /models 2>/dev/null \
+      || log "WARN: could not link /models -> ${MODELS_DIR}"
+    (
+      while :; do
+        aria2c --conf-path="${ARIA2_CONF}" --enable-rpc --rpc-listen-all=false \
+          --rpc-listen-port="${ARIA2_RPC_PORT}" \
+          --max-connection-per-server=16 --split=16 --min-split-size=8M \
+          --file-allocation=none --continue=true \
+          --allow-overwrite=true --auto-file-renaming=false \
+          --console-log-level=warn >>"${LOG_DIR}/aria2.log" 2>&1
+        echo "[comfyui-mcp/post_start] aria2c exited (rc=$?) — restarting in 3s" >>"${LOG_DIR}/aria2.log"
+        sleep 3
+      done
+    ) &
+    ARIA2_SUPERVISOR_PID=$!
+    ARIA2_READY=0
+    for _ in $(seq 1 40); do
+      if curl -s -m 2 "http://127.0.0.1:${ARIA2_RPC_PORT}/jsonrpc" \
+           -H 'Content-Type: application/json' \
+           -d "{\"jsonrpc\":\"2.0\",\"id\":\"boot\",\"method\":\"aria2.getVersion\",\"params\":[\"token:${ARIA2_RPC_SECRET}\"]}" \
+           2>/dev/null | grep -q '"result"'; then
+        ARIA2_READY=1
+        break
+      fi
+      sleep 0.5
+    done
+    if [ "${ARIA2_READY}" = "1" ]; then
+      export COMFYUI_MANAGER_ARIA2_SERVER="http://127.0.0.1:${ARIA2_RPC_PORT}"
+      export COMFYUI_MANAGER_ARIA2_SECRET="${ARIA2_RPC_SECRET}"
+      # Root-only state file so the boot test (and a debugging human) can make a
+      # REAL RPC call with the live secret instead of trusting a log line.
+      ( umask 077; printf 'COMFYUI_MANAGER_ARIA2_SERVER=%s\nCOMFYUI_MANAGER_ARIA2_SECRET=%s\n' \
+          "${COMFYUI_MANAGER_ARIA2_SERVER}" "${ARIA2_RPC_SECRET}" > "${RUNSTATE_DIR}/aria2-rpc.env" )
+      log "aria2 RPC sidecar up (127.0.0.1:${ARIA2_RPC_PORT}, RPC-verified, supervised) — Manager model downloads now multi-connection"
+    else
+      kill "${ARIA2_SUPERVISOR_PID}" 2>/dev/null || true
+      pkill -x aria2c 2>/dev/null || true
+      log "WARN: aria2 RPC did not answer within 20s — sidecar disabled, Manager falls back to its built-in downloader"
+    fi
   fi
 else
   log "aria2c/aria2p not baked in this image — Manager uses its built-in downloader"

--- a/docker/runpod/test_image.sh
+++ b/docker/runpod/test_image.sh
@@ -105,13 +105,25 @@ panel_check() {  # $1 = container name, $2 = label
 say "boot 1: fresh volume…"
 if boot "cmcp-t1-$$"; then
   panel_check "cmcp-t1-$$" "boot 1: symlink -> volume, panel non-empty, no 0-byte files"
-  # aria2 sidecar: the daemon must be up and the launch env wired, or Manager
+  # aria2 sidecar: the daemon must ANSWER RPC with the live secret (a log line
+  # or a pgrep can both be true of a wedged/mis-secreted daemon), or Manager
   # model downloads silently fall back to the <1-4 MB/s built-in downloader.
+  # Also assert the /models -> volume symlink (Manager's aria2 path joins
+  # relative dirs onto /models; a real dir there would swallow models into the
+  # ephemeral container fs).
   if docker logs "cmcp-t1-$$" 2>&1 | grep -q 'aria2 RPC sidecar up' \
-     && docker exec "cmcp-t1-$$" bash -c "pgrep -x aria2c >/dev/null"; then
-    pass "boot 1: aria2 RPC sidecar running (fast model downloads)"
+     && docker exec "cmcp-t1-$$" bash -c '
+          set -e
+          . /var/lib/comfyui-mcp/aria2-rpc.env
+          curl -s -m 3 "${COMFYUI_MANAGER_ARIA2_SERVER}/jsonrpc" \
+            -H "Content-Type: application/json" \
+            -d "{\"jsonrpc\":\"2.0\",\"id\":\"t\",\"method\":\"aria2.getVersion\",\"params\":[\"token:${COMFYUI_MANAGER_ARIA2_SECRET}\"]}" \
+            | grep -q "\"result\""
+          [ "$(readlink -f /models)" = "$(readlink -f /workspace/models)" ]
+        '; then
+    pass "boot 1: aria2 RPC answers with the live secret + /models -> volume symlink"
   else
-    fail "boot 1: aria2 sidecar not running — Manager would use the slow built-in downloader"
+    fail "boot 1: aria2 sidecar not RPC-healthy — Manager would use the slow built-in downloader"
   fi
   docker exec "cmcp-t1-$$" bash -c "mkdir -p /opt/ComfyUI/custom_nodes/user-test-node && echo 'MARKER = 1' > /opt/ComfyUI/custom_nodes/user-test-node/__init__.py"
 else


### PR DESCRIPTION
Follow-up to #138, addressing the codex adversarial-review findings before the 1.7 image ships:

1. **Readiness probe** — `COMFYUI_MANAGER_ARIA2_SERVER`/`SECRET` are exported only after a real `aria2.getVersion` RPC answers (a successful `--daemon` return says nothing about the listener; Manager commits to the aria2 path at import time). Probe failure tears the sidecar down and Manager keeps its built-in downloader.
2. **Supervision** — aria2c runs under a respawn loop; a daemon crash mid-session would otherwise leave Manager hard-failing with **no** fallback.
3. **`/models` → `/workspace/models` symlink** — Manager's aria2 path joins *relative* model dirs onto `/models` (container-ephemeral); the link turns that silent-model-loss edge case into a persistent write. Boot test asserts it.
4. **Secret hygiene** — RPC secret moved off the process cmdline into a 0600 conf file and length-checked; live server+secret written to `/var/lib/comfyui-mcp/aria2-rpc.env` (0600) so the boot test and a debugging human can make a real RPC call.
5. **`HF_HUB_ENABLE_HF_TRANSFER` no longer baked as image ENV** — post_start defaults it (and `HF_XET_HIGH_PERFORMANCE`) to 1 only after verifying `hf_transfer` imports; plain pod-env opt-out (`=0`), documented as the first troubleshooting step for a failing HF download (hf_transfer trades resume/proxy robustness for speed).
6. **Boot test upgraded** from log-grep + pgrep to a live RPC call with the real secret (a wedged or mis-secreted daemon passes the old check); aria2 console log level dropped to warn (unbounded log growth).
7. Stale Dockerfile section references fixed (§4.7 → §4.4).

Findings assessed as non-issues (documented in the review): partial-file overwrite semantics (`--allow-overwrite` restarts from scratch without a `.aria2` control file) and the loopback/secret security posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)