### PR TITLE
chore(runpod): bust the panel layer — 1.7 shipped a stale (pre-0.6.4) panel

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -242,7 +242,7 @@ RUN if [ -n "${WHEEL_SAGE}${WHEEL_XFORMERS}" ]; then \
 # Bump PANEL_CACHEBUST (e.g. to the target panel commit SHA) to force a fresh
 # panel clone WITHOUT busting the expensive torch/sage layers above. `git clone
 # --branch` only accepts a ref name (not a raw SHA), so pinning is done here.
-ARG PANEL_CACHEBUST=0
+ARG PANEL_CACHEBUST=923330b
 RUN echo "panel cachebust: ${PANEL_CACHEBUST}" \
  && git clone --depth 1 ${PANEL_REF:+--branch "${PANEL_REF}"} \
       "${PANEL_REPO}" "${COMFY_HOME}/custom_nodes/comfyui-mcp-panel" \


### PR DESCRIPTION
One-liner: `PANEL_CACHEBUST` 0 → `923330b` (panel 0.6.4 release SHA). Registry layer history shows 1.7's panel-clone layer was cached from the 05:46 UTC morning build — before the 0.6.4 fixes merged — while only the aria2/post_start layers rebuilt at 22:47. 1.8 will re-clone the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)