### PR TITLE
fix(runpod): manager_core shim — pip Manager's aria2 install-model path crashed on a legacy import

### DIFF
--- a/docker/runpod/Dockerfile
+++ b/docker/runpod/Dockerfile
@@ -341,6 +341,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends aria2 \
 # (hub uses it automatically when present).
 RUN "${VPIP}" install --no-cache-dir hf_transfer hf_xet
 
+# manager_core shim — the pip-packaged Manager's aria2 download path does a
+# legacy `import manager_core` (a custom_nodes-layout module that does NOT
+# exist in the pip package), so EVERY install-model crashed with
+# ModuleNotFoundError the moment COMFYUI_MANAGER_ARIA2_SERVER was set (field:
+# image 1.8, 2026-07-08 — Manager tasks "drained instantly", nothing landed,
+# aria2 never received a download). The function only consumes
+# `core.comfy_path` (to relativize model dirs under the ComfyUI root); provide
+# exactly that. The inline import check runs WITH the aria2 env set so the
+# whole call-path import chain is exercised at build time.
+RUN SP="$("${VPY}" -c 'import site; print(site.getsitepackages()[0])')" \
+ && printf '%s\n' \
+      "# comfyui-mcp shim: the pip-packaged comfyui_manager's aria2 install-model" \
+      "# path does a legacy 'import manager_core'; only comfy_path is consumed." \
+      "# See the Dockerfile step that wrote this file." \
+      "comfy_path = \"${COMFY_HOME}\"" > "${SP}/manager_core.py" \
+ && COMFYUI_MANAGER_ARIA2_SERVER=http://127.0.0.1:1 COMFYUI_MANAGER_ARIA2_SECRET=x \
+      "${VPY}" -c "import manager_core; from comfyui_manager.common import manager_downloader" \
+ && echo "manager_core shim in place — Manager aria2 install-model path importable"
+
 # -----------------------------------------------------------------------------
 # custom_nodes PERSISTENCE seed. Move the image's baked custom_nodes (the Agent
 # Panel + ComfyUI's builtins) to a SEED dir. At boot, post_start.sh symlinks
@@ -378,6 +397,8 @@ RUN set -e; \
       || { echo "INTEGRITY GATE FAILED: aria2p not importable in venv (Manager would crash at startup with COMFYUI_MANAGER_ARIA2_SERVER set)"; exit 1; }; \
     "${COMFY_HOME}/venv/bin/python" -c "import hf_transfer" \
       || { echo "INTEGRITY GATE FAILED: hf_transfer not importable in venv (HF_HUB_ENABLE_HF_TRANSFER=1 is baked — huggingface_hub downloads would raise at runtime)"; exit 1; }; \
+    "${COMFY_HOME}/venv/bin/python" -c "import manager_core" \
+      || { echo "INTEGRITY GATE FAILED: manager_core shim missing (Manager's aria2 install-model path would crash with ModuleNotFoundError)"; exit 1; }; \
     echo "integrity gate passed: panel seed + configs + entrypoint + venv + aria2 + hf_transfer all sane"
 
 # -----------------------------------------------------------------------------

--- a/docker/runpod/test_image.sh
+++ b/docker/runpod/test_image.sh
@@ -56,6 +56,7 @@ if drun '
   command -v aria2c >/dev/null || { echo "aria2c missing (fast model downloads)"; exit 1; }
   "$CH/venv/bin/python" -c "import aria2p" || { echo "aria2p not importable in venv"; exit 1; }
   "$CH/venv/bin/python" -c "import hf_transfer" || { echo "hf_transfer not importable in venv (HF_HUB_ENABLE_HF_TRANSFER=1 baked)"; exit 1; }
+  "$CH/venv/bin/python" -c "import manager_core" || { echo "manager_core shim missing (Manager aria2 install-model would ModuleNotFoundError)"; exit 1; }
   grep -q "^security_level" "$CH/config.ini.seed" || { echo "config.ini.seed lacks security_level"; exit 1; }
 '; then
   pass "baked files present + non-empty, post_start.sh parses, venv imports torch/comfyui_manager, aria2 baked"


### PR DESCRIPTION
## Field failure (image 1.8, pod flvb3aig2p8cid, 2026-07-08)

Every `install-model` task errored instantly (`Model installation error: <url>`; server log: `ERROR: No module named 'manager_core'`) and the aria2 sidecar never received a single download. The panel agent misread it as Manager's security gate rejecting downloads.

## Root cause

The pip-packaged `comfyui_manager`'s `aria2_download_url` does a **function-level `import manager_core`** — a legacy custom_nodes-layout module that doesn't exist in the pip package. Image 1.7 enabling `COMFYUI_MANAGER_ARIA2_SERVER` (the download-speed fix, #138) made every model install hit that import and die. 1.6 never hit it because without the env var Manager takes the slow torchvision path.

## Fix

The function only consumes `core.comfy_path` (to relativize model dirs under the ComfyUI root — which then join onto `/models`, already symlinked to the volume per #139). Bake a `manager_core.py` shim into site-packages exposing exactly that:

- build step verifies the **full call-path import chain with the aria2 env set** (`import manager_core; from comfyui_manager.common import manager_downloader`)
- integrity gate + `test_image.sh` assert the shim imports

## Verified live before baking

Hot-patched the running 1.8 pod (function-level import → no restart needed): a real `install-model` through `/v2/manager/queue/task` returned `success` and the file landed; aria2 pulled the Krea2 weights at **50–140 MB/s** (vs 0.8 MB/s on 1.6's built-in downloader).

Upstream issue to be filed against Comfy-Org/ComfyUI-Manager (their aria2 path is broken for all pip-package users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)