### PR TITLE
fix(remote-download): panel download tray for Manager-dispatched (remote/RunPod) model installs

### DIFF
--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -544,6 +544,7 @@ describe("applyManifest", () => {
         filename: "model.safetensors",
         type: "checkpoints",
         save_path: "default",
+        trayCategory: "checkpoints",
       });
       expect(byAction.model.status).toBe("applied");
     });
@@ -568,6 +569,7 @@ describe("applyManifest", () => {
         filename: "lora.safetensors",
         type: "lora",
         save_path: "loras/pusa",
+        trayCategory: "loras",
       });
     });
   });
@@ -610,6 +612,7 @@ describe("applyManifest", () => {
         filename: "model.safetensors",
         type: "checkpoints",
         save_path: "default",
+        trayCategory: "checkpoints",
       });
       expect(byAction.model.status).toBe("applied");
     });

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -298,6 +298,7 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       filename: "model.safetensors",
       type: "checkpoints",
       save_path: "default",
+      trayCategory: "checkpoints",
     });
     // No local-disk work in remote mode.
     expect(fetchMock).not.toHaveBeenCalled();
@@ -321,6 +322,7 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       filename: "lora.safetensors",
       type: "lora",
       save_path: "loras/pusa",
+      trayCategory: "loras",
     });
   });
 
@@ -337,6 +339,7 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       filename: "solo.safetensors",
       type: "lora",
       save_path: "default",
+      trayCategory: "loras",
     });
   });
 
@@ -354,6 +357,7 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       filename: "style.safetensors",
       type: "style_models",
       save_path: "style_models",
+      trayCategory: "style_models",
     });
   });
 

--- a/src/__tests__/services/remote-model-landing.test.ts
+++ b/src/__tests__/services/remote-model-landing.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// watchRemoteModelLanding (#143): remote (Manager-dispatched) model downloads
+// run server-side, so the tray watcher polls /models/<category> — the file is
+// listed only once the download COMPLETES — writing indeterminate rows
+// meanwhile and a terminal done/error row at the end.
+
+const PROGRESS_DIR = mkdtempSync(join(tmpdir(), "cmcp-tray-"));
+process.env.COMFYUI_MCP_PROGRESS_DIR = PROGRESS_DIR;
+
+const fetchMock = vi.fn();
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...args: unknown[]) => fetchMock(...args),
+}));
+
+const { watchRemoteModelLanding } = await import("../../services/node-management.js");
+
+function trayRows(): Array<Record<string, unknown>> {
+  return readdirSync(PROGRESS_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => JSON.parse(readFileSync(join(PROGRESS_DIR, f), "utf8")));
+}
+
+function listingResponse(names: string[]): Response {
+  return { ok: true, json: async () => names } as unknown as Response;
+}
+
+describe("watchRemoteModelLanding", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(PROGRESS_DIR, { recursive: true, force: true });
+  });
+
+  it("writes downloading immediately, then done once the file is listed", async () => {
+    fetchMock
+      .mockResolvedValueOnce(listingResponse([])) // poll 1: not landed yet
+      .mockResolvedValueOnce(listingResponse(["big_model.safetensors"])); // poll 2: landed
+    watchRemoteModelLanding("diffusion_models", "big_model.safetensors", "https://x/m");
+
+    let rows = trayRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ name: "big_model.safetensors", status: "downloading", total: 0 });
+
+    await vi.advanceTimersByTimeAsync(5_100); // poll 1 → still downloading (heartbeat)
+    rows = trayRows();
+    expect(rows[0].status).toBe("downloading");
+
+    await vi.advanceTimersByTimeAsync(5_100); // poll 2 → listed → done
+    rows = trayRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("done");
+
+    await vi.advanceTimersByTimeAsync(20_000); // watcher stopped — no further fetches
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/models/diffusion_models");
+  });
+
+  it("matches files listed under a subfolder path", async () => {
+    fetchMock.mockResolvedValue(listingResponse(["sub/dir/big_model.safetensors"]));
+    watchRemoteModelLanding("loras", "big_model.safetensors", "https://x/n");
+    await vi.advanceTimersByTimeAsync(5_100);
+    expect(trayRows()[0].status).toBe("done");
+  });
+
+  it("keeps heartbeating through fetch failures instead of erroring", async () => {
+    fetchMock.mockRejectedValue(new Error("mid-reboot"));
+    watchRemoteModelLanding("vae", "v.safetensors", "https://x/v");
+    await vi.advanceTimersByTimeAsync(16_000);
+    expect(trayRows()[0].status).toBe("downloading");
+  });
+
+  it("writes a terminal error row when the file never lands within the timeout", async () => {
+    fetchMock.mockResolvedValue(listingResponse([]));
+    watchRemoteModelLanding("checkpoints", "never.safetensors", "https://x/never");
+    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000 + 10_000);
+    const rows = trayRows();
+    expect(rows[0].status).toBe("error");
+    const calls = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(60_000); // stopped after the terminal row
+    expect(fetchMock.mock.calls.length).toBe(calls);
+  });
+});

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -443,6 +443,8 @@ function remoteModelTarget(model: ComfyManifest["models"][number]): {
   type: string;
   save_path: string;
   filename: string;
+  /** OUR canonical category folder — for the panel download-tray watcher. */
+  category: string;
 } {
   if (model.local_path) {
     if (isAbsolute(model.local_path)) {
@@ -470,13 +472,13 @@ function remoteModelTarget(model: ComfyManifest["models"][number]): {
       dirSegments[0],
       dirSegments.length > 1 ? dirSegments.join("/") : undefined,
     );
-    return { name: filename, type, save_path, filename };
+    return { name: filename, type, save_path, filename, category: dirSegments[0] };
   }
 
   const category: ModelType = model.model_type ?? "checkpoints";
   const filename = model.filename ?? defaultFilenameForUrl(model.url);
   const { type, save_path } = managerModelDestination(category);
-  return { name: filename, type, save_path, filename };
+  return { name: filename, type, save_path, filename, category };
 }
 
 async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
@@ -607,13 +609,15 @@ export async function applyManifest(
           );
           continue;
         }
-        const { name, type, save_path, filename } = remoteModelTarget(model);
+        const { name, type, save_path, filename, category } = remoteModelTarget(model);
         const res = await installModelViaManager({
           name,
           url: model.url,
           filename,
           type,
           save_path,
+          // Panel tray: watch the canonical category for the file to land (#143).
+          trayCategory: category,
         });
         results.push(report("model", item, "applied", res.message));
         continue;

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -521,9 +521,11 @@ async function downloadModelViaManagerRemote(
     filename: resolvedFilename,
     type: managerType,
     save_path: managerSavePath,
+    // Panel tray: watch OUR canonical category for the file to land (#143).
+    trayCategory: modelType,
   });
 
-  return `${normalizedSubfolder}/${resolvedFilename} (installed on the remote ComfyUI via ComfyUI-Manager)${authWarning}`;
+  return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authWarning}`;
 }
 
 export async function downloadModel(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -1299,6 +1300,76 @@ export interface InstallModelParams {
    * destination, or "default" for type-based resolution.
    */
   save_path?: string;
+  /**
+   * OUR canonical folder-paths category (e.g. "diffusion_models", "vae") —
+   * used ONLY for panel download-tray progress. When set and the panel
+   * progress channel is active, a background watcher reports an indeterminate
+   * tray row until the file shows up in the server's /models/<category>
+   * listing (in-progress files are hidden there, so "listed" = landed).
+   */
+  trayCategory?: string;
+}
+
+// Remote (Manager-dispatched) downloads run server-side: the queue reports
+// "done" at dispatch/aria2-handoff while the host still streams gigabytes, so
+// tray progress can't come from bytes we never see (issue #143). Instead, poll
+// the server's /models/<category> listing — verified live: an in-progress file
+// is NOT listed; it appears when the download completes.
+const REMOTE_LANDING_POLL_MS = 5_000;
+const REMOTE_LANDING_TIMEOUT_MS = 4 * 60 * 60 * 1000; // generous: multi-GB on slow links
+
+/**
+ * Background tray reporter for a server-side model download. Writes an
+ * indeterminate "downloading" row immediately (and as a heartbeat, so the
+ * orchestrator's 60s dead-writer sweep doesn't prune long downloads), then a
+ * terminal "done" when the filename appears in /models/<category>, or "error"
+ * if it never shows within the timeout. Fire-and-forget: the tool call returns
+ * at dispatch; this keeps the tray honest afterwards. No-op outside the panel
+ * (progress channel disabled).
+ */
+export function watchRemoteModelLanding(
+  category: string,
+  filename: string,
+  url: string,
+): void {
+  if (!progressEnabled()) return;
+  const id = createHash("sha256").update(url).digest("hex").slice(0, 16);
+  const row = { id, name: filename, downloaded: 0, total: 0, bytes_per_sec: 0 };
+  reportDownloadProgress({ ...row, status: "downloading" }, true);
+  const started = Date.now();
+  const timer = setInterval(() => {
+    void (async () => {
+      let listed = false;
+      try {
+        const res = await comfyuiFetch(
+          `${getComfyUIBaseUrl()}/models/${encodeURIComponent(category)}`,
+        );
+        if (res.ok) {
+          const names = (await res.json()) as unknown;
+          // Entries are relative paths ("file.safetensors" or "sub/file.safetensors").
+          listed =
+            Array.isArray(names) &&
+            names.some(
+              (n) =>
+                typeof n === "string" &&
+                (n === filename || n.endsWith(`/${filename}`) || n.endsWith(`\\${filename}`)),
+            );
+        }
+      } catch {
+        // Server briefly unreachable (e.g. mid-reboot) — keep waiting.
+      }
+      if (listed) {
+        clearInterval(timer);
+        reportDownloadProgress({ ...row, status: "done" }, true);
+      } else if (Date.now() - started > REMOTE_LANDING_TIMEOUT_MS) {
+        clearInterval(timer);
+        reportDownloadProgress({ ...row, status: "error" }, true);
+      } else {
+        reportDownloadProgress({ ...row, status: "downloading" }, true);
+      }
+    })();
+  }, REMOTE_LANDING_POLL_MS);
+  timer.unref?.();
 }
 
 /**
@@ -1331,24 +1402,37 @@ export async function installModelViaManager(
   const status = await queueManagerTask("install-model", taskParams);
   // NOTE: the Manager queue reports the task "done" once it DRAINS, even when
   // the underlying OperationResult failed (e.g. a 404 download, or Manager's
-  // security gate rejecting a network fetch). The v2 queue/status endpoint only
-  // exposes aggregate counts (no per-task result), so a clean drain here does
-  // NOT prove the file landed — phrase the result as "dispatched", not
+  // security gate rejecting a network fetch) — and with an aria2 sidecar
+  // (COMFYUI_MANAGER_ARIA2_SERVER) it drains at HANDOFF, while the host is
+  // still streaming gigabytes. The v2 queue/status endpoint only exposes
+  // aggregate counts (no per-task result), so a clean drain here does NOT
+  // prove the file landed — phrase the result as "dispatched", not
   // "installed", and leave final verification to a list on the pod.
   //
   // DEPLOYMENT: remote model install requires the pod's ComfyUI-Manager to be
   // in network_mode=personal_cloud (or loopback) with permissive security; a
   // stricter security_level rejects the server-side download.
+  if (params.trayCategory) {
+    watchRemoteModelLanding(params.trayCategory, params.filename, params.url);
+  }
   return {
     mechanism: "manager-http",
     message:
       `Dispatched model "${name}" (${params.filename}) to install into ` +
       `${params.type} on the connected ComfyUI via ComfyUI-Manager. The queue ` +
-      `drained, but Manager reports tasks "done" even on failure and exposes no ` +
-      `per-task result, so success is NOT guaranteed — verify the file landed on ` +
-      `the ComfyUI host (a restart may be required to see it). If nothing lands, ` +
-      `confirm Manager runs with network_mode=personal_cloud (or loopback) and a ` +
-      `permissive security level so server-side downloads aren't blocked.`,
+      `drained, but that only means the download was HANDED OFF (with an aria2 ` +
+      `sidecar the host keeps streaming after the queue drains), and Manager ` +
+      `reports tasks "done" even on failure with no per-task result — so ` +
+      `success is NOT guaranteed. The file appears in the server's ` +
+      `/models/<category> listing only once the download COMPLETES (in-progress ` +
+      `files are hidden), and Manager may store it under its own type dir ` +
+      `(e.g. unet/, clip/) which ComfyUI aliases to diffusion_models/` +
+      `text_encoders — an empty canonical folder mid-download is NORMAL, not a ` +
+      `failure. Wait and re-check before re-dispatching (duplicates waste ` +
+      `bandwidth); a restart may be required for loaders to see the file. If ` +
+      `nothing ever lands, confirm Manager runs with ` +
+      `network_mode=personal_cloud (or loopback) and a permissive security ` +
+      `level so server-side downloads aren't blocked.`,
     details: status,
   };
 }


### PR DESCRIPTION
Fixes #143. See the issue for the full live investigation (Krea2 pack test on pod flvb3aig2p8cid, image 1.8).

## What
Remote model installs (`download_model` in remote mode, `apply_manifest` models) dispatch to ComfyUI-Manager server-side — the MCP never streams bytes, so the panel download tray showed nothing. Worse, Manager's queue drains at aria2 HANDOFF, canonical model folders stay empty mid-download, and a cosmetic `manager_core` ERROR appears in the server log — a silence chain that drove a live agent to a wrong "security gate" diagnosis and duplicate multi-GB dispatches.

## How
- New `watchRemoteModelLanding(category, filename, url)` in node-management: indeterminate tray row at dispatch + heartbeat, background poll of `/models/<category>` (verified live: in-progress files are hidden, so *listed = landed*) → terminal done, or error after a 4h cap. Fire-and-forget; no-op outside the panel; survives mid-reboot fetch failures.
- `download_model` (remote) and `apply_manifest` pass their canonical category (`trayCategory`).
- `installModelViaManager` message rewritten to state the real semantics: queue drain = handoff (not downloaded), Manager stores under its own type dirs (`unet/`, `clip/` — ComfyUI aliases them), empty canonical folder mid-download is normal, don't re-dispatch duplicates.

## Tests
4 new tests (fake timers, temp progress dir, mocked comfyuiFetch): downloading→done on listing, subfolder-path match, heartbeat-through-failures, terminal error at timeout + watcher stop. Full suite green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)