### PR TITLE
feat(runpod): honor COMFY_AUTOUPDATE_MANAGER — Manager fast-forward at boot

### DIFF
--- a/docker/runpod/README.md
+++ b/docker/runpod/README.md
@@ -395,6 +395,7 @@ Create a **Pod template** (or fill these on a one-off GPU pod):
 | `PUBLIC_KEY` | *(RunPod injects)* | SSH public key (base behavior) |
 | `COMFY_SECURITY_LEVEL` | `weak` | Manager security level — `weak` lets the agent install nodes from git URLs (single-user pod); set `normal-` to restore Manager's guardrails |
 | `COMFY_NETWORK_MODE` | `personal_cloud` | must stay `personal_cloud` for remote installs |
+| `COMFY_AUTOUPDATE_MANAGER` | `1` | fast-forward `comfyui_manager` (pip) at boot: `1` = latest stable release, `nightly` = ComfyUI-Manager git main, `0` = keep the baked pin. The venv is ephemeral, so this is the only Manager fix that survives a restart short of a new image. Best-effort (180s cap), never blocks boot. |
 | `COMFY_EXTRA_ARGS` | *(empty)* | extra ComfyUI flags appended verbatim by the entrypoint |
 | `COMFY_HOME` | `/opt/ComfyUI` | baked ComfyUI path (rarely overridden) |
 | `WORKSPACE` | `/workspace` | network-volume mount (rarely overridden) |

--- a/docker/runpod/post_start.sh
+++ b/docker/runpod/post_start.sh
@@ -208,6 +208,47 @@ write_manager_config "${USER_DIR}/default/ComfyUI-Manager/config.ini"
 log "Manager config asserted: network_mode=${COMFY_NETWORK_MODE} security_level=${COMFY_SECURITY_LEVEL}"
 
 # -----------------------------------------------------------------------------
+# 3.5 Manager AUTO-UPDATE (honors the template's COMFY_AUTOUPDATE_MANAGER env,
+#     which existed on the template for ages but was silently ignored). The
+#     venv is EPHEMERAL by design, so any Manager fix applied inside a running
+#     pod (e.g. "update to nightly" to cure a broken install path) EVAPORATES
+#     on the next stop/start — this is the only runtime-persistent channel for
+#     Manager fixes short of shipping a new image.
+#       COMFY_AUTOUPDATE_MANAGER=1        (default) latest STABLE pip release
+#       COMFY_AUTOUPDATE_MANAGER=nightly  ComfyUI-Manager git main (bleeding edge)
+#       COMFY_AUTOUPDATE_MANAGER=0        keep the version baked in the image
+#     Best-effort with a hard timeout — an offline pod or a PyPI hiccup must
+#     never block boot. The baked manager_core shim is a SEPARATE site-packages
+#     module, so upgrades leave it in place (it goes inert if a future Manager
+#     drops the legacy import).
+# -----------------------------------------------------------------------------
+COMFY_AUTOUPDATE_MANAGER="${COMFY_AUTOUPDATE_MANAGER:-1}"
+MGR_PIP="${COMFY_HOME}/venv/bin/pip"
+MGR_PY="${COMFY_HOME}/venv/bin/python"
+mgr_ver() { "${MGR_PY}" -c "import importlib.metadata as m; print(m.version('comfyui-manager'))" 2>/dev/null || echo unknown; }
+if [ -x "${MGR_PIP}" ] && [ "${COMFY_AUTOUPDATE_MANAGER}" != "0" ]; then
+  MGR_BEFORE="$(mgr_ver)"
+  case "${COMFY_AUTOUPDATE_MANAGER}" in
+    nightly) MGR_SPEC="git+https://github.com/Comfy-Org/ComfyUI-Manager.git@main" ;;
+    *)       MGR_SPEC="comfyui_manager" ;;
+  esac
+  if timeout 180 "${MGR_PIP}" install -q -U --retries 2 "${MGR_SPEC}" \
+       >>"${LOG_DIR}/manager-update.log" 2>&1; then
+    MGR_AFTER="$(mgr_ver)"
+    if [ "${MGR_BEFORE}" = "${MGR_AFTER}" ]; then
+      log "Manager up to date: ${MGR_AFTER} (COMFY_AUTOUPDATE_MANAGER=${COMFY_AUTOUPDATE_MANAGER})"
+    else
+      log "Manager auto-updated: ${MGR_BEFORE} -> ${MGR_AFTER} (COMFY_AUTOUPDATE_MANAGER=${COMFY_AUTOUPDATE_MANAGER})"
+    fi
+  else
+    log "WARN: Manager auto-update failed/timed out — keeping baked $(mgr_ver) (see manager-update.log)"
+  fi
+else
+  [ "${COMFY_AUTOUPDATE_MANAGER}" = "0" ] \
+    && log "Manager auto-update disabled (COMFY_AUTOUPDATE_MANAGER=0) — baked $(mgr_ver)"
+fi
+
+# -----------------------------------------------------------------------------
 # 4. Ancillary services (best-effort — skipped if the binary is absent).
 # -----------------------------------------------------------------------------
 service cron start >/dev/null 2>&1 && log "cron started" || log "cron not available (skip)"


### PR DESCRIPTION
Field (image 1.8/1.9): a broken Manager install path was fixed in-pod by
updating Manager to nightly — but the venv is EPHEMERAL, so that fix
evaporates on the next stop/start and every fresh pod reships the broken
version until a new image lands. The template has set
COMFY_AUTOUPDATE_MANAGER=1 since the aitrepreneur lineage; the boot
script just never honored it.

New §3.5 (before service launch): pip fast-forward of comfyui_manager
  1 (default)  latest STABLE pip release
  nightly      ComfyUI-Manager git main
  0            keep the baked pin
Best-effort: 180s timeout, 2 retries, logs before->after versions, an
offline pod or PyPI hiccup never blocks boot. Composes with the baked
manager_core shim (separate site-packages module — pip upgrades leave it
in place; inert if a future Manager drops the legacy import).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
