### PR TITLE
fix(orchestrator): re-advertise the bridge URL on a timer — restart-after-install wiped the pod store, wedging reconnect

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1956,6 +1956,27 @@ export async function runPanelOrchestrator(): Promise<void> {
   const downloadTimer = setInterval(pollDownloads, 700);
   downloadTimer.unref?.();
 
+  // Keep the pod's stored bridge URL fresh so a ComfyUI RESTART self-heals fast.
+  // The panel's advertised wss:// URL/token lives in the pod ComfyUI process's
+  // MEMORY (the panel __init__'s advertise store). A restart — which the agent
+  // does after every custom-node install — WIPES it: the browser reloads,
+  // fetches an empty /bridge_url, falls back to the token-less
+  // ws://127.0.0.1:9180, and is rejected ("missing/invalid token"). It can't
+  // send a hello to trigger the on-hello re-advertise (line ~1452) BECAUSE it
+  // never gets a valid connection — a deadlock that only broke when something
+  // eventually nudged it, stranding the agent mid-task for minutes. Re-POSTing
+  // the advertise on a cheap idempotent timer repopulates the pod's store within
+  // one interval of any reboot (from any cause: the agent's restart, a Manager
+  // UI restart, a crash), so the browser's reclaim poll reconnects promptly.
+  // Only meaningful for a remote https target with a secure bridge.
+  let readvertiseTimer: ReturnType<typeof setInterval> | null = null;
+  if (secureBridge && isRemoteHttpsUrl(comfyuiUrl)) {
+    readvertiseTimer = setInterval(() => {
+      if (secureBridge && isRemoteHttpsUrl(comfyuiUrl)) void secureBridge.advertise(comfyuiUrl);
+    }, 5000);
+    readvertiseTimer.unref?.();
+  }
+
   // The no-path suffix must not read as an error when it is BY DESIGN: for a
   // remote target a local path is the wrong filesystem and is deliberately
   // dropped — installs/downloads run host-side via ComfyUI-Manager (remote
@@ -1976,6 +1997,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     shuttingDown = true;
     logger.info("[panel-orchestrator] shutting down — stopping agents…");
     clearInterval(downloadTimer);
+    if (readvertiseTimer) clearInterval(readvertiseTimer);
     QueueMonitor.stop();
     unsubscribeSecrets();
     unsubscribeAgentSecrets();

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1328,7 +1328,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_install_node",
-      "Install a custom-node pack into the user's ComfyUI via the BUILT-IN Manager (queues the install). Pass `id` (registry id like 'comfyui-kjnodes' or 'author/repo') from panel_search_nodes, or `repository` (git URL) for a nightly install. A ComfyUI restart (panel_restart_comfyui) is usually required afterward to load the nodes — poll panel_node_queue_status first. Prefer this over the headless install_custom_node tool.",
+      "Install a custom-node pack into the user's ComfyUI via the BUILT-IN Manager (queues the install). Pass `id` (registry id like 'comfyui-kjnodes' or 'author/repo') from panel_search_nodes, or `repository` (git URL) for a nightly install. A ComfyUI restart (panel_restart_comfyui) is usually required afterward to load the nodes — poll panel_node_queue_status first. Prefer this over the headless install_custom_node tool. " +
+        "⚠️ QUEUE-DONE IS NOT INSTALLED: Manager marks a task 'done' (queue drained) even when the git clone produced NOTHING — an empty dir, a transient git failure, or a repo not in its registry. So after the queue is idle you MUST VERIFY with panel_list_nodes that each pack actually appears before you restart or report success; a pack you installed that is absent from that list did NOT install (retry it, or install it from its git `repository` URL). " +
+        "Install packs ONE AT A TIME and confirm each populated before the next — batching several installs then restarting is exactly how you end up with empty dirs and a broken restart.",
       {
         id: z.string().optional().describe("Registry id or 'author/repo'."),
         repository: z.string().optional().describe("Git URL (for a nightly/from-source install)."),


### PR DESCRIPTION
## Symptom (field, 2026-07-08)

After the panel agent installs a custom node or model, it restarts ComfyUI — and the browser panel then spams `rejected a bridge connection with a missing/invalid token` for minutes, stranding the agent mid-task, until a manual `connect` reset. Reported repeatedly today.

## Root cause

The advertised `wss://` bridge URL + token live in the **pod ComfyUI process's memory** (the panel `__init__`'s advertise store). `panel_restart_comfyui` reboots that process → the store is **wiped**. The browser reloads, fetches an empty `/bridge_url`, and falls back to the token-less `ws://127.0.0.1:9180` → rejected. The existing self-heal (re-advertise on panel `hello`, line ~1452) **can't fire** — the panel can't send a hello because it never establishes a valid connection. Deadlock.

## Fix (MCP-only — ships without a new panel or image)

Re-advertise on a cheap, idempotent 5s timer whenever driving a remote-https target with a secure bridge. The pod's store is repopulated within one interval of **any** reboot cause (agent restart, Manager-UI restart, crash), so the browser's `reclaimAdvertisedBridgeUrl` poll reconnects promptly instead of wedging. `unref`'d; torn down in shutdown.

Suite green (1051).

## Not covered

The install itself failing (Manager's parallel git clones leaving empty dirs) is a separate bug — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)