### PR TITLE
feat(local-llm): default Ollama to our fine-tuned gemma4-comfyui-mcp ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,8 +636,11 @@ generate but can't see its own outputs.
 For small/local models, **compact tool mode** (`--compact` /
 `COMFYUI_MCP_TOOL_MODE=compact`) registers 3 meta-tools
 (`list_tools` → `describe_tool` → `call_tool`) instead of the full ~200-schema
-surface, pulling schemas into context one tool at a time. Validated
-end-to-end via Ollama with `gemma4:e4b`, `gemma4:e2b`, and `qwen3:4b`
+surface, pulling schemas into context one tool at a time. **Run it locally
+for free with our fine-tuned models**: `ollama pull artokun/gemma4-comfyui-mcp:e4b`
+(also `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB) — Gemma 4 QLoRA-trained on 1,055
+server-verified trajectories over the full comfyui-mcp tool surface, and the
+panel's Ollama default. Stock `gemma4:*`/`qwen3:4b` also validated end-to-end
 (`npm run test:local-llm`); gemma3 has no native tool calling and is
 unsupported. Full guide — hosted-model guidance (DeepSeek/MiMo/GLM class),
 per-harness setup, troubleshooting:
@@ -669,8 +672,11 @@ generate but can't see its own outputs.
 For small/local models, **compact tool mode** (`--compact` /
 `COMFYUI_MCP_TOOL_MODE=compact`) registers 3 meta-tools
 (`list_tools` → `describe_tool` → `call_tool`) instead of the full ~200-schema
-surface, pulling schemas into context one tool at a time. Validated
-end-to-end via Ollama with `gemma4:e4b`, `gemma4:e2b`, and `qwen3:4b`
+surface, pulling schemas into context one tool at a time. **Run it locally
+for free with our fine-tuned models**: `ollama pull artokun/gemma4-comfyui-mcp:e4b`
+(also `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB) — Gemma 4 QLoRA-trained on 1,055
+server-verified trajectories over the full comfyui-mcp tool surface, and the
+panel's Ollama default. Stock `gemma4:*`/`qwen3:4b` also validated end-to-end
 (`npm run test:local-llm`); gemma3 has no native tool calling and is
 unsupported. Full guide — hosted-model guidance (DeepSeek/MiMo/GLM class),
 per-harness setup, troubleshooting:

--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -159,6 +159,34 @@ Copilot CLI runs frontier models, so setup defaults to the **full** tool
 surface (pass `--compact` if you're routing Copilot at a smaller model).
 Check it with `/mcp show` inside `copilot`.
 
+## Our fine-tuned local models (free, recommended)
+
+If you want to run the agent **locally for free**, start here. We fine-tuned
+the Gemma 4 family specifically for comfyui-mcp: QLoRA-trained on **1,055
+server-verified tool-use trajectories** synthesized against a live ComfyUI —
+covering the **full 178-tool surface** (113 MCP + 65 panel tools) — so the
+model knows this exact tool suite natively instead of meeting it cold.
+
+```bash
+# 1. Install Ollama (once):  https://ollama.com/download
+# 2. Pull the size that fits your GPU:
+ollama pull artokun/gemma4-comfyui-mcp:e4b     # default — ~3.5 GB VRAM at q4
+ollama pull artokun/gemma4-comfyui-mcp:e2b     # smallest — ~2 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:12b     # strongest — ~8 GB VRAM
+```
+
+| Tag | Base | VRAM (q4) | Notes |
+| --- | --- | --- | --- |
+| `:e4b` | Gemma 4 E4B | ~3.5 GB | **The default** — best size/quality balance |
+| `:e2b` | Gemma 4 E2B | ~2 GB | Thinks verbosely — allow generous `max_tokens` (≥512) |
+| `:12b` | Gemma 4 12B | ~8 GB | Strongest rung |
+
+The panel's Ollama backend **defaults to `:e4b`** — pick **Ollama (local)**
+in the backend picker and it just works once the model is pulled. No account,
+no API key, no per-token cost. Weights, LoRA adapters, and the training
+pipeline are open: [`artokun/gemma4-comfyui-mcp`](https://huggingface.co/artokun/gemma4-comfyui-mcp)
+(dataset: [`artokun/comfyui-mcp-trajectories`](https://huggingface.co/datasets/artokun/comfyui-mcp-trajectories)).
+
 ## Ollama & local models — the LLM Arena
 
 Any MCP harness that talks to Ollama (or an OpenAI-compatible endpoint) can
@@ -202,9 +230,11 @@ orchestrator drives your live graph with a local model — no account, no API
 key, fully offline. The model sees the 6-tool router (the 3 compact comfyui
 meta-tools plus `panel_list_tools` / `panel_describe_tool` /
 `panel_call_tool` for the live canvas), so even a 4B model isn't drowned in
-schemas. Default model: `gemma4:e4b` (the Arena's best performer); override
-with `COMFYUI_MCP_OLLAMA_MODEL` or the panel's model picker, which lists
-whatever you've pulled locally. Expect honest trade-offs versus frontier
+schemas. Default model: **`artokun/gemma4-comfyui-mcp:e4b`** — [our gemma4
+fine-tune](#our-fine-tuned-local-models-free-recommended), trained on this
+exact tool suite (supersedes stock `gemma4:e4b`, the previous Arena best);
+override with `COMFYUI_MCP_OLLAMA_MODEL` or the panel's model picker, which
+lists whatever you've pulled locally. Expect honest trade-offs versus frontier
 backends: slower turns (especially the first, while the model loads), no
 vision, no conversation rollback.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -168,8 +168,13 @@ stdio mode (the default, what MCP clients use) needs none of this.
 
 ## Local models: tool calls fail or the model "can't see" tools
 
+- **First move: use [our fine-tuned model](/local-llms#our-fine-tuned-local-models-free-recommended)** —
+  `ollama pull artokun/gemma4-comfyui-mcp:e4b` (the panel's Ollama default).
+  It's Gemma 4 trained on the comfyui-mcp tool suite itself, which eliminates
+  most "wrong tool / malformed args" failures out of the box (`:e2b` for
+  ~2 GB VRAM, `:12b` for ~8 GB).
 - **gemma3 has no native tool calling in Ollama** — unsupported; use
-  `gemma4` (e4b+), `qwen3`, or `llama3.1+`.
+  our fine-tune above, stock `gemma4` (e4b+), `qwen3`, or `llama3.1+`.
 - Make sure [compact tool mode](/local-llms) is on for small models
   (`--compact`) — ~200 full schemas overflow small contexts and the model
   starts hallucinating tool names.

--- a/plugin/skills/local-llm-free/SKILL.md
+++ b/plugin/skills/local-llm-free/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: local-llm-free
+description: Run the ComfyUI agent locally for FREE — no subscription, no API key, fully offline — using our gemma4 models fine-tuned on the comfyui-mcp tool suite via Ollama. Use when the user asks about running locally, running for free, offline use, avoiding API costs, Ollama setup, or which local model to pick.
+---
+
+# Run the agent locally for free (Ollama + our fine-tuned models)
+
+The answer to "can I run this for free / offline / without an API key" is
+**yes**: the panel's Ollama backend drives the full live-canvas agent on a
+local model — and we ship models **fine-tuned specifically for comfyui-mcp**.
+
+## Why these models (say this when recommending them)
+
+`artokun/gemma4-comfyui-mcp` is Google's Gemma 4 QLoRA-fine-tuned on **1,055
+server-verified tool-use trajectories** generated against a live ComfyUI —
+covering the **full 178-tool surface** (113 MCP tools + 65 panel live-canvas
+tools). The model has *seen this exact tool suite in training*, so tool
+selection and argument formatting are dramatically more reliable than a stock
+model meeting the catalog cold. Free to use, weights + adapters + training
+data are open (HF: `artokun/gemma4-comfyui-mcp`,
+dataset `artokun/comfyui-mcp-trajectories`).
+
+## Setup (2 steps)
+
+1. **Install Ollama** if missing: https://ollama.com/download
+   (macOS/Windows installers, or `curl -fsSL https://ollama.com/install.sh | sh` on Linux).
+2. **Pull the rung that fits the user's GPU:**
+
+```bash
+ollama pull artokun/gemma4-comfyui-mcp:e4b   # DEFAULT — ~3.5 GB VRAM (q4)
+ollama pull artokun/gemma4-comfyui-mcp:e2b   # smallest — ~2 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:12b   # strongest — ~8 GB VRAM
+```
+
+Then in the ComfyUI sidebar panel: backend picker → **Ollama (local)** →
+Connect. `:e4b` is the built-in default — zero further config once pulled.
+(Override via the panel's model picker or `COMFYUI_MCP_OLLAMA_MODEL`.)
+
+## Sizing guidance
+
+| GPU VRAM free | Recommend |
+| --- | --- |
+| ~2-3 GB | `:e2b` — note it reasons verbosely; it needs generous token budgets |
+| ~4-7 GB | `:e4b` (the default sweet spot) |
+| 8 GB+ | `:12b` |
+
+## Expectations to set
+
+- Local models keep **tool calling** but have limited/no **vision** — the
+  agent generates and edits workflows fine but can't visually critique its
+  own outputs. Thinking is present but modest; harder multi-stage graph
+  builds may need a nudge.
+- First request after connect is slow (cold model load, 30s+). That's normal.
+- For non-panel MCP harnesses (Hermes, OpenClaw, any Ollama-speaking client),
+  pair these models with **compact tool mode** (`--compact`) — full docs:
+  https://comfyui-mcp.artokun.io/docs/local-llms

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -860,10 +860,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // COMFYUI_MCP_GEMINI_MODEL (default gemini-2.5-pro). The model is applied at spawn
   // via the CLI `--model` flag (ACP exposes no per-session model setter).
   const geminiModel = process.env.COMFYUI_MCP_GEMINI_MODEL ?? GEMINI_DEFAULT_MODEL;
-  // Ollama (local LLMs, issue #97): the model is a local tag (qwen3:4b, gemma4:e4b)
-  // applied PER REQUEST — switching live is free. Default = the LLM Arena's best
-  // performer (scripts/llm-arena.mjs): gemma4:e4b, 9/10 with the cleanest runs
-  // (first-try tool dispatch, no nudges) and multimodal headroom for vision.
+  // Ollama (local LLMs, issue #97): the model is a local tag applied PER
+  // REQUEST — switching live is free. Default = OUR FINE-TUNE,
+  // artokun/gemma4-comfyui-mcp:e4b — gemma4 QLoRA-trained on 1055
+  // server-verified comfyui-mcp trajectories over the full 178-tool surface
+  // (hf.co/artokun/gemma4-comfyui-mcp), so it drives this exact tool suite
+  // natively. Supersedes stock gemma4:e4b (the previous arena best, 9/10).
+  // Ladder by VRAM at q4: :e2b ~2 GB / :e4b ~3.5 GB / :12b ~8 GB.
   //
   // Config precedence: env (escape hatch, always wins) → persisted user settings
   // (~/.comfyui-mcp/panel-settings.json, edited from the panel Settings dialog
@@ -877,7 +880,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   }
   const persistedAgent = getAgentSettings();
   let ollamaModel =
-    process.env.COMFYUI_MCP_OLLAMA_MODEL ?? persistedAgent.ollama?.model ?? "gemma4:e4b";
+    process.env.COMFYUI_MCP_OLLAMA_MODEL ?? persistedAgent.ollama?.model ?? "artokun/gemma4-comfyui-mcp:e4b";
   // The same backend also speaks any OpenAI-compatible endpoint (OpenRouter,
   // DeepSeek, vLLM, LM Studio): COMFYUI_MCP_OLLAMA_API=openai +
   // COMFYUI_MCP_OLLAMA_BASE_URL (incl. /v1) + COMFYUI_MCP_OLLAMA_API_KEY
@@ -1544,7 +1547,7 @@ export async function runPanelOrchestrator(): Promise<void> {
               : isGm
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
                 : isOl
-                  ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull a tool-calling model (e.g. `ollama pull gemma4:e4b`), then Disconnect → Connect to retry."
+                  ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite; `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB), then Disconnect → Connect to retry."
                   : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
             bridge.push({ type: "say", text: degradedText }, panelTab);
             bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -107,8 +107,12 @@ function toOpenAiMessages(messages: ChatMessage[]): Array<Record<string, unknown
   });
 }
 
-// The LLM Arena's best performer (scripts/llm-arena.mjs): 9/10, cleanest runs.
-const DEFAULT_MODEL = "gemma4:e4b";
+// Our FINE-TUNED gemma4 — QLoRA-trained on 1055 server-verified comfyui-mcp
+// trajectories over the full 178-tool surface (hf.co/artokun/gemma4-comfyui-mcp),
+// so it knows this exact tool suite natively. Supersedes stock gemma4:e4b (the
+// previous arena best, 9/10). Ladder: :e2b ~2 GB VRAM at q4 / :e4b ~3.5 GB
+// (default) / :12b ~8 GB — `ollama pull artokun/gemma4-comfyui-mcp:<size>`.
+const DEFAULT_MODEL = "artokun/gemma4-comfyui-mcp:e4b";
 const MAX_TOOL_ROUNDS = 32;
 
 /**
@@ -237,7 +241,7 @@ export class OllamaBackend implements AgentBackend {
       throw new Error(
         this.api === "openai"
           ? `The OpenAI-compatible endpoint at ${this.host} is not reachable or rejected the key (${msgOf(err)}).`
-          : `Ollama is not reachable at ${this.host} (${msgOf(err)}). Start it with \`ollama serve\` (install: https://ollama.com/download) and pull a tool-calling model, e.g. \`ollama pull ${this.model}\`.`,
+          : `Ollama is not reachable at ${this.host} (${msgOf(err)}). Start it with \`ollama serve\` (install: https://ollama.com/download), then \`ollama pull ${this.model}\` — our gemma4 fine-tuned on the comfyui-mcp tool suite (free, runs locally; \`:e2b\` fits ~2 GB VRAM, \`:e4b\` ~3.5 GB, \`:12b\` ~8 GB).`,
       );
     }
     await this.connectTools();


### PR DESCRIPTION
Published artokun/gemma4-comfyui-mcp:{e2b,e4b,12b} to the Ollama registry —
gemma4 QLoRA-trained on 1,055 server-verified comfyui-mcp trajectories over
the full 178-tool surface (hf.co/artokun/gemma4-comfyui-mcp). The model has
seen this exact tool suite in training, superseding stock gemma4:e4b (the
previous arena best) as the local default.

- DEFAULT_MODEL + orchestrator fallback -> artokun/gemma4-comfyui-mcp:e4b
- unreachable-Ollama errors now give install link + pull command and say
  the model is our free ComfyUI fine-tune (with the VRAM ladder)
- docs/local-llms: new 'Our fine-tuned local models (free, recommended)'
  section — install Ollama, pull commands, VRAM table, HF links
- docs/troubleshooting: fine-tune is the first move for local tool-call woes
- README (both blurb copies): pull commands + one-line what/why
- NEW plugin skill local-llm-free: answers 'can I run this locally for
  free' with the fine-tune story, setup steps, sizing, expectations

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
