### PR TITLE
fix(ollama): tool-loop breaker — block identical repeat calls, end the turn at 4 repeats

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -156,6 +156,30 @@ describe("OllamaBackend", () => {
     }
   });
 
+  it("breaks a tool loop: identical repeat calls are blocked, 4th repeat ends the turn", async () => {
+    const { client, callTool } = fakeMcpClient(COMFY_META);
+    const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    const sameCall = [
+      { message: { content: "", tool_calls: [{ function: { name: "list_tools", arguments: { search: "krea" } } }] }, done: true },
+    ];
+    // The model re-issues the exact same call every round, forever.
+    chatScript.push(sameCall, sameCall, sameCall, sameCall, sameCall, sameCall);
+
+    const events = await collect(backend, turnsOf({ text: "find krea" }));
+    // Dispatched exactly once — repeats got the corrective nudge, not a re-run.
+    expect(callTool).toHaveBeenCalledTimes(1);
+    // Repeat calls receive the nudge as their tool result on the wire.
+    const nudges = chatRequests
+      .flatMap((r) => r.messages)
+      .filter((m) => m.role === "tool" && String(m.content).startsWith("REPEAT CALL BLOCKED"));
+    expect(nudges.length).toBeGreaterThanOrEqual(1);
+    // Turn ends with the loop-breaker, not max_tool_rounds (32 rounds later).
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "tool_loop" },
+    ]);
+    expect(chatRequests.length).toBeLessThanOrEqual(5);
+  });
+
   it("dispatches comfyui meta-tool calls and feeds results back to the next request", async () => {
     const { client, callTool } = fakeMcpClient(COMFY_META);
     const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -711,6 +711,14 @@ export class OllamaBackend implements AgentBackend {
     this.history.push({ role: "user", content: turn.text });
 
     let resultEmitted = false;
+    // Loop-breaker: small models (especially stock ones) can wedge into
+    // re-issuing the SAME tool call verbatim for dozens of rounds (field:
+    // 30+ identical list_tools searches hunting a pack name). Track exact
+    // (name, args) repeats per turn: 2nd+ identical call is blocked with a
+    // corrective tool result instead of dispatched; at 4 repeats the turn is
+    // ended outright.
+    const seenCalls = new Map<string, number>();
+    let maxRepeats = 0;
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         // Drain the chat stream manually: yield each delta event as it arrives,
@@ -744,8 +752,26 @@ export class OllamaBackend implements AgentBackend {
         for (const [i, tc] of toolCalls.entries()) {
           if (abort.signal.aborted) throw new Error("interrupted");
           const name = tc.function?.name ?? "?";
+          const args = tc.function?.arguments ?? {};
+          const callKey = `${name}:${typeof args === "string" ? args : JSON.stringify(args)}`;
+          const repeats = (seenCalls.get(callKey) ?? 0) + 1;
+          seenCalls.set(callKey, repeats);
+          maxRepeats = Math.max(maxRepeats, repeats);
           yield { type: "tool_call", name, phase: "start", detail: tc.function?.arguments };
-          const { text, isError } = await this.dispatch(name, tc.function?.arguments ?? {});
+          const { text, isError } =
+            repeats >= 2
+              ? {
+                  // Every emitted tool_call still needs a paired tool result
+                  // (the wire format breaks otherwise) — answer the repeat
+                  // with a corrective nudge instead of re-running it.
+                  text:
+                    `REPEAT CALL BLOCKED: you already called ${name} with these exact arguments this turn — the result has not changed. ` +
+                    `Do not call it again. Use the earlier result, or try DIFFERENT arguments or a different tool. ` +
+                    `Model families like krea2 / qwen-image-edit / wan / ltxv are installer PACKS, not tools: call_tool {"name":"list_packs"} to find them, then load one. ` +
+                    `If you are stuck, tell the user what you found and ask how to proceed.`,
+                  isError: true,
+                }
+              : await this.dispatch(name, args);
           opts.onActivity?.();
           yield { type: "tool_call", name, phase: "end", detail: { isError } };
           this.history.push({
@@ -754,6 +780,16 @@ export class OllamaBackend implements AgentBackend {
             tool_call_id: tc.id ?? `call_${i}`,
             content: text.slice(0, 16000),
           });
+        }
+        if (maxRepeats >= 4) {
+          logger.warn(`[ollama-backend] tool loop broken: a call repeated ${maxRepeats}x this turn (${this.model})`);
+          yield {
+            type: "assistant",
+            text: "(stopped: I kept repeating the same tool call without progress. Try rephrasing the request — and if you're on a stock model, switch to `artokun/gemma4-comfyui-mcp:e4b`, which knows this tool suite.)",
+          };
+          yield { type: "result", ok: false, subtype: "tool_loop" };
+          resultEmitted = true;
+          return;
         }
       }
       // Round budget exhausted — commit what we have so the turn gate advances.


### PR DESCRIPTION
Field (stock gemma4:e4b): the model wedged into re-issuing the same
list_tools search verbatim for 30+ rounds hunting a pack name it could
never find as a tool, burning the whole MAX_TOOL_ROUNDS budget and
flooding the context. Small local models do this under greedy decoding.

- per-turn (name, exact-args) repeat tracking: the 2nd+ identical call
  is NOT dispatched — it gets a corrective tool result telling the model
  the result hasn't changed, to vary its approach, and that model
  families (krea2/qwen-image-edit/wan/ltxv) are installer PACKS reached
  via list_packs, not tools
- at 4 repeats the turn ends cleanly (result subtype 'tool_loop') with
  a user-facing note suggesting the fine-tuned model
- every emitted tool_call still gets a paired tool result (wire format
  stays valid); regression test locks single-dispatch + early exit

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
