### PR TITLE
feat(ollama): free local-model VRAM during generation + pause chat until it finishes

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -50,6 +50,7 @@ import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-ht
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
+import { unloadAllOllama, warmOllama, resolveOllamaHost } from "../services/ollama-vram.js";
 import { getAgentSettings, setAgentSettings } from "../services/panel-settings.js";
 import {
   gatherEnvCapabilities,
@@ -1211,6 +1212,55 @@ export async function runPanelOrchestrator(): Promise<void> {
   // spawned after a ComfyUI restart/reconnect.
   liveManager = manager;
 
+  // ── Local-agent VRAM pause during generation ────────────────────────────
+  // On a single-GPU box the local Ollama chat model and ComfyUI fight for VRAM:
+  // a resident model can OOM a render, and a chat sent mid-render reloads the
+  // model on top of the running generation. So while a render is in flight we
+  // (a) unload the local model to free its VRAM, and (b) HOLD any chat the user
+  // sends and answer it once the render finishes (warming the model back). Only
+  // for the LOCAL ollama dialect (hosted openai endpoints don't touch local
+  // VRAM); default on, opt out with COMFYUI_MCP_OLLAMA_PAUSE_ON_GEN=0.
+  const pauseLocalDuringGen = process.env.COMFYUI_MCP_OLLAMA_PAUSE_ON_GEN !== "0";
+  const anyLocalOllama = (): boolean =>
+    ollamaApi === "ollama" &&
+    (defaultBackend === "ollama" || [...tabBackends.values()].includes("ollama"));
+  // agentKey -> messages held while a render runs (flushed on render end).
+  const heldDuringGen = new Map<string, Array<{ text: string; opts: Record<string, unknown> }>>();
+  let genPauseActive = false;
+  if (pauseLocalDuringGen) {
+    QueueMonitor.setTransitionHandlers({
+      onRunStart: () => {
+        if (!anyLocalOllama()) return;
+        genPauseActive = true;
+        // Free the local model's VRAM for the render (best-effort, fire-and-forget).
+        void unloadAllOllama(resolveOllamaHost());
+      },
+      onRunEnd: () => {
+        if (!genPauseActive) return;
+        genPauseActive = false;
+        const hadHeld = [...heldDuringGen.values()].some((a) => a.length > 0);
+        // If nothing was queued, proactively warm the model so the next chat is
+        // instant ("ready to chat"). If messages ARE queued, sending them below
+        // loads the model itself — no separate warm needed.
+        if (anyLocalOllama() && !hadHeld) void warmOllama(resolveOllamaHost(), ollamaModel);
+        for (const [key, msgs] of heldDuringGen) {
+          const tabId = panelTabOf(key);
+          if (msgs.length > 0) {
+            bridge.push(
+              { type: "say", text: "✅ Render finished — the local agent is back. Answering your queued message now." },
+              tabId,
+            );
+          }
+          for (const m of msgs) {
+            bridge.push({ type: "turn", state: "working" }, tabId);
+            manager.send(key, m.text, m.opts);
+          }
+        }
+        heldDuringGen.clear();
+      },
+    });
+  }
+
   // Retarget the live ComfyUI from the panel's `hello.comfyui_url` (the URL the
   // browser was SERVED FROM — window.location). This is what lets a bare
   // `--panel-orchestrator` (booted on the localhost default) auto-point at whatever
@@ -1893,11 +1943,37 @@ export async function runPanelOrchestrator(): Promise<void> {
         ? ((event as { context?: string }).context as string).trim()
         : "";
     if (replay) outText = `${replay}\n\n${outText}`;
-    manager.send(agentKeyFor(event.tab_id), outText, {
+    const sendOpts = {
       title: event.title,
       images: (event as { images?: Array<{ filename: string; subfolder?: string; type?: string }> }).images,
       mid: userMid,
-    });
+    };
+    // Local-agent VRAM pause: if this tab runs the local Ollama model AND a
+    // render is in flight, DON'T run the turn now — that would reload the model
+    // on top of the generation (VRAM contention / OOM). Hold it and answer when
+    // the render finishes (onRunEnd flushes the queue + warms the model).
+    if (
+      pauseLocalDuringGen &&
+      ollamaApi === "ollama" &&
+      backendForTab(event.tab_id) === "ollama" &&
+      QueueMonitor.isBusy()
+    ) {
+      const key = agentKeyFor(event.tab_id);
+      const arr = heldDuringGen.get(key) ?? [];
+      arr.push({ text: outText, opts: sendOpts });
+      heldDuringGen.set(key, arr);
+      genPauseActive = true; // ensure the end transition flushes even if start was missed
+      bridge.push(
+        {
+          type: "say",
+          text: "⏸ A render is running, so I've kept the GPU free for it and queued your message. I'll answer the moment it finishes.",
+        },
+        event.tab_id,
+      );
+      bridge.push({ type: "turn", state: "idle" }, event.tab_id); // clear the working spinner
+      return;
+    }
+    manager.send(agentKeyFor(event.tab_id), outText, sendOpts);
   };
 
   // ---- Download-progress watcher ----

--- a/src/services/ollama-vram.ts
+++ b/src/services/ollama-vram.ts
@@ -1,0 +1,94 @@
+// Free the local Ollama model's VRAM while ComfyUI generates.
+//
+// On a single-GPU box the local agent (Ollama) and ComfyUI fight for VRAM: a
+// resident chat model can OOM a render, and a chat sent mid-render reloads the
+// model on top of the running generation (the field report that motivated
+// this). Ollama unloads a model immediately when a request carries
+// `keep_alive: 0`, and re-loads it when a request carries a normal keep_alive —
+// verified live: {keep_alive:0} → done_reason "unload" (/api/ps then empty),
+// {keep_alive:"5m"} → done_reason "load" (model resident again).
+//
+// Everything here is BEST-EFFORT: any failure (Ollama down, timeout) is logged
+// and swallowed — freeing/warming VRAM must never break a turn or a render.
+
+import { logger } from "../utils/logger.js";
+
+export const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
+
+/** Normalize an Ollama host (env OLLAMA_HOST may lack a scheme / have a slash). */
+export function resolveOllamaHost(host?: string): string {
+  const raw = (host || process.env.OLLAMA_HOST || DEFAULT_OLLAMA_HOST).trim();
+  const withScheme = /^https?:\/\//.test(raw) ? raw : `http://${raw}`;
+  return withScheme.replace(/\/+$/, "");
+}
+
+interface PsModel {
+  name?: string;
+  model?: string;
+  size_vram?: number;
+}
+
+/** Models Ollama currently holds in VRAM (from /api/ps). */
+async function loadedModels(host: string): Promise<string[]> {
+  try {
+    const res = await fetch(`${host}/api/ps`, { signal: AbortSignal.timeout(4000) });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { models?: PsModel[] };
+    return (data.models ?? [])
+      .filter((m) => (m.size_vram ?? 0) > 0)
+      .map((m) => m.model || m.name || "")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Immediately unload EVERY resident Ollama model (keep_alive:0) to free VRAM
+ *  for a render. Returns the models it asked to unload. */
+export async function unloadAllOllama(host: string): Promise<string[]> {
+  const h = resolveOllamaHost(host);
+  const models = await loadedModels(h);
+  if (models.length === 0) return [];
+  await Promise.all(
+    models.map(async (model) => {
+      try {
+        await fetch(`${h}/api/generate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model, keep_alive: 0 }),
+          signal: AbortSignal.timeout(15000),
+        });
+      } catch (err) {
+        logger.debug(
+          `[ollama-vram] unload ${model} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }),
+  );
+  logger.info(`[ollama-vram] unloaded ${models.length} model(s) to free VRAM: ${models.join(", ")}`);
+  return models;
+}
+
+/** Re-load a model into VRAM (normal keep_alive) so the agent is responsive
+ *  again the moment a render finishes — a no-prompt /api/generate just loads. */
+export async function warmOllama(host: string, model: string, keepAlive: string = "10m"): Promise<boolean> {
+  if (!model) return false;
+  const h = resolveOllamaHost(host);
+  try {
+    const res = await fetch(`${h}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, keep_alive: keepAlive }),
+      signal: AbortSignal.timeout(120000), // a cold load of a big model can take a while
+    });
+    if (res.ok) {
+      logger.info(`[ollama-vram] warmed ${model} back into VRAM`);
+      return true;
+    }
+  } catch (err) {
+    logger.debug(
+      `[ollama-vram] warm ${model} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return false;
+}

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -66,6 +66,13 @@ class QueueMonitorImpl {
   private url: string | null = null;
   private stopped = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Generation start/end transition hooks (for the Ollama VRAM pause). Fired on
+  // the idle→running edge and the running→idle edge, best-effort (a throwing
+  // handler must never break the monitor). `busy` is our own edge-tracking flag,
+  // distinct from runningPromptId (which flips null between backlogged prompts).
+  private busy = false;
+  private onRunStart: (() => void) | null = null;
+  private onRunEnd: (() => void) | null = null;
   private state: MonitorState = {
     connected: false,
     runningPromptId: null,
@@ -82,6 +89,43 @@ class QueueMonitorImpl {
     this.url = comfyuiUrl;
     this.stopped = false;
     this.connect();
+  }
+
+  /** Register generation-transition handlers (idempotent overwrite). Called by
+   *  the orchestrator to unload/warm the local Ollama model around renders. */
+  setTransitionHandlers(h: { onRunStart?: () => void; onRunEnd?: () => void }): void {
+    this.onRunStart = h.onRunStart ?? null;
+    this.onRunEnd = h.onRunEnd ?? null;
+  }
+
+  private emitStart(): void {
+    if (this.busy) return;
+    this.busy = true;
+    try {
+      this.onRunStart?.();
+    } catch (err) {
+      logger.debug(`[queue-monitor] onRunStart threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private emitEndIfIdle(): void {
+    // Only truly idle when nothing is running AND the queue is drained — between
+    // backlogged prompts runningPromptId briefly clears but queueRemaining stays
+    // positive, and we must NOT warm the model just to unload it again.
+    if (!this.busy) return;
+    if (this.state.runningPromptId !== null) return;
+    if (this.state.queueRemaining > 0) return;
+    this.busy = false;
+    try {
+      this.onRunEnd?.();
+    } catch (err) {
+      logger.debug(`[queue-monitor] onRunEnd threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /** Is a generation currently in flight (edge-tracked)? */
+  isBusy(): boolean {
+    return this.busy;
   }
 
   stop(): void {
@@ -171,7 +215,12 @@ class QueueMonitorImpl {
         const status = data.status as Record<string, unknown> | undefined;
         const execInfo = status?.exec_info as Record<string, unknown> | undefined;
         const qr = execInfo?.queue_remaining;
-        if (typeof qr === "number") this.state.queueRemaining = qr;
+        if (typeof qr === "number") {
+          this.state.queueRemaining = qr;
+          // A status frame arriving with an empty queue after a run is the
+          // authoritative "fully idle" signal — flush a pending end transition.
+          if (qr === 0) this.emitEndIfIdle();
+        }
         break;
       }
       case "execution_start": {
@@ -180,6 +229,7 @@ class QueueMonitorImpl {
         this.state.progressValue = null;
         this.state.progressMax = null;
         this.touchActivity();
+        this.emitStart();
         break;
       }
       case "executing": {
@@ -187,6 +237,7 @@ class QueueMonitorImpl {
         if (node === null || node === undefined) {
           // ComfyUI sends node:null at the end of a prompt's execution.
           this.clearRunning();
+          this.emitEndIfIdle();
         } else {
           const n = String(node);
           if (n !== this.state.currentNode) this.touchActivity(); // a new node = real progress
@@ -210,6 +261,7 @@ class QueueMonitorImpl {
       case "execution_error":
       case "execution_interrupted": {
         this.clearRunning();
+        this.emitEndIfIdle();
         break;
       }
       default:


### PR DESCRIPTION
## Why
Field report (Discord): on a single-GPU box the local Ollama chat model and ComfyUI fight for VRAM — a resident model OOMs a render, and a chat sent mid-render reloads the model on top of the running generation. User asked for exactly this: unload during generation, reload after, and don't let chat fire mid-render.

## What (LOCAL ollama dialect only; default on, opt out `COMFYUI_MCP_OLLAMA_PAUSE_ON_GEN=0`)
- **QueueMonitor** gained run start/end transition hooks off the execution events it already receives (idle↔running edges; end only when the queue is truly drained, so backlogged prompts don't flap).
- **On render start:** unload every resident Ollama model (`keep_alive:0`) to free VRAM — new `services/ollama-vram.ts`.
- **Chat during a render is HELD** (running it would reload the model onto the GPU) with a "queued — I'll answer when the render finishes" notice.
- **On render end:** flush the held queue and warm the model back (`keep_alive:'10m'`).

## Verified
- Primitive live against the user's Ollama: `{keep_alive:0}`→`done_reason:'unload'` (/api/ps empties), `{keep_alive:'10m'}`→`'load'` (resident again).
- Compiled helper live: warm→loaded, unloadAll→VRAM freed.
- Full suite **1055 green**, `tsc` clean. No panel change (reuses the `say` channel).

## Follow-up
In-panel toggle (Sean's "no chatting here while generating" switch) is a fast-follow; the env opt-out ships now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)