### PR TITLE
release: v0.27.0 — fine-tuned local models by default, 64K context, tool-loop breaker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.26.5",
+      "version": "0.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI â€” MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
- Ollama backend defaults to artokun/gemma4-comfyui-mcp:e4b — our gemma4
  QLoRA fine-tune trained on the comfyui-mcp tool surface (Ollama registry
  tags :e2b/:e4b/:12b); docs, README, and a new local-llm-free plugin
  skill explain the free-local story (#151)
- model-aware num_ctx: the fine-tune runs at its baked 65,536-token
  window instead of a 16K clamp; COMFYUI_MCP_OLLAMA_NUM_CTX override;
  context-pressure warnings (#152)
- tool-loop breaker: identical repeated tool calls are blocked with a
  corrective nudge; 4 repeats ends the turn visibly (#153)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
