### PR TITLE
chore(changelog): automated hybrid generator wired into release + backfill 0.23–0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,274 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
-### Added
+## [0.27.0] - 2026-07-08
 
-- **`--force-remote` flag** (`COMFYUI_MCP_FORCE_REMOTE=1`) — classify a loopback
-  `--comfyui-url` as remote, for dstack/RunPod-style port-forwards where a remote
-  ComfyUI is reachable at `localhost:8188`. The orchestrator forwards it to spawned
-  agents.
-- **Interactive bridge-port reclaim**: when `--panel-orchestrator` (or `connect`)
-  can't bind its port because a previous session still holds it, it now reads that
-  session's lockfile and — when run in a real terminal — offers to stop it and take
-  over (`Stop pid <pid> and take over this port with the current version? [y/N]`),
-  naming its version/pid instead of just logging that panel tools are unavailable
-  until you go find and kill it yourself.
+_No user-facing changes._
 
-### Fixed
+## [0.26.5] - 2026-07-08
 
-- **Secure bridge (RunPod/remote pod) token going stale after a ComfyUI restart** —
-  the orchestrator only re-advertised its `wss://` bridge URL/token to the pod when
-  the reported ComfyUI URL actually changed, so a same-pod reconnect never retried a
-  failed advertise (which routinely raced the pod's HTTP server still booting after a
-  ComfyUI restart). Once that race was lost, the pod was left with a stale token for
-  the rest of the session — any *fresh* browser page load would fail with
-  `rejected a bridge connection with a missing/invalid token` and never recover
-  without a full orchestrator restart. Now the orchestrator re-advertises on every
-  panel `hello` (cheap, idempotent), so the next tab connect self-heals it.
+### MCP
 
-### Changed
+#### Added
+- free local-model VRAM during generation + pause chat until it finishes (#154)
+- default Ollama to our fine-tuned gemma4-comfyui-mcp ladder (#151)
 
-- **`generations.db` for remote/cloud/undetected targets** now lives under
-  `~/.comfyui-mcp/instances/<host_port>/` (override with `COMFYUI_MCP_DATA_DIR`)
-  instead of the current working directory. Loopback hosts share one
-  `localhost_<port>` slug. Existing remote users' CWD `generations.db` is not
-  migrated — the history restarts empty at the new location.
+#### Fixed
+- tool-loop breaker — block identical repeat calls, end the turn at 4 repeats (#153)
+- stop clamping the fine-tune's context to 16K — model-aware num_ctx (#152)
+
+## [0.26.4] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- honor COMFY_AUTOUPDATE_MANAGER — Manager fast-forward at boot (#148)
+
+#### Fixed
+- manager_core shim comfy_path must be EMPTY — non-empty stripped custom-node zip paths, breaking CNR installs (#150)
+
+### MCP
+
+#### Fixed
+- re-advertise the bridge URL on a timer — restart-after-install wiped the pod store, wedging reconnect (#149)
+
+## [0.26.3] - 2026-07-08
+
+### MCP
+
+#### Fixed
+- panel download tray for Manager-dispatched (remote/RunPod) model installs (#147)
+
+## [0.26.2] - 2026-07-08
+
+### RunPod image
+
+#### Fixed
+- shim verify step needs the ComfyUI root on sys.path
+- manager_core shim — pip Manager's aria2 install-model path crashed on a legacy import (#142)
+
+### MCP
+
+#### Added
+- takeover clears the port itself — tree-kill, port-resolved holders, one consent (#146)
+
+## [0.26.1] - 2026-07-08
+
+### MCP
+
+#### Fixed
+- remote-mode banner read as a failure ('no COMFYUI_PATH, tools limited') (#141)
+
+## [0.26.0] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- npm-publish-style release — version, build, gate, publish, verify, pin template (#135)
+
+#### Fixed
+- harden the aria2 sidecar per codex review (#139)
+- aria2 download sidecar — Manager's built-in downloader ran at <1-4 MB/s (#138)
+- deploy-dockerhub.sh — fall back to 'python' when python3 is absent (Git Bash on Windows) (#134)
+- 0-byte panel/custom-nodes on full volumes — self-heal + integrity gates (#133)
+- File Browser — pinned release binary instead of the deleted get.sh installer (#132)
+
+### MCP
+
+#### Added
+- auto-convert API-format graphs to Web UI format (#126) (#136)
+
+#### Fixed
+- find Desktop-recorded installs + auto-detect in the orchestrator (#137)
+
+## [0.25.2] - 2026-07-08
+
+### MCP
+
+#### Fixed
+- un-mangle the topbar star — double-encoded UTF-8 rendered as 'â­' (#129)
+- warn when saving API format — the canvas can't open it (#125)
+- ACP mcpServers — live CLI rejects type 'http'; use the SSE variant (#124)
+
+## [0.25.1] - 2026-07-08
+
+_No user-facing changes._
+
+## [0.25.0] - 2026-07-08
+
+### RunPod image
+
+#### Fixed
+- default the image to cu128 (driver >=570) — cu130 perf stack becomes an opt-in variant (#119)
+
+## [0.24.5] - 2026-07-08
+
+### MCP
+
+#### Added
+- LAN bind for the panel bridge - server-side orchestrator topology (panel #54)
+
+## [0.24.4] - 2026-07-08
+
+### MCP
+
+#### Added
+- graceful legacy-Manager degradation messaging
+
+## [0.24.3] - 2026-07-08
+
+### RunPod image
+
+#### Fixed
+- default Manager security_level to weak so git-URL node installs work
+
+### MCP
+
+#### Fixed
+- speak BOTH ComfyUI-Manager API generations (fixes #116) + troubleshooting docs
+
+## [0.24.2] - 2026-07-08
+
+### MCP
+
+#### Added
+- comfyui-launch-flags — VRAM/attention/cache/perf launch-flag matrix (#101)
+
+#### Fixed
+- re-advertise secure bridge on every hello + offer interactive port reclaim (#115)
+- readable fatal errors + correct Docker HTTP recipe
+
+## [0.24.1] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- panel auto-update on boot, independent of the image (#111 follow-up)
+
+### MCP
+
+#### Added
+- add --force-remote to override loopback detection
+- OpenAI-compatible panel backend, tiered LLM Arena v3, panel smoke harness, all-LLM repositioning
+- Ollama backend — drive the sidebar panel with a local LLM
+- ComfyUI LLM Arena + compact-mode catalog search over param docs
+- first-class Hermes/OpenClaw/Copilot CLI support + Gemma 4 validation
+- compact tool mode for Hermes Agent / Ollama / small models (#97)
+- opt-in relay backend for the secure bridge (comfyui-mcp-relay)
+
+#### Fixed
+- scope force-remote forwarding to opted-in / non-loopback targets
+- keep generations.db out of CWD for remote ComfyUI
+- local models were flying blind — dedicated system prompt, forgiving dispatch, markdown reconciliation, cold-load keepalive
+
+#### Changed
+- trim redundant comments in force-remote flag
+
+## [0.24.0] - 2026-07-08
+
+### MCP
+
+#### Added
+- OpenAI-compatible panel backend, tiered LLM Arena v3, panel smoke harness, all-LLM repositioning
+- Ollama backend — drive the sidebar panel with a local LLM
+- ComfyUI LLM Arena + compact-mode catalog search over param docs
+- first-class Hermes/OpenClaw/Copilot CLI support + Gemma 4 validation
+- compact tool mode for Hermes Agent / Ollama / small models (#97)
+
+#### Fixed
+- local models were flying blind — dedicated system prompt, forgiving dispatch, markdown reconciliation, cold-load keepalive
+
+## [0.23.6] - 2026-07-08
+
+### MCP
+
+#### Added
+- opt-in relay backend for the secure bridge (comfyui-mcp-relay)
+
+## [0.23.5] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- persist custom_nodes on the volume (survive restarts) (#111)
+
+### MCP
+
+#### Added
+- secure wss:// bridge by default when driving a remote https pod
+
+#### Fixed
+- WebSocket keepalive so the secure wss tunnel doesn't drop mid-turn
+
+## [0.23.4] - 2026-07-08
+
+### MCP
+
+#### Added
+- secure wss:// bridge by default when driving a remote https pod
+
+## [0.23.3] - 2026-07-08
+
+### MCP
+
+#### Added
+- banner clarifies the terminal stays quiet until you click Connect
+
+## [0.23.2] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- port GPU driver preflight into venv-in-image (CUDA 13 / driver >= 580)
+- perf variant — cu130 + torch 2.9.1 + SageAttention 2.2 + Triton
+
+#### Fixed
+- --enable-cors-header (proxy browser 403) + create ComfyUI 0.27 DB dir
+
+### MCP
+
+#### Added
+- match the frontend — every out-of-list combo value is an error (#110)
+
+## [0.23.1] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- GPU driver preflight — fail fast on a too-old host driver
+
+### MCP
+
+#### Fixed
+- report real provider readiness over the bridge + bump SDK for Sonnet 5 (#108)
+
+## [0.23.0] - 2026-07-08
+
+### RunPod image
+
+#### Added
+- clean, progressive seed-extract progress (pv, no log spam)
+
+#### Fixed
+- adopt an already-seeded volume without a marker (migration safety)
+
+#### Changed
+- seed the volume from ONE archive + completion marker (no re-copy)
+
+### MCP
+
+#### Added
+- retarget ComfyUI from the panel's hello.comfyui_url
+- wan-multitalk — audio-driven talking-avatar pack + skill
+- single-port multi-provider — per-tab backend selection
+- custom RunPod image for the comfyui-mcp agent (draft) (#98)
+- one-command `connect <comfyui-url>` to drive a remote ComfyUI locally (#99)
+- remote-mode parity — route model install/manifest/output-listing through Manager v2 HTTP (#96)
+
+#### Fixed
+- detect host Triton/SageAttention from the ComfyUI LOG (fixes remote mode)
+- orchestrator-owned session is authoritative on reconnect
+
 
 ## [0.22.0] - 2026-06-29
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "generations:stats": "node scripts/generation-stats.mjs",
     "release": "npm version patch && git push --follow-tags",
     "release:minor": "npm version minor && git push --follow-tags",
-    "release:major": "npm version major && git push --follow-tags"
+    "release:major": "npm version major && git push --follow-tags",
+    "changelog": "node scripts/gen-changelog.mjs",
+    "version": "node scripts/gen-changelog.mjs $npm_package_version && git add CHANGELOG.md"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Hybrid changelog generator, wired into the release flow.
+//
+//   node scripts/gen-changelog.mjs <version>
+//
+// It stamps a dated section for <version> at the top of CHANGELOG.md by:
+//   1. Promoting whatever you hand-wrote under "## [Unreleased]" VERBATIM
+//      (your highlights — the rich prose we care about), then
+//   2. Appending anything in the git history since the last tag that your
+//      highlights didn't already mention (deduped by PR number), grouped into
+//      COMPONENT sections (MCP / RunPod image) and Keep-a-Changelog buckets
+//      (Added / Fixed / Changed) from the conventional-commit type.
+//   3. Resetting "## [Unreleased]" to an empty stub.
+//
+// So nothing in the history is ever missed, and your hand-written notes are
+// never clobbered. Idempotent-ish: safe to re-run before the version is tagged.
+//
+// Repo config (COMPONENTS) below decides how a commit maps to a section — this
+// file is the comfyui-mcp variant (MCP + RunPod); the panel ships its own.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGELOG = join(ROOT, "CHANGELOG.md");
+
+// ── Repo config ─────────────────────────────────────────────────────────────
+// First matching component wins; the last (match:()=>true) is the fallback.
+const COMPONENTS = [
+  { name: "RunPod image", match: (scope) => /^runpod/.test(scope || "") },
+  { name: "MCP", match: () => true },
+];
+// conventional-commit type → Keep-a-Changelog bucket. Types not listed are
+// dropped from the changelog (chore/ci/test/build/style/docs housekeeping).
+const TYPE_SECTION = {
+  feat: "Added",
+  fix: "Fixed",
+  perf: "Changed",
+  refactor: "Changed",
+  revert: "Changed",
+};
+const SECTION_ORDER = ["Added", "Fixed", "Changed"];
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+// stderr ignored: several queries (e.g. describe with no tags) fail by design and are try/caught.
+const git = (args) => execSync(`git ${args}`, { cwd: ROOT, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+
+/** The ref to diff against = the previous release. Prefer the most recent
+ *  version tag (mcp); fall back to the most recent release commit (the panel
+ *  has no per-release tags); else the first commit. */
+function prevTag() {
+  try {
+    const t = git("describe --tags --abbrev=0");
+    if (t) return t;
+  } catch {
+    /* no tags */
+  }
+  try {
+    const sha = git('log -1 --pretty=format:%H --grep="^\\(chore(release)\\|release\\):"');
+    if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
+  } catch {
+    /* no release commit */
+  }
+  return git("rev-list --max-parents=0 HEAD").split(/\s+/)[0]; // first commit
+}
+
+/** Parsed conventional commits since `range`, newest-first, minus noise. */
+function parseCommits(range) {
+  const raw = git(`log ${range} --no-merges --pretty=format:%s`);
+  if (!raw) return [];
+  const out = [];
+  for (const subject of raw.split("\n")) {
+    if (/^release:/i.test(subject)) continue; // release commits describe themselves
+    const m = subject.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
+    if (!m) continue; // non-conventional → skip (usually already covered by a PR merge)
+    const [, type, scope, , desc] = m;
+    const section = TYPE_SECTION[type.toLowerCase()];
+    if (!section) continue;
+    const pr = (desc.match(/\(#(\d+)\)/) || [])[1] || null;
+    out.push({ type, scope: scope || "", desc: desc.trim(), section, pr });
+  }
+  return out;
+}
+
+function componentOf(scope) {
+  return (COMPONENTS.find((c) => c.match(scope)) || COMPONENTS[COMPONENTS.length - 1]).name;
+}
+
+/** Build the auto-generated component/section body for commits not already
+ *  covered by the hand-written highlights (deduped by PR number). */
+function autoBody(commits, coveredPRs) {
+  const fresh = commits.filter((c) => !(c.pr && coveredPRs.has(c.pr)));
+  if (fresh.length === 0) return "";
+  // component -> section -> bullets[]
+  const byComp = new Map();
+  for (const c of fresh) {
+    const comp = componentOf(c.scope);
+    if (!byComp.has(comp)) byComp.set(comp, new Map());
+    const secs = byComp.get(comp);
+    if (!secs.has(c.section)) secs.set(c.section, []);
+    secs.get(c.section).push(`- ${c.desc}`);
+  }
+  // Single-component repos (e.g. the panel) read cleaner with flat `### Added`
+  // headers; multi-component repos (mcp) nest `### Component` > `#### Added`.
+  const single = COMPONENTS.length === 1;
+  const lines = [];
+  for (const comp of COMPONENTS.map((c) => c.name)) {
+    const secs = byComp.get(comp);
+    if (!secs) continue;
+    if (!single) lines.push(`### ${comp}`, "");
+    for (const section of SECTION_ORDER) {
+      const bullets = secs.get(section);
+      if (!bullets) continue;
+      lines.push(single ? `### ${section}` : `#### ${section}`, ...bullets, "");
+    }
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function today() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+const backfill = process.argv.includes("--backfill");
+const version = (process.argv.find((a) => /^v?\d+\.\d+\.\d+/.test(a)) || "").replace(/^v/, "");
+if (!backfill && !/^\d+\.\d+\.\d+/.test(version)) {
+  console.error(`usage: node scripts/gen-changelog.mjs <version> | --backfill`);
+  process.exit(1);
+}
+// Preserve the file's own line-ending convention (mcp is CRLF, panel LF): work
+// in LF internally, restore on write so we never spuriously rewrite the whole file.
+const rawMd = readFileSync(CHANGELOG, "utf-8");
+const EOL = rawMd.includes("\r\n") ? "\r\n" : "\n";
+const writeChangelog = (s) => writeFileSync(CHANGELOG, EOL === "\r\n" ? s.replace(/\n/g, "\r\n") : s);
+
+/** Build a dated entry string for `ver` from commits in `range`, folding in any
+ *  hand-written highlights (deduped by PR). */
+function buildEntry(ver, range, highlights = "") {
+  const covered = new Set([...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]));
+  const commits = parseCommits(range);
+  const auto = autoBody(commits, covered);
+  const parts = [`## [${ver}] - ${today()}`, ""];
+  if (highlights) parts.push(highlights, "");
+  if (auto) parts.push(auto, "");
+  if (!highlights && !auto) parts.push("_No user-facing changes._", "");
+  return { text: parts.join("\n").trimEnd(), commits };
+}
+
+const md = rawMd.replace(/\r\n/g, "\n"); // normalized (LF) for matching + building
+// Accept both "## [Unreleased]" (panel) and "## Unreleased" (mcp); preserve the
+// exact header text so we don't reformat the file's own convention.
+const UNREL = /(##[ \t]*(?:\[Unreleased\]|Unreleased))[ \t]*\n([\s\S]*?)(?=\n##[ \t]|\n<!-- end -->|$)/i;
+const um = md.match(UNREL);
+if (!um) {
+  console.error("could not find an '## Unreleased' (or '## [Unreleased]') section in CHANGELOG.md");
+  process.exit(1);
+}
+const unrelHeader = um[1]; // e.g. "## Unreleased" or "## [Unreleased]"
+const highlights = um[2].trim();
+
+if (backfill) {
+  // One-time repair: emit a dated entry for every tag NEWER than the newest one
+  // already in the CHANGELOG, oldest→newest, from the commits between tags.
+  const tags = git("tag --sort=creatordate")
+    .split("\n")
+    .filter((t) => /^v?\d+\.\d+\.\d+$/.test(t));
+  // Only catch up the changelog from where it left off — the newest version it
+  // already documents. Don't resurrect ancient pre-changelog tags.
+  const cmp = (a, b) => {
+    const pa = a.split("."), pb = b.split(".");
+    for (let i = 0; i < 3; i++) if (+pa[i] !== +pb[i]) return +pa[i] - +pb[i];
+    return 0;
+  };
+  const documented = [...md.matchAll(/##\s*\[(\d+\.\d+\.\d+)\]/g)].map((m) => m[1]);
+  const newest = documented.sort(cmp).pop() || "0.0.0";
+  const missing = tags.filter(
+    (t) => cmp(t.replace(/^v/, ""), newest) > 0 && !md.includes(`## [${t.replace(/^v/, "")}]`),
+  );
+  if (missing.length === 0) {
+    console.log("backfill: nothing missing.");
+    process.exit(0);
+  }
+  const blocks = [];
+  for (let i = 0; i < missing.length; i++) {
+    const tag = missing[i];
+    const idx = tags.indexOf(tag);
+    const prev = tags[idx - 1];
+    const range = prev ? `${prev}..${tag}` : tag;
+    blocks.push(buildEntry(tag.replace(/^v/, ""), range).text);
+  }
+  // newest first under Unreleased
+  const body = blocks.reverse().join("\n\n");
+  const next = md.replace(UNREL, `${unrelHeader}\n\n${body}\n\n`);
+  writeChangelog(next);
+  console.log(`backfill: added ${missing.length} missing version(s): ${missing.join(", ")}`);
+  process.exit(0);
+}
+
+if (!version) {
+  // REFRESH mode (no version arg): fold commits since the last tag into
+  // [Unreleased] without stamping a version — keeps the changelog warm between
+  // releases (e.g. after a runpod:release). Idempotent: items already present
+  // (by PR number or exact text) are not re-added.
+  const covered = new Set([...highlights.matchAll(/\(#(\d+)\)/g)].map((m) => m[1]));
+  const commits = parseCommits(`${prevTag()}..HEAD`).filter(
+    (c) => !(c.pr && covered.has(c.pr)) && !highlights.includes(c.desc),
+  );
+  const auto = autoBody(commits, new Set());
+  if (!auto) {
+    console.log("changelog: [Unreleased] already covers every commit since " + prevTag());
+    process.exit(0);
+  }
+  const body = [highlights, auto].filter(Boolean).join("\n\n");
+  writeChangelog(md.replace(UNREL, `${unrelHeader}\n\n${body}\n\n`));
+  console.log(`changelog: refreshed [Unreleased] with ${commits.length} new commit(s) since ${prevTag()}`);
+  process.exit(0);
+}
+
+if (md.includes(`## [${version}]`)) {
+  console.error(`CHANGELOG already has a [${version}] section — nothing to do.`);
+  process.exit(0);
+}
+
+const { text: entry, commits } = buildEntry(version, `${prevTag()}..HEAD`, highlights);
+const next = md.replace(UNREL, `${unrelHeader}\n\n${entry}\n\n`);
+writeChangelog(next);
+
+const nComp = new Set(commits.map((c) => componentOf(c.scope))).size;
+console.log(
+  `changelog: wrote [${version}] — ${highlights ? "kept hand-written highlights + " : ""}${
+    commits.length
+  } commit(s) across ${nComp} component(s) since ${prevTag()}`,
+);


### PR DESCRIPTION
Automated changelog generation, per request.

**`scripts/gen-changelog.mjs`** — hybrid: on release it promotes your hand-written `[Unreleased]` highlights **verbatim**, then appends any commits they didn't mention (deduped by PR#), grouped into **component sections** (MCP / RunPod image, by conventional-commit scope) and Added/Fixed/Changed buckets. Nothing in git history is ever missed; your prose is never clobbered.

**Wiring:**
- `npm version <x>` → the `version` lifecycle regenerates + `git add`s CHANGELOG.md so it rides the version commit + tag. (RunPod-image commits land in the MCP changelog's RunPod section at the next npm release automatically — same repo history — so no separate runpod:release wiring needed.)
- `npm run changelog` → refresh `[Unreleased]` from recent commits (idempotent).
- `npm run changelog -- --backfill` → catch the changelog up to every tag past the newest documented.

**Also:** backfilled **0.23.0–0.27.0** (the changelog had been stuck at 0.22.0 since June 29) and cleared the stale pre-0.22 `[Unreleased]` content. EOL-preserving (CRLF here) so no spurious full-file diffs.

Companion PR on the panel repo adds the same generator (single-component, LF) wired into set-version.mjs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)