### PR TITLE
feat(providers): LM Studio as a first-class local backend (#160)

### DIFF
--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -194,6 +194,19 @@ orchestrator log: it warns when a turn fills ≥85% of the window. Weights, LoRA
 pipeline are open: [`artokun/gemma4-comfyui-mcp`](https://huggingface.co/artokun/gemma4-comfyui-mcp)
 (dataset: [`artokun/comfyui-mcp-trajectories`](https://huggingface.co/datasets/artokun/comfyui-mcp-trajectories)).
 
+## LM Studio
+
+The panel speaks LM Studio natively: pick **LM Studio** in the backend picker
+and the orchestrator drives its local server (`http://127.0.0.1:1234/v1`,
+override with `COMFYUI_MCP_LMSTUDIO_HOST`). Setup is two clicks: install from
+[lmstudio.ai](https://lmstudio.ai), then **Developer → Start Server** with a
+**tool-calling model** loaded. The model picker mirrors whatever the server
+offers; with no default set, the first served model is adopted automatically.
+
+Our fine-tuned GGUFs work here too — search `artokun/gemma4-comfyui-mcp` in
+LM Studio's model downloader and grab a `model-q4_k_m.gguf`. Expect the same
+JIT cold-load pause on the first message that Ollama has (30s+ is normal).
+
 ## Ollama & local models — the LLM Arena
 
 Any MCP harness that talks to Ollama (or an OpenAI-compatible endpoint) can

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -29,6 +29,8 @@ function ndjsonStream(chunks: Array<Record<string, unknown>>, hang = false): Rea
 }
 
 let hangNextChat = false;
+let modelsRequests: Array<{ url: string; headers: Record<string, string> }> = [];
+let modelsResponse: string[] | "404" = [];
 
 const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = String(input);
@@ -40,6 +42,13 @@ const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit): Pr
       JSON.stringify({ models: [{ name: "gemma4:e4b" }, { name: "qwen3:4b" }] }),
       { status: 200 },
     );
+  }
+  if (url.endsWith("/v1/models") || url.endsWith(":1234/models") || url.includes("1234/v1/models")) {
+    // openai-dialect model listing (LM Studio-shaped). Capture headers so tests
+    // can assert no Authorization leaks when no apiKey is configured.
+    modelsRequests.push({ url, headers: { ...((init?.headers as Record<string, string>) ?? {}) } });
+    if (modelsResponse === "404") return new Response("not found", { status: 404 });
+    return new Response(JSON.stringify({ data: modelsResponse.map((id) => ({ id })) }), { status: 200 });
   }
   if (url.endsWith("/api/chat")) {
     const body = JSON.parse(String(init?.body));
@@ -96,6 +105,8 @@ beforeEach(() => {
   chatScript = [];
   chatRequests = [];
   hangNextChat = false;
+  modelsRequests = [];
+  modelsResponse = [];
   hangingStreamController = null;
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockClear();
@@ -313,6 +324,24 @@ describe("OllamaBackend", () => {
       { id: "gemma4:e4b", label: "gemma4:e4b" },
       { id: "qwen3:4b", label: "qwen3:4b" },
     ]);
+  });
+
+  it("lmstudio-shaped openai dialect: listModels lists served ids and sends NO auth header without a key", async () => {
+    const backend = new OllamaBackend({ api: "openai", host: "http://127.0.0.1:1234/v1", model: "qwen2.5-7b" });
+    modelsResponse = ["qwen2.5-7b", "gemma-4-e4b"];
+    const models = await backend.listModels();
+    expect(models.map((m) => m.id)).toContain("qwen2.5-7b");
+    expect(models.map((m) => m.id)).toContain("gemma-4-e4b");
+    expect(modelsRequests).toHaveLength(1);
+    const headerKeys = Object.keys(modelsRequests[0].headers).map((k) => k.toLowerCase());
+    expect(headerKeys).not.toContain("authorization");
+  });
+
+  it("openai dialect: listModels falls back to the configured model when /models 404s", async () => {
+    const backend = new OllamaBackend({ api: "openai", host: "http://127.0.0.1:1234/v1", model: "my-local-model" });
+    modelsResponse = "404";
+    const models = await backend.listModels();
+    expect(models).toEqual([{ id: "my-local-model", label: "my-local-model" }]);
   });
 
   it("isOllamaModel accepts local tags and rejects provider ids", () => {

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -29,6 +29,7 @@ const CLI_NAMES: Record<string, string[]> = {
   codex: ["codex", "codex.cmd", "codex.exe"],
   gemini: ["gemini", "gemini.cmd", "gemini.exe"],
   ollama: ["ollama", "ollama.exe"],
+  lmstudio: ["lms", "lms.exe"],
 };
 
 /** Well-known Ollama install locations probed in addition to PATH (the Windows
@@ -41,6 +42,21 @@ function ollamaInstalled(home: string): boolean {
     return fileExists(localAppData, "Programs", "Ollama", "ollama.exe");
   }
   return fileExists("/usr/local/bin/ollama") || fileExists("/opt/homebrew/bin/ollama");
+}
+
+/** LM Studio install signals: the app drops its `lms` CLI at ~/.lmstudio/bin on
+ *  every platform (best cross-OS marker), plus the per-OS app locations. */
+function lmstudioInstalled(home: string): boolean {
+  if (onPath(CLI_NAMES.lmstudio)) return true;
+  if (fileExists(home, ".lmstudio", "bin", process.platform === "win32" ? "lms.exe" : "lms")) {
+    return true;
+  }
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    return fileExists(localAppData, "Programs", "LM Studio", "LM Studio.exe");
+  }
+  if (process.platform === "darwin") return fileExists("/Applications", "LM Studio.app");
+  return fileExists(home, ".lmstudio");
 }
 
 /** True if any of `names` resolves on the local PATH. */
@@ -101,6 +117,13 @@ export function backendReadiness(backend: string, opts?: { home?: string }): Bac
     // via the connect ack's model probe (GET /api/tags fails → degraded ack).
     const cli = ollamaInstalled(home);
     return { backend: "ollama", cli, auth: cli ? true : null, ready: cli };
+  }
+  if (b === "lmstudio") {
+    // Same posture as ollama: a local server, no login concept. App/CLI
+    // presence is the readiness signal; a stopped server still surfaces via
+    // the connect ack's model probe (GET /v1/models fails → degraded ack).
+    const cli = lmstudioInstalled(home);
+    return { backend: "lmstudio", cli, auth: cli ? true : null, ready: cli };
   }
   if (b === "openrouter") {
     // Hosted — no CLI. Readiness = an OpenRouter API key in the orchestrator's

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -918,6 +918,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       ...(key ? { apiKey: key } : {}),
     };
   };
+  // LM Studio (issue #160) = the same openai dialect pinned to LM Studio's
+  // local server. No API key, no login. Default model is EMPTY on purpose —
+  // LM Studio model ids are user-specific, so ensureModels() below fills it
+  // with the first id the server actually offers.
+  const LMSTUDIO_BASE_URL = (
+    process.env.COMFYUI_MCP_LMSTUDIO_HOST ?? "http://127.0.0.1:1234/v1"
+  ).replace(/[/]$/, "");
+  let lmstudioModel =
+    process.env.COMFYUI_MCP_LMSTUDIO_MODEL ?? persistedAgent.lmstudio?.model ?? "";
+  const lmstudioDeps = () => ({ api: "openai" as const, host: LMSTUDIO_BASE_URL });
   // ── Per-tab backend (single-port multi-provider) ──────────────────────────
   // ONE orchestrator on ONE bridge port serves ALL providers; the panel picks a
   // provider per tab via the `hello`/`set_backend` handshake, instead of the node
@@ -927,7 +937,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // provider (the panel replays the transcript to seed it) while a same-provider
   // reconnect RESUMES. `backendId`/`codexModel`/`geminiModel` above are the
   // DEFAULT + per-provider model config; the process is no longer pinned to one.
-  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "ollama", "openrouter"]);
+  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "ollama", "openrouter", "lmstudio"]);
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
@@ -1095,6 +1105,16 @@ export async function runPanelOrchestrator(): Promise<void> {
         ...openrouterDeps(),
       });
     }
+    if (backend === "lmstudio") {
+      return new OllamaBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: lmstudioModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+        ...lmstudioDeps(),
+      });
+    }
     return undefined; // claude → built-in ClaudeBackend
   };
   logger.info(
@@ -1118,7 +1138,9 @@ export async function runPanelOrchestrator(): Promise<void> {
             ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: ollamaModel, ...ollamaDeps() })
             : backend === "openrouter"
               ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: openrouterModel, ...openrouterDeps() })
-              : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
+              : backend === "lmstudio"
+                ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: lmstudioModel, ...lmstudioDeps() })
+                : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
       probeBackends.set(backend, pb);
     }
     return pb;
@@ -1387,6 +1409,14 @@ export async function runPanelOrchestrator(): Promise<void> {
         : fetchSupportedModels(model);
       p = probe.then((list) => {
         if (!list.length) modelsByBackend.delete(backend); // don't cache a failed probe
+        // LM Studio ships no sane hardcoded default (model ids are whatever the
+        // user downloaded) — adopt the server's first offering when unset.
+        if (backend === "lmstudio" && !lmstudioModel && list.length) {
+          lmstudioModel = (list[0] as { value?: string }).value ?? "";
+          if (lmstudioModel) {
+            logger.info(`[panel-orchestrator] lmstudio default model → ${lmstudioModel} (first served)`);
+          }
+        }
         // User-curated preferred models (panel Settings → set_config) pin to the
         // top of the ollama picker, ahead of the discovered catalog. Read fresh
         // on every probe; set_config evicts the cache so edits apply live.
@@ -1420,6 +1450,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "gemini") return geminiModel;
     if (backend === "ollama") return ollamaModel;
     if (backend === "openrouter") return openrouterModel;
+    if (backend === "lmstudio") return lmstudioModel || undefined;
     return model;
   }
   function pushModels(panelTabId: string): void {
@@ -1543,6 +1574,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const isGm = backend === "gemini";
       const isOl = backend === "ollama";
       const isOr = backend === "openrouter";
+      const isLs = backend === "lmstudio";
       // TRUTHFUL "connected": only claim ready after PROVING the SELECTED backend
       // can run, by probing its model list. If the probe fails — the "connected
       // but dead" wedge — send a degraded ack so the panel shows the real state.
@@ -1573,9 +1605,11 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
                 : isOl
                   ? (ollamaModel ?? (models[0] as { value?: string }).value ?? "Ollama")
-                  : isOr
-                    ? (openrouterModel ?? (models[0] as { value?: string }).value ?? "OpenRouter")
-                    : model;
+                  : isLs
+                    ? (lmstudioModel || ((models[0] as { value?: string }).value ?? "LM Studio"))
+                    : isOr
+                      ? (openrouterModel ?? (models[0] as { value?: string }).value ?? "OpenRouter")
+                      : model;
             // Greet only on a FRESH session (a resume/reconnect already has the thread).
             if (!resume) {
               const readyText = isCx
@@ -1584,7 +1618,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                   ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
                   : isOl
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
-                    : isOr
+                    : isLs
+                      ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via LM Studio (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
+                      : isOr
                       ? `🟢 comfyui-mcp agent ready — ${agentLabel} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`
                       : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
               bridge.push({ type: "say", text: readyText }, panelTab);
@@ -1598,7 +1634,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
                 : isOl
                   ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite; `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB), then Disconnect → Connect to retry."
-                  : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
+                  : isLs
+                    ? `⚠️ The background agent isn't responding — LM Studio isn't reachable at ${LMSTUDIO_BASE_URL}. Open LM Studio → Developer → Start Server and load a tool-calling model (our gemma4-comfyui-mcp GGUFs from Hugging Face work great), or set COMFYUI_MCP_LMSTUDIO_HOST if it serves elsewhere — then Disconnect → Connect to retry.`
+                    : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
             bridge.push({ type: "say", text: degradedText }, panelTab);
             bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
             logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) but model probe empty — degraded ack`);
@@ -1680,6 +1718,20 @@ export async function runPanelOrchestrator(): Promise<void> {
           logger.info(
             `[panel-orchestrator] ollama config → model=${ollamaModel} api=${ollamaApi} host=${ollamaBaseUrl ?? "(default)"}`,
           );
+        }
+      }
+      const lcfg = (event as { lmstudio?: unknown }).lmstudio;
+      if (lcfg && typeof lcfg === "object") {
+        const o = lcfg as { model?: unknown };
+        if (typeof o.model === "string" && o.model.trim()) {
+          const m = o.model.trim();
+          if (!process.env.COMFYUI_MCP_LMSTUDIO_MODEL) lmstudioModel = m;
+          setAgentSettings({ lmstudio: { model: m } });
+          const pb = probeBackends.get("lmstudio");
+          if (pb?.close) void pb.close().catch(() => {});
+          probeBackends.delete("lmstudio");
+          modelsByBackend.delete("lmstudio");
+          logger.info(`[panel-orchestrator] lmstudio config → model=${lmstudioModel}`);
         }
       }
       if (ollamaChanged) {

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -36,6 +36,9 @@ export interface AgentSettings {
   /** User-curated model ids pinned to the top of the panel's model picker. */
   preferredModels?: string[];
   ollama?: OllamaAgentConfig;
+  /** LM Studio provider (issue #160) — same shape; api/baseUrl unused today
+   *  (fixed openai dialect + COMFYUI_MCP_LMSTUDIO_HOST) but kept for #162. */
+  lmstudio?: OllamaAgentConfig;
 }
 
 export interface PanelSettings {
@@ -107,6 +110,9 @@ export function setAgentSettings(patch: AgentSettings): AgentSettings {
   }
   if (patch.ollama !== undefined) {
     next.ollama = { ...prev.ollama, ...patch.ollama };
+  }
+  if (patch.lmstudio !== undefined) {
+    next.lmstudio = { ...prev.lmstudio, ...patch.lmstudio };
   }
   settings.agent = next;
   write(settings);


### PR DESCRIPTION
Closes #160 (orchestrator half; panel chip: artokun/comfyui-mcp-panel PR pairs with this).

The proven openai wire dialect (= the OpenRouter provider's engine) pinned to LM Studio's local server. No key, no login. Empty default model by design — ensureModels adopts the server's first offering. Readiness mirrors ollama's posture (install presence = ready; stopped server → actionable degraded ack). Tests: no-auth-header guard + /models 404 fallback. Docs: LM Studio section in local-llms.

Live-verified against a local LM Studio server (see PR checks + issue thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)