### PR TITLE
feat(lmstudio): full hands-off model/server lifecycle (#160 follow-up)

### DIFF
--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -202,6 +202,11 @@ override with `COMFYUI_MCP_LMSTUDIO_HOST`). Setup is two clicks: install from
 [lmstudio.ai](https://lmstudio.ai), then **Developer → Start Server** with a
 **tool-calling model** loaded. The model picker mirrors whatever the server
 offers; with no default set, the first served model is adopted automatically.
+The orchestrator manages the **full lifecycle** hands-off: it auto-starts the
+server when needed, JIT-loads your model, frees its VRAM while a ComfyUI
+render runs (chat is held and answered when the render finishes), unloads the
+outgoing model on a model switch, and releases everything when you switch to
+a different provider.
 
 Our fine-tuned GGUFs work here too — search `artokun/gemma4-comfyui-mcp` in
 LM Studio's model downloader and grab a `model-q4_k_m.gguf`. Expect the same

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -47,16 +47,25 @@ function ollamaInstalled(home: string): boolean {
 /** LM Studio install signals: the app drops its `lms` CLI at ~/.lmstudio/bin on
  *  every platform (best cross-OS marker), plus the per-OS app locations. */
 function lmstudioInstalled(home: string): boolean {
-  if (onPath(CLI_NAMES.lmstudio)) return true;
-  if (fileExists(home, ".lmstudio", "bin", process.platform === "win32" ? "lms.exe" : "lms")) {
-    return true;
-  }
+  if (lmstudioCliPath(home)) return true;
   if (process.platform === "win32") {
     const localAppData = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
     return fileExists(localAppData, "Programs", "LM Studio", "LM Studio.exe");
   }
   if (process.platform === "darwin") return fileExists("/Applications", "LM Studio.app");
   return fileExists(home, ".lmstudio");
+}
+
+/** Absolute path (or bare name if on PATH) of the `lms` CLI — the supported
+ *  programmatic surface for load/unload/server lifecycle. Used by
+ *  services/lmstudio-lifecycle to shell out even when PATH lacks it (the app
+ *  adds ~/.lmstudio/bin to PATH for NEW shells only). Null when not found. */
+export function lmstudioCliPath(home: string = homedir()): string | null {
+  if (onPath(CLI_NAMES.lmstudio)) return "lms";
+  const binName = process.platform === "win32" ? "lms.exe" : "lms";
+  const inHome = join(home, ".lmstudio", "bin", binName);
+  if (fileExists(inHome)) return inHome;
+  return null;
 }
 
 /** True if any of `names` resolves on the local PATH. */

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -51,6 +51,12 @@ import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
 import { unloadAllOllama, warmOllama, resolveOllamaHost } from "../services/ollama-vram.js";
+import {
+  isLocalLmstudio,
+  startLmstudioServer,
+  unloadAllLmstudio,
+  warmLmstudio,
+} from "../services/lmstudio-lifecycle.js";
 import { getAgentSettings, setAgentSettings } from "../services/panel-settings.js";
 import {
   gatherEnvCapabilities,
@@ -1249,16 +1255,24 @@ export async function runPanelOrchestrator(): Promise<void> {
   const anyLocalOllama = (): boolean =>
     ollamaApi === "ollama" &&
     (defaultBackend === "ollama" || [...tabBackends.values()].includes("ollama"));
+  // LM Studio joins the same VRAM handoff (issue #160 follow-up): local server
+  // only — a remote COMFYUI_MCP_LMSTUDIO_HOST is someone else's VRAM.
+  const anyLocalLmstudio = (): boolean =>
+    isLocalLmstudio(LMSTUDIO_BASE_URL) &&
+    (defaultBackend === "lmstudio" || [...tabBackends.values()].includes("lmstudio"));
   // agentKey -> messages held while a render runs (flushed on render end).
   const heldDuringGen = new Map<string, Array<{ text: string; opts: Record<string, unknown> }>>();
   let genPauseActive = false;
   if (pauseLocalDuringGen) {
     QueueMonitor.setTransitionHandlers({
       onRunStart: () => {
-        if (!anyLocalOllama()) return;
+        const ol = anyLocalOllama();
+        const ls = anyLocalLmstudio();
+        if (!ol && !ls) return;
         genPauseActive = true;
         // Free the local model's VRAM for the render (best-effort, fire-and-forget).
-        void unloadAllOllama(resolveOllamaHost());
+        if (ol) void unloadAllOllama(resolveOllamaHost());
+        if (ls) void unloadAllLmstudio(LMSTUDIO_BASE_URL);
       },
       onRunEnd: () => {
         if (!genPauseActive) return;
@@ -1268,6 +1282,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // instant ("ready to chat"). If messages ARE queued, sending them below
         // loads the model itself — no separate warm needed.
         if (anyLocalOllama() && !hadHeld) void warmOllama(resolveOllamaHost(), ollamaModel);
+        if (anyLocalLmstudio() && !hadHeld && lmstudioModel) void warmLmstudio(LMSTUDIO_BASE_URL, lmstudioModel);
         for (const [key, msgs] of heldDuringGen) {
           const tabId = panelTabOf(key);
           if (msgs.length > 0) {
@@ -1596,7 +1611,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (openrouter) but no API key — degraded ack`);
         return;
       }
-      void ensureModels(backend)
+      void (isLs && isLocalLmstudio(LMSTUDIO_BASE_URL)
+        ? startLmstudioServer(LMSTUDIO_BASE_URL).then(() => ensureModels(backend))
+        : ensureModels(backend)
+      )
         .then((models) => {
           if (models.length) {
             const agentLabel = isCx
@@ -1665,6 +1683,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       const prev = tabBackends.get(panelTab) ?? defaultBackend;
       if (prev !== reqBackend) manager.reset(panelTab + AGENT_KEY_SEP + prev);
       tabBackends.set(panelTab, reqBackend);
+      // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —
+      // the point of switching to Claude/hosted is usually reclaiming the GPU.
+      if (prev !== reqBackend) {
+        const stillUsed = (b: string) => [...tabBackends.values()].includes(b) || defaultBackend === b;
+        if (prev === "lmstudio" && !stillUsed("lmstudio") && isLocalLmstudio(LMSTUDIO_BASE_URL)) {
+          void unloadAllLmstudio(LMSTUDIO_BASE_URL);
+        }
+        if (prev === "ollama" && !stillUsed("ollama") && ollamaApi === "ollama") {
+          void unloadAllOllama(resolveOllamaHost());
+        }
+        // Switching TO lmstudio: make sure its server is up (auto-start, no
+        // manual `lms server start`) so the readiness probe finds it alive.
+        if (reqBackend === "lmstudio") void startLmstudioServer(LMSTUDIO_BASE_URL);
+      }
       pushModels(panelTab);
       if (reqBackend === "claude") pushCommands(panelTab);
       bridge.push({ type: "ack", ok: true, kind: "set_backend", backend: reqBackend }, panelTab);
@@ -1792,6 +1824,12 @@ export async function runPanelOrchestrator(): Promise<void> {
             logger.warn(`[panel-orchestrator] ignoring unknown model "${nextModel}" — keeping current`);
             nextModel = undefined;
           }
+        }
+        // LM Studio model switch: unload everything EXCEPT the incoming model —
+        // the outgoing one would otherwise sit in VRAM next to the JIT-loaded
+        // replacement until its TTL expires.
+        if (nextModel && backendForTab(tabId) === "lmstudio" && isLocalLmstudio(LMSTUDIO_BASE_URL)) {
+          void unloadAllLmstudio(LMSTUDIO_BASE_URL, nextModel);
         }
         const applied = await manager.setOptions(agentKeyFor(tabId), { model: nextModel, effort: nextEffort });
         bridge.push(
@@ -2007,12 +2045,10 @@ export async function runPanelOrchestrator(): Promise<void> {
     // render is in flight, DON'T run the turn now — that would reload the model
     // on top of the generation (VRAM contention / OOM). Hold it and answer when
     // the render finishes (onRunEnd flushes the queue + warms the model).
-    if (
-      pauseLocalDuringGen &&
-      ollamaApi === "ollama" &&
-      backendForTab(event.tab_id) === "ollama" &&
-      QueueMonitor.isBusy()
-    ) {
+    const tabIsLocalVram =
+      (ollamaApi === "ollama" && backendForTab(event.tab_id) === "ollama") ||
+      (backendForTab(event.tab_id) === "lmstudio" && isLocalLmstudio(LMSTUDIO_BASE_URL));
+    if (pauseLocalDuringGen && tabIsLocalVram && QueueMonitor.isBusy()) {
       const key = agentKeyFor(event.tab_id);
       const arr = heldDuringGen.get(key) ?? [];
       arr.push({ text: outText, opts: sendOpts });

--- a/src/services/lmstudio-lifecycle.ts
+++ b/src/services/lmstudio-lifecycle.ts
@@ -1,0 +1,148 @@
+// Full LM Studio model/server lifecycle for the panel orchestrator — the
+// LM Studio sibling of ollama-vram.ts, so the provider is hands-off:
+//
+//   * server AUTO-START  (no "run `lms server start` yourself" step)
+//   * unload during ComfyUI renders (single-GPU VRAM handoff, like #154)
+//   * unload stale models on model SWITCH (JIT loads the new one on demand)
+//   * unload everything when the tab switches to a DIFFERENT provider
+//   * warm (JIT-load) the active model so the first post-render chat is fast
+//
+// Surfaces used: LM Studio's native REST (`/api/v0/models` reports per-model
+// `state: "loaded"`) for reads, and the `lms` CLI (the supported programmatic
+// control surface; located via backend-readiness.lmstudioCliPath even when
+// PATH lacks it) for load/unload/server start.
+//
+// Everything is BEST-EFFORT: any failure is logged and swallowed — lifecycle
+// management must never break a turn or a render.
+
+import { execFile } from "node:child_process";
+import { logger } from "../utils/logger.js";
+import { lmstudioCliPath } from "../orchestrator/backend-readiness.js";
+
+export const DEFAULT_LMSTUDIO_HOST = "http://127.0.0.1:1234/v1";
+
+/** The REST root (strip a trailing /v1 — /api/v0 hangs off the server root). */
+function serverRoot(host: string): string {
+  return host.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+/** True when the host is this machine — we only manage LOCAL VRAM/lifecycle
+ *  (never unload models on someone's remote LM Studio box). */
+export function isLocalLmstudio(host: string): boolean {
+  return /^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(:|\/|$)/i.test(host);
+}
+
+function lms(args: string[], timeoutMs = 20000): Promise<{ ok: boolean; out: string }> {
+  return new Promise((resolve) => {
+    const cli = lmstudioCliPath();
+    if (!cli) return resolve({ ok: false, out: "lms CLI not found" });
+    execFile(cli, args, { timeout: timeoutMs, windowsHide: true }, (err, stdout, stderr) => {
+      resolve({ ok: !err, out: `${stdout ?? ""}${stderr ?? ""}`.trim() });
+    });
+  });
+}
+
+/** Is the server answering? (native REST /api/v0/models — also our readiness probe) */
+export async function lmstudioServerUp(host: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${serverRoot(host)}/api/v0/models`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Start LM Studio's local server headlessly via the CLI, then wait for it to
+ *  answer (the CLI returns before the port is fully live). Returns true when
+ *  the endpoint is reachable afterwards. */
+export async function startLmstudioServer(host: string): Promise<boolean> {
+  if (await lmstudioServerUp(host)) return true;
+  const port = /:(\d+)/.exec(host)?.[1];
+  logger.info(`[lmstudio] server not reachable — attempting \`lms server start\`…`);
+  const r = await lms(["server", "start", ...(port ? ["--port", port] : [])], 30000);
+  if (!r.ok) {
+    logger.warn(`[lmstudio] lms server start failed: ${r.out.slice(0, 200)}`);
+    return false;
+  }
+  for (let i = 0; i < 10; i++) {
+    if (await lmstudioServerUp(host)) {
+      logger.info(`[lmstudio] server started on ${host}`);
+      return true;
+    }
+    await new Promise((res) => setTimeout(res, 1000));
+  }
+  logger.warn(`[lmstudio] server start reported ok but ${host} still not answering`);
+  return false;
+}
+
+interface V0Model {
+  id?: string;
+  state?: string;
+  type?: string;
+}
+
+/** Model ids currently LOADED in VRAM (native /api/v0/models state field);
+ *  embeddings excluded — unloading those breaks nothing but wastes a call. */
+export async function loadedLmstudioModels(host: string): Promise<string[]> {
+  try {
+    const res = await fetch(`${serverRoot(host)}/api/v0/models`, {
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { data?: V0Model[] };
+    return (body.data ?? [])
+      .filter((m) => m.state === "loaded" && m.type !== "embeddings")
+      .map((m) => m.id ?? "")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Unload every loaded LLM (optionally sparing one — used on model switch so
+ *  the outgoing model frees its VRAM while the incoming one JIT-loads). */
+export async function unloadAllLmstudio(host: string, except?: string): Promise<string[]> {
+  if (!isLocalLmstudio(host)) return [];
+  const loaded = (await loadedLmstudioModels(host)).filter((m) => m !== except);
+  if (loaded.length === 0) return [];
+  if (!except) {
+    const r = await lms(["unload", "--all"]);
+    if (!r.ok) logger.debug(`[lmstudio] unload --all failed: ${r.out.slice(0, 160)}`);
+  } else {
+    for (const m of loaded) {
+      const r = await lms(["unload", m]);
+      if (!r.ok) logger.debug(`[lmstudio] unload ${m} failed: ${r.out.slice(0, 160)}`);
+    }
+  }
+  logger.info(`[lmstudio] unloaded ${loaded.length} model(s) to free VRAM: ${loaded.join(", ")}`);
+  return loaded;
+}
+
+/** Warm a model back into VRAM (a 1-token completion triggers the JIT load) so
+ *  the agent answers instantly once a render finishes. */
+export async function warmLmstudio(host: string, model: string): Promise<boolean> {
+  if (!model || !isLocalLmstudio(host)) return false;
+  try {
+    const res = await fetch(`${host.replace(/\/+$/, "")}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ok" }],
+        max_tokens: 1,
+      }),
+      signal: AbortSignal.timeout(120000), // cold JIT load of a big model takes a while
+    });
+    if (res.ok) {
+      logger.info(`[lmstudio] warmed ${model} back into VRAM`);
+      return true;
+    }
+  } catch (err) {
+    logger.debug(
+      `[lmstudio] warm ${model} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return false;
+}


### PR DESCRIPTION
Community requirement: the MCP must own the full LM Studio lifecycle — no manual `lms server start`, programmatic load/unload around generations, same as the Ollama setup.

- **NEW `services/lmstudio-lifecycle.ts`** — auto-start (`lms` CLI, located even off-PATH), loaded-model detection (native `/api/v0/models` state), unload-all/-except, JIT warm. Best-effort, loopback-only.
- **Render VRAM handoff**: joins #154's QueueMonitor transitions — unload on render start, hold chat, warm + flush on render end.
- **Provider switch**: leaving lmstudio/ollama unloads when no tab still uses it; switching TO lmstudio auto-starts the server.
- **Model switch**: unloads everything except the incoming model.
- **Connect**: auto-start before the readiness probe.

Live-verified end-to-end on a real install: cold auto-start → JIT warm (loaded-state confirmed) → unload-all (confirmed empty). 80/80 orchestrator tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)