### PR TITLE
fix(openai-dialect): pin temperature 0 — nondeterministic empty finals after tool results

### DIFF
--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -494,6 +494,15 @@ export class OllamaBackend implements AgentBackend {
                 // 65k, which both invites runaways and 402s on low prepaid
                 // balances (the request reserves credits for max_tokens).
                 max_tokens: Number(process.env.COMFYUI_MCP_OLLAMA_MAX_TOKENS) || 8192,
+                // Pin temperature for tool precision — the project's recipe
+                // everywhere else (arena, GGUF validation, the Ollama tags'
+                // Modelfiles all run temp 0). Endpoints with no server-side
+                // default (LM Studio serving a raw GGUF) otherwise sample at
+                // ~0.8, where small models nondeterministically emit an EMPTY
+                // final message after tool results (found live on e2b).
+                temperature: process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE
+                  ? Number(process.env.COMFYUI_MCP_OLLAMA_TEMPERATURE)
+                  : 0,
               }),
               signal,
             })


### PR DESCRIPTION
Found live-testing the LM Studio provider: no temperature was sent, LM Studio sampled a raw GGUF at ~0.8, and small models nondeterministically emitted an empty final message after tool results. Temp 0 = the project's established tool-precision recipe (arena / validation / Ollama Modelfiles). COMFYUI_MCP_OLLAMA_TEMPERATURE overrides. Verified 3/3 stable against live LM Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)