### PR TITLE
feat(orchestrator): inline media bytes in show_media for headless clients

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1460,17 +1460,47 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             const filename = p.replace(/.*[\/]/, "");
             resolved.push({ kind, dataUrl, filename, caption: item.caption });
           } else {
-            // ComfyUI /view ref — forward to panel; panel builds the URL.
-            resolved.push({
-              kind: "viewRef",
-              viewRef: {
+            // ComfyUI /view ref. A browser panel fetches it same-origin — but a
+            // HEADLESS (mobile/remote) client can't reach ComfyUI, so resolve the
+            // bytes HERE and inline them as a data URL. Best-effort: any failure
+            // (fetch error, non-media, too big) falls back to forwarding the ref,
+            // which the client renders as a caption card.
+            let inlined = false;
+            if (ctx.bridge.isHeadless(ctx.tabId)) {
+              try {
+                const base = (process.env.COMFYUI_URL ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
+                const qs = new URLSearchParams({ filename: src.filename, type: src.type ?? "output" });
+                if (src.subfolder) qs.set("subfolder", src.subfolder);
+                const resp = await fetch(`${base}/view?${qs.toString()}`);
+                if (resp.ok) {
+                  const mime = resp.headers.get("content-type") ?? "";
+                  const buf = Buffer.from(await resp.arrayBuffer());
+                  if ((mime.startsWith("image/") || mime.startsWith("video/")) && buf.length <= MAX_BYTES) {
+                    resolved.push({
+                      kind: mime.startsWith("video/") ? "video" : "image",
+                      dataUrl: `data:${mime};base64,${buf.toString("base64")}`,
+                      filename: src.filename,
+                      caption: item.caption,
+                    });
+                    inlined = true;
+                  }
+                }
+              } catch {
+                // fall through to the viewRef path
+              }
+            }
+            if (!inlined) {
+              resolved.push({
+                kind: "viewRef",
+                viewRef: {
+                  filename: src.filename,
+                  subfolder: src.subfolder,
+                  type: src.type,
+                },
                 filename: src.filename,
-                subfolder: src.subfolder,
-                type: src.type,
-              },
-              filename: src.filename,
-              caption: item.caption,
-            });
+                caption: item.caption,
+              });
+            }
           }
         }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -65,6 +65,9 @@ interface Conn {
   tabId: string;
   title: string;
   connectedAt: string;
+  /** Canvas-less client (mobile/remote pseudo-panel) — advertised in `hello`.
+   *  Lets tools resolve media to inline bytes instead of a browser /view ref. */
+  headless: boolean;
 }
 
 export interface BridgeCommand {
@@ -329,6 +332,7 @@ export class UiBridge {
           tabId,
           title: typeof msg.title === "string" && msg.title ? msg.title : "untitled",
           connectedAt: existing?.connectedAt ?? new Date().toISOString(),
+          headless: (msg as { headless?: unknown }).headless === true,
         });
         logger.info(
           `[ui-bridge] panel tab connected: ${tabId.slice(0, 8)} (“${this.conns.get(tabId)?.title}”) — ${this.conns.size} tab(s) total`,
@@ -392,6 +396,12 @@ export class UiBridge {
 
   connected(): boolean {
     return this.conns.size > 0;
+  }
+
+  /** True when the tab advertised itself as a canvas-less (mobile/remote) client
+   *  in its `hello`. Unknown tabs → false. */
+  isHeadless(tabId: string): boolean {
+    return this.conns.get(tabId)?.headless === true;
   }
 
   /** All currently connected tabs, most recent hello last. */


### PR DESCRIPTION
Completes the **remote-safe half** of the mobile media gap (gap #2). Pairs with comfyui-mcp-mobile, which already renders inline `dataUrl`.

## Problem
`panel_show_media` hands a ComfyUI `/view` **reference**, not bytes. A browser panel is same-origin with ComfyUI so it fetches directly — but a **headless (mobile/remote) client** reaching the agent over a tunnel can't touch ComfyUI, so the image never loads (only a caption fallback).

## Fix
- **ui-bridge:** track `headless` per tab (advertised in the `hello` frame) + expose `isHeadless(tabId)`.
- **panel_show_media:** for a headless tab, resolve the `/view` bytes on the orchestrator (which *can* reach ComfyUI via `COMFYUI_URL`) and **inline them as a `data:` URL** (images/videos ≤ 20 MB). Non-headless tabs are unchanged (still get the lightweight `viewRef`). Best-effort — any fetch error/non-media/oversize falls back to the `viewRef`.

The bytes now flow over the **same bridge/tunnel** the client already trusts, so media works from anywhere.

## Verification (live)
A canvas-less WS pseudo-panel (`hello{headless:true}`) asked to show an output image. Before: `show_media` item was a bytes-less `viewRef`. After:
```
show_media  1 item
  - kind=image  filename=ComfyUI_00003_.png  INLINE dataUrl(data:image/png;base64,iV… 544502 chars)
```
`npm run build` (tsc) clean.

## Related
- Client half already merged in comfyui-mcp-mobile (renders `dataUrl` + derived base for LAN).
- Follows the headless in-turn delivery fix (#165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)