### PR TITLE
feat(orchestrator): on-demand phone pairing — token-gated LAN/tunnel listener

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -125,6 +125,48 @@ describe("UiBridge (LAN bind — panel #54)", () => {
   });
 });
 
+describe("UiBridge (on-demand pairing listener — addListener)", () => {
+  it("adds a token-gated second listener sharing tab routing; primary loopback stays token-less", async () => {
+    // The beforeEach bridge is loopback + token-less (the local panel case).
+    const pairPort = 20000 + Math.floor(Math.random() * 20000);
+    await bridge.addListener("127.0.0.1", pairPort, "pair-token");
+
+    // Pairing port WITHOUT a token → rejected.
+    await expect(
+      new Promise((resolve, reject) => {
+        const s = new WebSocket(`ws://127.0.0.1:${pairPort}`);
+        s.on("open", () => reject(new Error("opened pairing port without a token")));
+        s.on("error", () => resolve("rejected"));
+      }),
+    ).resolves.toBe("rejected");
+
+    // Wrong token → rejected.
+    await expect(
+      new Promise((resolve, reject) => {
+        const s = new WebSocket(`ws://127.0.0.1:${pairPort}/?token=nope`);
+        s.on("open", () => reject(new Error("opened pairing port with a wrong token")));
+        s.on("error", () => resolve("rejected"));
+      }),
+    ).resolves.toBe("rejected");
+
+    // Correct token → opens and registers a tab on the SAME bridge.
+    const phone = await new Promise<WebSocket>((resolve, reject) => {
+      const s = new WebSocket(`ws://127.0.0.1:${pairPort}/?token=pair-token`);
+      s.on("open", () => resolve(s));
+      s.on("error", reject);
+    });
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-1", title: "mobile" }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-1")).toBe(true));
+
+    // The primary loopback listener is STILL token-less (local panel unaffected).
+    const local = await connectPanel("local-1");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "local-1")).toBe(true));
+
+    phone.close();
+    local.close();
+  });
+});
+
 describe("UiBridge (multi-tab)", () => {
   it("routes to the single connected tab without tab_id", async () => {
     const a = await connectPanel("tab-aaaa-1111");

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -18,6 +18,7 @@ import { randomBytes } from "node:crypto";
 import readline from "node:readline";
 import { startUiBridge, isLoopbackBindHost, type UiBridge } from "../services/ui-bridge.js";
 import { setupSecureBridge, type SecureBridge } from "../services/secure-bridge.js";
+import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { SessionStore } from "./session-store.js";
 import { logger } from "../utils/logger.js";
@@ -656,6 +657,24 @@ export async function runPanelOrchestrator(): Promise<void> {
   const lockPort = Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180;
   const lockPath = orchLockPath(lockPort);
   const bridge = startUiBridge(lockPort, bridgeToken, bridgeHost);
+
+  // On-demand phone pairing (the panel "Remote control" button). Off by default:
+  // the FIRST pair request lazily binds a SECOND, token-gated listener on all
+  // interfaces (so a phone can reach it), while the primary loopback bridge stays
+  // token-less. LAN mode returns a same-wifi ws:// URL; tunnel mode fronts the same
+  // token-gated listener with a cloudflared wss:// for anywhere access.
+  const pairPort = lockPort + 2; // avoid the panel_* HTTP-MCP port (lockPort + 1)
+  let pairToken: string | null = null;
+  let pairListenerStarted = false;
+  let pairTunnel: { url: string; stop: () => void } | null = null;
+  const ensurePairListener = async (): Promise<string> => {
+    if (!pairToken) pairToken = randomBytes(24).toString("hex");
+    if (!pairListenerStarted) {
+      await bridge.addListener("0.0.0.0", pairPort, pairToken);
+      pairListenerStarted = true;
+    }
+    return pairToken;
+  };
 
   if (lanBridge) {
     // Ready-to-paste connection info: the panel's Settings → Advanced →
@@ -2029,6 +2048,53 @@ export async function runPanelOrchestrator(): Promise<void> {
         event.tab_id,
       );
       if (!error) pushReadiness(event.tab_id);
+      return;
+    }
+
+    // Phone pairing: mint a phone-reachable bridge URL for the panel's QR modal.
+    // `lan` → ws://<lan-ip>:<pairPort>/?token= (same wifi); `tunnel` → a cloudflared
+    // wss://…/?token= (anywhere). Both hit the on-demand token-gated pairing
+    // listener; async (tunnel startup can fail), so reply via a typed frame.
+    if (event.type === "pair" && event.tab_id) {
+      const mode = (event as { mode?: unknown }).mode === "tunnel" ? "tunnel" : "lan";
+      const tabId = event.tab_id;
+      void (async () => {
+        const token = await ensurePairListener();
+        let url: string;
+        if (mode === "tunnel") {
+          if (!pairTunnel) {
+            const t = await startQuickTunnel(pairPort, "127.0.0.1");
+            pairTunnel = { url: t.url, stop: t.stop };
+            process.once("exit", () => {
+              try {
+                pairTunnel?.stop();
+              } catch {
+                /* best-effort */
+              }
+            });
+          }
+          const u = new URL(pairTunnel.url);
+          u.protocol = "wss:";
+          u.search = "";
+          u.searchParams.set("token", token);
+          url = u.toString();
+        } else {
+          const ip = firstLanIPv4();
+          if (!ip) {
+            throw new Error(
+              "No LAN network found — connect this machine to wifi/ethernet, or use the Internet (tunnel) option.",
+            );
+          }
+          url = `ws://${ip}:${pairPort}/?token=${token}`;
+        }
+        logger.info(`[panel-orchestrator] pairing URL minted (${mode})`);
+        bridge.push({ type: "pair_url", mode, url }, tabId);
+      })().catch((err) => {
+        bridge.push(
+          { type: "pair_error", mode, error: err instanceof Error ? err.message : String(err) },
+          tabId,
+        );
+      });
       return;
     }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -91,6 +91,11 @@ export class UiBridge {
   private static readonly MAX_MISSED_PONGS = 2;
 
   private wss: WebSocketServer | null = null;
+  /** Extra always-token-gated listeners — the on-demand phone-pairing bind (LAN
+   *  and/or a loopback port a cloudflared tunnel fronts). Their connections route
+   *  through the same tab/rid logic as the primary bridge; the primary loopback
+   *  listener stays token-less so the local browser panel is unaffected. */
+  private readonly extraServers: WebSocketServer[] = [];
   private conns = new Map<string, Conn>(); // tabId -> connection
   private pending = new Map<string, Pending>();
   private portInUse = false;
@@ -161,23 +166,28 @@ export class UiBridge {
   private startHeartbeat(): void {
     if (this.heartbeatTimer) return;
     this.heartbeatTimer = setInterval(() => {
-      const wss = this.wss;
-      if (!wss) return;
-      for (const sock of wss.clients) {
-        const missed = this.missedPongs.get(sock) ?? 0;
-        if (missed >= UiBridge.MAX_MISSED_PONGS) {
-          try {
-            sock.terminate();
-          } catch {
-            // already gone
+      // Ping the primary listener AND any pairing listeners — a phone on a LAN or
+      // tunnel bind needs the same idle-keepalive the browser panel gets.
+      const servers = [this.wss, ...this.extraServers].filter(
+        (s): s is WebSocketServer => s !== null,
+      );
+      for (const server of servers) {
+        for (const sock of server.clients) {
+          const missed = this.missedPongs.get(sock) ?? 0;
+          if (missed >= UiBridge.MAX_MISSED_PONGS) {
+            try {
+              sock.terminate();
+            } catch {
+              // already gone
+            }
+            continue;
           }
-          continue;
-        }
-        this.missedPongs.set(sock, missed + 1);
-        try {
-          sock.ping();
-        } catch {
-          // socket mid-close — the next tick's terminate/close handler cleans up
+          this.missedPongs.set(sock, missed + 1);
+          try {
+            sock.ping();
+          } catch {
+            // socket mid-close — the next tick's terminate/close handler cleans up
+          }
         }
       }
     }, UiBridge.HEARTBEAT_MS);
@@ -299,6 +309,63 @@ export class UiBridge {
    */
   attachRelayConnection(sock: BridgeSocket): void {
     this.handleConnection(sock);
+  }
+
+  /**
+   * Open a SECOND, ALWAYS token-gated listener on `host:port` and route its
+   * connections through the same tab/rid logic as the primary bridge. Used by the
+   * on-demand "pair a phone" flow: a `0.0.0.0` bind so a phone can reach it over
+   * the LAN, and/or a loopback port a cloudflared quick-tunnel fronts. The primary
+   * loopback listener stays token-less, so the local browser panel is untouched.
+   * Resolves once bound; rejects if the port can't be bound. Idempotent-ish: the
+   * caller is responsible for not re-binding the same port.
+   */
+  addListener(host: string, port: number, token: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const wss = new WebSocketServer({
+        port,
+        host,
+        verifyClient: (info, cb) => {
+          let provided = "";
+          try {
+            provided =
+              new URL(info.req.url ?? "/", "http://127.0.0.1").searchParams.get("token") ?? "";
+          } catch {
+            provided = "";
+          }
+          const a = Buffer.from(provided);
+          const b = Buffer.from(token);
+          if (a.length === b.length && timingSafeEqual(a, b)) return cb(true);
+          logger.warn("[ui-bridge] pairing listener rejected a connection with a missing/invalid token");
+          cb(false, 401, "Unauthorized");
+        },
+      });
+      wss.on("connection", (sock) => {
+        this.missedPongs.set(sock, 0);
+        sock.on("pong", () => this.missedPongs.set(sock, 0));
+        this.handleConnection(sock);
+      });
+      wss.on("listening", () => {
+        settled = true;
+        this.extraServers.push(wss);
+        logger.info(`[ui-bridge] pairing listener on ws://${host}:${port} (token-gated)`);
+        resolve();
+      });
+      wss.on("error", (err: NodeJS.ErrnoException) => {
+        if (!settled) {
+          settled = true;
+          try {
+            wss.close();
+          } catch {
+            // nothing bound
+          }
+          reject(err);
+        } else {
+          logger.warn(`[ui-bridge] pairing listener error: ${err.message}`);
+        }
+      });
+    });
   }
 
   private handleConnection(sock: BridgeSocket): void {
@@ -542,6 +609,13 @@ export class UiBridge {
       }
     }
     this.conns.clear();
+    for (const s of this.extraServers.splice(0)) {
+      try {
+        s.close();
+      } catch {
+        // already gone
+      }
+    }
     await new Promise<void>((resolve) => {
       if (!this.wss) return resolve();
       this.wss.close(() => resolve());


### PR DESCRIPTION
The orchestrator enabler for the panel's **"Remote control"** button (roadmap F2). Lets the panel hand a phone a *reachable* bridge URL to pair with — **without exposing the local bridge by default**. Pairs with the QR scanner already in comfyui-mcp-mobile.

## What it does
- **`UiBridge.addListener(host, port, token)`** — a SECOND, **always-token-gated** listener whose connections route through the exact same tab/rid logic as the primary bridge. The primary loopback listener **stays token-less**, so the local browser panel is completely unaffected. Heartbeat + `stop()` now cover the extra listeners.
- **Orchestrator `pair` frame** — the panel sends `{type:"pair", mode}`; the orchestrator lazily binds **one** `0.0.0.0` pairing listener (fresh 24-byte token) on first request and replies with `pair_url`:
  - `lan` → `ws://<lan-ip>:<pairPort>/?token=…` (same wifi)
  - `tunnel` → `wss://<rand>.trycloudflare.com/?token=…` (anywhere, via `startQuickTunnel`)
  - errors → `pair_error`

## Security posture (please review)
- **Off by default** — nothing binds beyond loopback until the user clicks "Remote control".
- Both LAN and tunnel exposure are **token-gated**: a 24-byte secret in the URL query, constant-time compared on the WS upgrade. The tunnel fronts the *same* token-gated listener, so it is **never** unauthenticated (the map flagged that an ungated tunnel would be the danger — this avoids it by giving the pairing listener its own token, independent of the token-less loopback bridge).
- `pairPort = lockPort + 2` (avoids the `panel_*` HTTP-MCP port at `lockPort + 1`).

## Verification
- `npm run build` (tsc) clean.
- New unit test (`ui-bridge.test.ts`): the pairing listener accepts the correct token, **rejects** missing/wrong tokens, registers the tab on the same bridge, and the **primary loopback listener stays token-less**. Full suite: 1061/1062 (the one failure is a pre-existing parallel-load flake in `remote-model-landing`; passes in isolation).

## Follow-up
Panel-side "Remote control" button + QR modal (Local-wifi / Internet toggle) in **comfyui-mcp-panel**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)