### PR TITLE
feat(orchestrator): render mailbox — never lose a render while the phone is away

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -167,6 +167,52 @@ describe("UiBridge (on-demand pairing listener — addListener)", () => {
   });
 });
 
+describe("UiBridge (mailbox — offline render delivery)", () => {
+  it("buffers show_media for an offline tab and flushes it on reconnect", async () => {
+    // No tab connected. A finished-render delivery to a specific (offline) tab is
+    // buffered, not failed.
+    const res = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "a.png" }] },
+      { tabId: "phone-stable-1" },
+    );
+    expect(res).toMatchObject({ ok: true, mailboxed: true });
+
+    // An INTERACTIVE command to an offline tab still rejects (not mailboxable).
+    await expect(
+      bridge.send({ cmd: "graph_outline" }, { tabId: "phone-stable-1" }),
+    ).rejects.toThrow();
+
+    // The phone reconnects (same stable tab id) → it gets the buffered show_media
+    // (flagged mailbox:true) plus a mailbox_flush summary.
+    const got: Array<Record<string, unknown>> = [];
+    const phone = await connectPanel(); // open socket, no hello yet
+    phone.on("message", (buf) => got.push(JSON.parse(buf.toString())));
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-stable-1", title: "mobile" }));
+
+    await vi.waitFor(() => {
+      const media = got.find((m) => m.cmd === "show_media");
+      const flush = got.find((m) => m.type === "mailbox_flush");
+      expect(media).toMatchObject({ mailbox: true });
+      expect(flush).toMatchObject({ count: 1 });
+    });
+    phone.close();
+  });
+
+  it("does not mailbox interactive commands (only show_media)", async () => {
+    await expect(
+      bridge.send({ cmd: "graph_get_state" }, { tabId: "nobody" }),
+    ).rejects.toThrow();
+    // Reconnecting that tab flushes nothing.
+    const got: Array<Record<string, unknown>> = [];
+    const phone = await connectPanel();
+    phone.on("message", (buf) => got.push(JSON.parse(buf.toString())));
+    phone.send(JSON.stringify({ type: "hello", tab_id: "nobody", title: "x" }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "nobody")).toBe(true));
+    expect(got.find((m) => m.type === "mailbox_flush")).toBeUndefined();
+    phone.close();
+  });
+});
+
 describe("UiBridge (multi-tab)", () => {
   it("routes to the single connected tab without tab_id", async () => {
     const a = await connectPanel("tab-aaaa-1111");

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -97,6 +97,18 @@ export class UiBridge {
    *  listener stays token-less so the local browser panel is unaffected. */
   private readonly extraServers: WebSocketServer[] = [];
   private conns = new Map<string, Conn>(); // tabId -> connection
+  /** Per-tab "mailbox" of undeliverable render deliveries (show_media), buffered
+   *  while a client is OFFLINE and flushed on reconnect — so a finished render is
+   *  never lost when the mobile app is backgrounded/killed mid-render. Keyed by a
+   *  STABLE tab id (the phone persists one). In-memory: survives disconnect ⇄
+   *  reconnect within an orchestrator run, not a full orchestrator restart.
+   *  Bounded per tab + TTL'd. */
+  private readonly mailbox = new Map<string, Array<{ cmd: BridgeCommand; ts: number }>>();
+  private static readonly MAILBOX_MAX = 30;
+  private static readonly MAILBOX_TTL_MS = 24 * 60 * 60 * 1000;
+  /** Tab ids that ever connected as a headless (mobile/remote) client — kept so
+   *  `isHeadless` stays true across a disconnect (see isHeadless). */
+  private readonly headlessSeen = new Set<string>();
   private pending = new Map<string, Pending>();
   private portInUse = false;
   private bindRetryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -401,9 +413,12 @@ export class UiBridge {
           connectedAt: existing?.connectedAt ?? new Date().toISOString(),
           headless: (msg as { headless?: unknown }).headless === true,
         });
+        if ((msg as { headless?: unknown }).headless === true) this.headlessSeen.add(tabId);
         logger.info(
           `[ui-bridge] panel tab connected: ${tabId.slice(0, 8)} (“${this.conns.get(tabId)?.title}”) — ${this.conns.size} tab(s) total`,
         );
+        // Deliver anything that finished while this tab was away.
+        this.flushMailbox(tabId);
         this.onPanelMessage?.(msg as PanelEvent);
         return;
       }
@@ -468,7 +483,10 @@ export class UiBridge {
   /** True when the tab advertised itself as a canvas-less (mobile/remote) client
    *  in its `hello`. Unknown tabs → false. */
   isHeadless(tabId: string): boolean {
-    return this.conns.get(tabId)?.headless === true;
+    // Sticky: a tab that EVER connected headless stays "headless" even while
+    // offline, so a render finishing during a disconnect is byte-inlined (not a
+    // bytes-less viewRef) and is renderable when the mailbox flushes to the phone.
+    return this.conns.get(tabId)?.headless === true || this.headlessSeen.has(tabId);
   }
 
   /** All currently connected tabs, most recent hello last. */
@@ -526,15 +544,71 @@ export class UiBridge {
     );
   }
 
+  /** Deliveries worth mailboxing when the target is offline (a finished render),
+   *  vs. interactive canvas ops that should just fail. */
+  private static isMailboxable(cmd: BridgeCommand): boolean {
+    return cmd.cmd === "show_media";
+  }
+
+  private storeMailbox(tabId: string, cmd: BridgeCommand): void {
+    const box = this.mailbox.get(tabId) ?? [];
+    box.push({ cmd, ts: Date.now() });
+    while (box.length > UiBridge.MAILBOX_MAX) box.shift();
+    this.mailbox.set(tabId, box);
+    logger.info(
+      `[ui-bridge] mailboxed "${cmd.cmd}" for offline tab ${tabId.slice(0, 8)} (${box.length} queued)`,
+    );
+  }
+
+  /** Deliver any buffered render frames to a tab that just (re)connected, plus a
+   *  `mailbox_flush` summary so the client can notify "N renders finished while
+   *  you were away". Expired items (past TTL) are dropped. */
+  private flushMailbox(tabId: string): void {
+    const box = this.mailbox.get(tabId);
+    if (!box || box.length === 0) return;
+    this.mailbox.delete(tabId);
+    const conn = this.conns.get(tabId);
+    if (!conn) return;
+    const now = Date.now();
+    const fresh = box.filter((m) => now - m.ts <= UiBridge.MAILBOX_TTL_MS);
+    for (const m of fresh) {
+      try {
+        conn.sock.send(JSON.stringify({ rid: randomUUID(), ...m.cmd, mailbox: true }));
+      } catch {
+        // socket raced closed; drop
+      }
+    }
+    if (fresh.length > 0) {
+      try {
+        conn.sock.send(JSON.stringify({ type: "mailbox_flush", count: fresh.length }));
+      } catch {
+        /* best-effort */
+      }
+      logger.info(
+        `[ui-bridge] flushed ${fresh.length} mailboxed frame(s) to reconnected tab ${tabId.slice(0, 8)}`,
+      );
+    }
+  }
+
   send(cmd: BridgeCommand, opts: { tabId?: string; timeoutMs?: number } = {}): Promise<unknown> {
     const timeoutMs = opts.timeoutMs ?? 6000;
     let conn: Conn;
     try {
       conn = this.resolveTarget(opts.tabId);
     } catch (err) {
+      // Offline target: buffer a finished-render delivery for reconnect instead of
+      // failing, so the agent's "here's your image" isn't lost while the phone is away.
+      if (opts.tabId && UiBridge.isMailboxable(cmd)) {
+        this.storeMailbox(opts.tabId, cmd);
+        return Promise.resolve({ ok: true, mailboxed: true });
+      }
       return Promise.reject(err instanceof Error ? err : new Error(String(err)));
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {
+      if (opts.tabId && UiBridge.isMailboxable(cmd)) {
+        this.storeMailbox(opts.tabId, cmd);
+        return Promise.resolve({ ok: true, mailboxed: true });
+      }
       return Promise.reject(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`));
     }
     const rid = randomUUID();


### PR DESCRIPTION
The **self-hosted** half of the vision's "commission a render and get pinged" — no FCM / 3rd-party push. Pairs with the mobile foreground service (live pings) as the safety net.

## Problem
When the mobile app is backgrounded/killed, its WebSocket drops. A render that finishes during that window has nowhere to go — `panel_show_media` to an offline tab fails, and the render is lost.

## Fix — a per-tab mailbox in the orchestrator
- **Buffer on offline:** `send()` buffers an undeliverable `show_media` (keyed by the client's **stable tab id**) instead of failing — returns `{ok, mailboxed:true}`, so the agent's "here's your image" succeeds. Bounded (30/tab), 24h TTL, in-memory.
- **Flush on reconnect:** `hello` delivers the buffered frames (flagged `mailbox:true`) + a `mailbox_flush {count}` summary so the client can notify *"N renders finished while you were away."*
- **Sticky headless:** a tab that ever connected headless stays headless while offline, so a render finishing during the disconnect is **byte-inlined** (#171) and is renderable when it flushes to a remote phone — not a bytes-less `viewRef`.
- Only `show_media` is mailboxed; interactive canvas commands to an offline tab still fail.

## Verification
- Unit tests: buffer→flush on reconnect; interactive commands are not mailboxed (`ui-bridge.test.ts`, 21 pass).
- **Live E2E:** connect (stable id) → generate → **disconnect mid-render** → wait 45s → reconnect → the render flushes with `inlineBytes=true` + `mailbox_flush count=1`. Confirmed the agent survives the client disconnect (completes server-side).
- `npm run build` (tsc) clean.

## Follow-up
- Mobile: use a stable tab id + handle `mailbox_flush` (notify).
- Foreground service (live pings) — separate PR.
- Optional later: persist the mailbox to disk to survive an orchestrator restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)