### PR TITLE
docs(arena): fine-tune best-of-3 results — e4b takes the local crown

### DIFF
--- a/docs/images/arena-leaderboard-dark.svg
+++ b/docs/images/arena-leaderboard-dark.svg
@@ -1,23 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="632" viewBox="0 0 860 632" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
-<rect width="860" height="632" rx="12" fill="#1a1a19"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="734" viewBox="0 0 860 734" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+<rect width="860" height="734" rx="12" fill="#1a1a19"/>
 <text x="28" y="38" font-size="19" font-weight="700" fill="#ffffff">ComfyUI LLM Arena</text>
-<text x="28" y="60" font-size="12.5" fill="#c3c2b7">14 models · 10 real ComfyUI tasks over MCP · every score verified against the server, not the model's claims</text>
+<text x="28" y="60" font-size="12.5" fill="#c3c2b7">17 models · 10 real ComfyUI tasks over MCP · every score verified against the server, not the model's claims</text>
 <rect x="28" y="72" width="10" height="10" rx="2" fill="#3987e5"/>
 <text x="43" y="81" font-size="11.5" fill="#c3c2b7">SoTA</text>
 <rect x="91.4" y="72" width="10" height="10" rx="2" fill="#199e70"/>
 <text x="106.4" y="81" font-size="11.5" fill="#c3c2b7">B-tier</text>
 <rect x="168" y="72" width="10" height="10" rx="2" fill="#c98500"/>
 <text x="183" y="81" font-size="11.5" fill="#c3c2b7">local</text>
-<line x1="278" y1="86" x2="278" y2="568" stroke="#383835" stroke-width="1"/>
-<text x="278" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">0</text>
-<line x1="394" y1="86" x2="394" y2="568" stroke="#2c2c2a" stroke-width="1"/>
-<text x="394" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">5</text>
-<line x1="510" y1="86" x2="510" y2="568" stroke="#2c2c2a" stroke-width="1"/>
-<text x="510" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">10</text>
-<line x1="626" y1="86" x2="626" y2="568" stroke="#2c2c2a" stroke-width="1"/>
-<text x="626" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">15</text>
-<line x1="742" y1="86" x2="742" y2="568" stroke="#2c2c2a" stroke-width="1"/>
-<text x="742" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">20</text>
+<line x1="278" y1="86" x2="278" y2="670" stroke="#383835" stroke-width="1"/>
+<text x="278" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">0</text>
+<line x1="394" y1="86" x2="394" y2="670" stroke="#2c2c2a" stroke-width="1"/>
+<text x="394" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">5</text>
+<line x1="510" y1="86" x2="510" y2="670" stroke="#2c2c2a" stroke-width="1"/>
+<text x="510" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">10</text>
+<line x1="626" y1="86" x2="626" y2="670" stroke="#2c2c2a" stroke-width="1"/>
+<text x="626" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">15</text>
+<line x1="742" y1="86" x2="742" y2="670" stroke="#2c2c2a" stroke-width="1"/>
+<text x="742" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">20</text>
 <text x="28" y="108" font-size="12.5" font-weight="600" fill="#ffffff">google/gemini-3.1-pro-preview</text>
 <text x="28" y="121" font-size="10" fill="#c3c2b7">SoTA</text>
 <rect x="278" y="102" width="464" height="14" fill="#232322"/>
@@ -49,9 +49,9 @@
 <text x="754" y="249" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">19/20</text>
 <text x="754" y="261" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (18–19)</text>
 <text x="28" y="278" font-size="12.5" font-weight="600" fill="#ffffff">xiaomi/mimo-v2.5</text>
-<text x="28" y="291" font-size="10" fill="#c3c2b7">B-tier</text>
+<text x="28" y="291" font-size="10" fill="#c3c2b7">SoTA</text>
 <rect x="278" y="272" width="464" height="14" fill="#232322"/>
-<path d="M 278 272 H 714.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#199e70"/>
+<path d="M 278 272 H 714.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#3987e5"/>
 <text x="754" y="283" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">19/20</text>
 <text x="754" y="295" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (18–19)</text>
 <text x="28" y="312" font-size="12.5" font-weight="600" fill="#ffffff">deepseek/deepseek-v3.2</text>
@@ -69,31 +69,49 @@
 <rect x="278" y="374" width="464" height="14" fill="#232322"/>
 <path d="M 278 374 H 622 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#3987e5"/>
 <text x="754" y="385" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">15/20</text>
-<text x="28" y="414" font-size="12.5" font-weight="600" fill="#ffffff">qwen3:4b</text>
+<text x="28" y="414" font-size="12.5" font-weight="600" fill="#ffffff">artokun/gemma4-comfyui-mcp:e4b</text>
 <text x="28" y="427" font-size="10" fill="#c3c2b7">local</text>
 <rect x="278" y="408" width="464" height="14" fill="#232322"/>
-<path d="M 278 408 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
-<text x="754" y="419" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">13/20</text>
-<text x="28" y="448" font-size="12.5" font-weight="600" fill="#ffffff">gemma4:e4b</text>
+<path d="M 278 408 H 598.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="419" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">14/20</text>
+<text x="754" y="431" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (13–14)</text>
+<text x="28" y="448" font-size="12.5" font-weight="600" fill="#ffffff">qwen3:4b</text>
 <text x="28" y="461" font-size="10" fill="#c3c2b7">local</text>
 <rect x="278" y="442" width="464" height="14" fill="#232322"/>
-<path d="M 278 442 H 552.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
-<text x="754" y="453" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">12/20</text>
-<text x="28" y="482" font-size="12.5" font-weight="600" fill="#ffffff">qwen3:8b</text>
+<path d="M 278 442 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="453" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">13/20</text>
+<text x="28" y="482" font-size="12.5" font-weight="600" fill="#ffffff">artokun/gemma4-comfyui-mcp:12b</text>
 <text x="28" y="495" font-size="10" fill="#c3c2b7">local</text>
 <rect x="278" y="476" width="464" height="14" fill="#232322"/>
-<path d="M 278 476 H 529.2 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
-<text x="754" y="487" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">11/20</text>
-<text x="28" y="516" font-size="12.5" font-weight="600" fill="#ffffff">gemma4:e2b</text>
+<path d="M 278 476 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="487" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">13/20</text>
+<text x="754" y="499" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (12–13)</text>
+<text x="28" y="516" font-size="12.5" font-weight="600" fill="#ffffff">gemma4:e4b</text>
 <text x="28" y="529" font-size="10" fill="#c3c2b7">local</text>
 <rect x="278" y="510" width="464" height="14" fill="#232322"/>
-<path d="M 278 510 H 459.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
-<text x="754" y="521" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">8/20</text>
-<text x="28" y="550" font-size="12.5" font-weight="600" fill="#ffffff">llama3.1:8b</text>
+<path d="M 278 510 H 552.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="521" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">12/20</text>
+<text x="28" y="550" font-size="12.5" font-weight="600" fill="#ffffff">qwen3:8b</text>
 <text x="28" y="563" font-size="10" fill="#c3c2b7">local</text>
 <rect x="278" y="544" width="464" height="14" fill="#232322"/>
-<path d="M 278 544 H 320.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
-<text x="754" y="555" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">2/20</text>
-<text x="28" y="606" font-size="10.5" fill="#898781">cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync · temperature 0 · scenarios: health · models · registry · queue · generate · precision · breakfix · provenance · multiout · pipeline</text>
-<text x="28" y="621" font-size="10.5" fill="#898781">Reproduce with your own models: npm run arena — github.com/artokun/comfyui-mcp</text>
+<path d="M 278 544 H 529.2 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="555" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">11/20</text>
+<text x="28" y="584" font-size="12.5" font-weight="600" fill="#ffffff">gemma4:e2b</text>
+<text x="28" y="597" font-size="10" fill="#c3c2b7">local</text>
+<rect x="278" y="578" width="464" height="14" fill="#232322"/>
+<path d="M 278 578 H 459.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="589" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">8/20</text>
+<text x="28" y="618" font-size="12.5" font-weight="600" fill="#ffffff">artokun/gemma4-comfyui-mcp:e2b</text>
+<text x="28" y="631" font-size="10" fill="#c3c2b7">local</text>
+<rect x="278" y="612" width="464" height="14" fill="#232322"/>
+<path d="M 278 612 H 366.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="623" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">4/20</text>
+<text x="754" y="635" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (4–4)</text>
+<text x="28" y="652" font-size="12.5" font-weight="600" fill="#ffffff">llama3.1:8b</text>
+<text x="28" y="665" font-size="10" fill="#c3c2b7">local</text>
+<rect x="278" y="646" width="464" height="14" fill="#232322"/>
+<path d="M 278 646 H 320.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#c98500"/>
+<text x="754" y="657" font-size="13" font-weight="700" fill="#ffffff" font-variant-numeric="tabular-nums">2/20</text>
+<text x="28" y="708" font-size="10.5" fill="#898781">cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync · temperature 0 · scenarios: health · models · registry · queue · generate · precision · breakfix · provenance · multiout · pipeline</text>
+<text x="28" y="723" font-size="10.5" fill="#898781">Reproduce with your own models: npm run arena — github.com/artokun/comfyui-mcp</text>
 </svg>

--- a/docs/images/arena-leaderboard-light.svg
+++ b/docs/images/arena-leaderboard-light.svg
@@ -1,23 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="632" viewBox="0 0 860 632" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
-<rect width="860" height="632" rx="12" fill="#fcfcfb"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="734" viewBox="0 0 860 734" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+<rect width="860" height="734" rx="12" fill="#fcfcfb"/>
 <text x="28" y="38" font-size="19" font-weight="700" fill="#0b0b0b">ComfyUI LLM Arena</text>
-<text x="28" y="60" font-size="12.5" fill="#52514e">14 models · 10 real ComfyUI tasks over MCP · every score verified against the server, not the model's claims</text>
+<text x="28" y="60" font-size="12.5" fill="#52514e">17 models · 10 real ComfyUI tasks over MCP · every score verified against the server, not the model's claims</text>
 <rect x="28" y="72" width="10" height="10" rx="2" fill="#2a78d6"/>
 <text x="43" y="81" font-size="11.5" fill="#52514e">SoTA</text>
 <rect x="91.4" y="72" width="10" height="10" rx="2" fill="#1baf7a"/>
 <text x="106.4" y="81" font-size="11.5" fill="#52514e">B-tier</text>
 <rect x="168" y="72" width="10" height="10" rx="2" fill="#eda100"/>
 <text x="183" y="81" font-size="11.5" fill="#52514e">local</text>
-<line x1="278" y1="86" x2="278" y2="568" stroke="#c3c2b7" stroke-width="1"/>
-<text x="278" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">0</text>
-<line x1="394" y1="86" x2="394" y2="568" stroke="#e1e0d9" stroke-width="1"/>
-<text x="394" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">5</text>
-<line x1="510" y1="86" x2="510" y2="568" stroke="#e1e0d9" stroke-width="1"/>
-<text x="510" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">10</text>
-<line x1="626" y1="86" x2="626" y2="568" stroke="#e1e0d9" stroke-width="1"/>
-<text x="626" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">15</text>
-<line x1="742" y1="86" x2="742" y2="568" stroke="#e1e0d9" stroke-width="1"/>
-<text x="742" y="584" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">20</text>
+<line x1="278" y1="86" x2="278" y2="670" stroke="#c3c2b7" stroke-width="1"/>
+<text x="278" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">0</text>
+<line x1="394" y1="86" x2="394" y2="670" stroke="#e1e0d9" stroke-width="1"/>
+<text x="394" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">5</text>
+<line x1="510" y1="86" x2="510" y2="670" stroke="#e1e0d9" stroke-width="1"/>
+<text x="510" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">10</text>
+<line x1="626" y1="86" x2="626" y2="670" stroke="#e1e0d9" stroke-width="1"/>
+<text x="626" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">15</text>
+<line x1="742" y1="86" x2="742" y2="670" stroke="#e1e0d9" stroke-width="1"/>
+<text x="742" y="686" font-size="10.5" fill="#898781" text-anchor="middle" font-variant-numeric="tabular-nums">20</text>
 <text x="28" y="108" font-size="12.5" font-weight="600" fill="#0b0b0b">google/gemini-3.1-pro-preview</text>
 <text x="28" y="121" font-size="10" fill="#52514e">SoTA</text>
 <rect x="278" y="102" width="464" height="14" fill="#f0efec"/>
@@ -49,9 +49,9 @@
 <text x="754" y="249" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">19/20</text>
 <text x="754" y="261" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (18–19)</text>
 <text x="28" y="278" font-size="12.5" font-weight="600" fill="#0b0b0b">xiaomi/mimo-v2.5</text>
-<text x="28" y="291" font-size="10" fill="#52514e">B-tier</text>
+<text x="28" y="291" font-size="10" fill="#52514e">SoTA</text>
 <rect x="278" y="272" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 272 H 714.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#1baf7a"/>
+<path d="M 278 272 H 714.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#2a78d6"/>
 <text x="754" y="283" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">19/20</text>
 <text x="754" y="295" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (18–19)</text>
 <text x="28" y="312" font-size="12.5" font-weight="600" fill="#0b0b0b">deepseek/deepseek-v3.2</text>
@@ -69,31 +69,49 @@
 <rect x="278" y="374" width="464" height="14" fill="#f0efec"/>
 <path d="M 278 374 H 622 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#2a78d6"/>
 <text x="754" y="385" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">15/20</text>
-<text x="28" y="414" font-size="12.5" font-weight="600" fill="#0b0b0b">qwen3:4b</text>
+<text x="28" y="414" font-size="12.5" font-weight="600" fill="#0b0b0b">artokun/gemma4-comfyui-mcp:e4b</text>
 <text x="28" y="427" font-size="10" fill="#52514e">local</text>
 <rect x="278" y="408" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 408 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
-<text x="754" y="419" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">13/20</text>
-<text x="28" y="448" font-size="12.5" font-weight="600" fill="#0b0b0b">gemma4:e4b</text>
+<path d="M 278 408 H 598.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="419" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">14/20</text>
+<text x="754" y="431" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (13–14)</text>
+<text x="28" y="448" font-size="12.5" font-weight="600" fill="#0b0b0b">qwen3:4b</text>
 <text x="28" y="461" font-size="10" fill="#52514e">local</text>
 <rect x="278" y="442" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 442 H 552.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
-<text x="754" y="453" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">12/20</text>
-<text x="28" y="482" font-size="12.5" font-weight="600" fill="#0b0b0b">qwen3:8b</text>
+<path d="M 278 442 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="453" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">13/20</text>
+<text x="28" y="482" font-size="12.5" font-weight="600" fill="#0b0b0b">artokun/gemma4-comfyui-mcp:12b</text>
 <text x="28" y="495" font-size="10" fill="#52514e">local</text>
 <rect x="278" y="476" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 476 H 529.2 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
-<text x="754" y="487" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">11/20</text>
-<text x="28" y="516" font-size="12.5" font-weight="600" fill="#0b0b0b">gemma4:e2b</text>
+<path d="M 278 476 H 575.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="487" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">13/20</text>
+<text x="754" y="499" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (12–13)</text>
+<text x="28" y="516" font-size="12.5" font-weight="600" fill="#0b0b0b">gemma4:e4b</text>
 <text x="28" y="529" font-size="10" fill="#52514e">local</text>
 <rect x="278" y="510" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 510 H 459.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
-<text x="754" y="521" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">8/20</text>
-<text x="28" y="550" font-size="12.5" font-weight="600" fill="#0b0b0b">llama3.1:8b</text>
+<path d="M 278 510 H 552.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="521" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">12/20</text>
+<text x="28" y="550" font-size="12.5" font-weight="600" fill="#0b0b0b">qwen3:8b</text>
 <text x="28" y="563" font-size="10" fill="#52514e">local</text>
 <rect x="278" y="544" width="464" height="14" fill="#f0efec"/>
-<path d="M 278 544 H 320.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
-<text x="754" y="555" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">2/20</text>
-<text x="28" y="606" font-size="10.5" fill="#898781">cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync · temperature 0 · scenarios: health · models · registry · queue · generate · precision · breakfix · provenance · multiout · pipeline</text>
-<text x="28" y="621" font-size="10.5" fill="#898781">Reproduce with your own models: npm run arena — github.com/artokun/comfyui-mcp</text>
+<path d="M 278 544 H 529.2 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="555" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">11/20</text>
+<text x="28" y="584" font-size="12.5" font-weight="600" fill="#0b0b0b">gemma4:e2b</text>
+<text x="28" y="597" font-size="10" fill="#52514e">local</text>
+<rect x="278" y="578" width="464" height="14" fill="#f0efec"/>
+<path d="M 278 578 H 459.6 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="589" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">8/20</text>
+<text x="28" y="618" font-size="12.5" font-weight="600" fill="#0b0b0b">artokun/gemma4-comfyui-mcp:e2b</text>
+<text x="28" y="631" font-size="10" fill="#52514e">local</text>
+<rect x="278" y="612" width="464" height="14" fill="#f0efec"/>
+<path d="M 278 612 H 366.8 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="623" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">4/20</text>
+<text x="754" y="635" font-size="9.5" fill="#898781" font-variant-numeric="tabular-nums">best of 3 (4–4)</text>
+<text x="28" y="652" font-size="12.5" font-weight="600" fill="#0b0b0b">llama3.1:8b</text>
+<text x="28" y="665" font-size="10" fill="#52514e">local</text>
+<rect x="278" y="646" width="464" height="14" fill="#f0efec"/>
+<path d="M 278 646 H 320.4 a 4 4 0 0 1 4 4 v 6 a 4 4 0 0 1 -4 4 H 278 Z" fill="#eda100"/>
+<text x="754" y="657" font-size="13" font-weight="700" fill="#0b0b0b" font-variant-numeric="tabular-nums">2/20</text>
+<text x="28" y="708" font-size="10.5" fill="#898781">cuda:0 NVIDIA GeForce RTX 4090 : cudaMallocAsync · temperature 0 · scenarios: health · models · registry · queue · generate · precision · breakfix · provenance · multiout · pipeline</text>
+<text x="28" y="723" font-size="10.5" fill="#898781">Reproduce with your own models: npm run arena — github.com/artokun/comfyui-mcp</text>
 </svg>

--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -171,9 +171,25 @@ model knows this exact tool suite natively instead of meeting it cold.
 # 1. Install Ollama (once):  https://ollama.com/download
 # 2. Pull the size that fits your GPU:
 ollama pull artokun/gemma4-comfyui-mcp:e4b     # default — ~3.5 GB VRAM at q4
-ollama pull artokun/gemma4-comfyui-mcp:e2b     # smallest — ~2 GB VRAM
-ollama pull artokun/gemma4-comfyui-mcp:12b     # strongest — ~8 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:12b     # ~8 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:e2b     # smallest — ~2 GB VRAM (see caveat)
 ```
+
+**Measured, not promised** — [LLM Arena](/arena) scores on the real 10-scenario
+ladder (best of 3, every result verified against a live ComfyUI server, RTX 4090):
+
+| Tag | VRAM (q4) | Arena score | vs. stock |
+|---|---|---|---|
+| `:e4b` | ~3.5 GB | **14/20** (13–14) — best local model we've tested | stock gemma4:e4b: 12/20 |
+| `:12b` | ~8 GB | 13/20 (12–13) | stock 12b unbenchmarked |
+| `:e2b` | ~2 GB | 4/20 — **currently regresses** below stock | stock gemma4:e2b: 8/20 |
+
+The honest caveat: the `:e2b` rung picked up a `call_tool`-envelope quirk in
+this training round (it drops the `name` field under pressure) and scores
+below its stock base — a fix is queued for the next fine-tune cycle. Until
+then, `:e4b` is the recommendation even on small GPUs (it's only ~1.5 GB
+more), and `:12b` mostly buys steadiness on long multi-step tasks, not raw
+score.
 
 | Tag | Base | VRAM (q4) | Notes |
 | --- | --- | --- | --- |

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -183,9 +183,9 @@ stdio mode (the default, what MCP clients use) needs none of this.
   watchdog accounts for this, but a request that dies instantly usually
   means the model tag isn't pulled (`ollama pull <tag>`).
 - **Every request suddenly failing / connection refused on 11434** — the
-  Ollama daemon itself can crash under sustained model swapping (observed
-  twice on 0.31.x during back-to-back arena runs; the Windows app usually
-  self-restarts, but not always). Restart it (relaunch the app, or
+  Ollama app/daemon isn't running. Quitting the tray app kills the API with
+  it, which is easy to do by accident while an agent is mid-run (the panel
+  gives no warning that a local backend is in use). Relaunch the app (or
   `ollama serve`) and reconnect — sessions resume; no panel restart needed.
 
 ## Where to look for logs

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -171,8 +171,9 @@ stdio mode (the default, what MCP clients use) needs none of this.
 - **First move: use [our fine-tuned model](/local-llms#our-fine-tuned-local-models-free-recommended)** —
   `ollama pull artokun/gemma4-comfyui-mcp:e4b` (the panel's Ollama default).
   It's Gemma 4 trained on the comfyui-mcp tool suite itself, which eliminates
-  most "wrong tool / malformed args" failures out of the box (`:e2b` for
-  ~2 GB VRAM, `:12b` for ~8 GB).
+  most "wrong tool / malformed args" failures out of the box (`:12b` for
+  ~8 GB VRAM; the `:e2b` rung currently underperforms its stock base on the
+  arena — prefer `:e4b` even on small GPUs).
 - **gemma3 has no native tool calling in Ollama** — unsupported; use
   our fine-tune above, stock `gemma4` (e4b+), `qwen3`, or `llama3.1+`.
 - Make sure [compact tool mode](/local-llms) is on for small models
@@ -181,6 +182,11 @@ stdio mode (the default, what MCP clients use) needs none of this.
 - Cold model loads can take 30s+ before the first token — the panel's
   watchdog accounts for this, but a request that dies instantly usually
   means the model tag isn't pulled (`ollama pull <tag>`).
+- **Every request suddenly failing / connection refused on 11434** — the
+  Ollama daemon itself can crash under sustained model swapping (observed
+  twice on 0.31.x during back-to-back arena runs; the Windows app usually
+  self-restarts, but not always). Restart it (relaunch the app, or
+  `ollama serve`) and reconnect — sessions resume; no panel restart needed.
 
 ## Where to look for logs
 

--- a/plugin/skills/local-llm-free/SKILL.md
+++ b/plugin/skills/local-llm-free/SKILL.md
@@ -27,9 +27,9 @@ dataset `artokun/comfyui-mcp-trajectories`).
 2. **Pull the rung that fits the user's GPU:**
 
 ```bash
-ollama pull artokun/gemma4-comfyui-mcp:e4b   # DEFAULT — ~3.5 GB VRAM (q4)
-ollama pull artokun/gemma4-comfyui-mcp:e2b   # smallest — ~2 GB VRAM
-ollama pull artokun/gemma4-comfyui-mcp:12b   # strongest — ~8 GB VRAM
+ollama pull artokun/gemma4-comfyui-mcp:e4b   # DEFAULT — ~3.5 GB VRAM (q4); arena-best local (14/20)
+ollama pull artokun/gemma4-comfyui-mcp:12b   # ~8 GB VRAM (13/20)
+ollama pull artokun/gemma4-comfyui-mcp:e2b   # smallest — ~2 GB VRAM (currently WEAK: 4/20, fix queued)
 ```
 
 Then in the ComfyUI sidebar panel: backend picker → **Ollama (local)** →
@@ -40,9 +40,9 @@ Connect. `:e4b` is the built-in default — zero further config once pulled.
 
 | GPU VRAM free | Recommend |
 | --- | --- |
-| ~2-3 GB | `:e2b` — note it reasons verbosely; it needs generous token budgets |
-| ~4-7 GB | `:e4b` (the default sweet spot) |
-| 8 GB+ | `:12b` |
+| ~2-3 GB | `:e4b` anyway if at all possible (only ~1.5 GB more; `:e2b` currently scores 4/20 on the arena — below its stock base — a fix is queued for the next training cycle) |
+| ~4-7 GB | `:e4b` (the default sweet spot — best local model on the arena, 14/20) |
+| 8 GB+ | `:12b` (13/20; steadier on long multi-step tasks) |
 
 ## Expectations to set
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1853,7 +1853,7 @@ export async function runPanelOrchestrator(): Promise<void> {
               : isGm
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
                 : isOl
-                  ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite; `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB), then Disconnect → Connect to retry."
+                  ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry."
                   : isLs
                     ? `⚠️ The background agent isn't responding — LM Studio isn't reachable at ${LMSTUDIO_BASE_URL}. Open LM Studio → Developer → Start Server and load a tool-calling model (our gemma4-comfyui-mcp GGUFs from Hugging Face work great), or set COMFYUI_MCP_LMSTUDIO_HOST if it serves elsewhere — then Disconnect → Connect to retry.`
                     : isLc


### PR DESCRIPTION
Arena results for the gemma4-comfyui-mcp fine-tune ladder (best of 3, 10-scenario ladder, server-verified, RTX 4090):

| model | score | note |
|---|---|---|
| `:e4b` | **14/20** (13–14) | best local model on the board (prev best: qwen3:4b 13; stock e4b 12) |
| `:12b` | 13/20 (12–13) | steadier on long tasks, kept hitting round caps as PARTIALs |
| `:e2b` | 4/20 (4–4–4) | **regression below stock e2b (8/20)** — call_tool envelope drops `name`; #183 filed for fine-tune v2 |

Docs/copy updated to the honest numbers: local-llms table + caveat, troubleshooting (incl. a new bullet for the Ollama daemon crashing under sustained model swaps — bit us twice tonight on 0.31.x, both crashes excluded from scoring as env failures), the local-llm-free skill, the ollama degraded-ack copy, and regenerated leaderboard SVGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)