### PR TITLE
feat(orchestrator): call_tool — direct, whitelisted tool channel for the mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ arena-results-quality-probe/
 /*.mov
 /*.jpg
 /*.jpeg
+orch.log
+orch.err.log

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../config.js", () => {
 
 const statMock = vi.fn();
 const unlinkMock = vi.fn();
+const writeFileMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
   copyFile: vi.fn(),
   link: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock("node:fs/promises", () => ({
   stat: (...a: unknown[]) => statMock(...a),
   utimes: vi.fn(),
   unlink: (...a: unknown[]) => unlinkMock(...a),
+  writeFile: (...a: unknown[]) => writeFileMock(...a),
 }));
 
 const downloadModelMock = vi.fn();
@@ -42,10 +44,17 @@ vi.mock("../../services/model-resolver.js", async () => {
 
 const resolveCivitaiModelMock = vi.fn();
 const resolveCivitaiModelVersionMock = vi.fn();
-vi.mock("../../services/civitai-resolver.js", () => ({
-  resolveCivitaiModel: (...a: unknown[]) => resolveCivitaiModelMock(...a),
-  resolveCivitaiModelVersion: (...a: unknown[]) => resolveCivitaiModelVersionMock(...a),
-}));
+vi.mock("../../services/civitai-resolver.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/civitai-resolver.js")
+  >("../../services/civitai-resolver.js");
+  return {
+    ...actual,
+    resolveCivitaiModel: (...a: unknown[]) => resolveCivitaiModelMock(...a),
+    resolveCivitaiModelVersion: (...a: unknown[]) =>
+      resolveCivitaiModelVersionMock(...a),
+  };
+});
 
 // Isolate these tests from on-disk extra_model_paths config: no extra roots by
 // default. (Multi-root resolution is covered in model-resolver.test.ts.)
@@ -85,6 +94,8 @@ function makeServer() {
 beforeEach(() => {
   statMock.mockReset();
   unlinkMock.mockReset();
+  writeFileMock.mockReset();
+  writeFileMock.mockResolvedValue(undefined);
   downloadModelMock.mockReset();
   resolveCivitaiModelMock.mockReset();
   resolveCivitaiModelVersionMock.mockReset();
@@ -263,6 +274,61 @@ describe("download_civitai_model", () => {
       "loras",
       "custom.safetensors",
     );
+  });
+
+  it("writes .civitai.json + .civitai.md sidecars when metadata is present", async () => {
+    const savedPath = join(MODELS_ROOT, "loras", "cool.safetensors");
+    resolveCivitaiModelMock.mockResolvedValueOnce({
+      downloadUrl: "https://civitai.com/api/download/models/201",
+      filename: "cool.safetensors",
+      versionId: 201,
+      modelName: "Cool LoRA",
+      metadata: {
+        modelId: 100,
+        modelName: "Cool LoRA",
+        modelType: "LORA",
+        versionId: 201,
+        baseModel: "SDXL 1.0",
+        trainedWords: ["coolstyle", "vibrant"],
+        sourceUrl: "https://civitai.com/models/100?modelVersionId=201",
+        examples: [
+          { url: "https://img/1.jpeg", type: "image", meta: { seed: 42, prompt: "a cat" } },
+          { url: "https://img/2.jpeg", type: "image", meta: null },
+        ],
+      },
+    });
+    downloadModelMock.mockResolvedValueOnce(savedPath);
+
+    const { downloadCivitai } = makeServer();
+    const res = await downloadCivitai({ model_id: 100, target_subfolder: "loras" });
+
+    const written = writeFileMock.mock.calls.map((c) => c[0] as string);
+    expect(written).toContain(`${savedPath}.civitai.json`);
+    expect(written).toContain(`${savedPath}.civitai.md`);
+    // The markdown carries trigger words + the example recipe.
+    const md = writeFileMock.mock.calls.find(
+      (c) => (c[0] as string).endsWith(".md"),
+    )?.[1] as string;
+    expect(md).toContain("coolstyle");
+    expect(md).toContain("seed: 42");
+    // The tool result surfaces the trigger words + a recipe count.
+    expect(res.content[0].text).toContain("Trigger words: coolstyle, vibrant");
+    expect(res.content[0].text).toContain("1 example recipe");
+  });
+
+  it("does not write sidecars in remote mode (no local path)", async () => {
+    config.comfyuiPath = undefined; // remote
+    resolveCivitaiModelVersionMock.mockResolvedValueOnce({
+      downloadUrl: "https://civitai.com/api/download/models/55",
+      versionId: 55,
+      metadata: { versionId: 55, trainedWords: [], sourceUrl: "x", examples: [] },
+    });
+    downloadModelMock.mockResolvedValueOnce("Dispatched to ComfyUI host.");
+
+    const { downloadCivitai } = makeServer();
+    await downloadCivitai({ model_version_id: 55, target_subfolder: "loras" });
+
+    expect(writeFileMock).not.toHaveBeenCalled();
   });
 
   it("errors when neither model_id nor model_version_id is given", async () => {

--- a/src/__tests__/utils/html-to-markdown.test.ts
+++ b/src/__tests__/utils/html-to-markdown.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "../../utils/html-to-markdown.js";
+
+describe("htmlToMarkdown", () => {
+  it("returns empty string for empty/nullish input", () => {
+    expect(htmlToMarkdown("")).toBe("");
+    expect(htmlToMarkdown(undefined)).toBe("");
+    expect(htmlToMarkdown(null)).toBe("");
+  });
+
+  it("converts inline emphasis and code", () => {
+    expect(htmlToMarkdown("<strong>bold</strong>")).toBe("**bold**");
+    expect(htmlToMarkdown("<b>bold</b>")).toBe("**bold**");
+    expect(htmlToMarkdown("<em>it</em>")).toBe("_it_");
+    expect(htmlToMarkdown("<code>x=1</code>")).toBe("`x=1`");
+  });
+
+  it("converts links to markdown, falling back to the href as text", () => {
+    expect(htmlToMarkdown('<a href="https://x.io">site</a>')).toBe(
+      "[site](https://x.io)",
+    );
+    expect(htmlToMarkdown('<a href="https://x.io"></a>')).toBe(
+      "[https://x.io](https://x.io)",
+    );
+  });
+
+  it("converts headings to ATX", () => {
+    expect(htmlToMarkdown("<h2>Usage</h2>")).toBe("## Usage");
+    expect(htmlToMarkdown("<h4>Notes</h4>")).toBe("#### Notes");
+  });
+
+  it("converts lists to dash bullets", () => {
+    const md = htmlToMarkdown("<ul><li>one</li><li>two</li></ul>");
+    expect(md).toBe("- one\n- two");
+  });
+
+  it("turns <br> and </p> into line/paragraph breaks", () => {
+    expect(htmlToMarkdown("a<br>b")).toBe("a\nb");
+    expect(htmlToMarkdown("<p>a</p><p>b</p>")).toBe("a\n\nb");
+  });
+
+  it("decodes common HTML entities", () => {
+    expect(htmlToMarkdown("Tom &amp; Jerry &mdash; ok")).toBe(
+      "Tom & Jerry — ok",
+    );
+    expect(htmlToMarkdown("&#65;&#x42;")).toBe("AB");
+  });
+
+  it("strips unknown tags but keeps their text", () => {
+    expect(htmlToMarkdown('<span class="x">hi</span>')).toBe("hi");
+    expect(htmlToMarkdown("<script>evil()</script>keep")).toBe("keep");
+  });
+
+  it("collapses excessive blank lines", () => {
+    expect(htmlToMarkdown("<p>a</p><br><br><br><p>b</p>")).toBe("a\n\nb");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -592,6 +592,11 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "download_civitai_model",
   "download_model",
   "enqueue_workflow",
+  // Persist a workflow to the ComfyUI library (mobile "pull workflow from a
+  // CivitAI example" → save_workflow). Writes a workflow file (auto-converts
+  // API-format graphs to canvas-openable UI format); overwrites same-filename,
+  // so the client generates a unique name. No model/system mutation.
+  "save_workflow",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -34,6 +34,10 @@ import {
 } from "./panel-agent.js";
 import { createPanelMcpServer } from "./panel-tools.js";
 import { readUserMcpServers } from "../services/user-mcp-config.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerAllTools } from "../tools/index.js";
 import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath } from "../config.js";
 import {
   buildComfyuiMcpEnv,
@@ -570,6 +574,46 @@ function isRemoteHttpsUrl(u: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** The direct tool channel: a mobile client can invoke these READ/DOWNLOAD backend
+ *  tools without an agent turn (structured nav data + rig-side downloads). The
+ *  bridge is already token-gated; this whitelist keeps call_tool to non-destructive
+ *  tools (no restart/remove/clear/install). */
+const CALL_TOOL_WHITELIST = new Set<string>([
+  "list_workflows",
+  "get_workflow",
+  "analyze_workflow",
+  "query_workflow",
+  "workflow_from_image",
+  "list_output_images",
+  "get_image",
+  "list_local_models",
+  "download_civitai_model",
+  "download_model",
+  "enqueue_workflow",
+]);
+
+/** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,
+ *  reused across call_tool requests. Reuses the exact tool implementations (same
+ *  getClient()/COMFYUI_URL as the agents) — no logic duplication. */
+let callToolClientPromise: Promise<Client> | null = null;
+function getCallToolClient(): Promise<Client> {
+  if (!callToolClientPromise) {
+    callToolClientPromise = (async () => {
+      const server = new McpServer({ name: "comfyui-mcp-calltool", version: "1.0.0" });
+      await registerAllTools(server);
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+      const client = new Client({ name: "orchestrator-calltool", version: "1.0.0" });
+      await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+      logger.info("[panel-orchestrator] call_tool in-process MCP client ready");
+      return client;
+    })().catch((err) => {
+      callToolClientPromise = null; // allow retry on next call
+      throw err;
+    });
+  }
+  return callToolClientPromise;
 }
 
 export async function runPanelOrchestrator(): Promise<void> {
@@ -2092,6 +2136,50 @@ export async function runPanelOrchestrator(): Promise<void> {
       })().catch((err) => {
         bridge.push(
           { type: "pair_error", mode, error: err instanceof Error ? err.message : String(err) },
+          tabId,
+        );
+      });
+      return;
+    }
+
+    // Direct tool channel: the mobile app invokes a WHITELISTED read/download tool
+    // (structured data for nav lists + rig downloads) without an agent turn. Replies
+    // with a `tool_result` frame the client correlates by rid.
+    if (event.type === "call_tool" && event.tab_id) {
+      const tabId = event.tab_id;
+      // NOTE: correlate with `cid`, NOT `rid` — the bridge reserves top-level `rid`
+      // for orchestrator→panel command replies, so a `rid` frame would be misrouted.
+      const ev = event as { cid?: unknown; tool?: unknown; args?: unknown };
+      const cid = typeof ev.cid === "string" ? ev.cid : undefined;
+      const tool = typeof ev.tool === "string" ? ev.tool : "";
+      const toolArgs =
+        ev.args && typeof ev.args === "object" ? (ev.args as Record<string, unknown>) : {};
+      void (async () => {
+        if (!CALL_TOOL_WHITELIST.has(tool)) {
+          bridge.push({ type: "tool_result", cid, tool, ok: false, error: `tool "${tool}" is not permitted` }, tabId);
+          logger.warn(`[panel-orchestrator] call_tool rejected non-whitelisted "${tool}" (tab ${tabId.slice(0, 8)})`);
+          return;
+        }
+        const client = await getCallToolClient();
+        const result = (await client.callTool({ name: tool, arguments: toolArgs })) as {
+          content?: unknown;
+          isError?: boolean;
+        };
+        bridge.push(
+          {
+            type: "tool_result",
+            cid,
+            tool,
+            ok: result.isError !== true,
+            result: result.content ?? [],
+            ...(result.isError ? { error: "tool returned an error" } : {}),
+          },
+          tabId,
+        );
+        logger.info(`[panel-orchestrator] call_tool ${tool} → ${result.isError ? "error" : "ok"} (tab ${tabId.slice(0, 8)})`);
+      })().catch((err) => {
+        bridge.push(
+          { type: "tool_result", cid, tool, ok: false, error: err instanceof Error ? err.message : String(err) },
           tabId,
         );
       });

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -1,6 +1,7 @@
 import { config } from "../config.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { htmlToMarkdown } from "../utils/html-to-markdown.js";
 
 const CIVITAI_API_BASE = "https://civitai.com/api/v1";
 
@@ -13,20 +14,75 @@ interface CivitaiFile {
   downloadUrl?: string;
   primary?: boolean;
   type?: string;
+  sizeKB?: number;
+}
+
+/** An example image/video shown in the model's gallery, with generation params. */
+interface CivitaiImage {
+  url?: string;
+  width?: number;
+  height?: number;
+  nsfwLevel?: number;
+  type?: string; // "image" | "video"
+  hash?: string;
+  meta?: Record<string, unknown> | null;
 }
 
 interface CivitaiModelVersion {
   id: number;
   name?: string;
+  baseModel?: string;
+  description?: string;
+  trainedWords?: string[];
   downloadUrl?: string;
   files?: CivitaiFile[];
+  images?: CivitaiImage[];
+  // Present on GET /model-versions/{id} (not on the nested versions of /models/{id}).
+  model?: { name?: string; type?: string };
 }
 
 interface CivitaiModel {
   id: number;
   name?: string;
   type?: string;
+  description?: string;
+  tags?: string[];
+  creator?: { username?: string };
   modelVersions?: CivitaiModelVersion[];
+}
+
+/** One example generation captured from a model's gallery, for the recipe. */
+export interface CivitaiExample {
+  url?: string;
+  type?: string; // image | video
+  width?: number;
+  height?: number;
+  nsfwLevel?: number;
+  meta?: Record<string, unknown> | null;
+}
+
+/**
+ * Rich, human/agent-facing metadata about a downloaded CivitAI model, written
+ * as a sidecar next to the file so the panel agent can read usage docs, trigger
+ * words, and example generation params without re-querying CivitAI.
+ */
+export interface CivitaiMetadata {
+  modelId?: number;
+  modelName?: string;
+  modelType?: string;
+  creator?: string;
+  tags?: string[];
+  modelDescriptionHtml?: string;
+  versionId: number;
+  versionName?: string;
+  versionDescriptionHtml?: string;
+  baseModel?: string;
+  trainedWords: string[];
+  fileName?: string;
+  fileSizeKB?: number;
+  /** Canonical CivitAI page URL for this model/version. */
+  sourceUrl: string;
+  examples: CivitaiExample[];
 }
 
 export interface CivitaiResolved {
@@ -42,6 +98,8 @@ export interface CivitaiResolved {
   versionId: number;
   /** Model name, when resolvable. */
   modelName?: string;
+  /** Rich metadata for the download sidecar (best-effort; undefined if unbuildable). */
+  metadata?: CivitaiMetadata;
 }
 
 function authHeaders(): Record<string, string> {
@@ -80,9 +138,55 @@ function pickFile(version: CivitaiModelVersion): CivitaiFile | undefined {
   return files.find((f) => f.primary) ?? files[0];
 }
 
+/** Max example generations captured into the sidecar (those carrying params first). */
+const MAX_EXAMPLES = 8;
+
+function buildExamples(version: CivitaiModelVersion): CivitaiExample[] {
+  const imgs = version.images ?? [];
+  // Prefer examples that actually carry generation params (a usable recipe).
+  const withMeta = imgs.filter((i) => i.meta && Object.keys(i.meta).length > 0);
+  const ordered = [...withMeta, ...imgs.filter((i) => !withMeta.includes(i))];
+  return ordered.slice(0, MAX_EXAMPLES).map((i) => ({
+    url: i.url,
+    type: i.type,
+    width: i.width,
+    height: i.height,
+    nsfwLevel: i.nsfwLevel,
+    meta: i.meta ?? null,
+  }));
+}
+
+function buildMetadata(
+  version: CivitaiModelVersion,
+  file: CivitaiFile | undefined,
+  model?: CivitaiModel,
+): CivitaiMetadata {
+  const modelId = model?.id;
+  const sourceUrl = modelId
+    ? `https://civitai.com/models/${modelId}?modelVersionId=${version.id}`
+    : `https://civitai.com/model-versions/${version.id}`;
+  return {
+    modelId,
+    modelName: model?.name ?? version.model?.name,
+    modelType: model?.type ?? version.model?.type,
+    creator: model?.creator?.username,
+    tags: model?.tags,
+    modelDescriptionHtml: model?.description,
+    versionId: version.id,
+    versionName: version.name,
+    versionDescriptionHtml: version.description,
+    baseModel: version.baseModel,
+    trainedWords: version.trainedWords ?? [],
+    fileName: file?.name,
+    fileSizeKB: file?.sizeKB,
+    sourceUrl,
+    examples: buildExamples(version),
+  };
+}
+
 function resolveFromVersion(
   version: CivitaiModelVersion,
-  modelName?: string,
+  model?: CivitaiModel,
 ): CivitaiResolved {
   const file = pickFile(version);
   const downloadUrl =
@@ -94,7 +198,8 @@ function resolveFromVersion(
     downloadUrl,
     filename: file?.name,
     versionId: version.id,
-    modelName,
+    modelName: model?.name ?? version.model?.name,
+    metadata: buildMetadata(version, file, model),
   };
 }
 
@@ -109,6 +214,79 @@ export async function resolveCivitaiModelVersion(
     `/model-versions/${versionId}`,
   );
   return resolveFromVersion(version);
+}
+
+/**
+ * Render a CivitAI metadata bundle as agent-readable Markdown for the sidecar.
+ * Usage docs (trigger words, base model, descriptions) up top; a compact
+ * "example recipes" section from the gallery's generation params below.
+ */
+export function buildCivitaiMarkdown(m: CivitaiMetadata): string {
+  const lines: string[] = [];
+  lines.push(`# ${m.modelName ?? "CivitAI model"}`);
+  const facts: string[] = [];
+  if (m.modelType) facts.push(`**Type:** ${m.modelType}`);
+  if (m.baseModel) facts.push(`**Base model:** ${m.baseModel}`);
+  if (m.versionName) facts.push(`**Version:** ${m.versionName}`);
+  if (m.creator) facts.push(`**Creator:** ${m.creator}`);
+  if (facts.length) lines.push("", facts.join("  \n"));
+  lines.push("", `Source: ${m.sourceUrl}`);
+
+  if (m.trainedWords.length) {
+    lines.push("", "## Trigger words", "");
+    lines.push(m.trainedWords.map((w) => `\`${w}\``).join(", "));
+  }
+
+  const modelMd = htmlToMarkdown(m.modelDescriptionHtml);
+  if (modelMd) lines.push("", "## Description", "", modelMd);
+
+  const versionMd = htmlToMarkdown(m.versionDescriptionHtml);
+  if (versionMd) lines.push("", "## Version notes", "", versionMd);
+
+  const recipes = m.examples.filter(
+    (e) => e.meta && Object.keys(e.meta).length > 0,
+  );
+  if (recipes.length) {
+    lines.push("", "## Example recipes", "");
+    lines.push(
+      "Generation params pulled from the model's gallery — reuse the seed to replicate, or vary it to remix.",
+    );
+    recipes.forEach((e, i) => {
+      lines.push("", `### Example ${i + 1}`);
+      if (e.url) lines.push(`Image: ${e.url}`);
+      lines.push("", "```", formatMeta(e.meta!), "```");
+    });
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/** Flatten a CivitAI image `meta` object into readable `key: value` lines,
+ *  surfacing the params that matter for reproduction first. */
+function formatMeta(meta: Record<string, unknown>): string {
+  const order = [
+    "prompt",
+    "negativePrompt",
+    "seed",
+    "steps",
+    "sampler",
+    "cfgScale",
+    "Size",
+    "Model",
+    "Denoising strength",
+    "Clip skip",
+  ];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (k: string, v: unknown) => {
+    if (v === undefined || v === null || v === "") return;
+    if (typeof v === "object") return; // skip nested (resources/hashes) here
+    out.push(`${k}: ${v}`);
+    seen.add(k);
+  };
+  for (const k of order) if (k in meta) push(k, meta[k]);
+  for (const [k, v] of Object.entries(meta)) if (!seen.has(k)) push(k, v);
+  return out.join("\n");
 }
 
 /**
@@ -144,5 +322,5 @@ export async function resolveCivitaiModel(
     version = versions[0];
   }
 
-  return resolveFromVersion(version, model.name);
+  return resolveFromVersion(version, model);
 }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Stats } from "node:fs";
-import { readdir, stat, mkdir } from "node:fs/promises";
+import { readdir, stat, mkdir, readFile } from "node:fs/promises";
 import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient } from "../comfyui/client.js";
@@ -112,6 +112,11 @@ export interface LocalModel {
   size: number;
   modified: string;
   type: string;
+  /** Trigger/activation words from the CivitAI download sidecar, when present —
+   *  so the agent applies them automatically when generating with this model. */
+  triggerWords?: string[];
+  /** Base model from the CivitAI sidecar (e.g. "SDXL 1.0"), when present. */
+  baseModel?: string;
 }
 
 /**
@@ -217,7 +222,10 @@ export async function listLocalModels(
         logger.debug(`HTTP /models/${dir} failed, continuing`, { err });
       }
     }
-    if (httpReturnedAny) return results;
+    if (httpReturnedAny) {
+      await enrichWithCivitaiMetadata(results);
+      return results;
+    }
   } catch (err) {
     logger.debug("HTTP model listing unavailable, trying filesystem", { err });
   }
@@ -254,7 +262,41 @@ export async function listLocalModels(
     }
   }
 
+  await enrichWithCivitaiMetadata(results);
   return results;
+}
+
+/**
+ * Best-effort: attach `triggerWords` + `baseModel` from each model's CivitAI
+ * sidecar (`<file>.civitai.json`, written by download_civitai_model) so the
+ * agent applies the trigger words automatically when generating. Silent when a
+ * sidecar is missing or there's no local filesystem (remote/cloud).
+ */
+async function enrichWithCivitaiMetadata(models: LocalModel[]): Promise<void> {
+  const base = resolveComfyUIBase();
+  if (!base) return;
+  const modelsRoot = join(base, "models");
+  await Promise.all(
+    models.map(async (m) => {
+      // FS-scan paths are absolute; HTTP paths are `dir/name` relative to models/.
+      const abs = isAbsolute(m.path) ? m.path : join(modelsRoot, m.path);
+      try {
+        const raw = await readFile(`${abs}.civitai.json`, "utf8");
+        const j = JSON.parse(raw) as {
+          trainedWords?: unknown;
+          baseModel?: unknown;
+        };
+        if (Array.isArray(j.trainedWords) && j.trainedWords.length > 0) {
+          m.triggerWords = j.trainedWords.map(String);
+        }
+        if (typeof j.baseModel === "string" && j.baseModel) {
+          m.baseModel = j.baseModel;
+        }
+      } catch {
+        // No sidecar (or unreadable) — leave the model un-enriched.
+      }
+    }),
+  );
 }
 
 /** True when `url`'s host is civitai.com (or a subdomain), parsed safely. */

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { unlink } from "node:fs/promises";
+import { unlink, writeFile } from "node:fs/promises";
 import { isLocalMode } from "../config.js";
+import { logger } from "../utils/logger.js";
 import {
   downloadModel,
   resolveExistingModelFile,
@@ -10,8 +11,35 @@ import {
 import {
   resolveCivitaiModel,
   resolveCivitaiModelVersion,
+  buildCivitaiMarkdown,
+  type CivitaiMetadata,
 } from "../services/civitai-resolver.js";
 import { ValidationError, errorToToolResult } from "../utils/errors.js";
+
+/**
+ * Write the CivitAI metadata sidecars next to a freshly downloaded model:
+ * `<file>.civitai.json` (structured, incl. example generation params) and
+ * `<file>.civitai.md` (agent-readable usage docs + example recipes). Best-effort
+ * — a sidecar failure never fails the download. Returns the sidecar paths written.
+ */
+async function writeCivitaiSidecar(
+  savedPath: string,
+  metadata: CivitaiMetadata,
+): Promise<{ json: string; md: string } | null> {
+  try {
+    const jsonPath = `${savedPath}.civitai.json`;
+    const mdPath = `${savedPath}.civitai.md`;
+    await writeFile(jsonPath, JSON.stringify(metadata, null, 2), "utf8");
+    await writeFile(mdPath, buildCivitaiMarkdown(metadata), "utf8");
+    return { json: jsonPath, md: mdPath };
+  } catch (err) {
+    logger.warn("Failed to write CivitAI metadata sidecar", {
+      savedPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
 
 /** Graceful "not supported remotely" tool result (no isError), matching the
  *  degrade-don't-throw pattern list_local_models uses. */
@@ -151,6 +179,24 @@ export function registerModelExtrasTools(server: McpServer): void {
         ];
         if (resolved.modelName) lines.push(`  Model: ${resolved.modelName}`);
         lines.push(`  Version id: ${resolved.versionId}`);
+
+        // Write usage-docs sidecars beside the file so the panel agent has the
+        // description, trigger words, and example generation params on hand.
+        // Local-only: remote mode has no local FS (savedPath is a status string).
+        if (isLocalMode() && resolved.metadata) {
+          const sidecar = await writeCivitaiSidecar(savedPath, resolved.metadata);
+          if (sidecar) {
+            const tw = resolved.metadata.trainedWords;
+            if (tw.length) lines.push(`  Trigger words: ${tw.join(", ")}`);
+            const recipes = resolved.metadata.examples.filter(
+              (e) => e.meta && Object.keys(e.meta).length > 0,
+            ).length;
+            lines.push(
+              `  Metadata: ${sidecar.md}` +
+                (recipes ? ` (${recipes} example recipe${recipes === 1 ? "" : "s"})` : ""),
+            );
+          }
+        }
 
         return {
           content: [{ type: "text" as const, text: lines.join("\n") }],

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -138,7 +138,7 @@ export function registerModelManagementTools(server: McpServer): void {
 
   server.tool(
     "list_local_models",
-    "List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them.",
+    "List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them. For models fetched via download_civitai_model, any CivitAI trigger/activation words and base model are shown inline (read from the `<file>.civitai.json` sidecar) — apply those trigger words in your prompt when generating with that model.",
     {
       model_type: modelTypeEnum
         .optional()
@@ -177,6 +177,16 @@ export function registerModelManagementTools(server: McpServer): void {
               lines.push(`- ${m.name} (${sizeMB} MB) — modified ${m.modified}`);
             } else {
               lines.push(`- ${m.name}`);
+            }
+            // Surface CivitAI sidecar hints so the agent applies the trigger
+            // words (and picks the right base model) when it builds a workflow.
+            if (m.triggerWords && m.triggerWords.length > 0) {
+              lines.push(
+                `    trigger words: ${m.triggerWords.join(", ")}` +
+                  (m.baseModel ? `  ·  base: ${m.baseModel}` : ""),
+              );
+            } else if (m.baseModel) {
+              lines.push(`    base: ${m.baseModel}`);
             }
           }
           lines.push("");

--- a/src/utils/html-to-markdown.ts
+++ b/src/utils/html-to-markdown.ts
@@ -1,0 +1,109 @@
+// A small, dependency-free HTML → Markdown converter, scoped to the kind of
+// markup CivitAI model/version descriptions use (paragraphs, line breaks,
+// headings, bold/italic, links, lists, code, blockquotes). It is deliberately
+// forgiving: anything it doesn't recognise is stripped rather than escaped, so
+// the output is always readable plain-ish Markdown for an agent to consume — it
+// is NOT a faithful round-trippable transform.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  mdash: "—",
+  ndash: "–",
+  hellip: "…",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  deg: "°",
+};
+
+function decodeEntities(s: string): string {
+  return s.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (m, body: string) => {
+    if (body[0] === "#") {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? parseInt(body.slice(2), 16)
+          : parseInt(body.slice(1), 10);
+      return Number.isFinite(code) ? String.fromCodePoint(code) : m;
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()];
+    return named ?? m;
+  });
+}
+
+/**
+ * Convert a subset of HTML to Markdown. Returns "" for empty/whitespace input.
+ */
+export function htmlToMarkdown(html: string | undefined | null): string {
+  if (!html) return "";
+  let s = html;
+
+  // Drop elements whose content is never useful as text.
+  s = s.replace(/<(script|style|head)\b[\s\S]*?<\/\1>/gi, "");
+  // Comments.
+  s = s.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Inline formatting.
+  s = s.replace(/<\s*(strong|b)\b[^>]*>([\s\S]*?)<\/\s*\1\s*>/gi, "**$2**");
+  s = s.replace(/<\s*(em|i)\b[^>]*>([\s\S]*?)<\/\s*\1\s*>/gi, "_$2_");
+  s = s.replace(/<\s*code\b[^>]*>([\s\S]*?)<\/\s*code\s*>/gi, "`$1`");
+  s = s.replace(
+    /<\s*a\b[^>]*href\s*=\s*["']([^"']*)["'][^>]*>([\s\S]*?)<\/\s*a\s*>/gi,
+    (_m, href: string, text: string) => {
+      const t = text.trim() || href;
+      return href ? `[${t}](${href})` : t;
+    },
+  );
+
+  // Headings → ATX. Level from the tag number.
+  s = s.replace(
+    /<\s*h([1-6])\b[^>]*>([\s\S]*?)<\/\s*h\1\s*>/gi,
+    (_m, lvl: string, text: string) =>
+      `\n\n${"#".repeat(Number(lvl))} ${text.trim()}\n\n`,
+  );
+
+  // List items → "- " lines (ordered lists also become dashes; good enough).
+  s = s.replace(/<\s*li\b[^>]*>([\s\S]*?)<\/\s*li\s*>/gi, (_m, text: string) => {
+    return `\n- ${text.trim()}`;
+  });
+  s = s.replace(/<\/?\s*(ul|ol)\b[^>]*>/gi, "\n");
+
+  // Blockquotes.
+  s = s.replace(
+    /<\s*blockquote\b[^>]*>([\s\S]*?)<\/\s*blockquote\s*>/gi,
+    (_m, text: string) =>
+      "\n" +
+      text
+        .trim()
+        .split(/\n/)
+        .map((l) => `> ${l.trim()}`)
+        .join("\n") +
+      "\n",
+  );
+
+  // Block separators.
+  s = s.replace(/<\s*br\s*\/?\s*>/gi, "\n");
+  s = s.replace(/<\/\s*p\s*>/gi, "\n\n");
+  s = s.replace(/<\s*p\b[^>]*>/gi, "");
+  s = s.replace(/<\/?\s*div\b[^>]*>/gi, "\n");
+  s = s.replace(/<\s*hr\s*\/?\s*>/gi, "\n\n---\n\n");
+
+  // Strip any remaining tags.
+  s = s.replace(/<[^>]+>/g, "");
+
+  s = decodeEntities(s);
+
+  // Normalise whitespace: trim each line, collapse 3+ blank lines to one.
+  s = s
+    .split("\n")
+    .map((l) => l.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return s;
+}


### PR DESCRIPTION
The enabler for the mobile app's nav tabs (Workflows list, rig-side downloads) — structured backend data **without** an agent turn. **Security-sensitive → please review the whitelist.**

## What it does
A `{type:"call_tool", cid, tool, args}` frame from the (already token-gated) mobile client → **name-whitelist check** → invoke the tool via **one lazily-built in-process MCP client** (`registerAllTools` over an `InMemoryTransport` pair — the exact same tool implementations + `getClient()`/`COMFYUI_URL` the agents use, no duplication) → reply `{type:"tool_result", cid, tool, ok, result|error}`.

- Correlated by **`cid`**, not `rid` (the bridge reserves top-level `rid` for orchestrator→panel command replies — a `rid` frame gets misrouted).
- **Whitelist (READ/DOWNLOAD only):** `list_workflows`, `get_workflow`, `analyze_workflow`, `query_workflow`, `workflow_from_image`, `list_output_images`, `get_image`, `list_local_models`, `download_civitai_model`, `download_model`, `enqueue_workflow`. **Excluded:** anything destructive (restart/stop/remove/clear/install/update).

## Security posture
- Gated behind the existing bridge token (loopback/LAN/tunnel all token-gated).
- All tools are registered in the in-process server, but **only whitelisted names are reachable** via `call_tool`.
- No agent, no arbitrary tool execution, no destructive ops.

## Verification (live)
A canvas-less WS client called: `list_workflows` → real filename list (33 workflows); `list_local_models` → real checkpoint list; `restart_comfyui` → **rejected** ("tool not permitted"). `npm run build` (tsc) clean.

## Follow-up
Mobile `callTool()` method + the Workflows nav tab consume this (comfyui-mcp-mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)