### PR TITLE
docs(design): previz-to-video roadmap — Blender MCP + Mixamo + Meshy → motion-controlled video (RFC, draft)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,7 +154,7 @@ hardening first; this is the "shape it with users before building" track.
 > Scope: **v1 = local GPU only.** Reference client internals: `~/code/slutter` (CivitAI Video
 > Scroller, Flutter — decoded CivitAI API, OAuth login, account management).
 
-## Theme H — 3D previz → motion-controlled video (Blender MCP + Mixamo + Meshy)
+## Theme H — 3D previz → motion-controlled video (Blender MCP + Mixamo + Meshy) (#187)
 The most reliable way to direct an AI video shot is a pre-animated 3D scene: block it in Blender
 (agent-driven via the **official Blender MCP**, 5.1+), populate with **Mixamo** motion clips and
 **Meshy 6** / local img2mesh assets, render a rough viewport reference, then restyle it with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -177,7 +177,10 @@ shop, Mixamo auto-rigs its output, Blender is the stage Claude can fully see and
   GLB, `design/previz-assets/master-3d-model-maker.community.json`); plus `kind: "model"`
   (GLB/FBX/OBJ) in the output listing so import-to-Blender / stage-for-Mixamo resolve exact paths.
 - **H3 — Companion MCP servers in the orchestrator.** Config + session-spawn plumbing so the *panel*
-  agent can reach Blender MCP (generic mechanism, Blender is just the first customer).
+  agent can reach Blender MCP (generic mechanism, Blender is just the first customer). Open question
+  tracked in the RFC: whether small local backends additionally need a thin curated tool layer
+  (`blender_export_pose_map`-style named tools) over the official MCP's raw `execute_python` —
+  community proposal, decided by H0/H1 evidence.
 - **H4 — Director × previz.** Shot lists drive previz scenes; multi-shot cast/set continuity; style
   sweeps (one previz, N looks) as a first-class op.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -161,15 +161,21 @@ The most reliable way to direct an AI video shot is a pre-animated 3D scene: blo
 **Wan 2.2 Animate** (free, local) or **Seedance 2.0 Reference-to-Video** (paid API node) — motion,
 timing and camera survive; appearance comes from reference images. Full vision:
 [`design/previz-to-video.md`](./design/previz-to-video.md). comfyui-mcp does **not** wrap Blender —
-the agent holds both MCPs and a skill teaches the choreography.
+the agent holds both MCPs and a skill teaches the choreography. Headline (community feedback): the
+panel directs **natural motion between characters authored in ComfyUI** — ComfyUI is the character
+shop, Mixamo auto-rigs its output, Blender is the stage Claude can fully see and direct.
 
-- **H0 — Manual spike.** Run the recipe once end-to-end on this rig (asset → Mixamo → blocking →
-  viewport render → Wan Animate AND Seedance R2V); capture every snag.
-- **H1 — `previz-director` skill.** The whole recipe as knowledge (blocking conventions, retarget
-  procedure, render settings, handoff commands, R2V prompt templates). Zero code; works today from
-  Claude Desktop/Code with both MCPs configured.
-- **H2 — `wan-animate` pack.** The free path installable via `apply_manifest` (Wan 2.2 Animate 14B
-  fp8 + DWPose + SAM2 + wired template).
+- **H0 — Manual spike.** Run the recipe once end-to-end on this rig (asset → Mixamo auto-rig →
+  blocking → viewport render → Wan Animate AND Seedance R2V); capture every snag.
+- **H1 — `previz-director` skill.** The whole recipe as knowledge (blocking conventions, character
+  loop incl. the guided Mixamo auto-rig handoff, retarget procedure, render settings, handoff
+  commands, R2V prompt templates). Zero code; works today from Claude Desktop/Code with both MCPs
+  configured.
+- **H2 — `wan-animate` + `character-shop` packs + 3D-asset file awareness.** The free video path
+  installable via `apply_manifest` (Wan 2.2 Animate 14B fp8 + DWPose + SAM2 + wired template); the
+  community-seeded character-shop pack (SDXL hero → Qwen-Edit 2511 multi-angle → Hunyuan3D v2 MV →
+  GLB, `design/previz-assets/master-3d-model-maker.community.json`); plus `kind: "model"`
+  (GLB/FBX/OBJ) in the output listing so import-to-Blender / stage-for-Mixamo resolve exact paths.
 - **H3 — Companion MCP servers in the orchestrator.** Config + session-spawn plumbing so the *panel*
   agent can reach Blender MCP (generic mechanism, Blender is just the first customer).
 - **H4 — Director × previz.** Shot lists drive previz scenes; multi-shot cast/set continuity; style

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,6 +154,30 @@ hardening first; this is the "shape it with users before building" track.
 > Scope: **v1 = local GPU only.** Reference client internals: `~/code/slutter` (CivitAI Video
 > Scroller, Flutter — decoded CivitAI API, OAuth login, account management).
 
+## Theme H — 3D previz → motion-controlled video (Blender MCP + Mixamo + Meshy)
+The most reliable way to direct an AI video shot is a pre-animated 3D scene: block it in Blender
+(agent-driven via the **official Blender MCP**, 5.1+), populate with **Mixamo** motion clips and
+**Meshy 6** / local img2mesh assets, render a rough viewport reference, then restyle it with
+**Wan 2.2 Animate** (free, local) or **Seedance 2.0 Reference-to-Video** (paid API node) — motion,
+timing and camera survive; appearance comes from reference images. Full vision:
+[`design/previz-to-video.md`](./design/previz-to-video.md). comfyui-mcp does **not** wrap Blender —
+the agent holds both MCPs and a skill teaches the choreography.
+
+- **H0 — Manual spike.** Run the recipe once end-to-end on this rig (asset → Mixamo → blocking →
+  viewport render → Wan Animate AND Seedance R2V); capture every snag.
+- **H1 — `previz-director` skill.** The whole recipe as knowledge (blocking conventions, retarget
+  procedure, render settings, handoff commands, R2V prompt templates). Zero code; works today from
+  Claude Desktop/Code with both MCPs configured.
+- **H2 — `wan-animate` pack.** The free path installable via `apply_manifest` (Wan 2.2 Animate 14B
+  fp8 + DWPose + SAM2 + wired template).
+- **H3 — Companion MCP servers in the orchestrator.** Config + session-spawn plumbing so the *panel*
+  agent can reach Blender MCP (generic mechanism, Blender is just the first customer).
+- **H4 — Director × previz.** Shot lists drive previz scenes; multi-shot cast/set continuity; style
+  sweeps (one previz, N looks) as a first-class op.
+
+> Paid pieces (Meshy, Seedance) stay behind the existing `check_workflow_runtime` /
+> ask-before-spending convention; every paid step has a named free alternative.
+
 ## Theme G — Safety gates / enterprise hardening (deferred until needed)
 Declarative per-category safety gates (workflow-writes, model-deletes, process-control, git-writes,
 …) enforced at a single registration-time choke point, `COMFYUI_MCP_SAFE_MODE` lockdown for
@@ -177,6 +201,7 @@ purely to keep the design findable if that reality ever changes. Until then, iso
 | **2 — productionize** | Full agent panel + discovery + I/O | B5, B6, D1, E8, E9, E10, E12 |
 | **Hardening — continuous** | Reliability + I/O from comfyui-api | E1, E2, E3, E4, E7, E11 |
 | **3 — mobile / remote (teased)** | Agent-driven phone client on your own rig | F1, F2, F3, F4, F5, F6, F7 (F8 later) |
+| **4 — previz (drafting)** | 3D-blocked reference scenes → motion-controlled video | H0, H1, H2 first (no code); H3, H4 after |
 
 Phase 0 ships value immediately (skills + node tooling) and de-risks the panel (tunnel + streaming)
 before any frontend work. Phase 1 needs the v2 package closer to publish for the panel UI.

--- a/design/previz-assets/master-3d-model-maker.community.json
+++ b/design/previz-assets/master-3d-model-maker.community.json
@@ -1,0 +1,20442 @@
+{
+  "id": "60fc533c-cab0-4b1e-839b-b7783bd27ba5",
+  "revision": 0,
+  "last_node_id": 438,
+  "last_link_id": 501,
+  "nodes": [
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        2150,
+        58
+      ],
+      "size": [
+        315,
+        312
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 156
+        },
+        {
+          "label": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 161
+        },
+        {
+          "label": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 151
+        },
+        {
+          "label": "latent_image",
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 143
+        }
+      ],
+      "outputs": [
+        {
+          "label": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            130
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        502126049100058,
+        "randomize",
+        20,
+        7.5,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 51,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        1008.4049056399181,
+        223.92228929862836
+      ],
+      "size": [
+        253.59375,
+        104
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "clip_vision",
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 111
+        },
+        {
+          "label": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 145
+        }
+      ],
+      "outputs": [
+        {
+          "label": "CLIP_VISION_OUTPUT",
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "slot_index": 0,
+          "links": [
+            144
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "none"
+      ]
+    },
+    {
+      "id": 54,
+      "type": "ImageOnlyCheckpointLoader",
+      "pos": [
+        910,
+        -62
+      ],
+      "size": [
+        369.59375,
+        128
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "MODEL",
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            155
+          ]
+        },
+        {
+          "label": "CLIP_VISION",
+          "name": "CLIP_VISION",
+          "type": "CLIP_VISION",
+          "slot_index": 1,
+          "links": [
+            111,
+            163,
+            166,
+            172
+          ]
+        },
+        {
+          "label": "VAE",
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 2,
+          "links": [
+            158
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ImageOnlyCheckpointLoader",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "models": [
+          {
+            "name": "hunyuan3d-dit-v2-mv_fp16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/hunyuan3D_2.0_repackaged/resolve/main/split_files/hunyuan3d-dit-v2-mv_fp16.safetensors",
+            "directory": "checkpoints"
+          }
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "hunyuan3d-dit-v2-mv_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 56,
+      "type": "LoadImage",
+      "pos": [
+        920,
+        368
+      ],
+      "size": [
+        401.625,
+        372
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            145
+          ]
+        },
+        {
+          "label": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "mia_sheet_front_00002_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 61,
+      "type": "VAEDecodeHunyuan3D",
+      "pos": [
+        2500,
+        58
+      ],
+      "size": [
+        315,
+        136
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "samples",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 130
+        },
+        {
+          "label": "vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 158
+        }
+      ],
+      "outputs": [
+        {
+          "label": "VOXEL",
+          "name": "VOXEL",
+          "type": "VOXEL",
+          "slot_index": 0,
+          "links": [
+            168
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecodeHunyuan3D",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        8000,
+        256
+      ]
+    },
+    {
+      "id": 65,
+      "type": "Hunyuan3Dv2ConditioningMultiView",
+      "pos": [
+        1830,
+        198
+      ],
+      "size": [
+        282.71875,
+        120
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "front",
+          "name": "front",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 144
+        },
+        {
+          "label": "left",
+          "name": "left",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 164
+        },
+        {
+          "label": "back",
+          "name": "back",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 167
+        },
+        {
+          "label": "right",
+          "name": "right",
+          "shape": 7,
+          "type": "CLIP_VISION_OUTPUT",
+          "link": 171
+        }
+      ],
+      "outputs": [
+        {
+          "label": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            161
+          ]
+        },
+        {
+          "label": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "slot_index": 1,
+          "links": [
+            151
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Hunyuan3Dv2ConditioningMultiView",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 66,
+      "type": "EmptyLatentHunyuan3Dv2",
+      "pos": [
+        1830,
+        368
+      ],
+      "size": [
+        270,
+        112
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            143
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyLatentHunyuan3Dv2",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        3072,
+        1
+      ]
+    },
+    {
+      "id": 70,
+      "type": "ModelSamplingAuraFlow",
+      "pos": [
+        1830,
+        48
+      ],
+      "size": [
+        270,
+        80
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 155
+        }
+      ],
+      "outputs": [
+        {
+          "label": "MODEL",
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            156
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingAuraFlow",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        1.0000000000000002
+      ]
+    },
+    {
+      "id": 78,
+      "type": "LoadImage",
+      "pos": [
+        920,
+        948
+      ],
+      "size": [
+        401.625,
+        372
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            162
+          ]
+        },
+        {
+          "label": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "mia_sheet_90_right_00001_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 79,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        920,
+        818
+      ],
+      "size": [
+        253.59375,
+        104
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "clip_vision",
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 163
+        },
+        {
+          "label": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 162
+        }
+      ],
+      "outputs": [
+        {
+          "label": "CLIP_VISION_OUTPUT",
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "slot_index": 0,
+          "links": [
+            164
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "none"
+      ]
+    },
+    {
+      "id": 80,
+      "type": "LoadImage",
+      "pos": [
+        1360,
+        368
+      ],
+      "size": [
+        401.625,
+        372
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            165
+          ]
+        },
+        {
+          "label": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "mia_sheet_back_00001_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 81,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        1442.5521509761315,
+        223.92228929862836
+      ],
+      "size": [
+        253.59375,
+        104
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "clip_vision",
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 166
+        },
+        {
+          "label": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 165
+        }
+      ],
+      "outputs": [
+        {
+          "label": "CLIP_VISION_OUTPUT",
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "slot_index": 0,
+          "links": [
+            167
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "none"
+      ]
+    },
+    {
+      "id": 82,
+      "type": "VoxelToMesh",
+      "pos": [
+        2500,
+        228
+      ],
+      "size": [
+        270,
+        112
+      ],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "voxel",
+          "type": "VOXEL",
+          "link": 168
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MESH",
+          "type": "MESH",
+          "links": [
+            169
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VoxelToMesh",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "surface net",
+        0.6
+      ]
+    },
+    {
+      "id": 83,
+      "type": "SaveGLB",
+      "pos": [
+        2491,
+        388
+      ],
+      "size": [
+        620,
+        640
+      ],
+      "flags": {},
+      "order": 28,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "mesh",
+          "name": "mesh",
+          "type": "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          "link": 169
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveGLB",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "Camera Info": {
+          "position": {
+            "x": 11.122540839475917,
+            "y": 10.995429482054263,
+            "z": 11.122540839475919
+          },
+          "target": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "zoom": 1,
+          "cameraType": "perspective"
+        },
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "Last Time Model File": "mesh/Mia_00002_.glb",
+        "Last Time Model Folder": "output",
+        "Scene Config": {
+          "showGrid": true,
+          "backgroundColor": "#000000",
+          "backgroundImage": "",
+          "backgroundRenderMode": "tiled",
+          "models": [
+            {
+              "position": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              },
+              "quaternion": {
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "w": 1
+              },
+              "scale": {
+                "x": 1,
+                "y": 1,
+                "z": 1
+              }
+            }
+          ]
+        }
+      },
+      "widgets_values": [
+        "mesh/Mia",
+        ""
+      ]
+    },
+    {
+      "id": 84,
+      "type": "MarkdownNote",
+      "pos": [
+        2150,
+        398
+      ],
+      "size": [
+        320,
+        88
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "CFG setting",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "Try adjusting the CFG settings to get better output."
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 86,
+      "type": "CLIPVisionEncode",
+      "pos": [
+        1360,
+        818
+      ],
+      "size": [
+        253.59375,
+        104
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "clip_vision",
+          "name": "clip_vision",
+          "type": "CLIP_VISION",
+          "link": 172
+        },
+        {
+          "label": "image",
+          "name": "image",
+          "type": "IMAGE",
+          "link": 170
+        }
+      ],
+      "outputs": [
+        {
+          "label": "CLIP_VISION_OUTPUT",
+          "name": "CLIP_VISION_OUTPUT",
+          "type": "CLIP_VISION_OUTPUT",
+          "slot_index": 0,
+          "links": [
+            171
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPVisionEncode",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "none"
+      ]
+    },
+    {
+      "id": 87,
+      "type": "LoadImage",
+      "pos": [
+        1360,
+        948
+      ],
+      "size": [
+        401.625,
+        372
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            170
+          ]
+        },
+        {
+          "label": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": []
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.43",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "mia_sheet_90_left_00001_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 88,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        -942.4497820959099,
+        -639.7828160444807
+      ],
+      "size": [
+        270,
+        128
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            173
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            174,
+            175
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            180
+          ]
+        }
+      ],
+      "title": "Character Sheet Checkpoint",
+      "properties": {
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "waiIllustriousSDXL_v170.safetensors"
+      ]
+    },
+    {
+      "id": 89,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -568.5348072566195,
+        -777.6193994175529
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 174
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            176
+          ]
+        }
+      ],
+      "title": "Sheet Positive",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "masterpiece, best quality, 1 character, single figure, Mia, young woman, cyberpunk city dweller, undercut hairstyle with neon pink-dyed tips, denim jacket over crop top, ripped jeans, sneakers, small tech ear piercings, casual streetwear, front view, T-pose, arms out to sides, standing straight, full body, centered, white background, studio lighting, no shadows, flat even lighting, single character concept art, high detail, fully colored"
+      ]
+    },
+    {
+      "id": 90,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -582.2152671598343,
+        -521.9906792670487
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 175
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            177
+          ]
+        }
+      ],
+      "title": "Sheet Negative",
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "colored background, gradient background, patterned background, shadow, cast shadow, cropped, cut off, multiple characters, 2girls, 2boys, duplicate, clone, two figures, side by side comparison, turnaround sheet, reference sheet grid, multiple views, lineart, sketch, monochrome, uncolored, blurry, watermark, text, signature, cluttered background, dark lighting, low quality, worst quality, extra limbs, bad anatomy, bad hands, deformed, sitting, action pose"
+      ]
+    },
+    {
+      "id": 91,
+      "type": "EmptyLatentImage",
+      "pos": [
+        -505.5259895855926,
+        -260.3889512124747
+      ],
+      "size": [
+        270,
+        144
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            178
+          ]
+        }
+      ],
+      "title": "Sheet Latent",
+      "properties": {
+        "Node name for S&R": "EmptyLatentImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 92,
+      "type": "KSampler",
+      "pos": [
+        -122.48983943621104,
+        -649.3982901082703
+      ],
+      "size": [
+        270,
+        312
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 173
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 176
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 177
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 178
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            179
+          ]
+        }
+      ],
+      "title": "Sheet Sampler",
+      "properties": {
+        "Node name for S&R": "KSampler",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        778899,
+        "fixed",
+        30,
+        6,
+        "euler_ancestral",
+        "karras",
+        1
+      ]
+    },
+    {
+      "id": 93,
+      "type": "VAEDecode",
+      "pos": [
+        179.97987120078665,
+        -646.4276470230826
+      ],
+      "size": [
+        225,
+        72
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 179
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 180
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            181
+          ]
+        }
+      ],
+      "title": "Sheet VAE Decode",
+      "properties": {
+        "Node name for S&R": "VAEDecode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 94,
+      "type": "SaveImage",
+      "pos": [
+        286.48356931289777,
+        -475.6948057626604
+      ],
+      "size": [
+        270,
+        316
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 181
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "title": "Sheet Save",
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "mia_sheet_front"
+      ]
+    },
+    {
+      "id": 428,
+      "type": "LoadImage",
+      "pos": [
+        -1100,
+        100
+      ],
+      "size": [
+        480,
+        440
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            501
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "title": "Load Character Image",
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "image": true,
+            "upload": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.3.50",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "mia_sheet_front_00002_.png",
+        "image"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 433,
+      "type": "SaveImage",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        730,
+        700
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 497
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76"
+      },
+      "widgets_values": [
+        "mia_sheet_back"
+      ]
+    },
+    {
+      "id": 434,
+      "type": "SaveImage",
+      "pos": [
+        -1055.276184783239,
+        963.7301094266991
+      ],
+      "size": [
+        740,
+        710
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 498
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76"
+      },
+      "widgets_values": [
+        "mia_sheet_90_right"
+      ]
+    },
+    {
+      "id": 435,
+      "type": "SaveImage",
+      "pos": [
+        -29.758330590416335,
+        1008.0846634911527
+      ],
+      "size": [
+        740,
+        690
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 499
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76"
+      },
+      "widgets_values": [
+        "mia_sheet_90_left"
+      ]
+    },
+    {
+      "id": 437,
+      "type": "98c125f5-6fdd-4736-87a9-7d436431eaea",
+      "pos": [
+        -540,
+        100
+      ],
+      "size": [
+        440,
+        740
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 501
+        },
+        {
+          "label": "enable_turbo_mode",
+          "name": "value",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "value"
+          },
+          "link": null
+        },
+        {
+          "label": "lightning_lora",
+          "name": "lora_name_1",
+          "type": "COMBO",
+          "widget": {
+            "name": "lora_name_1"
+          },
+          "link": null
+        },
+        {
+          "label": "lora_name",
+          "name": "lora_name_1_1",
+          "type": "COMBO",
+          "widget": {
+            "name": "lora_name_1_1"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "label": "close_up",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "label": "45_right",
+          "name": "IMAGE_1",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "label": "aerial_view",
+          "name": "IMAGE_2",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "label": "wide_angle",
+          "name": "IMAGE_3",
+          "type": "IMAGE",
+          "links": [
+            497
+          ]
+        },
+        {
+          "label": "90_right",
+          "name": "IMAGE_4",
+          "type": "IMAGE",
+          "links": [
+            498
+          ]
+        },
+        {
+          "label": "low_angle",
+          "name": "IMAGE_5",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "label": "90_left",
+          "name": "IMAGE_6",
+          "type": "IMAGE",
+          "links": [
+            499
+          ]
+        },
+        {
+          "label": "45_left",
+          "name": "IMAGE_7",
+          "type": "IMAGE",
+          "links": []
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "221",
+            "value"
+          ],
+          [
+            "221",
+            "unet_name"
+          ],
+          [
+            "221",
+            "clip_name"
+          ],
+          [
+            "221",
+            "vae_name"
+          ],
+          [
+            "221",
+            "lora_name"
+          ],
+          [
+            "221",
+            "lora_name_1"
+          ],
+          [
+            "271",
+            "lora_name_1"
+          ]
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "value": true,
+            "lora_name_1": true,
+            "lora_name_1_1": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.20.1"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      111,
+      54,
+      1,
+      51,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      130,
+      3,
+      0,
+      61,
+      0,
+      "LATENT"
+    ],
+    [
+      143,
+      66,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      144,
+      51,
+      0,
+      65,
+      0,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      145,
+      56,
+      0,
+      51,
+      1,
+      "IMAGE"
+    ],
+    [
+      151,
+      65,
+      1,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      155,
+      54,
+      0,
+      70,
+      0,
+      "MODEL"
+    ],
+    [
+      156,
+      70,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      158,
+      54,
+      2,
+      61,
+      1,
+      "VAE"
+    ],
+    [
+      161,
+      65,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      162,
+      78,
+      0,
+      79,
+      1,
+      "IMAGE"
+    ],
+    [
+      163,
+      54,
+      1,
+      79,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      164,
+      79,
+      0,
+      65,
+      1,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      165,
+      80,
+      0,
+      81,
+      1,
+      "IMAGE"
+    ],
+    [
+      166,
+      54,
+      1,
+      81,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      167,
+      81,
+      0,
+      65,
+      2,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      168,
+      61,
+      0,
+      82,
+      0,
+      "VOXEL"
+    ],
+    [
+      169,
+      82,
+      0,
+      83,
+      0,
+      "MESH"
+    ],
+    [
+      170,
+      87,
+      0,
+      86,
+      1,
+      "IMAGE"
+    ],
+    [
+      171,
+      86,
+      0,
+      65,
+      3,
+      "CLIP_VISION_OUTPUT"
+    ],
+    [
+      172,
+      54,
+      1,
+      86,
+      0,
+      "CLIP_VISION"
+    ],
+    [
+      173,
+      88,
+      0,
+      92,
+      0,
+      "MODEL"
+    ],
+    [
+      174,
+      88,
+      1,
+      89,
+      0,
+      "CLIP"
+    ],
+    [
+      175,
+      88,
+      1,
+      90,
+      0,
+      "CLIP"
+    ],
+    [
+      176,
+      89,
+      0,
+      92,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      177,
+      90,
+      0,
+      92,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      178,
+      91,
+      0,
+      92,
+      3,
+      "LATENT"
+    ],
+    [
+      179,
+      92,
+      0,
+      93,
+      0,
+      "LATENT"
+    ],
+    [
+      180,
+      88,
+      2,
+      93,
+      1,
+      "VAE"
+    ],
+    [
+      181,
+      93,
+      0,
+      94,
+      0,
+      "IMAGE"
+    ],
+    [
+      497,
+      437,
+      3,
+      433,
+      0,
+      "IMAGE"
+    ],
+    [
+      498,
+      437,
+      4,
+      434,
+      0,
+      "IMAGE"
+    ],
+    [
+      499,
+      437,
+      6,
+      435,
+      0,
+      "IMAGE"
+    ],
+    [
+      501,
+      428,
+      0,
+      437,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 6,
+      "title": "Step2 - Upload multi-view images",
+      "bounding": [
+        900,
+        138,
+        880,
+        1183.5999755859375
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 1,
+      "title": "Front",
+      "bounding": [
+        910,
+        178,
+        421.6362609863281,
+        548.9354248046875
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "Back",
+      "bounding": [
+        1350,
+        178,
+        420,
+        550
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 3,
+      "title": "Left",
+      "bounding": [
+        910,
+        748,
+        420,
+        560
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "Right",
+      "bounding": [
+        1350,
+        748,
+        420,
+        560
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 5,
+      "title": "Step1- Load model",
+      "bounding": [
+        900,
+        -62,
+        389.6000061035156,
+        181.60000610351562
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 8,
+      "title": "Stage 2: Multi-Angle Views (Qwen)",
+      "bounding": [
+        -1130,
+        -70,
+        1900,
+        2320
+      ],
+      "color": "#d855f0",
+      "flags": {}
+    },
+    {
+      "id": 9,
+      "title": "Stage 3: Multiview to Mesh (Hunyuan3D)",
+      "bounding": [
+        880,
+        -132,
+        2261,
+        1482
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "Stage 1: Character Sheet (SDXL front view)",
+      "bounding": [
+        -1062.2377294133998,
+        -882.4792163325425,
+        1674.1623954796578,
+        780.1486494704418
+      ],
+      "color": "#8aaa40",
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "98c125f5-6fdd-4736-87a9-7d436431eaea",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Qwen-Image 2511: Batch Angle Generation",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            15230,
+            4040,
+            159.744140625,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            18340.000194797758,
+            3794.999898745823,
+            128,
+            208
+          ]
+        },
+        "inputs": [
+          {
+            "id": "2aebc7b2-a931-4085-ac57-182e7cff47af",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              384,
+              385,
+              386,
+              387,
+              388,
+              389,
+              390,
+              416
+            ],
+            "pos": [
+              15365.744140625,
+              4064
+            ]
+          },
+          {
+            "id": "896da056-e810-47fd-92a0-b447a52ba8a3",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              444,
+              445,
+              446,
+              447,
+              448,
+              450,
+              451,
+              492
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              15365.744140625,
+              4084
+            ]
+          },
+          {
+            "id": "3f330fd2-b51f-452b-9632-e083af6991c2",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              452,
+              453,
+              454,
+              455,
+              456,
+              457,
+              458,
+              459
+            ],
+            "pos": [
+              15365.744140625,
+              4104
+            ]
+          },
+          {
+            "id": "d48ac750-253d-4778-81d6-a1fc161aa532",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              460,
+              461,
+              462,
+              463,
+              464,
+              465,
+              472,
+              474
+            ],
+            "pos": [
+              15365.744140625,
+              4124
+            ]
+          },
+          {
+            "id": "53a27c2a-556d-48b9-bbbc-9cd7899ed0f5",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              466,
+              467,
+              468,
+              469,
+              470,
+              471,
+              473,
+              475
+            ],
+            "pos": [
+              15365.744140625,
+              4144
+            ]
+          },
+          {
+            "id": "8494444e-80e6-4a60-a1be-3064409a7245",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              476,
+              477,
+              478,
+              479,
+              480,
+              481,
+              482,
+              483
+            ],
+            "pos": [
+              15365.744140625,
+              4164
+            ]
+          },
+          {
+            "id": "fab438b2-fc30-4f91-b0c6-a122461042dc",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              484,
+              485,
+              486,
+              487
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              15365.744140625,
+              4184
+            ]
+          },
+          {
+            "id": "15eebefd-eb60-4529-aecf-1608659b7594",
+            "name": "lora_name_1_1",
+            "type": "COMBO",
+            "linkIds": [
+              488,
+              489,
+              490,
+              491
+            ],
+            "label": "lora_name",
+            "pos": [
+              15365.744140625,
+              4204
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "932c03c9-8d46-4e4c-9837-7d609465c087",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              391
+            ],
+            "localized_name": "IMAGE",
+            "label": "close_up",
+            "pos": [
+              18364.000194797758,
+              3818.999898745823
+            ]
+          },
+          {
+            "id": "60507036-4421-4784-aef5-b8727240eadc",
+            "name": "IMAGE_1",
+            "type": "IMAGE",
+            "linkIds": [
+              392
+            ],
+            "localized_name": "IMAGE_1",
+            "label": "45_right",
+            "pos": [
+              18364.000194797758,
+              3838.999898745823
+            ]
+          },
+          {
+            "id": "7b0ef656-505b-4d73-94f1-fdf195fbec7a",
+            "name": "IMAGE_2",
+            "type": "IMAGE",
+            "linkIds": [
+              393
+            ],
+            "localized_name": "IMAGE_2",
+            "label": "aerial_view",
+            "pos": [
+              18364.000194797758,
+              3858.999898745823
+            ]
+          },
+          {
+            "id": "e8eef4a8-850e-49d9-b905-2753ef56ce50",
+            "name": "IMAGE_3",
+            "type": "IMAGE",
+            "linkIds": [
+              395
+            ],
+            "localized_name": "IMAGE_3",
+            "label": "wide_angle",
+            "pos": [
+              18364.000194797758,
+              3878.999898745823
+            ]
+          },
+          {
+            "id": "03e7d392-bcca-4906-a626-5f95eab45f14",
+            "name": "IMAGE_4",
+            "type": "IMAGE",
+            "linkIds": [
+              398
+            ],
+            "localized_name": "IMAGE_4",
+            "label": "90_right",
+            "pos": [
+              18364.000194797758,
+              3898.999898745823
+            ]
+          },
+          {
+            "id": "a7be1ba5-2fa7-4441-8891-c181bb545563",
+            "name": "IMAGE_5",
+            "type": "IMAGE",
+            "linkIds": [
+              397
+            ],
+            "localized_name": "IMAGE_5",
+            "label": "low_angle",
+            "pos": [
+              18364.000194797758,
+              3918.999898745823
+            ]
+          },
+          {
+            "id": "60594445-b009-4241-aca5-5d37a27d131a",
+            "name": "IMAGE_6",
+            "type": "IMAGE",
+            "linkIds": [
+              399
+            ],
+            "localized_name": "IMAGE_6",
+            "label": "90_left",
+            "pos": [
+              18364.000194797758,
+              3938.999898745823
+            ]
+          },
+          {
+            "id": "531d21d4-7432-4269-be66-fd3ec5d231e5",
+            "name": "IMAGE_7",
+            "type": "IMAGE",
+            "linkIds": [
+              417
+            ],
+            "localized_name": "IMAGE_7",
+            "label": "45_left",
+            "pos": [
+              18364.000194797758,
+              3958.999898745823
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 221,
+            "type": "09a153fb-029e-4899-9db4-3022d0c6471e",
+            "pos": [
+              16560,
+              2620
+            ],
+            "size": [
+              400,
+              680
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 384
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 444
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 452
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 460
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 466
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 476
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 484
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  391
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "151",
+                  "prompt"
+                ],
+                [
+                  "168",
+                  "value"
+                ],
+                [
+                  "161",
+                  "unet_name"
+                ],
+                [
+                  "162",
+                  "clip_name"
+                ],
+                [
+                  "146",
+                  "vae_name"
+                ],
+                [
+                  "153",
+                  "lora_name"
+                ],
+                [
+                  "220",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 246,
+            "type": "91f512a2-0f7b-43c8-86e9-13acef67271f",
+            "pos": [
+              16580,
+              3430
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 385
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 492
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 454
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 462
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 468
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 478
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 486
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  392
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "228",
+                  "prompt"
+                ],
+                [
+                  "239",
+                  "value"
+                ],
+                [
+                  "234",
+                  "unet_name"
+                ],
+                [
+                  "235",
+                  "clip_name"
+                ],
+                [
+                  "223",
+                  "vae_name"
+                ],
+                [
+                  "230",
+                  "lora_name"
+                ],
+                [
+                  "245",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 271,
+            "type": "95b8e8d0-5b8d-4240-bbba-0a98797ea03d",
+            "pos": [
+              16580,
+              4220
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 386
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 445
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 456
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 464
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 470
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 480
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 488
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  393
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "253",
+                  "prompt"
+                ],
+                [
+                  "264",
+                  "value"
+                ],
+                [
+                  "259",
+                  "unet_name"
+                ],
+                [
+                  "260",
+                  "clip_name"
+                ],
+                [
+                  "248",
+                  "vae_name"
+                ],
+                [
+                  "255",
+                  "lora_name"
+                ],
+                [
+                  "270",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 296,
+            "type": "cd156ffc-89ca-4185-bcb1-df2b86f7a5c6",
+            "pos": [
+              17870,
+              2630
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 387
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 447
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 453
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 461
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 467
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 477
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 485
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  395
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "278",
+                  "prompt"
+                ],
+                [
+                  "289",
+                  "value"
+                ],
+                [
+                  "284",
+                  "unet_name"
+                ],
+                [
+                  "285",
+                  "clip_name"
+                ],
+                [
+                  "273",
+                  "vae_name"
+                ],
+                [
+                  "280",
+                  "lora_name"
+                ],
+                [
+                  "295",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 321,
+            "type": "b9dd3bfb-c208-4b50-a704-bfddb8f3bebe",
+            "pos": [
+              17850,
+              3450
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 388
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 448
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 455
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 463
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 469
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 479
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 487
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  398
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "303",
+                  "prompt"
+                ],
+                [
+                  "314",
+                  "value"
+                ],
+                [
+                  "309",
+                  "unet_name"
+                ],
+                [
+                  "310",
+                  "clip_name"
+                ],
+                [
+                  "298",
+                  "vae_name"
+                ],
+                [
+                  "305",
+                  "lora_name"
+                ],
+                [
+                  "320",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 346,
+            "type": "45633f1e-e462-4f91-a702-6819a8c5e571",
+            "pos": [
+              17870,
+              4230
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 389
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 451
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 457
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 472
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 471
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 481
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 489
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  397
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "328",
+                  "prompt"
+                ],
+                [
+                  "339",
+                  "value"
+                ],
+                [
+                  "334",
+                  "unet_name"
+                ],
+                [
+                  "335",
+                  "clip_name"
+                ],
+                [
+                  "323",
+                  "vae_name"
+                ],
+                [
+                  "330",
+                  "lora_name"
+                ],
+                [
+                  "345",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 371,
+            "type": "facaba71-e9e6-47a1-97b4-0e43d867c19e",
+            "pos": [
+              17880,
+              4770
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 390
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 450
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 459
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 465
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 475
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 483
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 491
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  399
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "353",
+                  "prompt"
+                ],
+                [
+                  "364",
+                  "value"
+                ],
+                [
+                  "359",
+                  "unet_name"
+                ],
+                [
+                  "360",
+                  "clip_name"
+                ],
+                [
+                  "348",
+                  "vae_name"
+                ],
+                [
+                  "355",
+                  "lora_name"
+                ],
+                [
+                  "370",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 423,
+            "type": "cd13a3cb-0ef1-4937-9e72-7319d4b28e3e",
+            "pos": [
+              16590,
+              4770
+            ],
+            "size": [
+              400,
+              650
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "name": "image",
+                "type": "IMAGE",
+                "link": 416
+              },
+              {
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "enable_turbo_mode",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 446
+              },
+              {
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 458
+              },
+              {
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 474
+              },
+              {
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 473
+              },
+              {
+                "label": "lightning_lora",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 482
+              },
+              {
+                "label": "lora_name",
+                "name": "lora_name_1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name_1"
+                },
+                "link": 490
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  417
+                ]
+              }
+            ],
+            "properties": {
+              "proxyWidgets": [
+                [
+                  "405",
+                  "prompt"
+                ],
+                [
+                  "416",
+                  "value"
+                ],
+                [
+                  "411",
+                  "unet_name"
+                ],
+                [
+                  "412",
+                  "clip_name"
+                ],
+                [
+                  "400",
+                  "vae_name"
+                ],
+                [
+                  "407",
+                  "lora_name"
+                ],
+                [
+                  "422",
+                  "lora_name"
+                ]
+              ],
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 384,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 221,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 385,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 246,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 386,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 271,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 387,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 296,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 388,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 321,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 389,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 346,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 390,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 371,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 416,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 423,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 391,
+            "origin_id": 221,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 392,
+            "origin_id": 246,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 393,
+            "origin_id": 271,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 395,
+            "origin_id": 296,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 398,
+            "origin_id": 321,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 397,
+            "origin_id": 346,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 5,
+            "type": "IMAGE"
+          },
+          {
+            "id": 399,
+            "origin_id": 371,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 6,
+            "type": "IMAGE"
+          },
+          {
+            "id": 417,
+            "origin_id": 423,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 7,
+            "type": "IMAGE"
+          },
+          {
+            "id": 444,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 221,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 445,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 271,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 446,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 423,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 447,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 296,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 448,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 321,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 450,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 371,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 451,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 346,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 452,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 221,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 453,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 296,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 454,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 246,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 455,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 321,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 456,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 271,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 457,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 346,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 458,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 423,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 459,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 371,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 460,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 221,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 461,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 296,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 462,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 246,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 463,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 321,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 464,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 271,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 465,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 371,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 466,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 221,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 467,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 296,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 468,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 246,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 469,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 321,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 470,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 271,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 471,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 346,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 472,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 346,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 473,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 423,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 474,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 423,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 475,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 371,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 476,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 221,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 477,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 296,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 478,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 246,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 479,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 321,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 480,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 271,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 481,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 346,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 482,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 423,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 483,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 371,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 484,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 221,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 485,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 296,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 486,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 246,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 487,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 321,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 488,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 271,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 489,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 346,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 490,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 423,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 491,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 371,
+            "target_slot": 8,
+            "type": "COMBO"
+          },
+          {
+            "id": 492,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 246,
+            "target_slot": 3,
+            "type": "BOOLEAN"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "09a153fb-029e-4899-9db4-3022d0c6471e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 145,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 146,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 147,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 148,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 149,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 150,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 151,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              " Turn the camera to a close-up."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 152,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 153,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 154,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 155,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 156,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 161,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 162,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 163,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 165,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 166,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 168,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 164,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 167,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 169,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              345666571704709,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 158,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 160,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 220,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 149,
+            "origin_slot": 0,
+            "target_id": 147,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 151,
+            "origin_slot": 0,
+            "target_id": 148,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": 149,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 146,
+            "origin_slot": 0,
+            "target_id": 149,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 160,
+            "origin_slot": 0,
+            "target_id": 149,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": 151,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 146,
+            "origin_slot": 0,
+            "target_id": 151,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 160,
+            "origin_slot": 0,
+            "target_id": 151,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 145,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 153,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 160,
+            "origin_slot": 0,
+            "target_id": 156,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 146,
+            "origin_slot": 0,
+            "target_id": 156,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 163,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 153,
+            "origin_slot": 0,
+            "target_id": 163,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 168,
+            "origin_slot": 0,
+            "target_id": 163,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 154,
+            "origin_slot": 0,
+            "target_id": 164,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 155,
+            "origin_slot": 0,
+            "target_id": 164,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 168,
+            "origin_slot": 0,
+            "target_id": 164,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 166,
+            "origin_slot": 0,
+            "target_id": 167,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 165,
+            "origin_slot": 0,
+            "target_id": 167,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 168,
+            "origin_slot": 0,
+            "target_id": 167,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 163,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 148,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 147,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 156,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 167,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 164,
+            "origin_slot": 0,
+            "target_id": 169,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 169,
+            "origin_slot": 0,
+            "target_id": 158,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 146,
+            "origin_slot": 0,
+            "target_id": 158,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 158,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 160,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 151,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 149,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 151,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 149,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 151,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 168,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 161,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 162,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 146,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 153,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 161,
+            "origin_slot": 0,
+            "target_id": 220,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 220,
+            "origin_slot": 0,
+            "target_id": 145,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 220,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "91f512a2-0f7b-43c8-86e9-13acef67271f",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 222,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 223,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 224,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 225,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 226,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 227,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 228,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Rotate the camera 45 degrees to the right.\n"
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 229,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 230,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 231,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 232,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 233,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 234,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 235,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 236,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 237,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 238,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 239,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 240,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 241,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 242,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              94413014144160,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 243,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 244,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 245,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 226,
+            "origin_slot": 0,
+            "target_id": 224,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 228,
+            "origin_slot": 0,
+            "target_id": 225,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 235,
+            "origin_slot": 0,
+            "target_id": 226,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 223,
+            "origin_slot": 0,
+            "target_id": 226,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 244,
+            "origin_slot": 0,
+            "target_id": 226,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 235,
+            "origin_slot": 0,
+            "target_id": 228,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 223,
+            "origin_slot": 0,
+            "target_id": 228,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 244,
+            "origin_slot": 0,
+            "target_id": 228,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 222,
+            "origin_slot": 0,
+            "target_id": 229,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 230,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 244,
+            "origin_slot": 0,
+            "target_id": 233,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 223,
+            "origin_slot": 0,
+            "target_id": 233,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 236,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 230,
+            "origin_slot": 0,
+            "target_id": 236,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 239,
+            "origin_slot": 0,
+            "target_id": 236,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 231,
+            "origin_slot": 0,
+            "target_id": 240,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 232,
+            "origin_slot": 0,
+            "target_id": 240,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 239,
+            "origin_slot": 0,
+            "target_id": 240,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 238,
+            "origin_slot": 0,
+            "target_id": 241,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 237,
+            "origin_slot": 0,
+            "target_id": 241,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 239,
+            "origin_slot": 0,
+            "target_id": 241,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 236,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 225,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 224,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 233,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 241,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 240,
+            "origin_slot": 0,
+            "target_id": 242,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 242,
+            "origin_slot": 0,
+            "target_id": 243,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 223,
+            "origin_slot": 0,
+            "target_id": 243,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 243,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 244,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 228,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 226,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 228,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 226,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 228,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 239,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 234,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 235,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 223,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 230,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 234,
+            "origin_slot": 0,
+            "target_id": 245,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 245,
+            "origin_slot": 0,
+            "target_id": 222,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 245,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "95b8e8d0-5b8d-4240-bbba-0a98797ea03d",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 247,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 248,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 249,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 250,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 251,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 252,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 253,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Turn the camera to an aerial view."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 254,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 255,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 256,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 257,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 258,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 259,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 260,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 261,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 262,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 263,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 264,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 265,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 266,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 267,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              125446141429890,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 268,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 269,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 270,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 251,
+            "origin_slot": 0,
+            "target_id": 249,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 253,
+            "origin_slot": 0,
+            "target_id": 250,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 260,
+            "origin_slot": 0,
+            "target_id": 251,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 248,
+            "origin_slot": 0,
+            "target_id": 251,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 269,
+            "origin_slot": 0,
+            "target_id": 251,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 260,
+            "origin_slot": 0,
+            "target_id": 253,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 248,
+            "origin_slot": 0,
+            "target_id": 253,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 269,
+            "origin_slot": 0,
+            "target_id": 253,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 247,
+            "origin_slot": 0,
+            "target_id": 254,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 254,
+            "origin_slot": 0,
+            "target_id": 255,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 269,
+            "origin_slot": 0,
+            "target_id": 258,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 248,
+            "origin_slot": 0,
+            "target_id": 258,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 254,
+            "origin_slot": 0,
+            "target_id": 261,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 255,
+            "origin_slot": 0,
+            "target_id": 261,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 264,
+            "origin_slot": 0,
+            "target_id": 261,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 256,
+            "origin_slot": 0,
+            "target_id": 265,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 257,
+            "origin_slot": 0,
+            "target_id": 265,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 264,
+            "origin_slot": 0,
+            "target_id": 265,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 263,
+            "origin_slot": 0,
+            "target_id": 266,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 262,
+            "origin_slot": 0,
+            "target_id": 266,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 264,
+            "origin_slot": 0,
+            "target_id": 266,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 261,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 250,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 249,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 258,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 266,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 265,
+            "origin_slot": 0,
+            "target_id": 267,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 267,
+            "origin_slot": 0,
+            "target_id": 268,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 248,
+            "origin_slot": 0,
+            "target_id": 268,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 268,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 269,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 253,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 251,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 253,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 251,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 253,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 264,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 259,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 260,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 248,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 255,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 259,
+            "origin_slot": 0,
+            "target_id": 270,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 270,
+            "origin_slot": 0,
+            "target_id": 247,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 270,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "cd156ffc-89ca-4185-bcb1-df2b86f7a5c6",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 272,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 273,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 274,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 275,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 276,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 277,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 278,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Rotate the camera 180 degrees to show the character's back."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 279,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 280,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 281,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 282,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 283,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 284,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 285,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 286,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 287,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 288,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 289,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 290,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 291,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 292,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              894019412835482,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 293,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 294,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 295,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 276,
+            "origin_slot": 0,
+            "target_id": 274,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 278,
+            "origin_slot": 0,
+            "target_id": 275,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 276,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 273,
+            "origin_slot": 0,
+            "target_id": 276,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 294,
+            "origin_slot": 0,
+            "target_id": 276,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 278,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 273,
+            "origin_slot": 0,
+            "target_id": 278,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 294,
+            "origin_slot": 0,
+            "target_id": 278,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 272,
+            "origin_slot": 0,
+            "target_id": 279,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 279,
+            "origin_slot": 0,
+            "target_id": 280,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 294,
+            "origin_slot": 0,
+            "target_id": 283,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 273,
+            "origin_slot": 0,
+            "target_id": 283,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 279,
+            "origin_slot": 0,
+            "target_id": 286,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 280,
+            "origin_slot": 0,
+            "target_id": 286,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 289,
+            "origin_slot": 0,
+            "target_id": 286,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 281,
+            "origin_slot": 0,
+            "target_id": 290,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 282,
+            "origin_slot": 0,
+            "target_id": 290,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 289,
+            "origin_slot": 0,
+            "target_id": 290,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 288,
+            "origin_slot": 0,
+            "target_id": 291,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 287,
+            "origin_slot": 0,
+            "target_id": 291,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 289,
+            "origin_slot": 0,
+            "target_id": 291,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 286,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 275,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 274,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 283,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 291,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 290,
+            "origin_slot": 0,
+            "target_id": 292,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 292,
+            "origin_slot": 0,
+            "target_id": 293,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 273,
+            "origin_slot": 0,
+            "target_id": 293,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 293,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 294,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 278,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 276,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 278,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 276,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 278,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 289,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 284,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 285,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 273,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 280,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 284,
+            "origin_slot": 0,
+            "target_id": 295,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 295,
+            "origin_slot": 0,
+            "target_id": 272,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 295,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "b9dd3bfb-c208-4b50-a704-bfddb8f3bebe",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            151.744140625,
+            240
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1488.255859375,
+              2970
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1488.255859375,
+              2990
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1488.255859375,
+              3010
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1488.255859375,
+              3030
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1488.255859375,
+              3050
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1488.255859375,
+              3070
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1488.255859375,
+              3090
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1488.255859375,
+              3110
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1488.255859375,
+              3130
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1488.255859375,
+              3150
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2290,
+              2710
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 297,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 298,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 299,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 300,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 301,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 302,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 303,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Rotate the camera 90 degrees to the right.\n"
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 304,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 305,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 306,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 307,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 308,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 309,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 310,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 311,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 312,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 313,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 314,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 315,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 316,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 317,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              293522831863199,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 318,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 319,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 320,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 301,
+            "origin_slot": 0,
+            "target_id": 299,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 303,
+            "origin_slot": 0,
+            "target_id": 300,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 310,
+            "origin_slot": 0,
+            "target_id": 301,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 298,
+            "origin_slot": 0,
+            "target_id": 301,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 319,
+            "origin_slot": 0,
+            "target_id": 301,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 310,
+            "origin_slot": 0,
+            "target_id": 303,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 298,
+            "origin_slot": 0,
+            "target_id": 303,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 319,
+            "origin_slot": 0,
+            "target_id": 303,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 297,
+            "origin_slot": 0,
+            "target_id": 304,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 304,
+            "origin_slot": 0,
+            "target_id": 305,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 319,
+            "origin_slot": 0,
+            "target_id": 308,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 298,
+            "origin_slot": 0,
+            "target_id": 308,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 304,
+            "origin_slot": 0,
+            "target_id": 311,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 305,
+            "origin_slot": 0,
+            "target_id": 311,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 314,
+            "origin_slot": 0,
+            "target_id": 311,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 306,
+            "origin_slot": 0,
+            "target_id": 315,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 307,
+            "origin_slot": 0,
+            "target_id": 315,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 314,
+            "origin_slot": 0,
+            "target_id": 315,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 313,
+            "origin_slot": 0,
+            "target_id": 316,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 312,
+            "origin_slot": 0,
+            "target_id": 316,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 314,
+            "origin_slot": 0,
+            "target_id": 316,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 311,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 300,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 299,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 308,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 316,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 315,
+            "origin_slot": 0,
+            "target_id": 317,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 317,
+            "origin_slot": 0,
+            "target_id": 318,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 298,
+            "origin_slot": 0,
+            "target_id": 318,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 318,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 319,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 303,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 301,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 303,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 301,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 303,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 314,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 309,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 310,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 298,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 305,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 309,
+            "origin_slot": 0,
+            "target_id": 320,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 320,
+            "origin_slot": 0,
+            "target_id": 297,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 320,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "45633f1e-e462-4f91-a702-6819a8c5e571",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 322,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 323,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 324,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 325,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 326,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 327,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 328,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Turn the camera to a low-angle view."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 329,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 330,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 331,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 332,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 333,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 334,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 335,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 336,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 337,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 338,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 339,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 340,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 341,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 342,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              396394480748806,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 343,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 344,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 345,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 326,
+            "origin_slot": 0,
+            "target_id": 324,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 328,
+            "origin_slot": 0,
+            "target_id": 325,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 335,
+            "origin_slot": 0,
+            "target_id": 326,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 323,
+            "origin_slot": 0,
+            "target_id": 326,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 344,
+            "origin_slot": 0,
+            "target_id": 326,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 335,
+            "origin_slot": 0,
+            "target_id": 328,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 323,
+            "origin_slot": 0,
+            "target_id": 328,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 344,
+            "origin_slot": 0,
+            "target_id": 328,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 322,
+            "origin_slot": 0,
+            "target_id": 329,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 329,
+            "origin_slot": 0,
+            "target_id": 330,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 344,
+            "origin_slot": 0,
+            "target_id": 333,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 323,
+            "origin_slot": 0,
+            "target_id": 333,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 329,
+            "origin_slot": 0,
+            "target_id": 336,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 330,
+            "origin_slot": 0,
+            "target_id": 336,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 339,
+            "origin_slot": 0,
+            "target_id": 336,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 331,
+            "origin_slot": 0,
+            "target_id": 340,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 332,
+            "origin_slot": 0,
+            "target_id": 340,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 339,
+            "origin_slot": 0,
+            "target_id": 340,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 338,
+            "origin_slot": 0,
+            "target_id": 341,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 337,
+            "origin_slot": 0,
+            "target_id": 341,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 339,
+            "origin_slot": 0,
+            "target_id": 341,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 336,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 325,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 324,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 333,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 341,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 340,
+            "origin_slot": 0,
+            "target_id": 342,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 342,
+            "origin_slot": 0,
+            "target_id": 343,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 323,
+            "origin_slot": 0,
+            "target_id": 343,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 343,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 344,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 328,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 326,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 328,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 326,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 328,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 339,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 334,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 335,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 323,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 330,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 334,
+            "origin_slot": 0,
+            "target_id": 345,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 345,
+            "origin_slot": 0,
+            "target_id": 322,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 345,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "facaba71-e9e6-47a1-97b4-0e43d867c19e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 347,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 348,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 349,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 350,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 351,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 352,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 353,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Rotate the camera 90 degrees to the left."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 354,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 355,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 356,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 357,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 358,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 359,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 360,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 361,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 362,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 363,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 364,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 365,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 366,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 367,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              96367255219346,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 368,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 369,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 370,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 351,
+            "origin_slot": 0,
+            "target_id": 349,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 353,
+            "origin_slot": 0,
+            "target_id": 350,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 360,
+            "origin_slot": 0,
+            "target_id": 351,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 348,
+            "origin_slot": 0,
+            "target_id": 351,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 369,
+            "origin_slot": 0,
+            "target_id": 351,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 360,
+            "origin_slot": 0,
+            "target_id": 353,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 348,
+            "origin_slot": 0,
+            "target_id": 353,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 369,
+            "origin_slot": 0,
+            "target_id": 353,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 347,
+            "origin_slot": 0,
+            "target_id": 354,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 354,
+            "origin_slot": 0,
+            "target_id": 355,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 369,
+            "origin_slot": 0,
+            "target_id": 358,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 348,
+            "origin_slot": 0,
+            "target_id": 358,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 354,
+            "origin_slot": 0,
+            "target_id": 361,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 355,
+            "origin_slot": 0,
+            "target_id": 361,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 364,
+            "origin_slot": 0,
+            "target_id": 361,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 356,
+            "origin_slot": 0,
+            "target_id": 365,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 357,
+            "origin_slot": 0,
+            "target_id": 365,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 364,
+            "origin_slot": 0,
+            "target_id": 365,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 363,
+            "origin_slot": 0,
+            "target_id": 366,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 362,
+            "origin_slot": 0,
+            "target_id": 366,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 364,
+            "origin_slot": 0,
+            "target_id": 366,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 361,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 350,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 349,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 358,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 366,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 365,
+            "origin_slot": 0,
+            "target_id": 367,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 367,
+            "origin_slot": 0,
+            "target_id": 368,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 348,
+            "origin_slot": 0,
+            "target_id": 368,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 368,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 369,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 353,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 351,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 353,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 351,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 353,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 364,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 359,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 360,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 348,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 355,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 359,
+            "origin_slot": 0,
+            "target_id": 370,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 370,
+            "origin_slot": 0,
+            "target_id": 347,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 370,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "cd13a3cb-0ef1-4937-9e72-7319d4b28e3e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 9,
+          "lastNodeId": 438,
+          "lastLinkId": 501,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Image Edit (Qwen-Image 2511 with LoRA)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1620,
+            2950,
+            159.744140625,
+            248
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2270,
+            2690,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "a803e780-d592-463f-8f79-ac40806342f5",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              362
+            ],
+            "pos": [
+              -1484.255859375,
+              2974
+            ]
+          },
+          {
+            "id": "b607ba47-9db6-4d46-8135-c9ce32fbe751",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              363,
+              366
+            ],
+            "pos": [
+              -1484.255859375,
+              2994
+            ]
+          },
+          {
+            "id": "3fed0eb3-229e-4cd2-b41b-930218b07bed",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              368,
+              369
+            ],
+            "pos": [
+              -1484.255859375,
+              3014
+            ]
+          },
+          {
+            "id": "af7cd39e-e733-45e6-9a4c-8114ba6afd7b",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              370
+            ],
+            "pos": [
+              -1484.255859375,
+              3034
+            ]
+          },
+          {
+            "id": "d51fee09-5345-45b4-9a04-211e5c05207b",
+            "name": "value",
+            "type": "BOOLEAN",
+            "linkIds": [
+              371
+            ],
+            "label": "enable_turbo_mode",
+            "pos": [
+              -1484.255859375,
+              3054
+            ]
+          },
+          {
+            "id": "6f315ea0-75ed-403e-9996-457c34b2d923",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              372
+            ],
+            "pos": [
+              -1484.255859375,
+              3074
+            ]
+          },
+          {
+            "id": "90cb3e3f-ba74-48c6-80da-a9d49e6f4df2",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              373
+            ],
+            "pos": [
+              -1484.255859375,
+              3094
+            ]
+          },
+          {
+            "id": "227ee226-4e5d-41c8-bd5f-f9fbdb8d9e07",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              374
+            ],
+            "pos": [
+              -1484.255859375,
+              3114
+            ]
+          },
+          {
+            "id": "5501ab11-f6c7-419c-94ac-03277c18f179",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              375
+            ],
+            "label": "lightning_lora",
+            "pos": [
+              -1484.255859375,
+              3134
+            ]
+          },
+          {
+            "id": "805253a5-a15c-4277-9243-94dff17f3501",
+            "name": "lora_name_1",
+            "type": "COMBO",
+            "linkIds": [
+              380
+            ],
+            "label": "lora_name",
+            "pos": [
+              -1484.255859375,
+              3154
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "0b1583f6-7dad-4f1c-b035-fd13da1fb9d9",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              344
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2294,
+              2714
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 399,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              80,
+              2700
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 379
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  326
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3.1
+            ]
+          },
+          {
+            "id": 400,
+            "type": "VAELoader",
+            "pos": [
+              -1080,
+              3160
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 374
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  321,
+                  324,
+                  335,
+                  337
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 401,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3170
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 318
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  353
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 402,
+            "type": "FluxKontextMultiReferenceLatentMethod",
+            "pos": [
+              70,
+              3030
+            ],
+            "size": [
+              260,
+              40
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 319
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  352
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextMultiReferenceLatentMethod",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "index_timestep_zero"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 403,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              3020
+            ],
+            "size": [
+              420,
+              240
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 320
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 321
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 322
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 366
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 369
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  318
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#322",
+            "bgcolor": "#533"
+          },
+          {
+            "id": 404,
+            "type": "Note",
+            "pos": [
+              50,
+              3340
+            ],
+            "size": [
+              300,
+              180
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "properties": {
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "The \"Edit Model Reference Method\" nodes above are not needed if you use Comfy files, but may be needed if you use repackaged ones from other people."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 405,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -580,
+              2700
+            ],
+            "size": [
+              430,
+              240
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 323
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 324
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 325
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 363
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 368
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 370
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  319
+                ]
+              }
+            ],
+            "title": "TextEncodeQwenImageEditPlus (Positive)",
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Rotate the camera 45 degrees to the left."
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 406,
+            "type": "CFGNorm",
+            "pos": [
+              80,
+              2870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 326
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  327,
+                  331
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 407,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              510,
+              2940
+            ],
+            "size": [
+              370,
+              170
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 327
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 375
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  332
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Edit-2511-Lightning/resolve/main/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 408,
+            "type": "PrimitiveFloat",
+            "pos": [
+              500,
+              2700
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  328
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4
+            ]
+          },
+          {
+            "id": 409,
+            "type": "PrimitiveFloat",
+            "pos": [
+              510,
+              3330
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  329
+                ]
+              }
+            ],
+            "title": "CFG",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1
+            ]
+          },
+          {
+            "id": 410,
+            "type": "VAEEncode",
+            "pos": [
+              -420,
+              3440
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 13,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "pixels",
+                "name": "pixels",
+                "type": "IMAGE",
+                "link": 334
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 335
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  354
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 411,
+            "type": "UNETLoader",
+            "pos": [
+              -1080,
+              2700
+            ],
+            "size": [
+              400,
+              140
+            ],
+            "flags": {},
+            "order": 14,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 372
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  378
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2511_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2511_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_image_edit_2511_fp8mixed.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 412,
+            "type": "CLIPLoader",
+            "pos": [
+              -1080,
+              2900
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 15,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 373
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  320,
+                  323
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/HunyuanVideo_1.5_repackaged/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 413,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2650
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 16,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "MODEL",
+                "link": 331
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "MODEL",
+                "link": 332
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 333
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "MODEL",
+                "links": [
+                  351
+                ]
+              }
+            ],
+            "title": "Switch (Model)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 414,
+            "type": "PrimitiveInt",
+            "pos": [
+              510,
+              3170
+            ],
+            "size": [
+              370,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  347
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              4,
+              "fixed"
+            ]
+          },
+          {
+            "id": 415,
+            "type": "PrimitiveInt",
+            "pos": [
+              500,
+              2560
+            ],
+            "size": [
+              380,
+              110
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  348
+                ]
+              }
+            ],
+            "title": "Steps",
+            "properties": {
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              40,
+              "fixed"
+            ]
+          },
+          {
+            "id": 416,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              510,
+              3540
+            ],
+            "size": [
+              360,
+              100
+            ],
+            "flags": {},
+            "order": 17,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  330,
+                  333,
+                  350
+                ]
+              }
+            ],
+            "title": "Enable 4steps LoRA?",
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 417,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              3050
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 18,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "FLOAT",
+                "link": 328
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "FLOAT",
+                "link": 329
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 330
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "FLOAT",
+                "links": [
+                  356
+                ]
+              }
+            ],
+            "title": "Switch (CFG)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 418,
+            "type": "ComfySwitchNode",
+            "pos": [
+              950,
+              2870
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 19,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "INT",
+                "link": 348
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "INT",
+                "link": 347
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 350
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "INT",
+                "links": [
+                  355
+                ]
+              }
+            ],
+            "title": "Switch (Steps)",
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 419,
+            "type": "KSampler",
+            "pos": [
+              1280,
+              2650
+            ],
+            "size": [
+              270,
+              350
+            ],
+            "flags": {},
+            "order": 20,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 351
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 352
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 353
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 354
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 355
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 356
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  357
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4"
+            },
+            "widgets_values": [
+              680317904436629,
+              "randomize",
+              40,
+              3,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 420,
+            "type": "VAEDecode",
+            "pos": [
+              1600,
+              2660
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 21,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 357
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 337
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  344
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 421,
+            "type": "FluxKontextImageScale",
+            "pos": [
+              -1090,
+              3440
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {},
+            "order": 22,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 362
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  322,
+                  325,
+                  334
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "FluxKontextImageScale",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.13.0",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 422,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -830,
+              2360
+            ],
+            "size": [
+              400,
+              170
+            ],
+            "flags": {},
+            "order": 23,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 378
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 380
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  379
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "models": [
+                {
+                  "name": "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "url": "https://huggingface.co/fal/Qwen-Image-Edit-2511-Multiple-Angles-LoRA/resolve/main/qwen-image-edit-2511-multiple-angles-lora.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen-image-edit-2511-multiple-angles-lora.safetensors",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Models",
+            "bounding": [
+              -1110,
+              2580,
+              460,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Prompt",
+            "bounding": [
+              -620,
+              2580,
+              519.9999316455545,
+              763.9997080852631
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Original Settings",
+            "bounding": [
+              470,
+              2490,
+              440,
+              343.99988235473757
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "4 Steps Ligtning LoRA",
+            "bounding": [
+              470,
+              2870,
+              450,
+              590
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 5,
+            "title": "Apply LoRA",
+            "bounding": [
+              -1110,
+              2270,
+              1010,
+              290
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 318,
+            "origin_id": 403,
+            "origin_slot": 0,
+            "target_id": 401,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 319,
+            "origin_id": 405,
+            "origin_slot": 0,
+            "target_id": 402,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 320,
+            "origin_id": 412,
+            "origin_slot": 0,
+            "target_id": 403,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 321,
+            "origin_id": 400,
+            "origin_slot": 0,
+            "target_id": 403,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 322,
+            "origin_id": 421,
+            "origin_slot": 0,
+            "target_id": 403,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 323,
+            "origin_id": 412,
+            "origin_slot": 0,
+            "target_id": 405,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 324,
+            "origin_id": 400,
+            "origin_slot": 0,
+            "target_id": 405,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 325,
+            "origin_id": 421,
+            "origin_slot": 0,
+            "target_id": 405,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 326,
+            "origin_id": 399,
+            "origin_slot": 0,
+            "target_id": 406,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 327,
+            "origin_id": 406,
+            "origin_slot": 0,
+            "target_id": 407,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 334,
+            "origin_id": 421,
+            "origin_slot": 0,
+            "target_id": 410,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 335,
+            "origin_id": 400,
+            "origin_slot": 0,
+            "target_id": 410,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 331,
+            "origin_id": 406,
+            "origin_slot": 0,
+            "target_id": 413,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 332,
+            "origin_id": 407,
+            "origin_slot": 0,
+            "target_id": 413,
+            "target_slot": 1,
+            "type": "MODEL"
+          },
+          {
+            "id": 333,
+            "origin_id": 416,
+            "origin_slot": 0,
+            "target_id": 413,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 328,
+            "origin_id": 408,
+            "origin_slot": 0,
+            "target_id": 417,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 329,
+            "origin_id": 409,
+            "origin_slot": 0,
+            "target_id": 417,
+            "target_slot": 1,
+            "type": "FLOAT"
+          },
+          {
+            "id": 330,
+            "origin_id": 416,
+            "origin_slot": 0,
+            "target_id": 417,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 348,
+            "origin_id": 415,
+            "origin_slot": 0,
+            "target_id": 418,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 347,
+            "origin_id": 414,
+            "origin_slot": 0,
+            "target_id": 418,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 350,
+            "origin_id": 416,
+            "origin_slot": 0,
+            "target_id": 418,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 351,
+            "origin_id": 413,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 352,
+            "origin_id": 402,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 353,
+            "origin_id": 401,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 354,
+            "origin_id": 410,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 355,
+            "origin_id": 418,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 356,
+            "origin_id": 417,
+            "origin_slot": 0,
+            "target_id": 419,
+            "target_slot": 5,
+            "type": "FLOAT"
+          },
+          {
+            "id": 357,
+            "origin_id": 419,
+            "origin_slot": 0,
+            "target_id": 420,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 337,
+            "origin_id": 400,
+            "origin_slot": 0,
+            "target_id": 420,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 344,
+            "origin_id": 420,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 362,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 421,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 363,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 405,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 366,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 403,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 368,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 405,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 369,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 403,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 370,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 405,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 371,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 416,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 372,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 411,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 373,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 412,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 374,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 400,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 375,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 407,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 378,
+            "origin_id": 411,
+            "origin_slot": 0,
+            "target_id": 422,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 379,
+            "origin_id": 422,
+            "origin_slot": 0,
+            "target_id": 399,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 380,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 422,
+            "target_slot": 1,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.29072531383148587,
+      "offset": [
+        3647.936432023975,
+        1609.661910954665
+      ]
+    },
+    "frontendVersion": "1.45.20",
+    "node_versions": {
+      "comfy-core": "0.3.35"
+    },
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "ue_links": [],
+    "links_added_by_ue": []
+  },
+  "version": 0.4
+}

--- a/design/previz-research-notes.md
+++ b/design/previz-research-notes.md
@@ -175,7 +175,141 @@ on this split is resolved — encode it as skill guidance.
   Direct-to-mp4: `file_format='FFMPEG'`, `ffmpeg.format='MPEG4'`,
   `ffmpeg.codec='H264'`, set `fps`/`frame_start`/`frame_end`/`filepath`.
 
-## 6. Numeric anchors for the H1 skill (cheat sheet)
+## 6. Round 3 — more creators, downloadable workflows, non-Blender sources
+
+### 6.1 Finds that change the plan
+
+- **ComfyUI-UniRig** ([PozzettiAndrea/ComfyUI-UniRig](https://github.com/PozzettiAndrea/ComfyUI-UniRig))
+  — wraps **UniRig** (VAST/Tripo, SIGGRAPH 2025, trained on 14k+ rigs incl.
+  quadrupeds) *and* **Make-It-Animatable** (CVPR 2025; skeleton/skin-weight
+  prediction "in under a second" — this is the "skin token" from the
+  PixelArtistry video). Mesh in → **Mixamo-compatible rigged FBX** out,
+  local, free, self-contained (bundles Blender). **The mixamo.com manual hop
+  is optional, not structural.** Cloud alternates with real APIs: Meshy
+  rigging/animation endpoints ([docs](https://docs.meshy.ai/en/api/rigging),
+  rig + 600-clip library retarget; zero-credit claim UNVERIFIED), Tripo
+  one-shot rig+retarget SDK, Anything World (best on non-humanoids).
+- **ComfyUI-Yedp-Action-Director** ([yedp123](https://github.com/yedp123/ComfyUI-Yedp-Action-Director))
+  — an interactive **3D viewport node inside ComfyUI**: up to 16
+  Mixamo-rigged characters, clip sequencing, webcam facial capture, cameras/
+  HDRIs, baking **7 synchronized passes** (OpenPose/Depth/Canny/Normal/
+  Shaded/Alpha/Textured) straight into ControlNet/VACE pipelines. "Previz
+  without opening Blender" — a natural first rung below the full Blender leg.
+- **SCAIL / SCAIL-2** (zai-org, on Wan 2.1 14B) — early-2026 content is
+  migrating motion transfer from Wan Animate to SCAIL-2: end-to-end (no
+  skeleton/pose maps), better multi-character, GGUF builds down to **~6GB**
+  ([tutorial](https://www.stablediffusiontutorials.com/2026/06/wan2.1-scail2.html),
+  [RunComfy graph](https://www.runcomfy.com/comfyui-workflows/scail-2-motion-transfer-in-comfyui-reference-image-to-video)).
+  The H2 pack choice (Animate vs SCAIL-2 vs both) should be re-checked at
+  build time.
+- **Kling 2.6 Motion Control** — third API path, simplest possible graph
+  (LoadVideo + LoadImage → `KlingMotionControl`): motion+expression transfer
+  with identity lock; reference 3–30s ([template](https://comfy.org/workflows/api_kling_motion_control-8f381a482443/)).
+- **Self-filmed phone video is the community default previz** for
+  single-character work (MDMZ, Max Novak, Benji, Intellectz all assume a
+  performer video). Filming consensus: full body/mid-shot with hands visible,
+  locked tripod, no cuts, even lighting, big readable motion, minimal frame
+  traversal. The 3D path stays necessary for camera choreography,
+  multi-character blocking, and non-human proportions.
+
+### 6.2 Creators (beyond rounds 1–2)
+
+- **Purz** ([comfy.org author](https://www.comfy.org/workflows/purz/)) —
+  official templates: Wan 2.2 Animate auto character-replace / full-scene
+  (**Nano Banana 2 auto-derives the swap reference from the video's first
+  frame** — unattended swaps), 4K Seedance R2V, SAM3 text-prompt video
+  masking; [blender-ai-keyframes](https://github.com/purzbeats/blender-ai-keyframes)
+  converts audio to Blender f-curves → exported as AI-param schedules.
+- **toyxyz** ([Gumroad rig](https://toyxyz.gumroad.com/l/ciojz)) — "character
+  bones that look like OpenPose": retarget any character/mocap onto it and
+  Blender renders **all ControlNet passes simultaneously** (OpenPose incl.
+  wan-scale, depth, canny, face landmark, fingers); the foundational Blender
+  control-pass rig everyone else builds on.
+- **ggvfx** ([production workflows](https://github.com/ggvfx/comfyui-workflows))
+  — real VFX production: camera-track a live plate → rebuild the move on
+  **Unreal grey-box geometry** → grey-box render as driving video → depth
+  ControlNets for Wan VACE *or* straight into Seedance R2V → comp in Nuke.
+  Also SCAIL for pose+camera match. Proves greybox-as-driving-plate at
+  production quality, 24GB VRAM.
+- **Benji (Future Thinker)** ([Patreon](https://www.patreon.com/aifuturetech))
+  — iClone 8 + AI Render → ComfyUI v2v; long-video "All-In-Looping": Animate
+  + VACE Fun + PUSA LoRA with **overlap-frame stitching** to kill reversed
+  motion and color shift.
+- **Sebastian Kamph** ([workflow](https://www.patreon.com/posts/restyle-with-wan-127437500))
+  — restyle-one-frame pattern: extract frame 1 (`frame_load_cap=1`), restyle
+  that single image anywhere, VACE 14B propagates it across the clip.
+  Cheapest look-dev iteration loop.
+- **MDMZ** ([RunComfy collab](https://www.runcomfy.com/comfyui-workflows/wan-2-2-animate-swap-characters-lip-sync-workflow-comfyui))
+  — character swap + lip-sync: original audio muxed back via
+  VHS_VideoCombine; filming guidance for self-filmed drivers.
+- **Max Novak** ([tutorial](https://www.youtube.com/watch?v=0trUwzli5G0)) —
+  masking-free pure pose-drive variant; long takes via un-bypassing WanVideo
+  **context options** with frame-window = context-frame count.
+- **Intellectz** ([free workflow](https://www.patreon.com/posts/wan-animate-for-141999455))
+  — QA gate: workflow **pauses at the Points Editor with an audio chime** so
+  masks are verified before GPU time burns.
+- **Esha Sharma / AIStudyNow** ([FusionX VACE](https://aistudynow.com/how-to-use-wan-2-1-fusionx-vace-in-comfyui-workflow-included/))
+  — dual ControlNet (Canny + DWPose) motion capture, 125 frames @ 1024×576;
+  documented drop-one-ControlNet VRAM fallback.
+- **Reallusion AI Render** (iClone/CC, [open beta](https://magazine.reallusion.com/2025/07/28/ai-render-for-iclone-character-creator-enters-open-beta-with-comfyui-workflow/))
+  — the productized competitor: iClone ships **3D-derived Depth / 3D OpenPose
+  / Normal / geometry Canny** into ComfyUI with 22 presets; their stated
+  finding matches ours — 3D-sourced passes beat 2D estimation for temporal
+  stability.
+- **Vladimir Chopine, Nerdy Rodent, enigmatic_e, GET GOING FAST** — v2v
+  restyle / Wan-Animate variants (depth-guided stylization; VACE Fun
+  character consistency; mask-region infill to repair hands/faces; FP8+GGUF
+  twin workflows + Triton/SageAttention ~50% speedups).
+- Negative findings: **Curious Refuge** (paywalled coursework, no public
+  pipeline), **Dave Clark/Promise** (advocacy, no reproducible workflow),
+  **JSFilmz** (previz education, no AI-restyle leg), **Latent Vision /
+  Olivio / Aitrepreneur / AI Search** (no 3D-previz pipeline published).
+
+### 6.3 Downloadable workflow shortlist (H2 pack candidates / references)
+
+| Workflow | Why it matters |
+| --- | --- |
+| [Wan2.1 VACE control video (official)](https://comfy.org/workflows/video_wan_vace_14B_v2v-2652985596d8/) | The graph our previz depth/pose render plugs into directly |
+| [shanef3d "Video Restyle"](https://comfy.org/workflows/templates_shane_video_restyle-5931e9bdf9db/) | First-frame styling + Canny/Depth switch, VACE propagation |
+| [Purz Wan2.2 Animate auto full-scene](https://comfy.org/workflows/templates_purz_wan22_animate_auto_full_scene-840b6e4c3983/) | Fully automatic replace (YOLO+ViTPose+SAM2, no point-picking) |
+| [The_frizzy1 GGUF unlimited-length loop](https://civitai.com/models/2046477) | Loop-node extension; 12GB @ Q8, down to 4GB @ Q4 |
+| [Coyote_98 low-VRAM Animate](https://civitai.com/models/1980698) | 12GB/32GB: 113 frames @ 640p in ~10 min |
+| [SCAIL-2 motion transfer](https://www.runcomfy.com/comfyui-workflows/scail-2-motion-transfer-in-comfyui-reference-image-to-video) | The multi-character / no-pose-map successor |
+| [Kling 2.6 Motion Control (API)](https://comfy.org/workflows/api_kling_motion_control-8f381a482443/) | 4-node API path; ref 3–30s |
+| [Minta Seedance Multiframe Stitch](https://www.comfy.org/workflows/araminta-k/) | Keyframe beat-boards → one continuous clip |
+| [Storyboard To Video (Seedance)](https://comfy.org/workflows/f4e29143100c-f4e29143100c/) | Scene text → 8-panel storyboard → animated — previz-to-final in one graph |
+| [LTX 2.3 Cameraman IC-LoRA](https://comfy.org/workflows/460daa6b205d-460daa6b205d/) | Camera-move transfer from reference clip onto a styled still |
+| [Video→OpenPose utility](https://comfy.org/workflows/utility-openpose-video-dc73712c1842/) | Standard front-end when the reference is live footage |
+
+### 6.4 Wan 2.2 Animate concrete settings (for the H1 skill)
+
+From [stablediffusiontutorials.com](https://www.stablediffusiontutorials.com/2025/09/wan2.2-animate.html):
+start at **640px** (author OOM'd at 1120, succeeded at 960); **KSampler 6
+steps** (1–2 test / 7–10 quality), **CFG 1.0**, Euler/simple, denoise 1.0;
+Relight + lightx2v rank64 LoRAs; ≤5s input recommended; Points Editor: 5–10
+green dots on character, red on background; Mix vs Pose mode = connect vs
+disconnect `background_video`+`mask`.
+
+### 6.5 Motion/mocap tools with agent-drivable APIs (Mixamo-library alternates)
+
+- **Move AI** ([developers.move.ai](https://developers.move.ai/docs/api-reference/)) —
+  phone video → FBX/BVH/GLB/**.blend** via GraphQL API; best-in-class agent fit.
+- **DeepMotion SayMotion** ([REST API](https://github.com/DeepMotion/SayMotion-REST-API)) —
+  **text prompt → animation** (FBX/GLB/BVH); free 25 credits/mo, $15/mo tier.
+- **Text2Motion** ([Blender add-on](https://github.com/text2motion/blender-integration)) —
+  text → animation applied directly to an in-scene armature via REST API; the
+  most agent-friendly text-to-animation path into Blender.
+- **Kinetix** — video→anim freeware + Text2Emotes API; its models are licensed
+  *into* Mixamo. **Cascadeur** ($12/mo Indie for FBX export) is human-in-the-loop
+  polish, poor headless fit. **Rokoko Vision** free tier is single-cam FBX only.
+- Camera-only: Seedance accepts **"@Video1 for camera movement only"**;
+  [CinePack](https://superhivemarket.com/products/cinepack-pre-animated-camera-moves)
+  ships 120+ pre-animated Blender camera moves — render them over greybox to
+  mass-produce camera reference clips (no published pre-rendered pack exists;
+  gap/opportunity). [ReCamMaster](https://jianhongbai.github.io/ReCamMaster/)
+  re-renders an existing video along a *new* camera path.
+
+## 7. Numeric anchors for the H1 skill (cheat sheet)
 
 | Thing | Number |
 | --- | --- |

--- a/design/previz-research-notes.md
+++ b/design/previz-research-notes.md
@@ -309,6 +309,50 @@ disconnect `background_video`+`mask`.
   gap/opportunity). [ReCamMaster](https://jianhongbai.github.io/ReCamMaster/)
   re-renders an existing video along a *new* camera path.
 
+## 6.6 Community counter-proposal (Discord, seanmcmagic — agent-drafted, taken with salt)
+
+A session-tested argument + alternative architecture, preserved faithfully:
+
+- **The "why", sharpened**: the panel's real value is that Claude acts on
+  **live, current state** instead of frozen training data — live model cards
+  corrected guessed CFG/negative/resolution settings all session; the
+  Hub catalog changes daily and can't be baked into weights; the agent had no
+  idea how the panel's own consent gate worked until it read live source. A
+  Blender integration gives the same superpower on the 3D side: the agent
+  sees *your actual rig, scene, and pose* instead of hallucinating plausible
+  bpy calls. And posed skeleton/depth export **solves multi-character
+  composition by construction** (who's touching whom, camera angle) — which
+  text prompting never reliably did.
+- **Proposed architecture** (differs from the RFC's): fork an existing bpy
+  socket bridge (ahujasid/blender-mcp), mirror the comfyui-mcp two-package
+  split — `blender-agent-panel` (thin Blender add-on, UI only) +
+  `blender-mcp-orchestrator` (npx-launched tool host, loopback WS, different
+  port) — and expose **~15 curated named tools instead of raw Python**
+  (`blender_get_scene_outline`, `blender_render_viewport`,
+  `blender_add_object`, `blender_set_transform`, `blender_list_bones`,
+  `blender_set_bone_rotation`, `blender_apply_pose_preset`,
+  `blender_export_pose_map`, `blender_export_camera_keyframes`,
+  `blender_bake_depth_pass`, `blender_bake_normal_pass`,
+  `blender_get_camera_params`, …). Reuse the existing consent file
+  (`~/.comfyui-mcp/panel-settings.json`). Build order: read-only bridge →
+  **pose + camera tools together** (not camera-first) → ComfyUI round trip
+  (both API and local paths) → mobile app card.
+- **Model-agnostic exports**: pose/camera leave Blender as generic artifacts
+  (skeleton image/video, depth map, keyframe JSON), and the *downstream* node
+  decides the backend — Seedance for paid cinematic work (server-side content
+  filtering), Wan Animate/ControlNet for local unrestricted work.
+- **Prior art flagged**: [alexisrolland/ComfyUI-Blender](https://github.com/alexisrolland/ComfyUI-Blender)
+  (175+ stars, on the Comfy Registry) — Blender triggers ComfyUI workflows,
+  but one-directional with no pose/scene export; UI-pattern reference only.
+
+RFC disposition (see the vision doc's architecture section): adopt the
+live-state framing, model-agnostic exports, pose+camera-together ordering,
+and the prior-art pointer; hold the fork-and-own-two-packages architecture as
+an open question against the official-MCP-via-companion-servers approach —
+the curated-tools concern is real (small local models struggle with raw bpy;
+same lesson as compact tool mode #97/#113) but may be answerable with skill
+recipes over the official server before owning a whole Blender add-on.
+
 ## 7. Numeric anchors for the H1 skill (cheat sheet)
 
 | Thing | Number |

--- a/design/previz-research-notes.md
+++ b/design/previz-research-notes.md
@@ -1,0 +1,190 @@
+# Previz-to-video — field research notes (round 2)
+
+**Companion to:** [`previz-to-video.md`](./previz-to-video.md) (RFC PR #187) ·
+**Researched:** 2026-07-09, web-sourced, citations inline. UNVERIFIED items flagged.
+
+How creators actually run "block in 3D → render motion reference → AI restyle"
+pipelines today, plus operational facts for the two model legs and the official
+Blender MCP. This is the evidence base for the H1 skill's concrete numbers.
+
+---
+
+## 1. Named prior art (processes worth stealing from)
+
+### Doug Hogan — "Seedance Playblast2Render" (closest analog to our Seedance leg)
+[comfy.org workflow](https://comfy.org/workflows/ef543bd4a773-ef543bd4a773/) ·
+[YouTube](https://www.youtube.com/watch?v=5DfpOf6VPR4)
+
+Raw CG **playblast** (blockout, no materials) → final shot. Five groups:
+`VHS_LoadVideo` + `VHS_VideoInfo` **extract fps/duration from the playblast
+itself** and compute output frame counts (sidesteps fps mismatch entirely) →
+optional hero-frame picks for style exploration → **Nano Banana Pro generates
+multi-angle reference boards** from those hero frames → a Gemini node builds a
+"shot-aware prompt" → `ByteDance2ReferenceNode` gets playblast + reference
+board to "lock in motion, silhouette, and camera." Troubleshooting: raise
+reference influence for style, **simplify the prompt when drift appears, fix
+seeds for repeatable iteration**.
+
+### Mickmumpitz — AI Renderer 2.0 + 3D Movie Pipeline (the control-pass school)
+[Guide](https://mickmumpitz.ai/guides/ai-powered-3d-animation-rendering) ·
+[RunComfy mirror](https://www.runcomfy.com/comfyui-workflows/blender-to-comfyui-ai-renderer-2-0-workflow-cinematic-video-output) ·
+[3D Movie Pipeline post](https://mickmumpitz.ai/posts/new-video-free-161509029?synced=1)
+
+Fully local (Wan 2.1 VACE + SkyReels merge; newer pipeline FLUX.2 + LTX-2.3).
+Renders **explicit control passes** from Blender rather than one clay video:
+- **Layout/outline**: Workbench engine, MatCap shading, Cavity + Outlines on
+  (feeds Canny-style control). Older recipe: Freestyle white-line pass.
+- **Depth**: Z pass → compositor Invert + Map Range (near=white, normalized).
+  Native Blender depth beats monocular estimation of the render.
+- **Color-ID masks**: flat emission shader per object, record hex codes →
+  regional prompting per object/character (the standard multi-character answer).
+- **Mouth mask** (dialogue): white = locked to 3D, black = AI freedom; + a
+  dialogue MP3 → LTX lip sync.
+Rules: **fps + aspect identical between Blender and workflow**; resolution
+divisible by 64 (LTX); ≤3 reference frames (LTX); character held by a
+"consistency LoRA" at ~0.7; Wan VACE window **121 frames, 4n+1 rule**, iterative
+batch-splitting beyond that. Multiple style refs override the start frame.
+
+### Evolink / community — "Awesome Blender + Seedance Workflow Usecases" (28 cases)
+[github.com/Evolink-AI/…](https://github.com/Evolink-AI/Awesome-Blender-Seedance-Workflow-Usecases)
+(mirror: cheercheung/…)
+
+The canonical loop, several cases **agent-built via Blender MCP** ("Codex/Claude
+builds the blockout in 2–3 minutes, exports MP4"). Renders are **gray-box /
+clay viewport previews, no materials** — "purely motion/camera guidance."
+Layered control: the reference *video* carries camera + character positioning;
+still *images* carry environment/style. Three camera patterns: Blender-only
+camera; hybrid (Blender camera + external start frame); position-only
+(reference controls placement, prompt recovers dynamism). Recorded failures:
+**foot sliding** (fix with prompt reinforcement, not stricter imitation), cloth
+physics, **character proportions must match beyond height**, multi-cut
+reference videos get "averaged."
+
+### Corridor Digital — "Anime Rock, Paper, Scissors" (the archetype, 2023)
+[Kotaku coverage](https://kotaku.com/anime-rock-paper-scissors-corridor-digital-ai-animation-1850186624)
+
+Live-action → Dreambooth-trained SD (style-locked on the target film) →
+per-frame img2img → deflicker. Lessons that still hold: strongest character
+consistency comes from **training on the target style/character** (today: a
+LoRA), and **backgrounds stay 3D and get restyled separately** from performers.
+
+### Adjacent
+- **Pallaidium** ([tin2tin/Pallaidium](https://github.com/tin2tin/Pallaidium)) —
+  gen-AI studio inside Blender's VSE; already wraps Seedance 2.0 R2V (≤9 image
+  refs) — the whole loop without leaving Blender.
+- **Banodoco / Steerable Motion** ([repo](https://github.com/banodoco/Steerable-Motion)) —
+  keyframe-batch alternative: render N hero stills from the previz and travel
+  between them (Wan VACE anchors).
+
+## 2. Seedance 2.0 in ComfyUI — operational facts
+
+- Nodes in ComfyUI core (`comfy_api_nodes/nodes_bytedance.py`, category
+  `partner/video/ByteDance`): `ByteDance2TextToVideoNode`,
+  **`ByteDance2ReferenceNode`** (R2V), `ByteDance2FirstLastFrameNode`, plus
+  Create Image/Video Asset (one-time liveness check for real-person portraits;
+  AI faces skip it). Templates: `api_seedance2_0_{t2v,r2v,flf2v}`,
+  `api_seedance2_0_mini_{t2v,r2v}`.
+  [docs.comfy.org](https://docs.comfy.org/tutorials/partner-nodes/bytedance/seedance-2-0)
+- **Reference limits**: ≤9 images, ≤3 videos (each ≥1.8s, total ≤15.1s,
+  480p–1080p, 24–60 fps, ≤50MB), ≤3 audio. Output: **4–15s discrete**
+  (default 7), 480p→4K (Fast/Mini: ≤720p), seed + watermark + audio toggles.
+- **Prompt syntax**: `@Image1…@Video1…@Audio1` with explicit roles — "Keep the
+  motion of @Video1, replace subject with @Image1", "Follow the camera path
+  from @Video1", "apply the slow right-to-left dolly from @video1 starting at
+  the 3-second mark". Omitting roles causes morphing. Motion = video refs;
+  aesthetics = text.
+- **Cost** ([pricing](https://docs.comfy.org/tutorials/partner-nodes/pricing),
+  211 credits = $1, tokens = dur × w × h × fps ÷ 1024): with a video ref a 5s
+  720p R2V ≈ **$0.66** (Mini ≈ $0.32); video-ref generations bill at a *lower*
+  per-token rate than pure T2V. Content-policy rejections still consume credits.
+- **Community sweet spot: 6–8s per shot**; 12s+ brings drift/color shift —
+  "3 shots and stitch." Greybox reference videos are a proven input; known
+  weak spots: foot contact, cloth, stiffness under pure imitation (reinforce
+  with prompt language).
+- **Versions**: Seedance 2.0 / 2.0 Fast / 2.0 Mini are what exist in ComfyUI
+  today. **"Seedance 5.0" does not exist** — that's **Seedream 5.0**, the
+  *image* model. Latest video model is **Seedance 2.5** (native 30s single
+  segment, up to 50 refs, region-local editing) with **no ComfyUI partner
+  nodes yet** as of 2026-07-09.
+
+## 3. Wan 2.2 Animate — operational facts
+
+- Native template `video_wan2_2_14B_animate` (core node `WanAnimateToVideo`) or
+  **Kijai WanVideoWrapper** for the power path (block swap, context windows,
+  fp8 scaled). [docs.comfy.org](https://docs.comfy.org/tutorials/video/wan/wan2-2-animate)
+- **16 fps native, 77-frame windows (~4.8s)**; extend by chaining 77-frame
+  segments (native) or `WanVideoContextOptions` sliding windows (wrapper —
+  "doesn't degrade over time," VRAM-capped regardless of length). Resolution
+  multiples of 16.
+- Quant tiers: fp8 scaled ~19GB (24GB cards standard fit); GGUF Q4_K_M 11.5GB →
+  Q8 18.7GB for 16GB cards; optional lightx2v 4-step LoRA; relight LoRA for
+  replacement-mode lighting harmonization.
+- Chain: **DWPose Estimator** extracts pose+face from the driving video (feed
+  normal RGB — no pre-baked skeleton needed); Points Editor + **SAM2** mask for
+  **mix/replace** mode; **move/animate** mode (our previz case) = disconnect
+  `background_video`/`character_mask`.
+- **Driving-video requirement**: DWPose needs a **readable humanoid** —
+  silhouette, face, hands. A greybox humanoid rig should track (UNVERIFIED for
+  literal flat-grey mannequins — H0 must test this); non-humanoid or extreme
+  proportions won't. Community guidance: **calm camera, fixed lens** when
+  identity matters — aggressive moves mutate faces.
+
+**Routing rule this implies (confirmed by both research threads):** camera
+language and staging live in the **Seedance** reference video; **Wan Animate**
+is the character-performance transfer with a stable camera. The RFC's gut-check
+on this split is resolved — encode it as skill guidance.
+
+## 4. Mixamo mechanics
+
+- **Auto-rig upload**: FBX (embed media for textures) / OBJ / ZIP, **≤300MB**;
+  T-pose or A-pose, clean humanoid, no extra scene objects (cameras/empties
+  break the rigger), no wings/tails/props, no existing rig. Marker placement
+  (chin/wrists/elbows/knees/groin) → server-side skeleton + weights.
+  [Adobe help](https://helpx.adobe.com/creative-cloud/help/mixamo-rigging-animation.html)
+- **Download for Blender**: FBX Binary, 30 or 60 fps, **no keyframe
+  reduction**; first clip *With Skin*, subsequent clips *Without Skin*.
+  **"In Place"** strips forward translation — usually wanted, so the Blender
+  scene owns world-space travel and the reference video stays readable.
+- **Retargeting (2026 state)**: free **"Retarget" extension** on
+  extensions.blender.org (Blender 5+, Mixamo preset) is the default;
+  **Auto-Rig Pro** (paid, Remap + Mixamo preset, hips-as-root so translation
+  retargets) is the quality pick; Rokoko plugin free but lags releases.
+  Mixamo skeletons root at the **hips** — the free "Import Mixamo - Root
+  Motion" extension bakes hip translation to a generated root bone when engines
+  need it.
+
+## 5. Official Blender MCP — what the agent actually gets
+
+> Distinguish **official** (`projects.blender.org/lab/blender_mcp`, Gitea) from
+> the community `ahujasid/blender-mcp` (PyPI) several tutorials use. The
+> official one: Blender add-on (TCP, auto-start) + stdio MCP server; tools
+> auto-discovered from `mcp/blmcp/tools/`; ships `prompts.yml` + bpy API docs +
+> manual excerpts as context. (Lab pages 403 automated fetchers; tool
+> identifiers below are from official descriptions, not confirmed verbatim.)
+
+- Tools: execute Python **in the connected instance** or **in a background
+  headless Blender** (sandbox that can't wreck the open file); blend-file
+  summary; bpy API docs lookup; **screenshot of an area/window**; render to
+  path with current settings.
+- **Fast previz render recipe** (via execute_python, for the H1 skill):
+  `bpy.ops.render.opengl(animation=True, view_context=True)` captures the
+  viewport shading — orders of magnitude faster than EEVEE/Cycles. Headless:
+  `view_context=False` + `scene.render.engine = 'BLENDER_WORKBENCH'`. Knobs:
+  `scene.display.shading.light = 'MATCAP'|'STUDIO'|'FLAT'`,
+  `.color_type = 'SINGLE'|'RANDOM'|'MATERIAL'`, `.show_object_outline`.
+  Direct-to-mp4: `file_format='FFMPEG'`, `ffmpeg.format='MPEG4'`,
+  `ffmpeg.codec='H264'`, set `fps`/`frame_start`/`frame_end`/`filepath`.
+
+## 6. Numeric anchors for the H1 skill (cheat sheet)
+
+| Thing | Number |
+| --- | --- |
+| Seedance refs | ≤9 images, ≤3 videos (≤15.1s total), ≤3 audio |
+| Seedance output | 4–15s discrete; aim **6–8s/shot**; 1080p@24 typical |
+| Seedance R2V cost | ~$0.66 / 5s @ 720p (Mini ~$0.32); rejections still bill |
+| Wan Animate | 16 fps, 77-frame (~4.8s) windows, chained; res %16 |
+| Wan VRAM | fp8 ~19GB (24GB cards); GGUF Q4_K_M 11.5GB (16GB cards) |
+| Wan VACE (control-pass leg) | 121-frame window, 4n+1 rule |
+| Blender render | fps/aspect must equal workflow; Hogan pattern: read fps from the playblast |
+| Mixamo upload | ≤300MB FBX/OBJ/ZIP, T/A-pose, no extra objects |
+| Mixamo download | FBX Binary 30/60fps, no keyframe reduction, In Place for locomotion |

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -1,5 +1,7 @@
 # Previz-to-video — 3D-blocked reference scenes for motion-controlled AI video (vision doc)
 
+**Status:** draft (RFC PR #187) · **Implementation branch:** `spec/previz-to-video`
+
 > Living doc. Casual "run it by a smart friend" framing at the top; concrete
 > architecture + phases below. Draft — shaping it before building.
 

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -1,0 +1,172 @@
+# Previz-to-video — 3D-blocked reference scenes for motion-controlled AI video (vision doc)
+
+> Living doc. Casual "run it by a smart friend" framing at the top; concrete
+> architecture + phases below. Draft — shaping it before building.
+
+---
+
+## The pitch
+
+Prompting alone can't direct a shot. You can get *a* beautiful video out of Wan
+or Seedance, but you can't get **the** shot — this character crosses frame left
+while the camera dollies past that prop, beat lands on frame 40. The most
+reliable control signal we have today isn't words, it's **a pre-animated 3D
+scene**: block the shot in Blender with rigged characters and a keyframed
+camera, render a cheap untextured preview, and hand that to a video model as a
+motion/camera reference. The model keeps the body movement, timing, camera
+motion and pacing — and repaints everything else from reference images. Swap
+the reference images, keep the animation: infinite restyles of one shot.
+
+ComfyUI's own demo of exactly this recipe:
+[Seedance 2.0 restyling a Blender/Mixamo previz](https://www.youtube.com/watch?v=3r6qzGGNK8s)
+— Mixamo characters + a generated bus + keyframed camera, rendered rough, then
+"follow the exact same body movement, timing, camera motion and pacing from the
+reference video; change the appearance to match the reference images."
+
+The reason this belongs in comfyui-mcp: **every step of that pipeline is
+agent-drivable now.** Blender ships an official MCP (5.1+). Meshy 6 partner
+nodes live in ComfyUI core for text/image→3D assets. Wan 2.2 Animate runs the
+free local path; Seedance 2.0 Reference-to-Video is the paid API path. Our
+agent already does story→scenes→frames→clips (the `director` skill). What's
+missing is the **cinematography department**: a skill + pack that teaches the
+agent to previz a scene in Blender and cash it out through ComfyUI. You'd tell
+the panel "two characters argue on a rooftop, camera circles them, then one
+walks off a ledge — make it look like a 90s anime" and the agent blocks it,
+renders the reference, and restyles it — asking before it spends credits.
+
+## Evidence this works today
+
+- [ComfyUI (official): style-swapping one Blender animation](https://www.youtube.com/watch?v=3r6qzGGNK8s)
+  — the core recipe end-to-end: Mixamo + Tripo asset + camera keyframes →
+  rough render → Seedance 2.0 R2V with character/environment ref images.
+  Confirms: no textures/lighting needed in the previz; camera motion survives.
+- [PixelArtistry: Claude took over ComfyUI + Blender](https://www.youtube.com/watch?v=KdYv_TT-ZnQ)
+  — Claude driving Blender MCP + a ComfyUI MCP together: batch asset kits
+  (image model → img2mesh → import to Blender), retopo/bake cleanup, and
+  text-to-animation (Kinetix) retargeted onto rigged characters. Confirms: the
+  dual-MCP orchestration pattern holds up for real multi-step 3D work.
+- [Stefan 3D AI: official Blender MCP setup](https://www.youtube.com/watch?v=wSY1kHXSap0)
+  — the official 5.1 add-on is drag-drop + auto-start, Claude connector is
+  one-click; agent-built materials, geometry nodes, baking, LODs all in single
+  prompts. Confirms: setup friction is low enough to put in a skill.
+- [PixelArtistry: 3D AI news #13](https://www.youtube.com/watch?v=N15zYcv0Snk)
+  — the surrounding ecosystem (retopo, splats, markerless mocap) is compounding
+  fast; spatial reasoning in current Claude models is measurably better.
+
+## The pieces on the board
+
+| Piece | What it gives us | Status / cost |
+| --- | --- | --- |
+| **Blender MCP (official)** | Scene assembly, import, retarget, camera keyframes, viewport render — via `execute_python` + scene-summary tools; add-on + TCP server (localhost:9876, auto-start), Blender 5.1+ | Free; separate MCP server ([projects.blender.org/lab/blender_mcp](https://projects.blender.org/lab/blender_mcp)) |
+| **Mixamo** | Huge free library of humanoid clips + auto-rigging | Free w/ Adobe account, **no API** — manual download; curated local FBX library + Blender retarget add-ons |
+| **Meshy 6 partner nodes** | text→3D / image→3D / multi-image→3D in ComfyUI core (Templates → 3D); GLB/FBX into `output/` | **Paid** (Comfy credits, ~211/$1) |
+| **Local 3D gen** | Trellis 2 / Hunyuan3D / TripoSplat custom nodes as the free asset path | Free, local GPU |
+| **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); animate & replace modes; native Comfy template | Free, local (14B fp8; width/height multiples of 16) |
+| **Seedance 2.0 R2V** | Up to 3 reference videos + 6 reference images, `@Video1`/`@Image1` prompt refs; follows choreography + camera | **Paid** API node (ByteDance partner); later Seedance versions as they land in Comfy |
+| **Already in this repo** | `director` skill (story→scenes→clips), packs system, `upload_video`/`stage_output_as_input` I/O, `list_api_nodes`/`generate_with_api_node`, `check_workflow_runtime` ask-before-spend | Shipped |
+
+## Architecture — who talks to whom
+
+**comfyui-mcp does not wrap Blender.** The agent (Claude) holds *two* MCP
+connections — comfyui-mcp for generation/canvas, Blender MCP for scene work —
+and a skill teaches it the choreography. That keeps us out of the business of
+proxying bpy, and it's exactly the pattern proven in the videos.
+
+Handoff points (all already representable):
+
+1. **ComfyUI → Blender**: Meshy/Trellis writes GLB/FBX into ComfyUI `output/`;
+   the agent imports it via Blender MCP `execute_python` (`bpy.ops.import_scene.gltf`).
+2. **Mixamo → Blender**: user-curated local FBX clip library (see below);
+   import + retarget onto the character rig via add-on or bpy.
+3. **Blender → ComfyUI**: viewport/OpenGL render (solid shading, no lights, no
+   materials — it's a motion reference) to mp4 or frame sequence →
+   `upload_video` → reference input of the Wan Animate graph or Seedance node.
+4. **Reference stills**: character/environment look-images from any local
+   image pack (Z-Image, Krea2, …) or provided by the user.
+
+**Mixamo reality check**: there is no official API and scraping is a ToS
+minefield, so the skill treats Mixamo as a **one-time shopping trip** — a
+documented starter list (idle/walk/run/turn/sit/fight/dance/death…) the user
+downloads once into a conventional folder (e.g. `~/.comfyui-mcp/previz/clips/`),
+which the agent then reuses forever. Text-to-animation add-ons (Kinetix-style)
+and markerless mocap slot into the same folder convention later.
+
+**Orchestrator gap (the one real feature ask)**: the panel agent currently
+speaks only to comfyui-mcp. Claude Desktop / Claude Code users can add the
+Blender MCP alongside today, but the *panel* needs **companion MCP server
+support** — a config that passes extra MCP servers into the spawned agent
+session. That's the only code change in this roadmap that isn't a skill, pack,
+or doc.
+
+## Deliverables
+
+- **`previz-director` skill** (`plugin/skills/previz-director/SKILL.md`) — the
+  whole recipe as knowledge: Blender MCP setup + port sanity check; scene
+  blocking conventions (real-world scale, 30 fps, camera rig patterns:
+  dolly/orbit/crane as reusable bpy snippets); Mixamo library convention +
+  retarget procedure; viewport render settings (workbench solid, flat lighting,
+  silhouette-readable for DWPose); the handoff commands; prompt templates for
+  Seedance R2V ("follow the exact same body movement, timing, camera motion
+  and pacing from @Video1 …") and Wan Animate mode selection (animate vs
+  replace); style-sweep pattern (one previz, N reference-image sets).
+- **`wan-animate` pack** (`packs/wan-animate/`) — the free path, installable:
+  Wan 2.2 Animate 14B fp8 + controlnet_aux (DWPose) + SAM2 nodes, template
+  workflow wired for reference-video input. Follows the existing manifest
+  conventions; `pack.yaml` links the skill.
+- **Meshy + Seedance guidance** — no pack needed (they're core API nodes);
+  the skill documents the built-in templates and wraps both in the
+  `check_workflow_runtime` / ask-before-spending convention. Free alternates
+  (Trellis/Hunyuan3D for assets, Wan Animate for video) are always named
+  first.
+- **Companion MCP servers for the panel orchestrator** — config +
+  session-spawn plumbing so the panel agent can reach Blender MCP. Specced
+  separately when we get there (it's generic, not Blender-specific).
+- **`director` integration** — a previz mode for the existing story pipeline:
+  scene list → one Blender previz per shot → batch restyle. Character
+  consistency comes free (same 3D characters every shot); the director skill's
+  hero-frame/ref-image machinery supplies the style side.
+
+## Phases
+
+| Phase | Goal | Contents |
+| --- | --- | --- |
+| **H0 — spike (manual)** | Prove the recipe on this rig, end-to-end, once | Meshy (or Trellis) asset → Mixamo character + clip → Blender blocking + camera → viewport render → Wan Animate local AND Seedance R2V; write down every snag |
+| **H1 — skill** | `previz-director` SKILL.md from H0's notes | Knowledge only, zero code; usable immediately from Claude Desktop/Code with both MCPs configured |
+| **H2 — pack** | `wan-animate` pack | Free path installable via `apply_manifest`; H1 skill references it |
+| **H3 — panel parity** | Companion MCP servers in the orchestrator | Panel agent gets Blender MCP; pairing-level UX ("Connect Blender" hint in panel) |
+| **H4 — storytelling** | Director × previz | Shot lists drive previz scenes; multi-shot continuity (same cast/set across shots); style sweeps as a first-class op |
+
+H0/H1 ship value with **no code at all** — that's the point of leading with a
+skill. H2 is manifest-writing. Only H3 touches the orchestrator.
+
+## Costs & safety
+
+Two of the pieces are paid (Meshy, Seedance — Comfy credits billed to the
+user's Comfy account). Existing convention applies unchanged: the agent calls
+`check_workflow_runtime`, treats `api`/`mixed` as possibly-paid, and **asks
+before spending credits — never silently**. Every paid step has a named free
+alternative (local img2mesh; Wan Animate), and the skill presents the free
+path as the default. Blender MCP is local and free; its `execute_python` is
+arbitrary code execution *inside the user's Blender* — the skill should say so
+plainly and keep generated bpy scripts inspectable in chat, same spirit as our
+graph mutations being undoable.
+
+## Where I actually want a gut-check
+
+- **Bundle a tiny CC0 previz kit?** A mannequin character + 3–5 CC0 motion
+  clips shipped in the pack would make H0-style demos work without the Mixamo
+  shopping trip (and without leaning on Adobe's ToS). Leaning yes.
+- **Headless Blender?** The official MCP can execute in a background Blender
+  process — a render-farm-ish mode for batch shots. Interactive-first feels
+  right (the user watches the blocking happen, same as the canvas), headless
+  later.
+- **DWPose readability as a skill rule** — Wan Animate needs human silhouettes
+  it can pose-track; stylized/non-humanoid previz should route to Seedance
+  (which follows raw motion, not skeletons). Is that split stable enough to
+  encode as guidance?
+- **Where does the clip library live** — `~/.comfyui-mcp/previz/` vs the
+  ComfyUI workspace vs a pack `templates/` dir. Orchestrator config already
+  has a home dir; leaning `~/.comfyui-mcp/previz/`.
+- **Seedance "5.0"** — versions beyond 2.0 will land as new partner nodes;
+  the skill should name capabilities ("reference-to-video with @Video refs"),
+  not pin node class names, so it survives version bumps.

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -1,6 +1,13 @@
 # Previz-to-video — 3D-blocked reference scenes for motion-controlled AI video (vision doc)
 
-**Status:** draft (RFC PR #187) · **Implementation branch:** `spec/previz-to-video`
+**Status:** draft (RFC PR #187) · **Implementation branch:** `spec/previz-to-video` · **Field research:** [`previz-research-notes.md`](./previz-research-notes.md)
+
+> Prior art: [Doug Hogan's Seedance Playblast2Render](https://comfy.org/workflows/ef543bd4a773-ef543bd4a773/)
+> (playblast → `ByteDance2ReferenceNode`, fps read from the playblast itself),
+> [Mickmumpitz's AI Renderer 2.0](https://mickmumpitz.ai/guides/ai-powered-3d-animation-rendering)
+> (local control-pass school: depth/outline/color-ID passes → Wan VACE), and the
+> [Awesome Blender + Seedance use-case collection](https://github.com/Evolink-AI/Awesome-Blender-Seedance-Workflow-Usecases)
+> (28 cases, several agent-built via Blender MCP).
 
 > Living doc. Casual "run it by a smart friend" framing at the top; concrete
 > architecture + phases below. Draft — shaping it before building.
@@ -79,8 +86,8 @@ natural language.
 | **Mixamo** | **Auto-rigging for ComfyUI-authored characters** (upload FBX/GLB → skeleton-bound FBX) + huge free library of humanoid clips | Free w/ Adobe account, **no API** — website hop is manual; curated local FBX library + Blender retarget add-ons |
 | **Meshy 6 partner nodes** | text→3D / image→3D / multi-image→3D in ComfyUI core (Templates → 3D); GLB/FBX into `output/` | **Paid** (Comfy credits, ~211/$1) |
 | **Local 3D gen** | Trellis 2 / Hunyuan3D / TripoSplat custom nodes as the free asset path; community-proven character-shop graph (SDXL → Qwen-Edit multi-angle → Hunyuan3D v2 MV → GLB, see Evidence) | Free, local GPU |
-| **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); animate & replace modes; native Comfy template | Free, local (14B fp8; width/height multiples of 16) |
-| **Seedance 2.0 R2V** | Up to 3 reference videos + 6 reference images, `@Video1`/`@Image1` prompt refs; follows choreography + camera | **Paid** API node (ByteDance partner); later Seedance versions as they land in Comfy |
+| **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); move/animate & mix/replace modes; native Comfy template | Free, local (fp8 ~19GB on 24GB cards, GGUF Q4 on 16GB; 16 fps, 77-frame windows, res %16) |
+| **Seedance 2.0 R2V** | ≤3 reference videos (≤15.1s total) + ≤9 reference images + ≤3 audio, `@Video1`/`@Image1` role-tagged prompts; follows choreography + camera; 4–15s out (sweet spot 6–8s) | **Paid** API node (`ByteDance2ReferenceNode`, ~$0.66 / 5s @ 720p; Mini ~$0.32); Seedance 2.5 exists (30s native) but has no Comfy nodes yet |
 | **Already in this repo** | `director` skill (story→scenes→clips), packs system, `upload_video`/`stage_output_as_input` I/O, `list_api_nodes`/`generate_with_api_node`, `check_workflow_runtime` ask-before-spend | Shipped |
 
 ## Architecture — who talks to whom
@@ -139,14 +146,21 @@ or doc.
 ## Deliverables
 
 - **`previz-director` skill** (`plugin/skills/previz-director/SKILL.md`) — the
-  whole recipe as knowledge: Blender MCP setup + port sanity check; scene
-  blocking conventions (real-world scale, 30 fps, camera rig patterns:
+  whole recipe as knowledge, with the field-research numbers baked in
+  ([research notes](./previz-research-notes.md)): Blender MCP setup + port
+  sanity check; scene blocking conventions (real-world scale — Seedance needs
+  character *proportions* to match, not just height; camera rig patterns:
   dolly/orbit/crane as reusable bpy snippets); Mixamo library convention +
-  retarget procedure; viewport render settings (workbench solid, flat lighting,
-  silhouette-readable for DWPose); the handoff commands; prompt templates for
-  Seedance R2V ("follow the exact same body movement, timing, camera motion
-  and pacing from @Video1 …") and Wan Animate mode selection (animate vs
-  replace); style-sweep pattern (one previz, N reference-image sets).
+  auto-rig handoff + retarget procedure (free Retarget extension / ARP);
+  viewport render recipe (`bpy.ops.render.opengl`, Workbench MatCap/solid,
+  outlines on, **fps read from the playblast and held identical through the
+  workflow**, silhouette-readable for DWPose); the **routing rule** — camera
+  language and staging go to Seedance R2V, character-performance transfer with
+  a calm camera goes to Wan Animate; role-tagged prompt templates ("Keep the
+  motion of @Video1 … replace subject with @Image1", "Follow the camera path
+  from @Video1"), shot length guidance (6–8s per shot, stitch longer);
+  known-weak-spots watchlist (foot contact, cloth, multi-cut references);
+  style-sweep pattern (one previz, N reference-image sets).
 - **`wan-animate` pack** (`packs/wan-animate/`) — the free path, installable:
   Wan 2.2 Animate 14B fp8 + controlnet_aux (DWPose) + SAM2 nodes, template
   workflow wired for reference-video input. Follows the existing manifest
@@ -179,7 +193,7 @@ or doc.
 
 | Phase | Goal | Contents |
 | --- | --- | --- |
-| **H0 — spike (manual)** | Prove the recipe on this rig, end-to-end, once | Meshy (or Trellis) asset → Mixamo character + clip → Blender blocking + camera → viewport render → Wan Animate local AND Seedance R2V; write down every snag |
+| **H0 — spike (manual)** | Prove the recipe on this rig, end-to-end, once | Meshy (or Trellis) asset → Mixamo character + clip → Blender blocking + camera → viewport render → Wan Animate local AND Seedance R2V; write down every snag. Must answer: does DWPose track a flat-grey mannequin, or does the previz need MatCap/toon shading + a visible face? |
 | **H1 — skill** | `previz-director` SKILL.md from H0's notes | Knowledge only, zero code; usable immediately from Claude Desktop/Code with both MCPs configured |
 | **H2 — pack + glue** | `wan-animate` pack; 3D-asset file awareness | Free path installable via `apply_manifest`; `kind: "model"` in output listing; H1 skill references both |
 | **H3 — panel parity** | Companion MCP servers in the orchestrator | Panel agent gets Blender MCP; pairing-level UX ("Connect Blender" hint in panel) |
@@ -215,13 +229,24 @@ graph mutations being undoable.
   process — a render-farm-ish mode for batch shots. Interactive-first feels
   right (the user watches the blocking happen, same as the canvas), headless
   later.
-- **DWPose readability as a skill rule** — Wan Animate needs human silhouettes
-  it can pose-track; stylized/non-humanoid previz should route to Seedance
-  (which follows raw motion, not skeletons). Is that split stable enough to
-  encode as guidance?
+- ~~DWPose readability as a skill rule~~ — **resolved by field research**: the
+  split is real and stable. Camera moves + staging → Seedance (follows the
+  reference video's trajectory faithfully); character performance with a calm
+  camera → Wan Animate (DWPose needs a readable humanoid; aggressive camera
+  moves mutate identity). One open sub-question for H0: does DWPose track a
+  *flat-grey mannequin* reliably, or does the previz need a MatCap/toon-shaded
+  humanoid with a visible face?
+- **A third leg worth a later pack?** The Mickmumpitz school renders explicit
+  control passes (depth via compositor Map Range, Freestyle/Workbench
+  outlines, per-object color-ID masks for regional prompting) into a local
+  Wan-VACE restyle. More setup, more control, fully free — and color-ID masks
+  are the best multi-character answer anyone has. Candidate `previz-restyle`
+  pack after H2, not in scope now.
 - **Where does the clip library live** — `~/.comfyui-mcp/previz/` vs the
   ComfyUI workspace vs a pack `templates/` dir. Orchestrator config already
   has a home dir; leaning `~/.comfyui-mcp/previz/`.
-- **Seedance "5.0"** — versions beyond 2.0 will land as new partner nodes;
-  the skill should name capabilities ("reference-to-video with @Video refs"),
-  not pin node class names, so it survives version bumps.
+- ~~Seedance "5.0"~~ — **resolved**: it doesn't exist ("Seedream 5.0" is the
+  *image* model). The current video line is 2.0 / 2.0 Fast / 2.0 Mini in
+  ComfyUI, with **Seedance 2.5** (native 30s, ≤50 refs) released but not yet
+  in ComfyUI partner nodes. The skill names capabilities, not node class
+  names, so 2.5 slots in when it lands.

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -83,10 +83,14 @@ natural language.
 | Piece | What it gives us | Status / cost |
 | --- | --- | --- |
 | **Blender MCP (official)** | Scene assembly, import, retarget, camera keyframes, viewport render — via `execute_python` + scene-summary tools; add-on + TCP server (localhost:9876, auto-start), Blender 5.1+ | Free; separate MCP server ([projects.blender.org/lab/blender_mcp](https://projects.blender.org/lab/blender_mcp)) |
-| **Mixamo** | **Auto-rigging for ComfyUI-authored characters** (upload FBX/GLB → skeleton-bound FBX) + huge free library of humanoid clips | Free w/ Adobe account, **no API** — website hop is manual; curated local FBX library + Blender retarget add-ons |
+| **ComfyUI-UniRig** | **Local auto-rigging**: mesh → Mixamo-compatible rigged FBX (UniRig + Make-It-Animatable, sub-second skinning; handles non-humanoids) | Free, local, in-graph — agent-drivable today; [repo](https://github.com/PozzettiAndrea/ComfyUI-UniRig) |
+| **Mixamo** | Fallback auto-rigger + huge free library of humanoid clips | Free w/ Adobe account, **no API** — website hop is manual; curated local FBX library + Blender retarget add-ons |
+| **Yedp Action Director** | **Previz inside ComfyUI**: 3D viewport node, ≤16 Mixamo-rigged characters, cameras/HDRIs → bakes 7 control passes (pose/depth/canny/normal/shaded/alpha/textured) | Free custom node — the lighter first rung below the full Blender stage |
 | **Meshy 6 partner nodes** | text→3D / image→3D / multi-image→3D in ComfyUI core (Templates → 3D); GLB/FBX into `output/` | **Paid** (Comfy credits, ~211/$1) |
 | **Local 3D gen** | Trellis 2 / Hunyuan3D / TripoSplat custom nodes as the free asset path; community-proven character-shop graph (SDXL → Qwen-Edit multi-angle → Hunyuan3D v2 MV → GLB, see Evidence) | Free, local GPU |
-| **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); move/animate & mix/replace modes; native Comfy template | Free, local (fp8 ~19GB on 24GB cards, GGUF Q4 on 16GB; 16 fps, 77-frame windows, res %16) |
+| **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); move/animate & mix/replace modes; native Comfy template | Free, local (fp8 ~19GB on 24GB cards, GGUF Q4 on 16GB; 16 fps, 77-frame windows, res %16). Watch **SCAIL-2** — end-to-end successor, no pose maps, better multi-character, GGUF ~6GB; re-check at H2 build time |
+| **Kling 2.6 Motion Control** | Simplest API path: character image + motion video (3–30s) → identity-locked transfer, 4-node graph | **Paid** API node — third restyle leg alongside Seedance/Wan |
+| **Self-filmed video** | A phone clip of the user performing IS a previz for single-character shots (community default); filming rules: full body, locked tripod, no cuts, even light | Free — the skill should accept it as a first-class motion source |
 | **Seedance 2.0 R2V** | ≤3 reference videos (≤15.1s total) + ≤9 reference images + ≤3 audio, `@Video1`/`@Image1` role-tagged prompts; follows choreography + camera; 4–15s out (sweet spot 6–8s) | **Paid** API node (`ByteDance2ReferenceNode`, ~$0.66 / 5s @ 720p; Mini ~$0.32); Seedance 2.5 exists (30s native) but has no Comfy nodes yet |
 | **Already in this repo** | `director` skill (story→scenes→clips), packs system, `upload_video`/`stage_output_as_input` I/O, `list_api_nodes`/`generate_with_api_node`, `check_workflow_runtime` ask-before-spend | Shipped |
 
@@ -116,16 +120,20 @@ Handoff points (all already representable):
 5. **Reference stills**: character/environment look-images from any local
    image pack (Z-Image, Krea2, …) or provided by the user.
 
-**The character loop (Discord feedback)**: characters are **authored in
-ComfyUI first** — image model → img2mesh → FBX/GLB in `output/` — then
-**auto-rigged through Mixamo**, and only then animated and directed in
-Blender. The agent fully automates the Blender side; the Mixamo *website* hop
-is the one manual step (no API), so the skill runs it as a guided handoff:
-stage the exact file, tell the user precisely what to upload and click, then
-pick the rigged FBX back up from the download folder and continue without
-being re-prompted. Direction stays verifiable: the agent inspects the scene
-graph and screenshots the viewport, so it *sees* every scene it's directing —
-the same trust model as the canvas, where it reads the graph it mutates.
+**The character loop (Discord feedback, revised by round-3 research)**:
+characters are **authored in ComfyUI first** — image model → img2mesh →
+FBX/GLB in `output/` — then auto-rigged, and only then animated and directed
+in Blender. Rigging now has a fully-automatic local path: **ComfyUI-UniRig**
+(UniRig + Make-It-Animatable) turns a mesh into a **Mixamo-compatible rigged
+FBX** locally, free, inside the same ComfyUI the agent already drives — no
+website hop at all. Mixamo's site remains the fallback rigger and the clip
+library; when used, the skill runs it as a guided handoff: stage the exact
+file, tell the user what to upload and click, pick the rigged FBX back up
+from the download folder. (Cloud alternates with real APIs: Meshy rigging +
+600-clip retarget, Tripo one-shot rig+retarget.) Direction stays verifiable:
+the agent inspects the scene graph and screenshots the viewport, so it *sees*
+every scene it's directing — the same trust model as the canvas, where it
+reads the graph it mutates.
 
 **Mixamo reality check**: there is no official API and scraping is a ToS
 minefield, so the skill treats Mixamo's clip library as a **one-time shopping
@@ -168,8 +176,9 @@ or doc.
 - **`character-shop` pack (community seed)** — productize the shared
   Master 3D Model Maker graph (SDXL hero → Qwen-Edit 2511 multi-angle LoRA →
   Hunyuan3D v2 MV → GLB) as the free character-authoring pack, with credit to
-  its author. It's the ComfyUI half of the character loop, already
-  panel-built.
+  its author, **extended with a ComfyUI-UniRig stage** so the pack's output is
+  a rigged, animation-ready FBX — the full character loop with zero manual
+  hops. It's the ComfyUI half of the character loop, already panel-built.
 - **Meshy + Seedance guidance** — no pack needed (they're core API nodes);
   the skill documents the built-in templates and wraps both in the
   `check_workflow_runtime` / ask-before-spending convention. Free alternates
@@ -224,7 +233,16 @@ graph mutations being undoable.
   lands fast once the skill is validated.
 - **Bundle a tiny CC0 previz kit?** A mannequin character + 3–5 CC0 motion
   clips shipped in the pack would make H0-style demos work without the Mixamo
-  shopping trip (and without leaning on Adobe's ToS). Leaning yes.
+  shopping trip (and without leaning on Adobe's ToS). Leaning yes — and
+  round-3 research softens the need further: UniRig rigs locally, and
+  text-to-animation APIs (DeepMotion SayMotion, Text2Motion's Blender add-on,
+  Move AI phone mocap) can *generate* clips instead of shopping for them.
+  Mixamo becomes the curated-quality option, not the bottleneck.
+- **Yedp Action Director as the on-ramp?** A 3D previz viewport *inside*
+  ComfyUI (Mixamo rigs, cameras, 7 baked control passes) covers simple shots
+  with zero Blender setup, and the full Blender MCP stage takes over when
+  shots need real set dressing, physics, or multi-take direction. Should H1
+  teach both rungs, or does two previz stages confuse the story?
 - **Headless Blender?** The official MCP can execute in a background Blender
   process — a render-farm-ish mode for batch shots. Interactive-first feels
   right (the user watches the blocking happen, same as the canvas), headless

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -49,6 +49,16 @@ the character shop, Mixamo auto-rigs what it produces, and Claude — with full
 visibility into the Blender scene — directs the performance from the user's
 natural language.
 
+Why this is the panel's home turf (community articulation, from a live
+session): the panel's whole value is that the agent acts on **live, current
+state instead of frozen training data** — live model cards correct guessed
+settings, the daily-changing workflow catalog can't live in weights, and the
+agent doesn't know how anything on disk works until it reads it. A Blender
+stage extends that same superpower to 3D: the agent sees *your actual rig,
+scene, and pose* rather than hallucinating plausible bpy calls. And a posed
+scene **solves multi-character composition by construction** — who's touching
+whom, from what angle — which text prompting has never done reliably.
+
 ## Evidence this works today
 
 - [ComfyUI (official): style-swapping one Blender animation](https://www.youtube.com/watch?v=3r6qzGGNK8s)
@@ -144,12 +154,34 @@ Auto-rigging is per-character but follows the same stage → guide → pick-up
 pattern. Text-to-animation add-ons (Kinetix-style) and markerless mocap slot
 into the same folder convention later.
 
-**Orchestrator gap (the one real feature ask)**: the panel agent currently
+**Model-agnostic exports (adopted from community feedback)**: everything that
+leaves Blender is a **generic control artifact** — clay/skeleton video, depth
+pass, camera-keyframe JSON — never tied to one backend. The downstream node
+decides: Seedance/Kling for hosted cinematic work, Wan Animate / VACE /
+ControlNet for local work. Same Blender tooling either way. Corollary from the
+same feedback: hosted backends filter content server-side, so the local leg
+isn't just the free leg — it's the only leg for content the APIs won't render.
+One more scope rule adopted: **pose export and camera export ship together**
+(H0/H1), not camera-first — multi-character shots need pose matching from day
+one, camera motion alone doesn't hold characters consistent.
+
+**Orchestrator gap + the architecture question**: the panel agent currently
 speaks only to comfyui-mcp. Claude Desktop / Claude Code users can add the
 Blender MCP alongside today, but the *panel* needs **companion MCP server
 support** — a config that passes extra MCP servers into the spawned agent
-session. That's the only code change in this roadmap that isn't a skill, pack,
-or doc.
+session (H3). A community counter-proposal (research notes §6.6) goes
+further: fork a bpy socket bridge and ship our own two-package Blender panel
+(`blender-agent-panel` add-on + `blender-mcp-orchestrator`) exposing **~15
+curated named tools instead of raw `execute_python`** — reusing the panel's
+consent file. The concern behind it is real: raw bpy is hostile to small
+local models (the exact lesson compact tool mode taught us on the ComfyUI
+side) and hard to consent-gate. Current lean: **don't own a Blender add-on
+yet** — official MCP underneath, curated *recipes* in the H1 skill on top,
+and revisit a thin curated tool layer (possibly proxying the official
+add-on's socket rather than forking) if H0/H1 show local models can't drive
+recipes reliably. Prior art either way:
+[alexisrolland/ComfyUI-Blender](https://github.com/alexisrolland/ComfyUI-Blender)
+(Blender→ComfyUI trigger, one-directional, UI-pattern reference).
 
 ## Deliverables
 
@@ -231,6 +263,15 @@ graph mutations being undoable.
   Claude Desktop/Code and prove the recipe before we touch the orchestrator.
   Current lean: keep H3 third, but spec it in parallel with H1 so panel parity
   lands fast once the skill is validated.
+- **Curated Blender tools vs raw bpy over the official MCP?** The community
+  proposal (notes §6.6) wants ~15 named tools (`blender_export_pose_map`,
+  `blender_set_bone_rotation`, …) instead of `execute_python`. Real tension:
+  named tools are what small local backends can actually drive, and what a
+  consent gate can reason about — but 15 tools can't cover retargeting,
+  physics, and the long tail that makes Blender worth having. H0/H1 decide:
+  if skill recipes over the official MCP work for Claude but fail for
+  qwen/gemma-class backends, a thin curated layer (proxying the official
+  add-on's socket, not forking a new one) becomes an H3-adjacent item.
 - **Bundle a tiny CC0 previz kit?** A mannequin character + 3–5 CC0 motion
   clips shipped in the pack would make H0-style demos work without the Mixamo
   shopping trip (and without leaning on Adobe's ToS). Leaning yes — and

--- a/design/previz-to-video.md
+++ b/design/previz-to-video.md
@@ -36,6 +36,12 @@ the panel "two characters argue on a rooftop, camera circles them, then one
 walks off a ledge — make it look like a 90s anime" and the agent blocks it,
 renders the reference, and restyles it — asking before it spends credits.
 
+The panel's job, first and foremost, is **natural motion between characters
+you created inside ComfyUI** (Discord feedback, verbatim intent): ComfyUI is
+the character shop, Mixamo auto-rigs what it produces, and Claude — with full
+visibility into the Blender scene — directs the performance from the user's
+natural language.
+
 ## Evidence this works today
 
 - [ComfyUI (official): style-swapping one Blender animation](https://www.youtube.com/watch?v=3r6qzGGNK8s)
@@ -54,15 +60,25 @@ renders the reference, and restyles it — asking before it spends credits.
 - [PixelArtistry: 3D AI news #13](https://www.youtube.com/watch?v=N15zYcv0Snk)
   — the surrounding ecosystem (retopo, splats, markerless mocap) is compounding
   fast; spatial reasoning in current Claude models is measurably better.
+- **Community, on Discord**: a member (seanmcmagic) built a fully-local
+  **character shop** *with the Agent Panel's help* and shared the workflow —
+  SDXL (WAI-Illustrious) hero image → Qwen-Image-Edit 2511 + multiple-angles
+  LoRA batch-generating consistent views → **Hunyuan3D v2 multi-view** → GLB.
+  Preserved at
+  [`previz-assets/master-3d-model-maker.community.json`](./previz-assets/master-3d-model-maker.community.json)
+  (Discord CDN links expire). Confirms: the free asset path is real today, and
+  people are already using the panel to build this pipeline's front half. The
+  same thread asked for **3D-modeling and audio skill files** — H1 answers the
+  3D half.
 
 ## The pieces on the board
 
 | Piece | What it gives us | Status / cost |
 | --- | --- | --- |
 | **Blender MCP (official)** | Scene assembly, import, retarget, camera keyframes, viewport render — via `execute_python` + scene-summary tools; add-on + TCP server (localhost:9876, auto-start), Blender 5.1+ | Free; separate MCP server ([projects.blender.org/lab/blender_mcp](https://projects.blender.org/lab/blender_mcp)) |
-| **Mixamo** | Huge free library of humanoid clips + auto-rigging | Free w/ Adobe account, **no API** — manual download; curated local FBX library + Blender retarget add-ons |
+| **Mixamo** | **Auto-rigging for ComfyUI-authored characters** (upload FBX/GLB → skeleton-bound FBX) + huge free library of humanoid clips | Free w/ Adobe account, **no API** — website hop is manual; curated local FBX library + Blender retarget add-ons |
 | **Meshy 6 partner nodes** | text→3D / image→3D / multi-image→3D in ComfyUI core (Templates → 3D); GLB/FBX into `output/` | **Paid** (Comfy credits, ~211/$1) |
-| **Local 3D gen** | Trellis 2 / Hunyuan3D / TripoSplat custom nodes as the free asset path | Free, local GPU |
+| **Local 3D gen** | Trellis 2 / Hunyuan3D / TripoSplat custom nodes as the free asset path; community-proven character-shop graph (SDXL → Qwen-Edit multi-angle → Hunyuan3D v2 MV → GLB, see Evidence) | Free, local GPU |
 | **Wan 2.2 Animate** | Reference video + character image → animated character (DWPose-driven); animate & replace modes; native Comfy template | Free, local (14B fp8; width/height multiples of 16) |
 | **Seedance 2.0 R2V** | Up to 3 reference videos + 6 reference images, `@Video1`/`@Image1` prompt refs; follows choreography + camera | **Paid** API node (ByteDance partner); later Seedance versions as they land in Comfy |
 | **Already in this repo** | `director` skill (story→scenes→clips), packs system, `upload_video`/`stage_output_as_input` I/O, `list_api_nodes`/`generate_with_api_node`, `check_workflow_runtime` ask-before-spend | Shipped |
@@ -77,21 +93,41 @@ proxying bpy, and it's exactly the pattern proven in the videos.
 Handoff points (all already representable):
 
 1. **ComfyUI → Blender**: Meshy/Trellis writes GLB/FBX into ComfyUI `output/`;
-   the agent imports it via Blender MCP `execute_python` (`bpy.ops.import_scene.gltf`).
-2. **Mixamo → Blender**: user-curated local FBX clip library (see below);
+   the agent imports it via Blender MCP `execute_python`
+   (`bpy.ops.import_scene.gltf`) — **directly from the output folder**, the
+   same file awareness the panel already has on the drive
+   (`list_output_images`, workspace paths). No copy step, no asking the user
+   where the file went.
+2. **ComfyUI → Mixamo (auto-rig)**: a ComfyUI-authored character mesh from
+   `output/` goes to mixamo.com for auto-rigging (or a Mixamo-family Blender
+   add-on) and comes back as a skeleton-bound FBX. See the character loop below.
+3. **Mixamo → Blender**: user-curated local FBX clip library (see below);
    import + retarget onto the character rig via add-on or bpy.
-3. **Blender → ComfyUI**: viewport/OpenGL render (solid shading, no lights, no
+4. **Blender → ComfyUI**: viewport/OpenGL render (solid shading, no lights, no
    materials — it's a motion reference) to mp4 or frame sequence →
    `upload_video` → reference input of the Wan Animate graph or Seedance node.
-4. **Reference stills**: character/environment look-images from any local
+5. **Reference stills**: character/environment look-images from any local
    image pack (Z-Image, Krea2, …) or provided by the user.
 
+**The character loop (Discord feedback)**: characters are **authored in
+ComfyUI first** — image model → img2mesh → FBX/GLB in `output/` — then
+**auto-rigged through Mixamo**, and only then animated and directed in
+Blender. The agent fully automates the Blender side; the Mixamo *website* hop
+is the one manual step (no API), so the skill runs it as a guided handoff:
+stage the exact file, tell the user precisely what to upload and click, then
+pick the rigged FBX back up from the download folder and continue without
+being re-prompted. Direction stays verifiable: the agent inspects the scene
+graph and screenshots the viewport, so it *sees* every scene it's directing —
+the same trust model as the canvas, where it reads the graph it mutates.
+
 **Mixamo reality check**: there is no official API and scraping is a ToS
-minefield, so the skill treats Mixamo as a **one-time shopping trip** — a
-documented starter list (idle/walk/run/turn/sit/fight/dance/death…) the user
-downloads once into a conventional folder (e.g. `~/.comfyui-mcp/previz/clips/`),
-which the agent then reuses forever. Text-to-animation add-ons (Kinetix-style)
-and markerless mocap slot into the same folder convention later.
+minefield, so the skill treats Mixamo's clip library as a **one-time shopping
+trip** — a documented starter list (idle/walk/run/turn/sit/fight/dance/death…)
+the user downloads once into a conventional folder (e.g.
+`~/.comfyui-mcp/previz/clips/`), which the agent then reuses forever.
+Auto-rigging is per-character but follows the same stage → guide → pick-up
+pattern. Text-to-animation add-ons (Kinetix-style) and markerless mocap slot
+into the same folder convention later.
 
 **Orchestrator gap (the one real feature ask)**: the panel agent currently
 speaks only to comfyui-mcp. Claude Desktop / Claude Code users can add the
@@ -115,11 +151,22 @@ or doc.
   Wan 2.2 Animate 14B fp8 + controlnet_aux (DWPose) + SAM2 nodes, template
   workflow wired for reference-video input. Follows the existing manifest
   conventions; `pack.yaml` links the skill.
+- **`character-shop` pack (community seed)** — productize the shared
+  Master 3D Model Maker graph (SDXL hero → Qwen-Edit 2511 multi-angle LoRA →
+  Hunyuan3D v2 MV → GLB) as the free character-authoring pack, with credit to
+  its author. It's the ComfyUI half of the character loop, already
+  panel-built.
 - **Meshy + Seedance guidance** — no pack needed (they're core API nodes);
   the skill documents the built-in templates and wraps both in the
   `check_workflow_runtime` / ask-before-spending convention. Free alternates
   (Trellis/Hunyuan3D for assets, Wan Animate for video) are always named
   first.
+- **3D-asset file awareness** — extend the existing output-folder awareness
+  (`list_output_images` already tags `kind: "video"`) to **3D assets**
+  (`kind: "model"` for GLB/FBX/OBJ in `output/`), so "import the character I
+  just generated into Blender" and "stage this mesh for Mixamo auto-rigging"
+  resolve to exact paths without the user hunting for files. Small, and it's
+  the glue the whole character loop stands on.
 - **Companion MCP servers for the panel orchestrator** — config +
   session-spawn plumbing so the panel agent can reach Blender MCP. Specced
   separately when we get there (it's generic, not Blender-specific).
@@ -134,7 +181,7 @@ or doc.
 | --- | --- | --- |
 | **H0 — spike (manual)** | Prove the recipe on this rig, end-to-end, once | Meshy (or Trellis) asset → Mixamo character + clip → Blender blocking + camera → viewport render → Wan Animate local AND Seedance R2V; write down every snag |
 | **H1 — skill** | `previz-director` SKILL.md from H0's notes | Knowledge only, zero code; usable immediately from Claude Desktop/Code with both MCPs configured |
-| **H2 — pack** | `wan-animate` pack | Free path installable via `apply_manifest`; H1 skill references it |
+| **H2 — pack + glue** | `wan-animate` pack; 3D-asset file awareness | Free path installable via `apply_manifest`; `kind: "model"` in output listing; H1 skill references both |
 | **H3 — panel parity** | Companion MCP servers in the orchestrator | Panel agent gets Blender MCP; pairing-level UX ("Connect Blender" hint in panel) |
 | **H4 — storytelling** | Director × previz | Shot lists drive previz scenes; multi-shot continuity (same cast/set across shots); style sweeps as a first-class op |
 
@@ -155,6 +202,12 @@ graph mutations being undoable.
 
 ## Where I actually want a gut-check
 
+- **How early does the panel need Blender?** Discord feedback says the *side
+  panel* controlling motion is the headline feature — which pulls H3
+  (companion MCP servers) forward. Counter-pressure: H0–H2 already work from
+  Claude Desktop/Code and prove the recipe before we touch the orchestrator.
+  Current lean: keep H3 third, but spec it in parallel with H1 so panel parity
+  lands fast once the skill is validated.
 - **Bundle a tiny CC0 previz kit?** A mannequin character + 3–5 CC0 motion
   clips shipped in the pack would make H0-style demos work without the Mixamo
   shopping trip (and without leaning on Adobe's ToS). Leaning yes.


### PR DESCRIPTION
## What

Roadmap / vision doc for a **previz-to-video** pipeline: use agent-driven Blender scenes as the motion/camera control signal for AI video generation.

- `design/previz-to-video.md` — the full vision: pitch, evidence (4 reference videos incl. ComfyUI's official Seedance-restyles-a-Blender-previz demo), the pieces on the board, dual-MCP architecture (comfyui-mcp + official Blender MCP — we do NOT wrap Blender), deliverables, phases, cost/safety, open questions.
- `ROADMAP.md` — new **Theme H** (H0–H4) + sequencing row.

## The recipe

1. Block the shot in **Blender 5.1** via the official Blender MCP — **Mixamo** clips (curated local FBX library; no API exists) retargeted onto characters, assets from **Meshy 6 partner nodes** (paid) or local img2mesh (free), keyframed camera.
2. Viewport-render a rough, untextured motion reference.
3. Restyle in ComfyUI: **Wan 2.2 Animate** (free, local, DWPose-driven) or **Seedance 2.0 Reference-to-Video** (paid API node, `@Video1`/`@Image1` refs) — body movement, timing, camera and pacing survive; appearance comes from reference images. One previz, infinite styles.

## Phases

| | |
|---|---|
| H0 | manual end-to-end spike on this rig |
| H1 | `previz-director` skill (knowledge only, zero code) |
| H2 | `wan-animate` pack (free path, `apply_manifest`) |
| H3 | companion MCP servers in the panel orchestrator (the only real code ask) |
| H4 | `director` skill integration — shot lists, continuity, style sweeps |

Paid pieces stay behind the existing `check_workflow_runtime` / ask-before-spending convention; every paid step has a named free alternative.

## Open questions (in the doc)

Bundle a CC0 previz kit (mannequin + clips) vs Mixamo shopping trip · headless Blender · DWPose-readability routing rule (Wan vs Seedance) · clip-library location · not pinning Seedance node class names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)