### PR TITLE
Fix vram-check hook defaulting to wrong ComfyUI port (8000 vs 8188)

### DIFF
--- a/plugin/hooks/vram-check.mjs
+++ b/plugin/hooks/vram-check.mjs
@@ -8,28 +8,71 @@
  * JSON stdout with hookSpecificOutput = structured control.
  */
 
-const COMFY_HOST = process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
-const COMFY_PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
-const COMFY_PROTOCOL = process.env.COMFYUI_SSL === "true" ? "https" : "http";
+function resolveUrlOverride() {
+  const raw = process.env.COMFYUI_URL;
+  if (!raw) return undefined;
+  try {
+    const u = new URL(raw);
+    return {
+      host: u.hostname,
+      port: u.port ? Number(u.port) : u.protocol === "https:" ? 443 : 80,
+      protocol: u.protocol.replace(":", ""),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+const urlOverride = resolveUrlOverride();
+const COMFY_HOST =
+  urlOverride?.host || process.env.COMFYUI_HOST || process.env.COMFY_HOST || "127.0.0.1";
+const COMFY_PROTOCOL =
+  urlOverride?.protocol || (process.env.COMFYUI_SSL === "true" ? "https" : "http");
 const VRAM_WARNING_MB = 1024; // Warn if less than 1GB free
+
+// Mirrors the main server's detectComfyUIPort() (src/config.ts): an explicit
+// port (via COMFYUI_URL or COMFYUI_PORT/COMFY_PORT) is honored as-is,
+// otherwise probe the same two well-known ports (8188 repo/CLI default first,
+// then 8000 Desktop default) so this hook agrees with whichever port the
+// server actually resolved to. Previously this hardcoded 8000 as the sole
+// default, which denied every enqueue_workflow call whenever ComfyUI was
+// actually running on the 8188 default (and something else answered on 8000
+// with a non-2xx status).
+const explicitPort =
+  urlOverride?.port || Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || undefined;
+const CANDIDATE_PORTS = explicitPort ? [explicitPort] : [8188, 8000];
+
+async function probePort(port) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 3000);
+  try {
+    const res = await fetch(`${COMFY_PROTOCOL}://${COMFY_HOST}:${port}/system_stats`, {
+      signal: controller.signal,
+    });
+    return res.ok ? res : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 async function check() {
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(`${COMFY_PROTOCOL}://${COMFY_HOST}:${COMFY_PORT}/system_stats`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
+    let res = null;
+    for (const port of CANDIDATE_PORTS) {
+      res = await probePort(port);
+      if (res) break;
+    }
 
-    if (!res.ok) {
+    if (!res) {
       console.log(
         JSON.stringify({
           hookSpecificOutput: {
             hookEventName: "PreToolUse",
             permissionDecision: "deny",
             permissionDecisionReason:
-              "ComfyUI returned a non-OK status. Check if it is running correctly.",
+              "ComfyUI is not running. Use start_comfyui to start it first.",
           },
         }),
       );


### PR DESCRIPTION
## What happened / root cause

`plugin/hooks/vram-check.mjs` is the `PreToolUse` hook that gates every `enqueue_workflow` call. It hardcodes:

```js
const COMFY_PORT = Number(process.env.COMFYUI_PORT || process.env.COMFY_PORT) || 8000;
```

But the main server's own port auto-detection (`detectComfyUIPort()` in `src/config.ts`) tries **8188 first**, then falls back to 8000:

```js
// Auto-detect which port ComfyUI is running on.
// Tries common ports: 8000 (Desktop app default), 8188 (repo/CLI default).
const ports = [8188, 8000];
```

On any install where ComfyUI is actually running on 8188 (the repo/CLI default — e.g. a portable Windows install launched via `run_nvidia_gpu.bat`) and nothing meaningful answers on 8000, the hook's health probe hits the wrong port. If port 8000 happens to have *anything* else listening that returns a non-2xx status, the hook denies **every single** `enqueue_workflow` call with:

> ComfyUI returned a non-OK status. Check if it is running correctly.

...even though ComfyUI itself is completely healthy (`health_check`, `get_system_stats`, `get_queue` all succeed against port 8188), and `generate_image` (a different tool, not gated by this hook) works fine.

## Steps to reproduce

1. Run ComfyUI on port 8188 (default), with nothing relevant on port 8000.
2. Call `enqueue_workflow` with any valid API-format workflow (confirmed via `validate_workflow`).
3. Observe the hook deny it with the non-OK message, regardless of workflow content.
4. Call `generate_image` instead — it succeeds normally.

## Exact error (scrubbed)

```
ComfyUI returned a non-OK status. Check if it is running correctly.
```

Returned even for a minimal, `validate_workflow`-confirmed-valid SD1.5 `CheckpointLoaderSimple` → `KSampler` → `SaveImage` graph.

## Fix

Applied locally: yes. Upstream-only: no.

Mirrors `detectComfyUIPort()`: honor an explicit `COMFYUI_URL` (parsed for host/port/protocol) or `COMFYUI_PORT`/`COMFY_PORT` if set; otherwise probe `8188` then `8000` and use whichever responds first with a 2xx. Also collapses the two near-duplicate "not running" deny paths into one accurate message once all candidate ports have been checked.

Verified locally against a live ComfyUI instance running on 8188: before the fix, `enqueue_workflow` denied 100% of calls; after the fix, the hook exits 0 and `enqueue_workflow` succeeds end-to-end (confirmed via `get_history` showing a successful execution).

See the diff in this PR (`plugin/hooks/vram-check.mjs`).

## Environment

- OS: Windows (ComfyUI portable), MCP server run from WSL2 (Ubuntu)
- ComfyUI: 0.26.0, Python 3.13.12, PyTorch 2.12.0+cu130
- GPU: RTX 4090, 24GB VRAM
- comfyui-mcp: installed via `npx comfyui-mcp` (plugin cache `comfy/0.1.0`), branched from `main` @ `da17856`