### PR TITLE
feat: integrate official comfy-cli control surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 COMFYUI_HOST=127.0.0.1
 COMFYUI_PORT=8188
 # COMFYUI_PATH=/Users/you/Documents/ComfyUI
+# Optional override for the official comfy-cli executable (requires >=1.11.1).
+# COMFY_CLI_PATH=/Users/you/.local/bin/comfy
 
 # Remote self-hosted ComfyUI behind a reverse proxy / API gateway:
 # COMFYUI_URL preserves a path prefix (e.g. /comfyapi), and the COMFYUI_AUTH_*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,19 @@ This works for both:
 
 After code changes: `npm run build` then `/mcp` reconnect in Claude Code.
 
+## Official comfy-cli Integration
+
+`comfyui-mcp` integrates with official `comfy-cli` 1.11.1 or newer. Resolve the executable in this order: `COMFY_CLI_PATH`, the selected ComfyUI workspace's `.venv`/`venv`, then `PATH`.
+
+- Prefer the `comfy_cli_*` MCP tools for CLI-owned behavior: environment/workspace discovery, managed server lifecycle, jobs, loaded-node search, workflow validation/execution, upload/download, model discovery/download/removal, and official agent skills.
+- Local custom-node install/update/reinstall/fix operations prefer `comfy node` when a supported CLI is available. Fall back to ComfyUI-Manager HTTP when the CLI is missing or too old. Remote custom-node operations use Manager HTTP because the MCP host cannot manage the remote filesystem.
+- Always invoke comfy-cli non-interactively with global `--json --skip-prompt`. Newer commands emit `envelope/1`; legacy `stop`, `node`, and singular `model` commands may still print plain text in v1.11.1, so the adapter normalizes their exit status/stdout/stderr into the same envelope contract.
+- Treat `comfy stop` reporting that no background ComfyUI is running as idempotent success, so restart can continue to launch.
+- Project-scoped `comfy skills` operations require an explicit project working directory. Do not let them inherit the MCP package directory.
+- Do not reintroduce ComfyUI-Manager's removed `cm-cli.py` subprocess path.
+
+See the **Official comfy-cli** section in `README.md` and `COMFY_CLI_PATH` in `.env.example` for the user-facing contract.
+
 ## Plugin File Sync
 
 The plugin runs from cached copies, not the source tree. After changing files in `plugin/`:

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ### Official comfy-cli
 
-Install [comfy-cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) 1.11.1 or newer to enable the official JSON-backed tools. The MCP resolves `comfy` from `COMFY_CLI_PATH`, `PATH`, or the selected workspace's `.venv`/`venv`. Local custom-node CLI operations use `comfy node`; remote targets retain the ComfyUI-Manager HTTP path.
+Install [comfy-cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) 1.11.1 or newer to enable the official JSON-backed tools. The MCP resolves `comfy` from `COMFY_CLI_PATH`, `PATH`, or the selected workspace's `.venv`/`venv`. Local custom-node operations prefer `comfy node` when a supported CLI is available and otherwise fall back to Manager HTTP; remote targets retain Manager HTTP.
 
 | Tool | Description |
 |------|-------------|
@@ -357,7 +357,7 @@ Install [comfy-cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli
 | `comfy_cli_jobs` | List, inspect, wait for, watch, or cancel local/cloud jobs |
 | `comfy_cli_workflow` | Validate or run workflow files through the official CLI |
 | `comfy_cli_transfer` | Upload inputs or download completed job outputs |
-| `comfy_cli_models` | Browse/search local model files or the cloud asset catalog |
+| `comfy_cli_models` | Browse/search local or cloud models; download/remove workspace model files |
 | `comfy_cli_skills` | List/show/validate/install/status/uninstall official bundled agent skills |
 
 ### Diagnostics

--- a/README.md
+++ b/README.md
@@ -344,6 +344,21 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 | `search_custom_nodes` | Search the ComfyUI Registry for custom node packs by keyword |
 | `get_node_pack_details` | Get full details of a custom node pack (description, author, nodes, install info) |
 | `generate_node_skill` | Generate a Claude skill `.md` file from a Registry ID or GitHub URL |
+| `comfy_cli_search_nodes` | Search actual loaded node classes through official `comfy nodes search` |
+
+### Official comfy-cli
+
+Install [comfy-cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) 1.11.1 or newer to enable the official JSON-backed tools. The MCP resolves `comfy` from `COMFY_CLI_PATH`, `PATH`, or the selected workspace's `.venv`/`venv`. Local custom-node CLI operations use `comfy node`; remote targets retain the ComfyUI-Manager HTTP path.
+
+| Tool | Description |
+|------|-------------|
+| `comfy_cli_status` | Inspect version, selected workspace (`which`), environment, or the self-describing command surface |
+| `comfy_cli_server` | Start, stop, or restart a CLI-managed background ComfyUI |
+| `comfy_cli_jobs` | List, inspect, wait for, watch, or cancel local/cloud jobs |
+| `comfy_cli_workflow` | Validate or run workflow files through the official CLI |
+| `comfy_cli_transfer` | Upload inputs or download completed job outputs |
+| `comfy_cli_models` | Browse/search local model files or the cloud asset catalog |
+| `comfy_cli_skills` | List/show/validate/install/status/uninstall official bundled agent skills |
 
 ### Diagnostics
 
@@ -573,7 +588,8 @@ npx -y comfyui-mcp@latest --comfyui-url http://localhost:8188 --force-remote
 | `COMFYUI_HOST` | `127.0.0.1` | ComfyUI server address |
 | `COMFYUI_PORT` | *(auto-detect)* | ComfyUI server port (tries 8188, then 8000) |
 | `COMFYUI_PATH` | *(auto-detect)* | Path to ComfyUI data directory. Auto-detection suppressed in remote/cloud modes. |
-| `COMFYUI_PYTHON` | `python` | Python interpreter for cm-cli subprocess operations (`useCmCli`, `sync_node_dependencies`) — point it at your ComfyUI venv's python. cm-cli needs the local filesystem, so these are **local-mode only**; on remote targets use the Manager HTTP path (the default). |
+| `COMFY_CLI_PATH` | *(auto-detect)* | Path to the official `comfy` executable (comfy-cli >=1.11.1). Resolution also checks `PATH` and the selected workspace's `.venv`/`venv`. |
+| `COMFYUI_PYTHON` | `python` | Python interpreter used by legacy git-clone dependency fallbacks. Point it at your ComfyUI venv's Python when needed. |
 | `COMFYUI_MCP_BRIDGE_HOST` | `127.0.0.1` | Panel-bridge bind host. Set `0.0.0.0` (or a LAN IP) to run the orchestrator on a 24/7 server and connect panels from other machines — **requires a token** (below); the orchestrator prints a ready-to-paste `ws://…/?token=…` Bridge URL. |
 | `COMFYUI_MCP_BRIDGE_TOKEN` | *(generated when needed)* | Shared secret gating every bridge connection (checked constant-time on the WS upgrade). Mandatory for a non-loopback `COMFYUI_MCP_BRIDGE_HOST`; pin it so the Bridge URL survives restarts. Never logged beyond the startup banner. |
 | `COMFYUI_MCP_DATA_DIR` | `~/.comfyui-mcp` | Base dir for per-instance data (the `generations.db` used by `suggest_settings`) when there's no local `COMFYUI_PATH` (remote/cloud/undetected). Scoped per target under `instances/<host_port>/`. |

--- a/src/__tests__/services/comfy-cli.test.ts
+++ b/src/__tests__/services/comfy-cli.test.ts
@@ -4,8 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   assertComfyCliOk,
+  isSupportedComfyCliVersion,
+  normalizeComfyCliResult,
   parseComfyCliEnvelope,
   resolveComfyCliExecutable,
+  shouldUseComfyCli,
 } from "../../services/comfy-cli.js";
 
 const originalCliPath = process.env.COMFY_CLI_PATH;
@@ -34,7 +37,7 @@ describe("comfy-cli adapter", () => {
 
   it("surfaces structured CLI errors", () => {
     const envelope = parseComfyCliEnvelope(
-      '{"ok":false,"command":"validate","version":"1.11.1","where":"local","data":null,"error":{"code":"workflow_invalid_json","message":"bad JSON","hint":"re-export"}}',
+      '{"schema":"envelope/1","type":"envelope","ok":false,"command":"validate","version":"1.11.1","where":"local","data":null,"error":{"code":"workflow_invalid_json","message":"bad JSON","hint":"re-export"}}',
     );
     expect(() => assertComfyCliOk(envelope)).toThrow(/workflow_invalid_json: bad JSON \(re-export\)/);
   });
@@ -46,5 +49,69 @@ describe("comfy-cli adapter", () => {
     writeFileSync(executable, "");
     process.env.COMFY_CLI_PATH = executable;
     expect(resolveComfyCliExecutable()).toBe(executable);
+  });
+
+  it("normalizes successful legacy plain-text commands", () => {
+    const result = normalizeComfyCliResult(
+      ["stop"],
+      { workspace: "/ws" },
+      { stdout: "No ComfyUI is running in the background.\n", stderr: "", exitCode: 0 },
+      "1.11.1",
+    );
+    expect(result).toMatchObject({
+      schema: "envelope/1",
+      type: "envelope",
+      ok: true,
+      command: "stop",
+      version: "1.11.1",
+      data: { stdout: "No ComfyUI is running in the background.", stderr: "" },
+    });
+  });
+
+  it("normalizes failed legacy commands without losing stderr", () => {
+    const result = normalizeComfyCliResult(
+      ["model", "remove"],
+      {},
+      { stdout: "", stderr: "model not found", exitCode: 2 },
+      "1.11.1",
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatchObject({ code: "legacy_command_failed", message: "model not found" });
+  });
+
+  it("treats stopping an already-stopped background server as idempotent success", () => {
+    const result = normalizeComfyCliResult(
+      ["stop"],
+      {},
+      { stdout: "", stderr: "No ComfyUI is running in the background.", exitCode: 1 },
+      "1.11.1",
+    );
+    expect(result).toMatchObject({ ok: true, data: { already_stopped: true } });
+  });
+
+  it("requires comfy-cli 1.11.1 or newer for automatic adoption", () => {
+    expect(isSupportedComfyCliVersion("1.11.0")).toBe(false);
+    expect(isSupportedComfyCliVersion("1.11.1")).toBe(true);
+    expect(isSupportedComfyCliVersion("2.0.0")).toBe(true);
+    expect(isSupportedComfyCliVersion(null)).toBe(false);
+  });
+
+  it("falls back to Manager HTTP unless a supported local CLI is available", () => {
+    expect(shouldUseComfyCli(undefined, true, "/bin/comfy", "1.11.1")).toBe(true);
+    expect(shouldUseComfyCli(undefined, true, null, null)).toBe(false);
+    expect(shouldUseComfyCli(undefined, true, "/bin/comfy", "1.11.0")).toBe(false);
+    expect(shouldUseComfyCli(undefined, false, "/bin/comfy", "1.11.1")).toBe(false);
+    expect(shouldUseComfyCli(true, false, null, null)).toBe(true);
+    expect(shouldUseComfyCli(false, true, "/bin/comfy", "1.11.1")).toBe(false);
+  });
+
+  it("rejects Windows command shims that execFile cannot launch directly", () => {
+    if (process.platform !== "win32") return;
+    const dir = mkdtempSync(join(tmpdir(), "comfy-cli-test-"));
+    tempDirs.push(dir);
+    const executable = join(dir, "comfy.cmd");
+    writeFileSync(executable, "@echo off\n");
+    process.env.COMFY_CLI_PATH = executable;
+    expect(resolveComfyCliExecutable()).toBeNull();
   });
 });

--- a/src/__tests__/services/comfy-cli.test.ts
+++ b/src/__tests__/services/comfy-cli.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertComfyCliOk,
+  parseComfyCliEnvelope,
+  resolveComfyCliExecutable,
+} from "../../services/comfy-cli.js";
+
+const originalCliPath = process.env.COMFY_CLI_PATH;
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  if (originalCliPath === undefined) delete process.env.COMFY_CLI_PATH;
+  else process.env.COMFY_CLI_PATH = originalCliPath;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("comfy-cli adapter", () => {
+  it("parses the final envelope after NDJSON events", () => {
+    const envelope = parseComfyCliEnvelope<{ jobs: number }>(
+      '{"schema":"event/1","type":"progress"}\n' +
+        '{"schema":"envelope/1","type":"envelope","ok":true,"command":"jobs ls","version":"1.11.1","where":"local","data":{"jobs":2},"error":null}\n',
+    );
+    expect(envelope.ok).toBe(true);
+    expect(envelope.version).toBe("1.11.1");
+    expect(envelope.data).toEqual({ jobs: 2 });
+  });
+
+  it("rejects non-envelope JSON", () => {
+    expect(() => parseComfyCliEnvelope('{"ok":"yes"}')).toThrow(/envelope\/1/);
+  });
+
+  it("surfaces structured CLI errors", () => {
+    const envelope = parseComfyCliEnvelope(
+      '{"ok":false,"command":"validate","version":"1.11.1","where":"local","data":null,"error":{"code":"workflow_invalid_json","message":"bad JSON","hint":"re-export"}}',
+    );
+    expect(() => assertComfyCliOk(envelope)).toThrow(/workflow_invalid_json: bad JSON \(re-export\)/);
+  });
+
+  it("honors COMFY_CLI_PATH", () => {
+    const dir = mkdtempSync(join(tmpdir(), "comfy-cli-test-"));
+    tempDirs.push(dir);
+    const executable = join(dir, process.platform === "win32" ? "comfy.exe" : "comfy");
+    writeFileSync(executable, "");
+    process.env.COMFY_CLI_PATH = executable;
+    expect(resolveComfyCliExecutable()).toBe(executable);
+  });
+});

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -34,6 +34,11 @@ vi.mock("../../config.js", () => {
 // Mock child_process for the cm-cli subprocess paths.
 vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({
+    status: 0,
+    stdout: JSON.stringify({ schema: "envelope/1", type: "envelope", ok: true, command: "version", version: "1.11.1", where: null, data: {}, error: null }),
+    stderr: "",
+  })),
 }));
 
 // Mock fs so resolveCmCliPath's existsSync check is controllable.
@@ -68,7 +73,7 @@ const mockedExists = vi.mocked(existsSync);
 // same way instead of hardcoding POSIX paths.
 const COMFY = "/fake/comfy";
 const COMFY_CLI = join(COMFY, ".venv", process.platform === "win32" ? "Scripts" : "bin", process.platform === "win32" ? "comfy.exe" : "comfy");
-const cliEnvelope = (data: unknown) => JSON.stringify({ ok: true, command: "node", version: "1.11.1", where: "local", data, error: null });
+const cliEnvelope = (data: unknown) => JSON.stringify({ schema: "envelope/1", type: "envelope", ok: true, command: "node", version: "1.11.1", where: "local", data, error: null });
 // runGitCheckout now resolves the target with path.resolve (containment check),
 // so the -C dir carries the drive letter on Windows — match it.
 const BAR_DIR = resolve(COMFY, "custom_nodes", "bar");

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -67,7 +67,8 @@ const mockedExists = vi.mocked(existsSync);
 // platform separator (backslashes on Windows). Build the expected values the
 // same way instead of hardcoding POSIX paths.
 const COMFY = "/fake/comfy";
-const CM_CLI = join(COMFY, "custom_nodes", "ComfyUI-Manager", "cm-cli.py");
+const COMFY_CLI = join(COMFY, ".venv", process.platform === "win32" ? "Scripts" : "bin", process.platform === "win32" ? "comfy.exe" : "comfy");
+const cliEnvelope = (data: unknown) => JSON.stringify({ ok: true, command: "node", version: "1.11.1", where: "local", data, error: null });
 // runGitCheckout now resolves the target with path.resolve (containment check),
 // so the -C dir carries the drive letter on Windows — match it.
 const BAR_DIR = resolve(COMFY, "custom_nodes", "bar");
@@ -591,14 +592,18 @@ describe("node-management service", () => {
     });
 
     it("uses cm-cli subprocess when forced", async () => {
-      mockedExec.mockReturnValue("installed ok" as never);
+      mockedExec.mockReturnValue(cliEnvelope({ message: "installed ok" }) as never);
       const res = await installCustomNode({ id: "some-pack", useCmCli: true });
 
-      expect(res.mechanism).toBe("cm-cli");
+      expect(res.mechanism).toBe("comfy-cli");
       const [bin, args] = mockedExec.mock.calls[0];
-      expect(bin).toBe("python");
+      expect(bin).toBe(COMFY_CLI);
       expect(args).toEqual([
-        CM_CLI,
+        "--json",
+        "--workspace",
+        COMFY,
+        "--skip-prompt",
+        "node",
         "install",
         "some-pack",
         "--mode",
@@ -609,17 +614,21 @@ describe("node-management service", () => {
     });
 
     it("checks out the requested git ref after forced cm-cli install", async () => {
-      mockedExec.mockReturnValue("installed ok" as never);
+      mockedExec.mockReturnValue(cliEnvelope({ message: "installed ok" }) as never);
       const res = await installCustomNode({
         id: "https://github.com/foo/bar/tree/dev",
         ref: "abc123",
         useCmCli: true,
       });
 
-      expect(res.mechanism).toBe("cm-cli");
+      expect(res.mechanism).toBe("comfy-cli");
       expect(mockedExec).toHaveBeenCalledTimes(3);
       expect(mockedExec.mock.calls[0][1]).toEqual([
-        CM_CLI,
+        "--json",
+        "--workspace",
+        COMFY,
+        "--skip-prompt",
+        "node",
         "install",
         "https://github.com/foo/bar",
         "--mode",
@@ -701,9 +710,9 @@ describe("node-management service", () => {
     });
 
     it("routes 'all' to the cm-cli subprocess", async () => {
-      mockedExec.mockReturnValue("fixed all" as never);
+      mockedExec.mockReturnValue(cliEnvelope({ message: "fixed all" }) as never);
       const res = await fixCustomNode({ id: "all" });
-      expect(res.mechanism).toBe("cm-cli");
+      expect(res.mechanism).toBe("comfy-cli");
       const [, args] = mockedExec.mock.calls[0];
       expect(args).toContain("fix");
       expect(args).toContain("all");
@@ -774,12 +783,16 @@ describe("node-management service", () => {
 
   describe("syncNodeDependencies", () => {
     it("runs cm-cli restore-dependencies", async () => {
-      mockedExec.mockReturnValue("deps restored" as never);
+      mockedExec.mockReturnValue(cliEnvelope({ message: "deps restored" }) as never);
       const res = await syncNodeDependencies();
-      expect(res.mechanism).toBe("cm-cli");
+      expect(res.mechanism).toBe("comfy-cli");
       const [, args] = mockedExec.mock.calls[0];
       expect(args).toEqual([
-        CM_CLI,
+        "--json",
+        "--workspace",
+        COMFY,
+        "--skip-prompt",
+        "node",
         "restore-dependencies",
       ]);
     });

--- a/src/__tests__/tools/comfy-cli.test.ts
+++ b/src/__tests__/tools/comfy-cli.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+const mocks = vi.hoisted(() => ({
+  run: vi.fn(),
+  resolve: vi.fn(() => "/bin/comfy"),
+  version: vi.fn(() => "1.11.1"),
+}));
+
+vi.mock("../../services/comfy-cli.js", () => ({
+  runComfyCli: mocks.run,
+  resolveComfyCliExecutable: mocks.resolve,
+  getComfyCliVersion: mocks.version,
+  assertComfyCliOk: (envelope: { ok: boolean }) => {
+    if (!envelope.ok) throw new Error("failed");
+    return envelope;
+  },
+}));
+
+import { registerComfyCliTools } from "../../tools/comfy-cli.js";
+
+type Handler = (args: Record<string, any>) => Promise<CallToolResult>;
+
+function handlers(): Map<string, Handler> {
+  const result = new Map<string, Handler>();
+  const server = {
+    tool: (...args: unknown[]) => {
+      result.set(args[0] as string, args.at(-1) as Handler);
+    },
+  };
+  registerComfyCliTools(server as never);
+  return result;
+}
+
+const envelope = (command = "test") => ({
+  schema: "envelope/1",
+  type: "envelope",
+  ok: true,
+  command,
+  version: "1.11.1",
+  where: "local",
+  data: {},
+  error: null,
+});
+
+describe("comfy-cli MCP command construction", () => {
+  beforeEach(() => {
+    mocks.run.mockReset();
+    mocks.run.mockResolvedValue(envelope());
+    mocks.resolve.mockClear();
+    mocks.version.mockClear();
+  });
+
+  it("uses the same workspace for status path and version", async () => {
+    await handlers().get("comfy_cli_status")!({ detail: "version", workspace: "/ws" });
+    expect(mocks.resolve).toHaveBeenCalledWith({ workspace: "/ws" });
+    expect(mocks.version).toHaveBeenCalledWith({ workspace: "/ws" });
+  });
+
+  it("restarts by stopping then launching in the background with extras", async () => {
+    await handlers().get("comfy_cli_server")!({
+      action: "restart",
+      workspace: "/ws",
+      launchArgs: ["--port", "9000"],
+    });
+    expect(mocks.run.mock.calls.map((call) => call[0])).toEqual([
+      ["stop"],
+      ["launch", "--background", "--", "--port", "9000"],
+    ]);
+  });
+
+  it("constructs job wait arguments and routing", async () => {
+    await handlers().get("comfy_cli_jobs")!({
+      action: "wait",
+      promptIds: ["a", "b"],
+      timeoutSeconds: 30,
+      where: "cloud",
+    });
+    expect(mocks.run).toHaveBeenCalledWith(
+      ["jobs", "wait", "a", "b", "--timeout", "30"],
+      expect.objectContaining({ where: "cloud", timeoutMs: 40_000 }),
+    );
+  });
+
+  it("constructs workflow validation and execution flags", async () => {
+    const handler = handlers().get("comfy_cli_workflow")!;
+    await handler({ action: "validate", workflowPath: "wf.json" });
+    await handler({ action: "run", workflowPath: "wf.json", wait: true, timeoutSeconds: 45 });
+    expect(mocks.run.mock.calls.map((call) => call[0])).toEqual([
+      ["validate", "--workflow", "wf.json"],
+      ["run", "--workflow", "wf.json", "--wait", "--timeout", "45"],
+    ]);
+  });
+
+  it("constructs upload and download commands", async () => {
+    const handler = handlers().get("comfy_cli_transfer")!;
+    await handler({ action: "upload", files: ["a.png", "b.png"], overwrite: false });
+    await handler({ action: "download", promptId: "p1", outDir: "out", urlOnly: true });
+    expect(mocks.run.mock.calls.map((call) => call[0])).toEqual([
+      ["upload", "a.png", "b.png", "--no-overwrite"],
+      ["download", "p1", "--out-dir", "out", "--url-only"],
+    ]);
+  });
+
+  it("uses plural discovery and singular model mutation commands", async () => {
+    const handler = handlers().get("comfy_cli_models")!;
+    await handler({ action: "search", text: "flux", type: "checkpoint", limit: 4 });
+    await handler({ action: "download", url: "https://example.com/m.safetensors", relativePath: "models/loras" });
+    await handler({ action: "remove", modelNames: ["a.safetensors", "b.safetensors"], relativePath: "models/loras" });
+    expect(mocks.run.mock.calls.map((call) => call[0])).toEqual([
+      ["models", "search", "--text", "flux", "--type", "checkpoint", "--limit", "4"],
+      ["model", "download", "--url", "https://example.com/m.safetensors", "--relative-path", "models/loras"],
+      ["model", "remove", "--relative-path", "models/loras", "--model-names", "a.safetensors b.safetensors"],
+    ]);
+  });
+
+  it("keeps skill installation dry-run unless apply is explicit", async () => {
+    const handler = handlers().get("comfy_cli_skills")!;
+    await handler({ action: "install", scope: "project", projectDir: "/project", targets: ["agents"], skills: ["comfy"], apply: false });
+    await handler({ action: "install", scope: "project", projectDir: "/project", apply: true });
+    expect(mocks.run.mock.calls.map((call) => call[0])).toEqual([
+      ["skills", "install", "--scope", "project", "--target", "agents", "--skill", "comfy", "--dry-run"],
+      ["skills", "install", "--scope", "project"],
+    ]);
+    expect(mocks.run.mock.calls[0][1]).toEqual(expect.objectContaining({ cwd: "/project" }));
+  });
+
+  it("rejects project-scoped skill operations without a project directory", async () => {
+    const result = await handlers().get("comfy_cli_skills")!({ action: "install", scope: "project", apply: false });
+    expect(result.isError).toBe(true);
+    expect(mocks.run).not.toHaveBeenCalled();
+  });
+
+  it("constructs loaded-node search with offline object info", async () => {
+    await handlers().get("comfy_cli_search_nodes")!({ query: "sampler", limit: 5, objectInfoPath: "object_info.json" });
+    expect(mocks.run).toHaveBeenCalledWith(
+      ["nodes", "search", "sampler", "--limit", "5", "--input", "object_info.json"],
+      expect.objectContaining({ timeoutMs: 60_000 }),
+    );
+  });
+
+  it("returns failed CLI envelopes intact and marks the MCP result as an error", async () => {
+    const failed = { ...envelope("validate"), ok: false, data: null, error: { code: "workflow_invalid_json", message: "bad JSON" } };
+    mocks.run.mockResolvedValueOnce(failed);
+    const result = await handlers().get("comfy_cli_workflow")!({ action: "validate", workflowPath: "bad.json" });
+    expect(result.isError).toBe(true);
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toEqual(failed);
+  });
+});

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -1,6 +1,6 @@
 import * as childProcess from "node:child_process";
 import { existsSync } from "node:fs";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, extname, join } from "node:path";
 import { config } from "../config.js";
 
 export interface ComfyCliError {
@@ -26,10 +26,14 @@ export interface ComfyCliRunOptions {
   where?: "local" | "cloud";
   timeoutMs?: number;
   env?: NodeJS.ProcessEnv;
+  cwd?: string;
 }
 
+const MIN_COMFY_CLI_VERSION = [1, 11, 1] as const;
+const versionCache = new Map<string, string | null>();
+
 function executableNames(): string[] {
-  return process.platform === "win32" ? ["comfy.exe", "comfy.cmd", "comfy"] : ["comfy"];
+  return process.platform === "win32" ? ["comfy.exe", "comfy"] : ["comfy"];
 }
 
 function workspaceCandidates(workspace?: string | null): string[] {
@@ -46,6 +50,9 @@ function workspaceCandidates(workspace?: string | null): string[] {
 export function resolveComfyCliExecutable(options: { refresh?: boolean; workspace?: string | null } = {}): string | null {
   const explicit = process.env.COMFY_CLI_PATH?.trim();
   if (explicit) {
+    if (process.platform === "win32" && [".cmd", ".bat"].includes(extname(explicit).toLowerCase())) {
+      return null;
+    }
     return existsSync(explicit) ? explicit : null;
   }
 
@@ -92,10 +99,85 @@ export function parseComfyCliEnvelope<T>(stdout: string, stderr = "", exitCode?:
     throw new Error(`comfy-cli did not return a JSON envelope${exitCode == null ? "" : ` (exit ${exitCode})`}: ${stderr || stdout}`);
   }
   const envelope = parsed as Partial<ComfyCliEnvelope<T>>;
-  if (typeof envelope.ok !== "boolean" || typeof envelope.command !== "string" || typeof envelope.version !== "string") {
+  if (
+    envelope.schema !== "envelope/1" ||
+    envelope.type !== "envelope" ||
+    typeof envelope.ok !== "boolean" ||
+    typeof envelope.command !== "string" ||
+    typeof envelope.version !== "string"
+  ) {
     throw new Error("comfy-cli returned JSON that does not match envelope/1");
   }
   return envelope as ComfyCliEnvelope<T>;
+}
+
+function hasJsonRecord(stdout: string): boolean {
+  return stdout.trim().split(/\r?\n/).some((line) => {
+    try {
+      JSON.parse(line);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function normalizeComfyCliResult<T = unknown>(
+  args: readonly string[],
+  options: ComfyCliRunOptions,
+  result: { stdout: string; stderr: string; exitCode: number },
+  version: string,
+): ComfyCliEnvelope<T> {
+  try {
+    return parseComfyCliEnvelope<T>(result.stdout, result.stderr, result.exitCode);
+  } catch (error) {
+    if (hasJsonRecord(result.stdout)) throw error;
+  }
+
+  const command = args.join(" ");
+  const details = { stdout: result.stdout.trim(), stderr: result.stderr.trim() };
+  const alreadyStopped =
+    args.length === 1 &&
+    args[0] === "stop" &&
+    /no comfyui is running in the background/i.test(details.stderr || details.stdout);
+  if (alreadyStopped) {
+    return {
+      schema: "envelope/1",
+      type: "envelope",
+      ok: true,
+      command,
+      version,
+      where: options.where ?? null,
+      data: { ...details, already_stopped: true } as T,
+      error: null,
+    };
+  }
+  if (result.exitCode !== 0) {
+    return {
+      schema: "envelope/1",
+      type: "envelope",
+      ok: false,
+      command,
+      version,
+      where: options.where ?? null,
+      data: null,
+      error: {
+        code: "legacy_command_failed",
+        message: details.stderr || details.stdout || `comfy-cli exited with code ${result.exitCode}`,
+        details: { ...details, exit_code: result.exitCode },
+      },
+    };
+  }
+  return {
+    schema: "envelope/1",
+    type: "envelope",
+    ok: true,
+    command,
+    version,
+    where: options.where ?? null,
+    data: details as T,
+    error: null,
+  };
 }
 
 function requireExecutable(options: ComfyCliRunOptions): string {
@@ -109,8 +191,34 @@ function requireExecutable(options: ComfyCliRunOptions): string {
   return executable;
 }
 
+function unsupportedVersionEnvelope<T>(
+  args: readonly string[],
+  options: ComfyCliRunOptions,
+  version: string | null,
+): ComfyCliEnvelope<T> {
+  return {
+    schema: "envelope/1",
+    type: "envelope",
+    ok: false,
+    command: args.join(" "),
+    version: version ?? "unknown",
+    where: options.where ?? null,
+    data: null,
+    error: {
+      code: "unsupported_version",
+      message: `comfy-cli >=1.11.1 is required; found ${version ?? "an unrecognized version"}.`,
+      hint: "Upgrade with: python -m pip install --upgrade comfy-cli",
+    },
+  };
+}
+
 export async function runComfyCli<T = unknown>(args: readonly string[], options: ComfyCliRunOptions = {}): Promise<ComfyCliEnvelope<T>> {
   const executable = requireExecutable(options);
+  const detectedVersion = getExecutableVersion(executable);
+  if (!isSupportedComfyCliVersion(detectedVersion)) {
+    return unsupportedVersionEnvelope<T>(args, options, detectedVersion);
+  }
+  const version = detectedVersion!;
   try {
     const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
       childProcess.execFile(
@@ -122,20 +230,36 @@ export async function runComfyCli<T = unknown>(args: readonly string[], options:
           windowsHide: true,
           maxBuffer: 16 * 1024 * 1024,
           env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+          cwd: options.cwd,
         },
         (error, stdout, stderr) => error ? reject(Object.assign(error, { stdout, stderr })) : resolve({ stdout, stderr }),
       );
     });
-    return parseComfyCliEnvelope<T>(result.stdout, result.stderr);
+    return normalizeComfyCliResult<T>(args, options, { ...result, exitCode: 0 }, version);
   } catch (error) {
-    const processError = error as Error & { stdout?: string; stderr?: string; code?: number };
-    if (processError.stdout) return parseComfyCliEnvelope<T>(processError.stdout, processError.stderr ?? "", processError.code);
-    throw error;
+    const processError = error as Error & { stdout?: string; stderr?: string; code?: number | string };
+    if (processError.code === "ENOENT") throw error;
+    const exitCode = typeof processError.code === "number" ? processError.code : 1;
+    return normalizeComfyCliResult<T>(
+      args,
+      options,
+      {
+        stdout: processError.stdout ?? "",
+        stderr: processError.stderr || processError.message,
+        exitCode,
+      },
+      version,
+    );
   }
 }
 
 export function runComfyCliSync<T = unknown>(args: readonly string[], options: ComfyCliRunOptions = {}): ComfyCliEnvelope<T> {
   const executable = requireExecutable(options);
+  const detectedVersion = getExecutableVersion(executable);
+  if (!isSupportedComfyCliVersion(detectedVersion)) {
+    return unsupportedVersionEnvelope<T>(args, options, detectedVersion);
+  }
+  const version = detectedVersion!;
   try {
     const stdout = childProcess.execFileSync(executable, buildArgs(args, options), {
       encoding: "utf8",
@@ -143,29 +267,61 @@ export function runComfyCliSync<T = unknown>(args: readonly string[], options: C
       windowsHide: true,
       maxBuffer: 16 * 1024 * 1024,
       env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+      cwd: options.cwd,
     });
-    return parseComfyCliEnvelope<T>(stdout, "");
+    return normalizeComfyCliResult<T>(args, options, { stdout, stderr: "", exitCode: 0 }, version);
   } catch (error) {
-    const processError = error as Error & { stdout?: string | Buffer; stderr?: string | Buffer; status?: number };
+    const processError = error as Error & { code?: string; stdout?: string | Buffer; stderr?: string | Buffer; status?: number };
+    if (processError.code === "ENOENT") throw error;
     const stdout = processError.stdout?.toString() ?? "";
-    if (stdout) return parseComfyCliEnvelope<T>(stdout, processError.stderr?.toString() ?? "", processError.status);
-    throw error;
+    const stderr = processError.stderr?.toString() || processError.message;
+    return normalizeComfyCliResult<T>(args, options, { stdout, stderr, exitCode: processError.status ?? 1 }, version);
   }
 }
 
-export function getComfyCliVersion(): string | null {
-  const executable = resolveComfyCliExecutable();
-  if (!executable) return null;
+function getExecutableVersion(executable: string): string | null {
+  if (versionCache.has(executable)) return versionCache.get(executable) ?? null;
   const result = childProcess.spawnSync(executable, ["--json", "--version"], {
     encoding: "utf8",
     windowsHide: true,
+    timeout: 10_000,
+    maxBuffer: 1024 * 1024,
     env: { ...process.env, PYTHONUTF8: "1" },
   });
   try {
-    return parseComfyCliEnvelope(result.stdout ?? "", result.stderr ?? "", result.status ?? undefined).version;
+    const version = parseComfyCliEnvelope(result.stdout ?? "", result.stderr ?? "", result.status ?? undefined).version;
+    versionCache.set(executable, version);
+    return version;
   } catch {
+    versionCache.set(executable, null);
     return null;
   }
+}
+
+export function getComfyCliVersion(options: { workspace?: string | null } = {}): string | null {
+  const executable = resolveComfyCliExecutable({ workspace: options.workspace });
+  return executable ? getExecutableVersion(executable) : null;
+}
+
+export function isSupportedComfyCliVersion(version: string | null): boolean {
+  if (!version) return false;
+  const parts = version.split(".").slice(0, 3).map((part) => Number.parseInt(part, 10));
+  if (parts.some((part) => !Number.isFinite(part))) return false;
+  for (let index = 0; index < MIN_COMFY_CLI_VERSION.length; index++) {
+    if ((parts[index] ?? 0) > MIN_COMFY_CLI_VERSION[index]) return true;
+    if ((parts[index] ?? 0) < MIN_COMFY_CLI_VERSION[index]) return false;
+  }
+  return true;
+}
+
+export function shouldUseComfyCli(
+  explicit: boolean | undefined,
+  localMode: boolean,
+  executable: string | null,
+  version: string | null,
+): boolean {
+  if (explicit !== undefined) return explicit;
+  return localMode && executable !== null && isSupportedComfyCliVersion(version);
 }
 
 export function assertComfyCliOk<T>(envelope: ComfyCliEnvelope<T>): ComfyCliEnvelope<T> {

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -1,0 +1,177 @@
+import * as childProcess from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+import { config } from "../config.js";
+
+export interface ComfyCliError {
+  code: string;
+  message: string;
+  hint?: string | null;
+  details?: unknown;
+}
+
+export interface ComfyCliEnvelope<T = unknown> {
+  schema?: string;
+  type?: string;
+  ok: boolean;
+  command: string;
+  version: string;
+  where: "local" | "cloud" | null;
+  data: T | null;
+  error: ComfyCliError | null;
+}
+
+export interface ComfyCliRunOptions {
+  workspace?: string | null;
+  where?: "local" | "cloud";
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+function executableNames(): string[] {
+  return process.platform === "win32" ? ["comfy.exe", "comfy.cmd", "comfy"] : ["comfy"];
+}
+
+function workspaceCandidates(workspace?: string | null): string[] {
+  if (!workspace) return [];
+  const roots = [workspace, dirname(workspace)];
+  const dirs = roots.flatMap((root) => [
+    join(root, ".venv", process.platform === "win32" ? "Scripts" : "bin"),
+    join(root, "venv", process.platform === "win32" ? "Scripts" : "bin"),
+  ]);
+  return dirs.flatMap((dir) => executableNames().map((name) => join(dir, name)));
+}
+
+/** Resolve comfy-cli without invoking a shell. COMFY_CLI_PATH is authoritative. */
+export function resolveComfyCliExecutable(options: { refresh?: boolean; workspace?: string | null } = {}): string | null {
+  const explicit = process.env.COMFY_CLI_PATH?.trim();
+  if (explicit) {
+    return existsSync(explicit) ? explicit : null;
+  }
+
+  const workspace = options.workspace ?? config.comfyuiPath;
+  for (const candidate of workspaceCandidates(workspace)) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const dir of (process.env.PATH ?? "").split(delimiter).filter(Boolean)) {
+    for (const name of executableNames()) {
+      const candidate = join(dir.replace(/^"|"$/g, ""), name);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function buildArgs(args: readonly string[], options: ComfyCliRunOptions): string[] {
+  const result = ["--json"];
+  const workspace = options.workspace === undefined ? config.comfyuiPath : options.workspace;
+  if (workspace) result.push("--workspace", workspace);
+  if (options.where) result.push("--where", options.where);
+  result.push("--skip-prompt", ...args);
+  return result;
+}
+
+export function parseComfyCliEnvelope<T>(stdout: string, stderr = "", exitCode?: number): ComfyCliEnvelope<T> {
+  const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+  let parsed: unknown;
+  for (let index = lines.length - 1; index >= 0; index--) {
+    try {
+      parsed = JSON.parse(lines[index]);
+      break;
+    } catch {
+      // JSON streaming commands may emit events before the final envelope.
+    }
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`comfy-cli did not return a JSON envelope${exitCode == null ? "" : ` (exit ${exitCode})`}: ${stderr || stdout}`);
+  }
+  const envelope = parsed as Partial<ComfyCliEnvelope<T>>;
+  if (typeof envelope.ok !== "boolean" || typeof envelope.command !== "string" || typeof envelope.version !== "string") {
+    throw new Error("comfy-cli returned JSON that does not match envelope/1");
+  }
+  return envelope as ComfyCliEnvelope<T>;
+}
+
+function requireExecutable(options: ComfyCliRunOptions): string {
+  const executable = resolveComfyCliExecutable({ workspace: options.workspace });
+  if (!executable) {
+    throw new Error(
+      "comfy-cli was not found. Install comfy-cli>=1.11.1 and ensure `comfy` is on PATH, " +
+        "set COMFY_CLI_PATH, or install it in the selected ComfyUI workspace's .venv.",
+    );
+  }
+  return executable;
+}
+
+export async function runComfyCli<T = unknown>(args: readonly string[], options: ComfyCliRunOptions = {}): Promise<ComfyCliEnvelope<T>> {
+  const executable = requireExecutable(options);
+  try {
+    const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      childProcess.execFile(
+        executable,
+        buildArgs(args, options),
+        {
+          encoding: "utf8",
+          timeout: options.timeoutMs ?? 120_000,
+          windowsHide: true,
+          maxBuffer: 16 * 1024 * 1024,
+          env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+        },
+        (error, stdout, stderr) => error ? reject(Object.assign(error, { stdout, stderr })) : resolve({ stdout, stderr }),
+      );
+    });
+    return parseComfyCliEnvelope<T>(result.stdout, result.stderr);
+  } catch (error) {
+    const processError = error as Error & { stdout?: string; stderr?: string; code?: number };
+    if (processError.stdout) return parseComfyCliEnvelope<T>(processError.stdout, processError.stderr ?? "", processError.code);
+    throw error;
+  }
+}
+
+export function runComfyCliSync<T = unknown>(args: readonly string[], options: ComfyCliRunOptions = {}): ComfyCliEnvelope<T> {
+  const executable = requireExecutable(options);
+  try {
+    const stdout = childProcess.execFileSync(executable, buildArgs(args, options), {
+      encoding: "utf8",
+      timeout: options.timeoutMs ?? 120_000,
+      windowsHide: true,
+      maxBuffer: 16 * 1024 * 1024,
+      env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+    });
+    return parseComfyCliEnvelope<T>(stdout, "");
+  } catch (error) {
+    const processError = error as Error & { stdout?: string | Buffer; stderr?: string | Buffer; status?: number };
+    const stdout = processError.stdout?.toString() ?? "";
+    if (stdout) return parseComfyCliEnvelope<T>(stdout, processError.stderr?.toString() ?? "", processError.status);
+    throw error;
+  }
+}
+
+export function getComfyCliVersion(): string | null {
+  const executable = resolveComfyCliExecutable();
+  if (!executable) return null;
+  const result = childProcess.spawnSync(executable, ["--json", "--version"], {
+    encoding: "utf8",
+    windowsHide: true,
+    env: { ...process.env, PYTHONUTF8: "1" },
+  });
+  try {
+    return parseComfyCliEnvelope(result.stdout ?? "", result.stderr ?? "", result.status ?? undefined).version;
+  } catch {
+    return null;
+  }
+}
+
+export function assertComfyCliOk<T>(envelope: ComfyCliEnvelope<T>): ComfyCliEnvelope<T> {
+  if (!envelope.ok) {
+    const error = envelope.error;
+    throw new Error(`${error?.code ? `${error.code}: ` : ""}${error?.message ?? "comfy-cli command failed"}${error?.hint ? ` (${error.hint})` : ""}`);
+  }
+  return envelope;
+}

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -417,7 +417,7 @@ async function queueManagerTask(
 }
 
 // ---------------------------------------------------------------------------
-// cm-cli subprocess helper
+// Official comfy-cli subprocess helper
 // ---------------------------------------------------------------------------
 
 const COMFY_CLI_TIMEOUT = 600_000;
@@ -440,33 +440,8 @@ export function nonInteractiveGitEnv(): NodeJS.ProcessEnv {
   };
 }
 
-function resolveCmCliPath(): string {
-  if (!config.comfyuiPath) {
-    throw new ProcessControlError(
-      "This operation requires a local ComfyUI install, but config.comfyuiPath " +
-        "is not set (running in remote --comfyui-url mode). Set COMFYUI_PATH or " +
-        "use the ComfyUI-Manager HTTP API instead.",
-    );
-  }
-  const cmCli = join(
-    config.comfyuiPath,
-    "custom_nodes",
-    "ComfyUI-Manager",
-    "cm-cli.py",
-  );
-  if (!existsSync(cmCli)) {
-    throw new NodeManagementError(
-      `cm-cli.py not found at ${cmCli}. Modern ComfyUI-Manager ships as the pip ` +
-        `package 'comfyui_manager' (no cm-cli.py), so the subprocess fallback is ` +
-        `unavailable on this install. Retry without useCmCli — the HTTP API covers ` +
-        `install/update/fix/uninstall/enable/disable.`,
-    );
-  }
-  return cmCli;
-}
-
 /**
- * Run a cm-cli.py subcommand. Returns combined stdout.
+ * Run an official `comfy node` subcommand. Returns normalized JSON data.
  * Throws ProcessControlError if comfyuiPath is undefined (remote mode).
  */
 function runCmCli(args: string[]): string {
@@ -923,7 +898,7 @@ export interface InstallOptions {
   ref?: string;
   mode?: ManagerMode;
   channel?: string;
-  /** Force the cm-cli subprocess instead of the HTTP API. */
+  /** Force the official comfy-cli subprocess instead of the HTTP API. */
   useCmCli?: boolean;
 }
 
@@ -961,7 +936,7 @@ export async function installCustomNode(
     }
     return {
       mechanism: "comfy-cli",
-      message: `Installed "${id}" via cm-cli.`,
+      message: `Installed "${id}" via official comfy-cli.`,
       details: out.trim(),
     };
   }
@@ -1070,8 +1045,8 @@ export async function updateCustomNode(
     return {
       mechanism: "comfy-cli",
       message: all
-        ? "Updated all installed node packs via cm-cli."
-        : `Updated "${id}" via cm-cli.`,
+        ? "Updated all installed node packs via official comfy-cli."
+        : `Updated "${id}" via official comfy-cli.`,
       details: out.trim(),
     };
   }
@@ -1134,7 +1109,7 @@ export async function reinstallCustomNode(
     const out = runCmCli(["reinstall", id, "--mode", mode, "--channel", channel]);
     return {
       mechanism: "comfy-cli",
-      message: `Reinstalled "${id}" via cm-cli.`,
+      message: `Reinstalled "${id}" via official comfy-cli.`,
       details: out.trim(),
     };
   }
@@ -1178,8 +1153,8 @@ export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
     return {
       mechanism: "comfy-cli",
       message: all
-        ? "Repaired all installed node packs via cm-cli."
-        : `Repaired "${id}" via cm-cli.`,
+        ? "Repaired all installed node packs via official comfy-cli."
+        : `Repaired "${id}" via official comfy-cli.`,
       details: out.trim(),
     };
   }
@@ -1251,7 +1226,7 @@ export async function syncNodeDependencies(): Promise<SyncDepsResult> {
   return {
     mechanism: "comfy-cli",
     message:
-      "Reconciled installed-node Python dependencies via cm-cli restore-dependencies.",
+      "Reconciled installed-node Python dependencies via official comfy-cli node restore-dependencies.",
     details: out.trim(),
   };
 }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -5,6 +5,7 @@ import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
+import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -85,7 +86,7 @@ export interface InstalledNode {
 
 export interface NodeOpResult {
   /** Which mechanism handled the request. */
-  mechanism: "manager-http" | "cm-cli" | "git-clone";
+  mechanism: "manager-http" | "comfy-cli" | "git-clone";
   /** Human-readable summary. */
   message: string;
   /** Raw queue status (HTTP path) or subprocess output (cm-cli path). */
@@ -419,7 +420,7 @@ async function queueManagerTask(
 // cm-cli subprocess helper
 // ---------------------------------------------------------------------------
 
-const CM_CLI_TIMEOUT = 600_000;
+const COMFY_CLI_TIMEOUT = 600_000;
 // A real custom-node repo clones well under this; with prompts disabled a
 // missing/private repo fails in ~1s rather than blocking the whole timeout.
 const GIT_CLONE_TIMEOUT = 180_000;
@@ -469,35 +470,32 @@ function resolveCmCliPath(): string {
  * Throws ProcessControlError if comfyuiPath is undefined (remote mode).
  */
 function runCmCli(args: string[]): string {
-  const cmCli = resolveCmCliPath();
-  const pythonExe = process.env.COMFYUI_PYTHON || "python";
-  logger.info("Running cm-cli", { args: [cmCli, ...args].join(" ") });
-
+  if (!config.comfyuiPath) {
+    throw new ProcessControlError(
+      "This operation requires a local ComfyUI install. Set COMFYUI_PATH or use the Manager HTTP API.",
+    );
+  }
+  logger.info("Running comfy-cli", { args: ["node", ...args].join(" ") });
   try {
-    const out = execFileSync(pythonExe, [cmCli, ...args], {
-      cwd: config.comfyuiPath,
-      encoding: "utf-8",
-      timeout: CM_CLI_TIMEOUT,
-      env: {
-        ...process.env,
-        ...(config.githubToken ? { GITHUB_TOKEN: config.githubToken } : {}),
-      },
-    });
-    return out;
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
-    const stdout = e.stdout ? e.stdout.toString() : "";
-    const stderr = e.stderr ? e.stderr.toString() : "";
-    if (e.code === "ENOENT") {
+    const envelope = assertComfyCliOk(
+      runComfyCliSync(["node", ...args], {
+        workspace: config.comfyuiPath,
+        timeoutMs: COMFY_CLI_TIMEOUT,
+        env: config.githubToken ? { GITHUB_TOKEN: config.githubToken } : undefined,
+      }),
+    );
+    return JSON.stringify(envelope.data ?? {}, null, 2);
+  } catch (error) {
+    const processError = error as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
+    if (processError.code === "ENOENT") {
       throw new ProcessControlError(
-        `Python executable "${pythonExe}" not found. Set COMFYUI_PYTHON to the ` +
-          `python interpreter for your ComfyUI install.`,
+        "The comfy-cli executable could not be started. Check COMFY_CLI_PATH and PATH.",
       );
     }
-    throw new NodeManagementError(
-      `cm-cli ${args[0]} failed: ${e.message}`,
-      { stdout, stderr },
-    );
+    throw new NodeManagementError(`comfy-cli node ${args[0]} failed: ${processError.message}`, {
+      stdout: processError.stdout?.toString() ?? "",
+      stderr: processError.stderr?.toString() ?? "",
+    });
   }
 }
 
@@ -877,7 +875,7 @@ function cloneCustomNodeFallback(
         execFileSync(python, ["-m", "pip", "install", "-r", requirements], {
           cwd: nodeDir,
           encoding: "utf-8",
-          timeout: CM_CLI_TIMEOUT,
+          timeout: COMFY_CLI_TIMEOUT,
         });
       } catch (err) {
         const e = err as Error;
@@ -891,7 +889,7 @@ function cloneCustomNodeFallback(
         execFileSync(python, [installScript], {
           cwd: nodeDir,
           encoding: "utf-8",
-          timeout: CM_CLI_TIMEOUT,
+          timeout: COMFY_CLI_TIMEOUT,
         });
       } catch (err) {
         const e = err as Error;
@@ -962,7 +960,7 @@ export async function installCustomNode(
       runGitCheckout(gitId, gitRef);
     }
     return {
-      mechanism: "cm-cli",
+      mechanism: "comfy-cli",
       message: `Installed "${id}" via cm-cli.`,
       details: out.trim(),
     };
@@ -1070,7 +1068,7 @@ export async function updateCustomNode(
   if (opts.useCmCli) {
     const out = runCmCli(["update", id, "--mode", mode, "--channel", channel]);
     return {
-      mechanism: "cm-cli",
+      mechanism: "comfy-cli",
       message: all
         ? "Updated all installed node packs via cm-cli."
         : `Updated "${id}" via cm-cli.`,
@@ -1135,7 +1133,7 @@ export async function reinstallCustomNode(
   if (opts.useCmCli) {
     const out = runCmCli(["reinstall", id, "--mode", mode, "--channel", channel]);
     return {
-      mechanism: "cm-cli",
+      mechanism: "comfy-cli",
       message: `Reinstalled "${id}" via cm-cli.`,
       details: out.trim(),
     };
@@ -1178,7 +1176,7 @@ export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
   if (opts.useCmCli || all) {
     const out = runCmCli(["fix", id, "--mode", mode, "--channel", channel]);
     return {
-      mechanism: "cm-cli",
+      mechanism: "comfy-cli",
       message: all
         ? "Repaired all installed node packs via cm-cli."
         : `Repaired "${id}" via cm-cli.`,
@@ -1237,7 +1235,7 @@ export async function listInstalledNodes(
 // ---------------------------------------------------------------------------
 
 export interface SyncDepsResult {
-  mechanism: "cm-cli";
+  mechanism: "comfy-cli";
   message: string;
   details?: unknown;
 }
@@ -1251,7 +1249,7 @@ export interface SyncDepsResult {
 export async function syncNodeDependencies(): Promise<SyncDepsResult> {
   const out = runCmCli(["restore-dependencies"]);
   return {
-    mechanism: "cm-cli",
+    mechanism: "comfy-cli",
     message:
       "Reconciled installed-node Python dependencies via cm-cli restore-dependencies.",
     details: out.trim(),

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -1,7 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
-  assertComfyCliOk,
   getComfyCliVersion,
   resolveComfyCliExecutable,
   runComfyCli,
@@ -12,11 +11,15 @@ const whereSchema = z.enum(["local", "cloud"]).optional();
 const workspaceSchema = z.string().optional().describe("Optional ComfyUI workspace override. Otherwise COMFYUI_PATH/auto-detection is used.");
 
 function textEnvelope(envelope: unknown) {
-  return { content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }] };
+  const failed = typeof envelope === "object" && envelope !== null && "ok" in envelope && envelope.ok === false;
+  return {
+    ...(failed ? { isError: true } : {}),
+    content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }],
+  };
 }
 
-async function call(args: string[], options: { workspace?: string; where?: "local" | "cloud"; timeoutMs?: number }) {
-  return textEnvelope(assertComfyCliOk(await runComfyCli(args, options)));
+async function call(args: string[], options: { workspace?: string; where?: "local" | "cloud"; timeoutMs?: number; cwd?: string }) {
+  return textEnvelope(await runComfyCli(args, options));
 }
 
 export function registerComfyCliTools(server: McpServer): void {
@@ -30,7 +33,7 @@ export function registerComfyCliTools(server: McpServer): void {
     async (args) => {
       try {
         if (args.detail === "version") {
-          return textEnvelope({ executable: resolveComfyCliExecutable({ workspace: args.workspace }), version: getComfyCliVersion() });
+          return textEnvelope({ executable: resolveComfyCliExecutable({ workspace: args.workspace }), version: getComfyCliVersion({ workspace: args.workspace }) });
         }
         return await call([args.detail], { workspace: args.workspace, timeoutMs: 30_000 });
       } catch (error) {
@@ -50,12 +53,13 @@ export function registerComfyCliTools(server: McpServer): void {
     async (args) => {
       try {
         const options = { workspace: args.workspace, timeoutMs: 120_000 };
-        let stopped: unknown;
-        if (args.action !== "start") stopped = assertComfyCliOk(await runComfyCli(["stop"], options));
+        let stopped: Awaited<ReturnType<typeof runComfyCli>> | undefined;
+        if (args.action !== "start") stopped = await runComfyCli(["stop"], options);
         if (args.action === "stop") return textEnvelope(stopped);
+        if (stopped && !stopped.ok) return textEnvelope(stopped);
         const launch = ["launch", "--background"];
         if (args.launchArgs?.length) launch.push("--", ...args.launchArgs);
-        const started = assertComfyCliOk(await runComfyCli(launch, options));
+        const started = await runComfyCli(launch, options);
         return textEnvelope(args.action === "restart" ? { stopped, started } : started);
       } catch (error) {
         return errorToToolResult(error);
@@ -177,20 +181,23 @@ export function registerComfyCliTools(server: McpServer): void {
 
   server.tool(
     "comfy_cli_models",
-    "Discover model folders/files through official comfy-cli locally or in Comfy Cloud. Search is filename-based locally and uses the enriched cloud asset catalog remotely.",
+    "Discover model folders/files locally or in Comfy Cloud, download model URLs into a workspace, or remove workspace model files through official comfy-cli.",
     {
-      action: z.enum(["list-folders", "list-folder", "search", "show"]),
+      action: z.enum(["list-folders", "list-folder", "search", "show", "download", "remove"]),
       folder: z.string().optional(),
       text: z.string().optional(),
       type: z.string().optional(),
       name: z.string().optional(),
+      url: z.string().url().optional(),
+      relativePath: z.string().optional().describe("Workspace-relative model directory (default models/checkpoints)."),
+      modelNames: z.array(z.string()).optional().describe("Model filenames to remove."),
       limit: z.number().int().min(1).max(100).optional(),
       where: whereSchema,
       workspace: workspaceSchema,
     },
     async (args) => {
       try {
-        const command = ["models", args.action];
+        const command = [args.action === "download" || args.action === "remove" ? "model" : "models", args.action];
         if (args.action === "list-folder") {
           if (!args.folder) throw new Error("folder is required for list-folder");
           command.push(args.folder);
@@ -202,6 +209,16 @@ export function registerComfyCliTools(server: McpServer): void {
         if (args.action === "search") {
           if (args.text) command.push("--text", args.text);
           if (args.type) command.push("--type", args.type);
+        }
+        if (args.action === "download") {
+          if (!args.url) throw new Error("url is required for model download");
+          command.push("--url", args.url);
+          if (args.relativePath) command.push("--relative-path", args.relativePath);
+        }
+        if (args.action === "remove") {
+          if (!args.modelNames?.length) throw new Error("modelNames is required for model remove");
+          if (args.relativePath) command.push("--relative-path", args.relativePath);
+          command.push("--model-names", args.modelNames.join(" "));
         }
         if (args.limit && args.action !== "show" && args.action !== "list-folders") command.push("--limit", String(args.limit));
         return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: 60_000 });
@@ -219,6 +236,7 @@ export function registerComfyCliTools(server: McpServer): void {
       name: z.string().optional(),
       path: z.string().optional(),
       scope: z.enum(["user", "project"]).optional(),
+      projectDir: z.string().optional().describe("Working directory for project-scoped skill operations. Required when scope='project'."),
       targets: z.array(z.string()).optional(),
       skills: z.array(z.string()).optional(),
       apply: z.boolean().optional().default(false),
@@ -227,6 +245,9 @@ export function registerComfyCliTools(server: McpServer): void {
     async (args) => {
       try {
         const command = ["skills", args.action];
+        if (args.scope === "project" && !args.projectDir) {
+          throw new Error("projectDir is required when scope='project'");
+        }
         if (args.action === "show" && args.name) command.push(args.name);
         if (args.action === "validate") {
           if (!args.path) throw new Error("path is required for skills validate");
@@ -238,7 +259,7 @@ export function registerComfyCliTools(server: McpServer): void {
           for (const skill of args.skills ?? []) command.push("--skill", skill);
           if (!args.apply) command.push("--dry-run");
         }
-        return await call(command, { workspace: args.workspace, timeoutMs: 60_000 });
+        return await call(command, { workspace: args.workspace, timeoutMs: 60_000, cwd: args.projectDir });
       } catch (error) {
         return errorToToolResult(error);
       }

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -1,0 +1,247 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  assertComfyCliOk,
+  getComfyCliVersion,
+  resolveComfyCliExecutable,
+  runComfyCli,
+} from "../services/comfy-cli.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+const whereSchema = z.enum(["local", "cloud"]).optional();
+const workspaceSchema = z.string().optional().describe("Optional ComfyUI workspace override. Otherwise COMFYUI_PATH/auto-detection is used.");
+
+function textEnvelope(envelope: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }] };
+}
+
+async function call(args: string[], options: { workspace?: string; where?: "local" | "cloud"; timeoutMs?: number }) {
+  return textEnvelope(assertComfyCliOk(await runComfyCli(args, options)));
+}
+
+export function registerComfyCliTools(server: McpServer): void {
+  server.tool(
+    "comfy_cli_status",
+    "Inspect the official comfy-cli integration and selected ComfyUI environment. Uses `comfy which` or `comfy env` with the envelope/1 JSON contract. Call this before local CLI operations when workspace or server routing is uncertain.",
+    {
+      detail: z.enum(["version", "which", "env", "discover"]).optional().default("env"),
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        if (args.detail === "version") {
+          return textEnvelope({ executable: resolveComfyCliExecutable({ workspace: args.workspace }), version: getComfyCliVersion() });
+        }
+        return await call([args.detail], { workspace: args.workspace, timeoutMs: 30_000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_server",
+    "Start, stop, or restart a local ComfyUI through official comfy-cli background process management. Restart performs `comfy stop` followed by `comfy launch --background`. Use comfy_cli_status(detail='env') to inspect the managed server.",
+    {
+      action: z.enum(["start", "stop", "restart"]),
+      workspace: workspaceSchema,
+      launchArgs: z.array(z.string()).optional().describe("Extra ComfyUI launch arguments, e.g. ['--listen','0.0.0.0','--port','8188'].")
+    },
+    async (args) => {
+      try {
+        const options = { workspace: args.workspace, timeoutMs: 120_000 };
+        let stopped: unknown;
+        if (args.action !== "start") stopped = assertComfyCliOk(await runComfyCli(["stop"], options));
+        if (args.action === "stop") return textEnvelope(stopped);
+        const launch = ["launch", "--background"];
+        if (args.launchArgs?.length) launch.push("--", ...args.launchArgs);
+        const started = assertComfyCliOk(await runComfyCli(launch, options));
+        return textEnvelope(args.action === "restart" ? { stopped, started } : started);
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_jobs",
+    "List, inspect, wait for, watch, or cancel local or Comfy Cloud jobs through official comfy-cli. Local jobs include CLI-tracked async submissions plus the ComfyUI queue/history.",
+    {
+      action: z.enum(["list", "status", "wait", "watch", "cancel"]),
+      promptId: z.string().optional(),
+      promptIds: z.array(z.string()).optional(),
+      all: z.boolean().optional(),
+      limit: z.number().int().min(1).max(100).optional(),
+      timeoutSeconds: z.number().int().min(1).optional(),
+      where: whereSchema,
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const subcommand = args.action === "list" ? "ls" : args.action;
+        const command = ["jobs", subcommand];
+        if (["status", "watch", "cancel"].includes(args.action)) {
+          if (!args.promptId) throw new Error(`promptId is required for jobs ${args.action}`);
+          command.push(args.promptId);
+        } else if (args.action === "wait") {
+          if (args.all) command.push("--all");
+          else if (args.promptIds?.length) command.push(...args.promptIds);
+          else throw new Error("promptIds or all=true is required for jobs wait");
+        }
+        if (args.limit && args.action === "list") command.push("--limit", String(args.limit));
+        if (args.timeoutSeconds && ["wait", "watch"].includes(args.action)) command.push("--timeout", String(args.timeoutSeconds));
+        return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: ((args.timeoutSeconds ?? 120) + 10) * 1000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_search_nodes",
+    "Fuzzy-search actual ComfyUI node classes by name, display name, or description using official `comfy nodes search`. This complements search_custom_nodes, which searches installable node packs. Works locally, in Comfy Cloud, or offline with object_info JSON.",
+    {
+      query: z.string().min(1),
+      limit: z.number().int().min(1).max(100).optional(),
+      objectInfoPath: z.string().optional(),
+      where: whereSchema,
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const command = ["nodes", "search", args.query];
+        if (args.limit) command.push("--limit", String(args.limit));
+        if (args.objectInfoPath) command.push("--input", args.objectInfoPath);
+        return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: 60_000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_workflow",
+    "Validate or run an API/UI workflow file using official comfy-cli. Validation checks class types, inputs, enums, and edge wiring without submission. Run submits asynchronously by default; set wait=true to await outputs.",
+    {
+      action: z.enum(["validate", "run"]),
+      workflowPath: z.string().min(1),
+      wait: z.boolean().optional(),
+      timeoutSeconds: z.number().int().min(1).optional(),
+      where: whereSchema,
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const command = [args.action, "--workflow", args.workflowPath];
+        if (args.action === "run" && args.wait) command.push("--wait");
+        if (args.action === "run" && args.timeoutSeconds) command.push("--timeout", String(args.timeoutSeconds));
+        return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: ((args.timeoutSeconds ?? 120) + 10) * 1000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_transfer",
+    "Upload input files or download completed job outputs using official comfy-cli for local ComfyUI or Comfy Cloud.",
+    {
+      action: z.enum(["upload", "download"]),
+      files: z.array(z.string()).optional(),
+      promptId: z.string().optional(),
+      outDir: z.string().optional(),
+      overwrite: z.boolean().optional(),
+      urlOnly: z.boolean().optional(),
+      where: whereSchema,
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const command: string[] = [args.action];
+        if (args.action === "upload") {
+          if (!args.files?.length) throw new Error("files is required for upload");
+          command.push(...args.files);
+          if (args.overwrite === false) command.push("--no-overwrite");
+        } else {
+          if (!args.promptId) throw new Error("promptId is required for download");
+          command.push(args.promptId);
+          if (args.outDir) command.push("--out-dir", args.outDir);
+          if (args.urlOnly) command.push("--url-only");
+        }
+        return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: 300_000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_models",
+    "Discover model folders/files through official comfy-cli locally or in Comfy Cloud. Search is filename-based locally and uses the enriched cloud asset catalog remotely.",
+    {
+      action: z.enum(["list-folders", "list-folder", "search", "show"]),
+      folder: z.string().optional(),
+      text: z.string().optional(),
+      type: z.string().optional(),
+      name: z.string().optional(),
+      limit: z.number().int().min(1).max(100).optional(),
+      where: whereSchema,
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const command = ["models", args.action];
+        if (args.action === "list-folder") {
+          if (!args.folder) throw new Error("folder is required for list-folder");
+          command.push(args.folder);
+        }
+        if (args.action === "show") {
+          if (!args.name) throw new Error("name is required for show");
+          command.push(args.name);
+        }
+        if (args.action === "search") {
+          if (args.text) command.push("--text", args.text);
+          if (args.type) command.push("--type", args.type);
+        }
+        if (args.limit && args.action !== "show" && args.action !== "list-folders") command.push("--limit", String(args.limit));
+        return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: 60_000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "comfy_cli_skills",
+    "List, show, validate, install, inspect, or uninstall the official comfy-cli bundled agent skills (comfy, fragments, debug, relay, director). Install/uninstall defaults to dry-run for safety unless apply=true.",
+    {
+      action: z.enum(["list", "show", "validate", "install", "status", "uninstall"]),
+      name: z.string().optional(),
+      path: z.string().optional(),
+      scope: z.enum(["user", "project"]).optional(),
+      targets: z.array(z.string()).optional(),
+      skills: z.array(z.string()).optional(),
+      apply: z.boolean().optional().default(false),
+      workspace: workspaceSchema,
+    },
+    async (args) => {
+      try {
+        const command = ["skills", args.action];
+        if (args.action === "show" && args.name) command.push(args.name);
+        if (args.action === "validate") {
+          if (!args.path) throw new Error("path is required for skills validate");
+          command.push(args.path);
+        }
+        if (["install", "uninstall", "status"].includes(args.action) && args.scope) command.push("--scope", args.scope);
+        if (["install", "uninstall"].includes(args.action)) {
+          for (const target of args.targets ?? []) command.push("--target", target);
+          for (const skill of args.skills ?? []) command.push("--skill", skill);
+          if (!args.apply) command.push("--dry-run");
+        }
+        return await call(command, { workspace: args.workspace, timeoutMs: 60_000 });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -50,6 +50,7 @@ import { registerSelfUpdateTools } from "./self-update.js";
 import { registerCalculateTools } from "./calculate.js";
 import { registerComfyUISettingsTools } from "./comfyui-settings.js";
 import { registerNodeDevTools } from "./node-dev.js";
+import { registerComfyCliTools } from "./comfy-cli.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -59,6 +60,7 @@ import { ToolCatalog } from "./catalog.js";
  * compact tool mode's list_tools manifest.
  */
 const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: McpServer) => void]> = [
+  ["comfy-cli", registerComfyCliTools],
   ["workflows", registerWorkflowExecuteTools],
   ["workflow-authoring", registerWorkflowVisualizeTools],
   ["workflow-authoring", registerWorkflowComposeTools],

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -11,11 +11,25 @@ import {
   type InstalledNode,
 } from "../services/node-management.js";
 import { errorToToolResult } from "../utils/errors.js";
+import { getComfyCliVersion, resolveComfyCliExecutable, shouldUseComfyCli } from "../services/comfy-cli.js";
 
 /** Graceful "not supported remotely" tool result (no isError), matching the
  *  degrade-don't-throw pattern list_local_models uses. */
 function remoteUnsupported(message: string) {
   return { content: [{ type: "text" as const, text: message }] };
+}
+
+function preferLocalComfyCli(explicit: boolean | undefined): boolean {
+  if (explicit !== undefined) return explicit;
+  if (!isLocalMode()) return false;
+  const executable = resolveComfyCliExecutable();
+  if (!executable) return false;
+  return shouldUseComfyCli(
+    undefined,
+    true,
+    executable,
+    getComfyCliVersion(),
+  );
 }
 
 const modeSchema = z
@@ -57,7 +71,7 @@ function formatInstalledNodes(nodes: InstalledNode[]): string {
 export function registerNodeManagementTools(server: McpServer): void {
   server.tool(
     "install_custom_node",
-    "Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), git URL, or name. Uses the ComfyUI-Manager HTTP API (works against remote instances) and falls back to the cm-cli subprocess when forced. A ComfyUI restart may be required to load newly installed nodes.",
+    "Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required.",
     {
       id: z
         .string()
@@ -86,7 +100,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await installCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
+        const result = await installCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -98,7 +112,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "update_custom_node",
-    "Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback.",
+    "Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP.",
     {
       id: z
         .string()
@@ -109,7 +123,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await updateCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
+        const result = await updateCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -121,7 +135,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "reinstall_custom_node",
-    "Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback. A ComfyUI restart may be required.",
+    "Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required.",
     {
       id: z.string().describe("Registry id / module name to reinstall."),
       version: z
@@ -134,7 +148,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await reinstallCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
+        const result = await reinstallCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -146,7 +160,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "fix_custom_node",
-    "Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Single-pack repair uses the ComfyUI-Manager HTTP API; 'all' and forced runs use the cm-cli subprocess (requires a local ComfyUI install).",
+    "Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP.",
     {
       id: z
         .string()
@@ -168,7 +182,7 @@ export function registerNodeManagementTools(server: McpServer): void {
         );
       }
       try {
-        const result = await fixCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
+        const result = await fixCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -204,7 +218,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "sync_node_dependencies",
-    "Reconcile the Python dependencies of all installed custom node packs (comfy-cli `node uv-sync` analogue). Runs cm-cli restore-dependencies as a subprocess and requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.",
+    "Reconcile the Python dependencies of all installed custom node packs through official `comfy node restore-dependencies`. Requires a local ComfyUI install and comfy-cli.",
     {},
     async () => {
       if (!isLocalMode()) {

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -29,7 +29,7 @@ const useCmCliSchema = z
   .boolean()
   .optional()
   .describe(
-    "Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.",
+    "Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.",
   );
 
 const channelSchema = z
@@ -86,7 +86,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await installCustomNode(args);
+        const result = await installCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -109,7 +109,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await updateCustomNode(args);
+        const result = await updateCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -134,7 +134,7 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const result = await reinstallCustomNode(args);
+        const result = await reinstallCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -168,7 +168,7 @@ export function registerNodeManagementTools(server: McpServer): void {
         );
       }
       try {
-        const result = await fixCustomNode(args);
+        const result = await fixCustomNode({ ...args, useCmCli: args.useCmCli ?? isLocalMode() });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
         };


### PR DESCRIPTION
## Summary
- integrate official comfy-cli 1.11.1+ with structured envelope handling
- add MCP tools for environment, server lifecycle, jobs, nodes, workflows, transfers, models, and bundled skills
- prefer comfy-cli for supported local custom-node operations with Manager HTTP fallback
- document executable resolution and runtime expectations in README, .env.example, and CLAUDE.md

## Compatibility
- normalizes legacy comfy-cli commands that still emit plain text despite --json
- preserves remote ComfyUI-Manager HTTP behavior
- rejects unsupported CLI versions and unsafe Windows command shims

## Validation
- npm run build
- 98 focused tests passing
- full suite: 1,223/1,224; sole failure is the pre-existing node-dev ripgrep-selection assertion that reproduces on main
- live smoke checks against comfy-cli 1.11.1