### PR TITLE
fix(local-agent): live-E2E follow-ups to #191 — honest stop copy + empty-final recovery

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -191,6 +191,37 @@ describe("OllamaBackend", () => {
     expect(chatRequests.length).toBeLessThanOrEqual(5);
   });
 
+  it("recovers an EMPTY final after tool rounds with one summarize nudge (never loops)", async () => {
+    const { client } = fakeMcpClient(COMFY_META);
+    const backend = new OllamaBackend({ model: "artokun/gemma4-comfyui-mcp:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    chatScript.push(
+      // round 0: one tool call
+      [{ message: { content: "", tool_calls: [{ function: { name: "list_tools", arguments: {} } }] }, done: true }],
+      // round 1: EMPTY final (the live-E2E quirk) → should trigger the nudge
+      [{ message: { content: "" }, done: true }],
+      // round 2: the nudged summary
+      [{ message: { content: "I found download_civitai_model — give me a model id and I'll fetch it." }, done: true }],
+    );
+    const events = await collect(backend, turnsOf({ text: "find a lora" }));
+    const assistant = events.filter((e) => e.type === "assistant") as Array<{ text: string }>;
+    expect(assistant).toHaveLength(1);
+    expect(assistant[0].text).toContain("download_civitai_model");
+    // The nudge rode the wire as a user message exactly once.
+    const nudges = chatRequests.flatMap((r) => r.messages).filter((m) => m.role === "user" && String(m.content).includes("your reply was EMPTY"));
+    expect(nudges).toHaveLength(1);
+    expect(events.filter((e) => e.type === "result")).toMatchObject([{ type: "result", ok: true }]);
+
+    // Second empty in a row → falls through (empty answer, but NO infinite nudging).
+    chatScript.push(
+      [{ message: { content: "", tool_calls: [{ function: { name: "list_tools", arguments: { search: "x" } } }] }, done: true }],
+      [{ message: { content: "" }, done: true }],
+      [{ message: { content: "" }, done: true }],
+    );
+    const backend2 = new OllamaBackend({ model: "artokun/gemma4-comfyui-mcp:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    const events2 = await collect(backend2, turnsOf({ text: "find a lora" }));
+    expect(events2.filter((e) => e.type === "result")).toMatchObject([{ type: "result", ok: true }]);
+  });
+
   it("breaks a DISCOVERY loop: list_tools with a different search each round (the Civitai-hunt wedge)", async () => {
     const { client, callTool } = fakeMcpClient(COMFY_META);
     const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -738,6 +738,7 @@ export class OllamaBackend implements AgentBackend {
     // NOT here — describing many distinct tools is legitimate exploration.
     const DISCOVERY_TOOLS = new Set(["list_tools", "panel_list_tools", "search_models", "search_custom_nodes"]);
     const discoveryCounts = new Map<string, number>();
+    let emptyFinalRetried = false;
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
         // Drain the chat stream manually: yield each delta event as it arrives,
@@ -757,6 +758,20 @@ export class OllamaBackend implements AgentBackend {
         }
 
         if (!toolCalls.length) {
+          // EMPTY-FINAL recovery (live E2E, native dialect, temp 0): after a
+          // run of tool rounds the model sometimes emits a final message with
+          // NO content — the turn would "complete" in total silence. Nudge it
+          // ONCE to summarize; a second empty reply falls through (never loop).
+          if (!content.trim() && round > 0 && !emptyFinalRetried) {
+            emptyFinalRetried = true;
+            this.history.push({ role: "assistant", content });
+            this.history.push({
+              role: "user",
+              content:
+                "(system: your reply was EMPTY. In 1-3 sentences, tell the user what you found or did with the tools above, and what you recommend next. Do not call any more tools.)",
+            });
+            continue;
+          }
           // Record the final answer in history too — without this, the NEXT
           // turn's context is missing the model's own previous replies (and
           // the transcript dump ends mid-conversation on a tool message).
@@ -820,9 +835,18 @@ export class OllamaBackend implements AgentBackend {
           logger.warn(
             `[ollama-backend] tool loop broken: repeats=${maxRepeats} discovery=${maxDiscovery} this turn (${this.model})`,
           );
+          // Honest, breaker-specific stop copy (live E2E caught the old one
+          // recommending the fine-tune TO the fine-tune). Discovery wedge →
+          // the capability likely isn't here; repeat wedge → the model stalled.
+          const switchTip = this.isFinetune()
+            ? ""
+            : " If you're on a stock model, `artokun/gemma4-comfyui-mcp:e4b` knows this tool suite and gets stuck far less.";
           yield {
             type: "assistant",
-            text: "(stopped: I kept repeating the same tool call without progress. Try rephrasing the request — and if you're on a stock model, switch to `artokun/gemma4-comfyui-mcp:e4b`, which knows this tool suite.)",
+            text:
+              maxDiscovery >= 8
+                ? `(stopped: I searched the tool catalog ${maxDiscovery} times without finding what I was looking for — that capability probably isn't available here. For example, Civitai keyword search needs the separate Civitai MCP server; with a Civitai model id I can download directly. Tell me how you'd like to proceed.${switchTip})`
+                : `(stopped: I kept repeating the same tool call without progress. Try rephrasing the request, or break it into smaller steps.${switchTip})`,
           };
           yield { type: "result", ok: false, subtype: "tool_loop" };
           resultEmitted = true;


### PR DESCRIPTION
Answer to 'did you test it locally': yes, now — 3 live runs of the reporter's literal prompt against real Ollama + `artokun/gemma4-comfyui-mcp:e4b` through a scratch orchestrator, transcripts inspected. #191's mechanism verified live (SEARCH LIMIT steered the model to `download_civitai_model`; hard stop in 73s where the field report spun indefinitely). The live runs also caught two bugs the unit mocks couldn't:

1. **Stop copy told an e4b user to switch to e4b.** Now breaker-aware + model-aware: a discovery-wedge stop says the capability probably isn't in the catalog (naming the Civitai case); the switch tip only renders on stock models.
2. **Empty final after tool rounds** — native dialect, temp 0, struck in **2 of 3** live runs: the turn 'completed' in total silence (very plausibly part of the original report's pain). Now recovered with a single summarize nudge, capped at one. Live run 3: nudge fired → the model delivered the ideal answer (found the right tool, explained Civitai search isn't available, gave the model-id instructions).

+1 unit test (nudge fires exactly once, second empty falls through); 1194/1194 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)