### PR TITLE
fix: community fixes — get_node_info summary, remote-safe upload, comfy-api-key fallback, doc clarity (from community forks)

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -122,6 +122,9 @@ error. Architecture and `cloud-client` dispatcher originally contributed by
 </ParamField>
 <ParamField path="COMFY_API_KEY" type="string">
   comfy.org API key forwarded to hosted API nodes via the `/prompt` `extra_data` payload.
+  If the env var is unset, the key is read from `~/.comfy-api-key` (trimmed file
+  contents; `chmod 600` recommended) — handy for headless setups that keep secrets
+  out of environment/process listings.
 </ParamField>
 <ParamField path="REGISTRY_ACCESS_TOKEN" type="string">
   Comfy Registry API key used by `publish_custom_node` to publish a node pack. Passed to comfy-cli via env, never placed in args or logs.

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -95,12 +95,15 @@ Validate a ComfyUI workflow without executing it. Checks for missing node types,
 
 ## get_node_info
 
-Query a running ComfyUI server's /object_info endpoint for installed node type definitions (inputs, outputs, category, description). Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Note: when more than 20 node types match, returns only a summarized list (name, display_name, category, description) and asks you to narrow the filter to get full input/output schemas; 20 or fewer returns complete definitions.
+Query a running ComfyUI server's /object_info endpoint for installed node type definitions. Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Default response is a STRUCTURAL summary: input/output names and type tags, with enum (dropdown) inputs collapsed to a value count — safe for context even on Loader nodes whose model dropdowns embed the entire local model list (hundreds of KB raw). Pass verbose=true (20 or fewer matches) for the complete raw definitions including every dropdown value. When more than 20 node types match, returns only a name/category list and asks you to narrow the filter.
 
 ### Parameters
 
 <ParamField path="node_type" type="string">
   Filter by node class_type name (case-insensitive substring match). Omit to list all available nodes.
+</ParamField>
+<ParamField path="verbose" type="boolean" required default="false">
+  If true, return the full raw /object_info definitions including enum dropdown values (model lists etc.) — can be hundreds of KB per Loader node, so only use it when you need the actual enum values (e.g. exact model filenames) and the filter matches few nodes. Default false: structural summary with enum value counts.
 </ParamField>
 
 ### Example
@@ -110,7 +113,9 @@ Query a running ComfyUI server's /object_info endpoint for installed node type d
 ```json
 {
   "tool": "get_node_info",
-  "arguments": {}
+  "arguments": {
+    "verbose": true
+  }
 }
 ```
 
@@ -143,7 +148,7 @@ Convert a ComfyUI API-format workflow into a compact, human/LLM-readable DSL —
 
 ## dsl_to_workflow
 
-Convert the compact workflow DSL (see workflow_to_dsl) back into executable ComfyUI API-format JSON. Useful for authoring/editing workflows in the legible DSL, then converting to run with enqueue_workflow. (Experimental.)
+Convert the compact workflow DSL (see workflow_to_dsl) back into executable ComfyUI API-format JSON. Useful for authoring/editing workflows in the legible DSL, then converting to run with enqueue_workflow. When ComfyUI is reachable, the result also carries advisory `warnings` (unknown class_type, output index out of range, type mismatches) — the conversion still succeeds regardless. (Experimental.)
 
 ### Parameters
 

--- a/plugin/skills/comfyui-core/SKILL.md
+++ b/plugin/skills/comfyui-core/SKILL.md
@@ -52,7 +52,7 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 - **API format** (for execution/analysis): `{ "1": { class_type, inputs }, "2": { ... } }` — compact, used by `enqueue_workflow`, `validate_workflow`, `modify_workflow`, etc.
 - **Web UI format** (for saving and frontend editing): `{ "nodes": [...], "links": [...] }` — includes layout positions, sizes, groups, and visual metadata so ComfyUI's canvas can open and edit it
 - Execution tools expect and return **API format**
-- **Saving tools must use Web UI format** so saved workflows stay readable and editable in the ComfyUI frontend — an API-format save "exists" in the library but loads blank in the canvas, which strands users (and tempts agents into creating yet another new workflow instead of reopening the old one)
+- **Save in Web UI format** so saved workflows stay readable and editable in the ComfyUI frontend. A raw API-format save is NOT canvas-editable — it "exists" in the library but loads blank in the canvas, which strands users (and tempts agents into creating yet another new workflow instead of reopening the old one). Because of this, `save_workflow` auto-converts API-format input to Web UI format with a generated layout — but prefer passing real Web UI format (from `get_workflow format="ui"`) since a generated layout loses the original node positions/groups <!-- API-vs-UI save-format clarification adapted from 1696762169/comfyui-mcp@3da56c9 -->
 - `get_workflow` defaults to `format="api"` for analysis/execution; use `format="ui"` when loading a workflow to re-save or edit in the canvas
 - Muted/bypassed nodes are preserved with `_meta.mode: "muted"` — these are inactive but visible for understanding the workflow
 - Get/Set virtual wire nodes are preserved with `_meta.title` and `Constant` key for tracing data flow
@@ -62,7 +62,7 @@ ComfyUI workflows are JSON objects mapping **string node IDs** to node definitio
 - **`analyze_workflow(filename)`** — **use this first** to understand any saved workflow. Returns a structured text summary with sections, node IDs, key settings, virtual wires, and connection graph. No raw JSON — just what you need to reason about the workflow. Supports views: summary (default), overview (mermaid), detail (section mermaid), list, flat.
 - **`list_workflows`** — list all saved workflows in ComfyUI's user library
 - **`get_workflow(filename)`** — load raw workflow JSON. Only use when you need the actual JSON for `enqueue_workflow`, `modify_workflow`, or `save_workflow`. Use `analyze_workflow` instead for understanding. **For `save_workflow`, request `format="ui"`** so the workflow stays editable in the frontend.
-- **`save_workflow(filename, workflow)`** — save a workflow to the user library. **Pass Web UI format (`{ nodes, links }`)** so it can be opened and edited in ComfyUI's canvas; API-format graphs are accepted but the frontend cannot open them.
+- **`save_workflow(filename, workflow)`** — save a workflow to the user library. **Pass Web UI format (`{ nodes, links }`)** so it keeps its real layout in ComfyUI's canvas. API-format graphs are accepted and are **auto-converted to Web UI format** (with a generated layout) precisely because a raw API-format save is not canvas-editable — the frontend cannot open it. When re-saving an existing workflow, load it with `get_workflow format="ui"` and edit that, so positions/groups survive.
 
 ## Data Types
 

--- a/src/__tests__/config-comfy-api-key.test.ts
+++ b/src/__tests__/config-comfy-api-key.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// COMFY_API_KEY resolution: env var first, then ~/.comfy-api-key file fallback.
+// File fallback originally contributed by @joaolvivas in
+// joaolvivas/comfyui-mcp-byjlucas@4b989e4 and reimplemented in config.ts.
+//
+// config.ts calls os.homedir() at module-eval time; point it at a temp dir we
+// control. The mock factory is hoisted but only EXECUTES on first import of the
+// mocked module (inside each test's dynamic import), after fakeHome is set.
+let fakeHome = "";
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => fakeHome,
+    default: { ...actual, homedir: () => fakeHome },
+  };
+});
+
+const OLD_ENV = process.env;
+const OLD_ARGV = process.argv;
+const tempRoot = mkdtempSync(join(tmpdir(), "comfy-api-key-test-"));
+const keyFile = join(tempRoot, ".comfy-api-key");
+
+describe("COMFY_API_KEY resolution (env → ~/.comfy-api-key)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    fakeHome = tempRoot;
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    // Empty-string (not delete) so dotenv can't re-inject from a package .env.
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_URL = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_PORT = "8188";
+    process.env.COMFYUI_MCP_FORCE_REMOTE = "";
+    process.env.COMFY_API_KEY = "";
+    if (existsSync(keyFile)) unlinkSync(keyFile);
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+  });
+
+  afterAll(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("uses the COMFY_API_KEY env var when set (file ignored)", async () => {
+    writeFileSync(keyFile, "file-key\n");
+    process.env.COMFY_API_KEY = "env-key";
+    const mod = await import("../config.js");
+    expect(mod.config.comfyApiKey).toBe("env-key");
+  });
+
+  it("falls back to trimmed ~/.comfy-api-key contents when env is unset", async () => {
+    writeFileSync(keyFile, "  file-key-123\n\n");
+    const mod = await import("../config.js");
+    expect(mod.config.comfyApiKey).toBe("file-key-123");
+  });
+
+  it("is undefined when neither env nor file provides a key", async () => {
+    const mod = await import("../config.js");
+    expect(mod.config.comfyApiKey).toBeUndefined();
+  });
+
+  it("treats an empty/whitespace-only key file as no key", async () => {
+    writeFileSync(keyFile, "   \n");
+    const mod = await import("../config.js");
+    expect(mod.config.comfyApiKey).toBeUndefined();
+  });
+});

--- a/src/__tests__/tools/get-node-info-summary.test.ts
+++ b/src/__tests__/tools/get-node-info-summary.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// get_node_info structural-summary behavior (default) vs verbose=true full dump.
+// Summary-by-default originally contributed by @joaolvivas in
+// joaolvivas/comfyui-mcp-byjlucas@de82ecd — the motivating case is Loader nodes
+// whose enum dropdowns embed the entire local model list (100s of KB per node).
+
+const getObjectInfoMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+}));
+
+import { registerWorkflowComposeTools, summarizeNodeDef } from "../../tools/workflow-compose.js";
+import type { ComfyUINodeDef } from "../../comfyui/types.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowComposeTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+// A Loader-style node: the checkpoint dropdown enumerates many model filenames.
+const modelList = Array.from({ length: 300 }, (_, i) => `model-${i}.safetensors`);
+const loaderDef: ComfyUINodeDef = {
+  input: {
+    required: {
+      ckpt_name: [modelList, { tooltip: "checkpoint to load" }],
+    },
+    optional: {
+      strength: ["FLOAT", { default: 1.0, min: 0, max: 2 }],
+    },
+  },
+  output: ["MODEL", "CLIP", "VAE"],
+  output_is_list: [false, false, false],
+  output_name: ["MODEL", "CLIP", "VAE"],
+  name: "CheckpointLoaderSimple",
+  display_name: "Load Checkpoint",
+  description: "Loads a checkpoint",
+  category: "loaders",
+  output_node: false,
+};
+
+beforeEach(() => {
+  getObjectInfoMock.mockReset();
+  getObjectInfoMock.mockResolvedValue({ CheckpointLoaderSimple: loaderDef });
+});
+
+describe("get_node_info default (structural summary)", () => {
+  it("collapses enum dropdowns to a value count and omits the values", async () => {
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CheckpointLoader" });
+    const text = res.content[0].text;
+
+    expect(text).toContain('"enum(300 values)"');
+    // No individual dropdown value may leak into the summary.
+    expect(text).not.toContain("model-0.safetensors");
+    expect(text).not.toContain("model-299.safetensors");
+
+    const parsed = JSON.parse(text);
+    expect(parsed.count).toBe(1);
+    const node = parsed.nodes[0];
+    expect(node.name).toBe("CheckpointLoaderSimple");
+    expect(node.input_required).toEqual({ ckpt_name: "enum(300 values)" });
+    expect(node.input_optional).toEqual({ strength: "FLOAT" });
+    expect(node.output_types).toEqual(["MODEL", "CLIP", "VAE"]);
+    expect(node.output_names).toEqual(["MODEL", "CLIP", "VAE"]);
+    expect(parsed.hint).toMatch(/verbose=true/);
+  });
+
+  it("is dramatically smaller than the raw definition for Loader nodes", async () => {
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CheckpointLoader" });
+    const rawSize = JSON.stringify({ CheckpointLoaderSimple: loaderDef }).length;
+    expect(res.content[0].text.length).toBeLessThan(rawSize / 5);
+  });
+});
+
+describe("get_node_info verbose=true (full dump)", () => {
+  it("returns the complete raw definition including dropdown values", async () => {
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CheckpointLoader", verbose: true });
+    const parsed = JSON.parse(res.content[0].text);
+    // Pre-summary behavior restored: keyed-by-name raw defs, enum values intact.
+    expect(parsed.CheckpointLoaderSimple.input.required.ckpt_name[0]).toEqual(modelList);
+  });
+});
+
+describe("get_node_info >20 matches (unchanged name-list behavior)", () => {
+  it("returns the summarized name list and narrowing hint", async () => {
+    const many: Record<string, ComfyUINodeDef> = {};
+    for (let i = 0; i < 25; i++) {
+      many[`Node${i}`] = { ...loaderDef, name: `Node${i}` };
+    }
+    getObjectInfoMock.mockResolvedValue(many);
+    const handler = getHandler("get_node_info");
+    const res = await handler({});
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.count).toBe(25);
+    expect(parsed.nodes[0]).not.toHaveProperty("input_required");
+    expect(parsed.hint).toMatch(/more specific/);
+  });
+});
+
+describe("summarizeNodeDef", () => {
+  it("stringifies scalar type tags and handles missing input sections", () => {
+    const def: ComfyUINodeDef = {
+      ...loaderDef,
+      input: {},
+    };
+    const s = summarizeNodeDef("X", def);
+    expect(s.input_required).toEqual({});
+    expect(s.input_optional).toEqual({});
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -380,6 +380,30 @@ if (forceRemote && !urlOverride) {
   );
 }
 
+/**
+ * Comfy.org API key for partner/API-node auth (extra_data.api_key_comfy_org).
+ * Precedence: COMFY_API_KEY env var, then ~/.comfy-api-key (trimmed file
+ * contents) — the file fallback lets headless setups keep the key out of env/
+ * process listings (chmod 600 recommended). Best-effort: unreadable/empty file
+ * just means no key. Never log the key value.
+ * File fallback originally contributed by @joaolvivas in
+ * `joaolvivas/comfyui-mcp-byjlucas@4b989e4` and reimplemented here with thanks.
+ */
+function resolveComfyApiKey(): string | undefined {
+  const env = process.env.COMFY_API_KEY;
+  if (env && env.trim()) return env.trim();
+  try {
+    const keyFile = join(homedir(), ".comfy-api-key");
+    if (existsSync(keyFile)) {
+      const key = readFileSync(keyFile, "utf-8").trim();
+      if (key) return key;
+    }
+  } catch {
+    // Unreadable file — behave as if no key is configured.
+  }
+  return undefined;
+}
+
 const parsedConfig = configSchema.parse({
   comfyuiHost: urlOverride?.host ?? process.env.COMFYUI_HOST,
   comfyuiPort: urlOverride?.port ?? (process.env.COMFYUI_PORT || undefined),
@@ -398,7 +422,7 @@ const parsedConfig = configSchema.parse({
   huggingfaceToken: process.env.HUGGINGFACE_TOKEN,
   githubToken: process.env.GITHUB_TOKEN,
   civitaiApiToken: process.env.CIVITAI_API_TOKEN,
-  comfyApiKey: process.env.COMFY_API_KEY,
+  comfyApiKey: resolveComfyApiKey(),
 });
 
 // Resolve port:

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { WorkflowJSON } from "../comfyui/types.js";
+import type { ComfyUINodeDef, WorkflowJSON } from "../comfyui/types.js";
 import {
   createWorkflow,
   modifyWorkflow,
@@ -145,7 +145,7 @@ export function registerWorkflowComposeTools(server: McpServer): void {
   // 3. get_node_info
   server.tool(
     "get_node_info",
-    "Query a running ComfyUI server's /object_info endpoint for installed node type definitions (inputs, outputs, category, description). Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Note: when more than 20 node types match, returns only a summarized list (name, display_name, category, description) and asks you to narrow the filter to get full input/output schemas; 20 or fewer returns complete definitions.",
+    "Query a running ComfyUI server's /object_info endpoint for installed node type definitions. Requires a reachable ComfyUI instance; results reflect that server's installed custom nodes. Use the node_type filter to inspect a specific node before composing or modifying a workflow. Default response is a STRUCTURAL summary: input/output names and type tags, with enum (dropdown) inputs collapsed to a value count — safe for context even on Loader nodes whose model dropdowns embed the entire local model list (hundreds of KB raw). Pass verbose=true (20 or fewer matches) for the complete raw definitions including every dropdown value. When more than 20 node types match, returns only a name/category list and asks you to narrow the filter.",
     {
       node_type: z
         .string()
@@ -153,10 +153,20 @@ export function registerWorkflowComposeTools(server: McpServer): void {
         .describe(
           "Filter by node class_type name (case-insensitive substring match). Omit to list all available nodes.",
         ),
+      verbose: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, return the full raw /object_info definitions including enum dropdown " +
+            "values (model lists etc.) — can be hundreds of KB per Loader node, so only use " +
+            "it when you need the actual enum values (e.g. exact model filenames) and the " +
+            "filter matches few nodes. Default false: structural summary with enum value counts.",
+        ),
     },
-    async ({ node_type }) => {
+    async ({ node_type, verbose }) => {
       try {
-        logger.info("Getting node info", { filter: node_type });
+        logger.info("Getting node info", { filter: node_type, verbose });
         const info = await getObjectInfo();
 
         let entries = Object.entries(info);
@@ -204,12 +214,37 @@ export function registerWorkflowComposeTools(server: McpServer): void {
           };
         }
 
-        const result = Object.fromEntries(entries);
+        // verbose=true restores the pre-summary behavior: full raw definitions
+        // (only reachable at <=20 matches, same threshold as before).
+        if (verbose) {
+          const result = Object.fromEntries(entries);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        }
+
+        // Default: structural summary. Keeps input/output names and type tags but
+        // collapses enum dropdowns to a value count — Loader nodes embed the entire
+        // local model list in their dropdowns, so a raw dump can be 100s of KB.
+        const summary = entries.map(([name, def]) => summarizeNodeDef(name, def));
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(result, null, 2),
+              text: JSON.stringify(
+                {
+                  count: summary.length,
+                  nodes: summary,
+                  hint: "Structural summary (enum dropdown values collapsed to counts). Pass verbose=true for full definitions including dropdown values.",
+                },
+                null,
+                2,
+              ),
             },
           ],
         };
@@ -218,4 +253,48 @@ export function registerWorkflowComposeTools(server: McpServer): void {
       }
     },
   );
+}
+
+// ── get_node_info structural summary ─────────────────────────────────────────
+// Summary-by-default (with verbose opt-out) originally contributed by
+// @joaolvivas in `joaolvivas/comfyui-mcp-byjlucas@de82ecd` and reimplemented
+// here with thanks — the motivating case was Loader nodes (UNETLoader,
+// CheckpointLoaderSimple, LoraLoader, …) whose model dropdowns embed the full
+// local model list, producing multi-hundred-KB /object_info dumps per node.
+
+/** Collapse one input-spec map to `{ name: typeTag }`, dropping enum value lists. */
+function summarizeInputSpecs(
+  specs: Record<string, unknown> | undefined,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(specs ?? {}).map(([inputName, spec]) => {
+      // Spec shape is [typeOrEnumValues, options?]; enum inputs carry the full
+      // value array in slot 0 — that array is what makes Loader nodes huge.
+      if (Array.isArray(spec)) {
+        const first = spec[0];
+        if (Array.isArray(first)) {
+          return [inputName, `enum(${first.length} values)`];
+        }
+        return [inputName, String(first)];
+      }
+      return [inputName, typeof spec];
+    }),
+  );
+}
+
+/** Structural summary of a node definition: names + type tags, no dropdown values. */
+export function summarizeNodeDef(
+  name: string,
+  def: ComfyUINodeDef,
+): Record<string, unknown> {
+  return {
+    name,
+    display_name: def.display_name,
+    category: def.category,
+    description: def.description || "",
+    input_required: summarizeInputSpecs(def.input?.required),
+    input_optional: summarizeInputSpecs(def.input?.optional),
+    output_types: def.output ?? [],
+    output_names: def.output_name ?? [],
+  };
 }


### PR DESCRIPTION
Small community-fork adaptations, reimplemented (not cherry-picked) with per-item attribution following the `generate-audio.ts` convention. Part of the fork-inheritance effort.

## Landed

### a. `get_node_info` structural summary — credit @joaolvivas ([joaolvivas/comfyui-mcp-byjlucas@de82ecd](https://github.com/joaolvivas/comfyui-mcp-byjlucas/commit/de82ecdad8d84463ef17439b84143c96f572eef1))
Default response is now a structural summary: input/output names + type tags, with enum (dropdown) inputs collapsed to `enum(N values)`. Motivating case: Loader nodes (UNETLoader, CheckpointLoaderSimple, LoraLoader, …) embed the entire local model list in their dropdowns — a single raw `/object_info` definition could be hundreds of KB. `verbose: true` restores the exact previous full-dump behavior (same ≤20-match threshold); the >20-match name-list path is byte-for-byte unchanged, keeping the response shape backward compatible. Tool description updated; docs regenerated.

### c. `~/.comfy-api-key` file fallback — credit @joaolvivas ([joaolvivas/comfyui-mcp-byjlucas@4b989e4](https://github.com/joaolvivas/comfyui-mcp-byjlucas/commit/4b989e47fe3f1b58b6538d9e9acb0a6448ff80d4))
When `COMFY_API_KEY` is unset/blank, `config.comfyApiKey` (partner-node auth via `extra_data.api_key_comfy_org` in `src/services/api-nodes.ts`) now falls back to the trimmed contents of `~/.comfy-api-key`, mirroring the existing file-based config fallbacks in `config.ts`. Env always wins; unreadable/empty file = no key; the key value is never logged. `docs/configuration.mdx` documents the fallback.

### d. `save_workflow` doc wording — credit @1696762169 ([1696762169/comfyui-mcp@3da56c9](https://github.com/1696762169/comfyui-mcp/commit/3da56c9))
`plugin/skills/comfyui-core/SKILL.md` still described the pre-auto-conversion behavior ("API-format graphs are accepted but the frontend cannot open them"). It now states explicitly that API-format input is **auto-converted** to Web UI format precisely **because a raw API-format save is not canvas-editable**, and that real Web UI format (`get_workflow format="ui"`) is still preferred so node positions/groups survive. Wording adapted from the fork's clarification, not translated verbatim. The `save_workflow` tool description itself already stated the auto-conversion + reason, so only the lagging skill text changed.

## Verified & skipped (already upstream)

### b. `upload_image` remote safety — credit @joaolvivas ([joaolvivas/comfyui-mcp-byjlucas@089180a](https://github.com/joaolvivas/comfyui-mcp-byjlucas/commit/089180ad57031a8e012c84a235c721822c1cc7be))
**Skipped — already merged upstream.** `src/tools/image-management.ts` is already HTTP-only for all three upload tools and already carries the attribution comment crediting this exact fork commit ("Originally diagnosed by João Lucas … joaolvivas/comfyui-mcp-byjlucas@089180ad"). The legacy filesystem `uploadImage` service function has no tool callers. Nothing left to gate.

### e. Z-Image VAE distinction — credit @epicDirk ([epicDirk/comfyui-mcp@7ed166a](https://github.com/epicDirk/comfyui-mcp/commit/7ed166a))
**Claim verified TRUE, but skipped — upstream is already correct.** Z-Image's VAE shares the Flux VAE architecture but ships different weights, and upstream already documents this everywhere: `plugin/skills/z-image-txt2img/SKILL.md` (lines 17/38/46: "NOT the same file as Flux's `ae.safetensors`", stored as `z-image-ae.safetensors`), `plugin/skills/flux-txt2img/SKILL.md` (line 26), `plugin/skills/ernie-image/SKILL.md`, and `model-settings.json` (`z_image_turbo.vae: "z-image-ae.safetensors"`). The fork's `flux1-ae.safetensors` rename was intentionally NOT adopted — `ae.safetensors` is the canonical BFL filename.

## Tests & gates
- New: `src/__tests__/tools/get-node-info-summary.test.ts` (summary collapses enums / leaks no dropdown values, verbose restores full dump, >20 path unchanged, size bound)
- New: `src/__tests__/config-comfy-api-key.test.ts` (env wins over file, trimmed file fallback, neither → undefined, whitespace-only file → undefined)
- `npx tsc --noEmit` clean; `npx vitest run` 110 files / 1234 tests green; `npm run docs:gen` run (only docs affected by this PR committed — pre-existing generated-doc drift in models/custom-nodes pages left out to avoid cross-PR noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)