### PR TITLE
feat(orchestrator): loopback MCP console + credential slots — ported from MichaelDanCurtis fork

### DIFF
--- a/src/__tests__/orchestrator/console-secrets.test.ts
+++ b/src/__tests__/orchestrator/console-secrets.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "../../orchestrator/panel-console-http.js";
+
+const TOKEN = "test-console-token";
+let srv: PanelConsoleHttpServer;
+const base = () => srv.url;
+
+describe("console /api/secrets", () => {
+  beforeEach(async () => {
+    process.env.COMFYUI_MCP_PANEL_SECRETS = join(tmpdir(), `secrets-${randomUUID()}.json`);
+    srv = await startPanelConsoleHttpServer({ port: 0, bridgePort: 9180, comfyuiUrl: "http://127.0.0.1:8188", token: TOKEN });
+  });
+  afterEach(async () => { await srv.stop(); });
+
+  it("401s without the token", async () => {
+    const r = await fetch(`${base()}/api/secrets`);
+    expect(r.status).toBe(401);
+  });
+
+  it("lists masked slots with the token", async () => {
+    const r = await fetch(`${base()}/api/secrets?token=${TOKEN}`);
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.slots.find((s: any) => s.id === "openrouter")).toBeTruthy();
+    expect(body.slots.every((s: any) => s.masked === null || typeof s.masked === "string")).toBe(true);
+  });
+
+  it("sets a key and reflects it masked; rejects unknown slot", async () => {
+    const ok = await fetch(`${base()}/api/secrets?token=${TOKEN}`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "civitai", value: "civ_key_123456789" }),
+    });
+    expect(ok.status).toBe(200);
+    expect((await ok.json()).masked).toBe("civ_…789");
+
+    const bad = await fetch(`${base()}/api/secrets?token=${TOKEN}`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ slot: "nope", value: "x" }),
+    });
+    expect(bad.status).toBe(400);
+  });
+});

--- a/src/__tests__/orchestrator/console-secrets.test.ts
+++ b/src/__tests__/orchestrator/console-secrets.test.ts
@@ -42,4 +42,14 @@ describe("console /api/secrets", () => {
     });
     expect(bad.status).toBe(400);
   });
+
+  it("rejects an oversized body instead of hanging", async () => {
+    const oversized = JSON.stringify({ slot: "civitai", value: "x".repeat(1_100_000) });
+    const r = await fetch(`${base()}/api/secrets?token=${TOKEN}`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: oversized,
+    });
+    expect(r.status).toBe(400);
+    await r.text().catch(() => {});
+  }, 5000);
 });

--- a/src/__tests__/orchestrator/panel-console-http.test.ts
+++ b/src/__tests__/orchestrator/panel-console-http.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { startPanelConsoleHttpServer } from "../../orchestrator/panel-console-http.js";
+
+describe("panel-console-http", () => {
+  it("serves /api/status and landing page on loopback", async () => {
+    const srv = await startPanelConsoleHttpServer({
+      port: 0,
+      bridgePort: 9180,
+      comfyuiUrl: "http://127.0.0.1:9500",
+    });
+    try {
+      const statusRes = await fetch(`${srv.url}/api/status`);
+      expect(statusRes.ok).toBe(true);
+      const body = (await statusRes.json()) as { ok: boolean; bridge_port: number; backends: unknown[] };
+      expect(body.ok).toBe(true);
+      expect(body.bridge_port).toBe(9180);
+      expect(Array.isArray(body.backends)).toBe(true);
+
+      const htmlRes = await fetch(srv.url);
+      expect(htmlRes.ok).toBe(true);
+      const html = await htmlRes.text();
+      expect(html).toContain("ComfyUI MCP Console");
+    } finally {
+      await srv.stop();
+    }
+  });
+});

--- a/src/__tests__/orchestrator/panel-console-http.test.ts
+++ b/src/__tests__/orchestrator/panel-console-http.test.ts
@@ -1,5 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { startPanelConsoleHttpServer } from "../../orchestrator/panel-console-http.js";
+
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return {
+    ...actual,
+    getInstanceSlug: () => "test-instance",
+  };
+});
+
+import { LoraCatalog, resetLoraCatalog } from "../../services/lora-catalog.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "panel-console-"));
+  process.env.COMFYUI_MCP_LORA_CATALOG = join(dir, "lora-catalog.json");
+  process.env.COMFYUI_MCP_LORA_PREVIEWS = join(dir, "previews");
+  resetLoraCatalog();
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_LORA_CATALOG;
+  delete process.env.COMFYUI_MCP_LORA_PREVIEWS;
+  resetLoraCatalog();
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe("panel-console-http", () => {
   it("serves /api/status and landing page on loopback", async () => {
@@ -20,6 +49,37 @@ describe("panel-console-http", () => {
       expect(htmlRes.ok).toBe(true);
       const html = await htmlRes.text();
       expect(html).toContain("ComfyUI MCP Console");
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("serves LoRA preview images by catalog id", async () => {
+    const previews = join(dir, "previews");
+    mkdirSync(previews, { recursive: true });
+    writeFileSync(join(previews, "thumb.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const catalog = new LoraCatalog();
+    const entry = catalog.upsert({
+      relPath: "loras/test.safetensors",
+      displayName: "Test LoRA",
+      previewFile: "thumb.png",
+    });
+
+    const srv = await startPanelConsoleHttpServer({
+      port: 0,
+      bridgePort: 9180,
+      comfyuiUrl: "http://127.0.0.1:9500",
+    });
+    try {
+      const miss = await fetch(`${srv.url}/api/lora-preview?id=missing`);
+      expect(miss.status).toBe(404);
+
+      const res = await fetch(`${srv.url}/api/lora-preview?id=${encodeURIComponent(entry.id)}`);
+      expect(res.ok).toBe(true);
+      expect(res.headers.get("content-type")).toMatch(/image\/png/);
+      const buf = Buffer.from(await res.arrayBuffer());
+      expect(buf.slice(0, 4).toString("hex")).toBe("89504e47");
     } finally {
       await srv.stop();
     }

--- a/src/__tests__/services/panel-secrets-slots.test.ts
+++ b/src/__tests__/services/panel-secrets-slots.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+describe("panel-secrets credential slots", () => {
+  beforeEach(() => {
+    process.env.COMFYUI_MCP_PANEL_SECRETS = join(tmpdir(), `secrets-${randomUUID()}.json`);
+    for (const k of ["OPENROUTER_API_KEY","XAI_API_KEY","GEMINI_API_KEY","GOOGLE_API_KEY","GOOGLE_GENERATIVE_AI_API_KEY","HF_TOKEN","HUGGINGFACE_TOKEN","GLM_API_KEY","ZHIPU_API_KEY","ZHIPUAI_API_KEY","ZAI_API_KEY","KIMI_API_KEY","RUNCOMFY_API_KEY","REGISTRY_ACCESS_TOKEN","CIVITAI_API_TOKEN"]) delete process.env[k];
+  });
+
+  it("fans a slot out to all its env keys in the right store file", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("huggingface", "hf_abc123456789");
+    const file = JSON.parse(readFileSync(process.env.COMFYUI_MCP_PANEL_SECRETS!, "utf-8"));
+    expect(file.comfyuiEnv.HF_TOKEN).toBe("hf_abc123456789");
+    expect(file.comfyuiEnv.HUGGINGFACE_TOKEN).toBe("hf_abc123456789");
+  });
+
+  it("routes a provider slot to the agent store and hydrates env", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("glm", "glm-secret-xyz789");
+    const file = JSON.parse(readFileSync(process.env.COMFYUI_MCP_PANEL_SECRETS!, "utf-8"));
+    expect(file.agentEnv.GLM_API_KEY).toBe("glm-secret-xyz789");
+    expect(process.env.GLM_API_KEY).toBe("glm-secret-xyz789");
+  });
+
+  it("rejects an unknown slot", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    expect(() => m.setPanelSecret("not-a-slot", "x")).toThrow(/unknown credential slot/i);
+  });
+
+  it("lists masked state without leaking values", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("openrouter", "sk-or-v1-abcdef123456");
+    const rows = m.listPanelSecretsMasked();
+    const or = rows.find((r) => r.id === "openrouter")!;
+    expect(or.set).toBe(true);
+    expect(or.masked).toBe("sk-o…456");
+    expect(JSON.stringify(rows)).not.toContain("abcdef");
+    const civ = rows.find((r) => r.id === "civitai")!;
+    expect(civ.set).toBe(false);
+    expect(civ.masked).toBeNull();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -54,6 +54,7 @@ import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
 import { OllamaBackend } from "./ollama-backend.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
+import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
@@ -1168,6 +1169,23 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
   }
 
+  // Loopback MCP console (control plane): OAuth, MCP mappings, service lifecycle.
+  // Default port bridge+2 (9180→9182). Opened from the panel Advanced section.
+  let panelConsoleHttp: PanelConsoleHttpServer | null = null;
+  const consolePort = Number(process.env.COMFYUI_MCP_CONSOLE_PORT) || bridgePort + 2;
+  try {
+    panelConsoleHttp = await startPanelConsoleHttpServer({
+      port: consolePort,
+      bridgePort,
+      comfyuiUrl,
+    });
+  } catch (err) {
+    logger.warn(
+      `[panel-orchestrator] could not start MCP console on :${consolePort}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const consoleUrl = panelConsoleHttp?.url ?? `http://127.0.0.1:${consolePort}`;
+
   // Shared MCP server config for BOTH the Codex and Gemini backends — they take an
   // identical { transport } spec (the headless comfyui stdio MCP + the panel HTTP
   // MCP for this tab). Claude keeps its own in-process server set unchanged.
@@ -1693,7 +1711,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const { backends, any_ready } = allBackendReadiness(KNOWN_BACKENDS, {
         customEndpointConfigured: !!customBaseUrl,
       });
-      bridge.push({ type: "backends", backends, any_ready }, tabId);
+      bridge.push({ type: "backends", backends, any_ready, console_url: consoleUrl }, tabId);
       // llama.cpp reality check (async re-push): the binary is often unzipped
       // anywhere (not on PATH), so static detection says "not installed" while
       // a server is HAPPILY ANSWERING. A live endpoint beats a missing binary —
@@ -1708,7 +1726,7 @@ export async function runPanelOrchestrator(): Promise<void> {
             lc.cli = true;
             lc.auth = true;
             lc.ready = true;
-            bridge.push({ type: "backends", backends, any_ready: true }, tabId);
+            bridge.push({ type: "backends", backends, any_ready: true, console_url: consoleUrl }, tabId);
           })
           .catch(() => {});
       }
@@ -2552,7 +2570,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       ? " — no local ComfyUI install found (COMFYUI_PATH unset, auto-detect came up empty); node/model installs still run via ComfyUI-Manager"
       : " — remote target: installs/downloads run ON the ComfyUI host via its Manager (a local path would be the wrong filesystem; only local-FS tools like verify_custom_node are unavailable)";
   logger.info(
-    `[panel-orchestrator] ready — bridge on ws://127.0.0.1:${bridgePort}; an agent spawns per ComfyUI tab on its first message (model=${model}, comfyui=${comfyuiUrl}${pathNote})`,
+    `[panel-orchestrator] ready — bridge on ws://127.0.0.1:${bridgePort}, console on ${consoleUrl}; an agent spawns per ComfyUI tab on its first message (model=${model}, comfyui=${comfyuiUrl}${pathNote})`,
   );
 
   let shuttingDown = false;
@@ -2572,6 +2590,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
     // Tear down the loopback panel HTTP MCP (codex/gemini mode only).
     if (panelMcpHttp) await panelMcpHttp.stop().catch(() => {});
+    if (panelConsoleHttp) await panelConsoleHttp.stop().catch(() => {});
     secureBridge?.stop();
     await bridge.stop();
     // Only remove the lockfile if it still names us — avoid clobbering a fresh

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1173,11 +1173,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Default port bridge+2 (9180→9182). Opened from the panel Advanced section.
   let panelConsoleHttp: PanelConsoleHttpServer | null = null;
   const consolePort = Number(process.env.COMFYUI_MCP_CONSOLE_PORT) || bridgePort + 2;
+  const consoleToken = randomBytes(24).toString("hex");
   try {
     panelConsoleHttp = await startPanelConsoleHttpServer({
       port: consolePort,
       bridgePort,
       comfyuiUrl,
+      token: consoleToken,
     });
   } catch (err) {
     logger.warn(
@@ -1711,7 +1713,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const { backends, any_ready } = allBackendReadiness(KNOWN_BACKENDS, {
         customEndpointConfigured: !!customBaseUrl,
       });
-      bridge.push({ type: "backends", backends, any_ready, console_url: consoleUrl }, tabId);
+      bridge.push({ type: "backends", backends, any_ready, console_url: consoleUrl, console_token: consoleToken }, tabId);
       // llama.cpp reality check (async re-push): the binary is often unzipped
       // anywhere (not on PATH), so static detection says "not installed" while
       // a server is HAPPILY ANSWERING. A live endpoint beats a missing binary —
@@ -1726,7 +1728,7 @@ export async function runPanelOrchestrator(): Promise<void> {
             lc.cli = true;
             lc.auth = true;
             lc.ready = true;
-            bridge.push({ type: "backends", backends, any_ready: true, console_url: consoleUrl }, tabId);
+            bridge.push({ type: "backends", backends, any_ready: true, console_url: consoleUrl, console_token: consoleToken }, tabId);
           })
           .catch(() => {});
       }

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -1,0 +1,199 @@
+// Loopback HTTP console for MCP / orchestrator settings (control plane).
+//
+// The ComfyUI sidebar panel stays a canvas-focused client: provider, effort,
+// context, storyboards. Service lifecycle, OAuth, MCP mappings, and advanced
+// tool suites live here — opened from the panel's Advanced → "Open MCP Console".
+//
+// Bound to 127.0.0.1 only; never exposed off-host.
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { allBackendReadiness } from "./backend-readiness.js";
+import { logger } from "../utils/logger.js";
+
+const KNOWN_BACKENDS = [
+  "claude",
+  "codex",
+  "chatgpt",
+  "gemini",
+  "grok",
+  "glm",
+  "kimi",
+  "ollama",
+] as const;
+
+export interface PanelConsoleHttpServer {
+  readonly port: number;
+  readonly url: string;
+  stop(): Promise<void>;
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(payload),
+    "Cache-Control": "no-store",
+  });
+  res.end(payload);
+}
+
+function sendHtml(res: ServerResponse, status: number, html: string): void {
+  res.writeHead(status, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": Buffer.byteLength(html),
+    "Cache-Control": "no-store",
+  });
+  res.end(html);
+}
+
+function consoleLandingHtml(opts: {
+  bridgePort: number;
+  consolePort: number;
+  comfyuiUrl: string;
+}): string {
+  const { bridgePort, consolePort, comfyuiUrl } = opts;
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ComfyUI MCP Console</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
+    body { margin: 0; background: #0f1115; color: #e8eaed; line-height: 1.5; }
+    main { max-width: 52rem; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+    h1 { font-size: 1.35rem; font-weight: 600; margin: 0 0 0.25rem; }
+    .sub { color: #9aa0a6; font-size: 0.9rem; margin-bottom: 1.5rem; }
+    section { background: #181b22; border: 1px solid #2a2f3a; border-radius: 10px; padding: 1rem 1.1rem; margin-bottom: 1rem; }
+    h2 { font-size: 0.95rem; margin: 0 0 0.6rem; color: #c4c7ce; }
+    ul { margin: 0.4rem 0 0; padding-left: 1.2rem; }
+    li { margin: 0.25rem 0; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.82rem; }
+    pre { background: #0b0d11; border: 1px solid #2a2f3a; border-radius: 8px; padding: 0.75rem; overflow-x: auto; }
+    .ok { color: #81c995; }
+    .warn { color: #fdd663; }
+    a { color: #8ab4f8; }
+    #status { font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>ComfyUI MCP Console</h1>
+    <p class="sub">Control plane for the panel orchestrator — MCP servers, OAuth, and service settings. The ComfyUI sidebar panel stays focused on chat, providers, and the live canvas.</p>
+
+    <section>
+      <h2>Connection</h2>
+      <p>Bridge <code>ws://127.0.0.1:${bridgePort}</code> · ComfyUI <code>${escapeHtml(comfyuiUrl)}</code></p>
+      <p id="status">Loading provider readiness…</p>
+    </section>
+
+    <section>
+      <h2>Coming here (panel stays in ComfyUI)</h2>
+      <ul>
+        <li>Start / stop / restart orchestrator</li>
+        <li>MCP server mappings &amp; inherited <code>~/.claude.json</code> tools</li>
+        <li>OAuth &amp; API provider sign-in</li>
+        <li>LoRA library, image collections, Photomap-style tooling</li>
+        <li>A2UI-rich tool surfaces</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Stays in the ComfyUI panel</h2>
+      <ul>
+        <li>Provider / model / effort pickers &amp; context window meter</li>
+        <li>Video storyboards &amp; live graph edits</li>
+        <li>Connect / Disconnect to this bridge</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>API</h2>
+      <pre>GET /api/status</pre>
+    </section>
+  </main>
+  <script>
+    fetch('/api/status').then(r => r.json()).then(d => {
+      const el = document.getElementById('status');
+      const rows = (d.backends || []).map(b =>
+        b.backend + ': ' + (b.ready ? 'ready' : (b.cli ? 'sign in' : 'install CLI'))
+      ).join(' · ');
+      el.innerHTML = '<span class="ok">Orchestrator running</span> — ' + (rows || 'no backends');
+    }).catch(() => {
+      document.getElementById('status').innerHTML = '<span class="warn">Could not load status</span>';
+    });
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function startPanelConsoleHttpServer(opts: {
+  port: number;
+  host?: string;
+  bridgePort: number;
+  comfyuiUrl: string;
+}): Promise<PanelConsoleHttpServer> {
+  const host = opts.host ?? "127.0.0.1";
+
+  const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const path = (req.url ?? "/").split("?")[0];
+    if (req.method === "GET" && path === "/api/status") {
+      const { backends, any_ready } = allBackendReadiness(KNOWN_BACKENDS);
+      const bound = server.address();
+      const boundPort =
+        bound && typeof bound === "object" ? bound.port : opts.port;
+      const liveUrl = `http://${host}:${boundPort}`;
+      sendJson(res, 200, {
+        ok: true,
+        console_url: liveUrl,
+        bridge_port: opts.bridgePort,
+        bridge_url: `ws://${host}:${opts.bridgePort}`,
+        comfyui_url: opts.comfyuiUrl,
+        backends,
+        any_ready,
+      });
+      return;
+    }
+    if (req.method === "GET" && (path === "/" || path === "/console")) {
+      sendHtml(
+        res,
+        200,
+        consoleLandingHtml({
+          bridgePort: opts.bridgePort,
+          consolePort: opts.port,
+          comfyuiUrl: opts.comfyuiUrl,
+        }),
+      );
+      return;
+    }
+    sendJson(res, 404, { ok: false, error: "not_found" });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts.port, host, () => {
+      server.removeListener("error", reject);
+      const bound = server.address();
+      const boundPort =
+        bound && typeof bound === "object" ? bound.port : opts.port;
+      const url = `http://${host}:${boundPort}`;
+      logger.info(`[panel-console] MCP console listening on ${url} (loopback)`);
+      resolve({
+        port: boundPort,
+        url,
+        stop: () =>
+          new Promise((res, rej) => {
+            server.close((err) => (err ? rej(err) : res()));
+          }),
+      });
+    });
+  });
+}

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -8,7 +8,7 @@
 
 import { createReadStream, existsSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { extname, join, resolve } from "node:path";
+import { extname, join, resolve, sep } from "node:path";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { getLoraCatalog, loraPreviewsDir } from "../services/lora-catalog.js";
 import { setPanelSecret, listPanelSecretsMasked, CREDENTIAL_SLOTS } from "../services/panel-secrets.js";
@@ -125,7 +125,9 @@ function serveLoraPreview(req: IncomingMessage, res: ServerResponse): void {
   }
   const previewsRoot = resolve(loraPreviewsDir());
   const abs = resolve(join(previewsRoot, entry.previewFile));
-  if (!abs.startsWith(previewsRoot + "/") && abs !== previewsRoot) {
+  // Path containment: use the platform separator (sep) so the check also holds
+  // on Windows, where resolve() yields backslash-separated paths.
+  if (!abs.startsWith(previewsRoot + sep) && abs !== previewsRoot) {
     sendJson(res, 403, { ok: false, error: "invalid preview path" });
     return;
   }

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -6,8 +6,11 @@
 //
 // Bound to 127.0.0.1 only; never exposed off-host.
 
+import { createReadStream, existsSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { extname, join, resolve } from "node:path";
 import { allBackendReadiness } from "./backend-readiness.js";
+import { getLoraCatalog, loraPreviewsDir } from "../services/lora-catalog.js";
 import { setPanelSecret, listPanelSecretsMasked, CREDENTIAL_SLOTS } from "../services/panel-secrets.js";
 import { logger } from "../utils/logger.js";
 
@@ -91,6 +94,51 @@ function readJsonBody(req: IncomingMessage): Promise<any> {
     req.on("error", (e) => { settle(() => reject(e)); });
     req.on("close", () => { settle(() => reject(new Error("request closed before body was fully received"))); });
   });
+}
+
+const PREVIEW_MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+};
+
+function serveLoraPreview(req: IncomingMessage, res: ServerResponse): void {
+  let id = "";
+  try {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    id = (url.searchParams.get("id") ?? "").trim();
+  } catch {
+    sendJson(res, 400, { ok: false, error: "bad request" });
+    return;
+  }
+  if (!id) {
+    sendJson(res, 400, { ok: false, error: "id required" });
+    return;
+  }
+  const catalog = getLoraCatalog();
+  const entry = catalog.get(id);
+  if (!entry?.previewFile) {
+    sendJson(res, 404, { ok: false, error: "no preview" });
+    return;
+  }
+  const previewsRoot = resolve(loraPreviewsDir());
+  const abs = resolve(join(previewsRoot, entry.previewFile));
+  if (!abs.startsWith(previewsRoot + "/") && abs !== previewsRoot) {
+    sendJson(res, 403, { ok: false, error: "invalid preview path" });
+    return;
+  }
+  if (!existsSync(abs)) {
+    sendJson(res, 404, { ok: false, error: "preview file missing" });
+    return;
+  }
+  const mime = PREVIEW_MIME[extname(abs).toLowerCase()] ?? "application/octet-stream";
+  res.writeHead(200, {
+    "Content-Type": mime,
+    "Cache-Control": "private, max-age=3600",
+  });
+  createReadStream(abs).pipe(res);
 }
 
 function consoleLandingHtml(opts: {
@@ -341,6 +389,10 @@ export function startPanelConsoleHttpServer(opts: {
         backends,
         any_ready,
       });
+      return;
+    }
+    if (req.method === "GET" && path === "/api/lora-preview") {
+      serveLoraPreview(req, res);
       return;
     }
     if (req.method === "GET" && path === "/credentials") {

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -8,7 +8,7 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { allBackendReadiness } from "./backend-readiness.js";
-import { setPanelSecret, listPanelSecretsMasked } from "../services/panel-secrets.js";
+import { setPanelSecret, listPanelSecretsMasked, CREDENTIAL_SLOTS } from "../services/panel-secrets.js";
 import { logger } from "../utils/logger.js";
 
 const KNOWN_BACKENDS = [
@@ -43,6 +43,17 @@ function sendHtml(res: ServerResponse, status: number, html: string): void {
     "Content-Type": "text/html; charset=utf-8",
     "Content-Length": Buffer.byteLength(html),
     "Cache-Control": "no-store",
+  });
+  res.end(html);
+}
+
+const FRAME_ANCESTORS = "frame-ancestors http://127.0.0.1:8188 http://localhost:8188 'self'";
+function sendFramedHtml(res: ServerResponse, status: number, html: string): void {
+  res.writeHead(status, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": Buffer.byteLength(html),
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": FRAME_ANCESTORS,
   });
   res.end(html);
 }
@@ -163,6 +174,117 @@ function consoleLandingHtml(opts: {
 </html>`;
 }
 
+function credentialsHtml(
+  slots: { id: string; label: string; help?: string }[],
+  consoleUrl: string,
+  token: string,
+): string {
+  const rows = slots
+    .map(
+      (s) => `      <div class="row" data-slot="${escapeHtml(s.id)}">
+        <div class="meta"><span class="label">${escapeHtml(s.label)}</span>${s.help ? `<span class="help">${escapeHtml(s.help)}</span>` : ""}</div>
+        <div class="state"><span class="badge" data-badge>—</span></div>
+        <div class="entry"><input type="password" placeholder="Paste key…" data-input autocomplete="off" spellcheck="false" /><button data-save>Save</button></div>
+      </div>`,
+    )
+    .join("\n");
+  const cfg = JSON.stringify({ consoleUrl, token });
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>API Keys</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
+    body { margin: 0; background: #0f1115; color: #e8eaed; }
+    main { padding: 0.9rem 1rem 1.2rem; }
+    header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.75rem; }
+    h1 { font-size: 1.05rem; font-weight: 600; margin: 0; }
+    .close { background: none; border: none; color: #9aa0a6; font-size: 1.1rem; cursor: pointer; }
+    .row { display: grid; grid-template-columns: 1fr auto; gap: 0.35rem 0.6rem; padding: 0.6rem 0; border-bottom: 1px solid #23272f; }
+    .meta { display: flex; flex-direction: column; }
+    .label { font-size: 0.9rem; font-weight: 500; }
+    .help { font-size: 0.72rem; color: #9aa0a6; }
+    .state { grid-column: 2; align-self: center; }
+    .badge { font-size: 0.72rem; color: #9aa0a6; }
+    .badge.set { color: #81c995; }
+    .entry { grid-column: 1 / -1; display: flex; gap: 0.4rem; }
+    input { flex: 1; background: #0b0d11; border: 1px solid #2a2f3a; border-radius: 7px; color: #e8eaed; padding: 0.4rem 0.5rem; font-size: 0.82rem; }
+    button { background: #2a3140; border: 1px solid #3a4150; color: #e8eaed; border-radius: 7px; padding: 0.4rem 0.7rem; font-size: 0.82rem; cursor: pointer; }
+    button:hover { background: #333c4d; }
+    button[data-save].ok { color: #81c995; border-color: #2f6b41; }
+    footer { margin-top: 0.9rem; display: flex; justify-content: space-between; align-items: center; }
+    .advanced { background: none; border: 1px solid #2a2f3a; color: #8ab4f8; }
+    .err { color: #f28b82; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <header><h1>API Keys</h1><button class="close" data-close title="Close">✕</button></header>
+    <div id="rows">
+${rows}
+    </div>
+    <p class="err" id="err"></p>
+    <footer>
+      <span class="help">Stored locally, per instance. Values never leave this machine.</span>
+      <button class="advanced" data-advanced>Advanced ↗</button>
+    </footer>
+  </main>
+  <script>
+    const CFG = ${cfg};
+    const q = (t) => "?token=" + encodeURIComponent(t);
+    function postHeight() {
+      try { parent.postMessage({ type: "resize", height: document.body.scrollHeight }, "*"); } catch {}
+    }
+    async function load() {
+      try {
+        const r = await fetch("/api/secrets" + q(CFG.token));
+        const d = await r.json();
+        for (const s of (d.slots || [])) {
+          const row = document.querySelector('.row[data-slot="' + s.id + '"]');
+          if (!row) continue;
+          const badge = row.querySelector("[data-badge]");
+          badge.textContent = s.set ? "set · " + s.masked : "not set";
+          badge.classList.toggle("set", !!s.set);
+        }
+      } catch (e) { document.getElementById("err").textContent = "Could not load status — reconnect the panel."; }
+      postHeight();
+    }
+    document.querySelectorAll(".row").forEach((row) => {
+      const btn = row.querySelector("[data-save]");
+      const input = row.querySelector("[data-input]");
+      btn.addEventListener("click", async () => {
+        const value = input.value.trim();
+        if (!value) return;
+        btn.disabled = true; btn.textContent = "Saving…";
+        try {
+          const r = await fetch("/api/secrets" + q(CFG.token), {
+            method: "POST", headers: { "content-type": "application/json" },
+            body: JSON.stringify({ slot: row.dataset.slot, value }),
+          });
+          const d = await r.json();
+          if (!r.ok || !d.ok) throw new Error(d.error || "save failed");
+          input.value = "";
+          const badge = row.querySelector("[data-badge]");
+          badge.textContent = "set · " + d.masked; badge.classList.add("set");
+          btn.textContent = "Saved ✓"; btn.classList.add("ok");
+          setTimeout(() => { btn.textContent = "Save"; btn.classList.remove("ok"); btn.disabled = false; }, 1500);
+        } catch (e) {
+          document.getElementById("err").textContent = String(e.message || e);
+          btn.textContent = "Save"; btn.disabled = false;
+        }
+      });
+    });
+    document.querySelector("[data-close]").addEventListener("click", () => { try { parent.postMessage({ type: "close" }, "*"); } catch {} });
+    document.querySelector("[data-advanced]").addEventListener("click", () => { window.open(CFG.consoleUrl + "/console", "_blank", "noopener"); });
+    window.addEventListener("load", load);
+    new ResizeObserver(postHeight).observe(document.body);
+  </script>
+</body>
+</html>`;
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
@@ -219,6 +341,13 @@ export function startPanelConsoleHttpServer(opts: {
         backends,
         any_ready,
       });
+      return;
+    }
+    if (req.method === "GET" && path === "/credentials") {
+      if (!tokenOk(req, opts.token)) { sendHtml(res, 401, "<p>Unauthorized — reconnect the panel.</p>"); return; }
+      const bound = server.address();
+      const boundPort = bound && typeof bound === "object" ? bound.port : opts.port;
+      sendFramedHtml(res, 200, credentialsHtml(CREDENTIAL_SLOTS, `http://${host}:${boundPort}`, opts.token ?? ""));
       return;
     }
     if (req.method === "GET" && (path === "/" || path === "/console")) {

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -60,9 +60,25 @@ function tokenOk(req: IncomingMessage, expected?: string): boolean {
 function readJsonBody(req: IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = "";
-    req.on("data", (c) => { data += c; if (data.length > 1_000_000) req.destroy(); });
-    req.on("end", () => { try { resolve(data ? JSON.parse(data) : {}); } catch (e) { reject(e); } });
-    req.on("error", reject);
+    let settled = false;
+    let oversized = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    req.on("data", (c) => {
+      if (oversized) return; // already over limit: drain and discard the rest, don't destroy mid-stream
+      data += c;
+      if (data.length > 1_000_000) {
+        oversized = true;
+        data = "";
+        settle(() => reject(new Error("body too large")));
+      }
+    });
+    req.on("end", () => { settle(() => { try { resolve(data ? JSON.parse(data) : {}); } catch (e) { reject(e); } }); });
+    req.on("error", (e) => { settle(() => reject(e)); });
+    req.on("close", () => { settle(() => reject(new Error("request closed before body was fully received"))); });
   });
 }
 

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -8,6 +8,7 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { allBackendReadiness } from "./backend-readiness.js";
+import { setPanelSecret, listPanelSecretsMasked } from "../services/panel-secrets.js";
 import { logger } from "../utils/logger.js";
 
 const KNOWN_BACKENDS = [
@@ -44,6 +45,25 @@ function sendHtml(res: ServerResponse, status: number, html: string): void {
     "Cache-Control": "no-store",
   });
   res.end(html);
+}
+
+function tokenOk(req: IncomingMessage, expected?: string): boolean {
+  if (!expected) return true; // no token configured → open (dev)
+  try {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const q = url.searchParams.get("token");
+    const h = (req.headers["authorization"] || "").replace(/^Bearer\s+/i, "");
+    return q === expected || h === expected;
+  } catch { return false; }
+}
+
+function readJsonBody(req: IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (c) => { data += c; if (data.length > 1_000_000) req.destroy(); });
+    req.on("end", () => { try { resolve(data ? JSON.parse(data) : {}); } catch (e) { reject(e); } });
+    req.on("error", reject);
+  });
 }
 
 function consoleLandingHtml(opts: {
@@ -140,11 +160,34 @@ export function startPanelConsoleHttpServer(opts: {
   host?: string;
   bridgePort: number;
   comfyuiUrl: string;
+  token?: string;
 }): Promise<PanelConsoleHttpServer> {
   const host = opts.host ?? "127.0.0.1";
 
   const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const path = (req.url ?? "/").split("?")[0];
+    if (path === "/api/secrets") {
+      if (!tokenOk(req, opts.token)) { sendJson(res, 401, { ok: false, error: "unauthorized" }); return; }
+      if (req.method === "GET") { sendJson(res, 200, { ok: true, slots: listPanelSecretsMasked() }); return; }
+      if (req.method === "POST") {
+        let body: any;
+        try { body = await readJsonBody(req); } catch { sendJson(res, 400, { ok: false, error: "bad json" }); return; }
+        const slot = String(body?.slot ?? "");
+        const value = String(body?.value ?? "");
+        if (!slot || !value) { sendJson(res, 400, { ok: false, error: "slot and value required" }); return; }
+        try {
+          setPanelSecret(slot, value);
+          const masked = listPanelSecretsMasked().find((s) => s.id === slot)?.masked ?? null;
+          sendJson(res, 200, { ok: true, slot, masked });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          sendJson(res, /unknown credential slot/i.test(msg) ? 400 : 500, { ok: false, error: msg });
+        }
+        return;
+      }
+      sendJson(res, 405, { ok: false, error: "method not allowed" });
+      return;
+    }
     if (req.method === "GET" && path === "/api/status") {
       const { backends, any_ready } = allBackendReadiness(KNOWN_BACKENDS);
       const bound = server.address();

--- a/src/services/lora-catalog.ts
+++ b/src/services/lora-catalog.ts
@@ -1,0 +1,416 @@
+// Persistent catalog of local LoRA files with human/agent-readable metadata:
+// descriptions, setup instructions, trigger keywords, strength hints, and
+// preview images. Synced against listLocalModels('loras') so missing files are
+// flagged without dropping curated notes.
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, extname, join } from "node:path";
+import { getInstanceSlug } from "../config.js";
+import { listLocalModels, type LocalModel } from "./model-resolver.js";
+import { logger } from "../utils/logger.js";
+
+/** ComfyUI-relative path under models/ (e.g. "loras/style/foo.safetensors"). */
+export type LoraRelPath = string;
+
+export interface LoraCatalogEntry {
+  /** Stable slug derived from relPath. */
+  id: string;
+  /** Path relative to ComfyUI models/ root. */
+  relPath: LoraRelPath;
+  /** Short label for pickers and UI. */
+  displayName: string;
+  /** What this LoRA does — style, subject, effect, etc. */
+  description: string;
+  /** How to wire it: checkpoint pairing, node type, clip placement, etc. */
+  setupInstructions: string;
+  /** Trigger words / tokens to include in prompts. */
+  keywords: string[];
+  /** Optional tokens to avoid or negative-prompt hints. */
+  negativeKeywords?: string[];
+  /** Compatible base models (SDXL, Flux, Pony, etc.). */
+  baseModels: string[];
+  /** Suggested strength range and default for LoraLoader widgets. */
+  strengthMin?: number;
+  strengthMax?: number;
+  strengthDefault?: number;
+  /** Filename under the instance previews dir (not absolute). */
+  previewFile?: string;
+  /** Optional CivitAI / source links. */
+  civitaiModelId?: number;
+  civitaiVersionId?: number;
+  sourceUrl?: string;
+  tags?: string[];
+  notes?: string;
+  /** Present after sync when the file is no longer on disk. */
+  missing?: boolean;
+  fileSize?: number;
+  modifiedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LoraCatalogFile {
+  version: 1;
+  entries: Record<string, LoraCatalogEntry>;
+}
+
+export interface LoraCatalogListOptions {
+  query?: string;
+  includeMissing?: boolean;
+  tag?: string;
+  baseModel?: string;
+  limit?: number;
+}
+
+export interface LoraCatalogSyncResult {
+  scanned: number;
+  added: number;
+  updated: number;
+  markedMissing: number;
+  total: number;
+}
+
+const CATALOG_VERSION = 1 as const;
+const PREVIEW_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
+
+function dataBaseDir(): string {
+  return process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp");
+}
+
+/** Override for tests. */
+export function loraCatalogPath(): string {
+  const override = process.env.COMFYUI_MCP_LORA_CATALOG?.trim();
+  if (override) return override;
+  const slug = getInstanceSlug();
+  return join(dataBaseDir(), "instances", slug, "lora-catalog.json");
+}
+
+export function loraPreviewsDir(): string {
+  const override = process.env.COMFYUI_MCP_LORA_PREVIEWS?.trim();
+  if (override) return override;
+  const slug = getInstanceSlug();
+  return join(dataBaseDir(), "instances", slug, "lora-previews");
+}
+
+export function loraIdFromPath(relPath: string): string {
+  const base = relPath.replace(/\\/g, "/").replace(/^\/+/, "");
+  const slug = base
+    .toLowerCase()
+    .replace(/\.(safetensors|ckpt|pt|bin)$/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "lora";
+}
+
+function defaultDisplayName(relPath: string): string {
+  const file = basename(relPath);
+  return file.replace(/\.(safetensors|ckpt|pt|bin)$/i, "").replace(/_/g, " ");
+}
+
+function readCatalogFile(): LoraCatalogFile {
+  const path = loraCatalogPath();
+  if (!existsSync(path)) {
+    return { version: CATALOG_VERSION, entries: {} };
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed as LoraCatalogFile).version === CATALOG_VERSION &&
+      typeof (parsed as LoraCatalogFile).entries === "object"
+    ) {
+      return parsed as LoraCatalogFile;
+    }
+  } catch (err) {
+    logger.warn(
+      `[lora-catalog] could not parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return { version: CATALOG_VERSION, entries: {} };
+}
+
+function writeCatalogFile(data: LoraCatalogFile): void {
+  const path = loraCatalogPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2));
+}
+
+function normalizeRelPath(path: string): string {
+  const p = path.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (p.startsWith("models/")) return p.slice("models/".length);
+  if (!p.startsWith("loras/") && !p.includes("/")) return `loras/${p}`;
+  return p;
+}
+
+function entryFromLocal(model: LocalModel, now: string): LoraCatalogEntry {
+  const relPath = normalizeRelPath(model.path.startsWith("loras/") ? model.path : `loras/${model.name}`);
+  const id = loraIdFromPath(relPath);
+  return {
+    id,
+    relPath,
+    displayName: defaultDisplayName(relPath),
+    description: "",
+    setupInstructions: "",
+    keywords: [],
+    baseModels: [],
+    fileSize: model.size || undefined,
+    modifiedAt: model.modified || undefined,
+    missing: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function mergeDiskEntry(existing: LoraCatalogEntry | undefined, disk: LoraCatalogEntry): LoraCatalogEntry {
+  if (!existing) return disk;
+  return {
+    ...existing,
+    relPath: disk.relPath,
+    fileSize: disk.fileSize,
+    modifiedAt: disk.modifiedAt,
+    missing: false,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function matchesQuery(entry: LoraCatalogEntry, query: string): boolean {
+  const q = query.toLowerCase().trim();
+  if (!q) return true;
+  const hay = [
+    entry.displayName,
+    entry.relPath,
+    entry.description,
+    entry.setupInstructions,
+    entry.notes ?? "",
+    ...(entry.keywords ?? []),
+    ...(entry.tags ?? []),
+    ...(entry.baseModels ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return hay.includes(q);
+}
+
+/** Public summary shape for panel UI and pickers. */
+export function toLoraSummary(entry: LoraCatalogEntry): Record<string, unknown> {
+  const previewUrl = entry.previewFile
+    ? join(loraPreviewsDir(), entry.previewFile)
+    : undefined;
+  return {
+    id: entry.id,
+    relPath: entry.relPath,
+    displayName: entry.displayName,
+    description: entry.description,
+    setupInstructions: entry.setupInstructions,
+    keywords: entry.keywords,
+    negativeKeywords: entry.negativeKeywords ?? [],
+    baseModels: entry.baseModels,
+    strengthDefault: entry.strengthDefault,
+    strengthMin: entry.strengthMin,
+    strengthMax: entry.strengthMax,
+    previewFile: entry.previewFile,
+    previewPath: previewUrl && existsSync(previewUrl) ? previewUrl : undefined,
+    tags: entry.tags ?? [],
+    missing: !!entry.missing,
+    sourceUrl: entry.sourceUrl,
+  };
+}
+
+export class LoraCatalog {
+  private data: LoraCatalogFile;
+
+  constructor() {
+    this.data = readCatalogFile();
+  }
+
+  reload(): void {
+    this.data = readCatalogFile();
+  }
+
+  list(opts: LoraCatalogListOptions = {}): LoraCatalogEntry[] {
+    let entries = Object.values(this.data.entries);
+    if (!opts.includeMissing) entries = entries.filter((e) => !e.missing);
+    if (opts.tag) {
+      const t = opts.tag.toLowerCase();
+      entries = entries.filter((e) => (e.tags ?? []).some((x) => x.toLowerCase() === t));
+    }
+    if (opts.baseModel) {
+      const b = opts.baseModel.toLowerCase();
+      entries = entries.filter((e) =>
+        (e.baseModels ?? []).some((x) => x.toLowerCase().includes(b)),
+      );
+    }
+    if (opts.query) entries = entries.filter((e) => matchesQuery(e, opts.query!));
+    entries.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    if (typeof opts.limit === "number" && opts.limit > 0) {
+      entries = entries.slice(0, opts.limit);
+    }
+    return entries;
+  }
+
+  get(idOrPath: string): LoraCatalogEntry | null {
+    const key = idOrPath.trim();
+    if (this.data.entries[key]) return this.data.entries[key];
+    const norm = normalizeRelPath(key);
+    const id = loraIdFromPath(norm);
+    if (this.data.entries[id]) return this.data.entries[id];
+    for (const e of Object.values(this.data.entries)) {
+      if (e.relPath === norm || e.relPath.endsWith(`/${basename(norm)}`)) return e;
+    }
+    return null;
+  }
+
+  async syncFromDisk(): Promise<LoraCatalogSyncResult> {
+    const models = await listLocalModels("loras");
+    const now = new Date().toISOString();
+    const seenIds = new Set<string>();
+    let added = 0;
+    let updated = 0;
+
+    for (const model of models) {
+      const disk = entryFromLocal(model, now);
+      seenIds.add(disk.id);
+      const prev = this.data.entries[disk.id];
+      if (!prev) {
+        this.data.entries[disk.id] = disk;
+        added++;
+      } else {
+        const wasMissing = !!prev.missing;
+        this.data.entries[disk.id] = mergeDiskEntry(prev, disk);
+        if (wasMissing) updated++;
+      }
+    }
+
+    let markedMissing = 0;
+    for (const [id, entry] of Object.entries(this.data.entries)) {
+      if (!seenIds.has(id) && !entry.missing) {
+        entry.missing = true;
+        entry.updatedAt = now;
+        markedMissing++;
+      }
+    }
+
+    writeCatalogFile(this.data);
+    return {
+      scanned: models.length,
+      added,
+      updated: updated + markedMissing,
+      markedMissing,
+      total: Object.keys(this.data.entries).length,
+    };
+  }
+
+  upsert(partial: Partial<LoraCatalogEntry> & { relPath?: string; id?: string }): LoraCatalogEntry {
+    const now = new Date().toISOString();
+    let id = partial.id?.trim();
+    let relPath = partial.relPath ? normalizeRelPath(partial.relPath) : undefined;
+
+    if (!id && relPath) id = loraIdFromPath(relPath);
+    if (id && !relPath) relPath = this.data.entries[id]?.relPath;
+    if (!id || !relPath) {
+      throw new Error("upsert requires id or relPath");
+    }
+
+    const prev = this.data.entries[id];
+    const entry: LoraCatalogEntry = {
+      id,
+      relPath,
+      displayName: partial.displayName?.trim() || prev?.displayName || defaultDisplayName(relPath),
+      description: partial.description ?? prev?.description ?? "",
+      setupInstructions: partial.setupInstructions ?? prev?.setupInstructions ?? "",
+      keywords: partial.keywords ?? prev?.keywords ?? [],
+      negativeKeywords: partial.negativeKeywords ?? prev?.negativeKeywords,
+      baseModels: partial.baseModels ?? prev?.baseModels ?? [],
+      strengthMin: partial.strengthMin ?? prev?.strengthMin,
+      strengthMax: partial.strengthMax ?? prev?.strengthMax,
+      strengthDefault: partial.strengthDefault ?? prev?.strengthDefault,
+      previewFile: partial.previewFile ?? prev?.previewFile,
+      civitaiModelId: partial.civitaiModelId ?? prev?.civitaiModelId,
+      civitaiVersionId: partial.civitaiVersionId ?? prev?.civitaiVersionId,
+      sourceUrl: partial.sourceUrl ?? prev?.sourceUrl,
+      tags: partial.tags ?? prev?.tags,
+      notes: partial.notes ?? prev?.notes,
+      missing: partial.missing ?? prev?.missing,
+      fileSize: partial.fileSize ?? prev?.fileSize,
+      modifiedAt: partial.modifiedAt ?? prev?.modifiedAt,
+      createdAt: prev?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    this.data.entries[id] = entry;
+    writeCatalogFile(this.data);
+    return entry;
+  }
+
+  setPreview(idOrPath: string, sourcePath: string): LoraCatalogEntry {
+    const entry = this.get(idOrPath);
+    if (!entry) throw new Error(`No catalog entry for "${idOrPath}"`);
+
+    const src = sourcePath.trim();
+    if (!existsSync(src)) throw new Error(`Preview source not found: ${src}`);
+    const ext = extname(src).toLowerCase();
+    if (!PREVIEW_EXTS.has(ext)) {
+      throw new Error(`Preview must be an image (${[...PREVIEW_EXTS].join(", ")})`);
+    }
+
+    const dir = loraPreviewsDir();
+    mkdirSync(dir, { recursive: true });
+    const destName = `${entry.id}${ext}`;
+    const dest = join(dir, destName);
+
+    if (entry.previewFile && entry.previewFile !== destName) {
+      const old = join(dir, entry.previewFile);
+      if (existsSync(old)) {
+        try {
+          unlinkSync(old);
+        } catch {
+          /* best effort */
+        }
+      }
+    }
+
+    copyFileSync(src, dest);
+    return this.upsert({ id: entry.id, previewFile: destName });
+  }
+
+  remove(idOrPath: string): boolean {
+    const entry = this.get(idOrPath);
+    if (!entry) return false;
+    if (entry.previewFile) {
+      const p = join(loraPreviewsDir(), entry.previewFile);
+      if (existsSync(p)) {
+        try {
+          unlinkSync(p);
+        } catch {
+          /* best effort */
+        }
+      }
+    }
+    delete this.data.entries[entry.id];
+    writeCatalogFile(this.data);
+    return true;
+  }
+}
+
+let singleton: LoraCatalog | null = null;
+
+export function getLoraCatalog(): LoraCatalog {
+  if (!singleton) singleton = new LoraCatalog();
+  else singleton.reload();
+  return singleton;
+}
+
+/** Reset singleton — tests only. */
+export function resetLoraCatalog(): void {
+  singleton = null;
+}

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -45,7 +45,6 @@ export const COMFYUI_SECRET_ENV_ALLOWLIST = [
   "CIVITAI_API_TOKEN",
   "HUGGINGFACE_TOKEN",
   "HF_TOKEN",
-  "XAI_API_KEY",
   "GEMINI_API_KEY",
   "GOOGLE_GENERATIVE_AI_API_KEY",
   "GOOGLE_API_KEY",
@@ -271,7 +270,6 @@ export const CREDENTIAL_SLOTS: CredentialSlot[] = [
   { id: "civitai", label: "Civitai", envKeys: ["CIVITAI_API_TOKEN"], store: "comfyui", help: "Model downloads" },
   { id: "huggingface", label: "HuggingFace", envKeys: ["HF_TOKEN", "HUGGINGFACE_TOKEN"], store: "comfyui", help: "Model downloads" },
   { id: "google", label: "Google / Gemini", envKeys: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"], store: "comfyui", help: "Nano Banana concept images" },
-  { id: "xai", label: "xAI", envKeys: ["XAI_API_KEY"], store: "comfyui", help: "Grok Imagine concept images" },
   { id: "runcomfy", label: "RunComfy", envKeys: ["RUNCOMFY_API_KEY"], store: "comfyui", help: "Cloud pods / training" },
   { id: "registry", label: "Comfy Registry", envKeys: ["REGISTRY_ACCESS_TOKEN"], store: "comfyui", help: "Publishing custom nodes" },
 ];

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -45,6 +45,12 @@ export const COMFYUI_SECRET_ENV_ALLOWLIST = [
   "CIVITAI_API_TOKEN",
   "HUGGINGFACE_TOKEN",
   "HF_TOKEN",
+  "XAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "GOOGLE_API_KEY",
+  "RUNCOMFY_API_KEY",
+  "REGISTRY_ACCESS_TOKEN",
 ] as const;
 
 const ALLOWLIST_SET = new Set<string>(COMFYUI_SECRET_ENV_ALLOWLIST);
@@ -60,7 +66,15 @@ export function isAllowedComfyuiSecretKey(key: string): boolean {
 // the same allowlist discipline so a corrupt file can't set arbitrary env.
 //   OPENROUTER_API_KEY → the OpenRouter provider backend (OllamaBackend openai)
 //   COMFYUI_MCP_CUSTOM_API_KEY → the user-defined Custom endpoint provider
-export const AGENT_SECRET_ENV_ALLOWLIST = ["OPENROUTER_API_KEY", "COMFYUI_MCP_CUSTOM_API_KEY"] as const;
+export const AGENT_SECRET_ENV_ALLOWLIST = [
+  "OPENROUTER_API_KEY",
+  "COMFYUI_MCP_CUSTOM_API_KEY",
+  "GLM_API_KEY",
+  "ZHIPU_API_KEY",
+  "ZHIPUAI_API_KEY",
+  "ZAI_API_KEY",
+  "KIMI_API_KEY",
+] as const;
 const AGENT_ALLOWLIST_SET = new Set<string>(AGENT_SECRET_ENV_ALLOWLIST);
 
 /** Is `key` a permitted orchestrator agent-secret env var? */
@@ -238,4 +252,54 @@ export function setAgentSecret(key: string, value: string): void {
  */
 export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string, string> {
   return { ...base, ...loadComfyuiSecretEnv() };
+}
+
+export interface CredentialSlot {
+  id: string;
+  label: string;
+  envKeys: string[];
+  store: "comfyui" | "agent";
+  help?: string;
+}
+
+/** UI credential slots. Each slot writes ALL its envKeys (alias fan-out) into its
+ *  store. `store` decides which allowlist/setter applies. */
+export const CREDENTIAL_SLOTS: CredentialSlot[] = [
+  { id: "openrouter", label: "OpenRouter", envKeys: ["OPENROUTER_API_KEY"], store: "agent", help: "Hosted models (MiMo, MiniMax, GPT, Claude…)" },
+  { id: "glm", label: "GLM / Zhipu", envKeys: ["GLM_API_KEY", "ZHIPU_API_KEY", "ZHIPUAI_API_KEY", "ZAI_API_KEY"], store: "agent", help: "GLM provider" },
+  { id: "kimi", label: "Kimi (API)", envKeys: ["KIMI_API_KEY"], store: "agent", help: "Kimi via API key (vs its OAuth)" },
+  { id: "civitai", label: "Civitai", envKeys: ["CIVITAI_API_TOKEN"], store: "comfyui", help: "Model downloads" },
+  { id: "huggingface", label: "HuggingFace", envKeys: ["HF_TOKEN", "HUGGINGFACE_TOKEN"], store: "comfyui", help: "Model downloads" },
+  { id: "google", label: "Google / Gemini", envKeys: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"], store: "comfyui", help: "Nano Banana concept images" },
+  { id: "xai", label: "xAI", envKeys: ["XAI_API_KEY"], store: "comfyui", help: "Grok Imagine concept images" },
+  { id: "runcomfy", label: "RunComfy", envKeys: ["RUNCOMFY_API_KEY"], store: "comfyui", help: "Cloud pods / training" },
+  { id: "registry", label: "Comfy Registry", envKeys: ["REGISTRY_ACCESS_TOKEN"], store: "comfyui", help: "Publishing custom nodes" },
+];
+
+const SLOT_BY_ID = new Map(CREDENTIAL_SLOTS.map((s) => [s.id, s]));
+
+/** Mask a secret for display: first 4 + ellipsis + last 3. Short values fully masked. */
+export function maskSecret(v: string): string {
+  if (v.length <= 8) return "•".repeat(v.length);
+  return `${v.slice(0, 4)}…${v.slice(-3)}`;
+}
+
+/** Set every env key of a slot (alias fan-out) into its store. Throws on unknown slot. */
+export function setPanelSecret(slotId: string, value: string): void {
+  const slot = SLOT_BY_ID.get(slotId);
+  if (!slot) throw new Error(`unknown credential slot "${slotId}"`);
+  const set = slot.store === "agent" ? setAgentSecret : setComfyuiSecret;
+  for (const key of slot.envKeys) set(key, value);
+}
+
+/** Masked per-slot state: set = the slot's PRIMARY (first) env key has a stored value. */
+export function listPanelSecretsMasked(): { id: string; label: string; set: boolean; masked: string | null }[] {
+  const comfyui = loadComfyuiSecretEnv();
+  const agent = loadAgentSecretEnv();
+  return CREDENTIAL_SLOTS.map((slot) => {
+    const store = slot.store === "agent" ? agent : comfyui;
+    const primary = slot.envKeys[0];
+    const val = store[primary];
+    return { id: slot.id, label: slot.label, set: !!val, masked: val ? maskSecret(val) : null };
+  });
 }


### PR DESCRIPTION
Ports MichaelDanCurtis's Stack 4 — the loopback MCP console + credential slots — onto current main.

## What this adds

- **Loopback HTTP MCP console** (`src/orchestrator/panel-console-http.ts`): a small control-plane HTTP server on bridge port + 2 (default 9182), bound strictly to `127.0.0.1`. Serves a landing page, `GET /api/status`, and is advertised to the ComfyUI panel via `console_url` on the bridge `backends` frame.
- **Console token gate**: the orchestrator mints a per-run `randomBytes(24)` token, passes it to the console, and advertises it to the panel as `console_token`. `/api/secrets` and `/credentials` require it (query param or `Authorization: Bearer`).
- **Credential slots** (`src/services/panel-secrets.ts`): `CREDENTIAL_SLOTS` UI facade over the existing allowlisted secret stores, with alias fan-out (e.g. HuggingFace writes both `HF_TOKEN` and `HUGGINGFACE_TOKEN`), `setPanelSecret`, `maskSecret`, and `listPanelSecretsMasked` (masked display only — raw values never leave the store).
- **`GET/POST /api/secrets`**: token-gated masked listing + slot writes, with a hardened `readJsonBody` (settles on oversize/closed bodies instead of hanging).
- **`GET /credentials`**: compact key-entry page served with a `frame-ancestors` CSP limited to `127.0.0.1:8188` / `localhost:8188` so the panel can embed it.
- **`GET /api/lora-preview?id=…`**: serves LoRA catalog preview thumbnails with path-containment checks.

Credit: **Ported from MichaelDanCurtis/comfyui-mcp (commits 1efda5e…a305156) with thanks — authorship preserved via cherry-pick.**

## Conflict resolutions

- `src/orchestrator/index.ts` (1efda5e, 2bc70a2): `pushReadiness` had diverged on main (customEndpointConfigured arg + the llama.cpp live re-probe re-push). Kept main's block and added `console_url` / `console_token` to **both** `bridge.push` frames (including the async llamacpp re-push). Kept main's richer `pathNote` ready-log line, adding the console URL to it.
- `src/services/panel-secrets.ts` (2d4d1da): agent allowlist had diverged — merged main's `COMFYUI_MCP_CUSTOM_API_KEY` with the fork's GLM/Zhipu/Kimi keys.
- `src/orchestrator/panel-console-http.ts` (f8632cc, 293ee99, a305156): the fork's file history interleaves an out-of-scope vault/PhotoMap commit (4848fb7), whose content leaked into the 3-way merges. Kept only this stack's changes each time.

## Dropped

- `docs/design/connections-hub.md` hunk from 5f045b1 (file doesn't exist on main — doc-only noise).
- Vault/PhotoMap console surface from fork commit 4848fb7 (not in this stack): `/api/vault`, `/api/photomap`, `listTrainingPacks`/`photomapHealth` imports, and the landing-page "Vault & PhotoMap" section.

## Added beyond the pick list

- `src/services/lora-catalog.ts` copied verbatim from the fork (its commit 9c6aa7c, LoRA-manager stack): `/api/lora-preview` and its test hard-depend on it. Content-identical to the fork file, so if the LoRA-manager stack lands separately the add/add merge is clean.
- One follow-up commit (821bd72): the ported preview path-containment check compared against `previewsRoot + "/"`, which never matches Windows backslash paths — every preview 403'd. Now uses `path.sep`.

## Security review (port audit)

- ✅ Binds loopback only: `host` defaults to `127.0.0.1` and the orchestrator never overrides it; never exposed off-host.
- ✅ Token is always minted and passed by the orchestrator; `/api/secrets` and `/credentials` reject without it. `/api/lora-preview`, `/api/status`, and the landing page are unauthenticated but loopback-only and read-only (status/thumbnails).
- ⚠️ Two soft spots worth knowing (as ported, not regressions): `tokenOk` returns true when **no** token is configured (dev-open fallback — unreachable via the orchestrator path, which always mints one), and the token is accepted as a `?token=` query param (URL-log exposure on the local machine).

## Tests

- `npx tsc --noEmit`: clean
- `npx vitest run`: **111 files, 1235/1235 passed** (includes the new `panel-console-http`, `console-secrets`, and `panel-secrets-slots` suites)
- No MCP tool descriptions changed → no `docs:gen` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
