### PR TITLE
feat(orchestrator): per-workflow agent sessions + prompt registry — ported from MichaelDanCurtis fork

### DIFF
--- a/docs/design/agent-platform-roadmap.md
+++ b/docs/design/agent-platform-roadmap.md
@@ -1,0 +1,43 @@
+# Agent platform roadmap
+
+Extend comfyui-mcp orchestrator + panel with multi-provider agents, cross-provider image sourcing, and autonomous infra management.
+
+## Phase 0 — Per-workflow agent (done in comfyui-mcp)
+
+- `WorkflowTargetStore` + `workflow_path` injection on graph commands
+- MCP: `panel_get_workflow_target`, `panel_set_workflow_target`
+- Bridge: `set_workflow_target` / `workflow_target` sync
+- **Panel follow-up:** honor `workflow_path` in graph executors ([workflow-target.md](./workflow-target.md))
+
+## Phase 1 — Grok backend (P0)
+
+- `GrokBackend` implementing `AgentBackend` (OAuth via Grok Build / xAI CLI)
+- Add `grok` to `BackendId`, readiness probe, panel provider chip
+- Spike: auth token location, chat/tool wire format, MCP over HTTP parity
+
+## Phase 2 — Cross-provider concept images (P1)
+
+- `fetch_concept_image` — Grok Imagine / Google image gen → temp files
+- `apply_reference_to_workflow` — wire refs into LoadImage / Qwen edit / Krea img2img nodes
+- Skill: structure-map → Qwen/Krea pipeline
+
+## Phase 3 — AI Toolkit supervisor (P2)
+
+- Process supervisor for local AI Toolkit installs (start/stop, job queue, health)
+- MCP tools: `toolkit_status`, `toolkit_run_job`, `toolkit_list_models`
+
+## Phase 4 — RunComfy connector (P3)
+
+- API recon for RunComfy pod lifecycle
+- Tools: `runcomfy_list_pods`, `runcomfy_sync_workflow`, `runcomfy_queue`
+
+## Phase 5 — Multi-workflow projects (P4)
+
+- YAML project manifest (ordered workflows, shared assets)
+- `run_workflow_pipeline` — execute stages with per-workflow pins
+
+## Notes
+
+- **Google AI Pro:** Gemini agent backend exists; image gen is a separate provider layer, not a new agent backend.
+- **Panel repo:** UI for workflow picker binds to `set_workflow_target`; graph executors must respect `workflow_path`.
+- **Do not replace comfyui-mcp-panel** — it remains the UI; this repo owns orchestration + MCP tools.

--- a/docs/design/workflow-target.md
+++ b/docs/design/workflow-target.md
@@ -1,0 +1,47 @@
+# Per-workflow agent targeting
+
+## Problem
+
+Each ComfyUI browser tab connects to the orchestrator with a `tab_id`, but ComfyUI can have **multiple workflow tabs** open inside that browser tab. Graph tools (`graph_get_state`, `graph_add_node`, …) default to whichever workflow the user is **currently viewing**. If the user switches workflow tabs while the agent is working, edits land on the wrong graph.
+
+## Solution
+
+The orchestrator keeps a per-`tab_id` **workflow target**:
+
+| mode | behavior |
+|------|----------|
+| `current` | Graph tools follow the user's active workflow tab (default) |
+| `pinned` | Graph tools include `workflow_path` on scoped commands |
+
+### Orchestrator API
+
+- **MCP tools:** `panel_get_workflow_target`, `panel_set_workflow_target`
+- **Bridge event (panel → orchestrator):** `{ type: "set_workflow_target", tab_id, mode, path?, filename? }`
+- **Bridge push (orchestrator → panel):** `{ type: "workflow_target", target }`
+- **Ack:** `{ type: "ack", ok, kind: "workflow_target", target? }`
+
+### Command injection
+
+When pinned, the orchestrator adds `workflow_path` to:
+
+- All `graph_*` commands
+- `workflow_save`, `workflow_save_as`, `workflow_rename`, `workflow_close` when `path` is omitted
+
+Never injected on: `workflow_list`, `workflow_new`, `workflow_open`.
+
+### Panel implementation (comfyui-mcp-panel)
+
+Each graph executor should:
+
+1. Read optional `workflow_path` on the incoming `{ rid, cmd, … }` frame.
+2. Resolve the workflow document for that path (not only the active tab).
+3. Apply the mutation on that document's graph store.
+4. Optionally refresh UI if that workflow is visible; **do not** switch the user's active tab unless `workflow_open` is called.
+
+Background edits on a non-active workflow should still persist and mark that tab modified.
+
+## Files
+
+- `src/services/workflow-target-store.ts` — store + injection helper
+- `src/orchestrator/panel-tools.ts` — MCP tools + `makePanelToolCtx` injection
+- `src/orchestrator/index.ts` — bridge handler + hello sync

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -64,7 +64,7 @@ Get full details for one ComfyUI custom node pack from the public ComfyUI Regist
 
 ## install_custom_node
 
-Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), git URL, or name. Uses the ComfyUI-Manager HTTP API (works against remote instances) and falls back to the cm-cli subprocess when forced. A ComfyUI restart may be required to load newly installed nodes.
+Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required.
 
 ### Parameters
 
@@ -87,7 +87,7 @@ Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), 
   ComfyUI-Manager channel name (default 'default').
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+  Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.
 </ParamField>
 
 ### Example
@@ -107,7 +107,7 @@ Install a ComfyUI custom node pack by registry id (e.g. 'comfyui-impact-pack'), 
 
 ## update_custom_node
 
-Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback.
+Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP.
 
 ### Parameters
 
@@ -121,7 +121,7 @@ Update an installed ComfyUI custom node pack, or pass 'all' to update every inst
   ComfyUI-Manager channel name (default 'default').
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+  Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.
 </ParamField>
 
 ### Example
@@ -141,7 +141,7 @@ Update an installed ComfyUI custom node pack, or pass 'all' to update every inst
 
 ## reinstall_custom_node
 
-Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-Manager HTTP API with a cm-cli subprocess fallback. A ComfyUI restart may be required.
+Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required.
 
 ### Parameters
 
@@ -158,7 +158,7 @@ Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-
   ComfyUI-Manager channel name (default 'default').
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+  Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.
 </ParamField>
 
 ### Example
@@ -178,7 +178,7 @@ Reinstall a ComfyUI custom node pack (uninstall then install). Uses the ComfyUI-
 
 ## fix_custom_node
 
-Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Single-pack repair uses the ComfyUI-Manager HTTP API; 'all' and forced runs use the cm-cli subprocess (requires a local ComfyUI install).
+Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP.
 
 ### Parameters
 
@@ -192,7 +192,7 @@ Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'al
   ComfyUI-Manager channel name (default 'default').
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+  Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.
 </ParamField>
 
 ### Example
@@ -220,7 +220,7 @@ List installed ComfyUI custom node packs with their version and enabled/disabled
   'default' lists all installed packs; 'imported' lists only those successfully imported this session. Options: `default`, `imported`.
 </ParamField>
 <ParamField path="useCmCli" type="boolean">
-  Force the cm-cli.py subprocess instead of the ComfyUI-Manager HTTP API. Requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+  Force the official comfy-cli subprocess instead of the ComfyUI-Manager HTTP API. Local operations use comfy-cli by default; set false to force Manager HTTP. Requires a local ComfyUI install.
 </ParamField>
 
 ### Example
@@ -238,7 +238,7 @@ List installed ComfyUI custom node packs with their version and enabled/disabled
 
 ## sync_node_dependencies
 
-Reconcile the Python dependencies of all installed custom node packs (comfy-cli `node uv-sync` analogue). Runs cm-cli restore-dependencies as a subprocess and requires a local ComfyUI install (COMFYUI_PATH); errors in remote --comfyui-url mode.
+Reconcile the Python dependencies of all installed custom node packs through official `comfy node restore-dependencies`. Requires a local ComfyUI install and comfy-cli.
 
 <Note>This tool takes no parameters.</Note>
 

--- a/docs/tools/models.mdx
+++ b/docs/tools/models.mdx
@@ -4,11 +4,11 @@ description: "Search, download, list, and remove models; manage embeddings and V
 icon: "box"
 ---
 
-<Info>10 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
+<Info>13 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
 ## search_models
 
-Search HuggingFace Hub for models usable in ComfyUI (checkpoints, LoRAs, VAEs, ControlNets, etc.). Read-only and network-only: queries HuggingFace over HTTP, does NOT require a running ComfyUI or COMFYUI_PATH and does not download anything. Returns a ranked list with modelId, author, downloads, likes, and tags. Pick a result's download URL and pass it to download_model to install it locally. For packs of custom nodes (not models) use search_custom_nodes.
+Search for models usable in ComfyUI (checkpoints, LoRAs, VAEs, ControlNets, etc.) — this searches HuggingFace Hub ONLY. Read-only and network-only: queries HuggingFace over HTTP, does NOT require a running ComfyUI or COMFYUI_PATH and does not download anything. Returns a ranked list with modelId, author, downloads, likes, and tags. Pick a result's download URL and pass it to download_model to install it locally. NOTE — CIVITAI: searching Civitai by keyword ('find a Flux LoRA on Civitai') is NOT possible from this server; there is no civitai search tool. If the user already has a Civitai model id or model-version id, use download_civitai_model; to browse Civitai by keyword, install the separate official Civitai MCP server (mcp.civitai.com/mcp) alongside this one. Do NOT keep re-searching for a Civitai search tool — it does not exist here. For packs of custom nodes (not models) use search_custom_nodes.
 
 ### Parameters
 
@@ -108,7 +108,7 @@ Download a model from CivitAI into the connected ComfyUI's models/ directory. Re
 
 ## list_local_models
 
-List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them.
+List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them. For models fetched via download_civitai_model, any CivitAI trigger/activation words and base model are shown inline (read from the `&lt;file&gt;.civitai.json` sidecar) — apply those trigger words in your prompt when generating with that model.
 
 ### Parameters
 
@@ -301,6 +301,103 @@ Free GPU VRAM by unloading cached models from ComfyUI. Use this between generati
   "arguments": {
     "unload_models": true,
     "free_memory": true
+  }
+}
+```
+
+---
+
+## model_metadata_read
+
+Read a model file's CURRENT embedded metadata + evidence, for curating it (Model Explorer). Returns classify (asset_type/base/precision/rank), the current model_card and prompt_director namespaces, read-only modelspec, top training tags (ss_tag_frequency), the Civitai description, and example prompts. Call this FIRST when the user wants to improve/curate a model's embedded .safetensors metadata, so you propose from real data. NOTE: this is the embedded-in-the-tensor metadata (model_card/prompt_director/modelspec/ss_*) — NOT the separate lora_catalog. `category` = ComfyUI model folder ('loras','checkpoints','vae',…); `name` = filename incl. .safetensors.
+
+### Parameters
+
+<ParamField path="category" type="string" required>
+  ComfyUI model folder, e.g. 'loras'
+</ParamField>
+<ParamField path="name" type="string" required>
+  model filename incl. .safetensors
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "model_metadata_read",
+  "arguments": {
+    "category": "<category>",
+    "name": "<name>"
+  }
+}
+```
+
+---
+
+## model_metadata_propose
+
+PROPOSE cleaned embedded metadata into the user's diff-review window (Model Explorer). This does NOT write the file — the user sees your proposed fields vs current, edits/discusses, and their Confirm does the write. Call whenever you have a proposal OR the user asks you to revise one; each call REPLACES the live proposal, so send the FULL field set you're proposing. Include only fields you're confident about. Keys: display_name, description_clean, semantic_intent, prompt_guidance, preservation_guidance, trigger_tokens[] (EXACT tokens — never invent), activation_phrases[], negative_tokens[], tags[], compatible_families[], default_strength_model, default_strength_clip, strength_min, strength_max. NEVER write metadata directly.
+
+### Parameters
+
+<ParamField path="category" type="string" required>
+  —
+</ParamField>
+<ParamField path="name" type="string" required>
+  —
+</ParamField>
+<ParamField path="fields" type="object" required>
+  Proposed field map (see description).
+</ParamField>
+<ParamField path="note" type="string">
+  Optional one-line note about this revision.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "model_metadata_propose",
+  "arguments": {
+    "category": "<category>",
+    "name": "<name>",
+    "fields": "<fields>"
+  }
+}
+```
+
+---
+
+## model_metadata_fetch_civitai
+
+READ-ONLY: pull this model's data from Civitai (civitai.com) — the rich description, trainedWords, example prompts (with the prompt text used in the sample images), tags, nsfw flag, and source_url — WITHOUT writing anything. Call this when the embedded metadata is thin (empty model_card/prompt_director, no ss_tag_frequency) or to flesh out details before proposing. Treat the result as RAW input: distill the (often marketing-heavy) description, and MINE THE EXAMPLE PROMPTS for the real trigger — the trigger is frequently ONLY in the sample prompts even when trainedWords is EMPTY (e.g. every prompt starting with 'photo in the style of X' means X is the trigger). Adult models (civitai.red) resolve through this same API. Then clean it up and call model_metadata_propose.
+
+### Parameters
+
+<ParamField path="category" type="string" required>
+  ComfyUI model folder, e.g. 'loras'
+</ParamField>
+<ParamField path="name" type="string" required>
+  model filename incl. .safetensors
+</ParamField>
+<ParamField path="version_id" type="integer">
+  Force a specific Civitai modelVersionId if hash lookup misses.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "model_metadata_fetch_civitai",
+  "arguments": {
+    "category": "<category>",
+    "name": "<name>"
   }
 }
 ```

--- a/docs/tools/workflow-authoring.mdx
+++ b/docs/tools/workflow-authoring.mdx
@@ -4,7 +4,7 @@ description: "Build, modify, validate, and visualize ComfyUI workflows."
 icon: "pen-ruler"
 ---
 
-<Info>9 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
+<Info>10 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
 
 ## create_workflow
 
@@ -263,6 +263,29 @@ Convert a Mermaid flowchart diagram back into a ComfyUI workflow JSON. Parses no
   "arguments": {
     "mermaid": "<mermaid>"
   }
+}
+```
+
+---
+
+## prompt_director_inspect
+
+Read Prompt Director's latest sanitized RUNTIME state after its nodes execute. Returns each node id, node kind, resolved Model Explorer model/LoRA context, structured edit plan, source analysis, exact final prompt, warnings, or Result Critic verdict. Secrets and image tensors are redacted. Use this with the live panel graph audit: graph inspection explains wiring and widget state, while this tool explains what the nodes actually resolved and compiled. Read-only: never changes the workflow. Pass node_id to inspect one executed Prompt Director node.
+
+### Parameters
+
+<ParamField path="node_id" type="string">
+  Optional ComfyUI node id; omit to list all recent Prompt Director runtime states.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "prompt_director_inspect",
+  "arguments": {}
 }
 ```
 

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -106,6 +106,7 @@ const CATEGORIES: Array<{
       "create_workflow", "modify_workflow", "validate_workflow", "get_node_info",
       "workflow_to_dsl", "dsl_to_workflow", "visualize_workflow",
       "visualize_workflow_hierarchical", "mermaid_to_workflow",
+      "prompt_director_inspect",
     ],
   },
   {
@@ -137,6 +138,7 @@ const CATEGORIES: Array<{
       "search_models", "download_model", "download_civitai_model", "list_local_models",
       "remove_model", "list_extra_paths", "add_extra_path", "remove_extra_path",
       "get_embeddings", "clear_vram",
+      "model_metadata_read", "model_metadata_propose", "model_metadata_fetch_civitai",
     ],
   },
   {

--- a/scripts/mock-panel.mjs
+++ b/scripts/mock-panel.mjs
@@ -20,16 +20,22 @@ const duration = Number(process.env.DURATION_MS || 60000);
 const t0 = Date.now();
 const ms = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
 
-// --- in-memory graph ---
+// --- in-memory workflows (multi-tab) ---
 let seq = 0;
-const nodes = new Map(); // id -> {id,type,title,widgets,inputs,outputs}
-const blueprints = new Map(); // saved subgraph blueprints: name -> { name, type }
-let clipboard = []; // copied node descriptors (persists across switches)
-let selection = []; // currently-selected node ids
-function addNode(type, title) {
+const workflows = new Map(); // path -> { nodes, title }
+let activePath = "workflows/current.json";
+function ensureWorkflow(path) {
+  if (!workflows.has(path)) {
+    workflows.set(path, { title: path.replace(/.*\//, ""), nodes: new Map() });
+  }
+  return workflows.get(path);
+}
+function wfFor(args) {
+  return ensureWorkflow(args.workflow_path || activePath);
+}
+function addNode(wf, type, title) {
   const id = ++seq;
-  // Give every node a couple of generic typed slots so connect() can succeed.
-  nodes.set(id, {
+  wf.nodes.set(id, {
     id,
     type,
     title: title || type,
@@ -43,9 +49,13 @@ function addNode(type, title) {
       { name: "MODEL", type: "MODEL", links: [] },
     ],
   });
-  return nodes.get(id);
+  return wf.nodes.get(id);
 }
-for (let i = 0; i < seed; i++) addNode(`SeedNode${i}`, `Existing node ${i}`);
+const current = ensureWorkflow(activePath);
+for (let i = 0; i < seed; i++) addNode(current, `SeedNode${i}`, `Existing node ${i}`);
+const blueprints = new Map();
+let clipboard = [];
+let selection = [];
 
 const commands = []; // { cmd, args }
 const says = [];
@@ -55,37 +65,45 @@ function summarize(n) {
 }
 
 const EXEC = {
-  graph_get_state: () => ({
-    viewing: { scope: "root" },
-    node_count: nodes.size,
-    truncated: false,
-    nodes: [...nodes.values()].map(summarize),
-  }),
-  graph_add_node: ({ class_type, title }) => {
-    if (!class_type) throw new Error("class_type required");
-    return { added: summarize(addNode(class_type, title)) };
+  graph_get_state: (args) => {
+    const wf = wfFor(args);
+    return {
+      viewing: { scope: "root" },
+      workflow_path: args.workflow_path || activePath,
+      node_count: wf.nodes.size,
+      truncated: false,
+      nodes: [...wf.nodes.values()].map(summarize),
+    };
   },
-  graph_remove_node: ({ node_id }) => {
-    const n = nodes.get(Number(node_id));
-    if (!n) throw new Error(`no node ${node_id}`);
-    nodes.delete(Number(node_id));
+  graph_add_node: (args) => {
+    const wf = wfFor(args);
+    if (!args.class_type) throw new Error("class_type required");
+    return { added: summarize(addNode(wf, args.class_type, args.title)), workflow_path: args.workflow_path || activePath };
+  },
+  graph_remove_node: (args) => {
+    const wf = wfFor(args);
+    const n = wf.nodes.get(Number(args.node_id));
+    if (!n) throw new Error(`no node ${args.node_id}`);
+    wf.nodes.delete(Number(args.node_id));
     return { removed: summarize(n) };
   },
-  graph_clear: () => {
-    const c = nodes.size;
-    nodes.clear();
-    return { cleared: c };
+  graph_clear: (args) => {
+    const wf = wfFor(args);
+    const c = wf.nodes.size;
+    wf.nodes.clear();
+    return { cleared: c, workflow_path: args.workflow_path || activePath };
   },
   graph_connect: ({ from_node_id, to_node_id }) => ({
     connected: { from: { node_id: from_node_id }, to: { node_id: to_node_id } },
   }),
   graph_disconnect: ({ node_id }) => ({ disconnected: { node_id } }),
-  graph_set_widget: ({ node_id, widget, value }) => {
-    const n = nodes.get(Number(node_id));
-    if (!n) throw new Error(`no node ${node_id}`);
-    const prev = n.widgets[widget];
-    n.widgets[widget] = value;
-    return { set: { node_id, widget, previous: prev, value } };
+  graph_set_widget: (args) => {
+    const wf = wfFor(args);
+    const n = wf.nodes.get(Number(args.node_id));
+    if (!n) throw new Error(`no node ${args.node_id}`);
+    const prev = n.widgets[args.widget];
+    n.widgets[args.widget] = args.value;
+    return { set: { node_id: args.node_id, widget: args.widget, previous: prev, value: args.value } };
   },
   graph_move_node: ({ node_id, pos }) => ({ moved: { node_id, to: pos } }),
   graph_canvas: ({ action }) => ({ canvas: { action } }),
@@ -96,41 +114,62 @@ const EXEC = {
   // New-workflow opens a NEW TAB — in the mock it must NOT wipe the seeded graph.
   workflow_new: () => ({ created: true, active: "Untitled (new tab)" }),
   workflow_list: () => ({
-    active: { path: "workflows/current.json", filename: "current.json", key: "current" },
-    open: [{ path: "workflows/current.json", filename: "current.json", key: "current", active: true, modified: true, persisted: true }],
+    active: { path: activePath, filename: activePath.replace(/.*\//, ""), key: "current" },
+    open: [...workflows.entries()].map(([path, wf]) => ({
+      path,
+      filename: wf.title,
+      key: path,
+      active: path === activePath,
+      modified: true,
+      persisted: true,
+    })),
   }),
-  workflow_open: ({ path }) => ({ opened: { path, filename: path } }),
+  workflow_open: ({ path }) => {
+    ensureWorkflow(path);
+    activePath = path;
+    return { opened: { path, filename: path } };
+  },
   workflow_rename: ({ name }) => ({ renamed: { to: `${name}.json` } }),
   workflow_close: ({ path }) => ({ closed: { path } }),
   graph_select_nodes: ({ node_ids }) => { selection = (node_ids || []).map(Number); return { selected: node_ids }; },
-  graph_create_subgraph: ({ node_ids }) => { const id = ++seq; nodes.set(id, { id, type: "Subgraph", title: "Subgraph", is_subgraph: true, widgets: {}, inputs: [], outputs: [] }); selection = [id]; return { subgraph: { node_id: id, name: "Subgraph", from_nodes: node_ids } }; },
-  graph_copy_nodes: ({ node_ids }) => {
-    const ids = (Array.isArray(node_ids) && node_ids.length ? node_ids.map(Number) : selection);
-    const src = ids.map((id) => nodes.get(Number(id))).filter(Boolean);
+  graph_create_subgraph: (args) => {
+    const wf = wfFor(args);
+    const id = ++seq;
+    wf.nodes.set(id, { id, type: "Subgraph", title: "Subgraph", is_subgraph: true, widgets: {}, inputs: [], outputs: [] });
+    selection = [id];
+    return { subgraph: { node_id: id, name: "Subgraph", from_nodes: args.node_ids } };
+  },
+  graph_copy_nodes: (args) => {
+    const wf = wfFor(args);
+    const ids = (Array.isArray(args.node_ids) && args.node_ids.length ? args.node_ids.map(Number) : selection);
+    const src = ids.map((id) => wf.nodes.get(Number(id))).filter(Boolean);
     if (!src.length) throw new Error("nothing selected to copy");
     clipboard = src.map((n) => ({ type: n.type, title: n.title, widgets: { ...n.widgets } }));
     return { copied: clipboard.length };
   },
-  graph_paste_nodes: () => {
+  graph_paste_nodes: (args) => {
+    const wf = wfFor(args);
     if (!clipboard.length) throw new Error("clipboard empty");
-    const pasted = clipboard.map((c) => addNode(c.type, c.title));
+    const pasted = clipboard.map((c) => addNode(wf, c.type, c.title));
     return { pasted_count: pasted.length, pasted_node_ids: pasted.map((n) => n.id), pasted: pasted.map(summarize) };
   },
-  graph_save_subgraph: ({ node_id, name }) => {
-    const id = node_id != null ? Number(node_id) : selection[0];
-    const n = id != null ? nodes.get(id) : null;
+  graph_save_subgraph: (args) => {
+    const wf = wfFor(args);
+    const id = args.node_id != null ? Number(args.node_id) : selection[0];
+    const n = id != null ? wf.nodes.get(id) : null;
     if (!n || !n.is_subgraph) throw new Error("select a subgraph node first");
-    const finalName = (typeof name === "string" && name.trim()) ? name.trim() : (n.title || "Subgraph");
+    const finalName = (typeof args.name === "string" && args.name.trim()) ? args.name.trim() : (n.title || "Subgraph");
     blueprints.set(finalName, { name: finalName, type: `SubgraphBlueprint.${finalName}` });
     return { saved: { name: finalName, from_node_id: id, type: `SubgraphBlueprint.${finalName}` } };
   },
   graph_list_subgraphs: () => ({ count: blueprints.size, blueprints: [...blueprints.values()].map((b) => ({ ...b, display_name: b.name, description: null, is_global: false })) }),
-  graph_add_subgraph: ({ name }) => {
-    const key = String(name).replace(/^SubgraphBlueprint\./, "");
-    if (!blueprints.has(key)) throw new Error(`No blueprint "${name}"`);
+  graph_add_subgraph: (args) => {
+    const wf = wfFor(args);
+    const key = String(args.name).replace(/^SubgraphBlueprint\./, "");
+    if (!blueprints.has(key)) throw new Error(`No blueprint "${args.name}"`);
     const id = ++seq;
-    nodes.set(id, { id, type: `SubgraphBlueprint.${key}`, title: key, is_subgraph: true, widgets: {}, inputs: [], outputs: [] });
-    return { added: summarize(nodes.get(id)), from_blueprint: `SubgraphBlueprint.${key}` };
+    wf.nodes.set(id, { id, type: `SubgraphBlueprint.${key}`, title: key, is_subgraph: true, widgets: {}, inputs: [], outputs: [] });
+    return { added: summarize(wf.nodes.get(id)), from_blueprint: `SubgraphBlueprint.${key}` };
   },
 };
 
@@ -180,7 +219,8 @@ setTimeout(() => {
   console.log("commands:", JSON.stringify(counts));
   console.log("graph_clear called:", counts.graph_clear ? `YES x${counts.graph_clear} (DESTRUCTIVE!)` : "no");
   console.log("workflow_new called:", counts.workflow_new ? `yes x${counts.workflow_new} (correct for new workflow)` : "no");
-  console.log("final node count:", nodes.size, `(seeded ${seed})`);
+  console.log("final node count (active):", current.nodes.size, `(seeded ${seed})`);
+  console.log("workflows:", [...workflows.keys()].join(", "));
   console.log("say count:", says.length);
   sock.close();
   process.exit(0);

--- a/scripts/test-generate.mjs
+++ b/scripts/test-generate.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * End-to-end test: drive the freshly-built comfyui-mcp (our branch) against a live
+ * ComfyUI and actually generate an image. Proves the full path — tool call →
+ * workflow build → enqueue → render → output file.
+ *
+ * Usage: COMFYUI_URL=http://127.0.0.1:8188 node scripts/test-generate.mjs
+ */
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const COMFYUI_URL = process.env.COMFYUI_URL ?? "http://127.0.0.1:8188";
+const CHECKPOINT = process.env.TEST_CHECKPOINT ?? "SD1.5_v1-5-pruned-emaonly-fp16.safetensors";
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [join(ROOT, "dist", "index.js")],
+  env: { ...process.env, COMFYUI_URL, COMFYUI_MCP_PANEL_AUTOINSTALL: "0", COMFYUI_MCP_AUTOUPDATE: "0", LOG_LEVEL: "error" },
+});
+
+const mcp = new Client({ name: "gen-test", version: "0.0.0" });
+await mcp.connect(transport);
+const textOf = (r) => r.content?.find((c) => c.type === "text")?.text ?? JSON.stringify(r);
+
+console.log(`→ generate_image via our build against ${COMFYUI_URL}`);
+const gen = await mcp.callTool({
+  name: "generate_image",
+  arguments: {
+    prompt: "a golden retriever puppy sitting in a field of wildflowers, soft morning light, sharp focus",
+    checkpoint: CHECKPOINT,
+    width: 512, height: 512, steps: 20, cfg: 7, sampler: "euler", scheduler: "normal", seed: 42,
+  },
+});
+const genText = textOf(gen);
+console.log("  response:", genText.replace(/\s+/g, " ").slice(0, 220));
+const pid = (genText.match(/([0-9a-f]{8}-[0-9a-f-]{27,})/) || genText.match(/prompt[_ ]?id[":\s]+([\w-]+)/i) || [])[1];
+if (!pid) { console.log("  ⚠️ no prompt_id parsed — dumping full response:\n", genText); await mcp.close(); process.exit(1); }
+console.log("  prompt_id:", pid);
+
+// Poll ComfyUI history until the render completes
+process.stdout.write("  rendering");
+let outputs = null;
+for (let i = 0; i < 90; i++) {
+  await new Promise((r) => setTimeout(r, 2000));
+  process.stdout.write(".");
+  const h = await fetch(`${COMFYUI_URL}/history/${pid}`).then((r) => r.json()).catch(() => ({}));
+  const entry = h[pid];
+  if (entry?.outputs && Object.keys(entry.outputs).length) { outputs = entry.outputs; break; }
+  if (entry?.status?.status_str === "error") { console.log("\n  ✗ ComfyUI reported error:", JSON.stringify(entry.status).slice(0, 300)); await mcp.close(); process.exit(1); }
+}
+console.log("");
+if (!outputs) { console.log("  ✗ timed out waiting for render"); await mcp.close(); process.exit(1); }
+
+const imgs = Object.values(outputs).flatMap((o) => o.images ?? []);
+console.log(`  ✅ rendered ${imgs.length} image(s):`);
+for (const im of imgs) console.log(`     ${im.subfolder ? im.subfolder + "/" : ""}${im.filename} (${im.type})`);
+await mcp.close();
+console.log("\n✅ end-to-end generation PASSED — MCP drove ComfyUI to a finished render");

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -490,9 +490,11 @@ describe("panel-tools: workflow target (per-workflow agent)", () => {
       push: () => 1,
     } as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "test-tab", store);
-    await defByName("panel_get_graph").handler({}, ctx);
+    // Upstream replaced panel_get_graph (graph_get_state) with panel_query_graph
+    // (graph_query) — same injection path: any graph_* command gets the pin.
+    await defByName("panel_query_graph").handler({}, ctx);
     expect(calls[0]).toMatchObject({
-      cmd: "graph_get_state",
+      cmd: "graph_query",
       workflow_path: "workflows/pinned.json",
     });
   });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -14,9 +14,11 @@ import { join } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   buildPanelToolDefs,
+  makePanelToolCtx,
   registerPanelTools,
   type PanelToolCtx,
 } from "../../orchestrator/panel-tools.js";
+import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
 type Forwarded = Record<string, unknown>;
 
@@ -454,5 +456,59 @@ describe("panel-tools: panel_subgraph_group (wrap a group into a subgraph)", () 
     expect(calls[0]).toMatchObject({ cmd: "graph_subgraph_group", group: "REPLACEMENT MODE" });
     await defByName("panel_subgraph_group").handler({ group: 2 }, ctx);
     expect(calls[1]).toMatchObject({ cmd: "graph_subgraph_group", group: 2 });
+  });
+});
+
+describe("panel-tools: workflow target (per-workflow agent)", () => {
+  it("registers get/set workflow target tools", () => {
+    const names = buildPanelToolDefs().map((d) => d.name);
+    expect(names).toContain("panel_get_workflow_target");
+    expect(names).toContain("panel_set_workflow_target");
+  });
+
+  it("injects workflow_path on graph commands when pinned", async () => {
+    const store = new WorkflowTargetStore();
+    store.set("test-tab", { mode: "pinned", path: "workflows/pinned.json" });
+    const calls: Forwarded[] = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        calls.push(cmd);
+        return { ok: true };
+      },
+      push: () => 1,
+    } as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    await defByName("panel_get_graph").handler({}, ctx);
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_get_state",
+      workflow_path: "workflows/pinned.json",
+    });
+  });
+
+  it("panel_set_workflow_target pins and returns note", async () => {
+    const store = new WorkflowTargetStore();
+    const pushes: unknown[] = [];
+    const bridge = {
+      send: async () => ({}),
+      push: (frame: unknown) => {
+        pushes.push(frame);
+        return 1;
+      },
+    } as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/a.json", filename: "a.json" },
+      ctx,
+    );
+    expect(store.get("test-tab")).toMatchObject({
+      mode: "pinned",
+      path: "workflows/a.json",
+    });
+    expect(pushes[0]).toMatchObject({
+      type: "workflow_target",
+      target: { mode: "pinned", path: "workflows/a.json", filename: "a.json" },
+    });
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain("Pinned");
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -439,6 +439,18 @@ describe("panel-tools: panel_graph_outline (compact text map)", () => {
   });
 });
 
+describe("panel-tools: panel_audit_prompt_director", () => {
+  it("is read-only, takes no args, and forwards the dedicated graph audit command", async () => {
+    const def = defByName("panel_audit_prompt_director");
+    expect(Object.keys(def.schema)).toEqual([]);
+    expect(def.description).toContain("READ-ONLY");
+
+    const { ctx, calls } = makeFakeCtx();
+    await def.handler({}, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_prompt_director_audit" });
+  });
+});
+
 describe("panel-tools: panel_subgraph_group (wrap a group into a subgraph)", () => {
   it("is registered and takes a string|number group ref", () => {
     expect(buildPanelToolDefs().map((d) => d.name)).toContain("panel_subgraph_group");

--- a/src/__tests__/services/workflow-target-store.test.ts
+++ b/src/__tests__/services/workflow-target-store.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  WorkflowTargetStore,
+  shouldInjectWorkflowPath,
+  withWorkflowTarget,
+} from "../../services/workflow-target-store.js";
+
+describe("workflow-target-store", () => {
+  it("defaults to current mode", () => {
+    const store = new WorkflowTargetStore();
+    expect(store.get("tab-a")).toEqual({ mode: "current" });
+  });
+
+  it("pins and clears per tab", () => {
+    const store = new WorkflowTargetStore();
+    const pinned = store.set("tab-a", {
+      mode: "pinned",
+      path: "workflows/foo.json",
+      filename: "foo.json",
+    });
+    expect(pinned).toEqual({
+      mode: "pinned",
+      path: "workflows/foo.json",
+      filename: "foo.json",
+    });
+    expect(store.get("tab-a")).toEqual(pinned);
+    expect(store.get("tab-b")).toEqual({ mode: "current" });
+
+    store.set("tab-a", { mode: "current" });
+    expect(store.get("tab-a")).toEqual({ mode: "current" });
+  });
+
+  it("rejects pinned without path", () => {
+    const store = new WorkflowTargetStore();
+    expect(store.set("tab-a", { mode: "pinned", path: "  " })).toEqual({ mode: "current" });
+  });
+});
+
+describe("withWorkflowTarget", () => {
+  const pinned = { mode: "pinned" as const, path: "workflows/a.json" };
+
+  it("injects workflow_path on graph commands", () => {
+    const out = withWorkflowTarget({ cmd: "graph_get_state" }, pinned);
+    expect(out).toEqual({ cmd: "graph_get_state", workflow_path: "workflows/a.json" });
+  });
+
+  it("does not inject on workflow_list or workflow_open", () => {
+    expect(withWorkflowTarget({ cmd: "workflow_list" }, pinned)).toEqual({ cmd: "workflow_list" });
+    expect(withWorkflowTarget({ cmd: "workflow_open", path: "x" }, pinned)).toEqual({
+      cmd: "workflow_open",
+      path: "x",
+    });
+  });
+
+  it("does not override explicit workflow_path", () => {
+    const out = withWorkflowTarget(
+      { cmd: "graph_add_node", workflow_path: "workflows/explicit.json" },
+      pinned,
+    );
+    expect(out.workflow_path).toBe("workflows/explicit.json");
+  });
+
+  it("leaves commands alone in current mode", () => {
+    const out = withWorkflowTarget({ cmd: "graph_run" }, { mode: "current" });
+    expect(out).toEqual({ cmd: "graph_run" });
+  });
+});
+
+describe("shouldInjectWorkflowPath", () => {
+  it("classifies workflow-scoped commands", () => {
+    expect(shouldInjectWorkflowPath("graph_get_state", {})).toBe(true);
+    expect(shouldInjectWorkflowPath("workflow_save", {})).toBe(true);
+    expect(shouldInjectWorkflowPath("workflow_close", { path: "x.json" })).toBe(false);
+    expect(shouldInjectWorkflowPath("workflow_list", {})).toBe(false);
+  });
+});

--- a/src/__tests__/tools/prompt-director.test.ts
+++ b/src/__tests__/tools/prompt-director.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { registerPromptDirectorTools } from "../../tools/prompt-director.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function makeServer() {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, handler: ToolHandler) => {
+      handlers.set(name, handler);
+    },
+  };
+  registerPromptDirectorTools(server as never);
+  return handlers.get("prompt_director_inspect")!;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("prompt_director_inspect tool", () => {
+  it("reads the bounded runtime inspection registry and filters by node id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        schema_version: "1.0",
+        inspections: [{ node_id: "42", kind: "prompt_director_auto", payload: { warnings: [] } }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const inspect = makeServer();
+    const result = await inspect({ node_id: "42" });
+
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:8188/prompt_director/inspection?node_id=42");
+    expect(result.content[0].text).toContain('"node_id": "42"');
+    expect(result.content[0].text).toContain("prompt_director_auto");
+  });
+});

--- a/src/orchestrator/ai-proposer.ts
+++ b/src/orchestrator/ai-proposer.ts
@@ -1,0 +1,118 @@
+// One-shot AI metadata proposer for Model Explorer's "Ask AI".
+//
+// Runs a SINGLE Claude Agent-SDK turn (no tools, no session) to distill the raw,
+// messy metadata scraped from a .safetensors + Civitai into clean, prompt-ready
+// structured fields. It reuses the orchestrator's Claude auth (same as the panel
+// chat) — the AI hub — but is a discrete structured call, not the per-tab
+// conversational agent (that "shared-context loop" is a larger, later rewrite).
+//
+// Returns a proposal the user REVIEWS and saves; nothing is written here.
+import { loadQuery } from "./claude-backend.js";
+import { logger } from "../utils/logger.js";
+import { resolvePrompt } from "../services/prompt-overrides.js";
+
+export interface ModelCardEvidence {
+  filename: string;
+  classify?: Record<string, unknown>;
+  model_card?: Record<string, unknown>;
+  prompt_director?: Record<string, unknown>;
+  modelspec?: Record<string, unknown>;
+  tag_frequency_top?: Array<{ token: string; count: number }>;
+  description?: string;
+  example_prompts?: string[];
+}
+
+export const SYSTEM = `You are a metadata curator for AI image/video model files (LoRAs, checkpoints, VAEs, etc.) used in ComfyUI. Given raw, messy metadata scraped from a .safetensors file and Civitai, produce CLEAN, concise, prompt-ready structured metadata.
+
+Rules:
+- Output ONLY a single JSON object. No prose, no markdown fences.
+- Distill marketing fluff into a tight, factual semantic_intent (1-2 sentences).
+- trigger_tokens: the EXACT activation tokens (short), deduped. NEVER invent tokens not evidenced by trained tags / trainedWords / example prompts.
+- prompt_guidance: 1-3 practical sentences on how to prompt this model well.
+- Suggest default_strength_model / default_strength_clip and a safe strength_min/max ONLY when the evidence supports it (e.g. a weight like <lora:name:0.8> appears in an example prompt). Otherwise OMIT those fields entirely — do not guess.
+- tags: short lowercase tags. compatible_families: only if reasonably certain.
+- Do NOT fabricate civitai ids, hashes, or any fact not present in the evidence.`;
+
+const SCHEMA_HINT = `Return a JSON object. All fields optional — include ONLY what the evidence supports:
+{
+  "display_name": string,
+  "semantic_intent": string,
+  "description_clean": string,
+  "prompt_guidance": string,
+  "preservation_guidance": string,
+  "trigger_tokens": string[],
+  "activation_phrases": string[],
+  "negative_tokens": string[],
+  "default_strength_model": number,
+  "default_strength_clip": number,
+  "strength_min": number,
+  "strength_max": number,
+  "tags": string[],
+  "compatible_families": string[]
+}`;
+
+function buildUserText(ev: ModelCardEvidence): string {
+  const parts: string[] = [`FILE: ${ev.filename}`];
+  if (ev.classify) parts.push(`CLASSIFY: ${JSON.stringify(ev.classify)}`);
+  if (ev.model_card && Object.keys(ev.model_card).length)
+    parts.push(`CURRENT model_card: ${JSON.stringify(ev.model_card)}`);
+  if (ev.prompt_director && Object.keys(ev.prompt_director).length)
+    parts.push(`CURRENT prompt_director: ${JSON.stringify(ev.prompt_director)}`);
+  if (ev.modelspec && Object.keys(ev.modelspec).length)
+    parts.push(`modelspec (read-only): ${JSON.stringify(ev.modelspec)}`);
+  if (ev.tag_frequency_top?.length)
+    parts.push(`TOP TRAINING TAGS (freq): ${JSON.stringify(ev.tag_frequency_top)}`);
+  if (ev.description)
+    parts.push(`CIVITAI DESCRIPTION (may be messy marketing):\n${ev.description.slice(0, 4000)}`);
+  if (ev.example_prompts?.length)
+    parts.push(`EXAMPLE PROMPTS:\n${ev.example_prompts.slice(0, 5).map((p, i) => `${i + 1}. ${p.slice(0, 500)}`).join("\n")}`);
+  parts.push(SCHEMA_HINT, "Return ONLY the JSON object.");
+  return parts.join("\n\n");
+}
+
+function extractJson(s: string): Record<string, unknown> | null {
+  let t = s.replace(/```json\s*/gi, "").replace(/```/g, "").trim();
+  const start = t.indexOf("{");
+  const end = t.lastIndexOf("}");
+  if (start >= 0 && end > start) t = t.slice(start, end + 1);
+  try {
+    const v = JSON.parse(t);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function proposeModelCard(
+  ev: ModelCardEvidence,
+  model?: string,
+): Promise<{ proposal: Record<string, unknown> | null; raw: string }> {
+  const query = await loadQuery();
+  const q = query({
+    prompt: buildUserText(ev),
+    options: {
+      ...(model ? { model } : {}),
+      systemPrompt: resolvePrompt("proposer.modelCard", SYSTEM),
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      allowedTools: [],
+      strictMcpConfig: true,
+      maxTurns: 1,
+    } as unknown as Parameters<typeof query>[0]["options"],
+  });
+
+  let text = "";
+  let result = "";
+  for await (const m of q as AsyncIterable<Record<string, unknown>>) {
+    const mm = m as any;
+    if (mm?.type === "assistant" && mm.message?.content) {
+      for (const b of mm.message.content) if (b?.type === "text" && b.text) text += b.text;
+    } else if (mm?.type === "result" && typeof mm.result === "string") {
+      result = mm.result;
+    }
+  }
+  const raw = (result || text).trim();
+  const proposal = extractJson(raw);
+  if (!proposal) logger.warn(`[ai-proposer] no JSON parsed from model reply (${raw.length} chars)`);
+  return { proposal, raw };
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -79,6 +79,7 @@ import {
   buildPanelSystemAppend,
   type EnvCapabilities,
 } from "../services/env-capabilities.js";
+import { WorkflowTargetStore } from "../services/workflow-target-store.js";
 
 const PANEL_SYSTEM_APPEND = `You are the autonomous assistant embedded directly in a ComfyUI sidebar panel. The person is working in ComfyUI and talks to you through that panel: their messages arrive as your prompts, and everything you write is shown to them in the panel chat. Write for that reader — lead with the result, keep replies short and concrete, and don't narrate routine internal steps.
 
@@ -93,6 +94,8 @@ If a workflow needs a custom node the user doesn't have, don't silently skip it 
 CRASH RECOVERY — when a custom node BREAKS or CRASHED ComfyUI, fix it before giving up. If your turn begins with a "⚠️ ComfyUI crashed …" note (it names the fatal log block and the most likely culprit custom node + file:line), or a run dies with a node-level error you can pin to one pack, do NOT just re-run the same graph — ESCALATE to actually fix that node, narrating each step to the user as you go: (a) UPDATE it to the latest code — call panel_update_node with the culprit's id (or the comfyui MCP update_custom_node / fix_custom_node). Try version 'nightly' to grab a just-landed upstream fix. Poll panel_node_queue_status, then panel_restart_comfyui → you resume and RETRY the action to see if the crash is gone. (b) If updating doesn't fix it, reach into COMFYUI_PATH/custom_nodes/<NodeDir> with your shell (Bash): if it's a git repo (a .git dir), run git fetch && git pull (or check out the nightly branch) to force the latest, reinstall its requirements if needed, then restart + retry. (c) If there's no git or it's still broken, attempt a TARGETED source patch of the crashing file:line, then VERIFY the fix actually resolves the crash (restart + retry the same action — confirm it no longer faults). Once verified, OFFER to suggest the fix upstream to the repo owner (open an issue or PR describing the crash + your patch) — describe it and ask the user first; do NOT auto-file anything. Combine this cleanly with the normal install→restart→continue flow above: a fresh install that crashes on first use is the same loop (update/patch the just-installed node, don't abandon it).
 
 WEDGED RENDER / OOM / VRAM PINNED — when a generation is stuck or hits CUDA out-of-memory, or a cancel didn't actually free GPU memory (models still resident, VRAM pinned, the next run still OOMs), call panel_free_vram to UNLOAD all models and free VRAM before retrying — it does NOT restart ComfyUI, so it's the cheap first move. Escalation ladder: cancel the run → panel_free_vram (unload + free) → retry; only as a LAST RESORT panel_restart_comfyui (which refuses mid-render and guards the running generation). Reach for panel_free_vram before a restart whenever a cancel left memory pinned.
+
+WORKFLOW TARGETING — by default your panel_* graph edits follow whichever workflow tab the user is currently viewing. If the user wants you to work on a DIFFERENT open workflow while they browse another tab, call panel_set_workflow_target(mode:"pinned", path:<from panel_list_workflows>) to pin edits to that workflow; panel_get_workflow_target shows the current binding. Set mode:"current" to follow the user's active tab again. Pinning does NOT switch what the user sees — it only routes your graph tools. When pinned, still use panel_open_workflow only when you intentionally want to switch the user's view.
 
 CRITICAL — never destroy the user's work. When they ask for a "new workflow", a "fresh canvas", or to "start over for a new project", call panel_new_workflow (it opens a NEW TAB and leaves their current workflow intact). NEVER use panel_clear for that — panel_clear wipes the CURRENTLY OPEN graph and is ONLY for an explicit "clear/reset this canvas". You can manage tabs with panel_list_workflows / panel_open_workflow / panel_rename_workflow / panel_close_workflow, and group nodes with panel_select_nodes / panel_create_subgraph. To label a node by its purpose, use panel_set_node_title. To read or edit nodes INSIDE a subgraph, call panel_enter_subgraph(node_id) first — then panel_query_graph / panel_graph_outline and the panel_* edit tools operate on the subgraph's inner nodes — and panel_exit_subgraph when you're done.
 
@@ -1098,6 +1101,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
+  const workflowTargets = new WorkflowTargetStore();
   const backendForTab = (panelTabId: string): string =>
     tabBackends.get(panelTabId) ?? defaultBackend;
   const agentKeyFor = (panelTabId: string): string =>
@@ -1190,7 +1194,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   {
     const panelMcpPort = Number(process.env.COMFYUI_MCP_PANEL_MCP_PORT) || bridgePort + 1;
     try {
-      panelMcpHttp = await startPanelMcpHttpServer(bridge, panelMcpPort);
+      panelMcpHttp = await startPanelMcpHttpServer(bridge, panelMcpPort, "127.0.0.1", workflowTargets);
     } catch (err) {
       logger.error(
         `[panel-orchestrator] could not start the panel HTTP MCP on :${panelMcpPort} — codex/gemini tabs will lack live-graph tools: ${err instanceof Error ? err.message : String(err)}`,
@@ -1442,7 +1446,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     // canvas through the loopback HTTP MCP instead). Bound to the PANEL tab so
     // panel_* tools reach the user's canvas regardless of the composite key.
     makePanelServer: (key) =>
-      backendOf(key) === "claude" ? createPanelMcpServer(bridge, panelTabOf(key)) : undefined,
+      backendOf(key) === "claude"
+        ? createPanelMcpServer(bridge, panelTabOf(key), workflowTargets)
+        : undefined,
     mcpServers: buildMcpServers(),
     // NOTE: manager callbacks fire with the composite agent key `tabId::backend`;
     // panelTabOf() recovers the PANEL tab so every push reaches the right socket.
@@ -1884,6 +1890,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // switcher stops falsely showing "CLI not installed" behind a remote pod.
       pushReadiness(panelTab);
       if (backend === "claude") pushCommands(panelTab);
+      bridge.push({ type: "workflow_target", target: workflowTargets.get(panelTab) }, panelTab);
       // Re-push the last usage so the context meter isn't blank after a reload.
       const lastStatus = manager.lastStatusFor(key);
       if (lastStatus) pushStatus(panelTab, lastStatus);
@@ -2106,6 +2113,41 @@ export async function runPanelOrchestrator(): Promise<void> {
       logger.info(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} switched backend ${prev} → ${reqBackend}`);
       return;
     }
+    // Workflow target picker: pin agent edits to a specific open workflow tab.
+    if (event.type === "set_workflow_target" && event.tab_id) {
+      const panelTab = event.tab_id;
+      const mode = (event as { mode?: unknown }).mode;
+      const path =
+        typeof (event as { path?: unknown }).path === "string"
+          ? String((event as { path?: unknown }).path)
+          : undefined;
+      const filename =
+        typeof (event as { filename?: unknown }).filename === "string"
+          ? String((event as { filename?: unknown }).filename)
+          : undefined;
+      if (mode !== "current" && mode !== "pinned") {
+        bridge.push(
+          { type: "ack", ok: false, kind: "workflow_target", message: "mode must be 'current' or 'pinned'" },
+          panelTab,
+        );
+        return;
+      }
+      if (mode === "pinned" && !(path ?? "").trim()) {
+        bridge.push(
+          { type: "ack", ok: false, kind: "workflow_target", message: "path required when pinning" },
+          panelTab,
+        );
+        return;
+      }
+      const target = workflowTargets.set(panelTab, { mode, path, filename });
+      bridge.push({ type: "ack", ok: true, kind: "workflow_target", target }, panelTab);
+      bridge.push({ type: "workflow_target", target }, panelTab);
+      logger.info(
+        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow target → ${target.mode}${target.path ? ` (${target.path})` : ""}`,
+      );
+      return;
+    }
+
     // Live panel config: render-stall threshold, plus the user's agent-model
     // preferences (preferred_models list + ollama endpoint config), persisted to
     // ~/.comfyui-mcp/panel-settings.json. Sent by the panel on connect and

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -52,11 +52,13 @@ import {
 import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
 import { GrokBackend, GROK_DEFAULT_MODEL } from "./grok-backend.js";
-import { OllamaBackend } from "./ollama-backend.js";
+import { OllamaBackend, OLLAMA_SYSTEM_PROMPT } from "./ollama-backend.js";
 import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-backend.js";
 import { GlmBackend, GLM_DEFAULT_MODEL } from "./glm-backend.js";
 import { KimiBackend, KIMI_DEFAULT_MODEL } from "./kimi-backend.js";
 import { CopilotBackend, COPILOT_DEFAULT_MODEL } from "./copilot-backend.js";
+import { SYSTEM as MODEL_CARD_SYSTEM } from "./ai-proposer.js";
+import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/prompt-overrides.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
@@ -84,6 +86,8 @@ import { WorkflowTargetStore } from "../services/workflow-target-store.js";
 const PANEL_SYSTEM_APPEND = `You are the autonomous assistant embedded directly in a ComfyUI sidebar panel. The person is working in ComfyUI and talks to you through that panel: their messages arrive as your prompts, and everything you write is shown to them in the panel chat. Write for that reader — lead with the result, keep replies short and concrete, and don't narrate routine internal steps.
 
 You can SEE and EDIT the workflow the user currently has open, via the panel_* tools (panel_graph_outline, panel_query_graph, panel_add_node, panel_connect, panel_set_widget, panel_run, panel_get_errors, panel_save_workflow, …). STRONGLY PREFER building on their live canvas: read it first (panel_graph_outline, then panel_query_graph for specifics), add/wire/configure nodes with the panel_* tools, then panel_run to queue it — so the user watches the work happen and the result loads in their own workflow with full Ctrl+Z undo. Only fall back to the headless generate_image/enqueue_workflow tools when the user explicitly wants a one-off they don't need on their canvas, or when no panel tab is connected (a panel_* call will error if so). On a LARGE graph (a loaded pack/template with dozens of nodes), do NOT dump the whole thing and scan it — and NEVER shell out to grep/jq/python over a saved workflow file. To UNDERSTAND the graph, call panel_graph_outline FIRST: a compact, dependency-ordered TEXT map (nodes topologically sorted source→sink, each with its key widgets and ← inputs / → outputs wiring, plus a groups index) made for you to read top-to-bottom. To PINPOINT and INSPECT specific nodes, use panel_query_graph: filter by types/title/widget predicates ('cfg>7'), traverse upstream_of/downstream_of a node, aggregate with group_by:'type', and read ONE node's exact slot/widget detail with {ids:[id], fields:'detail'} — output is token-bounded so it can never flood your context. panel_find_nodes remains for free-text search across all fields.
+
+PROMPT DIRECTOR AWARENESS. When the graph contains PromptDirector, PromptDirectorAuto, PromptDirectorContext, PromptProducer, or PromptDirectorResultCritic nodes, call panel_audit_prompt_director before declaring that the prompt/model/LoRA setup is correct or diagnosing a failed edit. The audit correlates live wiring and loader widgets with the nodes' resolved Model Explorer metadata, edit plan, LoRA compatibility/strengths, exact final prompt, warnings, and critic verdict. Surface concise, useful observations proactively (including when the configuration is coherent). Its recommendations are READ-ONLY proposals: ask before applying panel_set_widget/panel_connect changes unless the user already explicitly asked you to fix the workflow.
 
 TRUST REPORTED MANUAL CHANGES. The user can edit the canvas BY HAND between your turns (bypass/mute a node, change a widget, rewire, add/remove nodes). When that happens, your turn opens with a "⟳ MANUAL CANVAS CHANGES since your last turn" block listing exactly what they changed. Treat that block as GROUND TRUTH about the current graph — it overrides what you remember from earlier in the conversation. Do NOT assume the graph still matches your last edit or your earlier reading; if the listed changes are substantial (or contradict a plan you were mid-execution on), re-read with panel_graph_outline before you act or draw conclusions. This is also how you learn the user already tried something (e.g. they bypassed a node and it worked) — believe it over your own prior reasoning.
 
@@ -1127,7 +1131,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // just the static text (no env block). Built once; refreshed after a ComfyUI
   // restart/reconnect via refreshEnvCapabilities() below.
   let envCaps: EnvCapabilities | undefined;
-  let panelSystemAppend = PANEL_SYSTEM_APPEND;
+  let panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
   // Set once the manager exists so a later refresh (after a ComfyUI restart) feeds
   // the freshly-gathered env into newly-spawned agents too — Claude reads
   // manager.opts.systemAppend at each spawn; Codex reads the closed-over
@@ -1137,12 +1141,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   async function refreshEnvCapabilities(): Promise<void> {
     try {
       envCaps = await gatherEnvCapabilities({ comfyuiUrl, comfyuiPath, backendId });
-      panelSystemAppend = buildPanelSystemAppend(PANEL_SYSTEM_APPEND, envCaps);
+      panelSystemAppend = buildPanelSystemAppend(resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND), envCaps);
       if (liveManager) liveManager.setSystemAppend(panelSystemAppend);
     } catch (err) {
       // Belt-and-suspenders: gather is internally guarded, but never let a stray
       // throw break the prompt — fall back to the static append.
-      panelSystemAppend = PANEL_SYSTEM_APPEND;
+      panelSystemAppend = resolvePrompt("panel.persona", PANEL_SYSTEM_APPEND);
       logger.debug(
         `[panel-orchestrator] env-capabilities probe failed (using static prompt): ${err instanceof Error ? err.message : String(err)}`,
       );
@@ -1151,6 +1155,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Build it before any agent could spawn. Guarded so a probe stall can't block
   // orchestrator startup beyond the probes' own (short) timeouts.
   await refreshEnvCapabilities();
+
+  // Register every editable prompt's built-in default so a prompt editor can
+  // list + reset each one (overrides persist in ~/.comfyui-mcp/panel-prompts.json).
+  // The persona is live-applied here; the other prompts are read fresh at each
+  // session/turn, so they take effect on the next spawn without an explicit push.
+  registerPrompt("panel.persona", "Panel agent persona (all backends)", PANEL_SYSTEM_APPEND, "Injected into every backend; applies live to running agents.");
+  registerPrompt("backend.ollama", "Ollama / OpenRouter base prompt", OLLAMA_SYSTEM_PROMPT, "Applies on the next local/OpenRouter session.");
+  registerPrompt("proposer.modelCard", "Model Explorer “Ask AI” curator", MODEL_CARD_SYSTEM, "Applies to the next Ask-AI proposal.");
+  onPromptsChanged(() => { void refreshEnvCapabilities(); });
 
   // Render watchdog: a passive WS to ComfyUI that tracks live run progress so we
   // can warn the agent about a stalled render or a queue backlog it can't see
@@ -2040,7 +2053,7 @@ export async function runPanelOrchestrator(): Promise<void> {
               bridge.push({ type: "say", text: readyText }, panelTab);
             }
             bridge.push({ type: "ack", ok: true, kind: "ready", agent: agentLabel, backend }, panelTab);
-            logger.info(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) — agent healthy, ready ack`);
+            logger.debug(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) — agent healthy, ready ack`);
           } else {
             const degradedText = isCx
               ? "⚠️ The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry."
@@ -2156,10 +2169,14 @@ export async function runPanelOrchestrator(): Promise<void> {
     // live ollama sessions keep their connection until restarted.
     if (event.type === "set_config" && event.tab_id) {
       if ("stall_seconds" in event) {
+        const _prevStall = liveStallSeconds;
         setLiveStallSeconds((event as { stall_seconds?: unknown }).stall_seconds);
-        logger.info(
-          `[panel-orchestrator] live stall threshold → ${liveStallSeconds ?? "default"}s`,
-        );
+        // The panel re-sends set_config on every heartbeat; only log an ACTUAL change.
+        if (liveStallSeconds !== _prevStall) {
+          logger.info(
+            `[panel-orchestrator] live stall threshold → ${liveStallSeconds ?? "default"}s`,
+          );
+        }
       }
       const cfg = event as { preferred_models?: unknown; ollama?: unknown };
       let ollamaChanged = false;

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -26,6 +26,7 @@ import type {
 } from "./agent-backend.js";
 import { OLLAMA_CAPABILITIES } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
+import { resolvePrompt } from "../services/prompt-overrides.js";
 
 type McpToolInfo = { name: string; description?: string; inputSchema?: unknown };
 type McpCallResult = { isError?: boolean; content?: Array<{ type: string; text?: string }> };
@@ -133,7 +134,7 @@ const MAX_TOOL_ROUNDS = 32;
  * is short, router-shaped, and (deliberately, for local models) does NOT carry
  * the NSFW consent-gate flow — only the absolute hard limits.
  */
-const OLLAMA_SYSTEM_PROMPT = [
+export const OLLAMA_SYSTEM_PROMPT = [
   "You are the ComfyUI agent in a sidebar panel, driving the user's live ComfyUI graph and server. Answer in normal Markdown.",
   "",
   "You have exactly six tools:",
@@ -714,7 +715,7 @@ export class OllamaBackend implements AgentBackend {
     if (fresh) {
       // deps.systemAppend (the frontier panel prompt) is intentionally NOT
       // used — see OLLAMA_SYSTEM_PROMPT.
-      this.history = [{ role: "system", content: OLLAMA_SYSTEM_PROMPT }];
+      this.history = [{ role: "system", content: resolvePrompt("backend.ollama", OLLAMA_SYSTEM_PROMPT) }];
     }
     yield { type: "session", sessionId: this.sessionId, model: this.model };
 

--- a/src/orchestrator/panel-mcp-http.ts
+++ b/src/orchestrator/panel-mcp-http.ts
@@ -22,6 +22,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { UiBridge } from "../services/ui-bridge.js";
+import type { WorkflowTargetStore } from "../services/workflow-target-store.js";
 import { makePanelToolCtx, registerPanelTools } from "./panel-tools.js";
 import { logger } from "../utils/logger.js";
 
@@ -78,6 +79,7 @@ export function startPanelMcpHttpServer(
   bridge: UiBridge,
   port: number,
   host = "127.0.0.1",
+  workflowTargets?: WorkflowTargetStore,
 ): Promise<PanelMcpHttpServer> {
   // tabId -> (sessionId -> Session). A tab can hold multiple Codex sessions
   // across reconnects; each is its own server+transport over the SAME tab ctx.
@@ -87,7 +89,7 @@ export function startPanelMcpHttpServer(
     const server = new McpServer({ name: "comfyui-panel", version: "1.0.0" });
     // Tab-bound context: every tool forwards to the bridge for THIS tab — the
     // same surface the Claude in-process server exposes (shared defs).
-    registerPanelTools(server, makePanelToolCtx(bridge, tabId));
+    registerPanelTools(server, makePanelToolCtx(bridge, tabId, workflowTargets));
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       // Defense in depth against DNS rebinding (a malicious page resolving its own

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -33,6 +33,10 @@ import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
 import {
+  type WorkflowTargetStore,
+  withWorkflowTarget,
+} from "../services/workflow-target-store.js";
+import {
   addUserMcpServer,
   readUserMcpServers,
   removeUserMcpServer,
@@ -233,13 +237,21 @@ export interface PanelToolCtx {
    *  (image screenshots, secret collection). */
   bridge: UiBridge;
   tabId: string;
+  /** Per-tab workflow pin store (optional for tests). */
+  workflowTarget?: WorkflowTargetStore;
 }
 
 /** Build a tab-bound execution context shared by both transports. */
-export function makePanelToolCtx(bridge: UiBridge, tabId: string): PanelToolCtx {
+export function makePanelToolCtx(
+  bridge: UiBridge,
+  tabId: string,
+  workflowTargets?: WorkflowTargetStore,
+): PanelToolCtx {
   const call = async (cmd: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> => {
     try {
-      return ok(await bridge.send(cmd as { cmd: string }, { tabId, timeoutMs }));
+      const target = workflowTargets?.get(tabId);
+      const routed = target ? withWorkflowTarget(cmd, target) : cmd;
+      return ok(await bridge.send(routed as { cmd: string }, { tabId, timeoutMs }));
     } catch (err) {
       return fail(err);
     }
@@ -269,7 +281,7 @@ export function makePanelToolCtx(bridge: UiBridge, tabId: string): PanelToolCtx 
       return false;
     }
   };
-  return { call, confirm, bridge, tabId };
+  return { call, confirm, bridge, tabId, workflowTarget: workflowTargets };
 }
 
 /** One shared tool definition: name, description, zod raw-shape schema, and a
@@ -1086,6 +1098,47 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (_args, ctx) => ctx.call({ cmd: "workflow_list" }),
     ),
     def(
+      "panel_get_workflow_target",
+      "Read which workflow this agent is bound to edit. mode 'current' means graph tools follow whatever tab the user is viewing; mode 'pinned' means edits go to the pinned workflow even if the user switched to another tab. Call this when unsure which workflow your panel_* edits will affect.",
+      {},
+      async (_args, ctx) => {
+        const target = ctx.workflowTarget?.get(ctx.tabId) ?? { mode: "current" as const };
+        return ok(target);
+      },
+    ),
+    def(
+      "panel_set_workflow_target",
+      "Pin the agent to a specific open workflow tab, or release the pin to follow the user's current tab. Use pinned when the user asks you to work on workflow A while they browse workflow B — set mode:'pinned' and path from panel_list_workflows. Set mode:'current' (or omit path) to follow the active tab again. Does NOT switch what the user sees; it only routes your panel_* graph edits.",
+      {
+        mode: z
+          .enum(["current", "pinned"])
+          .describe("'current' = follow the user's active workflow tab; 'pinned' = always edit the given path."),
+        path: z
+          .string()
+          .optional()
+          .describe("Workflow path/filename/key from panel_list_workflows — required when mode is 'pinned'."),
+        filename: z.string().optional().describe("Optional display label for the pinned workflow."),
+      },
+      async (args: A, ctx) => {
+        if (!ctx.workflowTarget) {
+          return fail("Workflow targeting is not available in this session.");
+        }
+        const mode = args.mode === "pinned" ? "pinned" : "current";
+        const path = typeof args.path === "string" ? args.path : undefined;
+        const filename = typeof args.filename === "string" ? args.filename : undefined;
+        if (mode === "pinned" && !(path ?? "").trim()) {
+          return fail("Provide path when pinning — use panel_list_workflows to list open workflows.");
+        }
+        const target = ctx.workflowTarget.set(ctx.tabId, { mode, path, filename });
+        ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);
+        const hint =
+          target.mode === "pinned"
+            ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
+            : "Following the user's current workflow tab.";
+        return ok({ ...target, note: hint });
+      },
+    ),
+    def(
       "panel_new_workflow",
       "Open a brand-new BLANK workflow in a NEW TAB. Use this whenever the user wants a 'new workflow' / 'fresh canvas' / 'start over for a new project'. This does NOT touch their current workflow — it opens a separate tab. NEVER use panel_clear for a new workflow (panel_clear wipes the CURRENT graph and is only for 'clear/reset this canvas').",
       {},
@@ -1619,8 +1672,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
 export function createPanelMcpServer(
   bridge: UiBridge,
   tabId: string,
+  workflowTargets?: WorkflowTargetStore,
 ): McpSdkServerConfigWithInstance {
-  const ctx = makePanelToolCtx(bridge, tabId);
+  const ctx = makePanelToolCtx(bridge, tabId, workflowTargets);
   const defs = buildPanelToolDefs();
   // The Anthropic SDK's tool() accepts (name, description, zodRawShape, cb). The
   // shared handler is transport-agnostic — bind it to this tab's ctx. Each def's

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -379,6 +379,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (_args, ctx) => ctx.call({ cmd: "graph_outline" }),
     ),
     def(
+      "panel_audit_prompt_director",
+      "Audit Prompt Director on the LIVE canvas without changing it. Correlates Prompt Director/Producer/Auto/Context/Reference/Critic widget values and wiring with detected model-loader filenames, every LoRA loader's actual model/CLIP strengths, and Prompt Director's latest sanitized runtime edit plan, resolved Model Explorer metadata, warnings, exact final prompt, and critic verdict. Returns observations plus proposed panel_set_widget changes with requires_confirmation=true. Call this when Prompt Director nodes are present, before saying the model/LoRA setup is correct, or when an edit prompt is ignored. READ-ONLY: present useful findings to the user and ask before applying any recommendation unless they already explicitly asked you to fix it.",
+      {},
+      async (_args, ctx) => ctx.call({ cmd: "graph_prompt_director_audit" }),
+    ),
+    def(
       "panel_get_subgraph",
       "Read INSIDE a subgraph node on the user's open graph: ids, types, widget values, and connections of its inner nodes. Use after panel_graph_outline / panel_query_graph shows a node with is_subgraph=true. Read-only.",
       { node_id: z.number().int().describe("Subgraph node id (is_subgraph=true).") },

--- a/src/services/prompt-overrides.ts
+++ b/src/services/prompt-overrides.ts
@@ -1,0 +1,127 @@
+// User-editable overrides for EVERY agent prompt the orchestrator controls.
+//
+// Design: each prompt registers its built-in DEFAULT (id + label + default text).
+// The user's override is stored SEPARATELY (~/.comfyui-mcp/panel-prompts.json), so
+// a default is never destroyed — an empty override or an explicit Reset always falls
+// back to the built-in. This makes "edit any prompt" safe: a bad edit that breaks
+// tool use is one Reset away.
+//
+// resolvePrompt(id, fallback) is what call-sites use — it returns the override when
+// present and non-empty, else the inline default (which is also what gets registered
+// for the console listing). The store imports nothing from the backends, so wiring a
+// call-site (backends import THIS) never risks a circular import; defaults are
+// registered centrally at startup (see registerBuiltinPrompts in index.ts).
+
+import { EventEmitter } from "node:events";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { logger } from "../utils/logger.js";
+
+export interface PromptDef {
+  id: string;
+  label: string;
+  /** One-line note shown under the label in the editor (e.g. when it takes effect). */
+  help?: string;
+  default: string;
+}
+
+export interface PromptListItem {
+  id: string;
+  label: string;
+  help?: string;
+  default: string;
+  /** The stored override text, or null when using the default. */
+  override: string | null;
+  overridden: boolean;
+}
+
+const REGISTRY = new Map<string, PromptDef>();
+const emitter = new EventEmitter();
+
+/** Overrides file path. Overridable for tests. */
+export function panelPromptsPath(): string {
+  return (
+    process.env.COMFYUI_MCP_PANEL_PROMPTS ||
+    join(homedir(), ".comfyui-mcp", "panel-prompts.json")
+  );
+}
+
+function readOverrides(): Record<string, string> {
+  const p = panelPromptsPath();
+  if (!existsSync(p)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
+  } catch (err) {
+    logger.warn(`[prompt-overrides] could not parse ${p}: ${err instanceof Error ? err.message : String(err)}`);
+    return {};
+  }
+}
+
+function writeOverrides(o: Record<string, string>): void {
+  const p = panelPromptsPath();
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(o, null, 2), "utf-8");
+}
+
+/** Register a prompt's built-in default so the editor can list + reset it. Idempotent. */
+export function registerPrompt(id: string, label: string, def: string, help?: string): void {
+  REGISTRY.set(id, { id, label, default: def, help });
+}
+
+/**
+ * The effective prompt text for `id`: the stored override if present and non-empty,
+ * otherwise `fallback` (the call-site's inline default, which also seeds the registry
+ * default). A whitespace-only override counts as "use default".
+ */
+export function resolvePrompt(id: string, fallback: string): string {
+  const ov = readOverrides()[id];
+  if (typeof ov === "string" && ov.trim().length > 0) return ov;
+  return fallback;
+}
+
+/** Persist an override. Empty/whitespace clears it (→ back to default). Emits change. */
+export function setPromptOverride(id: string, value: string): void {
+  const o = readOverrides();
+  if (!value || !value.trim()) delete o[id];
+  else o[id] = value;
+  writeOverrides(o);
+  emitter.emit("change", id);
+}
+
+/** Remove an override → back to the built-in default. Emits change. */
+export function clearPromptOverride(id: string): void {
+  const o = readOverrides();
+  if (id in o) {
+    delete o[id];
+    writeOverrides(o);
+  }
+  emitter.emit("change", id);
+}
+
+/** All registered prompts with their default + current override, for the editor. */
+export function listPrompts(): PromptListItem[] {
+  const ov = readOverrides();
+  return [...REGISTRY.values()].map((e) => {
+    const o = ov[e.id];
+    const overridden = typeof o === "string" && o.trim().length > 0;
+    return { id: e.id, label: e.label, help: e.help, default: e.default, override: overridden ? o : null, overridden };
+  });
+}
+
+/** Is `id` a prompt we know about? (Guards the write endpoint.) */
+export function isKnownPrompt(id: string): boolean {
+  return REGISTRY.has(id);
+}
+
+/** Subscribe to "a prompt override changed" (arg: the changed id). Returns unsubscribe. */
+export function onPromptsChanged(cb: (id: string) => void): () => void {
+  emitter.on("change", cb);
+  return () => emitter.off("change", cb);
+}

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -109,6 +109,15 @@ export class UiBridge {
   /** Tab ids that ever connected as a headless (mobile/remote) client — kept so
    *  `isHeadless` stays true across a disconnect (see isHeadless). */
   private readonly headlessSeen = new Set<string>();
+  private seenTabs = new Set<string>(); // tabIds ever announced — dedup connect logs across reconnect churn
+  /** Frames pushed at a tab with NO live connection, buffered for replay when that
+   *  tab re-hellos. Per-workflow sessions re-target ONE socket between workflow tab
+   *  ids, so a backgrounded workflow's agent output would otherwise be dropped on
+   *  the floor and its finished turn lost to the user. Complements the send()-path
+   *  `mailbox` (which buffers show_media command deliveries): this one buffers
+   *  push()-path frames (agent turn output). Bounded per tab. */
+  private missedFrames = new Map<string, Record<string, unknown>[]>();
+  private static readonly MAX_MISSED_FRAMES = 100;
   private pending = new Map<string, Pending>();
   private portInUse = false;
   private bindRetryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -396,6 +405,13 @@ export class UiBridge {
 
       // Hello: register (or refresh) this connection under its tab id.
       if (msg.type === "hello" && typeof msg.tab_id === "string") {
+        // A single socket may RE-HELLO under a new tab id when the user switches
+        // ComfyUI workflow tabs (per-workflow sessions). Drop this socket's PRIOR
+        // tab mapping so a background agent's push() to the old tab can't leak into
+        // the newly-targeted view (frames carry no tab_id — the socket is the tab).
+        if (tabId && tabId !== msg.tab_id && this.conns.get(tabId)?.sock === sock) {
+          this.conns.delete(tabId);
+        }
         tabId = msg.tab_id;
         const existing = this.conns.get(tabId);
         if (existing && existing.sock !== sock) {
@@ -414,9 +430,33 @@ export class UiBridge {
           headless: (msg as { headless?: unknown }).headless === true,
         });
         if ((msg as { headless?: unknown }).headless === true) this.headlessSeen.add(tabId);
-        logger.info(
-          `[ui-bridge] panel tab connected: ${tabId.slice(0, 8)} (“${this.conns.get(tabId)?.title}”) — ${this.conns.size} tab(s) total`,
-        );
+        // Log a real connect ONCE per tab id. A reconnect/ping-pong loop (a new
+        // socket every couple seconds — e.g. two browser contexts sharing one tab
+        // id) would otherwise spam this; dedup by tab id so churn stays at debug.
+        if (!this.seenTabs.has(tabId)) {
+          this.seenTabs.add(tabId);
+          logger.info(
+            `[ui-bridge] panel tab connected: ${tabId.slice(0, 8)} (“${this.conns.get(tabId)?.title}”) — ${this.conns.size} tab(s) total`,
+          );
+        } else {
+          logger.debug(`[ui-bridge] tab ${tabId.slice(0, 8)} (re)hello`);
+        }
+        // Replay anything this tab's agent produced while the tab had no live
+        // connection (its socket was re-helloed to another workflow). The panel
+        // swaps to this workflow's thread synchronously before these frames can be
+        // processed, so they render + record into the RIGHT conversation.
+        const missed = this.missedFrames.get(tabId);
+        if (missed?.length) {
+          this.missedFrames.delete(tabId);
+          for (const f of missed) {
+            try {
+              sock.send(JSON.stringify(f));
+            } catch {
+              break; // socket died mid-flush — frames stay lost, next turn recovers
+            }
+          }
+          logger.debug(`[ui-bridge] replayed ${missed.length} missed frame(s) to tab ${tabId.slice(0, 8)}`);
+        }
         // Deliver anything that finished while this tab was away.
         this.flushMailbox(tabId);
         this.onPanelMessage?.(msg as PanelEvent);
@@ -644,7 +684,14 @@ export class UiBridge {
       try {
         targets = [this.resolveTarget(tabId)];
       } catch {
-        return 0; // tab not connected — nothing to push to
+        // Tab not connected (e.g. the user switched to another workflow and the
+        // shared socket re-helloed under that workflow's id). Buffer for replay on
+        // this tab's next hello, so a backgrounded agent's turn isn't lost.
+        const q = this.missedFrames.get(tabId) ?? [];
+        q.push(frame);
+        if (q.length > UiBridge.MAX_MISSED_FRAMES) q.splice(0, q.length - UiBridge.MAX_MISSED_FRAMES);
+        this.missedFrames.set(tabId, q);
+        return 0;
       }
     } else {
       targets = Array.from(this.conns.values());

--- a/src/services/workflow-target-store.ts
+++ b/src/services/workflow-target-store.ts
@@ -1,0 +1,79 @@
+// Per-panel-tab workflow target: which open ComfyUI workflow tab the agent
+// should edit. Without pinning, graph_* commands hit whatever workflow the user
+// is currently viewing — browsing another tab mid-conversation redirects edits.
+//
+// Pinning injects `workflow_path` on workflow-scoped bridge commands so the
+// panel can operate on a background workflow without switching the user's view.
+// The comfyui-mcp-panel pack must honor `workflow_path` on graph executors.
+
+export type WorkflowTargetMode = "current" | "pinned";
+
+export interface WorkflowTarget {
+  mode: WorkflowTargetMode;
+  /** Workflow path/key when mode is "pinned" (from workflow_list). */
+  path?: string;
+  /** Human label for UI / agent context. */
+  filename?: string;
+}
+
+const DEFAULT_TARGET: WorkflowTarget = { mode: "current" };
+
+/** In-memory per-tab workflow pin. Process-scoped; cleared on orchestrator restart. */
+export class WorkflowTargetStore {
+  private targets = new Map<string, WorkflowTarget>();
+
+  get(tabId: string): WorkflowTarget {
+    return this.targets.get(tabId) ?? DEFAULT_TARGET;
+  }
+
+  set(tabId: string, target: WorkflowTarget): WorkflowTarget {
+    const normalized = normalizeTarget(target);
+    if (normalized.mode === "current") {
+      this.targets.delete(tabId);
+      return DEFAULT_TARGET;
+    }
+    this.targets.set(tabId, normalized);
+    return normalized;
+  }
+
+  clear(tabId: string): void {
+    this.targets.delete(tabId);
+  }
+}
+
+function normalizeTarget(raw: WorkflowTarget): WorkflowTarget {
+  if (raw.mode !== "pinned") return { mode: "current" };
+  const path = (raw.path ?? "").trim();
+  if (!path) return { mode: "current" };
+  const filename = (raw.filename ?? "").trim() || undefined;
+  return { mode: "pinned", path, filename };
+}
+
+/** Bridge commands that target a specific workflow canvas (not tab navigation). */
+export function shouldInjectWorkflowPath(cmd: string, args: Record<string, unknown>): boolean {
+  if (cmd === "workflow_list" || cmd === "workflow_new" || cmd === "workflow_open") return false;
+  if (cmd.startsWith("graph_")) return true;
+  // workflow_* that default to "active" when path omitted
+  if (
+    (cmd === "workflow_save" ||
+      cmd === "workflow_save_as" ||
+      cmd === "workflow_rename" ||
+      cmd === "workflow_close") &&
+    args.path === undefined
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Attach workflow_path when the tab has a pinned target. */
+export function withWorkflowTarget(
+  cmd: Record<string, unknown>,
+  target: WorkflowTarget,
+): Record<string, unknown> {
+  if (target.mode !== "pinned" || !target.path) return cmd;
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  if (!name || cmd.workflow_path !== undefined) return cmd;
+  if (!shouldInjectWorkflowPath(name, cmd)) return cmd;
+  return { ...cmd, workflow_path: target.path };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -39,6 +39,8 @@ import { registerWorkspaceEnvTools } from "./workspace-env.js";
 import { registerApiNodesTools } from "./api-nodes.js";
 import { registerManagerConfigTools } from "./manager-config.js";
 import { registerManifestTools } from "./manifest.js";
+import { registerModelExplorerTools } from "./model-explorer.js";
+import { registerPromptDirectorTools } from "./prompt-director.js";
 import { registerImageConvertTools } from "./image-convert.js";
 import { registerColorAnalysisTools } from "./color-analysis.js";
 import { registerStorageUploadTools } from "./storage-upload.js";
@@ -93,6 +95,8 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["server", registerInstallComfyUITools],
   ["server", registerUpdateComfyUITools],
   ["models", registerModelExtrasTools],
+  ["models", registerModelExplorerTools],
+  ["workflow-authoring", registerPromptDirectorTools],
   ["models", registerExtraPathsTools],
   ["server", registerWorkspaceEnvTools],
   ["generation", registerApiNodesTools],

--- a/src/tools/model-explorer.ts
+++ b/src/tools/model-explorer.ts
@@ -1,0 +1,129 @@
+// Model Explorer metadata-curation tools, on the SHARED comfyui MCP surface so
+// EVERY backend (Claude, Kimi, Codex, Gemini, Grok, Ollama…) can call them — not
+// just the panel/Claude in-process path. They HTTP-proxy the ComfyUI
+// `comfyui-model-explorer` node's routes (the node is the single source of truth
+// for embedded safetensors metadata). "read" + "propose" only — the human Confirms
+// the write in the diff-review window, so there is intentionally no write tool here.
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+function comfyBase(): string {
+  return (
+    process.env.COMFYUI_URL ||
+    (process.env.COMFYUI_PORT ? `http://127.0.0.1:${process.env.COMFYUI_PORT}` : "http://127.0.0.1:8188")
+  ).replace(/\/$/, "");
+}
+
+const okText = (value: unknown) => ({
+  content: [{ type: "text" as const, text: typeof value === "string" ? value : JSON.stringify(value, null, 2) }],
+});
+
+export function registerModelExplorerTools(server: McpServer): void {
+  server.tool(
+    "model_metadata_read",
+    "Read a model file's CURRENT embedded metadata + evidence, for curating it (Model Explorer). " +
+      "Returns classify (asset_type/base/precision/rank), the current model_card and prompt_director namespaces, " +
+      "read-only modelspec, top training tags (ss_tag_frequency), the Civitai description, and example prompts. " +
+      "Call this FIRST when the user wants to improve/curate a model's embedded .safetensors metadata, so you " +
+      "propose from real data. NOTE: this is the embedded-in-the-tensor metadata (model_card/prompt_director/" +
+      "modelspec/ss_*) — NOT the separate lora_catalog. `category` = ComfyUI model folder ('loras','checkpoints'," +
+      "'vae',…); `name` = filename incl. .safetensors.",
+    {
+      category: z.string().describe("ComfyUI model folder, e.g. 'loras'"),
+      name: z.string().describe("model filename incl. .safetensors"),
+    },
+    async (args) => {
+      try {
+        const COMFY = comfyBase();
+        const q = `category=${encodeURIComponent(args.category)}&name=${encodeURIComponent(args.name)}`;
+        const dr = await fetch(`${COMFY}/model_explorer/detail?${q}`);
+        if (!dr.ok) return errorToToolResult(new Error(`model_explorer detail HTTP ${dr.status} (is ComfyUI running with the comfyui-model-explorer node?)`));
+        const detail = (await dr.json()) as any;
+        let tags = null;
+        try {
+          const tr = await fetch(`${COMFY}/model_explorer/suggest_triggers?${q}`);
+          if (tr.ok) tags = ((await tr.json()) as any).candidates;
+        } catch { /* optional */ }
+        return okText({
+          classify: detail.classify,
+          model_card: detail.namespaces?.model_card ?? {},
+          prompt_director: detail.namespaces?.prompt_director ?? {},
+          modelspec: detail.namespaces?.modelspec ?? {},
+          description: detail.namespaces?.model_card?.description ?? null,
+          example_prompts: detail.namespaces?.prompt_director?.example_prompts ?? [],
+          tag_frequency_top: tags,
+          compat_suggestions: detail.compat_suggestions ?? [],
+        });
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "model_metadata_propose",
+    "PROPOSE cleaned embedded metadata into the user's diff-review window (Model Explorer). This does NOT write " +
+      "the file — the user sees your proposed fields vs current, edits/discusses, and their Confirm does the write. " +
+      "Call whenever you have a proposal OR the user asks you to revise one; each call REPLACES the live proposal, " +
+      "so send the FULL field set you're proposing. Include only fields you're confident about. Keys: display_name, " +
+      "description_clean, semantic_intent, prompt_guidance, preservation_guidance, trigger_tokens[] (EXACT tokens — " +
+      "never invent), activation_phrases[], negative_tokens[], tags[], compatible_families[], default_strength_model, " +
+      "default_strength_clip, strength_min, strength_max. NEVER write metadata directly.",
+    {
+      category: z.string(),
+      name: z.string(),
+      fields: z.record(z.string(), z.any()).describe("Proposed field map (see description)."),
+      note: z.string().optional().describe("Optional one-line note about this revision."),
+    },
+    async (args) => {
+      try {
+        const COMFY = comfyBase();
+        const r = await fetch(`${COMFY}/model_explorer/proposal`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ category: args.category, name: args.name, fields: args.fields, note: args.note }),
+        });
+        const d = (await r.json()) as any;
+        if (!r.ok || !d.ok) return errorToToolResult(new Error(d.error || `proposal HTTP ${r.status}`));
+        return okText({
+          pushed: true,
+          seq: d.seq,
+          note: "Proposal is now in the user's review window. Wait for their feedback; revise by calling this again with the full field set.",
+        });
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "model_metadata_fetch_civitai",
+    "READ-ONLY: pull this model's data from Civitai (civitai.com) — the rich description, " +
+      "trainedWords, example prompts (with the prompt text used in the sample images), tags, nsfw flag, " +
+      "and source_url — WITHOUT writing anything. Call this when the embedded metadata is thin (empty " +
+      "model_card/prompt_director, no ss_tag_frequency) or to flesh out details before proposing. Treat the " +
+      "result as RAW input: distill the (often marketing-heavy) description, and MINE THE EXAMPLE PROMPTS for " +
+      "the real trigger — the trigger is frequently ONLY in the sample prompts even when trainedWords is EMPTY " +
+      "(e.g. every prompt starting with 'photo in the style of X' means X is the trigger). Adult models (civitai.red) " +
+      "resolve through this same API. Then clean it up and call model_metadata_propose.",
+    {
+      category: z.string().describe("ComfyUI model folder, e.g. 'loras'"),
+      name: z.string().describe("model filename incl. .safetensors"),
+      version_id: z.number().int().optional().describe("Force a specific Civitai modelVersionId if hash lookup misses."),
+    },
+    async (args) => {
+      try {
+        const COMFY = comfyBase();
+        const q =
+          `category=${encodeURIComponent(args.category)}&name=${encodeURIComponent(args.name)}` +
+          (args.version_id ? `&version_id=${args.version_id}` : "");
+        const r = await fetch(`${COMFY}/model_explorer/civitai?${q}`);
+        if (!r.ok) return errorToToolResult(new Error(`model_explorer civitai HTTP ${r.status}`));
+        return okText(await r.json());
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}

--- a/src/tools/prompt-director.ts
+++ b/src/tools/prompt-director.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+
+function comfyBase(): string {
+  return (
+    process.env.COMFYUI_URL ||
+    (process.env.COMFYUI_PORT ? `http://127.0.0.1:${process.env.COMFYUI_PORT}` : "http://127.0.0.1:8188")
+  ).replace(/\/$/, "");
+}
+
+
+export function registerPromptDirectorTools(server: McpServer): void {
+  server.tool(
+    "prompt_director_inspect",
+    "Read Prompt Director's latest sanitized RUNTIME state after its nodes execute. Returns each node id, node kind, " +
+      "resolved Model Explorer model/LoRA context, structured edit plan, source analysis, exact final prompt, warnings, " +
+      "or Result Critic verdict. Secrets and image tensors are redacted. Use this with the live panel graph audit: graph " +
+      "inspection explains wiring and widget state, while this tool explains what the nodes actually resolved and compiled. " +
+      "Read-only: never changes the workflow. Pass node_id to inspect one executed Prompt Director node.",
+    {
+      node_id: z.string().optional().describe("Optional ComfyUI node id; omit to list all recent Prompt Director runtime states."),
+    },
+    async (args) => {
+      try {
+        const query = args.node_id ? `?node_id=${encodeURIComponent(args.node_id)}` : "";
+        const response = await fetch(`${comfyBase()}/prompt_director/inspection${query}`);
+        if (!response.ok) {
+          return errorToToolResult(
+            new Error(
+              `Prompt Director inspection HTTP ${response.status}. Is ComfyUI running with ComfyUI-PromptDirector loaded?`,
+            ),
+          );
+        }
+        const payload = await response.json();
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+}
+
+
+export default registerPromptDirectorTools;


### PR DESCRIPTION
## Summary

Ports MichaelDanCurtis's Stack 3 ("per-workflow agent sessions + prompt registry + external launcher") onto current main.

Ported from MichaelDanCurtis/comfyui-mcp (1b5e7ca, 9174c91) with thanks — authorship preserved.

### Per-workflow agent targeting (1b5e7ca)
- **`WorkflowTargetStore`** (`src/services/workflow-target-store.ts`): per-panel-tab pin of which open ComfyUI workflow the agent edits. Default `mode:"current"` follows whatever tab the user is viewing; `mode:"pinned"` injects `workflow_path` on `graph_*` bridge commands (and path-less `workflow_save/save_as/rename/close`) so the agent can keep editing workflow A while the user browses workflow B.
- New panel tools **`panel_get_workflow_target` / `panel_set_workflow_target`**, a `set_workflow_target` bridge event + `workflow_target` push frames, a system-prompt "WORKFLOW TARGETING" section, mock-panel support, and design docs (`docs/design/workflow-target.md`, `agent-platform-roadmap.md`).
- Wired through **both** panel-tool transports: the in-process Claude MCP server and the loopback HTTP MCP (codex/gemini tabs).

### Prompt registry + panel platform fixes (9174c91)
- **`prompt-overrides` service** (`src/services/prompt-overrides.ts`): every agent prompt registers its built-in default; user overrides persist separately in `~/.comfyui-mcp/panel-prompts.json` so Reset is always safe. `resolvePrompt()` wired into the panel persona (live re-applied via `onPromptsChanged` → `refreshEnvCapabilities`) and the Ollama/OpenRouter base prompt.
- **`ai-proposer`** (`src/orchestrator/ai-proposer.ts`): headless "Ask AI" model-card curator over the Claude Agent SDK, prompt-registry aware.
- **New MCP tools**: `model_metadata_read` / `model_metadata_propose` / `model_metadata_fetch_civitai` (Model Explorer curation; HTTP-proxy the `comfyui-model-explorer` node) and `prompt_director_inspect` (+ panel tool `panel_audit_prompt_director`) for the ComfyUI-PromptDirector node pack. Read/propose only — no write path.
- **ui-bridge fixes for per-workflow sessions**: stale-conn drop when a single socket re-hellos under a new tab id, a bounded **missed-frame buffer** replaying push()-path agent output to a tab that had no live connection, and once-per-tab connect-log dedup.

## Semantic reconciliation (fork model × upstream session ownership)

Upstream has moved a lot since the fork branched (orchestrator-owns-session `SessionStore`, render **mailbox** keyed by stable tab ids, **headless** tab concept, `panel_query_graph` replacing `panel_get_graph`). The two models compose; nothing upstream was overwritten:

- **Sessions**: `WorkflowTargetStore` is keyed by *panel tab id* and only routes `panel_*` graph commands. It does not touch upstream's `SessionStore`, composite `tabId::backend` agent keys, or session resume — a pin survives backend switches and reconnects exactly as long as the orchestrator process (in-memory, like the fork). On reconnect the orchestrator re-pushes the tab's current `workflow_target` alongside readiness/commands.
- **Mailbox vs. missed frames**: these are complementary, both kept. Upstream's mailbox buffers **send()-path** `show_media` command deliveries for offline (mobile/headless) tabs; MDC's missed-frame buffer covers **push()-path** frames (agent turn output) for a tab whose socket re-helloed to another workflow. On hello the bridge now: drops the socket's prior tab mapping (MDC) → supersedes a stale same-tab socket (upstream) → registers headless state (upstream) → replays missed frames (MDC) → flushes the mailbox (upstream).
- **Headless tabs**: untouched — `headlessSeen`/`isHeadless` behavior is preserved verbatim next to the new bookkeeping.
- **Tool rename**: MDC's `workflow_path`-injection test targeted `panel_get_graph`/`graph_get_state`, which upstream replaced with `panel_query_graph`/`graph_query`. The test now targets the current tool; the injection rule (`cmd.startsWith("graph_")`) covers it unchanged.
- **Prompt registry**: `registerPrompt` runs for `panel.persona`, `backend.ollama`, and `proposer.modelCard`. The fork's `backend.chatgpt` registration was dropped — upstream has no ChatGPT-OAuth backend.

## Dropped from the picks

- `.gitignore` hunks (fork-local entries).
- `scripts/com.comfyui-mcp.orchestrator.plist`, `scripts/launch-orchestrator.sh` — mac-only local launcher tooling.
- `scripts/verify-agent-platform.mjs` — probes fork-only tools (`lora_catalog_*`, `toolkit_*`, `runcomfy_*`, `run_workflow_pipeline`) that are not part of this port; would report misleading MISSINGs. (`scripts/test-generate.mjs` is generic and kept.)
- `src/orchestrator/chatgpt-oauth-backend.ts` and `src/orchestrator/panel-console-http.ts` — fork-only files this commit also touched (the `/prompts` editor page + `/api/prompts` endpoints live in the fork's console server). **Divergence note**: the prompt registry lands fully functional (overrides read from `~/.comfyui-mcp/panel-prompts.json`, live re-apply on change) but without the fork's browser editor UI; editing is by file until an upstream editor surface exists.
- Fork-only import references (Grok/GLM/Kimi/ChatGPT backends) in `src/orchestrator/index.ts`.

## Follow-up commit in this PR

- Categorized the new tools in `scripts/gen-tool-docs.ts` and ran `npm run docs:gen` (the regen also caught up pre-existing description drift on main — comfy-cli wording in custom-nodes.mdx etc. — those pages had not been regenerated since the descriptions changed).

## Test results

- `npx tsc --noEmit` — clean
- `npx vitest run` — **110 files / 1238 tests passed** (includes MDC's workflow-target-store, prompt-director, and panel-tools workflow-target tests)
- `npm run docs:gen` — 12 pages, 126/135 tools categorized (remaining 9 uncategorized pre-date this PR)

Note: the panel-side halves (honoring `workflow_path` on graph executors, the workflow-target picker UI, `graph_prompt_director_audit`) live in comfyui-mcp-panel and are not part of this repo's PR; until they ship, pinning falls back to editing the active tab exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)