### PR TITLE
feat(orchestrator): OAuth engine + Grok/Kimi/GLM/ChatGPT/Copilot provider backends — ported from MichaelDanCurtis fork

### DIFF
--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -71,6 +71,16 @@ describe("backendReadiness", () => {
     expect(r.ready).toBe(true);
   });
 
+  it("grok: CLI on PATH AND auth.json on disk → ready", () => {
+    putOnPath(process.platform === "win32" ? "grok.cmd" : "grok");
+    mkdirSync(join(tmp, ".grok"), { recursive: true });
+    writeFileSync(join(tmp, ".grok", "auth.json"), "{}");
+    const r = backendReadiness("grok", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
   it("gemini: honors GEMINI_CLI_HOME for the oauth creds path", () => {
     putOnPath(process.platform === "win32" ? "gemini.cmd" : "gemini");
     const gh = join(tmp, "geminihome");

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -93,6 +93,31 @@ describe("backendReadiness", () => {
     expect(r.ready).toBe(true);
   });
 
+  it("chatgpt: ready when ~/.codex/auth.json exists (no CLI)", () => {
+    mkdirSync(join(tmp, ".codex"), { recursive: true });
+    writeFileSync(join(tmp, ".codex", "auth.json"), "{}");
+    const r = backendReadiness("chatgpt", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
+  it("glm: ready when ZAI_API_KEY is set", () => {
+    process.env.ZAI_API_KEY = "zai-key";
+    const r = backendReadiness("glm", { home: tmp });
+    expect(r.ready).toBe(true);
+    delete process.env.ZAI_API_KEY;
+  });
+
+  it("kimi: ready with oauth file or KIMI_API_KEY", () => {
+    mkdirSync(join(tmp, ".kimi", "credentials"), { recursive: true });
+    writeFileSync(join(tmp, ".kimi", "credentials", "kimi-code.json"), "{}");
+    process.env.KIMI_SHARE_DIR = join(tmp, ".kimi");
+    const r = backendReadiness("kimi", { home: tmp });
+    expect(r.ready).toBe(true);
+    delete process.env.KIMI_SHARE_DIR;
+  });
+
   it("unknown backend is never ready", () => {
     expect(backendReadiness("bogus").ready).toBe(false);
   });

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -136,6 +136,70 @@ describe("backendReadiness", () => {
   });
 });
 
+describe("backendReadiness: in-panel OAuth status", () => {
+  // The readiness fns take an injectable `oauthStatus` array + `now` (ms) so a
+  // test never has to touch the real ~/.comfyui-mcp/panel-secrets.json. Status
+  // records mirror OAuthStatusRecord: { provider, account_label, obtained_at,
+  // expires_at? (unix SECONDS), experimental? }.
+  const NOW = 1_700_000_000_000; // fixed ms clock
+  const FUTURE = Math.floor(NOW / 1000) + 3600; // +1h, in seconds
+  const PAST = Math.floor(NOW / 1000) - 3600; // -1h, in seconds
+
+  it("non-expired panel OAuth entry → auth true even when CLI+file are absent", () => {
+    // Empty PATH (no CLI) + fake home with no auth.json (no native file).
+    const r = backendReadiness("codex", {
+      home: tmp,
+      now: NOW,
+      oauthStatus: [{ provider: "codex", account_label: "user@example.com", obtained_at: NOW, expires_at: FUTURE }],
+    });
+    expect(r.cli).toBe(false); // no CLI on PATH
+    expect(r.auth).toBe(true); // flipped true purely by the panel-OAuth entry
+    expect(r.ready).toBe(false); // still gated on cli for codex
+  });
+
+  it("EXPIRED panel OAuth entry does NOT flip auth on its own (falls back to CLI/file check)", () => {
+    const r = backendReadiness("grok", {
+      home: tmp,
+      now: NOW,
+      oauthStatus: [{ provider: "grok", account_label: "x@ai", obtained_at: NOW, expires_at: PAST }],
+    });
+    // No ~/.grok/auth.json in the fake home either, so the OR-fallback yields false.
+    expect(r.auth).toBe(false);
+  });
+
+  it("panel OAuth entry with NO expires_at is treated as non-expiring (auth true)", () => {
+    const r = backendReadiness("codex", {
+      home: tmp,
+      now: NOW,
+      oauthStatus: [{ provider: "codex", account_label: "user@example.com", obtained_at: NOW }],
+    });
+    expect(r.auth).toBe(true);
+  });
+
+  it("expired panel entry still yields auth true when the native CLI/file login exists (OR-fallback)", () => {
+    // The external-CLI login path must keep winning regardless of a stale mirror entry.
+    putOnPath(process.platform === "win32" ? "codex.cmd" : "codex");
+    mkdirSync(join(tmp, ".codex"), { recursive: true });
+    writeFileSync(join(tmp, ".codex", "auth.json"), "{}");
+    const r = backendReadiness("codex", {
+      home: tmp,
+      now: NOW,
+      oauthStatus: [{ provider: "codex", account_label: "stale", obtained_at: NOW, expires_at: PAST }],
+    });
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+
+  it("external-CLI login with NO panel OAuth entry still yields auth true (backward-compat)", () => {
+    putOnPath(process.platform === "win32" ? "grok.cmd" : "grok");
+    mkdirSync(join(tmp, ".grok"), { recursive: true });
+    writeFileSync(join(tmp, ".grok", "auth.json"), "{}");
+    const r = backendReadiness("grok", { home: tmp, now: NOW, oauthStatus: [] });
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+  });
+});
+
 describe("allBackendReadiness", () => {
   it("rolls up any_ready (Claude alone makes it true)", () => {
     const { backends, any_ready } = allBackendReadiness(["claude", "codex", "gemini"]);

--- a/src/__tests__/orchestrator/copilot-backend.test.ts
+++ b/src/__tests__/orchestrator/copilot-backend.test.ts
@@ -1,0 +1,289 @@
+// Task 5b: the experimental, isolated GitHub Copilot chat backend.
+//
+// CopilotBackend (copilot-backend.ts) is a thin OllamaBackend subclass reusing
+// the inherited "openai" chat/completions dialect — the only Copilot-specific
+// behavior is (1) the ghu_ -> short-lived Copilot bearer exchange, (2) the
+// extra "editor identity" headers GitHub requires, and (3) the host allowlist.
+// These tests mock `fetch` end-to-end (no real network, no real
+// ~/.comfyui-mcp/copilot-auth.json) and drive the backend through its public
+// AgentBackend surface, mirroring grok-backend-oauth.test.ts's style.
+
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
+import {
+  CopilotBackend,
+  COPILOT_TOKEN_EXCHANGE_URL,
+  COPILOT_API_BASE,
+} from "../../orchestrator/copilot-backend.js";
+import { backendReadiness } from "../../orchestrator/backend-readiness.js";
+import { assertAllowedTokenHost } from "../../services/oauth-flow.js";
+
+/** A push-driven async channel of NeutralTurns (PanelAgent's "channel in" seam) —
+ *  mirrors grok-backend-oauth.test.ts's helper. */
+function makeChannel() {
+  const queue: NeutralTurn[] = [];
+  let resolveNext: ((r: IteratorResult<NeutralTurn>) => void) | null = null;
+  let closed = false;
+  const iterable: AsyncIterable<NeutralTurn> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<NeutralTurn>> {
+          if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+          if (closed) return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise((res) => {
+            resolveNext = res;
+          });
+        },
+      };
+    },
+  };
+  return {
+    iterable,
+    push(t: NeutralTurn) {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: t, done: false });
+      } else queue.push(t);
+    },
+    close() {
+      closed = true;
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: undefined as never, done: true });
+      }
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<void> {
+  return (async () => {
+    for await (const ev of gen) events.push(ev);
+  })();
+}
+
+/** A minimal OpenAI-compatible SSE body: one content delta then [DONE] —
+ *  matches what OllamaBackend's inherited readOpenAiSse() expects. */
+function openAiSseBody(text: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  const frames = [
+    `data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`,
+    `data: ${JSON.stringify({ usage: { prompt_tokens: 5, completion_tokens: 2 } })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f));
+      controller.close();
+    },
+  });
+}
+
+const EXCHANGE_RESPONSE = { token: "copilot-bearer-xyz", expires_at: Math.floor(Date.now() / 1000) + 1800 };
+
+describe("CopilotBackend — ghu_ -> Copilot bearer exchange", () => {
+  it("exchanges the ghu_ token for a short-lived bearer, with editor-identity headers", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === COPILOT_TOKEN_EXCHANGE_URL) {
+        return new Response(JSON.stringify(EXCHANGE_RESPONSE), { status: 200 });
+      }
+      if (url === `${COPILOT_API_BASE}/models`) {
+        return new Response(JSON.stringify({ data: [{ id: "gpt-4.1" }] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    // Stub the GLOBAL fetch too — OllamaBackend's inherited prepare() reachability
+    // check (GET {host}/models) always dials the bare global fetch, not the
+    // injected fetch seam (which this backend only threads through the ghu_
+    // exchange). Both must resolve for prepare() to succeed here.
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolveCopilotOAuthMock = vi.fn(async () => ({ ghuToken: "ghu_abc123" }));
+    const backend = new CopilotBackend({
+      resolveCopilotOAuth: resolveCopilotOAuthMock,
+      fetch: fetchMock,
+    });
+
+    await backend.prepare();
+
+    const exchangeCalls = fetchMock.mock.calls.filter(([u]) => String(u) === COPILOT_TOKEN_EXCHANGE_URL);
+    expect(exchangeCalls).toHaveLength(1);
+    const [, init] = exchangeCalls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("token ghu_abc123");
+    expect(headers["Editor-Version"]).toMatch(/^vscode\//);
+    expect(headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+
+    // The ghu_ never appears bare in a header value beyond the one Authorization
+    // line we just asserted verbatim — no accidental duplication/leak elsewhere.
+    expect(resolveCopilotOAuthMock).toHaveBeenCalledTimes(1);
+
+    await backend.close();
+    vi.unstubAllGlobals();
+  });
+
+  it("caches the exchanged bearer — a second prepare() within the same instance does not re-exchange", async () => {
+    let exchangeCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === COPILOT_TOKEN_EXCHANGE_URL) {
+        exchangeCount++;
+        return new Response(JSON.stringify(EXCHANGE_RESPONSE), { status: 200 });
+      }
+      if (url === `${COPILOT_API_BASE}/models`) {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const backend = new CopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_abc123" }),
+      fetch: fetchMock,
+    });
+
+    await backend.prepare();
+    // prepare() is idempotent on the OllamaBackend `prepared` guard, but the
+    // token-freshness check runs every call — a fresh (non-expiring) cached
+    // bearer must still short-circuit the exchange.
+    await backend.prepare();
+    expect(exchangeCount).toBe(1);
+
+    await backend.close();
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces a 403 exchange failure with a re-sign-in hint, without leaking the ghu_", async () => {
+    const fetchMock = vi.fn(async () => new Response("Forbidden", { status: 403 }));
+    const backend = new CopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_supersecret" }),
+      fetch: fetchMock,
+    });
+
+    await expect(backend.prepare()).rejects.toThrow(/re-run copilot sign-in/i);
+    // Confirm the rejection message never contains the raw ghu_ value.
+    try {
+      await backend.prepare();
+    } catch (err) {
+      expect(String(err)).not.toContain("ghu_supersecret");
+    }
+    await backend.close();
+  });
+});
+
+describe("CopilotBackend — chat turn hits api.githubcopilot.com", () => {
+  it("sends the Bearer + Copilot-Integration-Id + Editor-Version headers on chat/completions", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === COPILOT_TOKEN_EXCHANGE_URL) {
+        return new Response(JSON.stringify(EXCHANGE_RESPONSE), { status: 200 });
+      }
+      if (url === `${COPILOT_API_BASE}/models`) {
+        return new Response(JSON.stringify({ data: [{ id: "gpt-4.1" }] }), { status: 200 });
+      }
+      if (url === `${COPILOT_API_BASE}/chat/completions`) {
+        return new Response(openAiSseBody("hello from Copilot"), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = new CopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_abc123" }),
+      // no `fetch` override here — proves the chat path rides the GLOBAL fetch
+      // (OllamaBackend's inherited chatStream), while the exchange also works
+      // against the same stubbed global.
+    });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    const chatCalls = fetchMock.mock.calls.filter(([u]) => String(u) === `${COPILOT_API_BASE}/chat/completions`);
+    expect(chatCalls).toHaveLength(1);
+    const [, init] = chatCalls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer copilot-bearer-xyz");
+    expect(headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+    expect(headers["Editor-Version"]).toMatch(/^vscode\//);
+    expect(headers["Editor-Plugin-Version"]).toBeTruthy();
+    expect(headers["User-Agent"]).toMatch(/GitHubCopilotChat/);
+
+    const replyDeltas = events
+      .filter((e): e is Extract<AgentEvent, { type: "assistant_delta" }> => e.type === "assistant_delta")
+      .map((e) => e.text)
+      .join("");
+    expect(replyDeltas).toBe("hello from Copilot");
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+
+    await backend.close();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("CopilotBackend — host allowlist", () => {
+  it("assertAllowedTokenHost rejects a non-allowlisted override of the exchange URL", () => {
+    expect(() =>
+      assertAllowedTokenHost("https://evil.example.com/copilot_internal/v2/token", [
+        "github.com",
+        "githubcopilot.com",
+      ]),
+    ).toThrow(/not in allowlist/i);
+  });
+
+  it("accepts the real exchange + chat hosts", () => {
+    expect(() =>
+      assertAllowedTokenHost(COPILOT_TOKEN_EXCHANGE_URL, ["github.com", "githubcopilot.com"]),
+    ).not.toThrow();
+    expect(() =>
+      assertAllowedTokenHost(`${COPILOT_API_BASE}/chat/completions`, ["github.com", "githubcopilot.com"]),
+    ).not.toThrow();
+  });
+
+  it("refuses a plain-HTTP override (non-HTTPS) even if the host matches", () => {
+    expect(() =>
+      assertAllowedTokenHost("http://api.githubcopilot.com/chat/completions", ["githubcopilot.com"]),
+    ).toThrow(/non-https/i);
+  });
+});
+
+describe("CopilotBackend — identity + KNOWN_BACKENDS / readiness wiring", () => {
+  it("identifies itself as the 'copilot' backend with vision disabled (text-only 6-tool router)", () => {
+    const backend = new CopilotBackend({ resolveCopilotOAuth: async () => ({ ghuToken: "ghu_x" }) });
+    expect(backend.id).toBe("copilot");
+    expect(backend.capabilities.vision).toBe(false);
+    expect(backend.capabilities.persistentChannel).toBe(true);
+  });
+
+  it("readiness reports copilot as ready + experimental once a panel OAuth status exists", () => {
+    const now = Date.now();
+    const r = backendReadiness("copilot", {
+      oauthStatus: [{ provider: "copilot", account_label: "GitHub Copilot", obtained_at: now, experimental: true }],
+      now,
+    });
+    expect(r).toEqual({ backend: "copilot", cli: true, auth: true, ready: true, experimental: true });
+  });
+
+  it("readiness reports copilot as NOT ready (but still experimental) with no sign-in on record", () => {
+    const r = backendReadiness("copilot", { oauthStatus: [], now: Date.now() });
+    expect(r).toEqual({ backend: "copilot", cli: true, auth: false, ready: false, experimental: true });
+  });
+});

--- a/src/__tests__/orchestrator/copilot-backend.test.ts
+++ b/src/__tests__/orchestrator/copilot-backend.test.ts
@@ -8,7 +8,7 @@
 // ~/.comfyui-mcp/copilot-auth.json) and drive the backend through its public
 // AgentBackend surface, mirroring grok-backend-oauth.test.ts's style.
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 import {
   CopilotBackend,
@@ -262,6 +262,117 @@ describe("CopilotBackend — host allowlist", () => {
     expect(() =>
       assertAllowedTokenHost("http://api.githubcopilot.com/chat/completions", ["githubcopilot.com"]),
     ).toThrow(/non-https/i);
+  });
+});
+
+// The bare-function tests above prove assertAllowedTokenHost's logic; these
+// drive it through a REAL CopilotBackend so a regression that forgets to call
+// it on the chat/models base (the exact reviewer finding) is caught. Both use a
+// fresh module import so the env-driven COPILOT_API_BASE const reflects the
+// stubbed override.
+describe("CopilotBackend — host allowlist on the chat/models base (not just the exchange)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("rejects an off-host COMFYUI_MCP_COPILOT_API_BASE before any bearer-bearing request", async () => {
+    vi.stubEnv("COMFYUI_MCP_COPILOT_API_BASE", "https://evil.example.com");
+    vi.resetModules();
+    const { CopilotBackend: FreshCopilotBackend, COPILOT_TOKEN_EXCHANGE_URL: EX_URL } = await import(
+      "../../orchestrator/copilot-backend.js"
+    );
+
+    // A fetch mock that succeeds the exchange but records EVERY call, so we can
+    // assert the bearer never reached evil.example.com.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === EX_URL) {
+        return new Response(JSON.stringify(EXCHANGE_RESPONSE), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = new FreshCopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_abc123" }),
+      fetch: fetchMock,
+    });
+
+    await expect(backend.prepare()).rejects.toThrow(/not in allowlist/i);
+
+    // The bearer was NEVER attached to an evil.example.com request — the only
+    // call that fired was the (allowlisted) github.com exchange.
+    const offHostCalls = fetchMock.mock.calls.filter(([u]) => String(u).includes("evil.example.com"));
+    expect(offHostCalls).toHaveLength(0);
+
+    await backend.close();
+  });
+
+  it("accepts the default api.githubcopilot.com base (no override)", async () => {
+    vi.resetModules();
+    const {
+      CopilotBackend: FreshCopilotBackend,
+      COPILOT_TOKEN_EXCHANGE_URL: EX_URL,
+      COPILOT_API_BASE: API_BASE,
+    } = await import("../../orchestrator/copilot-backend.js");
+    expect(API_BASE).toBe("https://api.githubcopilot.com");
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === EX_URL) return new Response(JSON.stringify(EXCHANGE_RESPONSE), { status: 200 });
+      if (url === `${API_BASE}/models`) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = new FreshCopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_abc123" }),
+      fetch: fetchMock,
+    });
+
+    await expect(backend.prepare()).resolves.toBeUndefined();
+    await backend.close();
+  });
+
+  it("ignores a non-allowlisted endpoints.api from the exchange and falls back to the default base", async () => {
+    vi.resetModules();
+    const {
+      CopilotBackend: FreshCopilotBackend,
+      COPILOT_TOKEN_EXCHANGE_URL: EX_URL,
+      COPILOT_API_BASE: API_BASE,
+    } = await import("../../orchestrator/copilot-backend.js");
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === EX_URL) {
+        // The server advertises an off-allowlist api host — it must be dropped.
+        return new Response(
+          JSON.stringify({ ...EXCHANGE_RESPONSE, endpoints: { api: "https://evil.example.com" } }),
+          { status: 200 },
+        );
+      }
+      if (url === `${API_BASE}/models`) return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backend = new FreshCopilotBackend({
+      resolveCopilotOAuth: async () => ({ ghuToken: "ghu_abc123" }),
+      fetch: fetchMock,
+    });
+
+    // prepare() succeeds (fell back to the default base) and NO request ever
+    // went to the advertised evil host.
+    await expect(backend.prepare()).resolves.toBeUndefined();
+    const offHostCalls = fetchMock.mock.calls.filter(([u]) => String(u).includes("evil.example.com"));
+    expect(offHostCalls).toHaveLength(0);
+    // The reachability check DID hit the default githubcopilot.com base.
+    const modelsCalls = fetchMock.mock.calls.filter(([u]) => String(u) === `${API_BASE}/models`);
+    expect(modelsCalls).toHaveLength(1);
+
+    await backend.close();
   });
 });
 

--- a/src/__tests__/orchestrator/grok-backend-oauth.test.ts
+++ b/src/__tests__/orchestrator/grok-backend-oauth.test.ts
@@ -1,0 +1,284 @@
+// Task 6: direct-token vs ACP/CLI selection for the Grok backend.
+//
+// GrokBackend (grok-backend.ts) decides ONCE, per instance, whether a direct
+// xAI OAuth token is usable (via the injected `resolveGrokOAuth` test seam) and
+// either delegates every AgentBackend call to an internal GrokDirectBackend (hits
+// `https://api.x.ai/v1/responses`) or falls through to its own unchanged
+// ACP/CLI body (spawns `grok agent ... stdio`). These tests drive that decision
+// from both sides without touching the real filesystem: `node:child_process` is
+// mocked (so the ACP fallback never needs a real `grok` binary) and `fetch` is
+// mocked (so the direct path never dials the real network).
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { AgentEvent, NeutralTurn, BackendStartOptions } from "../../orchestrator/agent-backend.js";
+
+// ---- node:child_process mock: a minimal fake ACP server, just enough to prove
+// the ACP path is actually reachable (handshake → session/new → one completed
+// turn) when the fallback engages. Mirrors grok-backend.test.ts's fake server,
+// trimmed to the single "complete immediately" behavior this file needs. ----
+const hoisted = vi.hoisted(() => ({
+  spawnCalls: [] as Array<{ cmd: string; args: string[] }>,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+
+  function makeFakeProc() {
+    const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    proc.pid = 4242;
+    proc.exitCode = null;
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    proc.stdin = stdin;
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.kill = () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+      return true;
+    };
+    stdin.on("finish", () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+    });
+
+    const write = (obj: unknown) => stdout.write(`${JSON.stringify(obj)}\n`);
+    const SESSION_ID = "sess-acp-fallback";
+
+    let buf = "";
+    stdin.on("data", (chunk: Buffer) => {
+      buf += String(chunk);
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const method = msg.method as string | undefined;
+        const id = msg.id as number | string | undefined;
+        if (method === "initialize" && id !== undefined) {
+          write({
+            jsonrpc: "2.0",
+            id,
+            result: { protocolVersion: 1, agentCapabilities: {}, agentInfo: { name: "grok" }, authMethods: [] },
+          });
+        } else if (method === "session/new" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: { sessionId: SESSION_ID } });
+        } else if (method === "session/prompt" && id !== undefined) {
+          const sessionId = (msg.params as { sessionId: string }).sessionId;
+          setImmediate(() => {
+            write({
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId,
+                update: { sessionUpdate: "agent_message_chunk", messageId: "m1", content: { type: "text", text: "hi from ACP" } },
+              },
+            });
+            write({ jsonrpc: "2.0", id, result: { stopReason: "end_turn" } });
+          });
+        }
+      }
+    });
+
+    return proc;
+  }
+
+  return {
+    ...actual,
+    spawn: (cmd: string, args: string[]) => {
+      hoisted.spawnCalls.push({ cmd, args: Array.isArray(args) ? args : [] });
+      return makeFakeProc();
+    },
+    spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
+  };
+});
+
+let GrokBackend: typeof import("../../orchestrator/grok-backend.js").GrokBackend;
+
+beforeEach(async () => {
+  hoisted.spawnCalls.length = 0;
+  vi.resetModules();
+  ({ GrokBackend } = await import("../../orchestrator/grok-backend.js"));
+});
+
+/** A push-driven async channel of NeutralTurns (PanelAgent's "channel in" seam). */
+function makeChannel() {
+  const queue: NeutralTurn[] = [];
+  let resolveNext: ((r: IteratorResult<NeutralTurn>) => void) | null = null;
+  let closed = false;
+  const iterable: AsyncIterable<NeutralTurn> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<NeutralTurn>> {
+          if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+          if (closed) return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise((res) => {
+            resolveNext = res;
+          });
+        },
+      };
+    },
+  };
+  return {
+    iterable,
+    push(t: NeutralTurn) {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: t, done: false });
+      } else queue.push(t);
+    },
+    close() {
+      closed = true;
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: undefined as never, done: true });
+      }
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<void> {
+  return (async () => {
+    for await (const ev of gen) events.push(ev);
+  })();
+}
+
+/** A minimal SSE body for the xAI Responses endpoint: one text delta then completed. */
+function sseResponsesBody(text: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  const frames = [
+    `data: ${JSON.stringify({ type: "response.output_text.delta", delta: text })}\n\n`,
+    `data: ${JSON.stringify({ type: "response.completed", response: { usage: { input_tokens: 3, output_tokens: 2 } } })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(enc.encode(f));
+      controller.close();
+    },
+  });
+}
+
+describe("GrokBackend — direct-token vs ACP/CLI selection", () => {
+  it("prefers the direct xAI OAuth path when resolveGrokOAuth resolves a token", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://api.x.ai/v1/responses") {
+        return new Response(sseResponsesBody("hello from xAI"), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolveGrokOAuthMock = vi.fn(async () => ({ accessToken: "xai-token-abc" }));
+    const backend = new GrokBackend({ resolveGrokOAuth: resolveGrokOAuthMock });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // The OAuth resolver was consulted, and NO grok CLI process was ever spawned.
+    expect(resolveGrokOAuthMock).toHaveBeenCalled();
+    expect(hoisted.spawnCalls).toHaveLength(0);
+
+    // The direct path hit the xAI Responses endpoint with a Bearer token — and
+    // the token never leaked into a header/body a naive log line would echo.
+    const responsesCalls = fetchMock.mock.calls.filter(([u]) => String(u) === "https://api.x.ai/v1/responses");
+    expect(responsesCalls).toHaveLength(1);
+    const init = responsesCalls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer xai-token-abc");
+
+    // The turn completed normally through the direct-token path.
+    const replyDeltas = events
+      .filter((e): e is Extract<AgentEvent, { type: "assistant_delta" }> => e.type === "assistant_delta")
+      .map((e) => e.text)
+      .join("");
+    expect(replyDeltas).toBe("hello from xAI");
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true });
+
+    await backend.close();
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to the ACP/CLI path when resolveGrokOAuth rejects (no ~/.grok/auth.json)", async () => {
+    const fetchMock = vi.fn(async () => new Response("should not be called", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolveGrokOAuthMock = vi.fn(async () => {
+      throw new Error("Grok OAuth requires signing in via the panel's Connections tab first.");
+    });
+    const backend = new GrokBackend({ cwd: process.cwd(), resolveGrokOAuth: resolveGrokOAuthMock });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // The OAuth resolver was consulted and rejected, so the ACP/CLI path engaged:
+    // the fake `grok agent ... stdio` process was spawned, and xAI's HTTP
+    // endpoint was never dialed.
+    expect(resolveGrokOAuthMock).toHaveBeenCalled();
+    expect(hoisted.spawnCalls).toHaveLength(1);
+    expect(hoisted.spawnCalls[0]!.args).toContain("agent");
+    expect(hoisted.spawnCalls[0]!.args).toContain("stdio");
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // The ACP session/turn completed normally — no behavior change on this path.
+    expect(events[0]).toMatchObject({ type: "session", sessionId: "sess-acp-fallback" });
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true, subtype: "end_turn" });
+
+    await backend.close();
+    vi.unstubAllGlobals();
+  });
+
+  it("memoizes the mode decision — resolveGrokOAuth is consulted only once per instance", async () => {
+    const resolveGrokOAuthMock = vi.fn(async () => {
+      throw new Error("no token file");
+    });
+    const backend = new GrokBackend({ cwd: process.cwd(), resolveGrokOAuth: resolveGrokOAuthMock });
+
+    await backend.listModels();
+    await backend.setModel("grok-build");
+    await backend.interrupt(); // no-op (idle), still goes through the same memoized decision
+
+    expect(resolveGrokOAuthMock).toHaveBeenCalledTimes(1);
+    await backend.close();
+  });
+});

--- a/src/__tests__/orchestrator/grok-backend-oauth.test.ts
+++ b/src/__tests__/orchestrator/grok-backend-oauth.test.ts
@@ -207,9 +207,15 @@ describe("GrokBackend — direct-token vs ACP/CLI selection", () => {
     channel.close();
     await run;
 
-    // The OAuth resolver was consulted, and NO grok CLI process was ever spawned.
-    expect(resolveGrokOAuthMock).toHaveBeenCalled();
+    // The OAuth resolver was probed EXACTLY ONCE on the success path (the mode
+    // decision resolves the creds and threads them into the direct backend's
+    // prepare(), which must NOT re-resolve), and NO grok CLI process was spawned.
+    expect(resolveGrokOAuthMock).toHaveBeenCalledTimes(1);
     expect(hoisted.spawnCalls).toHaveLength(0);
+
+    // Direct mode must NOT advertise vision:true — the xAI vision contract is
+    // unverified and the 6-tool-router path would silently drop images.
+    expect(backend.capabilities.vision).toBe(false);
 
     // The direct path hit the xAI Responses endpoint with a Bearer token — and
     // the token never leaked into a header/body a naive log line would echo.
@@ -263,6 +269,10 @@ describe("GrokBackend — direct-token vs ACP/CLI selection", () => {
     const results = events.filter((e) => e.type === "result");
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({ ok: true, subtype: "end_turn" });
+
+    // Once ACP mode is resolved, the facade reports the full ACP capabilities —
+    // vision:true is honest here (the ACP path DOES forward inline image blocks).
+    expect(backend.capabilities.vision).toBe(true);
 
     await backend.close();
     vi.unstubAllGlobals();

--- a/src/__tests__/orchestrator/grok-backend.test.ts
+++ b/src/__tests__/orchestrator/grok-backend.test.ts
@@ -1,0 +1,418 @@
+// Unit tests for the Grok CLI ACP backend (grok-backend.ts).
+//
+// We CANNOT run the real `grok` CLI here, so we drive the REAL GrokBackend /
+// AcpClient code end-to-end against a FAKE ACP server spoken over a mocked
+// child_process. `node:child_process` is mocked so `spawn()` returns an in-process
+// fake child whose stdin/stdout are wired to a tiny JSON-RPC-2.0 ACP server that
+// implements the handshake (initialize → session/new), one streamed prompt turn
+// (agent_thought_chunk + tool_call + tool_call_update + agent_message_chunk, then
+// a session/prompt response with stopReason), and session/cancel. This exercises
+// the line framing, the request/response correlation, the session/update →
+// AgentEvent mapping, the terminal-result invariant, and interrupt — all
+// deterministically, with no real binary.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type {
+  AgentEvent,
+  NeutralTurn,
+  BackendStartOptions,
+} from "../../orchestrator/agent-backend.js";
+
+// ---- shared state the mocked child_process writes into / the tests read ----
+const hoisted = vi.hoisted(() => ({
+  // The spawned fake procs (one per backend prepare()).
+  procs: [] as Array<Record<string, unknown>>,
+  // The argv passed to spawn() for each spawned proc (to assert --model pinning).
+  spawnArgs: [] as string[][],
+  // Every JSON-RPC message the client SENT to the server (requests + notifications).
+  received: [] as Array<Record<string, unknown>>,
+  // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
+  // "cancel" streams a bit then WAITS for session/cancel before resolving.
+  config: { mode: "complete" as "complete" | "cancel" },
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+
+  function makeFakeProc() {
+    const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    proc.pid = 4242;
+    proc.exitCode = null;
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    proc.stdin = stdin;
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.kill = () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+      return true;
+    };
+    // When the client ends stdin (close()), surface a clean child exit so
+    // AcpClient.exitPromise resolves and close() returns.
+    stdin.on("finish", () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 0;
+        proc.emit("exit", 0, null);
+      }
+    });
+
+    const write = (obj: unknown) => stdout.write(`${JSON.stringify(obj)}\n`);
+    const notify = (sessionId: string, update: Record<string, unknown>) =>
+      write({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update } });
+
+    // Drive a streamed prompt turn, then resolve the request (or wait for cancel).
+    let pendingPromptId: number | string | null = null;
+    const SESSION_ID = "sess-test-1";
+
+    const streamTurn = (id: number | string, sessionId: string) => {
+      // Reasoning (thinking) chunk.
+      notify(sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "thinking..." },
+      });
+      // A tool call (start → completed).
+      notify(sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "panel_run",
+        kind: "other",
+        status: "pending",
+      });
+      notify(sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call_1",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "ran" } }],
+      });
+      // Reply message in two chunks (same messageId groups them).
+      notify(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "msg_1",
+        content: { type: "text", text: "Hello" },
+      });
+      notify(sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "msg_1",
+        content: { type: "text", text: " there!" },
+      });
+      if (hoisted.config.mode === "complete") {
+        write({ jsonrpc: "2.0", id, result: { stopReason: "end_turn" } });
+      } else {
+        // Park the prompt; session/cancel will resolve it.
+        pendingPromptId = id;
+      }
+    };
+
+    // Read newline-framed JSON-RPC from the client's stdin.
+    let buf = "";
+    stdin.on("data", (chunk: Buffer) => {
+      buf += String(chunk);
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        hoisted.received.push(msg);
+        const method = msg.method as string | undefined;
+        const id = msg.id as number | string | undefined;
+        if (method === "initialize" && id !== undefined) {
+          write({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: 1,
+              agentCapabilities: {
+                loadSession: true,
+                promptCapabilities: { image: true, audio: false, embeddedContext: true },
+                mcpCapabilities: { http: true, sse: false },
+              },
+              agentInfo: { name: "grok", title: "Grok", version: "test" },
+              authMethods: [],
+            },
+          });
+        } else if (method === "session/new" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: { sessionId: SESSION_ID } });
+        } else if (method === "session/load" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: {} });
+        } else if (method === "authenticate" && id !== undefined) {
+          write({ jsonrpc: "2.0", id, result: {} });
+        } else if (method === "session/prompt" && id !== undefined) {
+          // Stream on the next tick so the request is registered first.
+          setImmediate(() => streamTurn(id, (msg.params as { sessionId: string }).sessionId));
+        } else if (method === "session/cancel") {
+          if (pendingPromptId !== null) {
+            const pid = pendingPromptId;
+            pendingPromptId = null;
+            write({ jsonrpc: "2.0", id: pid, result: { stopReason: "cancelled" } });
+          }
+        }
+      }
+    });
+
+    hoisted.procs.push(proc);
+    return proc;
+  }
+
+  return {
+    ...actual,
+    spawn: (_cmd: string, args: string[]) => {
+      hoisted.spawnArgs.push(Array.isArray(args) ? args : []);
+      return makeFakeProc();
+    },
+    // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
+    spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
+  };
+});
+
+let GrokBackend: typeof import("../../orchestrator/grok-backend.js").GrokBackend;
+
+beforeEach(async () => {
+  hoisted.procs.length = 0;
+  hoisted.spawnArgs.length = 0;
+  hoisted.received.length = 0;
+  hoisted.config.mode = "complete";
+  ({ GrokBackend } = await import("../../orchestrator/grok-backend.js"));
+});
+
+/** A push-driven async channel of NeutralTurns (PanelAgent's "channel in" seam). */
+function makeChannel() {
+  const queue: NeutralTurn[] = [];
+  let resolveNext: ((r: IteratorResult<NeutralTurn>) => void) | null = null;
+  let closed = false;
+  const iterable: AsyncIterable<NeutralTurn> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<NeutralTurn>> {
+          if (queue.length) return Promise.resolve({ value: queue.shift()!, done: false });
+          if (closed) return Promise.resolve({ value: undefined as never, done: true });
+          return new Promise((res) => {
+            resolveNext = res;
+          });
+        },
+      };
+    },
+  };
+  return {
+    iterable,
+    push(t: NeutralTurn) {
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: t, done: false });
+      } else queue.push(t);
+    },
+    close() {
+      closed = true;
+      if (resolveNext) {
+        const r = resolveNext;
+        resolveNext = null;
+        r({ value: undefined as never, done: true });
+      }
+    },
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Start consuming a backend.run() generator into an events array. */
+function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<void> {
+  return (async () => {
+    for await (const ev of gen) events.push(ev);
+  })();
+}
+
+describe("GrokBackend (ACP over stdio)", () => {
+  it("handshake → prompt → streamed updates → result maps to the canonical AgentEvent sequence", async () => {
+    const backend = new GrokBackend({ cwd: process.cwd(), systemAppend: "BE NICE." });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const opts: BackendStartOptions = { channel: channel.iterable };
+    const run = consume(backend.run(opts), events);
+
+    channel.push({ text: "hi there" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // session event first, carrying the ACP sessionId.
+    expect(events[0]).toMatchObject({ type: "session", sessionId: "sess-test-1" });
+
+    // Thinking delta surfaced (agent_thought_chunk → assistant_delta thinking:true).
+    expect(events.some((e) => e.type === "assistant_delta" && e.thinking === true)).toBe(true);
+
+    // Reply deltas concatenate to the full message.
+    const replyDeltas = events
+      .filter((e): e is Extract<AgentEvent, { type: "assistant_delta" }> => e.type === "assistant_delta" && !e.thinking)
+      .map((e) => e.text)
+      .join("");
+    expect(replyDeltas).toBe("Hello there!");
+
+    // Tool call start + end both surfaced with the tool's title as the name.
+    const toolStart = events.find((e) => e.type === "tool_call" && e.phase === "start");
+    const toolEnd = events.find((e) => e.type === "tool_call" && e.phase === "end");
+    expect(toolStart).toMatchObject({ type: "tool_call", name: "panel_run", phase: "start" });
+    expect(toolEnd).toMatchObject({ type: "tool_call", name: "panel_run", phase: "end" });
+
+    // Exactly one committed assistant message with the full reply + its stream id.
+    const assistants = events.filter((e) => e.type === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]).toMatchObject({ type: "assistant", text: "Hello there!", id: "msg_1" });
+
+    // Exactly one terminal result (the "exactly one result" invariant), ok + subtype.
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: "result", ok: true, subtype: "end_turn" });
+
+    // Stream bubbles are balanced (every stream_start has a stream_end).
+    const starts = events.filter((e) => e.type === "stream_start").length;
+    const ends = events.filter((e) => e.type === "stream_end").length;
+    expect(starts).toBe(ends);
+    expect(starts).toBeGreaterThanOrEqual(2); // a thinking stream + a reply stream
+
+    // The handshake + session were established and the prompt carried the persona
+    // preamble (ACP session/new has no instructions field) as the first text block.
+    const methods = hoisted.received.map((m) => m.method);
+    expect(methods).toContain("initialize");
+    expect(methods).toContain("session/new");
+    const promptMsg = hoisted.received.find((m) => m.method === "session/prompt");
+    expect(promptMsg).toBeTruthy();
+    const promptBlocks = (promptMsg!.params as { prompt: Array<{ type: string; text?: string }> }).prompt;
+    expect(promptBlocks[0].type).toBe("text");
+    expect(promptBlocks[0].text).toContain("<system>");
+    expect(promptBlocks[0].text).toContain("BE NICE.");
+    expect(promptBlocks[0].text).toContain("hi there");
+
+    await backend.close();
+  });
+
+  it("interrupt() sends session/cancel and the turn ends with a single cancelled result", async () => {
+    hoisted.config.mode = "cancel";
+    const backend = new GrokBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "do a long thing" });
+    // Wait until the stream has started (proves the turn is in flight) before cancelling.
+    await waitFor(() => events.some((e) => e.type === "assistant_delta"));
+
+    await backend.interrupt();
+
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // The client sent a session/cancel for the live session.
+    const cancel = hoisted.received.find((m) => m.method === "session/cancel");
+    expect(cancel).toBeTruthy();
+    expect((cancel!.params as { sessionId: string }).sessionId).toBe("sess-test-1");
+
+    // Exactly one terminal result, marked not-ok with the cancelled stopReason.
+    const results = events.filter((e) => e.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ type: "result", ok: false, subtype: "cancelled" });
+
+    await backend.close();
+  });
+
+  it("listModels returns the static Grok catalog (no effort metadata)", async () => {
+    const backend = new GrokBackend();
+    const models = await backend.listModels();
+    expect(models.map((m) => m.id)).toEqual(["grok-composer-2.5-fast", "grok-build"]);
+    // Grok has no discrete effort scale → no effort metadata (panel hides picker).
+    expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
+  });
+
+  it("applies the panel-selected model to the FIRST spawn (--model) before prepare", async () => {
+    const backend = new GrokBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable, model: "grok-build" }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(hoisted.spawnArgs[0]).toContain("agent");
+    expect(hoisted.spawnArgs[0]).toContain("--always-approve");
+    expect(hoisted.spawnArgs[0]).toContain("stdio");
+    expect(hoisted.spawnArgs[0]).toContain("--model");
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("grok-build");
+
+    await backend.close();
+  });
+
+  it("a live setModel() respawns the CLI with the new --model and a fresh session", async () => {
+    const backend = new GrokBackend({ cwd: process.cwd(), model: "grok-composer-2.5-fast" });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "turn one" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 1);
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("grok-composer-2.5-fast");
+
+    await backend.setModel("grok-build");
+
+    channel.push({ text: "turn two" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 2);
+    channel.close();
+    await run;
+
+    expect(hoisted.spawnArgs).toHaveLength(2);
+    expect(hoisted.spawnArgs[1]).toContain("agent");
+    expect(hoisted.spawnArgs[1][hoisted.spawnArgs[1].indexOf("--model") + 1]).toBe("grok-build");
+
+    // The respawn opened a fresh session → a second `session` event was emitted.
+    expect(events.filter((e) => e.type === "session").length).toBe(2);
+    // Both turns completed cleanly.
+    expect(events.filter((e) => e.type === "result").every((r) => (r as { ok: boolean }).ok)).toBe(true);
+
+    await backend.close();
+  });
+
+  it("ignores a non-Grok model id passed to setModel (e.g. the Claude panel model)", async () => {
+    const backend = new GrokBackend({ cwd: process.cwd(), model: "grok-composer-2.5-fast" });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "turn one" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 1);
+
+    // PanelAgent may relay the Claude panel model — it must NOT respawn Grok.
+    await backend.setModel("claude-opus-4-8");
+
+    channel.push({ text: "turn two" });
+    await waitFor(() => events.filter((e) => e.type === "result").length >= 2);
+    channel.close();
+    await run;
+
+    // Still only one spawn (no respawn), and only one session.
+    expect(hoisted.spawnArgs).toHaveLength(1);
+    expect(events.filter((e) => e.type === "session").length).toBe(1);
+
+    await backend.close();
+  });
+});

--- a/src/__tests__/orchestrator/grok-backend.test.ts
+++ b/src/__tests__/orchestrator/grok-backend.test.ts
@@ -177,13 +177,32 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 let GrokBackend: typeof import("../../orchestrator/grok-backend.js").GrokBackend;
+let buildAcpMcpServers: typeof import("../../orchestrator/grok-backend.js").buildAcpMcpServers;
 
 beforeEach(async () => {
   hoisted.procs.length = 0;
   hoisted.spawnArgs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
-  ({ GrokBackend } = await import("../../orchestrator/grok-backend.js"));
+  ({ GrokBackend, buildAcpMcpServers } = await import("../../orchestrator/grok-backend.js"));
+});
+
+describe("buildAcpMcpServers", () => {
+  it("serializes HTTP panel MCP as SSE with empty headers (Grok rejects type:http)", () => {
+    const out = buildAcpMcpServers({
+      comfyui: { transport: "stdio", command: "node", args: ["mcp.js"], env: { FOO: "bar" } },
+      panel: { transport: "http", url: "http://127.0.0.1:9181/tab-1" },
+    });
+    expect(out).toEqual([
+      {
+        name: "comfyui",
+        command: "node",
+        args: ["mcp.js"],
+        env: [{ name: "FOO", value: "bar" }],
+      },
+      { type: "sse", name: "panel", url: "http://127.0.0.1:9181/tab-1", headers: [] },
+    ]);
+  });
 });
 
 /** A push-driven async channel of NeutralTurns (PanelAgent's "channel in" seam). */

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveGlmCodeCredentials,
+  resolveKimiCodeOAuth,
+  resolveOpenAICodexOAuth,
+  __testing,
+} from "../../services/code-provider-auth.js";
+
+describe("resolveGlmCodeCredentials", () => {
+  const keys = ["ZAI_API_KEY", "GLM_API_KEY", "ZHIPUAI_API_KEY", "ZHIPU_API_KEY"] as const;
+
+  afterEach(() => {
+    for (const k of keys) delete process.env[k];
+    delete process.env.COMFYUI_MCP_GLM_BASE_URL;
+  });
+
+  it("reads ZAI_API_KEY and default base URL", () => {
+    process.env.ZAI_API_KEY = "zai-test-key";
+    const creds = resolveGlmCodeCredentials();
+    expect(creds.apiKey).toBe("zai-test-key");
+    expect(creds.baseUrl).toBe(__testing.GLM_CODE_DEFAULT_BASE);
+  });
+
+  it("throws when no GLM key is set", () => {
+    expect(() => resolveGlmCodeCredentials()).toThrow(/ZAI_API_KEY/);
+  });
+});
+
+describe("resolveOpenAICodexOAuth", () => {
+  let home = "";
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "codex-oauth-test-"));
+  });
+
+  afterEach(async () => {
+    if (home) await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns access token and account id from auth.json", async () => {
+    const dir = join(home, ".codex");
+    await mkdir(dir, { recursive: true });
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+    await writeFile(
+      join(dir, "auth.json"),
+      JSON.stringify({
+        auth_mode: "chatgpt",
+        tokens: {
+          access_token: `hdr.${payload}.sig`,
+          refresh_token: "rt-1",
+          account_id: "acct-123",
+        },
+      }),
+      "utf8",
+    );
+
+    const creds = await resolveOpenAICodexOAuth({ home, now: () => Date.now() });
+    expect(creds.accessToken).toMatch(/^hdr\./);
+    expect(creds.accountId).toBe("acct-123");
+  });
+});
+
+describe("resolveKimiCodeOAuth", () => {
+  let home = "";
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kimi-oauth-test-"));
+  });
+
+  afterEach(async () => {
+    if (home) await rm(home, { recursive: true, force: true });
+    delete process.env.KIMI_API_KEY;
+  });
+
+  it("prefers KIMI_API_KEY when set", async () => {
+    process.env.KIMI_API_KEY = "kimi-api-key";
+    const creds = await resolveKimiCodeOAuth({ home });
+    expect(creds.accessToken).toBe("kimi-api-key");
+    expect(creds.baseUrl).toBe(__testing.KIMI_CODE_DEFAULT_BASE);
+  });
+
+  it("refreshes expired kimi-code.json tokens", async () => {
+    const credDir = join(home, ".kimi", "credentials");
+    await mkdir(credDir, { recursive: true });
+    await writeFile(
+      join(credDir, "kimi-code.json"),
+      JSON.stringify({
+        access_token: "stale",
+        refresh_token: "rt-kimi",
+        expires_at: Math.floor(Date.now() / 1000) - 60,
+      }),
+      "utf8",
+    );
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          access_token: "fresh-kimi",
+          refresh_token: "rt-kimi-2",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const creds = await resolveKimiCodeOAuth({
+      home,
+      fetch: fetchMock as typeof fetch,
+      now: () => Date.now(),
+    });
+    expect(creds.accessToken).toBe("fresh-kimi");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const saved = JSON.parse(await readFile(join(credDir, "kimi-code.json"), "utf8")) as {
+      access_token?: string;
+    };
+    expect(saved.access_token).toBe("fresh-kimi");
+  });
+});

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -18,7 +18,8 @@ export type BackendId =
   | "glm"
   | "kimi"
   | "ollama"
-  | "openrouter";
+  | "openrouter"
+  | "copilot";
 
 /**
  * A user turn in PROVIDER-NEUTRAL form. PanelAgent owns the queue/turn-gate and
@@ -286,5 +287,13 @@ export const GLM_CAPABILITIES: AgentCapabilities = {
 
 /** Kimi Code subscription OAuth or KIMI_API_KEY — OpenAI-compatible coding API. */
 export const KIMI_CAPABILITIES: AgentCapabilities = {
+  ...OLLAMA_CAPABILITIES,
+};
+
+/** GitHub Copilot chat via in-panel device-code OAuth — EXPERIMENTAL (ToS risk,
+ *  see OAUTH_PROVIDERS.copilot). OpenAI-compatible chat/completions + the same
+ *  6-tool router as Ollama/GLM/Kimi. The exact contract (endpoints, headers) is
+ *  UNVERIFIED offline — see copilot-backend.ts's module doc. */
+export const COPILOT_CAPABILITIES: AgentCapabilities = {
   ...OLLAMA_CAPABILITIES,
 };

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -9,7 +9,7 @@
 
 import type { ImageRef } from "./panel-agent.js";
 
-export type BackendId = "claude" | "codex" | "gemini" | "ollama" | "openrouter";
+export type BackendId = "claude" | "codex" | "gemini" | "grok" | "ollama" | "openrouter";
 
 /**
  * A user turn in PROVIDER-NEUTRAL form. PanelAgent owns the queue/turn-gate and
@@ -220,6 +220,21 @@ export const GEMINI_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: true, // gemini-2.5 sees images; delivered as inline base64 image ContentBlocks
+};
+
+/** Capability descriptor for the Grok CLI ACP backend (xAI / Grok Build).
+ *  Same ACP posture as Gemini: persistent session, streaming deltas, interrupt,
+ *  config-declared MCP servers, static model catalog at spawn. */
+export const GROK_CAPABILITIES: AgentCapabilities = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: false,
+  modelEnumeration: true, // grok-composer-2.5-fast / grok-build — ACP exposes no catalog
+  slashCommands: false,
+  hooks: false,
+  vision: true,
 };
 
 /** Capability descriptor for the Ollama local-LLM backend (issue #97's panel

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -9,7 +9,16 @@
 
 import type { ImageRef } from "./panel-agent.js";
 
-export type BackendId = "claude" | "codex" | "gemini" | "grok" | "ollama" | "openrouter";
+export type BackendId =
+  | "claude"
+  | "codex"
+  | "chatgpt"
+  | "gemini"
+  | "grok"
+  | "glm"
+  | "kimi"
+  | "ollama"
+  | "openrouter";
 
 /**
  * A user turn in PROVIDER-NEUTRAL form. PanelAgent owns the queue/turn-gate and
@@ -254,4 +263,28 @@ export const OLLAMA_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: false,
+};
+
+/** ChatGPT subscription via direct Codex OAuth (~/.codex/auth.json) — Codex Responses
+ *  HTTP backend (not the codex app-server CLI). Same 6-tool router as Ollama. */
+export const CHATGPT_CAPABILITIES: AgentCapabilities = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: false,
+  modelEnumeration: true, // ~/.codex/models_cache.json + configured default
+  slashCommands: false,
+  hooks: false,
+  vision: false,
+};
+
+/** Z.AI GLM Coding Plan — OpenAI-compatible /v1/chat/completions. */
+export const GLM_CAPABILITIES: AgentCapabilities = {
+  ...OLLAMA_CAPABILITIES,
+};
+
+/** Kimi Code subscription OAuth or KIMI_API_KEY — OpenAI-compatible coding API. */
+export const KIMI_CAPABILITIES: AgentCapabilities = {
+  ...OLLAMA_CAPABILITIES,
 };

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -117,6 +117,27 @@ export function backendReadiness(
     const auth = fileExists(home, ".codex", "auth.json");
     return { backend: "codex", cli, auth, ready: cli && auth };
   }
+  if (b === "chatgpt") {
+    // Direct Codex OAuth — no CLI; ~/.codex/auth.json from `codex login`.
+    const auth = fileExists(home, ".codex", "auth.json");
+    return { backend: "chatgpt", cli: true, auth, ready: !!auth };
+  }
+  if (b === "glm") {
+    const apiKey =
+      process.env.ZAI_API_KEY?.trim() ||
+      process.env.GLM_API_KEY?.trim() ||
+      process.env.ZHIPUAI_API_KEY?.trim() ||
+      process.env.ZHIPU_API_KEY?.trim();
+    const auth = !!apiKey;
+    return { backend: "glm", cli: true, auth, ready: auth };
+  }
+  if (b === "kimi") {
+    const apiKey = process.env.KIMI_API_KEY?.trim();
+    const kimiShare = process.env.KIMI_SHARE_DIR || join(home, ".kimi");
+    const oauth = fileExists(kimiShare, "credentials", "kimi-code.json");
+    const auth = !!apiKey || oauth;
+    return { backend: "kimi", cli: true, auth, ready: auth };
+  }
   if (b === "gemini") {
     const cli = onPath(CLI_NAMES.gemini);
     // The gemini CLI caches its Google OAuth at <home>/.gemini/oauth_creds.json

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -23,6 +23,11 @@ export type BackendReadiness = {
   auth: boolean | null;
   /** cli && auth-not-false. */
   ready: boolean;
+  /** True only for providers the panel must label/gate as experimental (ToS
+   *  risk, unverified contract) — currently just copilot. Omitted (not merely
+   *  false) for every other backend so this frame stays a pure ADDITION for
+   *  existing consumers/tests. */
+  experimental?: boolean;
 };
 
 // CLI binary names per provider (Windows resolves .cmd/.exe via PATHEXT, but we
@@ -199,8 +204,11 @@ export function backendReadiness(
     // No external CLI/native-file concept for Copilot — the in-panel device-
     // code OAuth (experimental, gated behind allow_experimental in
     // oauth-bridge.ts) is the ONLY sign-in path, so it's the only signal here.
+    // `experimental: true` lets the panel (Task 7) label/gate this row even
+    // once signed in — this backend is opt-in ToS-risk territory, never a
+    // default or auto-pick.
     const auth = hasValidPanelOAuth("copilot", panelOAuthRecords(opts), nowMs);
-    return { backend: "copilot", cli: true, auth, ready: auth };
+    return { backend: "copilot", cli: true, auth, ready: auth, experimental: true };
   }
   if (b === "ollama") {
     // No login concept — a local daemon. Binary presence is the readiness

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -12,6 +12,8 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { readOAuthStatus } from "../services/code-provider-auth.js";
+import type { OAuthStatusRecord } from "../services/panel-secrets.js";
 
 export type BackendReadiness = {
   backend: string;
@@ -94,6 +96,31 @@ function fileExists(...parts: string[]): boolean {
   }
 }
 
+/** The panel's in-panel-OAuth status records — injectable for tests (so a test
+ *  never has to touch the real ~/.comfyui-mcp/panel-secrets.json), defaulting
+ *  to the real store. Never throws — a corrupt/missing store just means "no
+ *  panel sign-ins known", not a readiness crash. */
+function panelOAuthRecords(opts?: { oauthStatus?: OAuthStatusRecord[] }): OAuthStatusRecord[] {
+  if (opts?.oauthStatus) return opts.oauthStatus;
+  try {
+    return readOAuthStatus();
+  } catch {
+    return [];
+  }
+}
+
+/** True if `providerId` has an in-panel OAuth status entry that isn't expired.
+ *  A record with no `expires_at` (copilot's device-code tokens, e.g.) is
+ *  treated as "no known expiry" — mirrors the resolvers' own tokenExpiring()
+ *  semantics in code-provider-auth.ts, which likewise never expires a token
+ *  it has no expiry info for. */
+function hasValidPanelOAuth(providerId: string, records: OAuthStatusRecord[], nowMs: number): boolean {
+  const rec = records.find((r) => r.provider === providerId);
+  if (!rec) return false;
+  if (typeof rec.expires_at !== "number") return true;
+  return rec.expires_at * 1000 > nowMs;
+}
+
 /**
  * Readiness for one backend, evaluated locally.
  *
@@ -105,16 +132,29 @@ function fileExists(...parts: string[]): boolean {
  */
 export function backendReadiness(
   backend: string,
-  opts?: { home?: string; customEndpointConfigured?: boolean },
+  opts?: {
+    home?: string;
+    customEndpointConfigured?: boolean;
+    oauthStatus?: OAuthStatusRecord[];
+    now?: number;
+  },
 ): BackendReadiness {
   const b = (backend || "").toLowerCase();
   const home = opts?.home ?? homedir();
+  const nowMs = opts?.now ?? Date.now();
   if (b === "claude") {
     return { backend: "claude", cli: true, auth: true, ready: true };
   }
   if (b === "codex") {
     const cli = onPath(CLI_NAMES.codex);
-    const auth = fileExists(home, ".codex", "auth.json");
+    // The panel's in-panel OAuth for codex writes the SAME ~/.codex/auth.json
+    // an external `codex login` would (see persistOAuthResult), so the native
+    // file check below already picks it up in practice — the OAuth-status
+    // check is kept as an explicit, independent signal (belt-and-suspenders,
+    // and the only signal at all for a provider with no dedicated file check).
+    const auth =
+      fileExists(home, ".codex", "auth.json") ||
+      hasValidPanelOAuth("codex", panelOAuthRecords(opts), nowMs);
     return { backend: "codex", cli, auth, ready: cli && auth };
   }
   if (b === "chatgpt") {
@@ -148,8 +188,19 @@ export function backendReadiness(
   }
   if (b === "grok") {
     const cli = onPath(CLI_NAMES.grok);
-    const auth = fileExists(home, ".grok", "auth.json");
+    // Same reasoning as codex above: the panel's in-panel OAuth writes the
+    // same ~/.grok/auth.json an external `grok` login would.
+    const auth =
+      fileExists(home, ".grok", "auth.json") ||
+      hasValidPanelOAuth("grok", panelOAuthRecords(opts), nowMs);
     return { backend: "grok", cli, auth, ready: cli && auth };
+  }
+  if (b === "copilot") {
+    // No external CLI/native-file concept for Copilot — the in-panel device-
+    // code OAuth (experimental, gated behind allow_experimental in
+    // oauth-bridge.ts) is the ONLY sign-in path, so it's the only signal here.
+    const auth = hasValidPanelOAuth("copilot", panelOAuthRecords(opts), nowMs);
+    return { backend: "copilot", cli: true, auth, ready: auth };
   }
   if (b === "ollama") {
     // No login concept — a local daemon. Binary presence is the readiness
@@ -198,7 +249,12 @@ export function backendReadiness(
 /** Readiness for every known backend, plus a rolled-up any_ready. */
 export function allBackendReadiness(
   backends: Iterable<string>,
-  opts?: { home?: string; customEndpointConfigured?: boolean },
+  opts?: {
+    home?: string;
+    customEndpointConfigured?: boolean;
+    oauthStatus?: OAuthStatusRecord[];
+    now?: number;
+  },
 ): {
   backends: BackendReadiness[];
   any_ready: boolean;

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -28,6 +28,7 @@ export type BackendReadiness = {
 const CLI_NAMES: Record<string, string[]> = {
   codex: ["codex", "codex.cmd", "codex.exe"],
   gemini: ["gemini", "gemini.cmd", "gemini.exe"],
+  grok: ["grok", "grok.cmd", "grok.exe"],
   ollama: ["ollama", "ollama.exe"],
   lmstudio: ["lms", "lms.exe"],
   llamacpp: ["llama-server", "llama-server.exe"],
@@ -123,6 +124,11 @@ export function backendReadiness(
     const geminiHome = process.env.GEMINI_CLI_HOME || home;
     const auth = fileExists(geminiHome, ".gemini", "oauth_creds.json");
     return { backend: "gemini", cli, auth, ready: cli && auth };
+  }
+  if (b === "grok") {
+    const cli = onPath(CLI_NAMES.grok);
+    const auth = fileExists(home, ".grok", "auth.json");
+    return { backend: "grok", cli, auth, ready: cli && auth };
   }
   if (b === "ollama") {
     // No login concept — a local daemon. Binary presence is the readiness

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -1,0 +1,402 @@
+// ChatGPT subscription via direct Codex OAuth (~/.codex/auth.json) — hits the
+// Codex Responses endpoint the CLI uses, NOT api.openai.com or codex app-server.
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { logger } from "../utils/logger.js";
+import type { AgentEvent, BackendStartOptions, ModelChoice, NeutralTurn } from "./agent-backend.js";
+import { CHATGPT_CAPABILITIES } from "./agent-backend.js";
+import { resolveOpenAICodexOAuth } from "../services/code-provider-auth.js";
+import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
+
+const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+const CHATGPT_SYSTEM_PROMPT = [
+  "You are the ComfyUI agent in a sidebar panel. Answer in Markdown.",
+  "",
+  "You have exactly six tools:",
+  "- list_tools / describe_tool / call_tool — headless ComfyUI server.",
+  "- panel_list_tools / panel_describe_tool / panel_call_tool — live canvas.",
+  "",
+  "Describe a tool before its first call. Finish tasks by running tools, not inventing results.",
+].join("\n");
+
+export const CHATGPT_DEFAULT_MODEL =
+  process.env.COMFYUI_MCP_CHATGPT_MODEL?.trim() || "gpt-5.4-mini";
+
+const MAX_TOOL_ROUNDS = 32;
+
+type CodexInputItem = Record<string, unknown>;
+
+type TurnMessage = {
+  role: "user" | "assistant" | "tool";
+  content: string;
+  tool_calls?: Array<{ id: string; name: string; arguments: string }>;
+  tool_call_id?: string;
+};
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Codex model slugs (gpt-5.x, codex-*) — not Claude panel ids. */
+export function isChatGptModel(id: string): boolean {
+  const m = id.trim().toLowerCase();
+  return /^gpt-5/.test(m) || m.startsWith("codex") || m.includes("codex");
+}
+
+function codexModelsCachePath(home = homedir()): string {
+  const root = process.env.CODEX_HOME || join(home, ".codex");
+  return join(root, "models_cache.json");
+}
+
+async function loadCodexModelIds(home = homedir()): Promise<string[]> {
+  const path = codexModelsCachePath(home);
+  if (!existsSync(path)) return [];
+  try {
+    const raw = JSON.parse(await readFile(path, "utf8")) as {
+      models?: Array<{ id?: string; slug?: string; name?: string }>;
+      data?: Array<{ id?: string }>;
+    };
+    const fromModels = (raw.models ?? []).map((m) => m.id ?? m.slug ?? m.name).filter(Boolean);
+    const fromData = (raw.data ?? []).map((m) => m.id).filter(Boolean);
+    return [...new Set([...fromModels, ...fromData].filter((x): x is string => !!x))];
+  } catch {
+    return [];
+  }
+}
+
+function toResponsesTools(tools: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return tools.map((t) => {
+    const fn = (t.function ?? t) as { name?: string; description?: string; parameters?: unknown };
+    return {
+      type: "function",
+      name: fn.name,
+      description: fn.description ?? "",
+      parameters: fn.parameters ?? { type: "object", properties: {} },
+    };
+  });
+}
+
+function historyToCodexInput(messages: TurnMessage[]): CodexInputItem[] {
+  const items: CodexInputItem[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      items.push({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: m.content }],
+      });
+      continue;
+    }
+    if (m.role === "assistant") {
+      if (m.tool_calls?.length) {
+        for (const tc of m.tool_calls) {
+          items.push({
+            type: "function_call",
+            call_id: tc.id,
+            name: tc.name,
+            arguments: tc.arguments || "{}",
+          });
+        }
+      }
+      if (m.content.trim()) {
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: m.content }],
+        });
+      }
+      continue;
+    }
+    if (m.role === "tool" && m.tool_call_id) {
+      items.push({
+        type: "function_call_output",
+        call_id: m.tool_call_id,
+        output: m.content,
+      });
+    }
+  }
+  return items;
+}
+
+/** ChatGPT direct OAuth backend — Codex Responses SSE + shared 6-tool router. */
+export class ChatGptOAuthBackend extends OllamaBackend {
+  readonly id = "chatgpt" as const;
+  readonly capabilities = CHATGPT_CAPABILITIES;
+
+  private accessToken = "";
+  private accountId = "";
+  private turnHistory: TurnMessage[] = [];
+  private chatgptSessionId: string | null = null;
+
+  constructor(deps: Omit<OllamaBackendDeps, "api" | "host" | "apiKey" | "backendId"> = {}) {
+    super({
+      ...deps,
+      backendId: "ollama",
+      api: "openai",
+      host: "https://unused",
+      model: deps.model ?? CHATGPT_DEFAULT_MODEL,
+    });
+    this.model = deps.model ?? CHATGPT_DEFAULT_MODEL;
+  }
+
+  override async prepare(): Promise<void> {
+    if (this.disposed) throw new Error("chatgpt backend is closed.");
+    if (this.prepared) return;
+    const creds = await resolveOpenAICodexOAuth();
+    this.accessToken = creds.accessToken;
+    this.accountId = creds.accountId;
+    await this.connectTools();
+    this.prepared = true;
+    logger.info(
+      `[chatgpt-oauth-backend] ready (Codex Responses, model ${this.model}, ${this.comfyTools.length} comfyui meta-tools, ${this.panelTools.length} panel tools behind the router)`,
+    );
+  }
+
+  private codexAuthHeaders(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.accessToken}`,
+      "chatgpt-account-id": this.accountId,
+    };
+  }
+
+  private async *codexResponsesStream(
+    instructions: string,
+    input: CodexInputItem[],
+    tools: Array<Record<string, unknown>>,
+    signal: AbortSignal,
+    onActivity?: () => void,
+  ): AsyncGenerator<
+    AgentEvent,
+    {
+      content: string;
+      toolCalls: Array<{ id: string; name: string; arguments: string }>;
+      usage?: Record<string, number>;
+      streamId: string | null;
+    }
+  > {
+    const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
+    let res: Response;
+    try {
+      res = await fetch(CODEX_RESPONSES_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "text/event-stream",
+          ...this.codexAuthHeaders(),
+        },
+        body: JSON.stringify({
+          model: this.model,
+          instructions,
+          input,
+          tools: toResponsesTools(tools),
+          stream: true,
+          store: false,
+        }),
+        signal,
+      });
+    } finally {
+      if (keepalive) clearInterval(keepalive);
+    }
+    if (!res.ok || !res.body) {
+      throw new Error(
+        `Codex Responses http ${res.status}: ${(await res.text().catch(() => "")).slice(0, 400)}`,
+      );
+    }
+
+    let content = "";
+    const partial = new Map<string, { id: string; name: string; args: string }>();
+    let usage: Record<string, number> | undefined;
+    let streamOpen = false;
+    const streamId = randomUUID();
+    let buffer = "";
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      onActivity?.();
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) >= 0) {
+        const block = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        let eventType = "";
+        let data = "";
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event:")) eventType = line.slice(6).trim();
+          else if (line.startsWith("data:")) data += line.slice(5).trim();
+        }
+        if (!data || data === "[DONE]") continue;
+        let payload: Record<string, unknown>;
+        try {
+          payload = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+
+        const type = eventType || String(payload.type ?? "");
+        if (type === "response.output_text.delta") {
+          const delta = String(payload.delta ?? "");
+          if (delta) {
+            if (!streamOpen) {
+              streamOpen = true;
+              yield { type: "stream_start", id: streamId };
+            }
+            content += delta;
+            yield { type: "assistant_delta", text: delta };
+          }
+        }
+
+        if (type === "response.function_call_arguments.delta") {
+          const itemId = String(payload.item_id ?? payload.call_id ?? "call");
+          const slot = partial.get(itemId) ?? { id: itemId, name: "", args: "" };
+          if (payload.name) slot.name = String(payload.name);
+          if (payload.arguments) slot.args += String(payload.arguments);
+          partial.set(itemId, slot);
+        }
+
+        if (type === "response.output_item.done") {
+          const item = (payload.item ?? payload) as Record<string, unknown>;
+          if (item.type === "function_call") {
+            const id = String(item.call_id ?? item.id ?? randomUUID());
+            partial.set(id, {
+              id,
+              name: String(item.name ?? ""),
+              args: String(item.arguments ?? "{}"),
+            });
+          }
+        }
+
+        if (type === "response.completed") {
+          const u =
+            (payload.response as { usage?: Record<string, number> } | undefined)?.usage ??
+            (payload.usage as Record<string, number> | undefined);
+          if (u) {
+            usage = {
+              input_tokens: Number(u.input_tokens ?? 0),
+              output_tokens: Number(u.output_tokens ?? 0),
+            };
+          }
+        }
+      }
+    }
+
+    if (streamOpen) yield { type: "stream_end" };
+    const toolCalls = [...partial.values()]
+      .filter((t) => t.name)
+      .map((t) => ({ id: t.id, name: t.name, arguments: t.args || "{}" }));
+    return { content, toolCalls, usage, streamId: streamOpen ? streamId : null };
+  }
+
+  override async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+    await this.prepare();
+    if (opts.model && isChatGptModel(opts.model)) this.model = opts.model;
+
+    const fresh = !this.chatgptSessionId || (opts.resume && opts.resume !== this.chatgptSessionId);
+    this.chatgptSessionId = opts.resume ?? this.chatgptSessionId ?? `chatgpt-${randomUUID()}`;
+    if (fresh) this.turnHistory = [];
+    yield { type: "session", sessionId: this.chatgptSessionId, model: this.model };
+
+    const instructions = [CHATGPT_SYSTEM_PROMPT, this.deps.systemAppend].filter(Boolean).join("\n\n");
+
+    for await (const turn of opts.channel) {
+      yield* this.runCodexTurn(turn, instructions, opts);
+    }
+  }
+
+  private async *runCodexTurn(
+    turn: NeutralTurn,
+    instructions: string,
+    opts: BackendStartOptions,
+  ): AsyncIterable<AgentEvent> {
+    const abort = new AbortController();
+    this.turnAbort = abort;
+    const tools = this.buildModelTools();
+    this.turnHistory.push({ role: "user", content: turn.text });
+
+    let resultEmitted = false;
+    try {
+      for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        const stream = this.codexResponsesStream(
+          instructions,
+          historyToCodexInput(this.turnHistory),
+          tools,
+          abort.signal,
+          opts.onActivity,
+        );
+        let content = "";
+        let toolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+        let usage: Record<string, number> | undefined;
+        let streamId: string | null = null;
+        for (;;) {
+          const r = await stream.next();
+          if (r.done) {
+            ({ content, toolCalls, usage, streamId } = r.value);
+            break;
+          }
+          yield r.value;
+        }
+
+        if (!toolCalls.length) {
+          this.turnHistory.push({ role: "assistant", content });
+          yield { type: "assistant", text: content, id: streamId ?? undefined, usage };
+          yield { type: "result", ok: true, usage };
+          resultEmitted = true;
+          return;
+        }
+
+        this.turnHistory.push({ role: "assistant", content, tool_calls: toolCalls });
+        for (const tc of toolCalls) {
+          if (abort.signal.aborted) throw new Error("interrupted");
+          yield { type: "tool_call", name: tc.name, phase: "start", detail: tc.arguments };
+          const { text, isError } = await this.dispatch(tc.name, tc.arguments);
+          opts.onActivity?.();
+          yield { type: "tool_call", name: tc.name, phase: "end", detail: { isError } };
+          this.turnHistory.push({
+            role: "tool",
+            tool_call_id: tc.id,
+            content: text.slice(0, 16000),
+          });
+        }
+      }
+      yield {
+        type: "assistant",
+        text: "(stopped: too many tool rounds in one turn — ask me to continue)",
+      };
+      yield { type: "result", ok: false, subtype: "max_tool_rounds" };
+      resultEmitted = true;
+    } catch (err) {
+      const interrupted = abort.signal.aborted;
+      if (!interrupted) {
+        logger.warn(`[chatgpt-oauth-backend] turn failed: ${msgOf(err)}`);
+        yield { type: "error", message: `chatgpt backend: ${msgOf(err)}` };
+        yield {
+          type: "assistant",
+          text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+        };
+      }
+      if (!resultEmitted) {
+        yield { type: "result", ok: false, subtype: interrupted ? "interrupted" : "error" };
+      }
+    } finally {
+      if (this.turnAbort === abort) this.turnAbort = null;
+    }
+  }
+
+  override async setModel(model: string): Promise<void> {
+    if (isChatGptModel(model)) this.model = model;
+  }
+
+  override async listModels(): Promise<ModelChoice[]> {
+    const cached = await loadCodexModelIds();
+    const ids = cached.length
+      ? cached
+      : [CHATGPT_DEFAULT_MODEL, "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"];
+    const rest = ids.filter((id) => id !== this.model).slice(0, 40);
+    return [this.model, ...rest].map((id) => ({ id, label: id }));
+  }
+}

--- a/src/orchestrator/copilot-backend.ts
+++ b/src/orchestrator/copilot-backend.ts
@@ -1,0 +1,297 @@
+// GitHub Copilot chat backend — Task 5b of the in-panel OAuth plan.
+// EXPERIMENTAL, ISOLATED, ToS-risk (the user explicitly accepted this when
+// asking for it): a failure anywhere in this module must surface only as a
+// normal turn/prepare error on THIS backend — it can never affect
+// Grok/Codex/Claude/other backends. See OAUTH_PROVIDERS.copilot
+// (experimental: true, in oauth-flow.ts) and oauth-bridge.ts's
+// allow_experimental gate, which is what makes a `~/.comfyui-mcp/copilot-
+// auth.json` ghu_ token exist in the first place.
+//
+// REUSE vs COPILOT-SPECIFIC:
+// Copilot's chat endpoint is OpenAI chat-completions compatible, so this
+// backend is a THIN subclass of OllamaBackend's "openai" dialect — exactly the
+// GlmBackend/KimiBackend pattern (glm-backend.ts / kimi-backend.ts), NOT the
+// Grok/Codex Responses-API adapter (grok-backend.ts's GrokDirectBackend),
+// because Copilot is a real /chat/completions endpoint, not /responses. The
+// inherited chatStream/readOpenAiSse/run/runTurn/dispatch/buildModelTools all
+// apply unchanged. The ONLY Copilot-specific parts, all isolated to this file:
+//   1. the ghu_ → short-lived Copilot bearer exchange
+//      (GET https://api.github.com/copilot_internal/v2/token)
+//   2. the "editor identity" headers GitHub requires on BOTH the exchange and
+//      every chat/completions call (Editor-Version / Editor-Plugin-Version /
+//      User-Agent / Copilot-Integration-Id) — GitHub 403s the exchange
+//      WITHOUT them even on a fully licensed Copilot account (this is the
+//      documented `github-copilot-token-exchange-needs-editor-headers` gotcha)
+//   3. the token source: ~/.comfyui-mcp/copilot-auth.json via
+//      `resolveCopilotOAuth` (code-provider-auth.ts), mirroring
+//      `resolveGrokOAuth` but WITHOUT refresh — ghu_ has no refresh_token; a
+//      dead/revoked one can only be fixed by re-running Copilot sign-in.
+//
+// UNVERIFIED AGAINST THE LIVE api.githubcopilot.com CONTRACT (flagged per the
+// task brief — Task 8 validates live with a real, licensed account):
+//   - the exact exchange response shape ({token, expires_at, endpoints:{api}})
+//   - the chat/completions and /models paths and their exact request/response
+//     shapes
+//   - whether the signed-in account is Copilot-licensed at all (a 403 from the
+//     exchange is ambiguous between "no license" and "bad/stale editor
+//     headers" — see the skill note above)
+//   - the default model slug (Copilot's catalog changes over time; utility
+//     models share a rate-limit bucket per the `copilot-utility-models-
+//     shared-rate-limit` gotcha, so a busy account may 429 even with a
+//     correct slug — this backend does not special-case that; it surfaces the
+//     429 like any other HTTP error)
+// Both base URLs AND the default model are overridable via env so a live
+// mismatch is a config flip, not a code change.
+
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+import type { AgentEvent, BackendStartOptions, NeutralTurn } from "./agent-backend.js";
+import { COPILOT_CAPABILITIES } from "./agent-backend.js";
+import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
+import {
+  resolveCopilotOAuth,
+  type CodeProviderAuthDeps,
+  type CopilotOAuthCredentials,
+} from "../services/code-provider-auth.js";
+import { assertAllowedTokenHost, OAUTH_PROVIDERS } from "../services/oauth-flow.js";
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** GET endpoint that exchanges the long-lived `ghu_` token for a short-lived
+ *  Copilot API bearer. Overridable — the exact host/path is UNVERIFIED
+ *  offline (see the module doc above). */
+export const COPILOT_TOKEN_EXCHANGE_URL =
+  process.env.COMFYUI_MCP_COPILOT_TOKEN_URL?.trim() ||
+  "https://api.github.com/copilot_internal/v2/token";
+
+/** Base URL for Copilot's OpenAI-compatible chat/completions + /models.
+ *  Overridable — a live exchange response's `endpoints.api` (when present)
+ *  wins over this default for the REST of that token's lifetime (individual
+ *  vs. business accounts may route to different hosts per the exchange
+ *  response, per research). */
+export const COPILOT_API_BASE =
+  process.env.COMFYUI_MCP_COPILOT_API_BASE?.trim().replace(/\/+$/, "") ||
+  "https://api.githubcopilot.com";
+
+/** UNVERIFIED against the live Copilot model catalog (slugs change — see the
+ *  module doc). Override with COMFYUI_MCP_COPILOT_MODEL, or rely on the
+ *  inherited listModels() (a live GET /models probe) to surface the account's
+ *  real, currently-provisioned slugs. */
+export const COPILOT_DEFAULT_MODEL = process.env.COMFYUI_MCP_COPILOT_MODEL?.trim() || "gpt-4.1";
+
+/**
+ * GitHub's VS Code Copilot Chat "editor identity" — REQUIRED on both the
+ * token exchange and every chat/completions call, or GitHub 403s even a fully
+ * licensed account (see the `github-copilot-token-exchange-needs-editor-
+ * headers` gotcha). Exact version numbers are not strictly validated by
+ * GitHub — kept as a plausible, recognizable VS Code Copilot Chat identity
+ * rather than an app-branded User-Agent (which IS rejected).
+ */
+const EDITOR_IDENTITY_HEADERS: Record<string, string> = {
+  "Editor-Version": "vscode/1.95.0",
+  "Editor-Plugin-Version": "copilot-chat/0.22.0",
+  "User-Agent": "GitHubCopilotChat/0.22.0",
+  "Copilot-Integration-Id": "vscode-chat",
+};
+
+/** Mirrors oauth-flow.ts's private `redactTokens` (kept local so this task's
+ *  only edit surface outside this file is code-provider-auth.ts/index.ts) —
+ *  strips token-shaped material from provider error text before it can reach
+ *  a thrown message or a log line. Never logs/throws the raw ghu_ or the
+ *  exchanged short-lived bearer. */
+function redactCopilotTokens(s: string): string {
+  return s
+    .replace(
+      /("?(?:access_token|refresh_token|token)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi,
+      "$1<redacted>",
+    )
+    .replace(/\b(ghu_|gho_|ghp_)[A-Za-z0-9._-]+/g, "$1<redacted>")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>")
+    .replace(/\btoken\s+[A-Za-z0-9._-]+/gi, "token <redacted>");
+}
+
+/** `github.com` / `githubcopilot.com` — the same allowlist the OAuth engine
+ *  already enforces for Copilot's device-code flow (oauth-flow.ts), reused
+ *  here for the token-exchange + chat/completions DATA calls. */
+function copilotApiHostAllowlist(): string[] {
+  return OAUTH_PROVIDERS.copilot?.apiHostAllowlist ?? ["github.com", "githubcopilot.com"];
+}
+
+/** Append a "re-run Copilot sign-in" hint to a 401/403 error message exactly
+ *  once (idempotent — never double-appends if the message already carries a
+ *  hint, e.g. from `exchangeCopilotToken` below). */
+function withCopilotAuthHint(err: unknown): Error {
+  const message = msgOf(err);
+  if (/\b(401|403)\b/.test(message) && !/re-run copilot sign-in/i.test(message)) {
+    return new Error(`${message} Re-run Copilot sign-in from the panel.`);
+  }
+  return err instanceof Error ? err : new Error(message);
+}
+
+interface CopilotTokenExchangeResult {
+  token: string;
+  expiresAtMs: number;
+  apiBase: string;
+}
+
+/**
+ * Step 1 of the two-step Copilot contract: exchange the long-lived `ghu_`
+ * token for a short-lived Copilot API bearer. Host-allowlisted before any
+ * network call; any error body is redacted before it can reach a thrown
+ * message. A 401/403 here is the PRIMARY "you're not signed in / not
+ * licensed" failure mode, so it gets the explicit re-sign-in hint.
+ */
+async function exchangeCopilotToken(
+  ghuToken: string,
+  fetchFn: typeof fetch,
+): Promise<CopilotTokenExchangeResult> {
+  assertAllowedTokenHost(COPILOT_TOKEN_EXCHANGE_URL, copilotApiHostAllowlist());
+  const res = await fetchFn(COPILOT_TOKEN_EXCHANGE_URL, {
+    method: "GET",
+    headers: {
+      Authorization: `token ${ghuToken}`,
+      Accept: "application/json",
+      ...EDITOR_IDENTITY_HEADERS,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const hint =
+      res.status === 401 || res.status === 403
+        ? " Re-run Copilot sign-in from the panel (this also happens if the signed-in account has no active Copilot subscription)."
+        : "";
+    throw new ValidationError(
+      `GitHub Copilot token exchange failed (${res.status}): ${redactCopilotTokens(text).slice(0, 300)}.${hint}`,
+    );
+  }
+  let payload: { token?: string; expires_at?: number; endpoints?: { api?: string } };
+  try {
+    payload = JSON.parse(text) as typeof payload;
+  } catch {
+    throw new ValidationError("GitHub Copilot token exchange returned an unparseable response.");
+  }
+  const token = payload.token?.trim();
+  if (!token) {
+    throw new ValidationError("GitHub Copilot token exchange response is missing 'token'.");
+  }
+  const expiresAtMs =
+    typeof payload.expires_at === "number" && Number.isFinite(payload.expires_at)
+      ? payload.expires_at * 1000
+      : Date.now() + 20 * 60_000; // conservative fallback if the field is absent/renamed
+  const apiBase = payload.endpoints?.api?.trim().replace(/\/+$/, "") || COPILOT_API_BASE;
+  return { token, expiresAtMs, apiBase };
+}
+
+/** Refresh 60s before the bearer's reported expiry — matches the skew used
+ *  elsewhere in code-provider-auth.ts (TOKEN_REFRESH_SKEW_MS-style guard). */
+const COPILOT_TOKEN_REFRESH_SKEW_MS = 60_000;
+
+/**
+ * GitHub Copilot chat — OpenAI-compatible chat/completions + the same 6-tool
+ * router as Ollama/GLM/Kimi. See the module doc above for the full contract,
+ * the reuse rationale, and the unverified-offline items.
+ */
+export class CopilotBackend extends OllamaBackend {
+  readonly capabilities = COPILOT_CAPABILITIES;
+
+  private ghuToken: string | null = null;
+  private copilotBearer: string | null = null;
+  private copilotBearerExpiresAtMs = 0;
+  private resolveOAuth: (deps?: CodeProviderAuthDeps) => Promise<CopilotOAuthCredentials>;
+  private fetchFn: typeof fetch;
+
+  constructor(
+    deps: Omit<OllamaBackendDeps, "api" | "host" | "apiKey" | "backendId"> & {
+      /** Test seam: override how the ghu_ token is resolved (defaults to
+       *  `resolveCopilotOAuth` from code-provider-auth.ts). */
+      resolveCopilotOAuth?: (deps?: CodeProviderAuthDeps) => Promise<CopilotOAuthCredentials>;
+      /** Test seam: override the fetch used for the token exchange (the chat
+       *  calls themselves go through OllamaBackend's own fetch usage, which
+       *  already honors a stubbed global fetch in tests). */
+      fetch?: typeof fetch;
+    } = {},
+  ) {
+    super({
+      ...deps,
+      backendId: "copilot",
+      api: "openai",
+      host: COPILOT_API_BASE, // placeholder until the first exchange resolves endpoints.api
+      apiKey: "pending-oauth", // never dialed with this value — ensureFreshCopilotToken() runs first
+      model: deps.model ?? COPILOT_DEFAULT_MODEL,
+    });
+    this.resolveOAuth = deps.resolveCopilotOAuth ?? resolveCopilotOAuth;
+    this.fetchFn = deps.fetch ?? fetch;
+  }
+
+  /** Adds GitHub's required editor-identity headers on top of the inherited
+   *  Bearer-token header — applies to every chat/completions and /models call
+   *  (OllamaBackend's "openai" dialect reads authHeaders() for both). */
+  protected override authHeaders(): Record<string, string> {
+    const base = super.authHeaders();
+    if (!base.authorization) return base;
+    return { ...base, ...EDITOR_IDENTITY_HEADERS };
+  }
+
+  /**
+   * Exchange (or reuse a cached, still-fresh) short-lived Copilot bearer.
+   * Called from prepare() (session start) AND before EVERY turn (see run()
+   * below) so a long-lived panel session survives the token's short,
+   * GitHub-controlled lifetime. The short-lived bearer is held ONLY in this
+   * instance's memory — never written to disk (only the ghu_ persists, in
+   * copilot-auth.json, and this function never rewrites that file).
+   */
+  private async ensureFreshCopilotToken(): Promise<void> {
+    const nowMs = Date.now();
+    if (this.copilotBearer && nowMs < this.copilotBearerExpiresAtMs - COPILOT_TOKEN_REFRESH_SKEW_MS) {
+      return;
+    }
+    if (!this.ghuToken) {
+      const creds = await this.resolveOAuth();
+      this.ghuToken = creds.ghuToken;
+    }
+    const { token, expiresAtMs, apiBase } = await exchangeCopilotToken(this.ghuToken, this.fetchFn);
+    this.copilotBearer = token;
+    this.copilotBearerExpiresAtMs = expiresAtMs;
+    this.setOpenAiAuth(apiBase, token);
+  }
+
+  override async prepare(): Promise<void> {
+    await this.ensureFreshCopilotToken();
+    try {
+      await super.prepare(); // GET {apiBase}/models reachability check + connectTools()
+    } catch (err) {
+      throw withCopilotAuthHint(err);
+    }
+    logger.info(`[copilot-backend] ready (experimental — see task-5b report for the unverified contract items)`);
+  }
+
+  /**
+   * Wrap the incoming turn channel so the Copilot bearer is refreshed BEFORE
+   * every turn, not just once at session start — a panel session can easily
+   * outlive the short-lived exchange token. Best-effort: a refresh failure
+   * mid-session is logged and the turn proceeds with whatever token is
+   * cached; if that token is actually stale the ensuing chat/completions call
+   * 401s and is surfaced through OllamaBackend's own turn-error path (a
+   * normal `result:false` + assistant error — never an unhandled rejection
+   * that could park the panel's turn-gate).
+   */
+  private async *wrapChannel(channel: AsyncIterable<NeutralTurn>): AsyncGenerator<NeutralTurn> {
+    for await (const turn of channel) {
+      try {
+        await this.ensureFreshCopilotToken();
+      } catch (err) {
+        logger.warn(
+          `[copilot-backend] token refresh before turn failed (${msgOf(err)}) — attempting the turn with the existing token.`,
+        );
+      }
+      yield turn;
+    }
+  }
+
+  override async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+    yield* super.run({ ...opts, channel: this.wrapChannel(opts.channel) });
+  }
+}

--- a/src/orchestrator/copilot-backend.ts
+++ b/src/orchestrator/copilot-backend.ts
@@ -181,7 +181,24 @@ async function exchangeCopilotToken(
     typeof payload.expires_at === "number" && Number.isFinite(payload.expires_at)
       ? payload.expires_at * 1000
       : Date.now() + 20 * 60_000; // conservative fallback if the field is absent/renamed
-  const apiBase = payload.endpoints?.api?.trim().replace(/\/+$/, "") || COPILOT_API_BASE;
+  // The exchange response's endpoints.api can route to a per-account host, but a
+  // server-supplied host is UNTRUSTED — if it isn't allowlisted, DROP it and
+  // fall back to the default base rather than dialing an off-allowlist host with
+  // the live bearer. (The default base itself is re-checked in
+  // ensureFreshCopilotToken before setOpenAiAuth, so a bad env override there is
+  // rejected outright — see below.)
+  const advertised = payload.endpoints?.api?.trim().replace(/\/+$/, "");
+  let apiBase = COPILOT_API_BASE;
+  if (advertised) {
+    try {
+      assertAllowedTokenHost(advertised, copilotApiHostAllowlist());
+      apiBase = advertised;
+    } catch {
+      logger.warn(
+        `[copilot-backend] token exchange advertised a non-allowlisted api host — ignoring it and using the default base.`,
+      );
+    }
+  }
   return { token, expiresAtMs, apiBase };
 }
 
@@ -253,6 +270,13 @@ export class CopilotBackend extends OllamaBackend {
       this.ghuToken = creds.ghuToken;
     }
     const { token, expiresAtMs, apiBase } = await exchangeCopilotToken(this.ghuToken, this.fetchFn);
+    // FINAL GATE before the live bearer is ever attached to a host: apiBase is
+    // either the allowlist-checked exchange endpoint or COPILOT_API_BASE (which
+    // may be a COMFYUI_MCP_COPILOT_API_BASE env override). An off-allowlist
+    // override must be REJECTED here — never silently dialed — so the inherited
+    // ollama-backend prepare()/chatStream()/listModels() (which attach the
+    // bearer to this.host) can only ever hit an allowlisted host.
+    assertAllowedTokenHost(apiBase, copilotApiHostAllowlist());
     this.copilotBearer = token;
     this.copilotBearerExpiresAtMs = expiresAtMs;
     this.setOpenAiAuth(apiBase, token);

--- a/src/orchestrator/copilot-backend.ts
+++ b/src/orchestrator/copilot-backend.ts
@@ -53,7 +53,7 @@ import {
   type CodeProviderAuthDeps,
   type CopilotOAuthCredentials,
 } from "../services/code-provider-auth.js";
-import { assertAllowedTokenHost, OAUTH_PROVIDERS } from "../services/oauth-flow.js";
+import { assertAllowedTokenHost, OAUTH_PROVIDERS, redactTokens } from "../services/oauth-flow.js";
 
 function msgOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -96,21 +96,12 @@ const EDITOR_IDENTITY_HEADERS: Record<string, string> = {
   "Copilot-Integration-Id": "vscode-chat",
 };
 
-/** Mirrors oauth-flow.ts's private `redactTokens` (kept local so this task's
- *  only edit surface outside this file is code-provider-auth.ts/index.ts) —
- *  strips token-shaped material from provider error text before it can reach
- *  a thrown message or a log line. Never logs/throws the raw ghu_ or the
- *  exchanged short-lived bearer. */
-function redactCopilotTokens(s: string): string {
-  return s
-    .replace(
-      /("?(?:access_token|refresh_token|token)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi,
-      "$1<redacted>",
-    )
-    .replace(/\b(ghu_|gho_|ghp_)[A-Za-z0-9._-]+/g, "$1<redacted>")
-    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>")
-    .replace(/\btoken\s+[A-Za-z0-9._-]+/gi, "token <redacted>");
-}
+// Uses the shared `redactTokens` from oauth-flow.ts (single source of truth —
+// this file used to carry a local `redactCopilotTokens` copy; its extra
+// ghp_/`token\s+` rules were folded into the exported superset, no coverage
+// lost) to strip token-shaped material from provider error text before it
+// can reach a thrown message or a log line. Never logs/throws the raw ghu_ or
+// the exchanged short-lived bearer.
 
 /** `github.com` / `githubcopilot.com` — the same allowlist the OAuth engine
  *  already enforces for Copilot's device-code flow (oauth-flow.ts), reused
@@ -164,7 +155,7 @@ async function exchangeCopilotToken(
         ? " Re-run Copilot sign-in from the panel (this also happens if the signed-in account has no active Copilot subscription)."
         : "";
     throw new ValidationError(
-      `GitHub Copilot token exchange failed (${res.status}): ${redactCopilotTokens(text).slice(0, 300)}.${hint}`,
+      `GitHub Copilot token exchange failed (${res.status}): ${redactTokens(text).slice(0, 300)}.${hint}`,
     );
   }
   let payload: { token?: string; expires_at?: number; endpoints?: { api?: string } };

--- a/src/orchestrator/glm-backend.ts
+++ b/src/orchestrator/glm-backend.ts
@@ -1,0 +1,22 @@
+import { GLM_CAPABILITIES } from "./agent-backend.js";
+import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
+import { resolveGlmCodeCredentials } from "../services/code-provider-auth.js";
+
+export const GLM_DEFAULT_MODEL = process.env.COMFYUI_MCP_GLM_MODEL?.trim() || "glm-4.7";
+
+/** Z.AI GLM Coding Plan — OpenAI-compatible chat/completions + 6-tool router. */
+export class GlmBackend extends OllamaBackend {
+  readonly capabilities = GLM_CAPABILITIES;
+
+  constructor(deps: Omit<OllamaBackendDeps, "api" | "host" | "apiKey" | "backendId"> = {}) {
+    const creds = resolveGlmCodeCredentials();
+    super({
+      ...deps,
+      backendId: "glm",
+      api: "openai",
+      host: creds.baseUrl,
+      apiKey: creds.apiKey,
+      model: deps.model ?? GLM_DEFAULT_MODEL,
+    });
+  }
+}

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -428,10 +428,9 @@ export type GrokMcpServerSpec =
 
 /**
  * Convert our MCP server specs into the ACP `session/new` `mcpServers` array.
- * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. The HTTP
- * variant ({ type:"http", name, url }) is the closest faithful mapping to the ACP
- * spec's HTTP transport (gated by the agent's mcpCapabilities.http) — FLAGGED as
- * unverified against the live gemini CLI. Empty env is the required `[]`.
+ * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. Streamable
+ * HTTP MCP uses the SSE variant ({ type:"sse", name, url, headers:[] }) — the
+ * live Grok/Gemini CLIs reject { type:"http" } with Invalid params.
  */
 export function buildAcpMcpServers(
   servers: Record<string, GrokMcpServerSpec>,
@@ -446,8 +445,7 @@ export function buildAcpMcpServers(
         env: Object.entries(spec.env ?? {}).map(([k, v]) => ({ name: k, value: v })),
       });
     } else {
-      // ASSUMPTION (unverified w/o live CLI): ACP HTTP McpServer variant.
-      out.push({ type: "http", name, url: spec.url });
+      out.push({ type: "sse", name, url: spec.url, headers: [] });
     }
   }
   return out;

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -60,6 +60,7 @@
 
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import readline from "node:readline";
+import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger.js";
 import {
   type AgentBackend,
@@ -70,6 +71,14 @@ import {
   GROK_CAPABILITIES,
 } from "./agent-backend.js";
 import type { ImageRef } from "./panel-agent.js";
+import {
+  resolveGrokOAuth,
+  type CodeProviderAuthDeps,
+  type GrokOAuthCredentials,
+} from "../services/code-provider-auth.js";
+import { OAUTH_PROVIDERS, assertAllowedTokenHost } from "../services/oauth-flow.js";
+import { OllamaBackend } from "./ollama-backend.js";
+import { resolvePrompt } from "../services/prompt-overrides.js";
 
 function msgOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -474,16 +483,39 @@ export interface GrokBackendDeps {
    * system/context preamble; later turns send plain text.
    */
   systemAppend?: string;
+  /**
+   * Test seam: override how the direct-token OAuth credentials are resolved
+   * (defaults to `resolveGrokOAuth` from code-provider-auth.ts). Threaded through
+   * to the internal `GrokDirectBackend` too, so the mode-decision probe and the
+   * live token refresh both go through the same injected resolver.
+   */
+  resolveGrokOAuth?: (deps?: CodeProviderAuthDeps) => Promise<GrokOAuthCredentials>;
 }
 
 /**
  * The Gemini CLI ACP adapter. One instance per PanelAgent; it holds the live ACP
  * client + current session id and re-opens on each `run()`.
+ *
+ * DIRECT-TOKEN SELECTION (Task 6): this class is also the public facade used
+ * everywhere (`new GrokBackend(deps)`, wired in orchestrator/index.ts). On the
+ * FIRST call to any AgentBackend method it decides — once, cached for the life of
+ * this instance — whether `~/.grok/auth.json` holds a usable OAuth token
+ * (`resolveGrokOAuth`, mirroring `resolveOpenAICodexOAuth`'s resolve+refresh). If
+ * so, EVERY call delegates to an internal `GrokDirectBackend` (a Responses-style
+ * HTTP adapter hitting `https://api.x.ai/v1`, reusing the same 6-tool router as
+ * Ollama/ChatGPT — see below). If the token file is absent, unreadable, or its
+ * refresh fails, the decision is "no" and this class's OWN ACP/CLI body below
+ * runs exactly as before — NO behavior change on that path. The Grok CLI thus
+ * becomes optional: only needed when no in-panel OAuth sign-in has happened.
  */
 export class GrokBackend implements AgentBackend {
   readonly id = "grok" as const;
   readonly capabilities = GROK_CAPABILITIES;
   private deps: GrokBackendDeps;
+  /** Memoized mode decision: resolves to a live GrokDirectBackend when a usable
+   *  OAuth token was found, or `null` to mean "use this class's own ACP body".
+   *  Decided at most once per instance (see the class doc above). */
+  private modePromise: Promise<GrokDirectBackend | null> | null = null;
   private client: AcpClient | null = null;
   /** The client an in-flight prepare() is spinning up, tracked so a concurrent
    *  close() can tear it down before it's published (P0-A). */
@@ -511,6 +543,37 @@ export class GrokBackend implements AgentBackend {
   constructor(deps: GrokBackendDeps = {}) {
     this.deps = deps;
     this.model = deps.model;
+  }
+
+  /**
+   * Decide ONCE (memoized) whether a direct OAuth token is usable: probes
+   * `resolveGrokOAuth` (or the injected test seam) and, on success, builds the
+   * `GrokDirectBackend` that every AgentBackend method below will delegate to.
+   * On ANY failure (no `~/.grok/auth.json`, unreadable, expired-with-no-refresh,
+   * refresh network error, wrong-shape file) it caches `null`, meaning "fall
+   * back to this class's own ACP/CLI body" — the probe itself does no spawning
+   * and no network call beyond the token endpoint, so a missing/foreign
+   * `~/.grok/auth.json` (e.g. the Grok CLI's OWN native login, a different JSON
+   * shape) is indistinguishable from "not signed in" and correctly falls back.
+   */
+  private resolveMode(): Promise<GrokDirectBackend | null> {
+    if (!this.modePromise) {
+      const resolveOAuth = this.deps.resolveGrokOAuth ?? resolveGrokOAuth;
+      this.modePromise = resolveOAuth()
+        .then(
+          () =>
+            new GrokDirectBackend({
+              cwd: this.deps.cwd,
+              model: this.deps.model,
+              comfyuiUrl: this.deps.comfyuiUrl,
+              mcpServers: this.deps.mcpServers,
+              systemAppend: this.deps.systemAppend,
+              resolveGrokOAuth: this.deps.resolveGrokOAuth,
+            }),
+        )
+        .catch(() => null);
+    }
+    return this.modePromise;
   }
 
   /**
@@ -568,6 +631,11 @@ export class GrokBackend implements AgentBackend {
    */
   async prepare(): Promise<void> {
     if (this.disposed) throw new Error("grok backend is closed.");
+    const direct = await this.resolveMode();
+    if (direct) {
+      await direct.prepare?.();
+      return;
+    }
     if (this.client) return;
     const { cmd, args, useShell } = this.resolveSpawn();
     const cwd = this.deps.cwd ?? process.cwd();
@@ -681,6 +749,11 @@ export class GrokBackend implements AgentBackend {
    * IS the turn-gate).
    */
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    const direct = await this.resolveMode();
+    if (direct) {
+      yield* direct.run(opts);
+      return;
+    }
     // MODEL PRECEDENCE (P1): apply the panel-selected model BEFORE prepare() so the
     // FIRST spawn uses it (the model is spawn-pinned via `--model`; preparing first
     // would spawn the wrong model). PanelAgent.start() usually passes opts.model =
@@ -989,6 +1062,11 @@ export class GrokBackend implements AgentBackend {
    *  (notification). The in-flight session/prompt then resolves with
    *  stopReason:"cancelled", which the run-turn path turns into a terminal result. */
   async interrupt(): Promise<void> {
+    const direct = await this.resolveMode();
+    if (direct) {
+      await direct.interrupt();
+      return;
+    }
     const client = this.client;
     if (!client || !this.sessionId) return;
     try {
@@ -1006,18 +1084,26 @@ export class GrokBackend implements AgentBackend {
    *  If the backend hasn't spawned yet, the first prepare() simply uses the new
    *  model. Ignores non-Gemini ids (PanelAgent may pass the Claude panel model). */
   async setModel(model: string): Promise<void> {
+    const direct = await this.resolveMode();
+    if (direct) {
+      await direct.setModel?.(model);
+      return;
+    }
     if (!isGrokModel(model)) return;
     this.model = model;
     this.spawnSpec = null; // next spawn rebuilds argv with the new --model
   }
 
   /**
-   * Gemini model enumeration. ACP exposes no model catalog, so we surface a static
-   * set (the current Gemini family); the panel picker degrades gracefully on an
-   * empty list. No effort metadata (Gemini uses a thinking BUDGET, not a discrete
-   * effort scale) → the panel hides the effort dropdown.
+   * Model enumeration. In direct-token mode this delegates to GrokDirectBackend
+   * (a live GET /v1/models probe). In ACP mode, ACP exposes no model catalog, so
+   * we surface a static set (the current Grok CLI composer family); the panel
+   * picker degrades gracefully on an empty list. No effort metadata (Grok's ACP
+   * mode has no discrete effort scale) → the panel hides the effort dropdown.
    */
   async listModels(): Promise<ModelChoice[]> {
+    const direct = await this.resolveMode();
+    if (direct) return direct.listModels();
     return GROK_MODELS;
   }
 
@@ -1027,6 +1113,11 @@ export class GrokBackend implements AgentBackend {
    *  interrupt() is a no-op when idle, so without this the child is orphaned. */
   async close(): Promise<void> {
     this.disposed = true; // tripwire FIRST (an in-flight prepare() bails) (P0-A)
+    const direct = await this.resolveMode();
+    if (direct) {
+      await direct.close?.();
+      return;
+    }
     const client = this.client;
     const preparing = this.preparingClient;
     this.client = null;
@@ -1039,6 +1130,452 @@ export class GrokBackend implements AgentBackend {
     if (preparing && preparing !== client) {
       preparing.notificationHandler = null;
       await preparing.close().catch(() => {});
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct-token Grok (xAI) backend — Task 6 of the in-panel OAuth plan.
+//
+// Hits `https://api.x.ai/v1/responses` with the OAuth bearer resolved from
+// `~/.grok/auth.json` (resolveGrokOAuth), instead of driving the Grok CLI over
+// ACP. This reuses the SAME Responses-style SSE adapter SHAPE as
+// chatgpt-oauth-backend.ts's Codex adapter (prior research judged xAI's public
+// API to be codex_responses-adapter compatible) and the SAME 6-tool router as
+// Ollama/ChatGPT (OllamaBackend.dispatch/connectTools/buildModelTools) — a
+// small model-agnostic HTTP endpoint has no agent harness of its own, so this
+// backend owns the whole tool loop the way Ollama/ChatGPT already do.
+//
+// DIVERGENCES from the Codex adapter (xAI is NOT a re-skinned ChatGPT):
+//   - No `chatgpt-account-id` header — that's OpenAI/ChatGPT account-routing
+//     plumbing with no xAI equivalent; the bearer token alone identifies the
+//     account.
+//   - Every outbound request is host-allowlist-checked (assertAllowedTokenHost
+//     against OAUTH_PROVIDERS.grok.apiHostAllowlist, i.e. `x.ai`/`*.x.ai`)
+//     before the bearer is attached, and any error response body is REDACTED
+//     (redactGrokTokens) before it can reach a thrown message or a log line —
+//     the access token itself is never logged anywhere in this path.
+//   - Model slug + exact endpoint sub-path are UNVERIFIED against the live xAI
+//     API (no network access at authoring time, and no Task-1 research
+//     artifact survived for this session to consult). GROK_XAI_DEFAULT_MODEL
+//     reuses the ACP CLI's existing composer alias as a placeholder rather
+//     than inventing a new model string; listModels() prefers a live
+//     `GET /v1/models` probe over any hardcoded catalog. CONFIRM both against
+//     xAI's docs (or override via COMFYUI_MCP_GROK_XAI_MODEL) before relying
+//     on this path in production — see the task-6 report for the flagged risk.
+// ---------------------------------------------------------------------------
+
+export const GROK_XAI_API_BASE = "https://api.x.ai/v1";
+const GROK_XAI_RESPONSES_URL = `${GROK_XAI_API_BASE}/responses`;
+const GROK_XAI_MODELS_URL = `${GROK_XAI_API_BASE}/models`;
+const GROK_MAX_TOOL_ROUNDS = 32;
+
+/** `x.ai` / `*.x.ai` — the same allowlist the OAuth engine already enforces for
+ *  the Grok token endpoint (oauth-flow.ts), reused here for the DATA API calls. */
+function grokApiHostAllowlist(): string[] {
+  return OAUTH_PROVIDERS.grok?.apiHostAllowlist ?? ["x.ai"];
+}
+
+// UNVERIFIED against the live xAI model catalog (see the divergences note
+// above) — reuses the ACP CLI's default composer alias as a safe, non-invented
+// placeholder rather than guessing a raw-API model slug. Override with
+// COMFYUI_MCP_GROK_XAI_MODEL once confirmed, or rely on listModels()'s live
+// /v1/models probe to surface the account's real slugs.
+export const GROK_XAI_DEFAULT_MODEL =
+  process.env.COMFYUI_MCP_GROK_XAI_MODEL?.trim() || GROK_DEFAULT_MODEL;
+
+export const GROK_XAI_SYSTEM_PROMPT = [
+  "You are the ComfyUI agent in a sidebar panel. Answer in Markdown.",
+  "",
+  "You have exactly six tools:",
+  "- list_tools / describe_tool / call_tool — headless ComfyUI server.",
+  "- panel_list_tools / panel_describe_tool / panel_call_tool — live canvas.",
+  "",
+  "Describe a tool before its first call. Finish tasks by running tools, not inventing results.",
+].join("\n");
+
+/** Mirrors oauth-flow.ts's private `redactTokens` (kept local so this task's
+ *  only edit surface is grok-backend.ts) — strips token-shaped material from
+ *  provider error text before it can reach a thrown message or a log line. */
+function redactGrokTokens(s: string): string {
+  return s
+    .replace(
+      /("?(?:access_token|refresh_token|id_token|code|code_verifier|client_secret)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi,
+      "$1<redacted>",
+    )
+    .replace(/\b(ghu_|gho_|ya29\.|sk-)[A-Za-z0-9._-]+/g, "$1<redacted>")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>");
+}
+
+type GrokTurnMessage = {
+  role: "user" | "assistant" | "tool";
+  content: string;
+  tool_calls?: Array<{ id: string; name: string; arguments: string }>;
+  tool_call_id?: string;
+};
+
+type GrokResponsesInputItem = Record<string, unknown>;
+
+/** OpenAI-tool-def → Responses `tools[]` shape (identical to Codex's toResponsesTools). */
+function grokToolsToResponses(tools: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return tools.map((t) => {
+    const fn = (t.function ?? t) as { name?: string; description?: string; parameters?: unknown };
+    return {
+      type: "function",
+      name: fn.name,
+      description: fn.description ?? "",
+      parameters: fn.parameters ?? { type: "object", properties: {} },
+    };
+  });
+}
+
+/** In-memory turn history → Responses `input[]` items (identical shaping to
+ *  Codex's historyToCodexInput — same Responses `input` schema). */
+function grokHistoryToResponsesInput(messages: GrokTurnMessage[]): GrokResponsesInputItem[] {
+  const items: GrokResponsesInputItem[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      items.push({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: m.content }],
+      });
+      continue;
+    }
+    if (m.role === "assistant") {
+      if (m.tool_calls?.length) {
+        for (const tc of m.tool_calls) {
+          items.push({
+            type: "function_call",
+            call_id: tc.id,
+            name: tc.name,
+            arguments: tc.arguments || "{}",
+          });
+        }
+      }
+      if (m.content.trim()) {
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: m.content }],
+        });
+      }
+      continue;
+    }
+    if (m.role === "tool" && m.tool_call_id) {
+      items.push({
+        type: "function_call_output",
+        call_id: m.tool_call_id,
+        output: m.content,
+      });
+    }
+  }
+  return items;
+}
+
+const GROK_DIRECT_CAPABILITIES = {
+  persistentChannel: true,
+  streamingDeltas: true,
+  interruptMidTurn: true,
+  forkAtAnchor: false,
+  inProcessMcp: false,
+  modelEnumeration: true, // live GET /v1/models probe
+  slashCommands: false,
+  hooks: false,
+  vision: false, // the 6-tool router is text-only (mirrors Ollama/ChatGPT); NeutralTurn.images unused here
+};
+
+/** Direct-token Grok (xAI) backend — see the module-level comment above for the
+ *  full rationale and the divergences from the Codex adapter it mirrors. */
+export class GrokDirectBackend extends OllamaBackend {
+  readonly id = "grok" as const;
+  readonly capabilities = GROK_DIRECT_CAPABILITIES;
+
+  private accessToken = "";
+  private grokTurnHistory: GrokTurnMessage[] = [];
+  private grokSessionId: string | null = null;
+  private resolveOAuth: (deps?: CodeProviderAuthDeps) => Promise<GrokOAuthCredentials>;
+
+  constructor(
+    deps: Pick<GrokBackendDeps, "cwd" | "model" | "comfyuiUrl" | "mcpServers" | "systemAppend"> & {
+      resolveGrokOAuth?: (deps?: CodeProviderAuthDeps) => Promise<GrokOAuthCredentials>;
+    } = {},
+  ) {
+    super({
+      cwd: deps.cwd,
+      comfyuiUrl: deps.comfyuiUrl,
+      mcpServers: deps.mcpServers,
+      systemAppend: deps.systemAppend,
+      backendId: "grok",
+      api: "openai",
+      host: "https://unused", // never dialed — every request goes straight to GROK_XAI_RESPONSES_URL
+      model: deps.model ?? GROK_XAI_DEFAULT_MODEL,
+    });
+    this.model = deps.model ?? GROK_XAI_DEFAULT_MODEL;
+    this.resolveOAuth = deps.resolveGrokOAuth ?? resolveGrokOAuth;
+  }
+
+  override async prepare(): Promise<void> {
+    if (this.disposed) throw new Error("grok backend is closed.");
+    if (this.prepared) return;
+    const creds = await this.resolveOAuth();
+    this.accessToken = creds.accessToken;
+    await this.connectTools();
+    this.prepared = true;
+    logger.info(
+      `[grok-backend] ready (direct xAI OAuth, model ${this.model}, ${this.comfyTools.length} comfyui meta-tools, ${this.panelTools.length} panel tools behind the router)`,
+    );
+  }
+
+  private async *xaiResponsesStream(
+    instructions: string,
+    input: GrokResponsesInputItem[],
+    tools: Array<Record<string, unknown>>,
+    signal: AbortSignal,
+    onActivity?: () => void,
+  ): AsyncGenerator<
+    AgentEvent,
+    {
+      content: string;
+      toolCalls: Array<{ id: string; name: string; arguments: string }>;
+      usage?: Record<string, number>;
+      streamId: string | null;
+    }
+  > {
+    assertAllowedTokenHost(GROK_XAI_RESPONSES_URL, grokApiHostAllowlist());
+    const keepalive = onActivity ? setInterval(onActivity, 5000) : null;
+    let res: Response;
+    try {
+      res = await fetch(GROK_XAI_RESPONSES_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "text/event-stream",
+          authorization: `Bearer ${this.accessToken}`,
+        },
+        body: JSON.stringify({
+          model: this.model,
+          instructions,
+          input,
+          tools: grokToolsToResponses(tools),
+          stream: true,
+          store: false,
+        }),
+        signal,
+      });
+    } finally {
+      if (keepalive) clearInterval(keepalive);
+    }
+    if (!res.ok || !res.body) {
+      const bodyText = await res.text().catch(() => "");
+      throw new Error(`xAI Responses http ${res.status}: ${redactGrokTokens(bodyText).slice(0, 400)}`);
+    }
+
+    let content = "";
+    const partial = new Map<string, { id: string; name: string; args: string }>();
+    let usage: Record<string, number> | undefined;
+    let streamOpen = false;
+    const streamId = randomUUID();
+    let buffer = "";
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      onActivity?.();
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) >= 0) {
+        const block = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        let eventType = "";
+        let data = "";
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event:")) eventType = line.slice(6).trim();
+          else if (line.startsWith("data:")) data += line.slice(5).trim();
+        }
+        if (!data || data === "[DONE]") continue;
+        let payload: Record<string, unknown>;
+        try {
+          payload = JSON.parse(data) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+
+        const type = eventType || String(payload.type ?? "");
+        if (type === "response.output_text.delta") {
+          const delta = String(payload.delta ?? "");
+          if (delta) {
+            if (!streamOpen) {
+              streamOpen = true;
+              yield { type: "stream_start", id: streamId };
+            }
+            content += delta;
+            yield { type: "assistant_delta", text: delta };
+          }
+        }
+
+        if (type === "response.function_call_arguments.delta") {
+          const itemId = String(payload.item_id ?? payload.call_id ?? "call");
+          const slot = partial.get(itemId) ?? { id: itemId, name: "", args: "" };
+          if (payload.name) slot.name = String(payload.name);
+          if (payload.arguments) slot.args += String(payload.arguments);
+          partial.set(itemId, slot);
+        }
+
+        if (type === "response.output_item.done") {
+          const item = (payload.item ?? payload) as Record<string, unknown>;
+          if (item.type === "function_call") {
+            const id = String(item.call_id ?? item.id ?? randomUUID());
+            partial.set(id, {
+              id,
+              name: String(item.name ?? ""),
+              args: String(item.arguments ?? "{}"),
+            });
+          }
+        }
+
+        if (type === "response.completed") {
+          const u =
+            (payload.response as { usage?: Record<string, number> } | undefined)?.usage ??
+            (payload.usage as Record<string, number> | undefined);
+          if (u) {
+            usage = {
+              input_tokens: Number(u.input_tokens ?? 0),
+              output_tokens: Number(u.output_tokens ?? 0),
+            };
+          }
+        }
+      }
+    }
+
+    if (streamOpen) yield { type: "stream_end" };
+    const toolCalls = [...partial.values()]
+      .filter((t) => t.name)
+      .map((t) => ({ id: t.id, name: t.name, arguments: t.args || "{}" }));
+    return { content, toolCalls, usage, streamId: streamOpen ? streamId : null };
+  }
+
+  override async *run(opts: BackendStartOptions): AsyncIterable<AgentEvent> {
+    await this.prepare();
+    if (opts.model && isGrokModel(opts.model)) this.model = opts.model;
+
+    const fresh = !this.grokSessionId || (opts.resume && opts.resume !== this.grokSessionId);
+    this.grokSessionId = opts.resume ?? this.grokSessionId ?? `grok-${randomUUID()}`;
+    if (fresh) this.grokTurnHistory = [];
+    yield { type: "session", sessionId: this.grokSessionId, model: this.model };
+
+    const instructions = [resolvePrompt("backend.grok", GROK_XAI_SYSTEM_PROMPT), this.deps.systemAppend]
+      .filter(Boolean)
+      .join("\n\n");
+
+    for await (const turn of opts.channel) {
+      yield* this.runGrokTurn(turn, instructions, opts);
+    }
+  }
+
+  private async *runGrokTurn(
+    turn: NeutralTurn,
+    instructions: string,
+    opts: BackendStartOptions,
+  ): AsyncIterable<AgentEvent> {
+    const abort = new AbortController();
+    this.turnAbort = abort;
+    const tools = this.buildModelTools();
+    this.grokTurnHistory.push({ role: "user", content: turn.text });
+
+    let resultEmitted = false;
+    try {
+      for (let round = 0; round < GROK_MAX_TOOL_ROUNDS; round++) {
+        const stream = this.xaiResponsesStream(
+          instructions,
+          grokHistoryToResponsesInput(this.grokTurnHistory),
+          tools,
+          abort.signal,
+          opts.onActivity,
+        );
+        let content = "";
+        let toolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+        let usage: Record<string, number> | undefined;
+        let streamId: string | null = null;
+        for (;;) {
+          const r = await stream.next();
+          if (r.done) {
+            ({ content, toolCalls, usage, streamId } = r.value);
+            break;
+          }
+          yield r.value;
+        }
+
+        if (!toolCalls.length) {
+          this.grokTurnHistory.push({ role: "assistant", content });
+          yield { type: "assistant", text: content, id: streamId ?? undefined, usage };
+          yield { type: "result", ok: true, usage };
+          resultEmitted = true;
+          return;
+        }
+
+        this.grokTurnHistory.push({ role: "assistant", content, tool_calls: toolCalls });
+        for (const tc of toolCalls) {
+          if (abort.signal.aborted) throw new Error("interrupted");
+          yield { type: "tool_call", name: tc.name, phase: "start", detail: tc.arguments };
+          const { text, isError } = await this.dispatch(tc.name, tc.arguments);
+          opts.onActivity?.();
+          yield { type: "tool_call", name: tc.name, phase: "end", detail: { isError } };
+          this.grokTurnHistory.push({
+            role: "tool",
+            tool_call_id: tc.id,
+            content: text.slice(0, 16000),
+          });
+        }
+      }
+      yield {
+        type: "assistant",
+        text: "(stopped: too many tool rounds in one turn — ask me to continue)",
+      };
+      yield { type: "result", ok: false, subtype: "max_tool_rounds" };
+      resultEmitted = true;
+    } catch (err) {
+      const interrupted = abort.signal.aborted;
+      if (!interrupted) {
+        logger.warn(`[grok-backend] direct-token turn failed: ${msgOf(err)}`);
+        yield { type: "error", message: `grok backend: ${msgOf(err)}` };
+        yield {
+          type: "assistant",
+          text: `⚠️ The model request failed: ${msgOf(err).slice(0, 400)}`,
+        };
+      }
+      if (!resultEmitted) {
+        yield { type: "result", ok: false, subtype: interrupted ? "interrupted" : "error" };
+      }
+    } finally {
+      if (this.turnAbort === abort) this.turnAbort = null;
+    }
+  }
+
+  override async setModel(model: string): Promise<void> {
+    if (isGrokModel(model)) this.model = model;
+  }
+
+  /** Prefer a live account probe over any hardcoded catalog (the exact xAI
+   *  model slugs are unverified — see the module-level comment). Falls back to
+   *  just the configured model id if the probe fails (offline, wrong scope, …). */
+  override async listModels(): Promise<ModelChoice[]> {
+    try {
+      assertAllowedTokenHost(GROK_XAI_MODELS_URL, grokApiHostAllowlist());
+      const res = await fetch(GROK_XAI_MODELS_URL, {
+        headers: { authorization: `Bearer ${this.accessToken}` },
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!res.ok) return [{ id: this.model, label: this.model }];
+      const data = (await res.json()) as { data?: Array<{ id?: string }> };
+      const ids = (data.data ?? []).map((m) => m.id).filter((id): id is string => !!id);
+      if (!ids.length) return [{ id: this.model, label: this.model }];
+      const rest = ids.filter((id) => id !== this.model).slice(0, 40);
+      return [this.model, ...rest].map((id) => ({ id, label: id }));
+    } catch {
+      return [{ id: this.model, label: this.model }];
     }
   }
 }

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -1,0 +1,1050 @@
+// Grok (xAI) backend — the provider-specific adapter behind the AgentBackend
+// port, driving the Grok CLI over its **ACP (Agent Client Protocol)** mode
+// (`grok agent stdio`), a JSON-RPC 2.0 client over stdio. This is a faithful
+// MIRROR of grok-backend.ts: same self-contained line-framed JSON-RPC client,
+// same per-turn event-queue bridge, same terminal-result invariant, same
+// Windows/POSIX process-tree kill.
+//
+// PanelAgent keeps all provider-agnostic orchestration (queue, turn-gate, bridge
+// push, self-restart) and drives this backend via
+// `for await (const ev of backend.run({...}))`. See
+// docs/design/agent-backend-injection.md.
+//
+// PROTOCOL MAPPING (AgentBackend ↔ ACP, per agentclientprotocol.com + the
+// Gemini CLI docs/cli/acp-mode.md):
+//   - prepare()           = spawn `grok agent` + `initialize` handshake
+//   - session             = an ACP SESSION (`session/new` new | `session/load` resume)
+//   - run() loop turn     = `session/prompt` (ONE request per neutral channel batch);
+//                           the request RESOLVES with a `stopReason` at turn end
+//                           (unlike Codex, where turn/start returns immediately
+//                           and a separate turn/completed notification ends it).
+//                           Images ride inline as base64 `image` ContentBlocks.
+//   - assistant_delta     ← `session/update` { update.sessionUpdate:"agent_message_chunk",
+//                            content:{type:"text",text} }
+//   - assistant_delta(th) ← `session/update` { ...:"agent_thought_chunk", ... } (thinking)
+//   - assistant (commit)  ← the accumulated agent_message_chunk text, emitted once
+//                            when the session/prompt request resolves (ACP has no
+//                            separate "final message" notification — the chunks ARE
+//                            the message; the prompt response is the turn boundary)
+//   - tool_call(start)    ← `session/update` { ...:"tool_call", toolCallId, title, kind }
+//   - tool_call(end)      ← `session/update` { ...:"tool_call_update", status:
+//                            "completed"|"failed" }
+//   - result              ← the `session/prompt` response { stopReason }
+//   - error               ← a failed `session/prompt` / the child dying mid-turn
+//   - interrupt()         → `session/cancel` (notification); the in-flight prompt
+//                            then resolves with stopReason:"cancelled"
+//   - listModels()        ← a static catalog (gemini-2.5-pro / -flash) — ACP exposes
+//                            no model enumeration; the model is selected at SPAWN via
+//                            the CLI `--model` flag (see resolveBin/spawn below)
+//
+// AUTH (NO API KEY — the CLI owns auth): Gemini CLI authenticates itself via
+// Google OAuth / Code Assist (the user runs `gemini` once to sign in). This
+// backend NEVER passes an API key; it just spawns the already-authenticated CLI.
+// If the CLI is signed out, `session/new` returns an `auth_required` error — we
+// attempt one `authenticate` with the first advertised auth method, then surface
+// a clear "run `gemini` and sign in" message (the OAuth browser flow itself is
+// owned by the CLI and cannot be completed headlessly).
+//
+// PARITY with Codex/Claude: the Gemini backend gets the SAME tool surface — the
+// headless `comfyui` stdio MCP plus the `panel` HTTP MCP for live-graph panel_*
+// tools — declared to `session/new` as ACP McpServers. The panel system prompt
+// is prepended to the FIRST turn's prompt (ACP `session/new` has no system /
+// instructions field, mirroring the Codex app-server's thread/start).
+//
+// ASSUMPTIONS we could NOT verify without the live `gemini` CLI (flagged inline,
+// see also the PR body): the exact ACP McpServer http variant shape, the
+// session/load resume semantics, the auth_required retry, and live model
+// switching (we set the model at spawn via --model since ACP exposes no standard
+// per-session model setter). Each is the closest faithful mapping to the
+// documented ACP spec.
+
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import readline from "node:readline";
+import { logger } from "../utils/logger.js";
+import {
+  type AgentBackend,
+  type AgentEvent,
+  type BackendStartOptions,
+  type ModelChoice,
+  type NeutralTurn,
+  GROK_CAPABILITIES,
+} from "./agent-backend.js";
+import type { ImageRef } from "./panel-agent.js";
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Kill an entire process tree, not just the direct child. On the Windows
+ * PATH/shell fallback the direct child is a cmd.exe/`.cmd` shim whose grandchild
+ * is the real `gemini` node process — killing only the shell leaves the tree
+ * alive. Use `taskkill /T /F`. On POSIX, signal the process group (negative pid)
+ * so a shell + its child both die, falling back to the single pid. Best-effort +
+ * swallows errors: it runs during teardown and must never throw into the host.
+ * (Identical to codex-backend's killProcessTree — same spawn posture.)
+ */
+function killProcessTree(pid: number | undefined): void {
+  if (!Number.isFinite(pid)) return;
+  const p = pid as number;
+  if (process.platform === "win32") {
+    try {
+      spawnSync("taskkill", ["/PID", String(p), "/T", "/F"], { windowsHide: true });
+    } catch {
+      try {
+        process.kill(p);
+      } catch {
+        // already gone
+      }
+    }
+    return;
+  }
+  try {
+    process.kill(-p, "SIGTERM"); // process group (we spawn detached on POSIX)
+  } catch {
+    try {
+      process.kill(p, "SIGTERM");
+    } catch {
+      // already gone
+    }
+  }
+}
+
+// ---- minimal JSON-RPC-2.0-over-stdio client for `grok agent` ----
+// A self-contained line-framed (newline-delimited) JSON-RPC 2.0 client, modeled
+// 1:1 on codex-backend's AppServerClient. The only wire differences from the
+// codex app-server client are: (1) we stamp `jsonrpc:"2.0"` on every outbound
+// message (ACP is strict JSON-RPC 2.0), and (2) the server→client request set we
+// auto-approve is the ACP one (session/request_permission).
+
+interface RpcMessage {
+  jsonrpc?: string;
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code?: number; message?: string; data?: unknown };
+}
+
+type NotificationHandler = (msg: RpcMessage) => void;
+
+/** An Error carrying the JSON-RPC error `data` so the auth_required reason
+ *  survives the request rejection (used to drive the authenticate retry). */
+class RpcError extends Error {
+  code?: number;
+  data?: unknown;
+  constructor(message: string, code?: number, data?: unknown) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+class AcpClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private rl: readline.Interface | null = null;
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void; method: string }
+  >();
+  private nextId = 1;
+  private closed = false;
+  private exitResolved = false;
+  /** The error that ended the connection (null = clean exit). */
+  exitError: Error | null = null;
+  stderr = "";
+  notificationHandler: NotificationHandler | null = null;
+  private resolveExit!: () => void;
+  /** Resolves when the `gemini` process exits or errors — runTurn() races its
+   *  per-turn drain against this so a child that dies mid-prompt never deadlocks
+   *  the turn forever (mirrors codex P0-2). */
+  readonly exitPromise: Promise<void>;
+
+  constructor(
+    private readonly cmd: string,
+    private readonly args: string[],
+    private readonly cwd: string,
+    private readonly env: NodeJS.ProcessEnv,
+    private readonly useShell: boolean,
+  ) {
+    this.exitPromise = new Promise<void>((resolve) => {
+      this.resolveExit = resolve;
+    });
+  }
+
+  /** Spawn `grok agent` and perform the ACP `initialize` handshake. Returns the
+   *  agent's initialize result (capabilities + authMethods). NOTE: ACP has NO
+   *  `initialized` notification (that's MCP, not ACP) — initialize is a plain
+   *  request/response, after which we go straight to session/new. */
+  async initialize(clientInfo: {
+    name: string;
+    title: string;
+    version: string;
+  }): Promise<AcpInitializeResult> {
+    this.proc = spawn(this.cmd, this.args, {
+      cwd: this.cwd,
+      env: this.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      shell: this.useShell,
+      // POSIX: own process group so close() can kill the whole tree with one
+      // negative-pid signal. Windows uses taskkill /T instead.
+      detached: process.platform !== "win32",
+    }) as ChildProcessWithoutNullStreams;
+
+    this.proc.stdout.setEncoding("utf8");
+    this.proc.stderr.setEncoding("utf8");
+    this.proc.stderr.on("data", (chunk: string) => {
+      this.stderr += chunk;
+    });
+    // Route pipe errors (EPIPE when the child dies mid-turn) through handleExit so
+    // the turn rejects cleanly instead of crashing the host as an uncaught error.
+    this.proc.stdin.on("error", (error) => this.handleExit(error));
+    this.proc.stdout.on("error", (error) => this.handleExit(error));
+    this.proc.on("error", (error) => this.handleExit(error));
+    this.proc.on("exit", (code, signal) => {
+      const detail =
+        code === 0
+          ? null
+          : new Error(
+              `grok agent exited unexpectedly (${signal ? `signal ${signal}` : `exit ${code}`}).${this.stderr ? ` ${this.stderr.trim().split(/\r?\n/).slice(-2).join(" ")}` : ""}`,
+            );
+      this.handleExit(detail);
+    });
+
+    this.rl = readline.createInterface({ input: this.proc.stdout });
+    this.rl.on("line", (line) => this.handleLine(line));
+
+    // ACP initialize: negotiate protocol version + advertise client capabilities.
+    // We do NOT implement the client fs/terminal methods, so advertise them false
+    // (the agent then won't issue fs/read_text_file, terminal/*, etc.).
+    const result = await this.request<AcpInitializeResult>("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+      clientInfo,
+    });
+    return result;
+  }
+
+  request<T = unknown>(method: string, params: unknown): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("grok agent client is closed."));
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject, method });
+      this.send({ id, method, params });
+    });
+  }
+
+  notify(method: string, params: unknown = {}): void {
+    if (this.closed) return;
+    // Fire-and-forget: a write failure (dead child) must not throw into the caller.
+    try {
+      this.send({ method, params });
+    } catch {
+      // connection gone; pending requests already rejected via handleExit
+    }
+  }
+
+  private send(message: RpcMessage): void {
+    const stdin = this.proc?.stdin;
+    if (!stdin || stdin.destroyed || stdin.writableEnded) {
+      this.handleExit(this.exitError ?? new Error("grok agent stdin is not available."));
+      throw this.exitError ?? new Error("grok agent stdin is not available.");
+    }
+    // ACP is strict JSON-RPC 2.0 — every outbound frame carries `jsonrpc:"2.0"`.
+    const framed: RpcMessage = { jsonrpc: "2.0", ...message };
+    try {
+      stdin.write(`${JSON.stringify(framed)}\n`);
+    } catch (err) {
+      this.handleExit(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
+  }
+
+  /**
+   * The auto-approve RESULT for a server→client request, or null if it isn't one
+   * we should auto-grant. The panel agent is an ISOLATED background agent (same
+   * posture as Claude's bypassPermissions / Codex's auto-approve), so we grant
+   * tool-permission requests to keep the live-graph work flowing.
+   *
+   * ACP permission flow: the agent sends `session/request_permission`
+   * ({ sessionId, toolCall, options:[{ optionId, name, kind }] }) and expects
+   * { outcome: { outcome:"selected", optionId } }. We pick the most-permissive
+   * "allow" option (allow_always > allow_once); if none is offered we cancel.
+   */
+  private autoApproveResult(msg: RpcMessage): Record<string, unknown> | null {
+    if (msg.method !== "session/request_permission") return null;
+    const params = (msg.params ?? {}) as { options?: Array<{ optionId?: string; kind?: string }> };
+    const options = Array.isArray(params.options) ? params.options : [];
+    const pick =
+      options.find((o) => o.kind === "allow_always") ??
+      options.find((o) => o.kind === "allow_once") ??
+      // Fall back to any option whose id/kind reads as an allow.
+      options.find((o) => /allow/i.test(o.kind ?? "") || /allow/i.test(o.optionId ?? ""));
+    if (pick?.optionId) {
+      return { outcome: { outcome: "selected", optionId: pick.optionId } };
+    }
+    // No allow option offered → decline gracefully so the agent moves on.
+    return { outcome: { outcome: "cancelled" } };
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+    let message: RpcMessage;
+    try {
+      message = JSON.parse(line) as RpcMessage;
+    } catch (error) {
+      this.handleExit(new Error(`Failed to parse grok agent JSONL: ${msgOf(error)}`));
+      return;
+    }
+    // Server→client request (id + method). Auto-approve permission prompts; reply
+    // method-not-found to anything else so the protocol keeps moving (we declared
+    // no fs/terminal client capabilities, so those shouldn't arrive).
+    if (message.id !== undefined && message.method) {
+      const result = this.autoApproveResult(message);
+      if (result) {
+        logger.debug(`[grok-backend] auto-approving server request ${message.method}`);
+        this.send({ id: message.id, result });
+      } else {
+        logger.debug(
+          `[grok-backend] unsupported server request ${message.method} — replying method-not-found`,
+        );
+        this.send({
+          id: message.id,
+          error: { code: -32601, message: `Unsupported server request: ${message.method}` },
+        });
+      }
+      return;
+    }
+    // Response to one of our requests.
+    if (message.id !== undefined) {
+      const p = this.pending.get(message.id as number);
+      if (!p) return;
+      this.pending.delete(message.id as number);
+      if (message.error) {
+        p.reject(
+          new RpcError(
+            message.error.message ?? `grok agent ${p.method} failed.`,
+            message.error.code,
+            message.error.data,
+          ),
+        );
+      } else {
+        p.resolve(message.result ?? {});
+      }
+      return;
+    }
+    // Notification.
+    if (message.method) this.notificationHandler?.(message);
+  }
+
+  private handleExit(error: Error | null): void {
+    if (this.exitResolved) return;
+    this.exitResolved = true;
+    this.exitError = error;
+    for (const p of this.pending.values())
+      p.reject(error ?? new Error("grok agent connection closed."));
+    this.pending.clear();
+    this.resolveExit();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      await this.exitPromise;
+      return;
+    }
+    this.closed = true;
+    this.notificationHandler = null;
+    this.rl?.close();
+    this.rl = null;
+    if (this.proc && this.proc.exitCode === null) {
+      try {
+        this.proc.stdin.end();
+      } catch {
+        // already gone
+      }
+      const proc = this.proc;
+      // Give a graceful stdin-EOF shutdown a beat, then KILL THE WHOLE TREE — on
+      // the Windows shell fallback the direct child is a shim whose grandchild is
+      // the real gemini node process, so proc.kill() alone would orphan it.
+      setTimeout(() => {
+        if (proc.exitCode === null) killProcessTree(proc.pid);
+      }, 50).unref?.();
+    }
+    await this.exitPromise;
+    this.proc = null;
+  }
+}
+
+// ---- ACP type shapes (the subset we read; best-effort, defensive) ----
+
+interface AcpAuthMethod {
+  id?: string;
+  name?: string;
+  description?: string;
+}
+
+interface AcpInitializeResult {
+  protocolVersion?: number;
+  agentCapabilities?: {
+    loadSession?: boolean;
+    promptCapabilities?: { image?: boolean; audio?: boolean; embeddedContext?: boolean };
+    mcpCapabilities?: { http?: boolean; sse?: boolean };
+  };
+  authMethods?: AcpAuthMethod[];
+  agentInfo?: { name?: string; title?: string; version?: string };
+}
+
+// ---- model catalog ----
+// ACP exposes no model enumeration, and the model is fixed at SPAWN via the CLI
+// `--model` flag — so we surface a static catalog of the current Gemini family.
+// Gemini's "thinking" is a token BUDGET, not a discrete effort scale, so we do
+// NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
+// then hides the effort dropdown (omission is the documented "no effort control"
+// signal). gemini-2.5-pro is the default.
+const GROK_MODELS: ModelChoice[] = [
+  { id: "grok-composer-2.5-fast", label: "Grok Composer 2.5 Fast" },
+  { id: "grok-build", label: "Grok Build" },
+];
+const GROK_DEFAULT_MODEL = "grok-composer-2.5-fast";
+
+/** Does this id look like a Grok model (vs. the Claude panel model PanelAgent
+ *  unconditionally passes as opts.model)? Used so the configured Grok model
+ *  wins — mirrors codex-backend's isCodexModel guard (P1-1). */
+function isGrokModel(id: string): boolean {
+  return /^grok[-/]/i.test(id);
+}
+
+/** A declared MCP server for the ACP session. Either a stdio command (the headless
+ *  comfyui MCP) or a streamable-HTTP url (the panel_* loopback server). Identical
+ *  shape to codex-backend's CodexMcpServerSpec so the orchestrator can build one
+ *  config for both. */
+export type GrokMcpServerSpec =
+  | { transport: "stdio"; command: string; args?: string[]; env?: Record<string, string> }
+  | { transport: "http"; url: string };
+
+/**
+ * Convert our MCP server specs into the ACP `session/new` `mcpServers` array.
+ * ACP stdio McpServer: { name, command, args, env:[{name,value}] }. The HTTP
+ * variant ({ type:"http", name, url }) is the closest faithful mapping to the ACP
+ * spec's HTTP transport (gated by the agent's mcpCapabilities.http) — FLAGGED as
+ * unverified against the live gemini CLI. Empty env is the required `[]`.
+ */
+export function buildAcpMcpServers(
+  servers: Record<string, GrokMcpServerSpec>,
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const [name, spec] of Object.entries(servers)) {
+    if (spec.transport === "stdio") {
+      out.push({
+        name,
+        command: spec.command,
+        args: spec.args ?? [],
+        env: Object.entries(spec.env ?? {}).map(([k, v]) => ({ name: k, value: v })),
+      });
+    } else {
+      // ASSUMPTION (unverified w/o live CLI): ACP HTTP McpServer variant.
+      out.push({ type: "http", name, url: spec.url });
+    }
+  }
+  return out;
+}
+
+/** Provider config the Gemini backend needs. Mirrors CodexBackendDeps. */
+export interface GrokBackendDeps {
+  /** Working directory for the ACP session (defaults to opts.cwd / process cwd). */
+  cwd?: string;
+  /** Default model for new sessions (e.g. gemini-2.5-pro); set at SPAWN via --model. */
+  model?: string;
+  /**
+   * Base URL of the ComfyUI instance, for fetching image bytes (/view). When set,
+   * NeutralTurn image refs are fetched and delivered inline as base64 `image`
+   * ContentBlocks on the prompt (vision parity with the Claude path).
+   */
+  comfyuiUrl?: string;
+  /**
+   * MCP servers to declare to the ACP `session/new` — the headless `comfyui`
+   * stdio MCP + the `panel` HTTP MCP for live-graph tools (full tool parity).
+   */
+  mcpServers?: Record<string, GrokMcpServerSpec>;
+  /**
+   * Panel system prompt (persona). ACP `session/new` has no instructions field,
+   * so this is PREPENDED to the first turn's prompt as a clearly-marked
+   * system/context preamble; later turns send plain text.
+   */
+  systemAppend?: string;
+}
+
+/**
+ * The Gemini CLI ACP adapter. One instance per PanelAgent; it holds the live ACP
+ * client + current session id and re-opens on each `run()`.
+ */
+export class GrokBackend implements AgentBackend {
+  readonly id = "grok" as const;
+  readonly capabilities = GROK_CAPABILITIES;
+  private deps: GrokBackendDeps;
+  private client: AcpClient | null = null;
+  /** The client an in-flight prepare() is spinning up, tracked so a concurrent
+   *  close() can tear it down before it's published (P0-A). */
+  private preparingClient: AcpClient | null = null;
+  /** Set once close() runs — a tripwire so an in-flight prepare() disposes its
+   *  local client instead of publishing it (P0-A). */
+  private disposed = false;
+  /** Cached resolved spawn command/args/shell (set in prepare()). */
+  private spawnSpec: { cmd: string; args: string[]; useShell: boolean } | null = null;
+  /** The live ACP session id — used for session/prompt + session/cancel. */
+  private sessionId: string | null = null;
+  /** The model requested for new sessions (applied at SPAWN via --model). */
+  private model: string | undefined;
+  /** The model the LIVE `grok agent` child was actually spawned with. Gemini
+   *  pins the model at spawn, so when this drifts from `this.model` (a live
+   *  setModel) the run loop respawns the CLI before the next turn (P1). */
+  private spawnedModel: string | undefined;
+  /** Capabilities the agent advertised at initialize (loadSession / image / http). */
+  private agentCaps: AcpInitializeResult["agentCapabilities"] = undefined;
+  private authMethods: AcpAuthMethod[] = [];
+  /** True until the panel system prompt has been prepended to a turn. Reset
+   *  whenever a NEW session starts (run()). */
+  private needsSystemPreamble = false;
+
+  constructor(deps: GrokBackendDeps = {}) {
+    this.deps = deps;
+    this.model = deps.model;
+  }
+
+  /**
+   * Resolve how to spawn `grok agent --always-approve stdio`. The Grok CLI must
+   * be on PATH (installed via Grok Build / xAI). The `--model` flag pins the
+   * model at spawn (ACP has no standard per-session model setter). On Windows,
+   * `grok` may resolve to a `.cmd` shim — spawn with a shell when needed.
+   */
+  private resolveSpawn(): { cmd: string; args: string[]; useShell: boolean } {
+    if (this.spawnSpec) return this.spawnSpec;
+    const modelArgs = this.model ? ["--model", this.model] : [];
+    const cmd = "grok";
+    const args = ["agent", ...modelArgs, "--always-approve", "stdio"];
+    const useShell = process.platform === "win32";
+    this.spawnSpec = { cmd, args, useShell };
+    return this.spawnSpec;
+  }
+
+  /**
+   * Fetch a ComfyUI image (/view) and return it as an ACP base64 `image`
+   * ContentBlock ({ type:"image", mimeType, data }) — or null on any failure (the
+   * text reference still names the image as a fallback). Unlike Codex (which
+   * spills to a temp file for its path-based localImage item), ACP takes inline
+   * base64, so this mirrors ClaudeBackend.fetchImageBlock exactly (only the key
+   * names differ: ACP uses `mimeType`/`data`).
+   */
+  private async fetchImageBlock(ref: ImageRef): Promise<Record<string, unknown> | null> {
+    if (!this.deps.comfyuiUrl || !ref?.filename) return null;
+    try {
+      const u = new URL("/view", this.deps.comfyuiUrl);
+      u.searchParams.set("filename", ref.filename);
+      u.searchParams.set("type", ref.type || "input");
+      if (ref.subfolder) u.searchParams.set("subfolder", ref.subfolder);
+      const res = await fetch(u, { signal: AbortSignal.timeout(15000) });
+      if (!res.ok) return null;
+      let mt = (res.headers.get("content-type") || "").split(";")[0].trim().toLowerCase();
+      if (!["image/png", "image/jpeg", "image/gif", "image/webp"].includes(mt)) {
+        mt = "image/png"; // ComfyUI outputs are PNG by default
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length > 12 * 1024 * 1024) return null; // keep context sane (parity with Claude)
+      return { type: "image", mimeType: mt, data: buf.toString("base64") };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Preflight: resolve + spawn `grok agent` and perform the ACP `initialize`
+   * handshake. Fails fast with a clear reject so a missing binary surfaces
+   * immediately instead of being retried as a dropped session. Idempotent —
+   * reuses the live client. NOTE: the actual login (Google OAuth) is verified
+   * lazily at `session/new` (ACP returns auth_required there) — see run() — since
+   * ACP has no pre-session account probe; flagged in the PR body.
+   */
+  async prepare(): Promise<void> {
+    if (this.disposed) throw new Error("grok backend is closed.");
+    if (this.client) return;
+    const { cmd, args, useShell } = this.resolveSpawn();
+    const cwd = this.deps.cwd ?? process.cwd();
+    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // Publish the in-flight client BEFORE the startup awaits so a concurrent
+    // close() can find and kill it (P0-A).
+    this.preparingClient = client;
+    const abortIfDisposed = async (): Promise<void> => {
+      if (!this.disposed) return;
+      if (this.preparingClient === client) this.preparingClient = null;
+      await client.close().catch(() => {});
+      throw new Error("grok backend was closed during prepare().");
+    };
+    try {
+      let init: AcpInitializeResult;
+      try {
+        init = await client.initialize({
+          name: "comfyui-mcp",
+          title: "comfyui-mcp panel",
+          version: "0.16.0",
+        });
+      } catch (err) {
+        await client.close().catch(() => {});
+        throw new Error(
+          `Could not start the Grok CLI in ACP mode (grok backend). Install the Grok CLI (Grok Build / xAI) and ensure \`grok\` is on PATH, then sign in with \`grok\`. Details: ${msgOf(err)}`,
+        );
+      }
+      await abortIfDisposed();
+      this.agentCaps = init.agentCapabilities;
+      this.authMethods = Array.isArray(init.authMethods) ? init.authMethods : [];
+      this.client = client;
+      // Record what the live child was spawned with so a later setModel can detect
+      // the model drifted and respawn (the model is spawn-pinned via --model) (P1).
+      this.spawnedModel = this.model;
+      logger.info(
+        `[grok-backend] ACP ready (protocol ${init.protocolVersion ?? "?"}, agent ${init.agentInfo?.name ?? "grok"}${this.authMethods.length ? `, ${this.authMethods.length} auth method(s)` : ""})`,
+      );
+    } finally {
+      if (this.preparingClient === client) this.preparingClient = null;
+    }
+  }
+
+  /** Ensure a live ACP session exists, creating (session/new) or resuming
+   *  (session/load) one. Handles an `auth_required` error from session/new by
+   *  attempting a single `authenticate` with the first advertised method, then
+   *  retrying — surfacing a clear sign-in message if it still fails. Returns the
+   *  session id. */
+  private async ensureSession(client: AcpClient, cwd: string, resumeId: string | null): Promise<string> {
+    const mcpServers = this.deps.mcpServers ? buildAcpMcpServers(this.deps.mcpServers) : [];
+    const canLoad = this.agentCaps?.loadSession === true;
+    // RESUME (session/load) — whole-session only (forkAtAnchor=false). Only if the
+    // agent advertised loadSession; otherwise fall through to a fresh session.
+    if (resumeId && canLoad) {
+      try {
+        await client.request("session/load", { sessionId: resumeId, cwd, mcpServers });
+        this.sessionId = resumeId;
+        this.needsSystemPreamble = false; // persona already delivered on the original first turn
+        return resumeId;
+      } catch (err) {
+        logger.warn(`[grok-backend] session/load failed (${msgOf(err)}) — starting a fresh session`);
+      }
+    }
+    // NEW session, with one auth_required retry.
+    const createNew = async (): Promise<string> => {
+      const res = await client.request<{ sessionId?: string }>("session/new", { cwd, mcpServers });
+      if (!res?.sessionId) throw new Error("grok agent session/new returned no sessionId.");
+      return res.sessionId;
+    };
+    try {
+      this.sessionId = await createNew();
+    } catch (err) {
+      if (this.isAuthRequired(err) && this.authMethods[0]?.id) {
+        // The CLI owns auth (Google OAuth). Try the first advertised method once;
+        // if the CLI isn't already signed in this cannot complete headlessly.
+        try {
+          await client.request("authenticate", { methodId: this.authMethods[0].id });
+          this.sessionId = await createNew();
+        } catch {
+          throw new Error(
+            "Grok CLI is not signed in. Run `grok` once and complete the xAI sign-in, then reconnect.",
+          );
+        }
+      } else if (this.isAuthRequired(err)) {
+        throw new Error(
+          "Grok CLI is not signed in. Run `grok` once and complete the xAI sign-in, then reconnect.",
+        );
+      } else {
+        throw err;
+      }
+    }
+    this.needsSystemPreamble = !!this.deps.systemAppend; // fresh session → persona on first turn
+    return this.sessionId!;
+  }
+
+  /** Does this error look like an ACP `auth_required`? Reads the JSON-RPC error
+   *  data.reason carried by RpcError, falling back to the message text. */
+  private isAuthRequired(err: unknown): boolean {
+    if (err instanceof RpcError) {
+      const data = err.data as { reason?: string } | undefined;
+      if (data?.reason === "auth_required") return true;
+    }
+    return /auth.?required|authenticat|not.*(logged|signed).*in/i.test(msgOf(err));
+  }
+
+  /**
+   * Open/continue an ACP session and yield canonical AgentEvents. The user
+   * channel (PanelAgent's gated queue) is consumed ONE turn at a time: each
+   * neutral batch becomes a `session/prompt`, whose streamed session/update
+   * notifications are normalized to AgentEvents, and only after the prompt
+   * resolves (stopReason) do we read the next batch (the channel async-iteration
+   * IS the turn-gate).
+   */
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    // MODEL PRECEDENCE (P1): apply the panel-selected model BEFORE prepare() so the
+    // FIRST spawn uses it (the model is spawn-pinned via `--model`; preparing first
+    // would spawn the wrong model). PanelAgent.start() usually passes opts.model =
+    // the CLAUDE panel model, which is NOT a valid Gemini model — so the configured
+    // Gemini model (deps.model, from COMFYUI_MCP_GEMINI_MODEL) wins; only honor
+    // opts.model when it actually looks like a Gemini model (e.g. the user picked
+    // one in the panel, which arrives as opts.model on a fresh spawn).
+    if (opts.model && isGrokModel(opts.model)) this.model = opts.model;
+
+    await this.prepare();
+    if (!this.client) throw new Error("grok agent not initialized");
+    const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
+
+    // forkAtAnchor is false → ignore opts.rewindAnchor; whole-session resume only.
+    const resumeId = opts.resume ?? opts.sessionId ?? null;
+    let sessionId = await this.ensureSession(this.client, cwd, resumeId);
+
+    // The session id is our session id (PanelAgent persists it for resume).
+    yield {
+      type: "session",
+      sessionId,
+      ...(this.model ? { model: this.model } : {}),
+    };
+
+    // Process the neutral channel one turn at a time.
+    for await (const turn of opts.channel) {
+      // LIVE MODEL SWITCH (P1): PanelAgent treats setModel as live and does NOT
+      // restart run() for a model-only change, so the persistent loop adopts it
+      // here. The model is spawn-pinned, so a switch means respawning the CLI with
+      // the new --model — which necessarily starts a FRESH session (a model swap
+      // can't carry the old session forward). Done transparently before the turn;
+      // we emit a new `session` event so PanelAgent persists the new id.
+      if (this.spawnedModel !== this.model) {
+        await this.respawnForModelChange();
+        if (!this.client) throw new Error("grok agent respawn failed");
+        sessionId = await this.ensureSession(this.client, cwd, null);
+        yield {
+          type: "session",
+          sessionId,
+          ...(this.model ? { model: this.model } : {}),
+        };
+      }
+      yield* this.runTurn(this.client, turn, opts.onActivity);
+    }
+  }
+
+  /** Tear down the live `grok agent` child (process-tree kill) and re-spawn it
+   *  with the current `this.model`'s `--model` flag, so a live setModel takes
+   *  effect. The model is spawn-pinned, so this is the only way to switch it. The
+   *  caller then opens a fresh session on the new child. */
+  private async respawnForModelChange(): Promise<void> {
+    const old = this.client;
+    this.client = null;
+    this.sessionId = null;
+    if (old) {
+      old.notificationHandler = null;
+      await old.close().catch(() => {});
+    }
+    this.spawnSpec = null; // force resolveSpawn to rebuild argv with the new --model
+    logger.info(`[grok-backend] model switch → respawning grok agent with --model ${this.model ?? "(default)"}`);
+    await this.prepare(); // spawns with this.model; records spawnedModel
+  }
+
+  /** Run ONE turn: send session/prompt + stream its session/update notifications →
+   *  AgentEvents, resolving when the prompt request returns a stopReason, OR when
+   *  the child exits mid-turn (never deadlock). ACP's prompt request IS the turn
+   *  boundary, so — unlike Codex — there is no separate completion notification and
+   *  no turn-id buffering: the sessionId is known before the prompt is sent. */
+  private async *runTurn(
+    client: AcpClient,
+    turn: NeutralTurn,
+    onActivity?: () => void,
+  ): AsyncGenerator<AgentEvent> {
+    const sessionId = this.sessionId!;
+    // Event queue bridging the push-based notification handler to this pull-based
+    // async generator (identical pattern to codex-backend).
+    const queue: AgentEvent[] = [];
+    let wake: (() => void) | null = null;
+    let done = false;
+    const push = (ev: AgentEvent) => {
+      queue.push(ev);
+      wake?.();
+      wake = null;
+    };
+    const finish = () => {
+      done = true;
+      wake?.();
+      wake = null;
+    };
+
+    // Accumulate the assistant reply text across agent_message_chunk so we can emit
+    // ONE authoritative `assistant` commit when the turn ends (ACP has no separate
+    // final-message notification). messageId (when present) groups the deltas + the
+    // commit under one bubble id, mirroring the Claude/Codex stream reconciliation.
+    let assistantText = "";
+    let messageId: string | null = null;
+
+    // Stream bubble state (reasoning vs reply each open/close their own stream).
+    let streamOpen = false;
+    let streamKind: "text" | "thinking" | null = null;
+    const openStream = (id: string | null, kind: "text" | "thinking") => {
+      if (streamOpen && streamKind === kind) return;
+      if (streamOpen) push({ type: "stream_end" }); // switch kinds → close the old one
+      streamOpen = true;
+      streamKind = kind;
+      push({ type: "stream_start", id });
+    };
+    const closeStream = () => {
+      if (streamOpen) {
+        push({ type: "stream_end" });
+        streamOpen = false;
+        streamKind = null;
+      }
+    };
+
+    // EXACTLY ONE terminal `result` (PanelAgent's turn-gate only advances on a
+    // result; a missing one parks the channel forever). This idempotent helper
+    // emits an `error` + `{result, ok:false}` and finishes; no-op once a result
+    // has fired (so the prompt rejection AND the exit watcher can both call it).
+    let finishedResult = false;
+    const emitTerminalError = (message: string) => {
+      if (finishedResult) return;
+      finishedResult = true;
+      closeStream();
+      push({ type: "error", message });
+      push({ type: "result", ok: false, subtype: "error" });
+      finish();
+    };
+
+    let interrupted = false;
+
+    // tool_call carries the title/kind; tool_call_update (ACP) repeats only the
+    // toolCallId — so remember each call's display name to label its end event.
+    const toolNames = new Map<string, string>();
+
+    // Normalize ONE session/update notification into canonical AgentEvents.
+    const apply = (msg: RpcMessage) => {
+      if (finishedResult) return;
+      const params = (msg.params ?? {}) as Record<string, unknown>;
+      // Only our session's updates.
+      if (params.sessionId && params.sessionId !== sessionId) return;
+      const update = (params.update ?? {}) as Record<string, unknown>;
+      const kind = update.sessionUpdate as string | undefined;
+      switch (kind) {
+        case "agent_message_chunk": {
+          const content = update.content as { type?: string; text?: string } | undefined;
+          const text = content?.type === "text" ? content.text : undefined;
+          const id = (update.messageId as string | undefined) ?? null;
+          if (typeof text === "string" && text) {
+            if (id) messageId = id;
+            openStream(messageId, "text");
+            assistantText += text;
+            push({ type: "assistant_delta", text });
+          }
+          break;
+        }
+        case "agent_thought_chunk": {
+          // Extended-thinking streaming. Open a reasoning stream on the FIRST delta
+          // so PanelAgent (which drops assistant_delta when no stream is open)
+          // renders early thinking, mirroring codex P2-1.
+          const content = update.content as { type?: string; text?: string } | undefined;
+          const text = content?.type === "text" ? content.text : undefined;
+          if (typeof text === "string" && text) {
+            openStream(messageId, "thinking");
+            push({ type: "assistant_delta", text, thinking: true });
+          }
+          break;
+        }
+        case "tool_call": {
+          // A tool call was requested — emit tool_call(start) for panel visibility.
+          const id = update.toolCallId as string | undefined;
+          const name =
+            (update.title as string | undefined) ||
+            (update.kind as string | undefined) ||
+            id ||
+            "tool";
+          if (id) toolNames.set(id, name);
+          push({ type: "tool_call", name, phase: "start", detail: update });
+          break;
+        }
+        case "tool_call_update": {
+          // Progress + completion of a tool call. Emit tool_call(end) only on a
+          // TERMINAL status; intermediate in_progress updates just keep the
+          // watchdog armed (onActivity already fired for them). ACP's update
+          // repeats only the toolCallId, so reuse the remembered title for the name.
+          const status = update.status as string | undefined;
+          if (status === "completed" || status === "failed") {
+            const id = update.toolCallId as string | undefined;
+            const name =
+              (update.title as string | undefined) ||
+              (id ? toolNames.get(id) : undefined) ||
+              (update.kind as string | undefined) ||
+              id ||
+              "tool";
+            push({ type: "tool_call", name, phase: "end", detail: update });
+          }
+          break;
+        }
+        // plan / available_commands_update / session_info_update / current_mode_update
+        // carry no AgentEvent — onActivity (below) already re-armed the watchdog.
+        default:
+          break;
+      }
+    };
+
+    const prev = client.notificationHandler;
+    client.notificationHandler = (msg: RpcMessage) => {
+      // LIVENESS: ANY notification while this turn is in flight means the agent is
+      // alive — fire onActivity BEFORE filtering/translating so even updates that
+      // produce no AgentEvent (a long MCP tool call mid-generation) keep
+      // PanelAgent's idle watchdog armed. A genuine zero-event freeze never
+      // reaches here, so the real freeze-catch is preserved.
+      try {
+        onActivity?.();
+      } catch {
+        // a watchdog bump must never break the protocol reader
+      }
+      if (msg.method === "session/update") apply(msg);
+      else prev?.(msg); // anything else (other methods) → pass through
+    };
+
+    // Watch for the child dying mid-turn: end the turn with a terminal result so
+    // the local drain is woken instead of waiting forever. emitTerminalError is a
+    // no-op if a result already fired, so it's safe alongside the prompt rejection.
+    void client.exitPromise.then(() => {
+      if (done) return;
+      emitTerminalError(
+        client.exitError ? msgOf(client.exitError) : "grok agent connection closed.",
+      );
+    });
+
+    // FIRST-TURN PERSONA: ACP session/new has no instructions field, so the panel
+    // system prompt is prepended to the first turn's prompt as a clearly-marked
+    // system/context preamble (later turns send plain text). Mirrors codex.
+    let turnText = turn.text;
+    if (this.needsSystemPreamble && this.deps.systemAppend) {
+      turnText =
+        `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
+        `The user's first message follows.\n\n${turn.text}`;
+      this.needsSystemPreamble = false;
+    }
+
+    // Build the prompt ContentBlock[]: the text block first (preserves prompt
+    // context), then any resolved inline base64 image blocks (vision parity).
+    // Images are only attached when the agent advertised promptCapabilities.image
+    // (default-allow when the capability is unknown).
+    const prompt: Array<Record<string, unknown>> = [{ type: "text", text: turnText }];
+    const imagesAllowed = this.agentCaps?.promptCapabilities?.image !== false;
+    if (imagesAllowed) {
+      for (const ref of turn.images ?? []) {
+        const block = await this.fetchImageBlock(ref);
+        if (block) prompt.push(block);
+      }
+    }
+
+    try {
+      // session/prompt is a REQUEST that RESOLVES with a stopReason at turn end.
+      client
+        .request<{ stopReason?: string }>("session/prompt", { sessionId, prompt })
+        .then((res) => {
+          if (finishedResult) return;
+          finishedResult = true;
+          closeStream();
+          const stop = res?.stopReason;
+          // Commit the accumulated assistant text (if any) as the authoritative
+          // turn-ending message — no per-turn rewind anchor (forkAtAnchor=false).
+          const text = assistantText.trim();
+          if (text) push({ type: "assistant", text, ...(messageId ? { id: messageId } : {}) });
+          // end_turn / max_tokens / max_turn_requests = a real completion; cancelled
+          // (user interrupt) and refusal are not "ok".
+          const ok = !!stop && stop !== "cancelled" && stop !== "refusal";
+          push({ type: "result", ok, ...(stop ? { subtype: stop } : {}) });
+          finish();
+        })
+        .catch((err) => {
+          // A failed prompt ends the turn. When the child dies mid-turn handleExit
+          // rejects this BEFORE exitPromise resolves, so this .catch runs first —
+          // it MUST end with a terminal result (the idempotent helper guarantees
+          // exactly one), or the exit watcher then sees done and hangs the gate.
+          if (interrupted) emitTerminalError("grok turn interrupted.");
+          else emitTerminalError(msgOf(err));
+        });
+
+      // Drain the bridged queue until the turn completes.
+      while (true) {
+        while (queue.length) {
+          yield queue.shift()!;
+        }
+        if (done) break;
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      while (queue.length) yield queue.shift()!;
+    } finally {
+      // Mark interrupted so a late prompt rejection doesn't surface a spurious
+      // error after teardown.
+      interrupted = true;
+      // Restore the prior handler ONLY if it's still ours (close() may have nulled
+      // it during shutdown — don't resurrect a stale handler onto a dead client).
+      if (client.notificationHandler && !client.exitError) client.notificationHandler = prev ?? null;
+    }
+  }
+
+  /** Stop the current turn without ending the session → `session/cancel`
+   *  (notification). The in-flight session/prompt then resolves with
+   *  stopReason:"cancelled", which the run-turn path turns into a terminal result. */
+  async interrupt(): Promise<void> {
+    const client = this.client;
+    if (!client || !this.sessionId) return;
+    try {
+      client.notify("session/cancel", { sessionId: this.sessionId });
+    } catch (err) {
+      logger.debug(`[grok-backend] interrupt: ${msgOf(err)}`);
+    }
+  }
+
+  /** Switch the model live. ACP pins the model at spawn (`--model`), so this can't
+   *  reconfigure a running child — instead it marks the model dirty (this.model !=
+   *  this.spawnedModel) and invalidates the cached spawn spec. The persistent run()
+   *  loop then RESPAWNS the `grok agent` CLI with the new --model (and a fresh
+   *  session) transparently before the next turn (see run()'s live-switch branch).
+   *  If the backend hasn't spawned yet, the first prepare() simply uses the new
+   *  model. Ignores non-Gemini ids (PanelAgent may pass the Claude panel model). */
+  async setModel(model: string): Promise<void> {
+    if (!isGrokModel(model)) return;
+    this.model = model;
+    this.spawnSpec = null; // next spawn rebuilds argv with the new --model
+  }
+
+  /**
+   * Gemini model enumeration. ACP exposes no model catalog, so we surface a static
+   * set (the current Gemini family); the panel picker degrades gracefully on an
+   * empty list. No effort metadata (Gemini uses a thinking BUDGET, not a discrete
+   * effort scale) → the panel hides the effort dropdown.
+   */
+  async listModels(): Promise<ModelChoice[]> {
+    return GROK_MODELS;
+  }
+
+  /** Permanently dispose of the backend (AgentBackend.close): kill the gemini
+   *  process TREE (Windows shell-fallback grandchild included), remove listeners,
+   *  null the client. Idempotent + safe when never prepared. Mirrors codex (P0-1):
+   *  interrupt() is a no-op when idle, so without this the child is orphaned. */
+  async close(): Promise<void> {
+    this.disposed = true; // tripwire FIRST (an in-flight prepare() bails) (P0-A)
+    const client = this.client;
+    const preparing = this.preparingClient;
+    this.client = null;
+    this.preparingClient = null;
+    this.sessionId = null;
+    if (client) {
+      client.notificationHandler = null;
+      await client.close().catch(() => {});
+    }
+    if (preparing && preparing !== client) {
+      preparing.notificationHandler = null;
+      await preparing.close().catch(() => {});
+    }
+  }
+}
+
+// Expose the default model id for the orchestrator wiring (COMFYUI_MCP_GEMINI_MODEL
+// fallback) without duplicating the literal.
+export { GROK_DEFAULT_MODEL };

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -61,9 +61,11 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import readline from "node:readline";
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { logger } from "../utils/logger.js";
 import {
   type AgentBackend,
+  type AgentCapabilities,
   type AgentEvent,
   type BackendStartOptions,
   type ModelChoice,
@@ -76,9 +78,8 @@ import {
   type CodeProviderAuthDeps,
   type GrokOAuthCredentials,
 } from "../services/code-provider-auth.js";
-import { OAUTH_PROVIDERS, assertAllowedTokenHost } from "../services/oauth-flow.js";
+import { OAUTH_PROVIDERS, assertAllowedTokenHost, grokTokenFile } from "../services/oauth-flow.js";
 import { OllamaBackend } from "./ollama-backend.js";
-import { resolvePrompt } from "../services/prompt-overrides.js";
 
 function msgOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -510,12 +511,15 @@ export interface GrokBackendDeps {
  */
 export class GrokBackend implements AgentBackend {
   readonly id = "grok" as const;
-  readonly capabilities = GROK_CAPABILITIES;
   private deps: GrokBackendDeps;
   /** Memoized mode decision: resolves to a live GrokDirectBackend when a usable
    *  OAuth token was found, or `null` to mean "use this class's own ACP body".
    *  Decided at most once per instance (see the class doc above). */
   private modePromise: Promise<GrokDirectBackend | null> | null = null;
+  /** Synchronous mirror of the resolved mode for the `capabilities` getter:
+   *  `undefined` = not yet decided, a backend = direct mode, `null` = ACP mode.
+   *  Set by resolveMode() the instant its probe settles. */
+  private resolvedDirect: GrokDirectBackend | null | undefined = undefined;
   private client: AcpClient | null = null;
   /** The client an in-flight prepare() is spinning up, tracked so a concurrent
    *  close() can tear it down before it's published (P0-A). */
@@ -546,6 +550,30 @@ export class GrokBackend implements AgentBackend {
   }
 
   /**
+   * Capabilities MUST reflect the mode that will actually serve turns — never
+   * advertise one this backend won't honor (over-reporting `vision` would make a
+   * caller send images the direct 6-tool-router path silently drops = data loss).
+   * `capabilities` is a synchronous `readonly` on the AgentBackend port, but the
+   * mode is resolved lazily/async — so:
+   *   - once the mode is KNOWN → report the real descriptor (direct = vision:false,
+   *     ACP = the full GROK_CAPABILITIES incl. vision:true).
+   *   - while UNKNOWN but the direct path is REACHABLE (a `~/.grok/auth.json`
+   *     exists, or a resolveGrokOAuth seam is injected) → report conservatively
+   *     with `vision:false`. Under-reporting is safe (the panel just won't offer
+   *     images); over-reporting is not.
+   *   - while UNKNOWN and the direct path is NOT reachable (no token file) → the
+   *     ACP path is the only possibility, so report its full capabilities.
+   * The xAI vision contract is unverified (Task 8), so the direct path never
+   * claims vision until that's confirmed. */
+  get capabilities(): AgentCapabilities {
+    if (this.resolvedDirect !== undefined) {
+      return this.resolvedDirect ? this.resolvedDirect.capabilities : GROK_CAPABILITIES;
+    }
+    const directReachable = !!this.deps.resolveGrokOAuth || existsSync(grokTokenFile);
+    return directReachable ? { ...GROK_CAPABILITIES, vision: false } : GROK_CAPABILITIES;
+  }
+
+  /**
    * Decide ONCE (memoized) whether a direct OAuth token is usable: probes
    * `resolveGrokOAuth` (or the injected test seam) and, on success, builds the
    * `GrokDirectBackend` that every AgentBackend method below will delegate to.
@@ -560,18 +588,26 @@ export class GrokBackend implements AgentBackend {
     if (!this.modePromise) {
       const resolveOAuth = this.deps.resolveGrokOAuth ?? resolveGrokOAuth;
       this.modePromise = resolveOAuth()
-        .then(
-          () =>
-            new GrokDirectBackend({
-              cwd: this.deps.cwd,
-              model: this.deps.model,
-              comfyuiUrl: this.deps.comfyuiUrl,
-              mcpServers: this.deps.mcpServers,
-              systemAppend: this.deps.systemAppend,
-              resolveGrokOAuth: this.deps.resolveGrokOAuth,
-            }),
-        )
-        .catch(() => null);
+        .then((creds) => {
+          // Thread the ALREADY-resolved credentials into the direct backend so its
+          // prepare() reuses them instead of probing resolveGrokOAuth a second time
+          // (single-probe on the success path — the task's explicit requirement).
+          const direct = new GrokDirectBackend({
+            cwd: this.deps.cwd,
+            model: this.deps.model,
+            comfyuiUrl: this.deps.comfyuiUrl,
+            mcpServers: this.deps.mcpServers,
+            systemAppend: this.deps.systemAppend,
+            resolveGrokOAuth: this.deps.resolveGrokOAuth,
+            initialCredentials: creds,
+          });
+          this.resolvedDirect = direct;
+          return direct;
+        })
+        .catch(() => {
+          this.resolvedDirect = null;
+          return null;
+        });
     }
     return this.modePromise;
   }
@@ -1166,7 +1202,12 @@ export class GrokBackend implements AgentBackend {
 // ---------------------------------------------------------------------------
 
 export const GROK_XAI_API_BASE = "https://api.x.ai/v1";
-const GROK_XAI_RESPONSES_URL = `${GROK_XAI_API_BASE}/responses`;
+// The exact Responses sub-path is UNVERIFIED against the live xAI API (Task 8's
+// smoke test confirms it). Made overridable via COMFYUI_MCP_GROK_XAI_RESPONSES_URL
+// so if the real path differs it's a config flip, not a code change — whatever URL
+// is used still passes assertAllowedTokenHost (x.ai/*.x.ai) before any bearer.
+export const GROK_XAI_RESPONSES_URL =
+  process.env.COMFYUI_MCP_GROK_XAI_RESPONSES_URL?.trim() || `${GROK_XAI_API_BASE}/responses`;
 const GROK_XAI_MODELS_URL = `${GROK_XAI_API_BASE}/models`;
 const GROK_MAX_TOOL_ROUNDS = 32;
 
@@ -1295,10 +1336,17 @@ export class GrokDirectBackend extends OllamaBackend {
   private grokTurnHistory: GrokTurnMessage[] = [];
   private grokSessionId: string | null = null;
   private resolveOAuth: (deps?: CodeProviderAuthDeps) => Promise<GrokOAuthCredentials>;
+  /** Credentials `GrokBackend.resolveMode()` ALREADY resolved to pick the mode,
+   *  handed straight to prepare() so the initial preflight does NOT re-probe
+   *  `resolveGrokOAuth` (single-probe on the success path). Consumed once, then
+   *  cleared; `resolveOAuth` remains for any future mid-session re-resolve. */
+  private initialCredentials: GrokOAuthCredentials | undefined;
 
   constructor(
     deps: Pick<GrokBackendDeps, "cwd" | "model" | "comfyuiUrl" | "mcpServers" | "systemAppend"> & {
       resolveGrokOAuth?: (deps?: CodeProviderAuthDeps) => Promise<GrokOAuthCredentials>;
+      /** The credentials the facade already resolved when deciding the mode. */
+      initialCredentials?: GrokOAuthCredentials;
     } = {},
   ) {
     super({
@@ -1313,12 +1361,18 @@ export class GrokDirectBackend extends OllamaBackend {
     });
     this.model = deps.model ?? GROK_XAI_DEFAULT_MODEL;
     this.resolveOAuth = deps.resolveGrokOAuth ?? resolveGrokOAuth;
+    this.initialCredentials = deps.initialCredentials;
   }
 
   override async prepare(): Promise<void> {
     if (this.disposed) throw new Error("grok backend is closed.");
     if (this.prepared) return;
-    const creds = await this.resolveOAuth();
+    // Prefer the credentials the facade already resolved to pick this mode — the
+    // initial preflight must NOT re-probe resolveGrokOAuth (single-probe on the
+    // success path). Only re-resolve if none were threaded in (e.g. a direct
+    // instantiation in a test or a future caller).
+    const creds = this.initialCredentials ?? (await this.resolveOAuth());
+    this.initialCredentials = undefined; // consumed
     this.accessToken = creds.accessToken;
     await this.connectTools();
     this.prepared = true;
@@ -1466,7 +1520,10 @@ export class GrokDirectBackend extends OllamaBackend {
     if (fresh) this.grokTurnHistory = [];
     yield { type: "session", sessionId: this.grokSessionId, model: this.model };
 
-    const instructions = [resolvePrompt("backend.grok", GROK_XAI_SYSTEM_PROMPT), this.deps.systemAppend]
+    // NOTE: upstream (MichaelDanCurtis fork) routes this through the editable
+    // prompt registry (services/prompt-overrides). That registry is not ported
+    // here, so the built-in prompt is used directly.
+    const instructions = [GROK_XAI_SYSTEM_PROMPT, this.deps.systemAppend]
       .filter(Boolean)
       .join("\n\n");
 

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -78,7 +78,7 @@ import {
   type CodeProviderAuthDeps,
   type GrokOAuthCredentials,
 } from "../services/code-provider-auth.js";
-import { OAUTH_PROVIDERS, assertAllowedTokenHost, grokTokenFile } from "../services/oauth-flow.js";
+import { OAUTH_PROVIDERS, assertAllowedTokenHost, grokTokenFile, redactTokens } from "../services/oauth-flow.js";
 import { OllamaBackend } from "./ollama-backend.js";
 
 function msgOf(err: unknown): string {
@@ -1189,8 +1189,9 @@ export class GrokBackend implements AgentBackend {
 //   - Every outbound request is host-allowlist-checked (assertAllowedTokenHost
 //     against OAUTH_PROVIDERS.grok.apiHostAllowlist, i.e. `x.ai`/`*.x.ai`)
 //     before the bearer is attached, and any error response body is REDACTED
-//     (redactGrokTokens) before it can reach a thrown message or a log line —
-//     the access token itself is never logged anywhere in this path.
+//     (redactTokens, from oauth-flow.ts — the single shared redactor) before
+//     it can reach a thrown message or a log line — the access token itself
+//     is never logged anywhere in this path.
 //   - Model slug + exact endpoint sub-path are UNVERIFIED against the live xAI
 //     API (no network access at authoring time, and no Task-1 research
 //     artifact survived for this session to consult). GROK_XAI_DEFAULT_MODEL
@@ -1234,19 +1235,6 @@ export const GROK_XAI_SYSTEM_PROMPT = [
   "",
   "Describe a tool before its first call. Finish tasks by running tools, not inventing results.",
 ].join("\n");
-
-/** Mirrors oauth-flow.ts's private `redactTokens` (kept local so this task's
- *  only edit surface is grok-backend.ts) — strips token-shaped material from
- *  provider error text before it can reach a thrown message or a log line. */
-function redactGrokTokens(s: string): string {
-  return s
-    .replace(
-      /("?(?:access_token|refresh_token|id_token|code|code_verifier|client_secret)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi,
-      "$1<redacted>",
-    )
-    .replace(/\b(ghu_|gho_|ya29\.|sk-)[A-Za-z0-9._-]+/g, "$1<redacted>")
-    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>");
-}
 
 type GrokTurnMessage = {
   role: "user" | "assistant" | "tool";
@@ -1422,7 +1410,7 @@ export class GrokDirectBackend extends OllamaBackend {
     }
     if (!res.ok || !res.body) {
       const bodyText = await res.text().catch(() => "");
-      throw new Error(`xAI Responses http ${res.status}: ${redactGrokTokens(bodyText).slice(0, 400)}`);
+      throw new Error(`xAI Responses http ${res.status}: ${redactTokens(bodyText).slice(0, 400)}`);
     }
 
     let content = "";

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -57,6 +57,8 @@ import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-back
 import { GlmBackend, GLM_DEFAULT_MODEL } from "./glm-backend.js";
 import { KimiBackend, KIMI_DEFAULT_MODEL } from "./kimi-backend.js";
 import { allBackendReadiness } from "./backend-readiness.js";
+import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
+import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
 import type { AgentBackend } from "./agent-backend.js";
@@ -2305,6 +2307,73 @@ export async function runPanelOrchestrator(): Promise<void> {
           tabId,
         );
       });
+      return;
+    }
+
+    // In-panel OAuth sign-in: kick a loopback (codex/grok) or device-code
+    // (copilot, experimental) flow. Reply comes back FAST (loopback: just
+    // "browser opened"; device: the user_code to show) — the actual sign-in
+    // completes in the background and pushes a refreshed `{type:"backends"}`
+    // frame via pushReadiness when it lands. STATUS ONLY ever crosses the
+    // bridge here — no token material (see oauth-bridge.ts).
+    if (event.type === "oauth_begin" && event.tab_id) {
+      const tabId = event.tab_id;
+      const provider = typeof (event as { provider?: unknown }).provider === "string"
+        ? (event as { provider?: string }).provider
+        : undefined;
+      const allowExperimental = (event as { allow_experimental?: unknown }).allow_experimental === true;
+      handleOAuthBegin(
+        { provider, allow_experimental: allowExperimental },
+        {
+          onAuthChanged: () => pushReadiness(tabId),
+          onBackgroundError: (providerId, message) => {
+            const label = OAUTH_PROVIDERS[providerId]?.label ?? providerId;
+            bridge.push({ type: "say", text: `⚠️ ${label} sign-in failed: ${message}` }, tabId);
+          },
+        },
+      )
+        .then((result) => {
+          bridge.push({ type: "ack", ok: true, kind: "oauth_begin", ...result }, tabId);
+          logger.info(`[panel-orchestrator] tab ${tabId.slice(0, 8)} oauth_begin ${provider} → ${result.mode}`);
+        })
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          bridge.push({ type: "ack", ok: false, kind: "oauth_begin", message }, tabId);
+          logger.warn(`[panel-orchestrator] tab ${tabId.slice(0, 8)} oauth_begin ${provider ?? "?"} refused: ${message}`);
+        });
+      return;
+    }
+
+    // In-panel OAuth status: the panel's Connections tab polls this to show
+    // "signed in as …" per provider. Status-only mirror — never tokens.
+    if (event.type === "oauth_status" && event.tab_id) {
+      const tabId = event.tab_id;
+      try {
+        const result = handleOAuthStatus({});
+        bridge.push({ type: "ack", ok: true, kind: "oauth_status", ...result }, tabId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        bridge.push({ type: "ack", ok: false, kind: "oauth_status", message }, tabId);
+      }
+      return;
+    }
+
+    // In-panel OAuth sign-out: clears the native token file + status mirror,
+    // then pushes refreshed readiness so the provider picker reflects it live.
+    if (event.type === "oauth_signout" && event.tab_id) {
+      const tabId = event.tab_id;
+      const provider = typeof (event as { provider?: unknown }).provider === "string"
+        ? (event as { provider?: string }).provider
+        : undefined;
+      try {
+        const result = handleOAuthSignout({ provider });
+        pushReadiness(tabId);
+        bridge.push({ type: "ack", kind: "oauth_signout", ...result }, tabId);
+        logger.info(`[panel-orchestrator] tab ${tabId.slice(0, 8)} oauth_signout ${provider}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        bridge.push({ type: "ack", ok: false, kind: "oauth_signout", message }, tabId);
+      }
       return;
     }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -56,6 +56,7 @@ import { OllamaBackend } from "./ollama-backend.js";
 import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-backend.js";
 import { GlmBackend, GLM_DEFAULT_MODEL } from "./glm-backend.js";
 import { KimiBackend, KIMI_DEFAULT_MODEL } from "./kimi-backend.js";
+import { CopilotBackend, COPILOT_DEFAULT_MODEL } from "./copilot-backend.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
@@ -987,6 +988,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   const chatgptModel = process.env.COMFYUI_MCP_CHATGPT_MODEL ?? CHATGPT_DEFAULT_MODEL;
   const glmModel = process.env.COMFYUI_MCP_GLM_MODEL ?? GLM_DEFAULT_MODEL;
   const kimiModel = process.env.COMFYUI_MCP_KIMI_MODEL ?? KIMI_DEFAULT_MODEL;
+  // EXPERIMENTAL (ToS risk) — off by default, only reachable once the user has
+  // signed in via the panel's experimental row (oauth-bridge.ts's
+  // allow_experimental gate); never the defaultBackend/auto-pick.
+  const copilotModel = process.env.COMFYUI_MCP_COPILOT_MODEL ?? COPILOT_DEFAULT_MODEL;
   // The same backend also speaks any OpenAI-compatible endpoint (OpenRouter,
   // DeepSeek, vLLM, LM Studio): COMFYUI_MCP_OLLAMA_API=openai +
   // COMFYUI_MCP_OLLAMA_BASE_URL (incl. /v1) + COMFYUI_MCP_OLLAMA_API_KEY
@@ -1087,6 +1092,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     "lmstudio",
     "llamacpp",
     "custom",
+    "copilot", // EXPERIMENTAL — see copilotModel's comment above
   ]);
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
@@ -1341,6 +1347,19 @@ export async function runPanelOrchestrator(): Promise<void> {
         mcpServers: makeHttpBackendMcpServers(panelTabId),
       });
     }
+    if (backend === "copilot") {
+      // EXPERIMENTAL (ToS risk) — prepare() throws a clear re-sign-in error if
+      // no ~/.comfyui-mcp/copilot-auth.json exists yet (resolveCopilotOAuth),
+      // so simply being selectable here does not make it USABLE without the
+      // panel's experimental opt-in sign-in flow having already run.
+      return new CopilotBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: copilotModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
     return undefined; // claude → built-in ClaudeBackend
   };
   logger.info(
@@ -1378,7 +1397,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                     ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: llamacppModel, ...llamacppDeps() })
                     : backend === "custom"
                       ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: customModel, ...customDeps() })
-                      : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
+                      : backend === "copilot"
+                        ? new CopilotBackend({ cwd: comfyuiPath ?? process.cwd(), model: copilotModel })
+                        : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
       probeBackends.set(backend, pb);
     }
     return pb;
@@ -1725,6 +1746,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "chatgpt") return chatgptModel;
     if (backend === "glm") return glmModel;
     if (backend === "kimi") return kimiModel;
+    if (backend === "copilot") return copilotModel;
     return model;
   }
   function pushModels(panelTabId: string): void {
@@ -1879,6 +1901,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const isLs = backend === "lmstudio";
       const isLc = backend === "llamacpp";
       const isCu = backend === "custom";
+      const isCp = backend === "copilot";
       // TRUTHFUL "connected": only claim ready after PROVING the SELECTED backend
       // can run, by probing its model list. If the probe fails — the "connected
       // but dead" wedge — send a degraded ack so the panel shows the real state.
@@ -1944,7 +1967,9 @@ export async function runPanelOrchestrator(): Promise<void> {
                         ? (customModel || ((models[0] as { value?: string }).value ?? "Custom endpoint"))
                         : isOr
                       ? (openrouterModel ?? (models[0] as { value?: string }).value ?? "OpenRouter")
-                      : model;
+                      : isCp
+                        ? (copilotModel ?? (models[0] as { value?: string }).value ?? "Copilot")
+                        : model;
             // llama.cpp launch gotchas (issue #161): a reachable server can still
             // be useless for us — tool calling needs --jinja (rejected requests),
             // and a launch-time -c under ~16K silently truncates the tool payload.
@@ -2002,6 +2027,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                           ? `🟢 comfyui-mcp agent ready — ${agentLabel} via your custom endpoint (${customBaseUrl}). Ask away.`
                           : isOr
                       ? `🟢 comfyui-mcp agent ready — ${agentLabel} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`
+                      : isCp
+                        ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your GitHub Copilot subscription (⚠️ experimental, ToS risk — you opted in). Ask away.`
                       : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
               bridge.push({ type: "say", text: readyText }, panelTab);
             }
@@ -2028,6 +2055,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                       ? `⚠️ The background agent isn't responding — llama-server isn't reachable at ${LLAMACPP_BASE_URL}. Start it with \`llama-server -m <model>.gguf -c 16384\` (our gemma4-comfyui-mcp GGUFs work great; add --jinja on older builds — required there for tool calling), or set COMFYUI_MCP_LLAMACPP_HOST — then Disconnect → Connect to retry.`
                       : isCu
                         ? `⚠️ The background agent isn't responding — your custom endpoint isn't answering at ${customBaseUrl}. Check the base URL in Settings → Custom endpoint (it must be OpenAI-compatible and include the /v1) and the API key if the server requires one — then Connect to retry.`
+                        : isCp
+                          ? "⚠️ The background agent isn't responding — GitHub Copilot (experimental) couldn't start. Sign in from the panel's experimental row, then Disconnect → Connect to retry."
                         : "⚠️ The background agent isn't responding — the Claude Agent SDK couldn't start. Make sure you're signed in (run `claude` once), then Disconnect → Connect to retry.";
             bridge.push({ type: "say", text: degradedText }, panelTab);
             bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2367,7 +2367,11 @@ export async function runPanelOrchestrator(): Promise<void> {
         })
         .catch((err) => {
           const message = err instanceof Error ? err.message : String(err);
-          bridge.push({ type: "ack", ok: false, kind: "oauth_begin", message }, tabId);
+          // Echo the requested provider on the failure ack too, so the panel
+          // routes the error to the row that asked (correlation) rather than
+          // guessing "last-clicked". provider may be undefined for a malformed
+          // request; the panel falls back to single-pending in that case.
+          bridge.push({ type: "ack", ok: false, kind: "oauth_begin", ...(provider ? { provider } : {}), message }, tabId);
           logger.warn(`[panel-orchestrator] tab ${tabId.slice(0, 8)} oauth_begin ${provider ?? "?"} refused: ${message}`);
         });
       return;
@@ -2401,7 +2405,8 @@ export async function runPanelOrchestrator(): Promise<void> {
         logger.info(`[panel-orchestrator] tab ${tabId.slice(0, 8)} oauth_signout ${provider}`);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        bridge.push({ type: "ack", ok: false, kind: "oauth_signout", message }, tabId);
+        // Echo provider on failure too (correlation) — see oauth_begin above.
+        bridge.push({ type: "ack", ok: false, kind: "oauth_signout", ...(provider ? { provider } : {}), message }, tabId);
       }
       return;
     }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -53,6 +53,9 @@ import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
 import { GrokBackend, GROK_DEFAULT_MODEL } from "./grok-backend.js";
 import { OllamaBackend } from "./ollama-backend.js";
+import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-backend.js";
+import { GlmBackend, GLM_DEFAULT_MODEL } from "./glm-backend.js";
+import { KimiBackend, KIMI_DEFAULT_MODEL } from "./kimi-backend.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
@@ -979,6 +982,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   const persistedAgent = getAgentSettings();
   let ollamaModel =
     process.env.COMFYUI_MCP_OLLAMA_MODEL ?? persistedAgent.ollama?.model ?? "artokun/gemma4-comfyui-mcp:e4b";
+  const chatgptModel = process.env.COMFYUI_MCP_CHATGPT_MODEL ?? CHATGPT_DEFAULT_MODEL;
+  const glmModel = process.env.COMFYUI_MCP_GLM_MODEL ?? GLM_DEFAULT_MODEL;
+  const kimiModel = process.env.COMFYUI_MCP_KIMI_MODEL ?? KIMI_DEFAULT_MODEL;
   // The same backend also speaks any OpenAI-compatible endpoint (OpenRouter,
   // DeepSeek, vLLM, LM Studio): COMFYUI_MCP_OLLAMA_API=openai +
   // COMFYUI_MCP_OLLAMA_BASE_URL (incl. /v1) + COMFYUI_MCP_OLLAMA_API_KEY
@@ -1066,7 +1072,20 @@ export async function runPanelOrchestrator(): Promise<void> {
   // provider (the panel replays the transcript to seed it) while a same-provider
   // reconnect RESUMES. `backendId`/`codexModel`/`geminiModel` above are the
   // DEFAULT + per-provider model config; the process is no longer pinned to one.
-  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "grok", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]);
+  const KNOWN_BACKENDS = new Set([
+    "claude",
+    "codex",
+    "chatgpt",
+    "gemini",
+    "grok",
+    "glm",
+    "kimi",
+    "ollama",
+    "openrouter",
+    "lmstudio",
+    "llamacpp",
+    "custom",
+  ]);
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
@@ -1293,6 +1312,33 @@ export async function runPanelOrchestrator(): Promise<void> {
         ...customDeps(),
       });
     }
+    if (backend === "chatgpt") {
+      return new ChatGptOAuthBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: chatgptModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
+    if (backend === "glm") {
+      return new GlmBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: glmModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
+    if (backend === "kimi") {
+      return new KimiBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: kimiModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
     return undefined; // claude → built-in ClaudeBackend
   };
   logger.info(
@@ -1312,6 +1358,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       pb =
         backend === "codex"
           ? new CodexBackend({ cwd: comfyuiPath ?? process.cwd(), model: codexModel })
+          : backend === "chatgpt"
+            ? new ChatGptOAuthBackend({ cwd: comfyuiPath ?? process.cwd(), model: chatgptModel })
+          : backend === "glm"
+            ? new GlmBackend({ cwd: comfyuiPath ?? process.cwd(), model: glmModel })
+          : backend === "kimi"
+            ? new KimiBackend({ cwd: comfyuiPath ?? process.cwd(), model: kimiModel })
           : backend === "ollama"
             ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: ollamaModel, ...ollamaDeps() })
             : backend === "grok"
@@ -1668,6 +1720,9 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "lmstudio") return lmstudioModel || undefined;
     if (backend === "llamacpp") return llamacppModel || undefined;
     if (backend === "custom") return customModel || undefined;
+    if (backend === "chatgpt") return chatgptModel;
+    if (backend === "glm") return glmModel;
+    if (backend === "kimi") return kimiModel;
     return model;
   }
   function pushModels(panelTabId: string): void {
@@ -1812,8 +1867,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (now - (lastAckAt.get(panelTab) ?? 0) < ACK_DEBOUNCE_MS) return;
       lastAckAt.set(panelTab, now);
       const isCx = backend === "codex";
+      const isCg = backend === "chatgpt";
       const isGm = backend === "gemini";
       const isGk = backend === "grok";
+      const isGl = backend === "glm";
+      const isKm = backend === "kimi";
       const isOl = backend === "ollama";
       const isOr = backend === "openrouter";
       const isLs = backend === "lmstudio";
@@ -1864,10 +1922,16 @@ export async function runPanelOrchestrator(): Promise<void> {
           if (models.length) {
             const agentLabel = isCx
               ? (codexModel ?? (models[0] as { value?: string }).value ?? "Codex")
+              : isCg
+                ? (chatgptModel ?? (models[0] as { value?: string }).value ?? "ChatGPT")
               : isGm
                 ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
                 : isGk
                   ? (grokModel ?? (models[0] as { value?: string }).value ?? "Grok")
+                : isGl
+                  ? (glmModel ?? (models[0] as { value?: string }).value ?? "GLM")
+                : isKm
+                  ? (kimiModel ?? (models[0] as { value?: string }).value ?? "Kimi")
                 : isOl
                   ? (ollamaModel ?? (models[0] as { value?: string }).value ?? "Ollama")
                   : isLs
@@ -1916,10 +1980,16 @@ export async function runPanelOrchestrator(): Promise<void> {
             if (!resume) {
               const readyText = isCx
                 ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Codex (ChatGPT) account. Ask away.`
+                : isCg
+                  ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your ChatGPT subscription (direct OAuth). Ask away.`
                 : isGm
                   ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
                   : isGk
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Grok (xAI) account. Ask away.`
+                  : isGl
+                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Z.AI GLM Coding Plan. Ask away.`
+                  : isKm
+                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Kimi Code subscription. Ask away.`
                   : isOl
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
                     : isLs
@@ -1938,10 +2008,16 @@ export async function runPanelOrchestrator(): Promise<void> {
           } else {
             const degradedText = isCx
               ? "⚠️ The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry."
+              : isCg
+                ? "⚠️ The background agent isn't responding — ChatGPT direct OAuth couldn't start. Make sure ~/.codex/auth.json exists (run `codex login`), then Disconnect → Connect to retry."
               : isGm
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
                 : isGk
                   ? "⚠️ The background agent isn't responding — the Grok CLI couldn't start. Make sure Grok is installed and signed in (run `grok` once and complete the xAI sign-in), then Disconnect → Connect to retry."
+                : isGl
+                  ? "⚠️ The background agent isn't responding — GLM Code API couldn't start. Set ZAI_API_KEY (Z.AI Coding Plan), then Disconnect → Connect to retry."
+                : isKm
+                  ? "⚠️ The background agent isn't responding — Kimi Code couldn't start. Run Kimi Code login (~/.kimi/credentials/kimi-code.json) or set KIMI_API_KEY, then Disconnect → Connect to retry."
                 : isOl
                   ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry."
                   : isLs

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -51,6 +51,7 @@ import {
 } from "../services/panel-secrets.js";
 import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
+import { GrokBackend, GROK_DEFAULT_MODEL } from "./grok-backend.js";
 import { OllamaBackend } from "./ollama-backend.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
@@ -956,6 +957,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // COMFYUI_MCP_GEMINI_MODEL (default gemini-2.5-pro). The model is applied at spawn
   // via the CLI `--model` flag (ACP exposes no per-session model setter).
   const geminiModel = process.env.COMFYUI_MCP_GEMINI_MODEL ?? GEMINI_DEFAULT_MODEL;
+  const grokModel = process.env.COMFYUI_MCP_GROK_MODEL ?? GROK_DEFAULT_MODEL;
   // Ollama (local LLMs, issue #97): the model is a local tag applied PER
   // REQUEST — switching live is free. Default = OUR FINE-TUNE,
   // artokun/gemma4-comfyui-mcp:e4b — gemma4 QLoRA-trained on 1055
@@ -1064,7 +1066,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // provider (the panel replays the transcript to seed it) while a same-provider
   // reconnect RESUMES. `backendId`/`codexModel`/`geminiModel` above are the
   // DEFAULT + per-provider model config; the process is no longer pinned to one.
-  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]);
+  const KNOWN_BACKENDS = new Set(["claude", "codex", "gemini", "grok", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]);
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
@@ -1232,6 +1234,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         mcpServers: makeHttpBackendMcpServers(panelTabId),
       });
     }
+    if (backend === "grok") {
+      return new GrokBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: grokModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
     if (backend === "ollama") {
       return new OllamaBackend({
         cwd: comfyuiPath ?? process.cwd(),
@@ -1286,7 +1297,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   };
   logger.info(
     `[panel-orchestrator] single-port multi-provider: default backend=${defaultBackend}; ` +
-      `codex/gemini panel_* live-graph tools via loopback HTTP MCP${panelMcpHttp ? ` on :${panelMcpHttp.port}` : " UNAVAILABLE"} + headless comfyui MCP`,
+      `codex/gemini/grok panel_* live-graph tools via loopback HTTP MCP${panelMcpHttp ? ` on :${panelMcpHttp.port}` : " UNAVAILABLE"} + headless comfyui MCP`,
   );
   // Readiness/model probing routes through the SELECTED backend PER TAB — a
   // codex/gemini tab's "ready" must NOT depend on Claude SDK/login health. Claude
@@ -1303,15 +1314,17 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? new CodexBackend({ cwd: comfyuiPath ?? process.cwd(), model: codexModel })
           : backend === "ollama"
             ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: ollamaModel, ...ollamaDeps() })
-            : backend === "openrouter"
-              ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: openrouterModel, ...openrouterDeps() })
-              : backend === "lmstudio"
-                ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: lmstudioModel, ...lmstudioDeps() })
-                : backend === "llamacpp"
-                  ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: llamacppModel, ...llamacppDeps() })
-                  : backend === "custom"
-                    ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: customModel, ...customDeps() })
-                    : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
+            : backend === "grok"
+              ? new GrokBackend({ cwd: comfyuiPath ?? process.cwd(), model: grokModel })
+              : backend === "openrouter"
+                ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: openrouterModel, ...openrouterDeps() })
+                : backend === "lmstudio"
+                  ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: lmstudioModel, ...lmstudioDeps() })
+                  : backend === "llamacpp"
+                    ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: llamacppModel, ...llamacppDeps() })
+                    : backend === "custom"
+                      ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: customModel, ...customDeps() })
+                      : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
       probeBackends.set(backend, pb);
     }
     return pb;
@@ -1649,6 +1662,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   function currentModelFor(backend: string): string | undefined {
     if (backend === "codex") return codexModel;
     if (backend === "gemini") return geminiModel;
+    if (backend === "grok") return grokModel;
     if (backend === "ollama") return ollamaModel;
     if (backend === "openrouter") return openrouterModel;
     if (backend === "lmstudio") return lmstudioModel || undefined;
@@ -1799,6 +1813,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       lastAckAt.set(panelTab, now);
       const isCx = backend === "codex";
       const isGm = backend === "gemini";
+      const isGk = backend === "grok";
       const isOl = backend === "ollama";
       const isOr = backend === "openrouter";
       const isLs = backend === "lmstudio";
@@ -1851,6 +1866,8 @@ export async function runPanelOrchestrator(): Promise<void> {
               ? (codexModel ?? (models[0] as { value?: string }).value ?? "Codex")
               : isGm
                 ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
+                : isGk
+                  ? (grokModel ?? (models[0] as { value?: string }).value ?? "Grok")
                 : isOl
                   ? (ollamaModel ?? (models[0] as { value?: string }).value ?? "Ollama")
                   : isLs
@@ -1901,6 +1918,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Codex (ChatGPT) account. Ask away.`
                 : isGm
                   ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
+                  : isGk
+                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Grok (xAI) account. Ask away.`
                   : isOl
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
                     : isLs
@@ -1921,6 +1940,8 @@ export async function runPanelOrchestrator(): Promise<void> {
               ? "⚠️ The background agent isn't responding — the Codex app-server couldn't start. Make sure Codex is installed and signed in (run `codex login`), then Disconnect → Connect to retry."
               : isGm
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
+                : isGk
+                  ? "⚠️ The background agent isn't responding — the Grok CLI couldn't start. Make sure Grok is installed and signed in (run `grok` once and complete the xAI sign-in), then Disconnect → Connect to retry."
                 : isOl
                   ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry."
                   : isLs

--- a/src/orchestrator/kimi-backend.ts
+++ b/src/orchestrator/kimi-backend.ts
@@ -1,0 +1,34 @@
+import { KIMI_CAPABILITIES } from "./agent-backend.js";
+import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
+import {
+  KIMI_CODE_DEFAULT_BASE,
+  resolveKimiCodeOAuth,
+} from "../services/code-provider-auth.js";
+
+export const KIMI_DEFAULT_MODEL =
+  process.env.COMFYUI_MCP_KIMI_MODEL?.trim() || "kimi-for-coding";
+
+/** Kimi Code subscription OAuth (or KIMI_API_KEY) — OpenAI-compatible coding API. */
+export class KimiBackend extends OllamaBackend {
+  readonly capabilities = KIMI_CAPABILITIES;
+
+  constructor(deps: Omit<OllamaBackendDeps, "api" | "host" | "apiKey" | "backendId"> = {}) {
+    const apiKey = process.env.KIMI_API_KEY?.trim() || "pending-oauth";
+    super({
+      ...deps,
+      backendId: "kimi",
+      api: "openai",
+      host:
+        process.env.COMFYUI_MCP_KIMI_BASE_URL?.trim().replace(/\/$/, "") ||
+        KIMI_CODE_DEFAULT_BASE,
+      apiKey,
+      model: deps.model ?? KIMI_DEFAULT_MODEL,
+    });
+  }
+
+  override async prepare(): Promise<void> {
+    const creds = await resolveKimiCodeOAuth();
+    this.setOpenAiAuth(creds.baseUrl, creds.accessToken);
+    return super.prepare();
+  }
+}

--- a/src/orchestrator/oauth-bridge.test.ts
+++ b/src/orchestrator/oauth-bridge.test.ts
@@ -77,6 +77,7 @@ describe("handleOAuthBegin", () => {
     );
 
     expect(result).toEqual({
+      provider: "copilot",
       mode: "device",
       user_code: "ABCD-1234",
       verification_url: "https://github.com/login/device",
@@ -103,7 +104,7 @@ describe("handleOAuthBegin", () => {
       { providers: PROVIDERS, runLoopbackPKCE, persistOAuthResult, onAuthChanged },
     );
 
-    expect(result).toEqual({ mode: "loopback", opened: true });
+    expect(result).toEqual({ provider: "codex", mode: "loopback", opened: true });
     expect(onAuthChanged).not.toHaveBeenCalled(); // flow hasn't completed yet
 
     resolveFlow(FAKE_TOKENS);
@@ -123,7 +124,7 @@ describe("handleOAuthBegin", () => {
       { provider: "codex" },
       { providers: PROVIDERS, runLoopbackPKCE, onBackgroundError },
     );
-    expect(result).toEqual({ mode: "loopback", opened: true });
+    expect(result).toEqual({ provider: "codex", mode: "loopback", opened: true });
 
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
@@ -159,9 +160,18 @@ describe("handleOAuthSignout", () => {
       { provider: "codex" },
       { providers: PROVIDERS, clearOAuth, onAuthChanged },
     );
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, provider: "codex" });
     expect(clearOAuth).toHaveBeenCalledWith("codex", {});
     expect(onAuthChanged).toHaveBeenCalledWith("codex");
+  });
+
+  it("echoes the provider so the panel can correlate the ack to the right row", () => {
+    // Two providers cleared in succession must each return their OWN id — this
+    // is what lets the panel route overlapping acks correctly (Fix 1a).
+    const codexResult = handleOAuthSignout({ provider: "codex" }, { providers: PROVIDERS, clearOAuth: vi.fn() });
+    const copilotResult = handleOAuthSignout({ provider: "copilot" }, { providers: PROVIDERS, clearOAuth: vi.fn() });
+    expect(codexResult.provider).toBe("codex");
+    expect(copilotResult.provider).toBe("copilot");
   });
 });
 

--- a/src/orchestrator/oauth-bridge.test.ts
+++ b/src/orchestrator/oauth-bridge.test.ts
@@ -1,0 +1,169 @@
+// Coverage for the panel-bridge OAuth handlers (oauth_begin/status/signout) —
+// unit-tested directly against the exported, deps-injected functions so no
+// live bridge socket, network, or filesystem is needed. Mirrors the injected-
+// ctx style of src/__tests__/orchestrator/panel-tools.test.ts.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleOAuthBegin,
+  handleOAuthStatus,
+  handleOAuthSignout,
+  type OAuthBridgeDeps,
+} from "./oauth-bridge.js";
+import type { OAuthProviderConfig, OAuthTokens } from "../services/oauth-flow.js";
+import type { OAuthStatusRecord } from "../services/panel-secrets.js";
+
+const CODEX: OAuthProviderConfig = {
+  id: "codex",
+  label: "ChatGPT",
+  kind: "loopback_pkce",
+  authorizeUrl: "https://auth.openai.com/oauth/authorize",
+  tokenUrl: "https://auth.openai.com/oauth/token",
+  clientId: "client-codex",
+  scopes: ["openid"],
+  tokenFile: "/tmp/codex-auth.json",
+  apiHostAllowlist: ["auth.openai.com"],
+};
+
+const COPILOT: OAuthProviderConfig = {
+  id: "copilot",
+  label: "GitHub Copilot",
+  kind: "device_code",
+  authorizeUrl: "",
+  tokenUrl: "https://github.com/login/oauth/access_token",
+  deviceCodeUrl: "https://github.com/login/device/code",
+  clientId: "client-copilot",
+  scopes: ["read:user"],
+  tokenFile: "/tmp/copilot-auth.json",
+  apiHostAllowlist: ["github.com"],
+  experimental: true,
+};
+
+const PROVIDERS: Record<string, OAuthProviderConfig> = { codex: CODEX, copilot: COPILOT };
+
+const FAKE_TOKENS: OAuthTokens = { access_token: "unused-in-test", raw: {} };
+
+describe("handleOAuthBegin", () => {
+  it("unknown provider → error", async () => {
+    await expect(
+      handleOAuthBegin({ provider: "bogus" }, { providers: PROVIDERS }),
+    ).rejects.toThrow(/unknown oauth provider/i);
+  });
+
+  it("refuses an experimental provider (copilot) without allow_experimental", async () => {
+    const beginDeviceCode = vi.fn();
+    await expect(
+      handleOAuthBegin({ provider: "copilot" }, { providers: PROVIDERS, beginDeviceCode }),
+    ).rejects.toThrow(/experimental/i);
+    expect(beginDeviceCode).not.toHaveBeenCalled();
+  });
+
+  it("device provider (copilot) with allow_experimental:true returns {mode:'device', user_code}", async () => {
+    const beginDeviceCode = vi.fn().mockResolvedValue({
+      user_code: "ABCD-1234",
+      verification_url: "https://github.com/login/device",
+      device_code: "dev-code-xyz",
+      interval: 5,
+      expires_in: 900,
+    });
+    // Never resolves during the test — proves the poll runs in the background
+    // and does not block the oauth_begin reply.
+    const pollDeviceToken = vi.fn().mockReturnValue(new Promise<OAuthTokens>(() => {}));
+    const persistOAuthResult = vi.fn();
+
+    const result = await handleOAuthBegin(
+      { provider: "copilot", allow_experimental: true },
+      { providers: PROVIDERS, beginDeviceCode, pollDeviceToken, persistOAuthResult },
+    );
+
+    expect(result).toEqual({
+      mode: "device",
+      user_code: "ABCD-1234",
+      verification_url: "https://github.com/login/device",
+    });
+    expect(beginDeviceCode).toHaveBeenCalledWith(COPILOT, {});
+    expect(pollDeviceToken).toHaveBeenCalledWith(COPILOT, "dev-code-xyz", {});
+    // The reply must never carry token material.
+    expect(JSON.stringify(result)).not.toMatch(/access_token|refresh_token/);
+  });
+
+  it("loopback provider (codex) returns {mode:'loopback', opened:true} immediately, then persists + notifies on completion", async () => {
+    let resolveFlow!: (t: OAuthTokens) => void;
+    const runLoopbackPKCE = vi.fn(
+      () =>
+        new Promise<OAuthTokens>((resolve) => {
+          resolveFlow = resolve;
+        }),
+    );
+    const persistOAuthResult = vi.fn().mockResolvedValue({ account_label: "user@example.com" });
+    const onAuthChanged = vi.fn();
+
+    const result = await handleOAuthBegin(
+      { provider: "codex" },
+      { providers: PROVIDERS, runLoopbackPKCE, persistOAuthResult, onAuthChanged },
+    );
+
+    expect(result).toEqual({ mode: "loopback", opened: true });
+    expect(onAuthChanged).not.toHaveBeenCalled(); // flow hasn't completed yet
+
+    resolveFlow(FAKE_TOKENS);
+    // Let the background .then() chain flush.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(persistOAuthResult).toHaveBeenCalledWith("codex", FAKE_TOKENS, {});
+    expect(onAuthChanged).toHaveBeenCalledWith("codex");
+  });
+
+  it("reports a background flow failure via onBackgroundError, without rejecting the outer call again", async () => {
+    const runLoopbackPKCE = vi.fn().mockRejectedValue(new Error("state mismatch"));
+    const onBackgroundError = vi.fn();
+
+    const result = await handleOAuthBegin(
+      { provider: "codex" },
+      { providers: PROVIDERS, runLoopbackPKCE, onBackgroundError },
+    );
+    expect(result).toEqual({ mode: "loopback", opened: true });
+
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onBackgroundError).toHaveBeenCalledWith("codex", "state mismatch");
+  });
+});
+
+describe("handleOAuthStatus", () => {
+  it("returns {providers: readOAuthStatus()} — status only, no token fields", () => {
+    const records: OAuthStatusRecord[] = [
+      { provider: "codex", account_label: "user@example.com", obtained_at: 1000 },
+    ];
+    const readOAuthStatus = vi.fn().mockReturnValue(records);
+    const result = handleOAuthStatus({}, { readOAuthStatus });
+    expect(result).toEqual({ providers: records });
+    expect(JSON.stringify(result)).not.toMatch(/access_token|refresh_token|id_token/);
+  });
+});
+
+describe("handleOAuthSignout", () => {
+  it("unknown provider → error, clearOAuth never called", () => {
+    const clearOAuth = vi.fn();
+    expect(() =>
+      handleOAuthSignout({ provider: "bogus" }, { providers: PROVIDERS, clearOAuth }),
+    ).toThrow(/unknown oauth provider/i);
+    expect(clearOAuth).not.toHaveBeenCalled();
+  });
+
+  it("clears the provider and notifies onAuthChanged, returning {ok:true}", () => {
+    const clearOAuth = vi.fn();
+    const onAuthChanged = vi.fn();
+    const result = handleOAuthSignout(
+      { provider: "codex" },
+      { providers: PROVIDERS, clearOAuth, onAuthChanged },
+    );
+    expect(result).toEqual({ ok: true });
+    expect(clearOAuth).toHaveBeenCalledWith("codex", {});
+    expect(onAuthChanged).toHaveBeenCalledWith("codex");
+  });
+});
+
+// deps type sanity — keeps the injected-deps surface honest at compile time.
+void (null as unknown as OAuthBridgeDeps);

--- a/src/orchestrator/oauth-bridge.ts
+++ b/src/orchestrator/oauth-bridge.ts
@@ -1,0 +1,155 @@
+// oauth-bridge.ts — panel↔orchestrator bridge handlers for in-panel OAuth:
+// oauth_begin / oauth_status / oauth_signout. Extracted as pure, deps-injected
+// functions so they're unit-testable without a live bridge/socket — index.ts's
+// onPanelMessage dispatch just forwards the matching control frames here and
+// ships the reply back over the bridge (see docs/superpowers/specs/2026-07-11-
+// oauth-in-panel-design.md).
+//
+// SECURITY: every reply here is STATUS ONLY — provider id, account_label, mode,
+// user_code, verification_url. Access/refresh/id tokens never leave oauth-flow.ts
+// / code-provider-auth.ts, and never flow through these handlers or their
+// return values. Copilot (`experimental: true` in OAUTH_PROVIDERS) is refused
+// unless the caller explicitly passes allow_experimental:true — the panel only
+// sets that from its experimental row, never by default.
+
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+import {
+  OAUTH_PROVIDERS,
+  runLoopbackPKCE,
+  beginDeviceCode,
+  pollDeviceToken,
+  type OAuthDeps,
+  type OAuthProviderConfig,
+} from "../services/oauth-flow.js";
+import {
+  persistOAuthResult,
+  readOAuthStatus,
+  clearOAuth,
+  type CodeProviderAuthDeps,
+} from "../services/code-provider-auth.js";
+import type { OAuthStatusRecord } from "../services/panel-secrets.js";
+
+/** Injected dependencies for the three handlers — lets tests mock the flow
+ *  engine + persistence without touching the network or the filesystem. */
+export interface OAuthBridgeDeps {
+  /** Provider registry override (defaults to the real OAUTH_PROVIDERS). */
+  providers?: Record<string, OAuthProviderConfig>;
+  runLoopbackPKCE?: typeof runLoopbackPKCE;
+  beginDeviceCode?: typeof beginDeviceCode;
+  pollDeviceToken?: typeof pollDeviceToken;
+  persistOAuthResult?: typeof persistOAuthResult;
+  readOAuthStatus?: typeof readOAuthStatus;
+  clearOAuth?: typeof clearOAuth;
+  /** Forwarded to runLoopbackPKCE/beginDeviceCode/pollDeviceToken (fetch/openBrowser/now). */
+  oauthFlowDeps?: OAuthDeps;
+  /** Forwarded to persistOAuthResult/clearOAuth (home/fetch/now). */
+  codeProviderAuthDeps?: CodeProviderAuthDeps;
+  /** Fired once a loopback/device sign-in (or a sign-out) actually lands, so the
+   *  caller can push a refreshed `{type:"backends"}` readiness frame. */
+  onAuthChanged?: (providerId: string) => void;
+  /** Best-effort error sink for a BACKGROUND loopback/device flow failure — the
+   *  oauth_begin reply has already gone out by the time this can fire. Message
+   *  text only (already redacted upstream) — never receives token material. */
+  onBackgroundError?: (providerId: string, message: string) => void;
+}
+
+function resolveProvider(providerId: unknown, deps: OAuthBridgeDeps): OAuthProviderConfig {
+  const id = typeof providerId === "string" ? providerId.trim().toLowerCase() : "";
+  const providers = deps.providers ?? OAUTH_PROVIDERS;
+  const cfg = id ? providers[id] : undefined;
+  if (!cfg) {
+    throw new ValidationError(
+      `Unknown OAuth provider "${String(providerId ?? "")}". Known providers: ${Object.keys(providers).join(", ")}.`,
+    );
+  }
+  return cfg;
+}
+
+export interface OAuthBeginResult {
+  mode: "loopback" | "device";
+  opened?: boolean;
+  user_code?: string;
+  verification_url?: string;
+}
+
+/**
+ * `oauth_begin {provider, allow_experimental?}` — starts sign-in for `provider`.
+ *
+ * - loopback providers (codex, grok): returns immediately with
+ *   `{mode:"loopback", opened:true}`; the browser round-trip + token exchange
+ *   run in the BACKGROUND (never blocking the bridge socket) and, on success,
+ *   persist the result then call `onAuthChanged`.
+ * - device providers (copilot): awaits the device-code request (fast — one
+ *   HTTP round trip) and returns `{mode:"device", user_code,
+ *   verification_url}` for the panel to display, then polls for completion in
+ *   the background the same way.
+ *
+ * copilot (and any future `experimental:true` provider) is REFUSED unless
+ * `allow_experimental === true`.
+ */
+export async function handleOAuthBegin(
+  args: { provider?: unknown; allow_experimental?: unknown },
+  deps: OAuthBridgeDeps = {},
+): Promise<OAuthBeginResult> {
+  const cfg = resolveProvider(args.provider, deps);
+  if (cfg.experimental && args.allow_experimental !== true) {
+    throw new ValidationError(
+      `${cfg.label} sign-in is experimental (ToS risk) — refused unless explicitly enabled from the experimental row.`,
+    );
+  }
+
+  const doLoopback = deps.runLoopbackPKCE ?? runLoopbackPKCE;
+  const doBeginDevice = deps.beginDeviceCode ?? beginDeviceCode;
+  const doPollDevice = deps.pollDeviceToken ?? pollDeviceToken;
+  const doPersist = deps.persistOAuthResult ?? persistOAuthResult;
+  const flowDeps = deps.oauthFlowDeps ?? {};
+  const authDeps = deps.codeProviderAuthDeps ?? {};
+
+  const onFlowError = (err: unknown): void => {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(`[oauth-bridge] ${cfg.id} sign-in failed: ${message}`);
+    deps.onBackgroundError?.(cfg.id, message);
+  };
+
+  if (cfg.kind === "loopback_pkce") {
+    // Fire-and-forget: the actual sign-in completes in the browser the flow
+    // opens, entirely out-of-band from this reply.
+    void doLoopback(cfg, flowDeps)
+      .then((tokens) => doPersist(cfg.id, tokens, authDeps))
+      .then(() => deps.onAuthChanged?.(cfg.id))
+      .catch(onFlowError);
+    return { mode: "loopback", opened: true };
+  }
+
+  // device_code
+  const { user_code, verification_url, device_code } = await doBeginDevice(cfg, flowDeps);
+  void doPollDevice(cfg, device_code, flowDeps)
+    .then((tokens) => doPersist(cfg.id, tokens, authDeps))
+    .then(() => deps.onAuthChanged?.(cfg.id))
+    .catch(onFlowError);
+  return { mode: "device", user_code, verification_url };
+}
+
+/** `oauth_status {}` — the status-only mirror (provider/account_label/timestamps)
+ *  for every provider ever signed into via the panel. Never token material. */
+export function handleOAuthStatus(
+  _args: Record<string, unknown>,
+  deps: OAuthBridgeDeps = {},
+): { providers: OAuthStatusRecord[] } {
+  const doRead = deps.readOAuthStatus ?? readOAuthStatus;
+  return { providers: doRead() };
+}
+
+/** `oauth_signout {provider}` — clears the native token file (best-effort) and
+ *  the status mirror entry, then notifies `onAuthChanged` so readiness refreshes. */
+export function handleOAuthSignout(
+  args: { provider?: unknown },
+  deps: OAuthBridgeDeps = {},
+): { ok: true } {
+  const cfg = resolveProvider(args.provider, deps);
+  const doClear = deps.clearOAuth ?? clearOAuth;
+  doClear(cfg.id, deps.codeProviderAuthDeps ?? {});
+  deps.onAuthChanged?.(cfg.id);
+  return { ok: true };
+}

--- a/src/orchestrator/oauth-bridge.ts
+++ b/src/orchestrator/oauth-bridge.ts
@@ -67,6 +67,10 @@ function resolveProvider(providerId: unknown, deps: OAuthBridgeDeps): OAuthProvi
 }
 
 export interface OAuthBeginResult {
+  /** Echoed back so the panel can correlate this reply with the row that
+   *  requested it — two overlapping sign-ins would otherwise be misrouted
+   *  (the panel can't tell which begin-ack belongs to which provider). */
+  provider: string;
   mode: "loopback" | "device";
   opened?: boolean;
   user_code?: string;
@@ -119,7 +123,7 @@ export async function handleOAuthBegin(
       .then((tokens) => doPersist(cfg.id, tokens, authDeps))
       .then(() => deps.onAuthChanged?.(cfg.id))
       .catch(onFlowError);
-    return { mode: "loopback", opened: true };
+    return { provider: cfg.id, mode: "loopback", opened: true };
   }
 
   // device_code
@@ -128,7 +132,7 @@ export async function handleOAuthBegin(
     .then((tokens) => doPersist(cfg.id, tokens, authDeps))
     .then(() => deps.onAuthChanged?.(cfg.id))
     .catch(onFlowError);
-  return { mode: "device", user_code, verification_url };
+  return { provider: cfg.id, mode: "device", user_code, verification_url };
 }
 
 /** `oauth_status {}` — the status-only mirror (provider/account_label/timestamps)
@@ -146,10 +150,12 @@ export function handleOAuthStatus(
 export function handleOAuthSignout(
   args: { provider?: unknown },
   deps: OAuthBridgeDeps = {},
-): { ok: true } {
+): { ok: true; provider: string } {
   const cfg = resolveProvider(args.provider, deps);
   const doClear = deps.clearOAuth ?? clearOAuth;
   doClear(cfg.id, deps.codeProviderAuthDeps ?? {});
   deps.onAuthChanged?.(cfg.id);
-  return { ok: true };
+  // `provider` is echoed so the panel routes this ack to the right row (see
+  // OAuthBeginResult.provider) — a signout can overlap a begin on another row.
+  return { ok: true, provider: cfg.id };
 }

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -19,6 +19,7 @@ import { logger } from "../utils/logger.js";
 import type {
   AgentBackend,
   AgentEvent,
+  BackendId,
   BackendStartOptions,
   ModelChoice,
   NeutralTurn,
@@ -67,6 +68,8 @@ export interface OllamaBackendDeps {
   numCtx?: number;
   /** Test seam: replaces the MCP client construction from mcpServers specs. */
   connectToolClients?: () => Promise<{ comfyui?: McpToolClient; panel?: McpToolClient }>;
+  /** Panel backend id when reusing this driver for GLM/Kimi/Ollama (default ollama). */
+  backendId?: BackendId;
 }
 
 type ChatMessage = {
@@ -193,38 +196,45 @@ export function isOllamaModel(id: string): boolean {
 }
 
 export class OllamaBackend implements AgentBackend {
-  readonly id = "ollama" as const;
+  readonly id: BackendId;
   readonly capabilities = OLLAMA_CAPABILITIES;
-  private deps: OllamaBackendDeps;
-  private host: string;
-  private model: string;
-  private disposed = false;
-  private prepared = false;
+  protected deps: OllamaBackendDeps;
+  protected host: string;
+  protected model: string;
+  protected disposed = false;
+  protected prepared = false;
   /** In-flight turn abort — interrupt() aborts the current fetch/loop. */
-  private turnAbort: AbortController | null = null;
-  private comfy: McpToolClient | null = null;
-  private panel: McpToolClient | null = null;
+  protected turnAbort: AbortController | null = null;
+  protected comfy: McpToolClient | null = null;
+  protected panel: McpToolClient | null = null;
   /** comfyui compact meta-tool defs (from tools/list) — handed to the model verbatim. */
-  private comfyTools: McpToolInfo[] = [];
+  protected comfyTools: McpToolInfo[] = [];
   /** panel_* tool list (full defs stay HERE; the model gets 3 meta-tools). */
-  private panelTools: McpToolInfo[] = [];
+  protected panelTools: McpToolInfo[] = [];
   /** Conversation history for the live session (Ollama is stateless per request). */
   private history: ChatMessage[] = [];
   private sessionId: string | null = null;
 
   /** Wire dialect (see OllamaBackendDeps.api). */
-  private api: "ollama" | "openai";
-  private apiKey: string | undefined;
+  protected api: "ollama" | "openai";
+  protected apiKey: string | undefined;
 
   constructor(deps: OllamaBackendDeps = {}) {
     this.deps = deps;
+    this.id = deps.backendId ?? "ollama";
     this.api = deps.api ?? "ollama";
     this.apiKey = deps.apiKey;
     this.host = (deps.host ?? process.env.OLLAMA_HOST ?? "http://127.0.0.1:11434").replace(/\/$/, "");
     this.model = deps.model ?? DEFAULT_MODEL;
   }
 
-  private authHeaders(): Record<string, string> {
+  protected setOpenAiAuth(host: string, apiKey: string): void {
+    this.api = "openai";
+    this.host = host.replace(/\/$/, "");
+    this.apiKey = apiKey;
+  }
+
+  protected authHeaders(): Record<string, string> {
     return this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {};
   }
 
@@ -279,7 +289,7 @@ export class OllamaBackend implements AgentBackend {
     );
   }
 
-  private async connectTools(): Promise<void> {
+  protected async connectTools(): Promise<void> {
     if (this.deps.connectToolClients) {
       const { comfyui, panel } = await this.deps.connectToolClients();
       this.comfy = comfyui ?? null;
@@ -317,7 +327,7 @@ export class OllamaBackend implements AgentBackend {
   }
 
   /** The six OpenAI-style tool defs the model sees. */
-  private buildModelTools(): Array<Record<string, unknown>> {
+  protected buildModelTools(): Array<Record<string, unknown>> {
     const defs: Array<Record<string, unknown>> = [];
     for (const t of this.comfyTools) {
       defs.push({
@@ -372,7 +382,7 @@ export class OllamaBackend implements AgentBackend {
   }
 
   /** Dispatch one model tool call; returns display text (never throws). */
-  private async dispatch(name: string, rawArgs: Record<string, unknown> | string): Promise<{ text: string; isError: boolean }> {
+  protected async dispatch(name: string, rawArgs: Record<string, unknown> | string): Promise<{ text: string; isError: boolean }> {
     let args: Record<string, unknown> = {};
     if (typeof rawArgs === "string") {
       try {

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -23,6 +23,7 @@ const KNOWN_BACKENDS = [
   "glm",
   "kimi",
   "ollama",
+  "copilot", // EXPERIMENTAL — see orchestrator/index.ts's copilotModel comment
 ] as const;
 
 export interface PanelConsoleHttpServer {

--- a/src/services/code-provider-auth-redact.test.ts
+++ b/src/services/code-provider-auth-redact.test.ts
@@ -1,0 +1,116 @@
+// Pre-merge fix (final whole-branch review, orchestrator side): the refresh
+// functions in code-provider-auth.ts used to embed the raw provider HTTP
+// error body in the thrown message unredacted. The refresh request body
+// contains `refresh_token`, and IdPs can echo request params back in error
+// bodies, so an error line could leak a live token. These tests pin that a
+// leaked-looking refresh_token in the error body never survives into the
+// thrown message, for all three refresh paths (Grok, Codex/OpenAI, Kimi),
+// plus the adjacent "2xx but malformed JSON" path.
+import { describe, expect, it, vi } from "vitest";
+import { __testing } from "./code-provider-auth.js";
+
+const { refreshGrokTokens, refreshOpenAICodexTokens, refreshKimiCodeTokens } = __testing;
+
+describe("refresh error paths redact token-shaped material", () => {
+  it("refreshGrokTokens: a leaked refresh_token in the error body never reaches the thrown message", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "bad", refresh_token: "LEAKED_RT_123" }), {
+          status: 400,
+        }),
+    );
+
+    const err = await refreshGrokTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain("bad");
+    expect(message).not.toContain("LEAKED_RT_123");
+    expect(message).toContain("<redacted>");
+  });
+
+  it("refreshGrokTokens: a 2xx-but-malformed body throws a generic error, not the raw text", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("not json at all refresh_token=LEAKED_RT_999", { status: 200 }),
+    );
+
+    const err = await refreshGrokTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).not.toContain("LEAKED_RT_999");
+    expect(message).toMatch(/malformed/i);
+  });
+
+  it("refreshOpenAICodexTokens: a leaked refresh_token in the error body never reaches the thrown message", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "bad", refresh_token: "LEAKED_RT_123" }), {
+          status: 400,
+        }),
+    );
+
+    const err = await refreshOpenAICodexTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain("bad");
+    expect(message).not.toContain("LEAKED_RT_123");
+    expect(message).toContain("<redacted>");
+  });
+
+  it("refreshOpenAICodexTokens: a 2xx-but-malformed body throws a generic error, not the raw text", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("not json at all refresh_token=LEAKED_RT_999", { status: 200 }),
+    );
+
+    const err = await refreshOpenAICodexTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).not.toContain("LEAKED_RT_999");
+    expect(message).toMatch(/malformed/i);
+  });
+
+  it("refreshKimiCodeTokens: a leaked refresh_token in the error body never reaches the thrown message", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: "bad", refresh_token: "LEAKED_RT_123" }), {
+          status: 400,
+        }),
+    );
+
+    const err = await refreshKimiCodeTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain("bad");
+    expect(message).not.toContain("LEAKED_RT_123");
+    expect(message).toContain("<redacted>");
+  });
+
+  it("refreshKimiCodeTokens: a 2xx-but-malformed body throws a generic error, not the raw text", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("not json at all refresh_token=LEAKED_RT_999", { status: 200 }),
+    );
+
+    const err = await refreshKimiCodeTokens("some-refresh-token", {
+      fetch: fetchMock as unknown as typeof fetch,
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).not.toContain("LEAKED_RT_999");
+    expect(message).toMatch(/malformed/i);
+  });
+});

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -147,9 +147,14 @@ async function atomicWriteJson(path: string, data: unknown): Promise<void> {
   // unlike the resolve* paths above, which only ever re-write an existing
   // file. Ensure the parent dir exists so this stays a drop-in atomic writer
   // for both "update in place" and "create for the first time" callers.
-  await mkdir(dir, { recursive: true });
+  await mkdir(dir, { recursive: true, mode: 0o700 });
   const tmp = join(dir, `.auth-${randomBytes(8).toString("hex")}.tmp`);
-  await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  // 0600 on the TEMP file so it is never world-readable even briefly, and so
+  // `rename` carries that mode to the destination — this both creates new token
+  // files 0600 AND prevents an in-place refresh from downgrading a pre-existing
+  // 0600 file (e.g. ~/.codex/auth.json) to the umask default. This helper only
+  // ever writes credential/token files, so 0600 is universally correct here.
+  await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);
 }
 

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -1,9 +1,16 @@
-import { readFile, writeFile, rename } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ValidationError } from "../utils/errors.js";
+import { assertAllowedTokenHost, OAUTH_PROVIDERS, type OAuthTokens } from "./oauth-flow.js";
+import {
+  setOAuthStatus,
+  listOAuthStatus,
+  clearOAuthStatus,
+  type OAuthStatusRecord,
+} from "./panel-secrets.js";
 
 const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OPENAI_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
@@ -58,6 +65,17 @@ interface KimiCodeAuthFile {
   token_type?: string;
 }
 
+interface GrokAuthFile {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  expires_at?: number;
+}
+
+export interface GrokOAuthCredentials {
+  accessToken: string;
+}
+
 function codexAuthPath(home = homedir()): string {
   const root = process.env.CODEX_HOME || join(home, ".codex");
   return join(root, "auth.json");
@@ -66,6 +84,14 @@ function codexAuthPath(home = homedir()): string {
 function kimiCodeAuthPath(home = homedir()): string {
   const share = process.env.KIMI_SHARE_DIR || join(home, ".kimi");
   return join(share, "credentials", "kimi-code.json");
+}
+
+function grokAuthPath(home = homedir()): string {
+  return join(home, ".grok", "auth.json");
+}
+
+function copilotAuthPath(home = homedir()): string {
+  return join(home, ".comfyui-mcp", "copilot-auth.json");
 }
 
 function jwtExpMs(token: string): number | null {
@@ -83,22 +109,45 @@ function jwtExpMs(token: string): number | null {
   }
 }
 
-function jwtChatgptAccountId(idToken: string | undefined): string | null {
-  if (!idToken?.trim()) return null;
-  const parts = idToken.split(".");
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
   if (parts.length < 2) return null;
   try {
-    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as {
-      "https://api.openai.com/auth"?: { chatgpt_account_id?: string };
-    };
-    return payload["https://api.openai.com/auth"]?.chatgpt_account_id?.trim() || null;
+    return JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as Record<string, unknown>;
   } catch {
     return null;
   }
 }
 
+function jwtChatgptAccountId(idToken: string | undefined): string | null {
+  if (!idToken?.trim()) return null;
+  const payload = decodeJwtPayload(idToken) as {
+    "https://api.openai.com/auth"?: { chatgpt_account_id?: string };
+    chatgpt_account_id?: string;
+  } | null;
+  if (!payload) return null;
+  return (
+    payload["https://api.openai.com/auth"]?.chatgpt_account_id?.trim() ||
+    payload.chatgpt_account_id?.trim() ||
+    null
+  );
+}
+
+/** Best-effort email claim from an id_token, for a human-readable account label. */
+function jwtEmailClaim(idToken: string | undefined): string | null {
+  if (!idToken?.trim()) return null;
+  const payload = decodeJwtPayload(idToken) as { email?: string } | null;
+  return payload?.email?.trim() || null;
+}
+
 async function atomicWriteJson(path: string, data: unknown): Promise<void> {
   const dir = dirname(path);
+  // Landing a fresh OAuth sign-in may be the FIRST write to this provider's
+  // credential directory (e.g. ~/.grok didn't exist before Grok sign-in) —
+  // unlike the resolve* paths above, which only ever re-write an existing
+  // file. Ensure the parent dir exists so this stays a drop-in atomic writer
+  // for both "update in place" and "create for the first time" callers.
+  await mkdir(dir, { recursive: true });
   const tmp = join(dir, `.auth-${randomBytes(8).toString("hex")}.tmp`);
   await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
   await rename(tmp, path);
@@ -189,6 +238,49 @@ async function refreshKimiCodeTokens(
   };
 }
 
+/** Grok (xAI) OAuth refresh — mirrors `refreshOpenAICodexTokens`. Host-allowlist-checked
+ *  against the provider config in oauth-flow.ts before any network call. */
+async function refreshGrokTokens(
+  refreshToken: string,
+  deps: CodeProviderAuthDeps,
+): Promise<{ access_token: string; refresh_token?: string; expires_in?: number }> {
+  const cfg = OAUTH_PROVIDERS.grok;
+  if (!cfg) throw new ValidationError("Grok OAuth is not configured.");
+  assertAllowedTokenHost(cfg.tokenUrl, cfg.apiHostAllowlist);
+  const fetchFn = deps.fetch ?? fetch;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: cfg.clientId,
+  });
+  const res = await fetchFn(cfg.tokenUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const hint = res.status === 401 || res.status === 400 ? " Re-run Grok sign-in from the panel." : "";
+    throw new ValidationError(
+      `Grok OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+    );
+  }
+  const payload = JSON.parse(text) as { access_token?: string; refresh_token?: string; expires_in?: number };
+  const access = payload.access_token?.trim();
+  if (!access) {
+    throw new ValidationError("Grok OAuth refresh response missing access_token.");
+  }
+  return {
+    access_token: access,
+    refresh_token: payload.refresh_token?.trim(),
+    expires_in: typeof payload.expires_in === "number" ? payload.expires_in : undefined,
+  };
+}
+
 /**
  * Resolve ChatGPT/Codex subscription OAuth from ~/.codex/auth.json (written by `codex login`).
  * Refreshes expired access tokens in place. Use with the Codex Responses backend — not api.openai.com.
@@ -246,6 +338,55 @@ export async function resolveOpenAICodexOAuth(
     accountId,
     authMode: raw.auth_mode,
   };
+}
+
+/**
+ * Resolve Grok (xAI) OAuth from ~/.grok/auth.json (written by the in-panel sign-in
+ * via `persistOAuthResult`). Refreshes expired access tokens in place — mirrors
+ * `resolveOpenAICodexOAuth`.
+ */
+export async function resolveGrokOAuth(
+  deps: CodeProviderAuthDeps = {},
+): Promise<GrokOAuthCredentials> {
+  const home = deps.home ?? homedir();
+  const path = grokAuthPath(home);
+  if (!existsSync(path)) {
+    throw new ValidationError(
+      "Grok OAuth requires signing in via the panel's Connections tab first.",
+    );
+  }
+
+  let creds = JSON.parse(await readFile(path, "utf8")) as GrokAuthFile;
+  if (!creds.access_token?.trim() && !creds.refresh_token?.trim()) {
+    throw new ValidationError("No Grok OAuth tokens in ~/.grok/auth.json. Sign in again from the panel.");
+  }
+
+  const nowMs = deps.now?.() ?? Date.now();
+  const expMs = typeof creds.expires_at === "number" ? creds.expires_at * 1000 : null;
+  const needsRefresh = !creds.access_token?.trim() || tokenExpiring(expMs, nowMs);
+
+  if (needsRefresh) {
+    const refreshToken = creds.refresh_token?.trim();
+    if (!refreshToken) {
+      throw new ValidationError("Grok access token expired and refresh_token is missing. Sign in again from the panel.");
+    }
+    const refreshed = await refreshGrokTokens(refreshToken, deps);
+    const nowSec = Math.floor(nowMs / 1000);
+    creds = {
+      access_token: refreshed.access_token,
+      refresh_token: refreshed.refresh_token ?? refreshToken,
+      expires_in: refreshed.expires_in,
+      expires_at:
+        typeof refreshed.expires_in === "number" ? nowSec + refreshed.expires_in : undefined,
+    };
+    await atomicWriteJson(path, creds);
+  }
+
+  const accessToken = creds.access_token?.trim();
+  if (!accessToken) {
+    throw new ValidationError("Grok OAuth access_token is missing after refresh.");
+  }
+  return { accessToken };
 }
 
 /** GLM Coding Plan API key (Z.AI). Env: ZAI_API_KEY, GLM_API_KEY, or ZHIPUAI_API_KEY. */
@@ -319,6 +460,115 @@ export async function resolveKimiCodeOAuth(
   return { accessToken, baseUrl };
 }
 
+/** Best-effort delete of a provider's native token file. Never throws — a
+ *  missing file, missing directory, or permission wobble is not fatal to
+ *  clearing the (separate) status mirror. */
+function deleteNativeTokenFile(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function nativeTokenFilePath(providerId: string, home: string): string | null {
+  if (providerId === "codex") return codexAuthPath(home);
+  if (providerId === "grok") return grokAuthPath(home);
+  if (providerId === "copilot") return copilotAuthPath(home);
+  return null;
+}
+
+/**
+ * Persist the tokens an OAuth flow (`runLoopbackPKCE` / `pollDeviceToken` in
+ * oauth-flow.ts) returned: writes the NATIVE token file in the shape that
+ * provider's resolver reads (codex → `resolveOpenAICodexOAuth`, grok →
+ * `resolveGrokOAuth`, copilot → the raw `{access_token, token_type}` GitHub
+ * Copilot expects), derives a human-readable account label, and records a
+ * STATUS-ONLY mirror entry via `setOAuthStatus` for the panel UI.
+ *
+ * SECURITY: only `account_label` (plus timestamps/flags) reaches the mirror —
+ * never `access_token`/`refresh_token`/`id_token`. See panel-secrets.ts.
+ */
+export async function persistOAuthResult(
+  providerId: string,
+  tokens: OAuthTokens,
+  deps: CodeProviderAuthDeps = {},
+): Promise<{ account_label: string }> {
+  const home = deps.home ?? homedir();
+  const nowMs = deps.now?.() ?? Date.now();
+  const experimental = providerId === "copilot";
+
+  let accountLabel: string;
+  let expiresAt: number | undefined;
+
+  if (providerId === "codex") {
+    const accountId = jwtChatgptAccountId(tokens.id_token) || "";
+    const email = jwtEmailClaim(tokens.id_token);
+    accountLabel = email || accountId || "ChatGPT account";
+    const auth: CodexAuthFile = {
+      auth_mode: "chatgpt",
+      tokens: {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        account_id: accountId || undefined,
+        id_token: tokens.id_token,
+      },
+      last_refresh: new Date(nowMs).toISOString(),
+    };
+    await atomicWriteJson(codexAuthPath(home), auth);
+    const expMs = jwtExpMs(tokens.access_token);
+    expiresAt = expMs != null ? Math.floor(expMs / 1000) : undefined;
+  } else if (providerId === "grok") {
+    const email = jwtEmailClaim(tokens.id_token);
+    accountLabel = email || "xAI account";
+    const expiresIn = tokens.expires_in;
+    const expAt =
+      typeof expiresIn === "number" ? Math.floor(nowMs / 1000) + expiresIn : undefined;
+    const auth: GrokAuthFile = {
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_in: expiresIn,
+      expires_at: expAt,
+    };
+    await atomicWriteJson(grokAuthPath(home), auth);
+    expiresAt = expAt;
+  } else if (providerId === "copilot") {
+    accountLabel = "GitHub Copilot";
+    const tokenType =
+      typeof tokens.raw?.token_type === "string" ? (tokens.raw.token_type as string) : "bearer";
+    await atomicWriteJson(copilotAuthPath(home), {
+      access_token: tokens.access_token,
+      token_type: tokenType,
+    });
+  } else {
+    throw new ValidationError(`persistOAuthResult: unknown OAuth provider "${providerId}".`);
+  }
+
+  setOAuthStatus({
+    provider: providerId,
+    account_label: accountLabel,
+    obtained_at: nowMs,
+    expires_at: expiresAt,
+    experimental,
+  });
+
+  return { account_label: accountLabel };
+}
+
+/** All in-panel OAuth sign-ins' status (for the UI) — status only, never tokens. */
+export function readOAuthStatus(): OAuthStatusRecord[] {
+  return listOAuthStatus();
+}
+
+/** Sign a provider out: deletes its native token file (best-effort) and the
+ *  status mirror entry. */
+export function clearOAuth(providerId: string, deps: CodeProviderAuthDeps = {}): void {
+  const home = deps.home ?? homedir();
+  const path = nativeTokenFilePath(providerId, home);
+  if (path) deleteNativeTokenFile(path);
+  clearOAuthStatus(providerId);
+}
+
 export const __testing = {
   OPENAI_CODEX_CLIENT_ID,
   KIMI_CODE_CLIENT_ID,
@@ -326,8 +576,12 @@ export const __testing = {
   KIMI_CODE_DEFAULT_BASE,
   codexAuthPath,
   kimiCodeAuthPath,
+  grokAuthPath,
+  copilotAuthPath,
   jwtExpMs,
   jwtChatgptAccountId,
+  jwtEmailClaim,
   refreshOpenAICodexTokens,
   refreshKimiCodeTokens,
+  refreshGrokTokens,
 };

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -76,6 +76,14 @@ export interface GrokOAuthCredentials {
   accessToken: string;
 }
 
+export interface CopilotOAuthCredentials {
+  /** The long-lived `ghu_` device-code token from ~/.comfyui-mcp/copilot-auth.json.
+   *  This is NOT usable against api.githubcopilot.com directly — the caller
+   *  (copilot-backend.ts) exchanges it for a short-lived Copilot bearer via
+   *  GET https://api.github.com/copilot_internal/v2/token. */
+  ghuToken: string;
+}
+
 function codexAuthPath(home = homedir()): string {
   const root = process.env.CODEX_HOME || join(home, ".codex");
   return join(root, "auth.json");
@@ -392,6 +400,38 @@ export async function resolveGrokOAuth(
     throw new ValidationError("Grok OAuth access_token is missing after refresh.");
   }
   return { accessToken };
+}
+
+/**
+ * Resolve the GitHub Copilot `ghu_` device-code token from
+ * ~/.comfyui-mcp/copilot-auth.json (written by the in-panel sign-in via
+ * `persistOAuthResult`). Mirrors `resolveGrokOAuth`'s file-resolution shape,
+ * but WITHOUT refresh — GitHub's device-code `ghu_` token has no refresh_token
+ * (see OAUTH_PROVIDERS.copilot's scopes/kind: device_code, read:user only); a
+ * revoked/expired ghu_ can only be fixed by re-running Copilot sign-in from the
+ * panel, never by a background refresh call. The short-lived Copilot API
+ * bearer this token exchanges for (copilot-backend.ts) is a SEPARATE, higher-
+ * frequency concern this function knows nothing about.
+ */
+export async function resolveCopilotOAuth(
+  deps: CodeProviderAuthDeps = {},
+): Promise<CopilotOAuthCredentials> {
+  const home = deps.home ?? homedir();
+  const path = copilotAuthPath(home);
+  if (!existsSync(path)) {
+    throw new ValidationError(
+      "GitHub Copilot OAuth requires signing in via the panel's Connections tab first (experimental — ToS risk; opt in from the experimental row).",
+    );
+  }
+
+  const raw = JSON.parse(await readFile(path, "utf8")) as { access_token?: string; token_type?: string };
+  const ghuToken = raw.access_token?.trim();
+  if (!ghuToken) {
+    throw new ValidationError(
+      "No GitHub Copilot token in ~/.comfyui-mcp/copilot-auth.json. Sign in again from the panel.",
+    );
+  }
+  return { ghuToken };
 }
 
 /** GLM Coding Plan API key (Z.AI). Env: ZAI_API_KEY, GLM_API_KEY, or ZHIPUAI_API_KEY. */

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomBytes } from "node:crypto";
 import { ValidationError } from "../utils/errors.js";
-import { assertAllowedTokenHost, OAUTH_PROVIDERS, type OAuthTokens } from "./oauth-flow.js";
+import { assertAllowedTokenHost, OAUTH_PROVIDERS, redactTokens, type OAuthTokens } from "./oauth-flow.js";
 import {
   setOAuthStatus,
   listOAuthStatus,
@@ -194,10 +194,18 @@ async function refreshOpenAICodexTokens(
   if (!res.ok) {
     const hint = res.status === 401 || res.status === 400 ? " Run `codex login` to re-authenticate." : "";
     throw new ValidationError(
-      `OpenAI Codex OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+      `OpenAI Codex OAuth refresh failed (${res.status}): ${redactTokens(text).slice(0, 300)}.${hint}`,
     );
   }
-  const payload = JSON.parse(text) as { access_token?: string; refresh_token?: string };
+  let payload: { access_token?: string; refresh_token?: string };
+  try {
+    payload = JSON.parse(text) as { access_token?: string; refresh_token?: string };
+  } catch {
+    // A 2xx-but-malformed body must never reach the caller raw — JSON.parse's
+    // SyntaxError can embed a snippet of the offending text (which may carry
+    // refresh_token material echoed back by the IdP) in its own message.
+    throw new ValidationError("OpenAI Codex OAuth refresh returned a malformed (non-JSON) response.");
+  }
   const access = payload.access_token?.trim();
   if (!access) {
     throw new ValidationError("OpenAI Codex OAuth refresh response missing access_token.");
@@ -228,10 +236,17 @@ async function refreshKimiCodeTokens(
   if (!res.ok) {
     const hint = res.status === 401 || res.status === 400 ? " Re-run `kimi` / Kimi Code login." : "";
     throw new ValidationError(
-      `Kimi Code OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+      `Kimi Code OAuth refresh failed (${res.status}): ${redactTokens(text).slice(0, 300)}.${hint}`,
     );
   }
-  const payload = JSON.parse(text) as KimiCodeAuthFile;
+  let payload: KimiCodeAuthFile;
+  try {
+    payload = JSON.parse(text) as KimiCodeAuthFile;
+  } catch {
+    // See refreshOpenAICodexTokens's matching catch: a 2xx-but-malformed body
+    // must never reach the caller raw via JSON.parse's own SyntaxError.
+    throw new ValidationError("Kimi Code OAuth refresh returned a malformed (non-JSON) response.");
+  }
   const access = payload.access_token?.trim();
   if (!access) {
     throw new ValidationError("Kimi Code OAuth refresh response missing access_token.");
@@ -279,10 +294,17 @@ async function refreshGrokTokens(
   if (!res.ok) {
     const hint = res.status === 401 || res.status === 400 ? " Re-run Grok sign-in from the panel." : "";
     throw new ValidationError(
-      `Grok OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+      `Grok OAuth refresh failed (${res.status}): ${redactTokens(text).slice(0, 300)}.${hint}`,
     );
   }
-  const payload = JSON.parse(text) as { access_token?: string; refresh_token?: string; expires_in?: number };
+  let payload: { access_token?: string; refresh_token?: string; expires_in?: number };
+  try {
+    payload = JSON.parse(text) as { access_token?: string; refresh_token?: string; expires_in?: number };
+  } catch {
+    // See refreshOpenAICodexTokens's matching catch: a 2xx-but-malformed body
+    // must never reach the caller raw via JSON.parse's own SyntaxError.
+    throw new ValidationError("Grok OAuth refresh returned a malformed (non-JSON) response.");
+  }
   const access = payload.access_token?.trim();
   if (!access) {
     throw new ValidationError("Grok OAuth refresh response missing access_token.");

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -1,0 +1,333 @@
+import { readFile, writeFile, rename } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { ValidationError } from "../utils/errors.js";
+
+const OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENAI_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+
+const KIMI_CODE_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
+const KIMI_OAUTH_TOKEN_URL = "https://api.kimi.com/oauth/token";
+
+export const GLM_CODE_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4";
+export const KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1";
+
+const TOKEN_REFRESH_SKEW_MS = 120_000;
+
+export type CodeProviderAuthDeps = {
+  home?: string;
+  fetch?: typeof fetch;
+  now?: () => number;
+};
+
+export type OpenAICodexOAuthCredentials = {
+  accessToken: string;
+  accountId: string;
+  authMode?: string;
+};
+
+export type GlmCodeCredentials = {
+  apiKey: string;
+  baseUrl: string;
+};
+
+export type KimiCodeOAuthCredentials = {
+  accessToken: string;
+  baseUrl: string;
+};
+
+interface CodexAuthFile {
+  auth_mode?: string;
+  tokens?: {
+    access_token?: string;
+    refresh_token?: string;
+    account_id?: string;
+    id_token?: string;
+  };
+  last_refresh?: string;
+}
+
+interface KimiCodeAuthFile {
+  access_token?: string;
+  refresh_token?: string;
+  expires_at?: number;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+function codexAuthPath(home = homedir()): string {
+  const root = process.env.CODEX_HOME || join(home, ".codex");
+  return join(root, "auth.json");
+}
+
+function kimiCodeAuthPath(home = homedir()): string {
+  const share = process.env.KIMI_SHARE_DIR || join(home, ".kimi");
+  return join(share, "credentials", "kimi-code.json");
+}
+
+function jwtExpMs(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as {
+      exp?: number;
+    };
+    return typeof payload.exp === "number" && Number.isFinite(payload.exp)
+      ? payload.exp * 1000
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function jwtChatgptAccountId(idToken: string | undefined): string | null {
+  if (!idToken?.trim()) return null;
+  const parts = idToken.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, "base64url").toString("utf8")) as {
+      "https://api.openai.com/auth"?: { chatgpt_account_id?: string };
+    };
+    return payload["https://api.openai.com/auth"]?.chatgpt_account_id?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function atomicWriteJson(path: string, data: unknown): Promise<void> {
+  const dir = dirname(path);
+  const tmp = join(dir, `.auth-${randomBytes(8).toString("hex")}.tmp`);
+  await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+function tokenExpiring(expiryMs: number | null, nowMs: number, skewMs = TOKEN_REFRESH_SKEW_MS): boolean {
+  if (expiryMs == null) return false;
+  return nowMs >= expiryMs - skewMs;
+}
+
+async function refreshOpenAICodexTokens(
+  refreshToken: string,
+  deps: CodeProviderAuthDeps,
+): Promise<{ access_token: string; refresh_token?: string }> {
+  const fetchFn = deps.fetch ?? fetch;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: OPENAI_CODEX_CLIENT_ID,
+  });
+  const res = await fetchFn(OPENAI_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const hint = res.status === 401 || res.status === 400 ? " Run `codex login` to re-authenticate." : "";
+    throw new ValidationError(
+      `OpenAI Codex OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+    );
+  }
+  const payload = JSON.parse(text) as { access_token?: string; refresh_token?: string };
+  const access = payload.access_token?.trim();
+  if (!access) {
+    throw new ValidationError("OpenAI Codex OAuth refresh response missing access_token.");
+  }
+  return { access_token: access, refresh_token: payload.refresh_token?.trim() };
+}
+
+async function refreshKimiCodeTokens(
+  refreshToken: string,
+  deps: CodeProviderAuthDeps,
+): Promise<KimiCodeAuthFile> {
+  const fetchFn = deps.fetch ?? fetch;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: KIMI_CODE_CLIENT_ID,
+  });
+  const res = await fetchFn(KIMI_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    const hint = res.status === 401 || res.status === 400 ? " Re-run `kimi` / Kimi Code login." : "";
+    throw new ValidationError(
+      `Kimi Code OAuth refresh failed (${res.status}): ${text.slice(0, 300)}.${hint}`,
+    );
+  }
+  const payload = JSON.parse(text) as KimiCodeAuthFile;
+  const access = payload.access_token?.trim();
+  if (!access) {
+    throw new ValidationError("Kimi Code OAuth refresh response missing access_token.");
+  }
+  const nowSec = (deps.now?.() ?? Date.now()) / 1000;
+  const expiresIn = Number(payload.expires_in);
+  return {
+    ...payload,
+    access_token: access,
+    refresh_token: payload.refresh_token?.trim() || refreshToken,
+    expires_at:
+      typeof payload.expires_at === "number" && Number.isFinite(payload.expires_at)
+        ? payload.expires_at
+        : Number.isFinite(expiresIn) && expiresIn > 0
+          ? nowSec + expiresIn
+          : undefined,
+  };
+}
+
+/**
+ * Resolve ChatGPT/Codex subscription OAuth from ~/.codex/auth.json (written by `codex login`).
+ * Refreshes expired access tokens in place. Use with the Codex Responses backend — not api.openai.com.
+ */
+export async function resolveOpenAICodexOAuth(
+  deps: CodeProviderAuthDeps = {},
+): Promise<OpenAICodexOAuthCredentials> {
+  const home = deps.home ?? homedir();
+  const path = codexAuthPath(home);
+  if (!existsSync(path)) {
+    throw new ValidationError(
+      "ChatGPT OAuth requires ~/.codex/auth.json. Run `codex login` once, then pick the ChatGPT (direct OAuth) backend.",
+    );
+  }
+
+  const raw = JSON.parse(await readFile(path, "utf8")) as CodexAuthFile;
+  const tokens = raw.tokens;
+  if (!tokens?.access_token?.trim() && !tokens?.refresh_token?.trim()) {
+    throw new ValidationError("No Codex OAuth tokens in ~/.codex/auth.json. Run `codex login`.");
+  }
+
+  const nowMs = deps.now?.() ?? Date.now();
+  let accessToken = tokens.access_token?.trim() ?? "";
+  const expMs = accessToken ? jwtExpMs(accessToken) : null;
+  const needsRefresh = !accessToken || tokenExpiring(expMs, nowMs);
+
+  if (needsRefresh) {
+    const refreshToken = tokens.refresh_token?.trim();
+    if (!refreshToken) {
+      throw new ValidationError("Codex access token expired and refresh_token is missing. Run `codex login`.");
+    }
+    const refreshed = await refreshOpenAICodexTokens(refreshToken, deps);
+    accessToken = refreshed.access_token;
+    raw.tokens = {
+      ...tokens,
+      access_token: accessToken,
+      refresh_token: refreshed.refresh_token ?? refreshToken,
+    };
+    raw.last_refresh = new Date(nowMs).toISOString();
+    await atomicWriteJson(path, raw);
+  }
+
+  const accountId =
+    tokens.account_id?.trim() ||
+    jwtChatgptAccountId(tokens.id_token) ||
+    "";
+  if (!accountId) {
+    throw new ValidationError(
+      "Codex OAuth is missing chatgpt account_id. Run `codex login` again to refresh ~/.codex/auth.json.",
+    );
+  }
+
+  return {
+    accessToken,
+    accountId,
+    authMode: raw.auth_mode,
+  };
+}
+
+/** GLM Coding Plan API key (Z.AI). Env: ZAI_API_KEY, GLM_API_KEY, or ZHIPUAI_API_KEY. */
+export function resolveGlmCodeCredentials(): GlmCodeCredentials {
+  const apiKey =
+    process.env.ZAI_API_KEY?.trim() ||
+    process.env.GLM_API_KEY?.trim() ||
+    process.env.ZHIPUAI_API_KEY?.trim() ||
+    process.env.ZHIPU_API_KEY?.trim();
+  if (!apiKey) {
+    throw new ValidationError(
+      "GLM Code API requires ZAI_API_KEY (or GLM_API_KEY / ZHIPUAI_API_KEY) from your Z.AI Coding Plan.",
+    );
+  }
+  const baseUrl =
+    process.env.COMFYUI_MCP_GLM_BASE_URL?.trim().replace(/\/$/, "") || GLM_CODE_DEFAULT_BASE;
+  return { apiKey, baseUrl };
+}
+
+/**
+ * Resolve Kimi Code subscription OAuth from ~/.kimi/credentials/kimi-code.json.
+ * Falls back to KIMI_API_KEY when set (pay-per-token / CI).
+ */
+export async function resolveKimiCodeOAuth(
+  deps: CodeProviderAuthDeps = {},
+): Promise<KimiCodeOAuthCredentials> {
+  const baseUrl =
+    process.env.COMFYUI_MCP_KIMI_BASE_URL?.trim().replace(/\/$/, "") || KIMI_CODE_DEFAULT_BASE;
+
+  const apiKey = process.env.KIMI_API_KEY?.trim();
+  if (apiKey) {
+    return { accessToken: apiKey, baseUrl };
+  }
+
+  const home = deps.home ?? homedir();
+  const path = kimiCodeAuthPath(home);
+  if (!existsSync(path)) {
+    throw new ValidationError(
+      "Kimi Code OAuth requires ~/.kimi/credentials/kimi-code.json (from Kimi Code login) or KIMI_API_KEY.",
+    );
+  }
+
+  let creds = JSON.parse(await readFile(path, "utf8")) as KimiCodeAuthFile;
+  const nowMs = deps.now?.() ?? Date.now();
+  const nowSec = nowMs / 1000;
+  const expirySec =
+    typeof creds.expires_at === "number" && Number.isFinite(creds.expires_at)
+      ? creds.expires_at
+      : creds.access_token
+        ? (jwtExpMs(creds.access_token) ?? 0) / 1000
+        : null;
+
+  const needsRefresh =
+    !creds.access_token?.trim() ||
+    (expirySec != null && nowSec >= expirySec - TOKEN_REFRESH_SKEW_MS / 1000);
+
+  if (needsRefresh) {
+    const refreshToken = creds.refresh_token?.trim();
+    if (!refreshToken) {
+      throw new ValidationError("Kimi Code access token expired and refresh_token is missing. Re-run Kimi Code login.");
+    }
+    creds = await refreshKimiCodeTokens(refreshToken, deps);
+    await atomicWriteJson(path, creds);
+  }
+
+  const accessToken = creds.access_token?.trim();
+  if (!accessToken) {
+    throw new ValidationError("Kimi Code OAuth access_token is missing after refresh.");
+  }
+
+  return { accessToken, baseUrl };
+}
+
+export const __testing = {
+  OPENAI_CODEX_CLIENT_ID,
+  KIMI_CODE_CLIENT_ID,
+  GLM_CODE_DEFAULT_BASE,
+  KIMI_CODE_DEFAULT_BASE,
+  codexAuthPath,
+  kimiCodeAuthPath,
+  jwtExpMs,
+  jwtChatgptAccountId,
+  refreshOpenAICodexTokens,
+  refreshKimiCodeTokens,
+};

--- a/src/services/oauth-flow.test.ts
+++ b/src/services/oauth-flow.test.ts
@@ -66,6 +66,28 @@ describe("runLoopbackPKCE", () => {
     expect(capturedAuthorizeUrl).toContain("code_challenge_method=S256");
   });
 
+  it("redacts token-shaped material from a failed-exchange error message", async () => {
+    const openBrowser = vi.fn(async (url: string) => {
+      const u = new URL(url);
+      const state = u.searchParams.get("state")!;
+      const redirect = u.searchParams.get("redirect_uri")!;
+      await fetch(`${redirect}?code=THECODE&state=${state}`);
+    });
+    const fetchFn = vi.fn(async (url: string, init?: any) => {
+      if (String(url) === cfg.tokenUrl) {
+        return new Response(JSON.stringify({ error: "bad", access_token: "LEAKED123" }), { status: 400 });
+      }
+      return (globalThis as any).__realFetch(url, init);
+    });
+    (globalThis as any).__realFetch = (globalThis as any).__realFetch ?? fetch;
+    const err = await runLoopbackPKCE(cfg, { fetch: fetchFn as any, openBrowser }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain("bad");
+    expect(message).not.toContain("LEAKED123");
+    expect(message).toContain("<redacted>");
+  });
+
   it("rejects a callback whose state does not match", async () => {
     const openBrowser = vi.fn(async (url: string) => {
       const redirect = new URL(url).searchParams.get("redirect_uri")!;

--- a/src/services/oauth-flow.test.ts
+++ b/src/services/oauth-flow.test.ts
@@ -148,6 +148,42 @@ describe("device-code", () => {
     expect(calls).toBe(2);
   });
 
+  it("honors slow_down (grows interval) then succeeds", async () => {
+    let calls = 0;
+    const fetchFn = vi.fn(async () => {
+      calls++;
+      if (calls < 2) return new Response(JSON.stringify({ error: "slow_down" }), { status: 200 });
+      return new Response(JSON.stringify({ access_token: "ghu_X", token_type: "bearer" }), { status: 200 });
+    });
+    const tokens = await pollDeviceToken(dcfg, "DC", { fetch: fetchFn as any, now: () => 0 });
+    expect(tokens.access_token).toBe("ghu_X");
+    expect(calls).toBe(2);
+  });
+
+  it("throws on expiry instead of looping to the cap", async () => {
+    let calls = 0;
+    // now() reads 0 first (deadline = 15min), then jumps past it — so the loop
+    // terminates via the expiry guard after a couple of iterations, not at 1000.
+    let reads = 0;
+    const now = () => (reads++ === 0 ? 0 : 20 * 60_000);
+    const fetchFn = vi.fn(async () => {
+      calls++;
+      return new Response(JSON.stringify({ error: "authorization_pending" }), { status: 200 });
+    });
+    await expect(pollDeviceToken(dcfg, "DC", { fetch: fetchFn as any, now })).rejects.toThrow(/expired/i);
+    expect(calls).toBeLessThanOrEqual(3); // nowhere near the 1000 loop cap
+  });
+
+  it("stops on a terminal error on the first response (no retry)", async () => {
+    let calls = 0;
+    const fetchFn = vi.fn(async () => {
+      calls++;
+      return new Response(JSON.stringify({ error: "access_denied" }), { status: 200 });
+    });
+    await expect(pollDeviceToken(dcfg, "DC", { fetch: fetchFn as any, now: () => 0 })).rejects.toThrow(/access_denied/i);
+    expect(calls).toBe(1);
+  });
+
   it("copilot registry entry is experimental", async () => {
     const { OAUTH_PROVIDERS } = await import("./oauth-flow.js");
     expect(OAUTH_PROVIDERS.copilot.experimental).toBe(true);

--- a/src/services/oauth-flow.test.ts
+++ b/src/services/oauth-flow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { pkcePair, assertAllowedTokenHost, runLoopbackPKCE, OAUTH_PROVIDERS } from "./oauth-flow.js";
+import { beginDeviceCode, pollDeviceToken } from "./oauth-flow.js";
 import { createHash } from "node:crypto";
 
 describe("pkcePair", () => {
@@ -113,5 +114,43 @@ describe("OAUTH_PROVIDERS", () => {
     expect(g.tokenUrl).toBe("https://auth.x.ai/oauth2/token");
     expect(g.apiHostAllowlist).toContain("x.ai");
     expect(g.loopbackPort).toBe(56121);
+  });
+});
+
+const dcfg = {
+  id: "copilot" as const, label: "GitHub Copilot", kind: "device_code" as const,
+  authorizeUrl: "", tokenUrl: "https://github.com/login/oauth/access_token",
+  deviceCodeUrl: "https://github.com/login/device/code",
+  clientId: "Iv1.b507a08c87ecfe98", scopes: ["read:user"],
+  tokenFile: "/tmp/copilot.json", apiHostAllowlist: ["github.com", "githubcopilot.com"],
+  experimental: true,
+};
+
+describe("device-code", () => {
+  it("begins a device code and returns the user_code + verification url", async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response(JSON.stringify({ device_code: "DC", user_code: "WXYZ-1234", verification_uri: "https://github.com/login/device", interval: 5, expires_in: 900 }), { status: 200 }));
+    const r = await beginDeviceCode(dcfg, { fetch: fetchFn as any });
+    expect(r.user_code).toBe("WXYZ-1234");
+    expect(r.verification_url).toBe("https://github.com/login/device");
+    expect(r.device_code).toBe("DC");
+  });
+
+  it("polls through authorization_pending then succeeds", async () => {
+    let calls = 0;
+    const fetchFn = vi.fn(async () => {
+      calls++;
+      if (calls < 2) return new Response(JSON.stringify({ error: "authorization_pending" }), { status: 200 });
+      return new Response(JSON.stringify({ access_token: "ghu_AT", token_type: "bearer" }), { status: 200 });
+    });
+    const tokens = await pollDeviceToken(dcfg, "DC", { fetch: fetchFn as any, now: () => 0 });
+    expect(tokens.access_token).toBe("ghu_AT");
+    expect(calls).toBe(2);
+  });
+
+  it("copilot registry entry is experimental", async () => {
+    const { OAUTH_PROVIDERS } = await import("./oauth-flow.js");
+    expect(OAUTH_PROVIDERS.copilot.experimental).toBe(true);
+    expect(OAUTH_PROVIDERS.copilot.clientId).toBe("Iv1.b507a08c87ecfe98");
   });
 });

--- a/src/services/oauth-flow.test.ts
+++ b/src/services/oauth-flow.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { pkcePair, assertAllowedTokenHost, runLoopbackPKCE, OAUTH_PROVIDERS } from "./oauth-flow.js";
+import { createHash } from "node:crypto";
+
+describe("pkcePair", () => {
+  it("produces a verifier and its S256 challenge (base64url, no padding)", () => {
+    const { verifier, challenge } = pkcePair();
+    expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+    const expected = createHash("sha256").update(verifier).digest("base64url");
+    expect(challenge).toBe(expected);
+    expect(challenge).not.toMatch(/[=+/]/); // base64url, unpadded
+  });
+  it("is different each call", () => {
+    expect(pkcePair().verifier).not.toBe(pkcePair().verifier);
+  });
+});
+
+describe("assertAllowedTokenHost", () => {
+  it("accepts https on an allowlisted host (exact + subdomain)", () => {
+    expect(() => assertAllowedTokenHost("https://api.x.ai/v1", ["api.x.ai"])).not.toThrow();
+    expect(() => assertAllowedTokenHost("https://foo.x.ai/v1", ["x.ai"])).not.toThrow();
+  });
+  it("rejects http, off-host, and lookalike hosts", () => {
+    expect(() => assertAllowedTokenHost("http://api.x.ai/v1", ["api.x.ai"])).toThrow(/https/i);
+    expect(() => assertAllowedTokenHost("https://evil.example/v1", ["api.x.ai"])).toThrow(/allow/i);
+    expect(() => assertAllowedTokenHost("https://api.x.ai.evil.com/v1", ["x.ai"])).toThrow(/allow/i);
+  });
+});
+
+describe("runLoopbackPKCE", () => {
+  const cfg = {
+    id: "codex" as const, label: "ChatGPT", kind: "loopback_pkce" as const,
+    authorizeUrl: "https://auth.example/oauth/authorize",
+    tokenUrl: "https://auth.example/oauth/token",
+    clientId: "test-client", scopes: ["openid"],
+    loopbackPort: 0, redirectPath: "/auth/callback",
+    tokenFile: "/tmp/unused.json", apiHostAllowlist: ["auth.example"],
+  };
+
+  it("verifies state and exchanges the code for tokens", async () => {
+    let capturedAuthorizeUrl = "";
+    const openBrowser = vi.fn(async (url: string) => {
+      capturedAuthorizeUrl = url;
+      // Simulate the provider redirecting back to the loopback with code+state.
+      const u = new URL(url);
+      const state = u.searchParams.get("state")!;
+      const redirect = u.searchParams.get("redirect_uri")!;
+      await fetch(`${redirect}?code=THECODE&state=${state}`);
+    });
+    const fetchFn = vi.fn(async (url: string, init?: any) => {
+      if (String(url) === cfg.tokenUrl) {
+        const body = new URLSearchParams(init.body);
+        expect(body.get("grant_type")).toBe("authorization_code");
+        expect(body.get("code")).toBe("THECODE");
+        expect(body.get("code_verifier")).toMatch(/.+/);
+        return new Response(JSON.stringify({ access_token: "AT", refresh_token: "RT", expires_in: 3600 }), { status: 200 });
+      }
+      // The loopback self-fetch from openBrowser goes to the real listener — pass through.
+      return (globalThis as any).__realFetch(url, init);
+    });
+    (globalThis as any).__realFetch = (globalThis as any).__realFetch ?? fetch;
+    const tokens = await runLoopbackPKCE(cfg, { fetch: fetchFn as any, openBrowser });
+    expect(tokens.access_token).toBe("AT");
+    expect(tokens.refresh_token).toBe("RT");
+    expect(capturedAuthorizeUrl).toContain("code_challenge=");
+    expect(capturedAuthorizeUrl).toContain("code_challenge_method=S256");
+  });
+
+  it("rejects a callback whose state does not match", async () => {
+    const openBrowser = vi.fn(async (url: string) => {
+      const redirect = new URL(url).searchParams.get("redirect_uri")!;
+      await fetch(`${redirect}?code=X&state=WRONG`);
+    });
+    await expect(runLoopbackPKCE(cfg, { openBrowser })).rejects.toThrow(/state/i);
+  });
+});
+
+describe("OAUTH_PROVIDERS", () => {
+  it("always includes codex with the pinned loopback port and locked redirect", () => {
+    const c = OAUTH_PROVIDERS.codex;
+    expect(c.loopbackPort).toBe(1455);
+    expect(c.redirectPath).toBe("/auth/callback");
+    expect(c.clientId).toBe("app_EMoamEEZ73f0CkXaXp7hrann");
+    expect(c.tokenUrl).toBe("https://auth.openai.com/oauth/token");
+    expect(c.apiHostAllowlist).toContain("auth.openai.com");
+  });
+
+  it("includes grok with the pinned client, endpoints, and loopback port", () => {
+    const g = OAUTH_PROVIDERS.grok;
+    expect(g.clientId).toBe("b1a00492-073a-47ea-816f-4c329264a828");
+    expect(g.tokenUrl).toBe("https://auth.x.ai/oauth2/token");
+    expect(g.apiHostAllowlist).toContain("x.ai");
+    expect(g.loopbackPort).toBe(56121);
+  });
+});

--- a/src/services/oauth-flow.ts
+++ b/src/services/oauth-flow.ts
@@ -199,6 +199,90 @@ export function runLoopbackPKCE(cfg: OAuthProviderConfig, deps: OAuthDeps = {}):
   });
 }
 
+/**
+ * Device-code step 1: request a device/user code pair from `cfg.deviceCodeUrl`.
+ * The caller shows `user_code` + `verification_url` to the user, then calls
+ * `pollDeviceToken` to wait for them to complete sign-in in their browser.
+ */
+export async function beginDeviceCode(
+  cfg: OAuthProviderConfig,
+  deps: OAuthDeps = {},
+): Promise<{ user_code: string; verification_url: string; device_code: string; interval: number; expires_in: number }> {
+  const fetchFn = deps.fetch ?? fetch;
+  if (!cfg.deviceCodeUrl) throw new ValidationError(`${cfg.label}: no device-code endpoint configured.`);
+  assertAllowedTokenHost(cfg.deviceCodeUrl, cfg.apiHostAllowlist);
+  const res = await fetchFn(cfg.deviceCodeUrl, {
+    method: "POST",
+    headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ client_id: cfg.clientId, scope: cfg.scopes.join(" ") }).toString(),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new ValidationError(`${cfg.label} device-code request failed (${res.status}): ${redactTokens(text).slice(0, 200)}`);
+  const j = JSON.parse(text) as Record<string, unknown>;
+  const user_code = String(j.user_code ?? "");
+  const verification_url = String(j.verification_uri ?? j.verification_url ?? "");
+  const device_code = String(j.device_code ?? "");
+  if (!user_code || !verification_url || !device_code) throw new ValidationError(`${cfg.label} device-code response incomplete.`);
+  return {
+    user_code,
+    verification_url,
+    device_code,
+    interval: typeof j.interval === "number" ? j.interval : 5,
+    expires_in: typeof j.expires_in === "number" ? j.expires_in : 900,
+  };
+}
+
+/**
+ * Device-code step 2: poll `cfg.tokenUrl` until the user completes sign-in
+ * (or expiry). Honors `authorization_pending` (keep polling at the current
+ * interval) and `slow_down` (grow the interval) per RFC 8628. When
+ * `deps.now` is injected (test mode), sleeps resolve immediately so tests
+ * don't actually wait, and the poll loop is bounded so a fixed injected
+ * clock can't spin forever.
+ */
+export async function pollDeviceToken(
+  cfg: OAuthProviderConfig,
+  deviceCode: string,
+  deps: OAuthDeps = {},
+): Promise<OAuthTokens> {
+  const fetchFn = deps.fetch ?? fetch;
+  assertAllowedTokenHost(cfg.tokenUrl, cfg.apiHostAllowlist);
+  const testMode = typeof deps.now === "function";
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, testMode ? 0 : ms));
+  const deadline = (deps.now?.() ?? Date.now()) + 15 * 60_000;
+  let intervalMs = 5000;
+  // Bounded loop so a test with a fixed injected now() can't spin forever.
+  for (let i = 0; i < 1000; i++) {
+    if ((deps.now?.() ?? Date.now()) > deadline) throw new ValidationError(`${cfg.label} device sign-in expired.`);
+    const res = await fetchFn(cfg.tokenUrl, {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: cfg.clientId,
+        device_code: deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }).toString(),
+      signal: AbortSignal.timeout(30_000),
+    });
+    const j = JSON.parse(await res.text()) as Record<string, unknown>;
+    const access = String(j.access_token ?? "").trim();
+    if (access) {
+      return {
+        access_token: access,
+        refresh_token: j.refresh_token ? String(j.refresh_token) : undefined,
+        expires_in: typeof j.expires_in === "number" ? j.expires_in : undefined,
+        raw: j,
+      };
+    }
+    const err = String(j.error ?? "");
+    if (err === "authorization_pending") { await sleep(intervalMs); continue; }
+    if (err === "slow_down") { intervalMs += 5000; await sleep(intervalMs); continue; }
+    throw new ValidationError(`${cfg.label} device sign-in failed: ${err || "unknown error"}`);
+  }
+  throw new ValidationError(`${cfg.label} device sign-in did not complete.`);
+}
+
 const codexTokenFile = join(homedir(), ".codex", "auth.json");
 const grokTokenFile = join(homedir(), ".grok", "auth.json");
 const copilotTokenFile = join(homedir(), ".comfyui-mcp", "copilot-auth.json");
@@ -232,6 +316,20 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     redirectPath: "/callback",
     tokenFile: grokTokenFile,
     apiHostAllowlist: ["x.ai"],
+  },
+  // copilot: device-code only (Copilot's other flows don't work outside VS Code) — EXPERIMENTAL, ToS risk.
+  copilot: {
+    id: "copilot",
+    label: "GitHub Copilot",
+    kind: "device_code",
+    authorizeUrl: "",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    deviceCodeUrl: "https://github.com/login/device/code",
+    clientId: "Iv1.b507a08c87ecfe98", // VS Code Copilot extension id — EXPERIMENTAL, ToS risk
+    scopes: ["read:user"],
+    tokenFile: copilotTokenFile,
+    apiHostAllowlist: ["github.com", "githubcopilot.com"],
+    experimental: true,
   },
 };
 

--- a/src/services/oauth-flow.ts
+++ b/src/services/oauth-flow.ts
@@ -44,12 +44,36 @@ export interface OAuthDeps {
 
 const b64url = (buf: Buffer): string => buf.toString("base64url");
 
-/** Strip token-shaped material from provider error text before it can reach a log/UI. */
-function redactTokens(s: string): string {
+/**
+ * Strip token-shaped material from provider error text before it can reach a
+ * log/UI. SINGLE SOURCE OF TRUTH — grok-backend.ts and copilot-backend.ts
+ * used to carry their own local copies (`redactGrokTokens`/
+ * `redactCopilotTokens`); those were folded into this exported superset (no
+ * coverage lost) and the call sites now import this function directly. Any
+ * new provider error path (refresh, exchange, device-poll, data-API call)
+ * MUST run its raw response body through this before it can reach a thrown
+ * Error message or a log line.
+ *
+ * Covers, across all three prior variants:
+ *  - key:value / key=value pairs for access_token, refresh_token, id_token,
+ *    code, code_verifier, client_secret, and bare token (the Copilot copy's
+ *    addition, for `{token: "..."}` exchange-response shapes).
+ *  - raw prefixed tokens: ghu_/gho_ (GitHub device-code), ghp_ (Copilot's
+ *    addition, GitHub PAT), ya29. (Google), sk- (OpenAI-style), xai- (xAI API
+ *    keys — the Grok copy was missing this one).
+ *  - `Bearer <token>` headers/strings.
+ *  - bare `token <value>` (the Copilot copy's addition, for GitHub's
+ *    `Authorization: token ghu_...` scheme appearing in echoed text).
+ */
+export function redactTokens(s: string): string {
   return s
-    .replace(/("?(?:access_token|refresh_token|id_token|code|code_verifier|client_secret)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi, "$1<redacted>")
-    .replace(/\b(ghu_|gho_|ya29\.|sk-)[A-Za-z0-9._-]+/g, "$1<redacted>")
-    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>");
+    .replace(
+      /("?(?:access_token|refresh_token|id_token|code|code_verifier|client_secret|token)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi,
+      "$1<redacted>",
+    )
+    .replace(/\b(ghu_|gho_|ghp_|ya29\.|sk-|xai-)[A-Za-z0-9._-]+/g, "$1<redacted>")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>")
+    .replace(/\btoken\s+[A-Za-z0-9._-]+/gi, "token <redacted>");
 }
 
 /** S256 PKCE pair. verifier: 43-128 chars unreserved; challenge = base64url(sha256(verifier)). */

--- a/src/services/oauth-flow.ts
+++ b/src/services/oauth-flow.ts
@@ -1,0 +1,230 @@
+// oauth-flow.ts — generic OAuth engine for in-panel provider sign-in.
+// Two primitives (loopback-PKCE, device-code) driven by a per-provider config.
+// SECURITY: PKCE S256 + state on every loopback exchange; loopback bound to
+// 127.0.0.1 only and torn down after use; bearer only sent to allowlisted HTTPS
+// hosts; token material never logged. See docs/superpowers/specs/2026-07-11-oauth-in-panel-design.md.
+import { createHash, randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+export type OAuthFlowKind = "loopback_pkce" | "device_code";
+
+export interface OAuthProviderConfig {
+  id: "grok" | "codex" | "copilot";
+  label: string;
+  kind: OAuthFlowKind;
+  authorizeUrl: string;
+  tokenUrl: string;
+  deviceCodeUrl?: string;
+  clientId: string;
+  scopes: string[];
+  loopbackPort?: number;
+  redirectPath?: string;
+  tokenFile: string;
+  apiHostAllowlist: string[];
+  experimental?: boolean;
+}
+
+export interface OAuthTokens {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+  expires_in?: number;
+  raw: Record<string, unknown>;
+}
+
+export interface OAuthDeps {
+  fetch?: typeof fetch;
+  openBrowser?: (url: string) => Promise<void> | void;
+  now?: () => number;
+}
+
+const b64url = (buf: Buffer): string => buf.toString("base64url");
+
+/** S256 PKCE pair. verifier: 43-128 chars unreserved; challenge = base64url(sha256(verifier)). */
+export function pkcePair(): { verifier: string; challenge: string } {
+  const verifier = b64url(randomBytes(32)); // 43 base64url chars, all in the unreserved set
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+/** Throw unless `url` is HTTPS on an allowlisted host (exact host or a subdomain of one). */
+export function assertAllowedTokenHost(url: string, allowlist: string[]): void {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    throw new ValidationError(`OAuth: malformed URL "${String(url).slice(0, 80)}"`);
+  }
+  if (u.protocol !== "https:") throw new ValidationError(`OAuth: refusing non-HTTPS token host "${u.protocol}"`);
+  const host = u.hostname.toLowerCase();
+  const ok = allowlist.some((a) => {
+    const base = a.toLowerCase();
+    return host === base || host.endsWith(`.${base}`);
+  });
+  if (!ok) throw new ValidationError(`OAuth: token host "${host}" not in allowlist [${allowlist.join(", ")}]`);
+}
+
+async function defaultOpenBrowser(url: string): Promise<void> {
+  const { spawn } = await import("node:child_process");
+  const cmd = process.platform === "win32" ? "cmd" : process.platform === "darwin" ? "open" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+  } catch {
+    logger.warn(`[oauth] could not open a browser automatically — visit: ${url}`);
+  }
+}
+
+/**
+ * Loopback authorization-code + PKCE. Binds 127.0.0.1:cfg.loopbackPort, opens the
+ * browser to the authorize URL, resolves when the provider redirects back with a
+ * matching state, exchanges the code, and always tears the listener down.
+ */
+export function runLoopbackPKCE(cfg: OAuthProviderConfig, deps: OAuthDeps = {}): Promise<OAuthTokens> {
+  const fetchFn = deps.fetch ?? fetch;
+  const openBrowser = deps.openBrowser ?? defaultOpenBrowser;
+  const port = cfg.loopbackPort ?? 0;
+  const redirectPath = cfg.redirectPath ?? "/auth/callback";
+  const { verifier, challenge } = pkcePair();
+  const state = b64url(randomBytes(16));
+
+  return new Promise<OAuthTokens>((resolve, reject) => {
+    let settled = false;
+    const done = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      server.close();
+      fn();
+    };
+
+    const server = createServer(async (req, res) => {
+      try {
+        const url = new URL(req.url ?? "/", `http://127.0.0.1:${addrPort}`);
+        if (url.pathname !== redirectPath) {
+          res.writeHead(404).end("not found");
+          return;
+        }
+        const code = url.searchParams.get("code");
+        const gotState = url.searchParams.get("state");
+        if (!gotState || gotState !== state) {
+          res.writeHead(400).end("state mismatch");
+          done(() => reject(new ValidationError("OAuth: callback state did not match — aborting (possible CSRF).")));
+          return;
+        }
+        if (!code) {
+          res.writeHead(400).end("missing code");
+          done(() => reject(new ValidationError("OAuth: callback missing authorization code.")));
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "text/html" }).end(
+          "<html><body style='font:14px system-ui;padding:2rem'>Signed in — you can close this tab and return to ComfyUI.</body></html>",
+        );
+        // Exchange the code.
+        assertAllowedTokenHost(cfg.tokenUrl, cfg.apiHostAllowlist);
+        const body = new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id: cfg.clientId,
+          code_verifier: verifier,
+          redirect_uri: redirectUri,
+        });
+        const tokRes = await fetchFn(cfg.tokenUrl, {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/x-www-form-urlencoded" },
+          body: body.toString(),
+          signal: AbortSignal.timeout(30_000),
+        });
+        const text = await tokRes.text();
+        if (!tokRes.ok) {
+          done(() => reject(new ValidationError(`OAuth token exchange failed (${tokRes.status}): ${text.slice(0, 300)}`)));
+          return;
+        }
+        const raw = JSON.parse(text) as Record<string, unknown>;
+        const access = String(raw.access_token ?? "").trim();
+        if (!access) {
+          done(() => reject(new ValidationError("OAuth token exchange response missing access_token.")));
+          return;
+        }
+        done(() =>
+          resolve({
+            access_token: access,
+            refresh_token: raw.refresh_token ? String(raw.refresh_token) : undefined,
+            id_token: raw.id_token ? String(raw.id_token) : undefined,
+            expires_in: typeof raw.expires_in === "number" ? raw.expires_in : undefined,
+            raw,
+          }),
+        );
+      } catch (err) {
+        done(() => reject(err instanceof Error ? err : new ValidationError(String(err))));
+      }
+    });
+
+    let addrPort = port;
+    let redirectUri = "";
+    const timer = setTimeout(
+      () => done(() => reject(new ValidationError("OAuth sign-in timed out (5 min) — no callback received."))),
+      5 * 60_000,
+    );
+
+    server.on("error", (err) => done(() => reject(err)));
+    server.listen(port, "127.0.0.1", () => {
+      const addr = server.address();
+      addrPort = typeof addr === "object" && addr ? addr.port : port;
+      redirectUri = `http://127.0.0.1:${addrPort}${redirectPath}`;
+      const authUrl = new URL(cfg.authorizeUrl);
+      authUrl.searchParams.set("response_type", "code");
+      authUrl.searchParams.set("client_id", cfg.clientId);
+      authUrl.searchParams.set("redirect_uri", redirectUri);
+      authUrl.searchParams.set("scope", cfg.scopes.join(" "));
+      authUrl.searchParams.set("state", state);
+      authUrl.searchParams.set("code_challenge", challenge);
+      authUrl.searchParams.set("code_challenge_method", "S256");
+      Promise.resolve(openBrowser(authUrl.toString())).catch((err) =>
+        done(() => reject(err instanceof Error ? err : new ValidationError(String(err)))),
+      );
+    });
+  });
+}
+
+const codexTokenFile = join(homedir(), ".codex", "auth.json");
+const grokTokenFile = join(homedir(), ".grok", "auth.json");
+const copilotTokenFile = join(homedir(), ".comfyui-mcp", "copilot-auth.json");
+
+/** Provider registry. Codex always present; grok added ONLY if Task 1 was GO
+ *  (fill in clientId/scopes from the recorded decision); copilot in Task 3. */
+export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
+  codex: {
+    id: "codex",
+    label: "ChatGPT",
+    kind: "loopback_pkce",
+    authorizeUrl: "https://auth.openai.com/oauth/authorize",
+    tokenUrl: "https://auth.openai.com/oauth/token",
+    clientId: "app_EMoamEEZ73f0CkXaXp7hrann",
+    scopes: ["openid", "profile", "email", "offline_access"],
+    loopbackPort: 1455,
+    redirectPath: "/auth/callback",
+    tokenFile: codexTokenFile,
+    apiHostAllowlist: ["auth.openai.com", "chatgpt.com"],
+  },
+  // grok: Task 1 recorded GO — clientId/scopes/endpoints from the recorded decision.
+  grok: {
+    id: "grok",
+    label: "Grok",
+    kind: "loopback_pkce",
+    authorizeUrl: "https://auth.x.ai/oauth2/authorize",
+    tokenUrl: "https://auth.x.ai/oauth2/token",
+    clientId: "b1a00492-073a-47ea-816f-4c329264a828",
+    scopes: ["openid", "profile", "email", "offline_access", "grok-cli:access", "api:access"],
+    loopbackPort: 56121,
+    redirectPath: "/callback",
+    tokenFile: grokTokenFile,
+    apiHostAllowlist: ["x.ai"],
+  },
+};
+
+export { grokTokenFile, copilotTokenFile };

--- a/src/services/oauth-flow.ts
+++ b/src/services/oauth-flow.ts
@@ -44,6 +44,14 @@ export interface OAuthDeps {
 
 const b64url = (buf: Buffer): string => buf.toString("base64url");
 
+/** Strip token-shaped material from provider error text before it can reach a log/UI. */
+function redactTokens(s: string): string {
+  return s
+    .replace(/("?(?:access_token|refresh_token|id_token|code|code_verifier|client_secret)"?\s*[:=]\s*"?)[^"'\s,&}]+/gi, "$1<redacted>")
+    .replace(/\b(ghu_|gho_|ya29\.|sk-)[A-Za-z0-9._-]+/g, "$1<redacted>")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted>");
+}
+
 /** S256 PKCE pair. verifier: 43-128 chars unreserved; challenge = base64url(sha256(verifier)). */
 export function pkcePair(): { verifier: string; challenge: string } {
   const verifier = b64url(randomBytes(32)); // 43 base64url chars, all in the unreserved set
@@ -122,7 +130,7 @@ export function runLoopbackPKCE(cfg: OAuthProviderConfig, deps: OAuthDeps = {}):
           return;
         }
         res.writeHead(200, { "Content-Type": "text/html" }).end(
-          "<html><body style='font:14px system-ui;padding:2rem'>Signed in — you can close this tab and return to ComfyUI.</body></html>",
+          "<html><body style='font:14px system-ui;padding:2rem'>Finishing sign-in — you can close this tab and return to ComfyUI.</body></html>",
         );
         // Exchange the code.
         assertAllowedTokenHost(cfg.tokenUrl, cfg.apiHostAllowlist);
@@ -141,7 +149,7 @@ export function runLoopbackPKCE(cfg: OAuthProviderConfig, deps: OAuthDeps = {}):
         });
         const text = await tokRes.text();
         if (!tokRes.ok) {
-          done(() => reject(new ValidationError(`OAuth token exchange failed (${tokRes.status}): ${text.slice(0, 300)}`)));
+          done(() => reject(new ValidationError(`OAuth token exchange failed (${tokRes.status}): ${redactTokens(text).slice(0, 300)}`)));
           return;
         }
         const raw = JSON.parse(text) as Record<string, unknown>;

--- a/src/services/oauth-flow.ts
+++ b/src/services/oauth-flow.ts
@@ -265,6 +265,7 @@ export async function pollDeviceToken(
       }).toString(),
       signal: AbortSignal.timeout(30_000),
     });
+    if (!res.ok) throw new ValidationError(`${cfg.label} device poll failed (${res.status}): ${redactTokens(await res.text()).slice(0, 200)}`);
     const j = JSON.parse(await res.text()) as Record<string, unknown>;
     const access = String(j.access_token ?? "").trim();
     if (access) {

--- a/src/services/oauth-landing.test.ts
+++ b/src/services/oauth-landing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { persistOAuthResult, readOAuthStatus, clearOAuth } from "./code-provider-auth.js";
@@ -31,6 +31,13 @@ it("copilot: writes its own store + status flagged experimental", async () => {
   expect(existsSync(join(home, ".comfyui-mcp", "copilot-auth.json"))).toBe(true);
   const c = readOAuthStatus().find((s) => s.provider === "copilot")!;
   expect(c.experimental).toBe(true);
+});
+
+it("writes native token files 0600 (POSIX)", async () => {
+  if (process.platform === "win32") return; // mode not enforced on Windows
+  await persistOAuthResult("grok", { access_token: "AT", refresh_token: "RT", expires_in: 3600, raw: {} }, { home });
+  const mode = statSync(join(home, ".grok", "auth.json")).mode & 0o777;
+  expect(mode).toBe(0o600);
 });
 
 it("clearOAuth removes the native file and the mirror entry", async () => {

--- a/src/services/oauth-landing.test.ts
+++ b/src/services/oauth-landing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { persistOAuthResult, readOAuthStatus, clearOAuth } from "./code-provider-auth.js";
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "oauth-land-"));
+  process.env.COMFYUI_MCP_PANEL_SECRETS = join(home, "panel-secrets.json");
+});
+
+it("codex: writes ~/.codex/auth.json in tokens{} shape + a status mirror without token material", async () => {
+  const idToken = "h." + Buffer.from(JSON.stringify({ chatgpt_account_id: "acct_1", email: "a@b.co" })).toString("base64url") + ".s";
+  const { account_label } = await persistOAuthResult("codex", {
+    access_token: "AT", refresh_token: "RT", id_token: idToken, raw: {},
+  }, { home });
+  const auth = JSON.parse(readFileSync(join(home, ".codex", "auth.json"), "utf8"));
+  expect(auth.tokens.access_token).toBe("AT");
+  expect(auth.tokens.account_id).toBe("acct_1");
+  expect(account_label).toContain("a@b.co");
+  const status = readOAuthStatus();
+  const codex = status.find((s) => s.provider === "codex")!;
+  expect(codex.account_label).toContain("a@b.co");
+  // mirror must NOT contain the token
+  expect(JSON.stringify(status)).not.toContain("AT");
+});
+
+it("copilot: writes its own store + status flagged experimental", async () => {
+  await persistOAuthResult("copilot", { access_token: "ghu_AT", raw: { token_type: "bearer" } }, { home });
+  expect(existsSync(join(home, ".comfyui-mcp", "copilot-auth.json"))).toBe(true);
+  const c = readOAuthStatus().find((s) => s.provider === "copilot")!;
+  expect(c.experimental).toBe(true);
+});
+
+it("clearOAuth removes the native file and the mirror entry", async () => {
+  await persistOAuthResult("copilot", { access_token: "ghu_AT", raw: {} }, { home });
+  clearOAuth("copilot", { home });
+  expect(existsSync(join(home, ".comfyui-mcp", "copilot-auth.json"))).toBe(false);
+  expect(readOAuthStatus().find((s) => s.provider === "copilot")).toBeUndefined();
+});

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -30,6 +30,23 @@ interface PanelSecrets {
    *  from comfyuiEnv (different allowlist) so a provider key is never injected
    *  into the tool subprocess and a tool token never reaches the LLM backend. */
   agentEnv?: Record<string, string>;
+  /** STATUS-ONLY mirror of in-panel OAuth sign-ins (Codex/Grok/Copilot), keyed by
+   *  provider id. Holds NO secrets — the native token files (~/.codex/auth.json,
+   *  ~/.grok/auth.json, ~/.comfyui-mcp/copilot-auth.json) are the source of truth
+   *  for token material. This is deliberately NOT under either allowlist above:
+   *  it is read by the panel UI to show "signed in as …" without ever touching a
+   *  credential. `setOAuthStatus` sanitizes on write so a hand-edited/corrupt file
+   *  can never smuggle anything beyond the five known status fields. */
+  oauthStatus?: Record<string, OAuthStatusRecord>;
+}
+
+/** Status-only record for an in-panel OAuth sign-in. NEVER put token material here. */
+export interface OAuthStatusRecord {
+  provider: string;
+  account_label: string;
+  obtained_at: number;
+  expires_at?: number;
+  experimental?: boolean;
 }
 
 // STRICT ALLOWLIST of env keys a panel-collected secret may set on the comfyui
@@ -127,6 +144,59 @@ function write(secrets: PanelSecrets): void {
   } catch {
     /* chmod is a no-op on Windows; ignore */
   }
+}
+
+// SANITIZE on every write: copy only the five known status fields and coerce
+// their types. Even a hand-edited or corrupt panel-secrets.json therefore can
+// never inject anything beyond this shape into the mirror — critically, it
+// can never smuggle in token material via an unexpected key.
+function sanitizeOAuthStatus(rec: OAuthStatusRecord): OAuthStatusRecord {
+  const out: OAuthStatusRecord = {
+    provider: String(rec?.provider ?? "").trim(),
+    account_label: String(rec?.account_label ?? "").trim(),
+    obtained_at:
+      typeof rec?.obtained_at === "number" && Number.isFinite(rec.obtained_at)
+        ? rec.obtained_at
+        : Date.now(),
+  };
+  if (typeof rec?.expires_at === "number" && Number.isFinite(rec.expires_at)) {
+    out.expires_at = rec.expires_at;
+  }
+  if (typeof rec?.experimental === "boolean") {
+    out.experimental = rec.experimental;
+  }
+  return out;
+}
+
+/** Upsert the status-only OAuth mirror entry for `rec.provider`. Sanitizes the
+ *  record first (see `sanitizeOAuthStatus`) — callers pass status fields only,
+ *  never token material. */
+export function setOAuthStatus(rec: OAuthStatusRecord): void {
+  const sanitized = sanitizeOAuthStatus(rec);
+  if (!sanitized.provider) throw new Error("setOAuthStatus: record is missing a provider id.");
+  const secrets = read();
+  const status =
+    secrets.oauthStatus && typeof secrets.oauthStatus === "object" ? secrets.oauthStatus : {};
+  status[sanitized.provider] = sanitized;
+  secrets.oauthStatus = status;
+  write(secrets);
+}
+
+/** All stored OAuth status records (re-sanitized on read, defense in depth). */
+export function listOAuthStatus(): OAuthStatusRecord[] {
+  const status = read().oauthStatus;
+  if (!status || typeof status !== "object") return [];
+  return Object.values(status).map(sanitizeOAuthStatus);
+}
+
+/** Remove a provider's status mirror entry. No-op if absent. */
+export function clearOAuthStatus(provider: string): void {
+  const secrets = read();
+  const status = secrets.oauthStatus;
+  if (!status || typeof status !== "object" || !(provider in status)) return;
+  delete status[provider];
+  secrets.oauthStatus = status;
+  write(secrets);
 }
 
 /** The persisted env vars to inject into the comfyui MCP server. Never logged.


### PR DESCRIPTION
Ports **Stack 1** of the MichaelDanCurtis fork inheritance: the loopback-PKCE / device-code OAuth engine and the Grok, Kimi, GLM, ChatGPT (direct OAuth), and experimental Copilot provider backends.

**Stacked on #197 (console/credentials) — merge #197 first; this PR's diff vs main includes it until then.**

## What's ported (17 commits, authorship preserved)

Ported from MichaelDanCurtis/comfyui-mcp (`7bbfe41`…`1b18a43`) with thanks — authorship preserved via `cherry-pick -x`; `04ab724` split to exclude the RunComfy trainer (lands in the Stack-5 draft).

- `7bbfe41` Grok ACP backend (`src/orchestrator/grok-backend.ts`)
- `3dcc692` SSE serialization for panel MCP on Grok/Gemini ACP
- `04ab724` **split**: Kimi/GLM/ChatGPT-OAuth backends + `code-provider-auth` only — RunComfy trainer service/tools excluded (`[split: provider backends only; RunComfy trainer parts land separately]`)
- `a6125e4`…`1b18a43` OAuth series: loopback-PKCE engine + provider registry, device-code primitive, native token persistence + status-only panel mirror, oauth_begin/status/signout bridge, OAuth-aware readiness, Grok direct-OAuth chat path, experimental Copilot backend, host-allowlist + redaction hardening

## Security review (done while porting)

- **Token files 0600, credential dirs 0700** (`19b7976`): confirmed — `code-provider-auth.ts` writes via a single private-write helper (`mkdir mode 0o700`, temp file `mode 0o600` + rename, so an existing 0600 `~/.codex/auth.json` is never clobbered to umask defaults).
- **Redaction in all error paths** (`edf5783`, `1b18a43`): confirmed — one exported `redactTokens` in `oauth-flow.ts` (JWT-shaped, `ghu_/gho_/ghp_/ya29./sk-/xai-` prefixes, `Bearer …`, `token …`) used in the exchange, device-code request/poll, all three refresh paths (Codex/Kimi/Grok), and the Copilot exchange. Former per-file redactor copies unified.
- **Copilot host allowlist on chat/models base, not just exchange** (`df7c3ca`): confirmed — the server-advertised API endpoint is treated as untrusted; if it fails `assertAllowedTokenHost` (github.com / githubcopilot.com), it is dropped and the default base is used.
- **Copilot never ready-by-default**: confirmed server-side — readiness reports `experimental: true` and `ready` only with a valid panel OAuth record; `oauth_begin` for Copilot is gated behind an explicit `allow_experimental: true` frame; the backend's `prepare()` throws without `~/.comfyui-mcp/copilot-auth.json`. (Only an explicit `PANEL_AGENT_BACKEND=copilot` env override could default to it — deliberate user action.)
- **Grok client_id provenance**: the Grok flow uses xAI's published public OAuth client id (documented in MDC's panel docs); PKCE + loopback redirect, no client secret involved.
- **Status-only OAuth mirror**: `panel-secrets.ts` `setOAuthStatus` sanitizes to five known fields on every write — no token material can enter the mirror; no duplicate keys introduced in the agent-secret allowlist (base #197 already carried the GLM/Kimi keys; the pick deduped cleanly).

## Conflict/reconciliation notes

- `src/orchestrator/index.ts`: merged MDC's grok/chatgpt/glm/kimi/copilot wiring with main's openrouter/lmstudio/llamacpp/custom providers (KNOWN_BACKENDS, makeBackend, probe ternary, agent labels, ready/degraded texts, currentModelFor) and with #197's console wiring + call_tool/pairing handlers.
- `src/orchestrator/backend-readiness.ts`: reconciled semantics — readiness is CLI-auth **or** valid panel-OAuth per provider (codex/grok), while keeping main's lmstudio/llamacpp/custom-endpoint probing; `opts` now carries both `customEndpointConfigured` and `oauthStatus`/`now`.
- `src/orchestrator/agent-backend.ts`: BackendId union merged (adds chatgpt/grok/glm/kimi/copilot alongside openrouter).
- `d5e4dba` (upstream `785a461`) referenced `services/prompt-overrides.js` from an unported MDC commit (editable prompt registry); the Grok system prompt is used inline with a note — no functional change until that registry is ported.
- `src/tools/index.ts`: kept ours (the fork's trainer/toolkit tool registrations excluded per the split).
- #197's `lora-catalog.ts` and the Windows `path.sep` containment fix in `panel-console-http.ts` are untouched (verified by diff).

## Tests

- `npx tsc --noEmit` clean.
- `npx vitest run`: **119 files, 1306 tests passed** (base was 1235 — +71 from the ported oauth-flow, oauth-bridge, oauth-landing, code-provider-auth(+redact), grok-backend(+oauth), copilot-backend, and readiness suites).
- Every intermediate commit is marker-free and the tip typechecks; no MCP tool descriptions changed, so no docs regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
