### PR TITLE
fix(local-agent): a tool-using turn can never end in silence

### DIFF
--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -220,6 +220,11 @@ describe("OllamaBackend", () => {
     const backend2 = new OllamaBackend({ model: "artokun/gemma4-comfyui-mcp:e4b", connectToolClients: async () => ({ comfyui: client }) });
     const events2 = await collect(backend2, turnsOf({ text: "find a lora" }));
     expect(events2.filter((e) => e.type === "result")).toMatchObject([{ type: "result", ok: true }]);
+    // …but never SILENTLY: the double-empty turn still shows a fallback line
+    // (live panel test: Civitai 503 → double empty → user saw nothing at all).
+    const finals2 = events2.filter((e) => e.type === "assistant") as Array<{ text: string }>;
+    expect(finals2).toHaveLength(1);
+    expect(finals2[0].text).toContain("couldn't compose a reply");
   });
 
   it("breaks a DISCOVERY loop: list_tools with a different search each round (the Civitai-hunt wedge)", async () => {

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -776,7 +776,15 @@ export class OllamaBackend implements AgentBackend {
           // turn's context is missing the model's own previous replies (and
           // the transcript dump ends mid-conversation on a tool message).
           this.history.push({ role: "assistant", content });
-          yield { type: "assistant", text: content, id: streamId ?? undefined, usage };
+          // NEVER end a tool-using turn in total silence (live panel test: a
+          // Civitai 503 → empty final → empty retry → the user stared at a raw
+          // tool error with no explanation). History keeps the raw empty
+          // content; only the USER-FACING text gets the fallback.
+          const finalText =
+            content.trim() || (round === 0
+              ? content
+              : "(I ran the tools above but couldn't compose a reply — check the last tool result. Say “continue” to have me try again, or rephrase the request.)");
+          yield { type: "assistant", text: finalText, id: streamId ?? undefined, usage };
           yield { type: "result", ok: true, usage };
           resultEmitted = true;
           return;


### PR DESCRIPTION
Found live in the real panel UI (the 'test it in the panel' pass): with Civitai's API mid-outage (real 503), the model emitted an empty final AND an empty nudge-retry — the capped fallthrough ended the turn with zero visible text, leaving the user staring at a raw tool error.

Fix: keep the cap (never loop), but the user-facing assistant text falls back to an honest one-liner pointing at the last tool result. Raw empty content still goes to history.

+1 test assertion (double-empty turn must still render the fallback); 1229/1229 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)