### PR TITLE
fix(panel): panel_connect slot aliases — stop silent auto-match on stripped params

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -526,3 +526,31 @@ describe("panel-tools: workflow target (per-workflow agent)", () => {
     expect(text).toContain("Pinned");
   });
 });
+
+describe("panel_connect slot aliases (live panel finding: stripped aliases → auto-match scramble)", () => {
+  it("maps from_slot_name/to_slot_name onto from_output/to_input on the wire", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const def = defByName("panel_connect");
+    await def.handler(
+      { from_node_id: 10, from_slot_name: "MODEL", to_node_id: 3, to_slot_name: "model" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_connect",
+      from_node_id: 10,
+      from_output: "MODEL",
+      to_node_id: 3,
+      to_input: "model",
+    });
+  });
+
+  it("canonical names win over aliases; bare aliases output/input also map", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const def = defByName("panel_connect");
+    await def.handler(
+      { from_node_id: 1, from_output: "LATENT", from_slot: "WRONG", to_node_id: 2, input: "samples" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({ from_output: "LATENT", to_input: "samples" });
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -667,14 +667,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .boolean()
           .optional()
           .describe("Default true. Set false to force legacy exact resolution (omitted slot = index 0)."),
+        // ALIASES small models actually emit (live panel finding): zod silently
+        // STRIPPED from_slot_name/to_slot_name, both slots fell to "auto", and
+        // auto-match wired something the model never asked for — reported as
+        // success, scrambling the graph. Accept the aliases so intent survives.
+        from_slot_name: slotRef.optional().describe("Alias for from_output."),
+        to_slot_name: slotRef.optional().describe("Alias for to_input."),
+        from_slot: slotRef.optional().describe("Alias for from_output."),
+        to_slot: slotRef.optional().describe("Alias for to_input."),
+        output: slotRef.optional().describe("Alias for from_output."),
+        input: slotRef.optional().describe("Alias for to_input."),
       },
       async (args: A, ctx) =>
         ctx.call({
           cmd: "graph_connect",
           from_node_id: args.from_node_id,
-          from_output: args.from_output,
+          from_output: args.from_output ?? args.from_slot_name ?? args.from_slot ?? args.output,
           to_node_id: args.to_node_id,
-          to_input: args.to_input,
+          to_input: args.to_input ?? args.to_slot_name ?? args.to_slot ?? args.input,
           auto_match: args.auto_match,
         }),
     ),


### PR DESCRIPTION
Found live in the panel ('test it in the panel' round 2, the wiring half): the model sent `from_slot_name`/`to_slot_name`, zod stripped the unknown keys, both slots defaulted to auto, and auto-match **wired things the model never asked for while reporting success** (asked CONDITIONING→negative, got →positive). The model looped trying to fix a graph the tool was scrambling — read as an 'infinite thinking loop' from the outside.

Fix: accept the aliases small models actually emit (`from_slot_name`, `to_slot_name`, `from_slot`, `to_slot`, `output`, `input`); canonical params win on conflict. With intent preserved, a wrong-but-named slot errors with the full slot listing (self-correctable) instead of silently auto-matching.

+2 tests (alias mapping, canonical precedence); 1250/1250 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)