### PR TITLE
fix(orchestrator): a throwing backend constructor can never kill the process

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1291,9 +1291,30 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Claude → undefined (PanelAgent uses its built-in in-process SDK backend);
   // codex/gemini → their CLI-driven backend, wired to the panel_* tools over the
   // loopback HTTP MCP for THIS panel tab's canvas (comfyuiUrl gives vision parity).
+  // A backend whose CONSTRUCTOR failed (e.g. GlmBackend throws when
+  // ZAI_API_KEY is absent) must never take the orchestrator down — the field
+  // failure was: click the GLM chip keyless → uncaught ValidationError → FATAL
+  // process exit. This stub satisfies AgentBackend and surfaces the original
+  // error as a normal degraded probe / in-chat error instead.
+  const brokenBackend = (backend: string, msg: string): AgentBackend =>
+    ({
+      id: backend,
+      capabilities: { modelEnumeration: false },
+      async *run() {
+        yield { type: "assistant", text: `⚠️ ${msg}` };
+        yield { type: "result", ok: false, subtype: "backend_unavailable" };
+      },
+      interrupt: async () => {},
+      listModels: async () => {
+        throw new Error(msg);
+      },
+      close: async () => {},
+    }) as unknown as AgentBackend;
+
   const makeBackend = (key: string): AgentBackend | undefined => {
     const backend = backendOf(key);
     const panelTabId = panelTabOf(key);
+    try {
     if (backend === "codex") {
       return new CodexBackend({
         cwd: comfyuiPath ?? process.cwd(),
@@ -1412,6 +1433,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       });
     }
     return undefined; // claude → built-in ClaudeBackend
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`[panel-orchestrator] ${backend} backend construction failed: ${msg}`);
+      return brokenBackend(backend, msg);
+    }
   };
   logger.info(
     `[panel-orchestrator] single-port multi-provider: default backend=${defaultBackend}; ` +
@@ -1427,6 +1453,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "claude") return null; // claude uses the SDK probe below
     let pb = probeBackends.get(backend);
     if (!pb) {
+      try {
       pb =
         backend === "codex"
           ? new CodexBackend({ cwd: comfyuiPath ?? process.cwd(), model: codexModel })
@@ -1452,6 +1479,12 @@ export async function runPanelOrchestrator(): Promise<void> {
                         ? new CopilotBackend({ cwd: comfyuiPath ?? process.cwd(), model: copilotModel })
                         : new GeminiBackend({ cwd: comfyuiPath ?? process.cwd(), model: geminiModel });
       probeBackends.set(backend, pb);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[panel-orchestrator] ${backend} probe construction failed: ${msg}`);
+        // NOT cached: once the user supplies credentials, the next hello retries.
+        return brokenBackend(backend, msg);
+      }
     }
     return pb;
   };


### PR DESCRIPTION
Pre-release smoke on the #201 provider batch found a release blocker: `new GlmBackend()` **throws** when `ZAI_API_KEY` is absent, both `getProbeBackend` and `makeBackend` construct bare inside bridge handlers, and the FATAL uncaught handler exits — so **clicking the GLM chip without a key killed the whole orchestrator** (smoke proof: every backend after glm got ECONNREFUSED).

Fix: both construction sites catch. Probe path → stub whose `listModels` rejects with the original actionable message (rides the existing degraded-ack flow; not cached, so supplying credentials retries). Spawn path → stub whose `run()` surfaces the error in-chat with `ok:false`.

1350/1350 green; re-smoke of all 9 backends below in thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)