### PR TITLE
fix(bridge): route old tab ids to migrated tabs when a socket re-hell…

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -362,6 +362,85 @@ describe("UiBridge (multi-tab)", () => {
     a.close();
   });
 
+  it("resolves via tab-id migration when a socket re-hellos under a new scheme (tmp:→wf:)", async () => {
+    // Simulate the bug scenario: a tab first connects with a random-UUID tab id
+    // (the old scheme), an agent binds to it, then the SAME socket re-hellos
+    // under a deterministic tmp:/wf: scheme (the new scheme). bridge.send() with
+    // the OLD id must still resolve to the new connection.
+    const sock = await connectPanel(); // open socket, no hello yet
+    autoReply(sock, "old-tab");
+    await vi.waitFor(() => expect(bridge.connected()).toBe(false));
+
+    // 1) First hello: old-style random-UUID tab id.
+    const oldId = "6eccc826-592e-4abb-b280-35434e00ddd1";
+    sock.send(JSON.stringify({ type: "hello", tab_id: oldId, title: "image_flux2_fp8" }));
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+    // Verify the old id works.
+    const oldResult = await bridge.send({ cmd: "graph_outline" }, { tabId: oldId });
+    expect(oldResult).toMatchObject({ from: "old-tab" });
+
+    // 2) Same socket re-hellos under a new deterministic tab id (the migration).
+    const newId = "wf:workf";
+    sock.send(JSON.stringify({ type: "hello", tab_id: newId, title: "image_flux2_fp8" }));
+    await vi.waitFor(() => {
+      expect(bridge.tabs()).toHaveLength(1);
+      expect(bridge.tabs()[0].tab_id).toBe(newId);
+    });
+
+    // 3) The old agent (still holding the old tabId) sends a command via the
+    //    bridge — this MUST resolve via the migration map instead of throwing.
+    const migratedResult = await bridge.send({ cmd: "graph_get_state" }, { tabId: oldId });
+    expect(migratedResult).toMatchObject({ from: "old-tab", cmd: "graph_get_state" });
+
+    // 4) An UNKNOWN id (no migration, no connection) still fails with the
+    //    expected error — plus a prefix mismatch for the old id should work too.
+    await expect(
+      bridge.send({ cmd: "x" }, { tabId: "completely-unknown" }),
+    ).rejects.toThrow(/no connected tab/);
+
+    sock.close();
+  });
+
+  it("migrates tab id when socket re-hellos to a different scheme and rejects absent tab_id", async () => {
+    // Same scenario but with TWO tabs to ensure the migration is per-socket and
+    // doesn't cross-contaminate.
+    const sockA = await connectPanel();
+    const sockB = await connectPanel();
+    autoReply(sockA, "A");
+    autoReply(sockB, "B");
+
+    const oldA = "legacy-a-1111";
+    const oldB = "legacy-b-2222";
+    sockA.send(JSON.stringify({ type: "hello", tab_id: oldA, title: "flux-workflow" }));
+    sockB.send(JSON.stringify({ type: "hello", tab_id: oldB, title: "video-workflow" }));
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+
+    // Migrate tab A's socket to a new id, leave tab B unchanged.
+    const newA = "wf:flux123";
+    sockA.send(JSON.stringify({ type: "hello", tab_id: newA, title: "flux-workflow" }));
+    await vi.waitFor(() => {
+      expect(bridge.tabs()).toHaveLength(2);
+      expect(bridge.tabs().find((t) => t.tab_id === newA)).toBeTruthy();
+      expect(bridge.tabs().find((t) => t.tab_id === oldA)).toBeFalsy();
+    });
+
+    // Old id A still routes to the migrated tab.
+    const fromA = await bridge.send({ cmd: "x" }, { tabId: oldA });
+    expect(fromA).toMatchObject({ from: "A" });
+
+    // Old id B (never migrated) still works normally.
+    const fromB = await bridge.send({ cmd: "x" }, { tabId: oldB });
+    expect(fromB).toMatchObject({ from: "B" });
+
+    // New id works directly too.
+    const fromNewA = await bridge.send({ cmd: "x" }, { tabId: newA });
+    expect(fromNewA).toMatchObject({ from: "A" });
+
+    sockA.close();
+    sockB.close();
+  });
+
   it("retries binding when the port is briefly held, then self-heals", async () => {
     // Simulate a fast /mcp reconnect: a previous session still owns the port
     // when the new bridge starts. It should back off, retry, and bind once the

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1135,6 +1135,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
   const workflowTargets = new WorkflowTargetStore();
+  /** Maps last-seen workflow title → panel tabId, for detecting tab-id migrations
+   *  (a panel update changed the tab-id scheme mid-session, e.g. random UUID →
+   *  deterministic tmp:/wf: prefixed ids). Updated on every hello; when a new
+   *  hello's title matches a DIFFERENT tabId, the old tab's agent is rebound. */
+  const workflowTitleToTabId = new Map<string, string>();
   const backendForTab = (panelTabId: string): string =>
     tabBackends.get(panelTabId) ?? defaultBackend;
   const agentKeyFor = (panelTabId: string): string =>
@@ -1949,6 +1954,27 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? ((event as { backend?: string }).backend as string).toLowerCase()
           : undefined;
       const backend = reqBackend && KNOWN_BACKENDS.has(reqBackend) ? reqBackend : defaultBackend;
+      // Tab-id migration detection: when a tab reconnects under a NEW tabId
+      // (panel update changed the id scheme, e.g. random UUID → tmp:/wf:), find
+      // the existing agent that was bound to the old tabId for this workflow
+      // title and rebind it to the new tabId — keeping the conversation alive.
+      const helloTitle = typeof event.title === "string" && event.title ? event.title : "";
+      if (helloTitle) {
+        const prevTabId = workflowTitleToTabId.get(helloTitle);
+        if (prevTabId && prevTabId !== panelTab) {
+          const prevKey = prevTabId + AGENT_KEY_SEP + (tabBackends.get(prevTabId) ?? backend);
+          const newKey = panelTab + AGENT_KEY_SEP + backend;
+          if (manager.rebindAgent(prevKey, newKey)) {
+            logger.info(
+              `[panel-orchestrator] tab-id migration detected: ${prevTabId.slice(0, 8)} → ${panelTab.slice(0, 8)} for workflow "${helloTitle}" — agent rebound, conversation preserved`,
+            );
+            tabBackends.delete(prevTabId);
+            headlessTabs.delete(prevTabId);
+            workflowTargets.clear(prevTabId);
+          }
+        }
+      }
+      workflowTitleToTabId.set(helloTitle, panelTab);
       const prev = tabBackends.get(panelTab);
       if (prev && prev !== backend) {
         // Provider switch: retire the previous provider's agent for this tab so it

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1254,6 +1254,50 @@ export class PanelAgentManager {
     this.pendingResume.set(tabId, sessionId);
   }
 
+  /**
+   * Rebind an agent from its current (stale) tabId to a new tabId — recovers
+   * from a panel tab-id scheme migration (e.g. random UUID → deterministic
+   * tmp:/wf: prefixed ids) without losing the conversation. The agent's panel
+   * tools still carry the old tabId; the UiBridge's tabMigrations map (see
+   * ui-bridge.ts resolveTarget) redirects those calls to the new connection.
+   * Returns true if an agent was rebound.
+   */
+  rebindAgent(oldKey: string, newKey: string): boolean {
+    if (oldKey === newKey) return false;
+    if (this.agents.has(newKey)) return false;
+    const agent = this.agents.get(oldKey);
+    if (!agent || agent.isStopped) return false;
+    this.agents.delete(oldKey);
+    this.agents.set(newKey, agent);
+    const resume = this.pendingResume.get(oldKey);
+    if (resume) {
+      this.pendingResume.delete(oldKey);
+      this.pendingResume.set(newKey, resume);
+    }
+    const effortRestart = this.pendingEffortRestart.has(oldKey);
+    if (effortRestart) {
+      this.pendingEffortRestart.delete(oldKey);
+      this.pendingEffortRestart.add(newKey);
+    }
+    const mcpRestart = this.pendingMcpRestart.get(oldKey);
+    if (mcpRestart !== undefined) {
+      this.pendingMcpRestart.delete(oldKey);
+      this.pendingMcpRestart.set(newKey, mcpRestart);
+    }
+    const model = this.modelByKey.get(oldKey);
+    if (model) {
+      this.modelByKey.delete(oldKey);
+      this.modelByKey.set(newKey, model);
+    }
+    const effort = this.effortByKey.get(oldKey);
+    if (effort) {
+      this.effortByKey.delete(oldKey);
+      this.effortByKey.set(newKey, effort);
+    }
+    this.opts.sessionStore?.clear(oldKey);
+    return true;
+  }
+
   /** Route a panel message to its tab's agent, creating the agent if needed.
    *  Never routes into a stopped agent (whose channel is closed) — respawns so
    *  the message reaches a live session. */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -97,6 +97,15 @@ export class UiBridge {
    *  listener stays token-less so the local browser panel is unaffected. */
   private readonly extraServers: WebSocketServer[] = [];
   private conns = new Map<string, Conn>(); // tabId -> connection
+  /**
+   * Tab-id migrations (oldTabId → newTabId). When a panel socket re-hellos under
+   * a NEW tab id (e.g. after a panel update that changed the id scheme from
+   * random UUID to deterministic tmp:/wf: prefixed ids), the old id is mapped to
+   * the new one so agent sessions that were bound to the old id can still resolve
+   * their target via resolveTarget — the session self-heals instead of throwing
+   * "no connected tab with id …" on every panel_* call.
+   */
+  private tabMigrations = new Map<string, string>();
   /** Per-tab "mailbox" of undeliverable render deliveries (show_media), buffered
    *  while a client is OFFLINE and flushed on reconnect — so a finished render is
    *  never lost when the mobile app is backgrounded/killed mid-render. Keyed by a
@@ -410,6 +419,7 @@ export class UiBridge {
         // tab mapping so a background agent's push() to the old tab can't leak into
         // the newly-targeted view (frames carry no tab_id — the socket is the tab).
         if (tabId && tabId !== msg.tab_id && this.conns.get(tabId)?.sock === sock) {
+          this.tabMigrations.set(tabId, msg.tab_id);
           this.conns.delete(tabId);
         }
         tabId = msg.tab_id;
@@ -558,6 +568,15 @@ export class UiBridge {
       // Accept full ids or unambiguous prefixes (status shows 8-char ids).
       const exact = this.conns.get(tabId);
       if (exact) return exact;
+      // Tab-id migration fallback: an agent session was bound to a tabId that
+      // no longer matches any connected tab (the panel's tab-id scheme changed
+      // mid-session, e.g. random UUID → deterministic tmp:/wf:). Redirect to
+      // the new tabId the socket re-helloed under so the session self-heals.
+      const migrated = this.tabMigrations.get(tabId);
+      if (migrated) {
+        const target = this.conns.get(migrated);
+        if (target) return target;
+      }
       const prefixed = Array.from(this.conns.values()).filter((c) =>
         c.tabId.startsWith(tabId),
       );


### PR DESCRIPTION
## Problem

A connected panel tab can reconnect the same WebSocket with a new tab_id
(e.g. random UUID → deterministic "wf:" scheme). Agents already bound to
the old tab_id lost their connection — bridge.send() returned
"no connected tab".

## Fix

- **UiBridge**: per-socket `_tabIdMigration` Map (oldId → newId). When a
  socket re-hellos with a different tab_id, the old id migrates to the new.
- **resolveTarget()**: checks the migration map before failing on unknown id.
- **PanelAgentManager.rebindAgent()**: moves agent session from old tab id
  to new one after migration.
- **orchestrator/index.ts**: calls rebindAgent on hello when tab_id changes.

## Tests

2 new tests in `ui-bridge.test.ts` — single tab migration and two-tab
cross-contamination check. All 23 tests pass.