### PR TITLE
chore: git+docker-ignore the fine-tune data dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,15 @@ dist
 .git
 .claude
 
+# Fine-tune data + eval artifacts — multi-GB, irrelevant to the image
+# (root Dockerfile only COPYs package.json/scripts/tsconfig/src, but the
+# whole repo root is the BUILD CONTEXT — without these lines every build
+# tars gigabytes to the daemon for nothing)
+finetune
+finetune-v2
+arena-results
+docs
+
 # Env / secrets / local user config
 .env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,10 @@ arena-results*/panel-arena-results.json
 /*.png
 arena-results-local-batch/
 arena-results*/transcripts/
-finetune/artifacts/
+# Fine-tune training data/artifacts — canonical copies live on HF
+# (artokun/gemma4-comfyui-mcp finetune/); multi-GB, never committed.
+/finetune/
+/finetune-v2/
 arena-results-podverify/
 arena-results-quality-probe/
 /*.mp4


### PR DESCRIPTION
Follow-up to the near-miss during the v0.31.1 cut: `git add -A` in the primary clone swept the untracked multi-GB `finetune/`/`finetune-v2/` dirs into a commit (rejected at GitHub's 2 GiB pack limit — nothing landed). Both are now gitignored wholesale (canonical copies live on HF), and dockerignored along with `arena-results/` and `docs/` — the root Dockerfile's build context is the repo root, so every image build was tarring gigabytes to the daemon that no COPY layer ever used. The RunPod image is unaffected (its context is `docker/runpod/` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)