### PR TITLE
feat(pairing): stable pair token so the phone reconnects across restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,15 @@ COMFYUI_PORT=8188
 # ~200-schema surface. Same as the --compact flag. Values: full (default) | compact
 # COMFYUI_MCP_TOOL_MODE=compact
 
+# Stable phone-pairing token for the mobile app. Without it, the pairing token is
+# regenerated every session, so the phone's saved bridge URL stops working after
+# each orchestrator restart and you must re-pair from the panel. Pin any long
+# random string here and the LAN pairing listener (port = bridge port + 2, default
+# 9182) auto-starts at boot with this token — paste the printed ws:// URL into the
+# app once and it reconnects across restarts. Anyone with the URL can drive the
+# agent, so treat it like a password. Leave unset to keep on-demand pairing.
+# COMFYUI_MCP_PAIR_TOKEN=
+
 HUGGINGFACE_TOKEN=
 GITHUB_TOKEN=
 CIVITAI_API_TOKEN=

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -757,7 +757,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // token-less. LAN mode returns a same-wifi ws:// URL; tunnel mode fronts the same
   // token-gated listener with a cloudflared wss:// for anywhere access.
   const pairPort = lockPort + 2; // avoid the panel_* HTTP-MCP port (lockPort + 1)
-  let pairToken: string | null = null;
+  // A stable pairing token can be pinned via COMFYUI_MCP_PAIR_TOKEN. Without it,
+  // the token is generated per session, so a phone's saved bridge URL dies on the
+  // next orchestrator restart and the user must re-pair. With it pinned, the token
+  // is stable AND the LAN pairing listener is auto-started at boot (below), so the
+  // phone silently reconnects across restarts with no panel interaction.
+  const envPairToken = process.env.COMFYUI_MCP_PAIR_TOKEN?.trim() || null;
+  let pairToken: string | null = envPairToken;
   let pairListenerStarted = false;
   let pairTunnel: { url: string; stop: () => void } | null = null;
   const ensurePairListener = async (): Promise<string> => {
@@ -809,6 +815,38 @@ export async function runPanelOrchestrator(): Promise<void> {
       `[panel-orchestrator] could not bind the panel bridge port — another process owns it. Free that port and restart the orchestrator. Override the port with COMFYUI_MCP_BRIDGE_PORT.\n${portKillHint(lockPort)}`,
     );
     process.exit(1);
+  }
+
+  // With a pinned pair token, bring the LAN pairing listener up now so a phone's
+  // saved URL reconnects across restarts without ever touching the panel. This is
+  // strictly opt-in (COMFYUI_MCP_PAIR_TOKEN unset → the on-demand behavior above is
+  // unchanged). Tunnel pairing stays on-demand: cloudflared quick-tunnel hostnames
+  // rotate per run, so a stable token alone can't make a tunnel URL persist.
+  if (envPairToken) {
+    try {
+      await ensurePairListener();
+      const ip = firstLanIPv4();
+      const pairUrl = `ws://${ip ?? "<this-machine-ip>"}:${pairPort}/?token=${envPairToken}`;
+      process.stderr.write(
+        [
+          "",
+          "════════════════════════════════════════════════════════════════════",
+          " ComfyUI MCP — phone pairing listener AUTO-STARTED (stable token)",
+          "════════════════════════════════════════════════════════════════════",
+          ` Pair URL : ${pairUrl}`,
+          "",
+          " Paste this into the mobile app once — it survives restarts because",
+          " COMFYUI_MCP_PAIR_TOKEN is pinned. Anyone with this URL can drive the",
+          " agent — treat it like a password. Unset the env var to disable.",
+          "════════════════════════════════════════════════════════════════════",
+          "",
+        ].join("\n") + "\n",
+      );
+    } catch (err) {
+      logger.warn(
+        `[panel-orchestrator] could not auto-start the phone pairing listener on ${pairPort}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   // We own the port — register our REAL pid + the launching ComfyUI pid so the


### PR DESCRIPTION
## Problem
The phone-pairing listener (bridge port + 2, default `9182`) minted a **fresh random token every session** and only started **on demand** (first panel "Remote control" request). So after any orchestrator restart — Comfy restart, crash, respawn — the mobile app's saved bridge URL was dead: **wrong token AND no listener**. The user had to re-pair from the panel every single time. (This is the "won't reconnect / doesn't save prefs" behavior seen on the mobile beta.)

## Fix (opt-in — default behavior unchanged)
`COMFYUI_MCP_PAIR_TOKEN` pins the pairing token. When set:
- the token is **stable across restarts**, and
- the LAN pairing listener **auto-starts at boot** with it, printing the ready-to-paste `ws://<lan-ip>:<pairPort>/?token=…` URL.

Paste it into the app once and it silently reconnects across restarts — on LAN, USB, and tunnel.

With the env var **unset**, pairing stays exactly as before: on-demand, per-session token, no listener until the user asks. So the security posture (nothing exposed by default) is untouched. Tunnel pairing also stays on-demand — cloudflared quick-tunnel hostnames rotate per run, so a stable token alone can't make a tunnel URL persist.

## Verification
- Banner + `0.0.0.0:9282 LISTENING` at boot with the pinned token.
- Good token → handshake accepted; bad token → `401`.
- **Same token still accepted after a full orchestrator restart** (the old code regenerated it and would have rejected).
- `tsc --noEmit` clean; existing bridge/pairing tests pass.

Docs: `.env.example` documents the new var (treat the URL like a password).