### PR TITLE
fix(orchestrator): a user interrupt (Stop / send-now) is not a turn failure

### DIFF
--- a/src/__tests__/orchestrator/send-now-requeue.test.ts
+++ b/src/__tests__/orchestrator/send-now-requeue.test.ts
@@ -40,14 +40,21 @@ class RecordingBackend implements AgentBackend {
   private brokenByInterrupt = false;
   /** When true a turn completes cleanly (emits result) instead of hanging. */
   autoComplete = false;
+  /** Subtype for autoComplete results — lets a test simulate a REAL failed turn
+   *  (error subtype without any interrupt). */
+  completeSubtype = "success";
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     yield { type: "session", sessionId: "sess-rec" };
     for await (const turn of opts.channel) {
       this.turns.push(turn.text);
       if (this.autoComplete) {
-        // Clean completion → terminal result, no hang.
-        yield { type: "result", ok: true, subtype: "success" };
+        // Completion → terminal result, no hang (subtype per completeSubtype).
+        yield {
+          type: "result",
+          ok: this.completeSubtype === "success",
+          subtype: this.completeSubtype,
+        };
         continue;
       }
       // Hang until interrupt() breaks us (the in-flight turn the user "stops").
@@ -57,9 +64,12 @@ class RecordingBackend implements AgentBackend {
       this.breakTurn = null;
       if (this.brokenByInterrupt) {
         // The interrupted turn ends with a result (like the real SDK) — this is
-        // the signal that releases the turn gate for the next batch.
+        // the signal that releases the turn gate for the next batch. The real
+        // Claude SDK reports an interrupted turn with an ERROR subtype
+        // (error_during_execution), so mirror that: the panel must not paint it
+        // as a turn failure.
         this.brokenByInterrupt = false;
-        yield { type: "result", ok: false, subtype: "interrupted" };
+        yield { type: "result", ok: false, subtype: "error_during_execution" };
       }
     }
   }
@@ -77,12 +87,14 @@ class RecordingBackend implements AgentBackend {
   }
 }
 
-function makeDeps() {
+function makeDeps(says: string[] = []) {
   return {
     mcpServers: {},
     systemAppend: "",
     model: "claude-test",
-    onSay: () => {},
+    onSay: (_tab: string, text: string) => {
+      says.push(text);
+    },
     onTurn: () => {},
   };
 }
@@ -167,6 +179,39 @@ describe("send-now re-queues the interrupted message", () => {
     await new Promise((r) => setTimeout(r, 100));
     expect(backend.turns).toHaveLength(1);
     expect(backend.turns[0]).toContain("only message");
+
+    await agent.stop();
+  });
+
+  it("a user interrupt does NOT paint the '⚠️ That turn failed' banner", async () => {
+    // The real Claude SDK ends an interrupted turn with an error-subtype result
+    // (error_during_execution). That is the INTERRUPT landing, not a failure —
+    // the never-end-in-silence guard must stay quiet for it.
+    const says: string[] = [];
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-banner", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("message the user send-nows past");
+    await waitFor(() => backend.turns.length === 1);
+    agent.send("the send-now message");
+    await agent.interrupt({ requeueInFlight: true });
+    await waitFor(() => backend.turns.length === 2, 500);
+
+    expect(says.filter((s) => s.includes("That turn failed"))).toHaveLength(0);
+    await agent.stop();
+  });
+
+  it("a REAL failed turn (no interrupt) still paints the failure banner", async () => {
+    const says: string[] = [];
+    const backend = new RecordingBackend();
+    backend.autoComplete = true;
+    backend.completeSubtype = "error_during_execution"; // genuine failure, no interrupt
+    const agent = new PanelAgent("tab-realerr", makeDeps(says) as never, backend);
+    void agent.start();
+
+    agent.send("message whose turn genuinely fails");
+    await waitFor(() => says.some((s) => s.includes("That turn failed")), 2000);
 
     await agent.stop();
   });

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -188,6 +188,14 @@ export class PanelAgent {
    *  `error` event case so an error-subtype `result` right behind it doesn't
    *  paint a second failure line. Reset when a turn starts (busy = true). */
   private errorSurfaced = false;
+  /** True between a USER-initiated interrupt (Stop / send-now) and the aborted
+   *  turn's terminal result. The Claude SDK reports an interrupted turn as an
+   *  error-subtype result (error_during_execution), which the never-end-in-
+   *  silence guard below would otherwise paint as "⚠️ That turn failed" — a
+   *  scary failure line for something the user did on purpose. Cleared on the
+   *  next result and at the next turn dispatch, so a REAL later failure still
+   *  surfaces. */
+  private interruptRequested = false;
   // ---- turn idle watchdog (freeze safety net) ----
   // A stalled turn (the backend stops emitting ANY events — e.g. a wedged Codex
   // app-server) would otherwise leave the panel "working" forever. This is an
@@ -467,6 +475,9 @@ export class PanelAgent {
     // both clear it and have us re-queue a stale copy.
     const interrupted = this.inFlight;
     this.inFlight = null;
+    // The aborted turn's result is EXPECTED (and error-subtyped on the Claude
+    // SDK) — don't let the result case report it as a turn failure.
+    this.interruptRequested = true;
     // The turn that's in flight RIGHT NOW — the one we're aborting. Captured
     // before the await so the release fallback below targets exactly this turn's
     // gate (not a later one the channel may legitimately advance to if the
@@ -632,6 +643,7 @@ export class PanelAgent {
       // it's meant to catch, so onTurnStalled() would no-op. (handleEvent's later
       // `busy = true` becomes a harmless no-op.) Also shows "working" immediately.
       this.errorSurfaced = false; // fresh turn → its failure (if any) is unreported
+      this.interruptRequested = false; // a stale interrupt can't mute THIS turn's failure
       this.busy = true;
       this.deps.onTurn?.(this.tabId, "working");
       // Arm the freeze watchdog AT DISPATCH: a turn that produces NO events at all
@@ -948,8 +960,12 @@ export class PanelAgent {
         // Failed turn that never produced a visible error (the claude SDK path
         // reports failures only via the result subtype; the `error` event case
         // covers codex/gemini/grok) → say SOMETHING. A turn must never end in
-        // silence, error turns included.
-        if ((ev.ok === false || /error/i.test(ev.subtype ?? "")) && !this.errorSurfaced) {
+        // silence, error turns included. EXCEPT a turn the user just interrupted
+        // (Stop / send-now): its error-subtype result is the interrupt landing,
+        // not a failure.
+        const wasInterrupted = this.interruptRequested;
+        this.interruptRequested = false; // one result consumes the flag
+        if ((ev.ok === false || /error/i.test(ev.subtype ?? "")) && !this.errorSurfaced && !wasInterrupted) {
           this.errorSurfaced = true;
           this.deps.onSay(
             this.tabId,


### PR DESCRIPTION
## The bug

Every panel **Send now** (and Stop) painted:

> ⚠️ That turn failed (error_during_execution) without a reply. Nothing was lost — try again…

…right before the agent correctly answered the re-queued batch. The Claude SDK reports an interrupted turn with an **error-subtype result** (`error_during_execution`), and the never-end-in-silence guard (from the 'error turns are never silent' hardening) treated it as a real failure. An intentional interrupt read as a crash — this is what makes send-now look broken.

## The fix

`PanelAgent.interrupt()` sets `interruptRequested`; the aborted turn's result consumes it and skips the failure banner for exactly that result. The flag is also cleared at the next turn dispatch, so a genuine later failure still surfaces.

## Verification

- Unit: send-now mock backend now emits the SDK's real `error_during_execution` subtype; new tests assert no banner on interrupt and banner-still-paints on a genuine failed turn (16 files / 144 orchestrator tests pass).
- **Live** over the bridge WS against the real orchestrator + opus: interrupt mid-**thinking**, mid-**text-stream**, and mid-**tool-call** — in all three the queued message was seen + answered ~1s after Send now, with no failure banner (before the fix the banner appeared every time).

## Investigation context (why 'send now is broken' was reported)

The functional 'send now doesn't dequeue' regression did **not** reproduce on current main in any of the above scenarios. The reporting session was served by an orchestrator process started **Jul 12 20:52** (v0.31.0-era build) that was never restarted — later rebuilds (0.32/0.33) never took effect. Additionally the global npm link was dangling (`~/code/wt/mcp-singleport`, deleted Jul 9), so `npx comfyui-mcp` fell back to the registry package; the link now points at the main checkout again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)