### PR TITLE
feat(panel-tools): panel_flatten_workflow — in-place UE + Get/Set flatten preserving the author's layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Added
+- **panel_flatten_workflow** — one-call, formatting-preserving flatten of the
+  live canvas: Get/Set buses, Reroutes, and cg-use-everywhere broadcasts
+  resolve to direct real links and the virtual nodes are deleted, while kept
+  nodes never move (groups/positions/colors/titles survive exactly; one undo
+  restores). UE broadcasts materialize from the pack's own computed
+  `extra.ue_links`; real executable nodes (rgthree Context, Seed Everywhere)
+  are kept
+
 ## [0.34.0] - 2026-07-14
 
 ### MCP

--- a/src/__tests__/services/flatten-workflow.test.ts
+++ b/src/__tests__/services/flatten-workflow.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { flattenUiWorkflow, isUeSender } from "../../services/flatten-workflow.js";
+import type { UiWorkflow } from "../../comfyui/types.js";
+
+// Helpers — litegraph link: [id, origin, oslot, target, tslot, type]
+function node(
+  id: number,
+  type: string,
+  extra: Partial<UiWorkflow["nodes"][number]> = {},
+): UiWorkflow["nodes"][number] {
+  return {
+    id,
+    type,
+    pos: [id * 100, id * 50],
+    inputs: [],
+    outputs: [],
+    widgets_values: [],
+    ...extra,
+  } as UiWorkflow["nodes"][number];
+}
+
+describe("flattenUiWorkflow — Get/Set + Reroute", () => {
+  // Loader(1) → Set"model"(2) … Get"model"(3) → Sampler(4).model, via bus.
+  function getSetGraph(): UiWorkflow {
+    return {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", {
+          outputs: [{ name: "MODEL", type: "MODEL", links: [10] }],
+        }),
+        node(2, "SetNode", {
+          widgets_values: ["model"],
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "*", links: [] }],
+        }),
+        node(3, "GetNode", {
+          widgets_values: ["model"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [11] }],
+        }),
+        node(4, "KSampler", {
+          inputs: [{ name: "model", type: "MODEL", link: 11 }],
+        }),
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 3, 0, 4, 0, "MODEL"],
+      ],
+      last_link_id: 11,
+      groups: [{ title: "Loaders", bounding: [0, 0, 400, 300], color: "#A88" }],
+    };
+  }
+
+  it("rewires the consumer straight to the real producer and deletes the bus", () => {
+    const { graph, report } = flattenUiWorkflow(getSetGraph());
+    expect(report.removed.getset).toBe(2);
+    expect(graph.nodes.map((n) => n.type).sort()).toEqual(["CheckpointLoaderSimple", "KSampler"]);
+    const sampler = graph.nodes.find((n) => n.type === "KSampler")!;
+    const linkId = sampler.inputs![0].link!;
+    const link = graph.links.find((l) => l[0] === linkId)!;
+    expect([link[1], link[2], link[3], link[4]]).toEqual([1, 0, 4, 0]);
+    // producer's output list carries the fresh link, and no stale ids survive
+    const loader = graph.nodes.find((n) => n.type === "CheckpointLoaderSimple")!;
+    expect(loader.outputs![0].links).toContain(linkId);
+    const ids = new Set(graph.links.map((l) => l[0]));
+    for (const n of graph.nodes) {
+      for (const i of n.inputs ?? []) if (i.link != null) expect(ids.has(i.link)).toBe(true);
+      for (const o of n.outputs ?? []) for (const id of o.links ?? []) expect(ids.has(id)).toBe(true);
+    }
+  });
+
+  it("preserves positions, groups, widgets, and mode of kept nodes exactly", () => {
+    const src = getSetGraph();
+    src.nodes[3].mode = 4; // author's bypass toggle must survive
+    src.nodes[3].widgets_values = [123, "euler"];
+    const { graph } = flattenUiWorkflow(src);
+    const sampler = graph.nodes.find((n) => n.type === "KSampler")!;
+    expect(sampler.pos).toEqual([400, 200]);
+    expect(sampler.mode).toBe(4);
+    expect(sampler.widgets_values).toEqual([123, "euler"]);
+    expect(graph.groups).toEqual(src.groups);
+  });
+
+  it("dangling Get (no matching Set) leaves the input unconnected with a warning", () => {
+    const g = getSetGraph();
+    (g.nodes[2].widgets_values as unknown[])[0] = "other_bus";
+    const { graph, report } = flattenUiWorkflow(g);
+    const sampler = graph.nodes.find((n) => n.type === "KSampler")!;
+    expect(sampler.inputs![0].link).toBeNull();
+    expect(report.warnings.some((w) => w.includes("dangling"))).toBe(true);
+  });
+
+  it("resolves Reroute chains", () => {
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [1] }] }),
+        node(2, "Reroute", {
+          inputs: [{ name: "", type: "*", link: 1 }],
+          outputs: [{ name: "", type: "MODEL", links: [2] }],
+        }),
+        node(3, "KSampler", { inputs: [{ name: "model", type: "MODEL", link: 2 }] }),
+      ],
+      links: [
+        [1, 1, 0, 2, 0, "MODEL"],
+        [2, 2, 0, 3, 0, "MODEL"],
+      ],
+      last_link_id: 2,
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(report.removed.reroute).toBe(1);
+    const link = graph.links.find((l) => l[3] === 3)!;
+    expect(link[1]).toBe(1);
+  });
+});
+
+describe("flattenUiWorkflow — Use-Everywhere", () => {
+  // Loader(1) → AE(2).anything (link 5); CLIP(3) has an unconnected model input;
+  // ue_links (the pack's own analysis) says upstream 1.0 → downstream 3.0.
+  function ueGraph(withUeLinks: boolean): UiWorkflow {
+    return {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [5] }] }),
+        node(2, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: 5 }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: null }] }),
+      ],
+      links: [[5, 1, 0, 2, 0, "MODEL"]],
+      last_link_id: 5,
+      extra: withUeLinks
+        ? {
+            ue_links: [
+              { downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 2, type: "MODEL" },
+            ],
+          }
+        : {},
+    };
+  }
+
+  it("materializes ue_links as direct links and deletes the sender", () => {
+    const { graph, report } = flattenUiWorkflow(ueGraph(true));
+    expect(report.removed.ue).toBe(1);
+    expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(false);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    const link = graph.links.find((l) => l[0] === consumer.inputs![0].link)!;
+    expect([link[1], link[2]]).toEqual([1, 0]);
+    // stale UE bookkeeping is scrubbed once all senders are gone
+    expect(graph.extra?.ue_links).toBeUndefined();
+  });
+
+  it("keeps Seed Everywhere — it is its own real producer", () => {
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "Seed Everywhere", {
+          widgets_values: [42],
+          outputs: [{ name: "int", type: "INT", links: [] }],
+        }),
+        node(2, "KSampler", { inputs: [{ name: "seed", type: "INT", link: null }] }),
+      ],
+      links: [],
+      last_link_id: 0,
+      extra: {
+        ue_links: [{ downstream: 2, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 1, type: "INT" }],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g);
+    expect(report.removed.ue).toBe(0);
+    expect(graph.nodes.some((n) => n.type === "Seed Everywhere")).toBe(true);
+    const link = graph.links.find((l) => l[3] === 2)!;
+    expect(link[1]).toBe(1);
+  });
+
+  it("UE senders without ue_links are left in place with a loud warning", () => {
+    const { graph, report } = flattenUiWorkflow(ueGraph(false));
+    expect(report.removed.ue).toBe(0);
+    expect(graph.nodes.some((n) => n.type === "Anything Everywhere")).toBe(true);
+    expect(report.warnings.some((w) => w.includes("ue_links is empty"))).toBe(true);
+  });
+
+  it("skips a ue_link whose receiver input got a real link since analysis", () => {
+    const g = ueGraph(true);
+    // give the consumer a real direct link already
+    g.nodes[2].inputs![0].link = 7;
+    g.links.push([7, 1, 0, 3, 0, "MODEL"]);
+    const { graph } = flattenUiWorkflow(g);
+    const consumer = graph.nodes.find((n) => n.type === "SomeConsumer")!;
+    expect(consumer.inputs![0].link).toBe(7); // untouched
+  });
+
+  it("detects all sender variants", () => {
+    for (const t of [
+      "Anything Everywhere",
+      "Anything Everywhere?",
+      "Anything Everywhere3",
+      "Prompts Everywhere",
+      "Seed Everywhere",
+    ]) {
+      expect(isUeSender(t)).toBe(true);
+    }
+    expect(isUeSender("KSampler")).toBe(false);
+  });
+});
+
+describe("flattenUiWorkflow — mixed + toggles", () => {
+  it("include_getset=false leaves buses alone while UE still materializes", () => {
+    const g: UiWorkflow = {
+      nodes: [
+        node(1, "CheckpointLoaderSimple", { outputs: [{ name: "MODEL", type: "MODEL", links: [5] }] }),
+        node(2, "Anything Everywhere", { inputs: [{ name: "anything", type: "*", link: 5 }] }),
+        node(3, "SomeConsumer", { inputs: [{ name: "model", type: "MODEL", link: null }] }),
+        node(4, "GetNode", { widgets_values: ["x"], outputs: [{ name: "*", type: "*", links: [] }] }),
+      ],
+      links: [[5, 1, 0, 2, 0, "MODEL"]],
+      last_link_id: 5,
+      extra: {
+        ue_links: [{ downstream: 3, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 2, type: "MODEL" }],
+      },
+    };
+    const { graph, report } = flattenUiWorkflow(g, { includeGetSet: false });
+    expect(report.removed.getset).toBe(0);
+    expect(graph.nodes.some((n) => n.type === "GetNode")).toBe(true);
+    expect(report.removed.ue).toBe(1);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -43,6 +43,7 @@ import {
   setUserMcpServerSecret,
 } from "../services/user-mcp-config.js";
 import { setComfyuiSecret, setAgentSecret, isAllowedAgentSecretKey } from "../services/panel-secrets.js";
+import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
@@ -580,6 +581,55 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               : "") +
             `\n\n${JSON.stringify(workflow, null, 2)}`,
         );
+      },
+    ),
+    def(
+      "panel_flatten_workflow",
+      "Flatten the user's workflow IN PLACE, preserving their layout: every Get/Set bus, Reroute, and " +
+        "cg-use-everywhere (UE) broadcast is resolved into a direct real link, and the virtual nodes are " +
+        "deleted — kept nodes never move, so groups/positions/colors/titles survive exactly (unlike " +
+        "panel_strip_workflow, whose API-format output can't go back on the canvas). With no source it " +
+        "flattens the LIVE CANVAS and reloads the result onto it (one undo restores); pass a `pack`, " +
+        "server-side `path`, or inline `graph` to flatten that instead (still loads onto the canvas " +
+        "unless `apply:false`). UE broadcasts materialize from the pack's own computed extra.ue_links; " +
+        "if senders exist without it, they're left in place with a warning (save/queue once, retry). " +
+        "Real executable nodes (rgthree Context/Context Switch, Seed Everywhere) are KEPT — they run.",
+      {
+        pack: z.string().optional().describe("Bundled pack name — its UI workflow.json is read server-side."),
+        path: z
+          .string()
+          .optional()
+          .describe("Workflow .json on the ComfyUI machine's disk — absolute or relative to user/default/workflows."),
+        graph: z
+          .union([z.string(), z.record(z.string(), z.unknown())])
+          .optional()
+          .describe("Inline UI workflow (object or JSON string) to flatten instead of the live canvas."),
+        include_ue: z.boolean().optional().describe("Materialize Use-Everywhere broadcasts (default true)."),
+        include_getset: z.boolean().optional().describe("Resolve Get/Set buses + Reroutes (default true)."),
+        apply: z
+          .boolean()
+          .optional()
+          .describe("Load the flattened graph onto the canvas (default true). false = return the graph JSON only."),
+      },
+      async (args: A, ctx) => {
+        const raw = await resolveWorkflowInput(args, ctx);
+        const { graph, report } = flattenUiWorkflow(raw as never, {
+          includeUe: args.include_ue !== false,
+          includeGetSet: args.include_getset !== false,
+        });
+        const summary =
+          `Flattened: removed ${report.removed.getset} Get/Set, ${report.removed.reroute} Reroute, ` +
+          `${report.removed.ue} UE sender(s); added ${report.added_links} direct link(s) ` +
+          `(${report.rewired_inputs} inputs rewired); ${report.kept_nodes} nodes kept in place.` +
+          (report.warnings.length
+            ? `\nWarnings:\n${report.warnings.map((w) => `- ${w}`).join("\n")}`
+            : "");
+        if (args.apply === false) {
+          return ok(`${summary}\n\n${JSON.stringify(graph)}`);
+        }
+        const loaded = await ctx.call({ cmd: "graph_load", graph: graph as never }, 30000);
+        const loadText = (loaded as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? "";
+        return ok(`${summary}\nLoaded onto the canvas (one undo restores the original). ${loadText.slice(0, 120)}`);
       },
     ),
     def(

--- a/src/services/flatten-workflow.ts
+++ b/src/services/flatten-workflow.ts
@@ -1,0 +1,276 @@
+// In-place workflow flattener: resolve virtual wiring — rgthree/KJ Get/Set
+// buses, Reroutes, and cg-use-everywhere (UE) broadcast links — into direct
+// real links on the ORIGINAL UI graph, deleting the now-dead virtual nodes.
+//
+// This deliberately does NOT round-trip through the API converter
+// (convertUiToApi → convertApiToUi): that regenerates the layout and throws
+// away everything the author arranged. Litegraph groups are geometric (a
+// titled bounding box — no node membership), so by never moving a kept node,
+// positions/sizes/colors/groups/titles are preserved for free; the only
+// visible change is the deleted virtual nodes leaving empty space.
+//
+// UE resolution strategy (see docs in the panel_flatten_workflow tool):
+//   1. `extra.ue_links` — cg-use-everywhere writes its computed broadcast
+//      links there on every graph analysis, as objects
+//      { downstream, downstream_slot, upstream, upstream_slot, controller, type }
+//      where `upstream` is already the REAL producer (for Seed Everywhere the
+//      controller IS the producer — it owns the seed widget). Materializing
+//      these is the pack's own ground truth: zero re-implementation.
+//   2. If UE sender nodes exist but ue_links is absent/stale → warn and leave
+//      those senders in place (never guess a broadcast match).
+//
+// Unlike the API converter, the resolver here stops at ANY real node
+// regardless of mode: muted/bypassed toggle branches are the author's state
+// and a wiring-only flatten must not collapse or drop them.
+
+import type { UiLink, UiNode, UiWorkflow } from "../comfyui/types.js";
+
+const GET_SET_TYPES = new Set([
+  "GetNode", "SetNode", "PRO_GetNode", "PRO_SetNode",
+  "SetNode_GetNode", "SetNode_SetNode",
+]);
+const isGetType = (t: string) => GET_SET_TYPES.has(t) && /get/i.test(t);
+const isSetType = (t: string) => GET_SET_TYPES.has(t) && /set/i.test(t) && !/get/i.test(t);
+const isRerouteType = (t: string) => t === "Reroute";
+/** Wiring-only virtual node: exists purely to carry a connection. */
+const isWiringVirtual = (t: string) => isRerouteType(t) || GET_SET_TYPES.has(t);
+
+/** cg-use-everywhere sender detection — mirrors the pack's own is_UEnode(). */
+export const isUeSender = (t: string): boolean =>
+  t.startsWith("Anything Everywhere") || t === "Seed Everywhere" || t === "Prompts Everywhere";
+
+/** Shape cg-use-everywhere writes into graph.extra.ue_links. */
+interface UeLink {
+  downstream: number;
+  downstream_slot: number;
+  upstream: number;
+  upstream_slot: number;
+  controller: number;
+  type?: string;
+}
+
+export interface FlattenOptions {
+  /** Resolve Get/Set buses + Reroutes (default true). */
+  includeGetSet?: boolean;
+  /** Materialize cg-use-everywhere broadcasts + remove senders (default true). */
+  includeUe?: boolean;
+}
+
+export interface FlattenReport {
+  removed: { getset: number; reroute: number; ue: number };
+  added_links: number;
+  rewired_inputs: number;
+  kept_nodes: number;
+  warnings: string[];
+}
+
+/**
+ * Flatten a UI workflow in place (on a deep copy): every consumer input fed
+ * through virtual wiring gets a fresh direct link to its real producer, UE
+ * broadcasts become real links, and the virtual nodes are deleted. Kept nodes
+ * are NEVER moved or otherwise altered (widgets, mode, size, color, title all
+ * untouched), so the author's formatting survives exactly.
+ */
+export function flattenUiWorkflow(
+  input: UiWorkflow,
+  opts: FlattenOptions = {},
+): { graph: UiWorkflow; report: FlattenReport } {
+  const includeGetSet = opts.includeGetSet !== false;
+  const includeUe = opts.includeUe !== false;
+  const ui = JSON.parse(JSON.stringify(input)) as UiWorkflow;
+  const warnings: string[] = [];
+
+  const nodes = ui.nodes ?? [];
+  const nodesById = new Map<number, UiNode>(nodes.map((n) => [n.id, n]));
+  const linkMap = new Map<number, UiLink>();
+  for (const l of ui.links ?? []) if (Array.isArray(l)) linkMap.set(l[0], l);
+
+  // bus name (Set node's first widget) -> the link id feeding that Set's input.
+  // Multiple Sets writing the same key: LAST one wins (matches litegraph's
+  // iteration order at prompt time) — warn so the author knows.
+  const busSource = new Map<string, number>();
+  if (includeGetSet) {
+    for (const n of nodes) {
+      if (!isSetType(n.type)) continue;
+      const bus = n.widgets_values?.[0];
+      const inp = (n.inputs ?? []).find((i) => i.link != null);
+      if (bus == null || inp?.link == null) continue;
+      if (busSource.has(String(bus))) {
+        warnings.push(`multiple Set nodes write bus "${String(bus)}" — the last one wins`);
+      }
+      busSource.set(String(bus), inp.link);
+    }
+  }
+
+  /** Walk upstream past Get/Set/Reroute to the first REAL node (any mode). */
+  const resolveReal = (
+    linkId: number,
+    depth = 0,
+  ): { id: number; slot: number; type: string } | null => {
+    if (depth > 100) return null;
+    const link = linkMap.get(linkId);
+    if (!link) return null;
+    const src = nodesById.get(link[1]);
+    if (!src) return { id: link[1], slot: link[2], type: link[5] };
+    if (includeGetSet && isGetType(src.type)) {
+      const bus = src.widgets_values?.[0];
+      const setLink = bus != null ? busSource.get(String(bus)) : undefined;
+      return setLink != null ? resolveReal(setLink, depth + 1) : null;
+    }
+    if (includeGetSet && (isSetType(src.type) || isRerouteType(src.type))) {
+      const inp = (src.inputs ?? []).find((i) => i.link != null);
+      return inp?.link != null ? resolveReal(inp.link, depth + 1) : null;
+    }
+    return { id: link[1], slot: link[2], type: link[5] };
+  };
+
+  let nextLinkId = (ui.last_link_id ?? Math.max(0, ...linkMap.keys())) + 1;
+  const freshLinks: UiLink[] = [];
+  let rewired = 0;
+
+  const addDirectLink = (
+    srcId: number,
+    srcSlot: number,
+    dstId: number,
+    dstSlot: number,
+    type: string,
+  ): number | null => {
+    const src = nodesById.get(srcId);
+    const dst = nodesById.get(dstId);
+    const dstInput = dst?.inputs?.[dstSlot];
+    const srcOutput = src?.outputs?.[srcSlot];
+    if (!src || !dst || !dstInput || !srcOutput) return null;
+    const id = nextLinkId++;
+    freshLinks.push([id, srcId, srcSlot, dstId, dstSlot, type]);
+    dstInput.link = id;
+    srcOutput.links = [...(srcOutput.links ?? []), id];
+    return id;
+  };
+
+  // ── Pass 1: rewire consumer inputs fed through Get/Set/Reroute chains ─────
+  if (includeGetSet) {
+    for (const node of nodes) {
+      if (isWiringVirtual(node.type)) continue;
+      for (let slot = 0; slot < (node.inputs?.length ?? 0); slot++) {
+        const inp = node.inputs?.[slot];
+        if (inp?.link == null) continue;
+        const link = linkMap.get(inp.link);
+        if (!link) continue;
+        const origin = nodesById.get(link[1]);
+        if (!origin || !isWiringVirtual(origin.type)) continue; // already direct
+        const resolved = resolveReal(inp.link);
+        if (!resolved) {
+          inp.link = null;
+          warnings.push(
+            `${node.type} #${node.id} input "${inp.name ?? slot}" fed by a dangling ${origin.type} chain — left unconnected`,
+          );
+          continue;
+        }
+        addDirectLink(resolved.id, resolved.slot, node.id, slot, resolved.type ?? link[5]);
+        rewired++;
+      }
+    }
+  }
+
+  // ── Pass 2: materialize UE broadcasts from the pack's own computed list ───
+  const ueSenders = nodes.filter((n) => isUeSender(n.type));
+  const ueDeletable = new Set<number>();
+  if (includeUe && ueSenders.length) {
+    const ueLinks = (ui.extra?.ue_links as UeLink[] | undefined) ?? null;
+    if (!Array.isArray(ueLinks) || ueLinks.length === 0) {
+      warnings.push(
+        `${ueSenders.length} Use-Everywhere sender(s) present but extra.ue_links is empty — ` +
+          `UE broadcasts NOT materialized (open the graph with cg-use-everywhere active and save/queue once, then retry); senders left in place`,
+      );
+    } else {
+      for (const uel of ueLinks) {
+        const dst = nodesById.get(uel.downstream);
+        const dstInput = dst?.inputs?.[uel.downstream_slot];
+        if (!dst || !dstInput) {
+          warnings.push(`ue_link → node #${uel.downstream} slot ${uel.downstream_slot} no longer exists — skipped`);
+          continue;
+        }
+        if (dstInput.link != null) continue; // got a real link since analysis — UE wouldn't fire
+        // upstream is the real producer per the pack's analysis; if it is itself
+        // virtual wiring (producer behind a Get/Set), normalize through pass-1 logic.
+        let srcId = uel.upstream;
+        let srcSlot = uel.upstream_slot;
+        const up = nodesById.get(srcId);
+        if (up && isWiringVirtual(up.type)) {
+          const viaInp = (up.inputs ?? []).find((i) => i.link != null);
+          const resolved = viaInp?.link != null ? resolveReal(viaInp.link) : null;
+          if (!resolved) {
+            warnings.push(`ue_link upstream #${srcId} is an unresolvable virtual node — skipped`);
+            continue;
+          }
+          srcId = resolved.id;
+          srcSlot = resolved.slot;
+        }
+        const added = addDirectLink(srcId, srcSlot, uel.downstream, uel.downstream_slot, uel.type ?? dstInput.type ?? "*");
+        if (added != null) rewired++;
+      }
+      // A sender is deletable only when it is not the real producer of any
+      // surviving link (Seed Everywhere IS its own upstream — it must stay).
+      const liveOrigins = new Set<number>();
+      for (const l of freshLinks) liveOrigins.add(l[1]);
+      for (const s of ueSenders) {
+        if (!liveOrigins.has(s.id)) ueDeletable.add(s.id);
+      }
+    }
+  }
+
+  // ── Deletion + purge ───────────────────────────────────────────────────────
+  const removedIds = new Set<number>();
+  let getset = 0;
+  let reroute = 0;
+  let ue = 0;
+  for (const n of nodes) {
+    if (includeGetSet && GET_SET_TYPES.has(n.type)) {
+      removedIds.add(n.id);
+      getset++;
+    } else if (includeGetSet && isRerouteType(n.type)) {
+      removedIds.add(n.id);
+      reroute++;
+    } else if (ueDeletable.has(n.id)) {
+      removedIds.add(n.id);
+      ue++;
+    }
+  }
+
+  ui.nodes = nodes.filter((n) => !removedIds.has(n.id));
+  const survivingLinks = [...(ui.links ?? []), ...freshLinks].filter(
+    (l) => Array.isArray(l) && !removedIds.has(l[1]) && !removedIds.has(l[3]),
+  );
+  const survivingIds = new Set(survivingLinks.map((l) => l[0]));
+  ui.links = survivingLinks;
+  ui.last_link_id = nextLinkId - 1;
+
+  // Scrub dangling link references on kept nodes (inputs fed by a deleted
+  // virtual node that pass-1 already rewired keep their fresh id; anything
+  // still pointing at a purged link gets cleared).
+  for (const n of ui.nodes) {
+    for (const inp of n.inputs ?? []) {
+      if (inp.link != null && !survivingIds.has(inp.link)) inp.link = null;
+    }
+    for (const out of n.outputs ?? []) {
+      if (out.links) out.links = out.links.filter((id) => survivingIds.has(id));
+    }
+  }
+
+  // The senders are gone — stale UE bookkeeping would confuse the pack's JS.
+  if (ui.extra && includeUe && ueSenders.length && ueDeletable.size === ueSenders.length) {
+    delete ui.extra.ue_links;
+    delete ui.extra.links_added_by_ue;
+  }
+
+  return {
+    graph: ui,
+    report: {
+      removed: { getset, reroute, ue },
+      added_links: freshLinks.length,
+      rewired_inputs: rewired,
+      kept_nodes: ui.nodes.length,
+      warnings,
+    },
+  };
+}


### PR DESCRIPTION
One-call flatten of the live canvas, per the spec written in the panel session that hit the layout-loss problem.

## Approach
- **Never round-trips through the API converter** — mutates the original UI graph: fresh direct link per virtually-fed consumer input, then deletes Get/Set/Reroute/UE senders and purges their links. Kept nodes never move → groups (geometric in litegraph), positions, colors, sizes, titles, widgets all survive exactly.
- **UE**: materializes cg-use-everywhere's own computed `extra.ue_links` (upstream is already the real producer — verified against the pack's source; detection mirrors its `is_UEnode`). Seed Everywhere is its own producer and is kept. Senders without `ue_links` → left in place + loud warning, never guessed.
- **Toggle branches respected**: the resolver stops at any real node regardless of mode — a wiring-only transform.
- Tool defaults to the live canvas (graph_serialize) and reloads the result in place (single undo); `pack`/`path`/`graph` sources and `apply:false` supported.

## Verification
- 10 new unit tests (Get/Set, Reroute, UE variants incl. Seed-Everywhere-stays, receiver-got-real-link skip, no-ue_links warning, formatting/mode preservation, opt-outs); full suite 1392/1392 green
- Real data: director V20 → 55/55 Get/Set removed, 43 links added, **0 kept nodes moved**, 29/29 groups, LTXDirector widgets byte-identical, 0 dangling refs
- Live E2E through the real browser canvas (loopback MCP + Chrome): flattened in place, `panel_query_graph` confirms 0 GetNode/SetNode/Reroute, 73 nodes, 29 groups — and the self-restarter picked up the build with zero manual restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)