### PR TITLE
feat(civitai): creator search — search_civitai_creators + search_civitai_models creator filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to this project are documented here. This project adheres to
 ### MCP
 
 #### Added
+- **search_civitai_creators** — CivitAI creator discovery: with no query it
+  returns the site's creator leaderboard (rank, score, downloads, likes;
+  boards: `overall`, `overall_90`, `overall_nsfw`, `new_creators`), with a
+  query it searches usernames via the public `/api/v1/creators`. Each hit
+  feeds `search_civitai_models {creator}` directly, so "show me top creators
+  → their models → download" works end-to-end (Discord mobile-beta request)
+- **search_civitai_models `creator` filter** — list one creator's models by
+  exact username, with or without a keyword (the keyword is applied
+  client-side because CivitAI returns an empty page when `query` and
+  `username` are combined). Both CivitAI search tools are now whitelisted on
+  the mobile `call_tool` channel (read-only)
 - **panel_flatten_workflow** — one-call, formatting-preserving flatten of the
   live canvas: Get/Set buses, Reroutes, and cg-use-everywhere broadcasts
   resolve to direct real links and the virtual nodes are deleted, while kept

--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -338,6 +338,62 @@ describe("searchCivitaiModels", () => {
     expect(scanCapped).toBe(false);
   });
 
+  it("creator + keyword: an empty-string nextCursor terminates the scan (full scan, no cap)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [{ id: 1, name: "Detail A", modelVersions: [] }],
+        metadata: { nextCursor: "" }, // degenerate: falsy, not just missing
+      }),
+    );
+    const { hits, scanCapped } = await searchCivitaiModels("detail", { creator: "jed" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hits).toHaveLength(1);
+    expect(scanCapped).toBe(false); // exhausted, not capped
+  });
+
+  it("creator + keyword: a REPEATED cursor breaks out instead of looping, and reports the cap", async () => {
+    // Page 1 → cursor "stuck"; page 2 replays the SAME items and the SAME cursor.
+    const page = {
+      items: [{ id: 1, name: "Unrelated", modelVersions: [] }],
+      metadata: { nextCursor: "stuck" },
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(page)).mockResolvedValueOnce(jsonResponse(page));
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", { creator: "jed" });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // followed "stuck" once, then refused the repeat
+    expect(hits).toEqual([]);
+    expect(scanned).toBe(1); // the replayed page is NOT double-counted
+    expect(scanCapped).toBe(true); // stuck mid-catalog → the miss is not definitive
+  });
+
+  it("creator + keyword: duplicate model ids across pages are deduped (never fill limit twice)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            { id: 1, name: "Detail A", modelVersions: [] },
+            { id: 2, name: "Other", modelVersions: [] },
+          ],
+          metadata: { nextCursor: "p2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          // id 1 replayed by a misbehaving cursor + one genuinely new match.
+          items: [
+            { id: 1, name: "Detail A", modelVersions: [] },
+            { id: 3, name: "Detail B", modelVersions: [] },
+          ],
+        }),
+      );
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", {
+      creator: "jed",
+      limit: 2,
+    });
+    expect(hits.map((h) => h.model_id)).toEqual([1, 3]); // no duplicate id 1
+    expect(scanned).toBe(3); // unique models only
+    expect(scanCapped).toBe(false);
+  });
+
   it("creator-only mode uses the caller's limit (no over-fetch)", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ items: [] }));
     await searchCivitaiModels("", { creator: "jed", limit: 5 });

--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -206,7 +206,7 @@ describe("searchCivitaiModels", () => {
 
   it("builds the query (types/baseModels/sort/nsfw pinned) and maps the download handoff fields", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(SEARCH_BODY));
-    const hits = await searchCivitaiModels("flux detail", {
+    const { hits } = await searchCivitaiModels("flux detail", {
       types: ["LORA"],
       baseModels: ["Flux.1 D"],
     });
@@ -260,7 +260,7 @@ describe("searchCivitaiModels", () => {
     expect(url).not.toContain("query=");
   });
 
-  it("creator + keyword: over-fetches, filters client-side on name/tags, and respects limit", async () => {
+  it("creator + keyword: over-fetches, filters client-side on name/tags, no cap on a single page", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         items: [
@@ -270,13 +270,78 @@ describe("searchCivitaiModels", () => {
         ],
       }),
     );
-    const hits = await searchCivitaiModels("detail", { creator: "jed" });
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", { creator: "jed" });
     const url = String(fetchMock.mock.calls[0][0]);
     expect(url).toContain("username=jed");
     expect(url).not.toContain("query=");
     expect(url).toContain("limit=100"); // over-fetch for the client-side filter
     // "Flux Detailer" matches on name, "Portrait Pack" on the "detail" tag.
     expect(hits.map((h) => h.model_id)).toEqual([1, 3]);
+    expect(scanned).toBe(3);
+    expect(scanCapped).toBe(false); // no nextCursor → the whole catalog was scanned
+  });
+
+  it("creator + keyword: follows cursor pagination so a match past page one is found", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, name: "Anime Style", modelVersions: [] }],
+          metadata: { nextCursor: "abc" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 2, name: "Detail Slider", modelVersions: [] }],
+        }),
+      );
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", { creator: "prolific" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1][0])).toContain("cursor=abc");
+    expect(hits.map((h) => h.model_id)).toEqual([2]);
+    expect(scanned).toBe(2);
+    expect(scanCapped).toBe(false);
+  });
+
+  it("creator + keyword: stops at the page cap and reports scanCapped when short of limit", async () => {
+    // 4 pages (the cap), every page keeps offering a next cursor, zero matches.
+    for (let i = 0; i < 4; i++) {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 100 + i, name: "Unrelated", modelVersions: [] }],
+          metadata: { nextCursor: `c${i}` },
+        }),
+      );
+    }
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", { creator: "prolific" });
+    expect(fetchMock).toHaveBeenCalledTimes(4); // bounded — never a 5th page
+    expect(hits).toEqual([]);
+    expect(scanned).toBe(4);
+    expect(scanCapped).toBe(true); // pages remained unscanned → the miss is not definitive
+  });
+
+  it("creator + keyword: stops paging early once limit matches are found (no cap flag)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { id: 1, name: "Detail A", modelVersions: [] },
+          { id: 2, name: "Detail B", modelVersions: [] },
+        ],
+        metadata: { nextCursor: "more" },
+      }),
+    );
+    const { hits, scanCapped } = await searchCivitaiModels("detail", {
+      creator: "prolific",
+      limit: 2,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // limit filled on page one
+    expect(hits).toHaveLength(2);
+    expect(scanCapped).toBe(false);
+  });
+
+  it("creator-only mode uses the caller's limit (no over-fetch)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: [] }));
+    await searchCivitaiModels("", { creator: "jed", limit: 5 });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("limit=5");
   });
 
   it("rejects an empty query with no creator", async () => {

--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -365,6 +365,35 @@ describe("searchCivitaiModels", () => {
     expect(scanCapped).toBe(true); // stuck mid-catalog → the miss is not definitive
   });
 
+  it("creator + keyword: a LONGER cursor cycle (A→B→A) breaks out and reports the cap", async () => {
+    // A two-cursor cycle: a previous-cursor-only check would follow A→B→A→B…
+    // until the page cap; the seen-cursors set refuses A the second time.
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, name: "Unrelated 1", modelVersions: [] }],
+          metadata: { nextCursor: "A" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 2, name: "Unrelated 2", modelVersions: [] }],
+          metadata: { nextCursor: "B" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 3, name: "Unrelated 3", modelVersions: [] }],
+          metadata: { nextCursor: "A" }, // cycles back — already followed
+        }),
+      );
+    const { hits, scanned, scanCapped } = await searchCivitaiModels("detail", { creator: "jed" });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // start → A → B, then A is refused
+    expect(hits).toEqual([]);
+    expect(scanned).toBe(3);
+    expect(scanCapped).toBe(true); // cycling mid-catalog → the miss is not definitive
+  });
+
   it("creator + keyword: duplicate model ids across pages are deduped (never fill limit twice)", async () => {
     fetchMock
       .mockResolvedValueOnce(

--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -10,6 +10,8 @@ import {
   resolveCivitaiModel,
   resolveCivitaiModelVersion,
   searchCivitaiModels,
+  searchCivitaiCreators,
+  fetchCivitaiTopCreators,
 } from "../../services/civitai-resolver.js";
 import { ModelError, ValidationError } from "../../utils/errors.js";
 
@@ -248,5 +250,161 @@ describe("searchCivitaiModels", () => {
     await searchCivitaiModels("y");
     const headers = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
     expect(headers["Authorization"]).toBe("Bearer civ_tok");
+  });
+
+  it("creator mode sends username INSTEAD of query (combined = empty page, live-verified quirk)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(SEARCH_BODY));
+    await searchCivitaiModels("", { creator: "jed" });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("username=jed");
+    expect(url).not.toContain("query=");
+  });
+
+  it("creator + keyword: over-fetches, filters client-side on name/tags, and respects limit", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { id: 1, name: "Flux Detailer", modelVersions: [] },
+          { id: 2, name: "Anime Style", tags: ["style"], modelVersions: [] },
+          { id: 3, name: "Portrait Pack", tags: ["detail", "portrait"], modelVersions: [] },
+        ],
+      }),
+    );
+    const hits = await searchCivitaiModels("detail", { creator: "jed" });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("username=jed");
+    expect(url).not.toContain("query=");
+    expect(url).toContain("limit=100"); // over-fetch for the client-side filter
+    // "Flux Detailer" matches on name, "Portrait Pack" on the "detail" tag.
+    expect(hits.map((h) => h.model_id)).toEqual([1, 3]);
+  });
+
+  it("rejects an empty query with no creator", async () => {
+    await expect(searchCivitaiModels("  ")).rejects.toBeInstanceOf(ValidationError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("searchCivitaiCreators", () => {
+  it("builds the /creators query and maps username/model_count/profile_url + total", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { username: "jedikun", modelCount: 18, link: "https://civitai.com/api/v1/models?username=jedikun" },
+          { username: "techjedi", link: "https://civitai.com/api/v1/models?username=techjedi" },
+        ],
+        metadata: { totalItems: 6 },
+      }),
+    );
+    const { hits, total } = await searchCivitaiCreators("jed", { limit: 5 });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("/creators?");
+    expect(url).toContain("query=jed");
+    expect(url).toContain("limit=5");
+    expect(total).toBe(6);
+    expect(hits).toEqual([
+      {
+        username: "jedikun",
+        profile_url: "https://civitai.com/user/jedikun",
+        model_count: 18,
+      },
+      {
+        username: "techjedi",
+        profile_url: "https://civitai.com/user/techjedi",
+        model_count: 0, // API omits modelCount for creators with none visible
+      },
+    ]);
+  });
+
+  it("fails FAST when CIVITAI_ENABLED=0 (kill-switch, #127)", async () => {
+    process.env.CIVITAI_ENABLED = "0";
+    try {
+      await expect(searchCivitaiCreators("x")).rejects.toThrow(/disabled by config/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.CIVITAI_ENABLED;
+    }
+  });
+});
+
+describe("fetchCivitaiTopCreators", () => {
+  const BOARD_BODY = {
+    result: {
+      data: {
+        json: [
+          {
+            position: 1,
+            score: 81140,
+            user: { username: "alcaitiff", deletedAt: null },
+            metrics: [
+              { type: "downloadCount", value: 42294 },
+              { type: "entries", value: 13 },
+              { type: "thumbsUpCount", value: 2253 },
+              { type: "generationCount", value: 719 },
+            ],
+          },
+          {
+            position: 2,
+            score: 100,
+            user: { username: "ghost", deletedAt: "2026-01-01T00:00:00Z" },
+            metrics: [],
+          },
+          {
+            position: 3,
+            score: 75439,
+            user: { username: "circlestone_labs", deletedAt: null },
+            metrics: [{ type: "downloadCount", value: 39000 }],
+          },
+        ],
+      },
+    },
+  };
+
+  it("hits the tRPC leaderboard with browser-shaped headers (bot gate) and NO bearer token", async () => {
+    config.civitaiApiToken = "civ_tok";
+    fetchMock.mockResolvedValueOnce(jsonResponse(BOARD_BODY));
+    await fetchCivitaiTopCreators();
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("civitai.com/api/trpc/leaderboard.getLeaderboard");
+    expect(url).toContain(encodeURIComponent(JSON.stringify({ json: { id: "overall" } })));
+    const headers = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+    expect(headers["User-Agent"]).toContain("Mozilla/5.0"); // bot gate 401s a plain fetch UA
+    expect(headers["Authorization"]).toBeUndefined(); // token stays on the v1 API surface
+  });
+
+  it("maps rank/score/metrics, skips deleted users, and respects limit + board", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(BOARD_BODY));
+    const hits = await fetchCivitaiTopCreators({ board: "new_creators", limit: 2 });
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      encodeURIComponent(JSON.stringify({ json: { id: "new_creators" } })),
+    );
+    expect(hits).toHaveLength(2); // deleted "ghost" is skipped, then limit applies
+    expect(hits[0]).toEqual({
+      username: "alcaitiff",
+      profile_url: "https://civitai.com/user/alcaitiff",
+      position: 1,
+      score: 81140,
+      downloads: 42294,
+      thumbs_up: 2253,
+      generations: 719,
+      entries: 13,
+    });
+    expect(hits[1].username).toBe("circlestone_labs");
+    expect(hits[1].thumbs_up).toBeUndefined();
+  });
+
+  it("throws ModelError on a bot-gate 401", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401));
+    await expect(fetchCivitaiTopCreators()).rejects.toBeInstanceOf(ModelError);
+  });
+
+  it("fails FAST when CIVITAI_ENABLED=0 (kill-switch, #127)", async () => {
+    process.env.CIVITAI_ENABLED = "0";
+    try {
+      await expect(fetchCivitaiTopCreators()).rejects.toThrow(/disabled by config/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.CIVITAI_ENABLED;
+    }
   });
 });

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -363,9 +363,11 @@ describe("search_civitai_models creator filter", () => {
   });
 
   it("passes creator through and labels the results with it", async () => {
-    searchCivitaiModelsMock.mockResolvedValueOnce([
-      { model_id: 1, name: "Detail Slider", type: "LORA", creator: "alcaitiff", version_id: 9 },
-    ]);
+    searchCivitaiModelsMock.mockResolvedValueOnce({
+      hits: [
+        { model_id: 1, name: "Detail Slider", type: "LORA", creator: "alcaitiff", version_id: 9 },
+      ],
+    });
     const { searchCivitai } = makeServer();
     const res = await searchCivitai({ creator: "alcaitiff" });
 
@@ -376,15 +378,30 @@ describe("search_civitai_models creator filter", () => {
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("creator alcaitiff");
     expect(res.content[0].text).toContain("Detail Slider");
+    expect(res.content[0].text).not.toContain("scan cap");
   });
 
   it("no-hits message points at search_civitai_creators for a creator miss", async () => {
-    searchCivitaiModelsMock.mockResolvedValueOnce([]);
+    searchCivitaiModelsMock.mockResolvedValueOnce({ hits: [] });
     const { searchCivitai } = makeServer();
     const res = await searchCivitai({ creator: "nobody" });
 
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("search_civitai_creators");
+  });
+
+  it("surfaces the bounded-scan cap so a capped miss is never presented as definitive", async () => {
+    searchCivitaiModelsMock.mockResolvedValueOnce({
+      hits: [],
+      scanned: 400,
+      scanCapped: true,
+    });
+    const { searchCivitai } = makeServer();
+    const res = await searchCivitai({ creator: "prolific", query: "detail" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("No CivitAI models matched");
+    expect(res.content[0].text).toContain("first 400 models (scan cap)");
   });
 });
 

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -44,6 +44,9 @@ vi.mock("../../services/model-resolver.js", async () => {
 
 const resolveCivitaiModelMock = vi.fn();
 const resolveCivitaiModelVersionMock = vi.fn();
+const searchCivitaiModelsMock = vi.fn();
+const searchCivitaiCreatorsMock = vi.fn();
+const fetchCivitaiTopCreatorsMock = vi.fn();
 vi.mock("../../services/civitai-resolver.js", async () => {
   const actual = await vi.importActual<
     typeof import("../../services/civitai-resolver.js")
@@ -53,6 +56,9 @@ vi.mock("../../services/civitai-resolver.js", async () => {
     resolveCivitaiModel: (...a: unknown[]) => resolveCivitaiModelMock(...a),
     resolveCivitaiModelVersion: (...a: unknown[]) =>
       resolveCivitaiModelVersionMock(...a),
+    searchCivitaiModels: (...a: unknown[]) => searchCivitaiModelsMock(...a),
+    searchCivitaiCreators: (...a: unknown[]) => searchCivitaiCreatorsMock(...a),
+    fetchCivitaiTopCreators: (...a: unknown[]) => fetchCivitaiTopCreatorsMock(...a),
   };
 });
 
@@ -88,6 +94,8 @@ function makeServer() {
   return {
     removeModel: handlers.get("remove_model")!,
     downloadCivitai: handlers.get("download_civitai_model")!,
+    searchCivitai: handlers.get("search_civitai_models")!,
+    searchCreators: handlers.get("search_civitai_creators")!,
   };
 }
 
@@ -99,6 +107,9 @@ beforeEach(() => {
   downloadModelMock.mockReset();
   resolveCivitaiModelMock.mockReset();
   resolveCivitaiModelVersionMock.mockReset();
+  searchCivitaiModelsMock.mockReset();
+  searchCivitaiCreatorsMock.mockReset();
+  fetchCivitaiTopCreatorsMock.mockReset();
   config.comfyuiPath = "/comfy";
   config.civitaiApiToken = undefined;
 });
@@ -338,5 +349,97 @@ describe("download_civitai_model", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toContain("model_id");
     expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("search_civitai_models creator filter", () => {
+  it("errors when neither query nor creator is given", async () => {
+    const { searchCivitai } = makeServer();
+    const res = await searchCivitai({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("VALIDATION_ERROR");
+    expect(searchCivitaiModelsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes creator through and labels the results with it", async () => {
+    searchCivitaiModelsMock.mockResolvedValueOnce([
+      { model_id: 1, name: "Detail Slider", type: "LORA", creator: "alcaitiff", version_id: 9 },
+    ]);
+    const { searchCivitai } = makeServer();
+    const res = await searchCivitai({ creator: "alcaitiff" });
+
+    expect(searchCivitaiModelsMock).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ creator: "alcaitiff" }),
+    );
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("creator alcaitiff");
+    expect(res.content[0].text).toContain("Detail Slider");
+  });
+
+  it("no-hits message points at search_civitai_creators for a creator miss", async () => {
+    searchCivitaiModelsMock.mockResolvedValueOnce([]);
+    const { searchCivitai } = makeServer();
+    const res = await searchCivitai({ creator: "nobody" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("search_civitai_creators");
+  });
+});
+
+describe("search_civitai_creators", () => {
+  it("no query → leaderboard mode (default 'overall'), ranked lines + models hand-off", async () => {
+    fetchCivitaiTopCreatorsMock.mockResolvedValueOnce([
+      {
+        username: "alcaitiff",
+        profile_url: "https://civitai.com/user/alcaitiff",
+        position: 1,
+        score: 81140,
+        downloads: 42294,
+        thumbs_up: 2253,
+        entries: 13,
+      },
+    ]);
+    const { searchCreators } = makeServer();
+    const res = await searchCreators({});
+
+    expect(fetchCivitaiTopCreatorsMock).toHaveBeenCalledWith({
+      board: "overall",
+      limit: undefined,
+    });
+    expect(searchCivitaiCreatorsMock).not.toHaveBeenCalled();
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain('"overall" leaderboard');
+    expect(res.content[0].text).toContain("1. **alcaitiff**");
+    expect(res.content[0].text).toContain("https://civitai.com/user/alcaitiff");
+    expect(res.content[0].text).toContain('search_civitai_models {"creator"');
+  });
+
+  it("query → username-search mode with model counts", async () => {
+    searchCivitaiCreatorsMock.mockResolvedValueOnce({
+      hits: [
+        { username: "jedikun", profile_url: "https://civitai.com/user/jedikun", model_count: 18 },
+      ],
+      total: 6,
+    });
+    const { searchCreators } = makeServer();
+    const res = await searchCreators({ query: "jed", limit: 5 });
+
+    expect(searchCivitaiCreatorsMock).toHaveBeenCalledWith("jed", { limit: 5 });
+    expect(fetchCivitaiTopCreatorsMock).not.toHaveBeenCalled();
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("jedikun");
+    expect(res.content[0].text).toContain("18 model(s)");
+    expect(res.content[0].text).toContain("6 total matches");
+  });
+
+  it("query with no matches suggests the leaderboard", async () => {
+    searchCivitaiCreatorsMock.mockResolvedValueOnce({ hits: [], total: 0 });
+    const { searchCreators } = makeServer();
+    const res = await searchCreators({ query: "zzz" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content[0].text).toContain("No CivitAI creators matched");
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -615,6 +615,10 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "list_output_images",
   "get_image",
   "list_local_models",
+  // Read-only CivitAI lookups (creator-search feature): let a client browse
+  // models/creators through the rig without an agent turn.
+  "search_civitai_models",
+  "search_civitai_creators",
   "download_civitai_model",
   "download_model",
   "enqueue_workflow",

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -459,11 +459,14 @@ export async function searchCivitaiModels(
   const q = keyword.toLowerCase();
   const matches: CivitaiSearchItem[] = [];
   const seenIds = new Set<number>();
+  // Every cursor already followed — refuses ANY cycle (immediate repeat AND
+  // longer A→B→A loops), not just the previous cursor.
+  const seenCursors = new Set<string>();
   let scanned = 0;
   let cursor: string | undefined;
   // True when the scan stopped with pages plausibly unseen: the page cap was
   // hit with a next cursor remaining, or the API handed back a degenerate
-  // (repeated) cursor we refuse to follow.
+  // (cycling) cursor we refuse to follow.
   let stoppedEarly = false;
   for (let page = 0; page < CREATOR_SCAN_MAX_PAGES; page++) {
     if (cursor !== undefined) params.set("cursor", cursor);
@@ -481,12 +484,15 @@ export async function searchCivitaiModels(
       ),
     );
     // Falsy (missing OR empty-string) cursor → the catalog is exhausted; a
-    // REPEATED cursor would loop the same page forever → treat as stuck.
+    // cursor we ALREADY followed (immediate repeat or a longer cycle) would
+    // page in circles forever → treat as stuck.
     const next = data.metadata?.nextCursor || undefined;
-    if (!next || next === cursor) {
-      stoppedEarly = next !== undefined; // repeated cursor: pages may remain unseen
+    if (!next) break;
+    if (seenCursors.has(next)) {
+      stoppedEarly = true; // cycling cursor: pages may remain unseen
       break;
     }
+    seenCursors.add(next);
     cursor = next;
     if (matches.length >= limit) break;
     if (page === CREATOR_SCAN_MAX_PAGES - 1) stoppedEarly = true; // page cap, more remained

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -367,6 +367,11 @@ export interface CivitaiSearchOptions {
   sort?: CivitaiSort;
   nsfw?: boolean;
   limit?: number;
+  /** Only models by this CivitAI creator (exact username). Sent as the API's
+   *  `username` param; any keyword query is applied client-side because the
+   *  API returns an empty page when `query` and `username` are combined
+   *  (live-verified quirk). */
+  creator?: string;
 }
 
 interface CivitaiSearchResponse {
@@ -382,18 +387,41 @@ export async function searchCivitaiModels(
   query: string,
   opts: CivitaiSearchOptions = {},
 ): Promise<CivitaiSearchHit[]> {
+  const creator = opts.creator?.trim();
+  const keyword = query.trim();
+  if (!creator && !keyword) {
+    throw new ValidationError("Provide a query, a creator, or both.");
+  }
+  const limit = Math.min(Math.max(opts.limit ?? 10, 1), 25);
   const params = new URLSearchParams();
-  params.set("query", query);
-  params.set("limit", String(Math.min(Math.max(opts.limit ?? 10, 1), 25)));
   params.set("sort", opts.sort ?? "Highest Rated");
   // Civitai defaults to including NSFW for authed accounts — pin it explicitly
   // so results are SFW unless the caller opted in.
   params.set("nsfw", opts.nsfw ? "true" : "false");
   for (const t of opts.types ?? []) params.append("types", t);
   for (const b of opts.baseModels ?? []) params.append("baseModels", b);
+  if (creator) {
+    // Creator mode: `query` + `username` together return an EMPTY page
+    // (live-verified), so send only `username` and apply the keyword
+    // client-side. Over-fetch so the post-filter still fills `limit`.
+    params.set("username", creator);
+    params.set("limit", String(keyword ? 100 : limit));
+  } else {
+    params.set("query", keyword);
+    params.set("limit", String(limit));
+  }
 
   const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
-  return (data.items ?? []).map((m) => {
+  let items = data.items ?? [];
+  if (creator && keyword) {
+    const q = keyword.toLowerCase();
+    items = items.filter(
+      (m) =>
+        (m.name ?? "").toLowerCase().includes(q) ||
+        (m.tags ?? []).some((t) => t.toLowerCase().includes(q)),
+    );
+  }
+  return items.slice(0, limit).map((m) => {
     const v = m.modelVersions?.[0];
     const file = v ? pickFile(v) : undefined;
     const sizeKb = (file as { sizeKB?: number } | undefined)?.sizeKB;
@@ -412,4 +440,139 @@ export async function searchCivitaiModels(
       ...(sizeKb ? { size_mb: Math.round(sizeKb / 1024) } : {}),
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Creator search + top-creators leaderboard. Field driver: a mobile-beta user
+// asked to "search posts by top creators, similar to the leaderboard on the
+// actual website" (Discord). Two backends, one hit shape:
+//   • GET /api/v1/creators           — username search (documented public API)
+//   • tRPC leaderboard.getLeaderboard — the website's ranked creator boards;
+//     the v1 API exposes NO leaderboard ordering (/creators is join-date
+//     ordered), so this mirrors the site's own request. Civitai's bot gate
+//     401s a plain fetch UA ("Please use the public API instead"), so the
+//     request carries browser-shaped headers — same approach the mobile app
+//     already uses for its tRPC calls.
+// ---------------------------------------------------------------------------
+
+export interface CivitaiCreatorHit {
+  username: string;
+  /** civitai.com profile page for the creator. */
+  profile_url: string;
+  /** Number of published models (username-search mode; API omits it for 0). */
+  model_count?: number;
+  /** Leaderboard rank, 1-based (top-creators mode only). */
+  position?: number;
+  /** Leaderboard score (top-creators mode only). */
+  score?: number;
+  downloads?: number;
+  thumbs_up?: number;
+  generations?: number;
+  /** Models counted into the leaderboard score (top-creators mode only). */
+  entries?: number;
+}
+
+const CIVITAI_LEADERBOARDS = [
+  "overall",
+  "overall_90",
+  "overall_nsfw",
+  "new_creators",
+] as const;
+export type CivitaiLeaderboard = (typeof CIVITAI_LEADERBOARDS)[number];
+
+function creatorProfileUrl(username: string): string {
+  return `https://civitai.com/user/${encodeURIComponent(username)}`;
+}
+
+interface CivitaiCreatorsResponse {
+  items?: Array<{ username?: string; modelCount?: number; link?: string }>;
+  metadata?: { totalItems?: number };
+}
+
+/**
+ * Search CivitAI creators by (partial) username via GET /api/v1/creators.
+ * Returns matching creators plus the API's total match count.
+ */
+export async function searchCivitaiCreators(
+  query: string,
+  opts: { limit?: number } = {},
+): Promise<{ hits: CivitaiCreatorHit[]; total?: number }> {
+  const params = new URLSearchParams();
+  params.set("query", query);
+  params.set("limit", String(Math.min(Math.max(opts.limit ?? 10, 1), 50)));
+  const data = await civitaiGet<CivitaiCreatorsResponse>(
+    `/creators?${params.toString()}`,
+  );
+  const hits = (data.items ?? [])
+    .filter((c): c is { username: string; modelCount?: number } => !!c.username)
+    .map((c) => ({
+      username: c.username,
+      profile_url: creatorProfileUrl(c.username),
+      model_count: c.modelCount ?? 0,
+    }));
+  return { hits, total: data.metadata?.totalItems };
+}
+
+/** Browser-shaped headers for the tRPC leaderboard request (see section note). */
+const TRPC_BROWSER_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+  Referer: "https://civitai.com/",
+};
+
+interface CivitaiLeaderboardEntry {
+  position?: number;
+  score?: number;
+  user?: { username?: string; deletedAt?: string | null };
+  metrics?: Array<{ type?: string; value?: number }>;
+}
+
+/**
+ * Fetch a CivitAI creator leaderboard (the site's civitai.com/leaderboard
+ * ranking). `board` picks which one: "overall" (default), "overall_90",
+ * "overall_nsfw", or "new_creators".
+ */
+export async function fetchCivitaiTopCreators(
+  opts: { board?: CivitaiLeaderboard; limit?: number } = {},
+): Promise<CivitaiCreatorHit[]> {
+  if (civitaiDisabled()) {
+    throw new ModelError(CIVITAI_DISABLED_MESSAGE);
+  }
+  const board = opts.board ?? "overall";
+  const limit = Math.min(Math.max(opts.limit ?? 10, 1), 100);
+  const input = encodeURIComponent(JSON.stringify({ json: { id: board } }));
+  const url = `https://civitai.com/api/trpc/leaderboard.getLeaderboard?input=${input}`;
+  logger.debug("CivitAI leaderboard request", { url });
+
+  // No bearer token here: the leaderboard is public and the API token belongs
+  // to the documented v1 surface, not the site's tRPC endpoints.
+  const res = await fetch(url, { headers: TRPC_BROWSER_HEADERS });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ModelError(`CivitAI leaderboard ${res.status}: ${res.statusText}`, {
+      url,
+      status: res.status,
+      body,
+    });
+  }
+  const data = (await res.json()) as {
+    result?: { data?: { json?: CivitaiLeaderboardEntry[] } };
+  };
+  const entries = data.result?.data?.json ?? [];
+  const metric = (e: CivitaiLeaderboardEntry, type: string) =>
+    e.metrics?.find((m) => m.type === type)?.value;
+  return entries
+    .filter((e) => e.user?.username && !e.user.deletedAt)
+    .slice(0, limit)
+    .map((e) => ({
+      username: e.user!.username!,
+      profile_url: creatorProfileUrl(e.user!.username!),
+      position: e.position,
+      score: e.score,
+      downloads: metric(e, "downloadCount"),
+      thumbs_up: metric(e, "thumbsUpCount"),
+      generations: metric(e, "generationCount"),
+      entries: metric(e, "entries"),
+    }));
 }

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -458,12 +458,20 @@ export async function searchCivitaiModels(
   params.set("limit", String(CREATOR_SCAN_PAGE_SIZE));
   const q = keyword.toLowerCase();
   const matches: CivitaiSearchItem[] = [];
+  const seenIds = new Set<number>();
   let scanned = 0;
   let cursor: string | undefined;
+  // True when the scan stopped with pages plausibly unseen: the page cap was
+  // hit with a next cursor remaining, or the API handed back a degenerate
+  // (repeated) cursor we refuse to follow.
+  let stoppedEarly = false;
   for (let page = 0; page < CREATOR_SCAN_MAX_PAGES; page++) {
     if (cursor !== undefined) params.set("cursor", cursor);
     const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
-    const items = data.items ?? [];
+    // Dedupe across pages by model id — a misbehaving cursor that replays a
+    // page must not double-count `scanned` or fill `limit` with duplicates.
+    const items = (data.items ?? []).filter((m) => !seenIds.has(m.id));
+    for (const m of items) seenIds.add(m.id);
     scanned += items.length;
     matches.push(
       ...items.filter(
@@ -472,13 +480,21 @@ export async function searchCivitaiModels(
           (m.tags ?? []).some((t) => t.toLowerCase().includes(q)),
       ),
     );
-    cursor = data.metadata?.nextCursor;
-    if (cursor === undefined || matches.length >= limit) break;
+    // Falsy (missing OR empty-string) cursor → the catalog is exhausted; a
+    // REPEATED cursor would loop the same page forever → treat as stuck.
+    const next = data.metadata?.nextCursor || undefined;
+    if (!next || next === cursor) {
+      stoppedEarly = next !== undefined; // repeated cursor: pages may remain unseen
+      break;
+    }
+    cursor = next;
+    if (matches.length >= limit) break;
+    if (page === CREATOR_SCAN_MAX_PAGES - 1) stoppedEarly = true; // page cap, more remained
   }
   return {
     hits: matches.slice(0, limit).map(toSearchHit),
     scanned,
-    scanCapped: cursor !== undefined && matches.length < limit,
+    scanCapped: stoppedEarly && matches.length < limit,
   };
 }
 

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -374,19 +374,56 @@ export interface CivitaiSearchOptions {
   creator?: string;
 }
 
+type CivitaiSearchItem = CivitaiModel & {
+  nsfw?: boolean;
+  stats?: { downloadCount?: number; thumbsUpCount?: number };
+};
+
 interface CivitaiSearchResponse {
-  items?: Array<
-    CivitaiModel & {
-      nsfw?: boolean;
-      stats?: { downloadCount?: number; thumbsUpCount?: number };
-    }
-  >;
+  items?: CivitaiSearchItem[];
+  metadata?: { nextCursor?: string };
 }
+
+export interface CivitaiSearchResult {
+  hits: CivitaiSearchHit[];
+  /** Creator+keyword mode only: how many of the creator's models the
+   *  client-side keyword filter scanned. */
+  scanned?: number;
+  /** Creator+keyword mode only: true when the bounded scan stopped at the
+   *  page cap with pages left AND fewer than `limit` matches — matching
+   *  models past the cap may exist but were not seen. */
+  scanCapped?: boolean;
+}
+
+function toSearchHit(m: CivitaiSearchItem): CivitaiSearchHit {
+  const v = m.modelVersions?.[0];
+  const file = v ? pickFile(v) : undefined;
+  const sizeKb = (file as { sizeKB?: number } | undefined)?.sizeKB;
+  return {
+    model_id: m.id,
+    name: m.name ?? `model ${m.id}`,
+    type: m.type,
+    creator: m.creator?.username,
+    downloads: m.stats?.downloadCount,
+    thumbs_up: m.stats?.thumbsUpCount,
+    nsfw: m.nsfw,
+    version_id: v?.id,
+    version_name: v?.name,
+    base_model: v?.baseModel,
+    trained_words: v?.trainedWords?.slice(0, 6),
+    ...(sizeKb ? { size_mb: Math.round(sizeKb / 1024) } : {}),
+  };
+}
+
+/** Creator+keyword mode: pages of 100 scanned client-side, and how many pages
+ *  to follow before giving up (4 → up to 400 of the creator's models). */
+const CREATOR_SCAN_PAGE_SIZE = 100;
+const CREATOR_SCAN_MAX_PAGES = 4;
 
 export async function searchCivitaiModels(
   query: string,
   opts: CivitaiSearchOptions = {},
-): Promise<CivitaiSearchHit[]> {
+): Promise<CivitaiSearchResult> {
   const creator = opts.creator?.trim();
   const keyword = query.trim();
   if (!creator && !keyword) {
@@ -400,46 +437,49 @@ export async function searchCivitaiModels(
   params.set("nsfw", opts.nsfw ? "true" : "false");
   for (const t of opts.types ?? []) params.append("types", t);
   for (const b of opts.baseModels ?? []) params.append("baseModels", b);
-  if (creator) {
-    // Creator mode: `query` + `username` together return an EMPTY page
-    // (live-verified), so send only `username` and apply the keyword
-    // client-side. Over-fetch so the post-filter still fills `limit`.
-    params.set("username", creator);
-    params.set("limit", String(keyword ? 100 : limit));
-  } else {
-    params.set("query", keyword);
+
+  if (!creator || !keyword) {
+    // Single-page modes: a plain keyword search, or ALL of a creator's models.
+    if (creator) {
+      params.set("username", creator);
+    } else {
+      params.set("query", keyword);
+    }
     params.set("limit", String(limit));
+    const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
+    return { hits: (data.items ?? []).slice(0, limit).map(toSearchHit) };
   }
 
-  const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
-  let items = data.items ?? [];
-  if (creator && keyword) {
-    const q = keyword.toLowerCase();
-    items = items.filter(
-      (m) =>
-        (m.name ?? "").toLowerCase().includes(q) ||
-        (m.tags ?? []).some((t) => t.toLowerCase().includes(q)),
+  // Creator + keyword: `query` + `username` together return an EMPTY page
+  // (live-verified), so send only `username` and apply the keyword client-side
+  // — following cursor pagination (bounded) so a prolific creator's matching
+  // model past the first page is still found.
+  params.set("username", creator);
+  params.set("limit", String(CREATOR_SCAN_PAGE_SIZE));
+  const q = keyword.toLowerCase();
+  const matches: CivitaiSearchItem[] = [];
+  let scanned = 0;
+  let cursor: string | undefined;
+  for (let page = 0; page < CREATOR_SCAN_MAX_PAGES; page++) {
+    if (cursor !== undefined) params.set("cursor", cursor);
+    const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
+    const items = data.items ?? [];
+    scanned += items.length;
+    matches.push(
+      ...items.filter(
+        (m) =>
+          (m.name ?? "").toLowerCase().includes(q) ||
+          (m.tags ?? []).some((t) => t.toLowerCase().includes(q)),
+      ),
     );
+    cursor = data.metadata?.nextCursor;
+    if (cursor === undefined || matches.length >= limit) break;
   }
-  return items.slice(0, limit).map((m) => {
-    const v = m.modelVersions?.[0];
-    const file = v ? pickFile(v) : undefined;
-    const sizeKb = (file as { sizeKB?: number } | undefined)?.sizeKB;
-    return {
-      model_id: m.id,
-      name: m.name ?? `model ${m.id}`,
-      type: m.type,
-      creator: m.creator?.username,
-      downloads: m.stats?.downloadCount,
-      thumbs_up: m.stats?.thumbsUpCount,
-      nsfw: m.nsfw,
-      version_id: v?.id,
-      version_name: v?.name,
-      base_model: v?.baseModel,
-      trained_words: v?.trainedWords?.slice(0, 6),
-      ...(sizeKb ? { size_mb: Math.round(sizeKb / 1024) } : {}),
-    };
-  });
+  return {
+    hits: matches.slice(0, limit).map(toSearchHit),
+    scanned,
+    scanCapped: cursor !== undefined && matches.length < limit,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -13,6 +13,8 @@ import {
   resolveCivitaiModelVersion,
   buildCivitaiMarkdown,
   searchCivitaiModels,
+  searchCivitaiCreators,
+  fetchCivitaiTopCreators,
   type CivitaiMetadata,
 } from "../services/civitai-resolver.js";
 import { ValidationError, errorToToolResult } from "../utils/errors.js";
@@ -113,10 +115,26 @@ export function registerModelExtrasTools(server: McpServer): void {
       "the user's checkpoint family is known, so results actually fit their setup. Each hit returns the " +
       "model_id and version_id that download_civitai_model takes directly, plus trigger words to use in the " +
       "prompt after installing. Flow: search_civitai_models → pick a hit → download_civitai_model " +
-      "{model_version_id, target_subfolder} → wire/prompt with the trained words. SFW-only by default. " +
-      "For HuggingFace search use search_models.",
+      "{model_version_id, target_subfolder} → wire/prompt with the trained words. Pass `creator` (exact " +
+      "username, e.g. from search_civitai_creators) to list ONE creator's models — with or without a query. " +
+      "SFW-only by default. For HuggingFace search use search_models.",
     {
-      query: z.string().min(1).describe("Keyword search (e.g. 'detail enhancer', 'anime style', a character name)"),
+      query: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Keyword search (e.g. 'detail enhancer', 'anime style', a character name). " +
+            "Optional when creator is given (then it narrows that creator's models).",
+        ),
+      creator: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Only models by this CivitAI creator (EXACT username — find it with " +
+            "search_civitai_creators). At least one of query/creator is required.",
+        ),
       types: z
         .array(z.enum(["Checkpoint", "LORA", "LoCon", "DoRA", "TextualInversion", "VAE", "Controlnet", "Upscaler", "MotionModule", "Workflows"]))
         .optional()
@@ -134,22 +152,38 @@ export function registerModelExtrasTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const hits = await searchCivitaiModels(args.query, {
+        if (!args.query?.trim() && !args.creator?.trim()) {
+          throw new ValidationError(
+            "Provide a query, a creator (exact username), or both.",
+          );
+        }
+        const hits = await searchCivitaiModels(args.query ?? "", {
           types: args.types,
           baseModels: args.base_models,
           sort: args.sort,
           nsfw: args.nsfw,
           limit: args.limit,
+          creator: args.creator,
         });
+        const what = [
+          args.query?.trim() && `"${args.query}"`,
+          args.creator?.trim() && `creator ${args.creator}`,
+        ]
+          .filter(Boolean)
+          .join(" by ");
         if (hits.length === 0) {
           return {
             content: [
               {
                 type: "text",
                 text:
-                  `No CivitAI models matched "${args.query}"` +
+                  `No CivitAI models matched ${what}` +
                   (args.base_models?.length ? ` for base ${args.base_models.join("/")}` : "") +
-                  `. Try a broader query, drop the filters, or search HuggingFace with search_models.`,
+                  `. Try a broader query, drop the filters` +
+                  (args.creator
+                    ? `, check the exact username with search_civitai_creators (creators with only NSFW models need nsfw:true)`
+                    : "") +
+                  `, or search HuggingFace with search_models.`,
               },
             ],
           };
@@ -180,9 +214,110 @@ export function registerModelExtrasTools(server: McpServer): void {
             {
               type: "text",
               text:
-                `${hits.length} CivitAI result(s) for "${args.query}":\n\n${lines.join("\n\n")}\n\n` +
+                `${hits.length} CivitAI result(s) for ${what}:\n\n${lines.join("\n\n")}\n\n` +
                 `Next: download_civitai_model {"model_version_id": <id>, "target_subfolder": "<loras|checkpoints|...>"} — then use the trigger words in the prompt.` +
                 tokenNote,
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "search_civitai_creators",
+    "Find CivitAI CREATORS — THE tool for 'who are the top creators on Civitai' and 'find creator <name>'. " +
+      "Read-only and network-only (no token or running ComfyUI required). Two modes: with NO query it returns " +
+      "the site's creator LEADERBOARD (civitai.com/leaderboard — rank, score, downloads, likes; pick a `board`: " +
+      "'overall' [default], 'overall_90' [last 90 days], 'overall_nsfw' [mature], 'new_creators' [first model " +
+      "<30 days ago]); with a `query` it searches usernames (public /api/v1/creators; partial match, returns " +
+      "model counts, NOT ranked). Each hit's username feeds search_civitai_models {creator: <username>} " +
+      "directly. Flow: search_civitai_creators → pick a creator → search_civitai_models {creator, types?} → " +
+      "download_civitai_model.",
+    {
+      query: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Username search (partial match, e.g. 'alcait'). Omit to get the top-creators leaderboard instead.",
+        ),
+      board: z
+        .enum(["overall", "overall_90", "overall_nsfw", "new_creators"])
+        .optional()
+        .describe(
+          "Leaderboard to rank by when no query is given (default 'overall'). Ignored with a query.",
+        ),
+      limit: z.number().int().min(1).max(50).optional().describe("Max results (default 10)."),
+    },
+    async (args) => {
+      try {
+        if (args.query?.trim()) {
+          const { hits, total } = await searchCivitaiCreators(args.query, {
+            limit: args.limit,
+          });
+          if (hits.length === 0) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `No CivitAI creators matched "${args.query}". Usernames match on substrings — ` +
+                    `try a shorter fragment, or omit the query for the top-creators leaderboard.`,
+                },
+              ],
+            };
+          }
+          const lines = hits.map(
+            (h, i) =>
+              `${i + 1}. **${h.username}** — ${h.model_count ?? 0} model(s) · ${h.profile_url}`,
+          );
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `${hits.length} CivitAI creator(s) for "${args.query}"` +
+                  (total != null ? ` (${total.toLocaleString()} total match${total === 1 ? "" : "es"})` : "") +
+                  `:\n\n${lines.join("\n")}\n\n` +
+                  `Next: search_civitai_models {"creator": "<username>"} to list a creator's models.`,
+              },
+            ],
+          };
+        }
+
+        const board = args.board ?? "overall";
+        const hits = await fetchCivitaiTopCreators({ board, limit: args.limit });
+        if (hits.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `CivitAI returned an empty "${board}" leaderboard. Try again later or search by name with a query.`,
+              },
+            ],
+          };
+        }
+        const lines = hits.map((h) => {
+          const stats = [
+            h.score != null && `score ${h.score.toLocaleString()}`,
+            h.downloads != null && `${h.downloads.toLocaleString()} downloads`,
+            h.thumbs_up != null && `${h.thumbs_up.toLocaleString()} 👍`,
+            h.entries != null && `${h.entries} model(s) counted`,
+          ]
+            .filter(Boolean)
+            .join(" · ");
+          return `${h.position ?? "?"}. **${h.username}** — ${stats}\n   ${h.profile_url}`;
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Top ${hits.length} CivitAI creators ("${board}" leaderboard):\n\n${lines.join("\n\n")}\n\n` +
+                `Next: search_civitai_models {"creator": "<username>"} to list a creator's models, then download_civitai_model.`,
             },
           ],
         };

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -157,7 +157,7 @@ export function registerModelExtrasTools(server: McpServer): void {
             "Provide a query, a creator (exact username), or both.",
           );
         }
-        const hits = await searchCivitaiModels(args.query ?? "", {
+        const { hits, scanned, scanCapped } = await searchCivitaiModels(args.query ?? "", {
           types: args.types,
           baseModels: args.base_models,
           sort: args.sort,
@@ -165,6 +165,11 @@ export function registerModelExtrasTools(server: McpServer): void {
           limit: args.limit,
           creator: args.creator,
         });
+        // Creator+keyword scans are bounded (client-side keyword filter over
+        // paged results) — never present a capped miss as definitive.
+        const capNote = scanCapped
+          ? `\nNOTE: the keyword was matched client-side over only this creator's first ${scanned} models (scan cap) — matching models past that may exist. Narrow with types/base_models, or drop the query to list everything.`
+          : "";
         const what = [
           args.query?.trim() && `"${args.query}"`,
           args.creator?.trim() && `creator ${args.creator}`,
@@ -183,7 +188,8 @@ export function registerModelExtrasTools(server: McpServer): void {
                   (args.creator
                     ? `, check the exact username with search_civitai_creators (creators with only NSFW models need nsfw:true)`
                     : "") +
-                  `, or search HuggingFace with search_models.`,
+                  `, or search HuggingFace with search_models.` +
+                  capNote,
               },
             ],
           };
@@ -216,6 +222,7 @@ export function registerModelExtrasTools(server: McpServer): void {
               text:
                 `${hits.length} CivitAI result(s) for ${what}:\n\n${lines.join("\n\n")}\n\n` +
                 `Next: download_civitai_model {"model_version_id": <id>, "target_subfolder": "<loras|checkpoints|...>"} — then use the trigger words in the prompt.` +
+                capNote +
                 tokenNote,
             },
           ],


### PR DESCRIPTION
## What

Discord mobile-beta request (help thread 1527122588189327421, seanmcmagic): *"An option to search posts by top creators, similar to the leaderboard on the actual website"* (Civitai).

- **New tool `search_civitai_creators`**
  - **No query → top creators**: the site's creator leaderboard (what civitai.com/leaderboard shows) — rank, score, downloads, likes, entries, profile link. `board` picks `overall` (default), `overall_90`, `overall_nsfw`, or `new_creators`.
  - **With a query → username search** via the documented public `GET /api/v1/creators` (partial match, model counts, total).
  - Every hit hands off to `search_civitai_models {"creator": "<username>"}`.
- **`search_civitai_models` gains `creator`** (exact username; `query` is now optional — at least one of the two is required). Lists one creator's models, optionally narrowed by keyword.
- Both search tools added to the mobile `call_tool` whitelist (read-only, non-destructive).
- CHANGELOG Unreleased entry.

## Why the tRPC leaderboard

The public v1 API has **no leaderboard ordering** — `/api/v1/creators` is join-date ordered (first result is JustMaier, user #1). The website's own ranking comes from `GET /api/trpc/leaderboard.getLeaderboard`, which works unauthenticated **but** the bot gate intermittently 401s a plain fetch UA ("Please use the public API instead"), so the request carries browser-shaped headers — the exact approach the mobile app already uses for its other tRPC calls (`image.getGenerationData`, favorites). No API token is sent to the tRPC surface.

## API quirk (live-verified)

`/api/v1/models?query=X&username=Y` returns an **empty page** even when the creator has matching models (e.g. `username=alcaitiff&query=detail` → `[]` despite their "Detail Slider"). So creator mode sends only `username` (over-fetching to 100) and applies the keyword client-side over model name + tags.

## Verified

- `npm run build` — clean.
- Full vitest suite: **127 files / 1407 tests passed** (16 new: resolver creator/leaderboard parsing + kill-switch + bot-gate headers; tool-level modes/validation/hand-off text).
- **Live against civitai.com** (built dist): `fetchCivitaiTopCreators` → alcaitiff / circlestone_labs / MIAOKA with ranks+scores; `searchCivitaiCreators('alcait')` → alcaitiff (55 models); `searchCivitaiModels('', {creator})` → their LoRAs; `searchCivitaiModels('detail', {creator})` → only the Detail-named models.

## Not verified / risks

- The leaderboard tRPC endpoint is **undocumented** — Civitai could change its shape or tighten the bot gate; failure mode is a clean `ModelError` surfaced as a tool error. The mobile app already carries this exact dependency.
- The bot gate is flaky (one bare-UA probe returned 200, the next 401) — browser headers made 100% of probes succeed, but rate-limit behavior under heavy use is unknown.
- Leaderboard boards beyond the 4 exposed (images, generators, trainers, …) exist upstream but are creator-of-*content* boards; kept scope to model creators since the hand-off is `search_civitai_models`.

Companion mobile PR: artokun/comfyui-mcp-mobile (creator filter + top-creators picker in the CivitAI browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 1 (Codex) — addressed in d6eba53

- **Bounded pagination for the creator+keyword scan**: the client-side keyword filter previously saw only the creator's first 100 models; it now follows cursor pagination up to 4 pages (100/page), stops early once `limit` matches are found, and the tool result carries an explicit *scan cap* note whenever pages were left unscanned with fewer than `limit` matches — a capped miss is never presented as definitive. `searchCivitaiModels` returns `{ hits, scanned?, scanCapped? }`; new tests cover a page-two match, the 4-page cap, early stop on limit, and the cap note. Full suite: 127 files / 1412 tests green; all three modes re-verified live against civitai.com.

## Design note: mobile talks to Civitai directly

The companion mobile PR (artokun/comfyui-mcp-mobile#2) intentionally does **not** consume these MCP tools: the mobile app's CivitAI browser has always spoken to CivitAI directly (civitai.red REST + MeiliSearch + tRPC) so browsing works without the rig connected, and its creator filter follows that existing pattern. The MCP tools here serve every *agent* client (panel, Claude, compact/Ollama tool mode) and are additionally whitelisted on the `call_tool` channel so the mobile client *could* switch to rig-side search later without a server change. Divergence is deliberate and documented in both PRs.
