### PR TITLE
feat: mobile workflows-over-tunnel fix + desktop-tab mirror (remote control)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -674,6 +674,60 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(phoneGotResult).toBe(false);
   });
 
+  it("mirrors only allowlisted activity frames — never secret/correlated ones (cid-less too)", async () => {
+    await connectPanel("desktop-8", "G");
+    const phone = await connectHeadless("phone-8");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-8" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    const leaked: string[] = [];
+    phone.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.type && m.type !== "tab_attached" && m.type !== "tab_list") leaked.push(m.type);
+    });
+    // cid-LESS correlated/secret frames that a denylist-by-cid would have leaked.
+    bridge.push({ type: "pair_url", url: "https://pair.example/secret" }, "desktop-8");
+    bridge.push({ type: "secret_saved", key: "CIVITAI_API_TOKEN" }, "desktop-8");
+    bridge.push({ type: "ack", ok: true, kind: "new_session" }, "desktop-8");
+    bridge.push({ type: "backends", backends: [] }, "desktop-8");
+    // history_list reply to a NO-cid request → cid:undefined, would slip a cid guard.
+    bridge.push({ type: "history_list", cid: undefined, sessions: [] }, "desktop-8");
+    await settle();
+    expect(leaked).toEqual([]); // nothing off the allowlist reached the viewer
+
+    // …but a genuine activity frame still mirrors.
+    const onPhone = nextFrame(phone, (m) => m.type === "say" && m.text === "hi");
+    bridge.push({ type: "say", text: "hi" }, "desktop-8");
+    await onPhone;
+  });
+
+  it("routes an attached viewer's input to the mirrored tab's session (remote control)", async () => {
+    await connectPanel("desktop-9", "G");
+    const phone = await connectHeadless("phone-9");
+    await settle();
+    const seen: Array<{ type?: string; tab_id?: string; text?: string }> = [];
+    bridge.onPanelMessage = (e) => seen.push(e as { type?: string; tab_id?: string; text?: string });
+
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-9" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    // The phone sends a chat message (no tab_id — the server stamps it). While
+    // attached it must drive desktop-9's session, NOT the phone's own tab.
+    phone.send(JSON.stringify({ type: "user_message", text: "drive it", context: {} }));
+    await settle();
+    const drove = seen.find((e) => e.type === "user_message" && e.text === "drive it");
+    expect(drove?.tab_id).toBe("desktop-9");
+
+    // After detach, the phone's input reverts to its own tab.
+    phone.send(JSON.stringify({ type: "detach_tab" }));
+    await settle();
+    phone.send(JSON.stringify({ type: "user_message", text: "my own", context: {} }));
+    await settle();
+    const own = seen.find((e) => e.type === "user_message" && e.text === "my own");
+    expect(own?.tab_id).toBe("phone-9");
+  });
+
   it("rejects attach to a non-existent desktop tab", async () => {
     const phone = await connectHeadless("phone-5");
     await settle();

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -755,4 +755,62 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     bridge.push({ type: "say", text: "post-migrate" }, "old-id");
     await onPhone; // resolves, or the test times out (fan-out broke)
   });
+
+  it("refuses a headless hello takeover of a desktop tab id (no drive-path hijack)", async () => {
+    const desktop = await connectPanel("desktop-h", "G");
+    autoReply(desktop, "desktop");
+    const phone = await connectHeadless("phone-h");
+    await settle();
+
+    // Malicious: the phone re-hellos under the DESKTOP's id to seize it without
+    // going through attach_tab. This must be refused — the desktop stays primary.
+    phone.send(JSON.stringify({ type: "hello", tab_id: "desktop-h", title: "evil", headless: true }));
+    await settle();
+
+    const res = (await bridge.send({ cmd: "graph_state" } as { cmd: string }, {
+      tabId: "desktop-h",
+    })) as { from?: string };
+    expect(res.from).toBe("desktop"); // desktop not evicted; the takeover was refused
+  });
+
+  it("re-attaching to another tab stops the first tab's fanout", async () => {
+    await connectPanel("desktop-A", "A");
+    await connectPanel("desktop-B", "B");
+    const phone = await connectHeadless("phone-ab");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "1", target_tab_id: "desktop-A" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached" && m.cid === "1");
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "2", target_tab_id: "desktop-B" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached" && m.cid === "2");
+
+    let gotA = false;
+    phone.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.type === "say" && m.text === "from-A") gotA = true;
+    });
+    bridge.push({ type: "say", text: "from-A" }, "desktop-A"); // old tab — must NOT arrive
+    const onB = nextFrame(phone, (m) => m.type === "say" && m.text === "from-B");
+    bridge.push({ type: "say", text: "from-B" }, "desktop-B"); // new tab — must arrive
+    await onB;
+    expect(gotA).toBe(false);
+  });
+
+  it("reverts a viewer's drive to its own tab when the mirrored desktop closes", async () => {
+    const desktop = await connectPanel("desktop-c", "G");
+    const phone = await connectHeadless("phone-c");
+    await settle();
+    const seen: Array<{ type?: string; tab_id?: string; text?: string }> = [];
+    bridge.onPanelMessage = (e) => seen.push(e as { type?: string; tab_id?: string; text?: string });
+
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-c" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    desktop.close(); // the mirrored desktop goes away
+    await settle();
+
+    phone.send(JSON.stringify({ type: "user_message", text: "after-close", context: {} }));
+    await settle();
+    const msg = seen.find((e) => e.type === "user_message" && e.text === "after-close");
+    expect(msg?.tab_id).toBe("phone-c"); // reverted to own tab, not routed into the dead id
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -773,6 +773,24 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(res.from).toBe("desktop"); // desktop not evicted; the takeover was refused
   });
 
+  it("refuses a hello takeover even when the viewer FORGES headless:false (kind is pinned)", async () => {
+    const desktop = await connectPanel("desktop-hf", "G");
+    autoReply(desktop, "desktop");
+    // The phone's FIRST hello pins it as headless; connectHeadless sends headless:true.
+    const phone = await connectHeadless("phone-hf");
+    await settle();
+
+    // The bypass: forge headless:false to match the desktop's kind. The pinned
+    // socket kind must win, so this is still refused and the desktop stays primary.
+    phone.send(JSON.stringify({ type: "hello", tab_id: "desktop-hf", title: "evil", headless: false }));
+    await settle();
+
+    const res = (await bridge.send({ cmd: "graph_state" } as { cmd: string }, {
+      tabId: "desktop-hf",
+    })) as { from?: string };
+    expect(res.from).toBe("desktop"); // forged flag ignored — takeover refused
+  });
+
   it("re-attaching to another tab stops the first tab's fanout", async () => {
     await connectPanel("desktop-A", "A");
     await connectPanel("desktop-B", "B");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -653,4 +653,49 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await settle();
     expect(phoneGotSay).toBe(false);
   });
+
+  it("never fans out a correlated reply (cid-bearing) to mirror viewers", async () => {
+    await connectPanel("desktop-4", "G");
+    const phone = await connectHeadless("phone-4");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-4" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    let phoneGotResult = false;
+    phone.on("message", (buf) => {
+      if (JSON.parse(buf.toString()).type === "tool_result") phoneGotResult = true;
+    });
+    // A tool_result for the desktop tab must NOT leak to the mirror viewer.
+    bridge.push(
+      { type: "tool_result", cid: "x", tool: "list_workflows", ok: true, result: [] },
+      "desktop-4",
+    );
+    await settle();
+    expect(phoneGotResult).toBe(false);
+  });
+
+  it("rejects attach to a non-existent desktop tab", async () => {
+    const phone = await connectHeadless("phone-5");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "ghost" }));
+    const att = await nextFrame(phone, (m) => m.type === "tab_attached");
+    expect(att.ok).toBe(false);
+  });
+
+  it("keeps mirroring across a same-socket tab-id migration", async () => {
+    const desktop = await connectPanel("old-id", "G");
+    const phone = await connectHeadless("phone-6");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "old-id" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    // Desktop re-hellos under a NEW id on the SAME socket (the migration path).
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "new-id", title: "G" }));
+    await settle();
+
+    // A push to the NEW id must still reach the phone (subscriber set moved).
+    const onPhone = nextFrame(phone, (m) => m.type === "say" && m.text === "post-migrate");
+    bridge.push({ type: "say", text: "post-migrate" }, "new-id");
+    await onPhone; // resolves, or the test times out (fan-out broke)
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -693,9 +693,12 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.send(JSON.stringify({ type: "hello", tab_id: "new-id", title: "G" }));
     await settle();
 
-    // A push to the NEW id must still reach the phone (subscriber set moved).
+    // The real scenario: the tab's AGENT keeps pushing under the ORIGINAL id
+    // ("old-id") after the migration — the fan-out must resolve that through the
+    // migration map to the moved subscriber set (keyed under the canonical id).
+    // Pushing under the new id would mask the bug (codex review).
     const onPhone = nextFrame(phone, (m) => m.type === "say" && m.text === "post-migrate");
-    bridge.push({ type: "say", text: "post-migrate" }, "new-id");
+    bridge.push({ type: "say", text: "post-migrate" }, "old-id");
     await onPhone; // resolves, or the test times out (fan-out broke)
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -555,3 +555,102 @@ describe("UiBridge (multi-tab)", () => {
     }
   });
 });
+
+// ── Desktop-tab mirror: multi-viewer fanout (mobile remote control) ───────────
+function connectHeadless(tabId: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const sock = new WebSocket(`ws://127.0.0.1:${port}`);
+    sock.on("open", () => {
+      sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title: "phone", headless: true }));
+      resolve(sock);
+    });
+    sock.on("error", reject);
+  });
+}
+
+function nextFrame(
+  sock: WebSocket,
+  match: (m: Record<string, unknown>) => boolean,
+  timeoutMs = 1500,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => {
+      sock.off("message", h);
+      reject(new Error("timeout waiting for frame"));
+    }, timeoutMs);
+    function h(buf: WebSocket.RawData) {
+      const m = JSON.parse(buf.toString());
+      if (match(m)) {
+        clearTimeout(t);
+        sock.off("message", h);
+        resolve(m);
+      }
+    }
+    sock.on("message", h);
+  });
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 60));
+
+describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
+  it("lists desktop tabs (excluding headless viewers), attaches, and fans push out to primary + viewer", async () => {
+    const desktop = await connectPanel("desktop-1", "My Graph");
+    const phone = await connectHeadless("phone-1");
+    await settle();
+
+    phone.send(JSON.stringify({ type: "list_tabs", cid: "c1" }));
+    const list = await nextFrame(phone, (m) => m.type === "tab_list" && m.cid === "c1");
+    const tabs = list.tabs as Array<{ tab_id: string; title: string }>;
+    expect(tabs.map((t) => t.tab_id)).toContain("desktop-1");
+    expect(tabs.find((t) => t.tab_id === "desktop-1")?.title).toBe("My Graph");
+    expect(tabs.some((t) => t.tab_id === "phone-1")).toBe(false); // headless not listed
+
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "c2", target_tab_id: "desktop-1" }));
+    const att = await nextFrame(phone, (m) => m.type === "tab_attached" && m.cid === "c2");
+    expect(att.ok).toBe(true);
+    expect(bridge.connected()).toBe(true); // attach did NOT evict the primary
+
+    const onDesktop = nextFrame(desktop, (m) => m.type === "say" && m.text === "hello");
+    const onPhone = nextFrame(phone, (m) => m.type === "say" && m.text === "hello");
+    bridge.push({ type: "say", text: "hello" }, "desktop-1");
+    await Promise.all([onDesktop, onPhone]); // both receive, or the test times out
+  });
+
+  it("canvas send() targets the primary only, never a mirror viewer", async () => {
+    const desktop = await connectPanel("desktop-2", "G");
+    autoReply(desktop, "desktop");
+    const phone = await connectHeadless("phone-2");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-2" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    let phoneGotCmd = false;
+    phone.on("message", (buf) => {
+      if (JSON.parse(buf.toString()).cmd) phoneGotCmd = true;
+    });
+    const res = (await bridge.send({ cmd: "graph_state" } as { cmd: string }, {
+      tabId: "desktop-2",
+    })) as { from?: string };
+    expect(res.from).toBe("desktop");
+    await settle();
+    expect(phoneGotCmd).toBe(false);
+  });
+
+  it("detach_tab stops the fanout", async () => {
+    await connectPanel("desktop-3", "G");
+    const phone = await connectHeadless("phone-3");
+    await settle();
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "desktop-3" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+    phone.send(JSON.stringify({ type: "detach_tab" }));
+    await settle();
+
+    let phoneGotSay = false;
+    phone.on("message", (buf) => {
+      if (JSON.parse(buf.toString()).type === "say") phoneGotSay = true;
+    });
+    bridge.push({ type: "say", text: "after-detach" }, "desktop-3");
+    await settle();
+    expect(phoneGotSay).toBe(false);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -509,6 +509,30 @@ export function getApiKey(): string {
   return config.comfyuiApiKey;
 }
 
+/**
+ * Retarget the shared `config` (and thus getComfyUIApiHost()/getClient()) to a new
+ * ComfyUI URL at runtime. The panel orchestrator calls this from applyComfyuiUrl when
+ * the desktop `hello` points at a different ComfyUI, so the orchestrator's OWN
+ * in-process client — the direct call_tool path used by the mobile app (list_workflows,
+ * get_image, …) — follows the retarget instead of staying pinned to the process-start
+ * ComfyUI. Callers MUST resetClient() afterwards so the cached client rebuilds against
+ * the new host. Returns false on a malformed URL (target left unchanged).
+ */
+export function setComfyuiTarget(url: string): boolean {
+  let t: ComfyUITarget;
+  try {
+    t = parseComfyUIUrl(url);
+  } catch {
+    return false;
+  }
+  config.comfyuiHost = t.host;
+  config.comfyuiPort = t.port;
+  config.resolvedPort = t.port;
+  config.comfyuiSsl = t.ssl;
+  config.comfyuiBasePath = t.basePath;
+  return true;
+}
+
 export function getComfyUIApiHost(): string {
   return `${config.comfyuiHost}:${config.resolvedPort}`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -386,7 +386,9 @@ const urlOverride = resolveUrlOverride();
 const cloudApiKey = process.env.COMFYUI_API_KEY?.trim() || undefined;
 const cloudActive = Boolean(cloudApiKey);
 const forceRemote = resolveForceRemote();
-const remoteUrlActive =
+// Mutable: setComfyuiTarget() re-classifies this on a runtime retarget so
+// isRemoteMode()/isLocalMode() track the new host instead of the startup one.
+let remoteUrlActive =
   Boolean(urlOverride) && (forceRemote || !isLoopbackHost(urlOverride?.host));
 
 if (cloudActive) {
@@ -530,6 +532,19 @@ export function setComfyuiTarget(url: string): boolean {
   config.resolvedPort = t.port;
   config.comfyuiSsl = t.ssl;
   config.comfyuiBasePath = t.basePath;
+  // Re-classify local vs remote so isRemoteMode()/isLocalMode() follow the new
+  // target — they read this module-level flag, not the host on each call, so a
+  // retarget that crosses the loopback boundary would otherwise stay misclassed.
+  remoteUrlActive = forceRemote || !isLoopbackHost(t.host);
+  // Keep comfyuiPath consistent with the mode: a remote target has no local FS
+  // (local-FS tools must throw), a loopback target re-resolves the local path
+  // (honoring COMFYUI_PATH). Without this, remote→local leaves path undefined and
+  // local→remote leaves a stale local path that FS tools would wrongly trust.
+  config.comfyuiPath = resolveComfyUIPath(process.env.COMFYUI_PATH, {
+    remoteUrl: remoteUrlActive,
+    cloud: isCloudMode(),
+    remoteHost: t.host,
+  });
   return true;
 }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2061,6 +2061,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // doesn't linger. The new provider starts a FRESH session (the panel
         // replays the transcript as context on its first message to seed it).
         manager.reset(panelTab + AGENT_KEY_SEP + prev);
+        bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
       }
       tabBackends.set(panelTab, backend);
       // A headless client (mobile/remote pseudo-panel, no browser canvas) advertises
@@ -2282,7 +2283,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         return;
       }
       const prev = tabBackends.get(panelTab) ?? defaultBackend;
-      if (prev !== reqBackend) manager.reset(panelTab + AGENT_KEY_SEP + prev);
+      if (prev !== reqBackend) {
+        manager.reset(panelTab + AGENT_KEY_SEP + prev);
+        bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
+      }
       tabBackends.set(panelTab, reqBackend);
       // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —
       // the point of switching to Claude/hosted is usually reclaiming the GPU.

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1597,6 +1597,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     // Report the SDK session id so the panel can persist it and resume on reload.
     onSession: (key, sessionId) => {
       bridge.push({ type: "session", session_id: sessionId }, panelTabOf(key));
+      bridge.broadcastTabList(); // a session started/changed → refresh mirror pickers
     },
     // Per-turn rewind anchor (assistant UUID) → the panel stores it so a later
     // "rewind conversation to here" can fork the session at that point.
@@ -1637,6 +1638,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Let refreshEnvCapabilities() feed a freshly-gathered env block into agents
   // spawned after a ComfyUI restart/reconnect.
   liveManager = manager;
+
+  // Flag the mobile mirror picker's "session attached" (green) dot from live agents.
+  bridge.setHasSessionPredicate((tabId) => manager.hasLiveAgent(agentKeyFor(tabId)));
 
   // ── Local-agent VRAM pause during generation ────────────────────────────
   // On a single-GPU box the local Ollama chat model and ComfyUI fight for VRAM:

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2761,6 +2761,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       manager.reset(agentKeyFor(tabId));
       bridge.push({ type: "session", session_id: null }, tabId);
       bridge.push({ type: "ack", ok: true, kind: "new_session" }, tabId);
+      bridge.broadcastTabList(); // session cleared → mirror pickers' green dot off
       return;
     }
 
@@ -2799,6 +2800,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       manager.reset(key);
       if (sid) manager.setResume(key, sid);
       bridge.push({ type: "ack", ok: true, kind: "resume_session" }, tabId);
+      bridge.broadcastTabList(); // live agent dropped → refresh mirror pickers
       return;
     }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -23,7 +23,7 @@ import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
 import { SessionStore } from "./session-store.js";
 import { listSessions, loadTranscript } from "./history.js";
-import { uploadImageHttp } from "../comfyui/client.js";
+import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
 import {
   PanelAgentManager,
@@ -41,7 +41,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
-import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath } from "../config.js";
+import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget } from "../config.js";
 import {
   buildComfyuiMcpEnv,
   comfyuiSecretKeys,
@@ -1718,6 +1718,14 @@ export async function runPanelOrchestrator(): Promise<void> {
     const prev = comfyuiUrl;
     comfyuiUrl = next;
     comfyuiPath = localPathForTarget(next);
+    // Retarget the orchestrator's OWN in-process ComfyUI client too — the direct
+    // call_tool path the mobile app uses (list_workflows, get_image, …) goes through
+    // getClient(), which caches against the process-start host. Without this, a
+    // retargeted orchestrator keeps that client pinned to the old ComfyUI, so mobile
+    // list_workflows silently reads the wrong (often empty) library. resetClient()
+    // forces getClient() to rebuild against the new host on its next use.
+    setComfyuiTarget(next);
+    resetClient();
     // Point every provider at the new target: Claude via its rebuilt MCP env, the
     // manager's image-fetch URL, then respawn active agents so the live comfyui MCP
     // subprocess is recreated with the new COMFYUI_URL (no-op if none are running —

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1168,6 +1168,12 @@ export class PanelAgentManager {
     this.opts.comfyuiUrl = comfyuiUrl;
   }
 
+  /** Whether a live agent (session) exists for this composite key — used to flag
+   *  the mobile mirror picker's "session attached" dot. */
+  hasLiveAgent(key: string): boolean {
+    return this.agents.has(key);
+  }
+
   /** Respawn every active tab's agent (resume + carry-over) so the live comfyui
    *  MCP subprocess is recreated with the updated env. Deferred to each tab's
    *  next idle so the turn that SAVED the secret finishes first (we never

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -495,8 +495,27 @@ export class UiBridge {
           }
         }
         tabId = msg.tab_id;
+        const incomingHeadless = (msg as { headless?: unknown }).headless === true;
         const existing = this.conns.get(tabId);
         if (existing && existing.sock !== sock) {
+          // SECURITY: a viewer must not hello-hijack another client's tab id. The
+          // reconnect-supersede path evicts the current holder, so without this a
+          // headless phone could re-hello under a DESKTOP's id, kill its socket, and
+          // register as that tab — bypassing attach_tab's authoritative stamping and
+          // driving the tab it never attached to. Only same-kind reconnects (a real
+          // reload: desktop→desktop, phone→phone) may supersede. Cross-kind is refused.
+          if (existing.headless !== incomingHeadless) {
+            logger.warn(
+              `[ui-bridge] refused cross-kind hello takeover of tab ${tabId.slice(0, 8)} ` +
+              `(existing headless=${existing.headless}, incoming headless=${incomingHeadless})`,
+            );
+            try {
+              sock.close();
+            } catch {
+              // Already gone.
+            }
+            return;
+          }
           // Same tab reconnected (reload) — supersede the stale socket.
           try {
             existing.sock.close();
@@ -587,6 +606,11 @@ export class UiBridge {
         // and prevent subscribing to another headless (mobile) client.
         const valid = this.conns.has(target) && !this.headlessSeen.has(target);
         if (valid) {
+          // A viewer mirrors ONE tab at a time — drop any prior subscription first so
+          // re-attaching (A→B) doesn't keep streaming A's activity alongside B's.
+          for (const [tid, s] of this.subscribers) {
+            if (s.delete(sock) && s.size === 0) this.subscribers.delete(tid);
+          }
           let set = this.subscribers.get(target);
           if (!set) {
             set = new Set();
@@ -653,6 +677,13 @@ export class UiBridge {
         wasPrimary = true;
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.lastActiveTabId = null;
+        // The mirrored desktop tab is gone — detach its viewers so their input
+        // reverts to their OWN session instead of routing into a dead id (and its
+        // output isn't silently buffered forever). They can re-attach if it returns.
+        for (const [s, drivenTab] of this.mirrorViewers) {
+          if (drivenTab === tabId) this.mirrorViewers.delete(s);
+        }
+        this.subscribers.delete(tabId);
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -75,6 +75,28 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
+/**
+ * Frame `type`s that are safe to MIRROR to a tab's viewers — genuine shared-session
+ * activity a remote-control phone should see. This is an ALLOWLIST (default-deny):
+ * a `cid`-based denylist leaked cid-less correlated replies (pair_url, secret_saved,
+ * OAuth acks, and history replies to a no-cid request). Anything not listed here —
+ * acks, model/backend config, pairing/secret frames, correlated replies — stays with
+ * the primary and the ONE socket that asked. New frame types are non-mirroring until
+ * explicitly added, so a future secret-bearing frame can't leak by default.
+ */
+const MIRROR_SAFE_FRAME_TYPES: ReadonlySet<string> = new Set([
+  "say",
+  "stream",
+  "thinking",
+  "echo",
+  "turn",
+  "turn_anchor",
+  "session",
+  "agent_status",
+  "action",
+  "download_progress",
+]);
+
 export class UiBridge {
   /** Max EADDRINUSE retries before degrading to "panel unavailable". */
   private static readonly MAX_BIND_ATTEMPTS = 5;
@@ -104,6 +126,11 @@ export class UiBridge {
    *  socket-scoped. Keyed by the mirrored (primary) tabId. Empty in the normal
    *  case → zero effect on existing panel behavior. */
   private subscribers = new Map<string, Set<BridgeSocket>>();
+  /** A mirroring viewer's socket → the desktop tab it drives. While attached, the
+   *  viewer's INBOUND events (user_message, interrupt, new_session, …) are routed
+   *  to THIS tab's shared session instead of the viewer's own — that's what makes
+   *  it remote control rather than a passive view. Cleared on detach/disconnect. */
+  private mirrorViewers = new Map<BridgeSocket, string>();
   /** Injected by the orchestrator: does this tabId have a live agent session?
    *  (SessionStore/PanelAgentManager live there.) Flags desktopTabs() for the
    *  mobile mirror picker's green "session attached" dot. */
@@ -461,6 +488,11 @@ export class UiBridge {
             for (const s of migSubs) dest.add(s);
             this.subscribers.set(msg.tab_id as string, dest);
           }
+          // Re-point any viewers driving the OLD id at the new one so their input
+          // keeps reaching this tab's session across the re-hello.
+          for (const [s, drivenTab] of this.mirrorViewers) {
+            if (drivenTab === tabId) this.mirrorViewers.set(s, msg.tab_id as string);
+          }
         }
         tabId = msg.tab_id;
         const existing = this.conns.get(tabId);
@@ -561,6 +593,8 @@ export class UiBridge {
             this.subscribers.set(target, set);
           }
           set.add(sock);
+          // Route this viewer's inbound events to the mirrored tab (remote control).
+          this.mirrorViewers.set(sock, target);
         }
         try {
           sock.send(
@@ -581,15 +615,22 @@ export class UiBridge {
         for (const [tid, set] of this.subscribers) {
           if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
         }
+        this.mirrorViewers.delete(sock); // stop routing its input to the mirrored tab
         return;
       }
 
-      // Panel-initiated event. Stamp the tab and track activity.
+      // Panel-initiated event. Stamp the tab and track activity. A mirroring viewer
+      // (phone attached to a desktop tab) DRIVES that tab's shared session, so its
+      // events route to the mirrored tab id — not the viewer's own — which is what
+      // turns the mirror into remote control. Stamping is server-authoritative here
+      // (it overwrites any client-supplied tab_id), so a viewer can't target a tab
+      // it hasn't attached to.
       if (typeof msg.type === "string") {
-        if (tabId) {
-          msg.tab_id = tabId;
-          msg.title = this.conns.get(tabId)?.title;
-          if (msg.type === "user_message") this.lastActiveTabId = tabId;
+        const effectiveTab = this.mirrorViewers.get(sock) ?? tabId;
+        if (effectiveTab) {
+          msg.tab_id = effectiveTab;
+          msg.title = this.conns.get(effectiveTab)?.title;
+          if (msg.type === "user_message") this.lastActiveTabId = effectiveTab;
         }
         this.onPanelMessage?.(msg as PanelEvent);
       }
@@ -606,6 +647,7 @@ export class UiBridge {
       for (const [tid, set] of this.subscribers) {
         if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
       }
+      this.mirrorViewers.delete(sock);
       let wasPrimary = false;
       if (tabId && this.conns.get(tabId)?.sock === sock) {
         wasPrimary = true;
@@ -871,17 +913,10 @@ export class UiBridge {
     // Mirror fan-out: also deliver a tab-scoped frame to any phones mirroring this
     // tab (remote control). No-op when nothing is subscribed → existing panel
     // behavior unchanged. The primary is already in `targets`, so skip it here.
-    // NEVER fan out a correlated reply — those carry a `cid` and belong to the ONE
-    // socket that made the request (e.g. tool_result); mirroring them would leak
-    // another client's result to viewers. `pair_url`/`pair_error` are correlated
-    // too but carry no cid, so exclude them by type — a pairing URL is meant for
-    // the ONE panel that asked, never for a mirroring phone.
-    if (
-      tabId &&
-      frame.cid === undefined &&
-      frame.type !== "pair_url" &&
-      frame.type !== "pair_error"
-    ) {
+    // ONLY shared-session activity frames mirror (allowlist, default-deny) — this
+    // is what keeps correlated/secret frames (acks, pair_url, secret_saved, OAuth,
+    // history replies, tool_result) with the ONE socket that asked.
+    if (tabId && typeof frame.type === "string" && MIRROR_SAFE_FRAME_TYPES.has(frame.type)) {
       // Look subscribers up under the RESOLVED (canonical) tab id: after a
       // migration, agents keep pushing under a tab's ORIGINAL id while its
       // subscribers moved to the new id, so `targets[0]` (the resolved primary)

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -439,6 +439,11 @@ export class UiBridge {
   private handleConnection(sock: BridgeSocket): void {
     // The connection is anonymous until its hello frame names a tab id.
     let tabId: string | null = null;
+    // A socket's KIND (canvas-owning panel vs headless viewer) is pinned on its
+    // FIRST hello and is authoritative thereafter. The `headless` flag on later
+    // hellos is client-controlled, so a headless viewer could otherwise flip it to
+    // `false` to pass the same-kind takeover check and seize a desktop tab's id.
+    let socketHeadless: boolean | null = null;
 
     sock.on("message", (buf: unknown) => {
       const raw = String(buf);
@@ -495,7 +500,12 @@ export class UiBridge {
           }
         }
         tabId = msg.tab_id;
-        const incomingHeadless = (msg as { headless?: unknown }).headless === true;
+        // Pin the socket's kind on its first hello; ignore any later flip so the
+        // takeover guard below can't be bypassed with a forged `headless` value.
+        if (socketHeadless === null) {
+          socketHeadless = (msg as { headless?: unknown }).headless === true;
+        }
+        const incomingHeadless = socketHeadless;
         const existing = this.conns.get(tabId);
         if (existing && existing.sock !== sock) {
           // SECURITY: a viewer must not hello-hijack another client's tab id. The
@@ -528,9 +538,9 @@ export class UiBridge {
           tabId,
           title: typeof msg.title === "string" && msg.title ? msg.title : "untitled",
           connectedAt: existing?.connectedAt ?? new Date().toISOString(),
-          headless: (msg as { headless?: unknown }).headless === true,
+          headless: incomingHeadless,
         });
-        if ((msg as { headless?: unknown }).headless === true) this.headlessSeen.add(tabId);
+        if (incomingHeadless) this.headlessSeen.add(tabId);
         this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
         // Log a real connect ONCE per tab id. A reconnect/ping-pong loop (a new
         // socket every couple seconds — e.g. two browser contexts sharing one tab

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -873,11 +873,23 @@ export class UiBridge {
     // behavior unchanged. The primary is already in `targets`, so skip it here.
     // NEVER fan out a correlated reply — those carry a `cid` and belong to the ONE
     // socket that made the request (e.g. tool_result); mirroring them would leak
-    // another client's result to viewers.
-    if (tabId && frame.cid === undefined) {
-      const subs = this.subscribers.get(tabId);
+    // another client's result to viewers. `pair_url`/`pair_error` are correlated
+    // too but carry no cid, so exclude them by type — a pairing URL is meant for
+    // the ONE panel that asked, never for a mirroring phone.
+    if (
+      tabId &&
+      frame.cid === undefined &&
+      frame.type !== "pair_url" &&
+      frame.type !== "pair_error"
+    ) {
+      // Look subscribers up under the RESOLVED (canonical) tab id: after a
+      // migration, agents keep pushing under a tab's ORIGINAL id while its
+      // subscribers moved to the new id, so `targets[0]` (the resolved primary)
+      // holds the id the viewers are actually keyed under.
+      const canonicalId = targets.length === 1 ? targets[0].tabId : tabId;
+      const subs = this.subscribers.get(canonicalId);
       if (subs) {
-        const primarySock = this.conns.get(tabId)?.sock;
+        const primarySock = targets[0]?.sock;
         for (const sock of subs) {
           if (sock === primarySock || sock.readyState !== WebSocket.OPEN) continue;
           try {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -551,15 +551,26 @@ export class UiBridge {
       }
       if (msg.type === "attach_tab" && typeof msg.target_tab_id === "string") {
         const target = msg.target_tab_id;
-        let set = this.subscribers.get(target);
-        if (!set) {
-          set = new Set();
-          this.subscribers.set(target, set);
+        // Only allow mirroring a real, non-headless desktop tab — reject stale ids
+        // and prevent subscribing to another headless (mobile) client.
+        const valid = this.conns.has(target) && !this.headlessSeen.has(target);
+        if (valid) {
+          let set = this.subscribers.get(target);
+          if (!set) {
+            set = new Set();
+            this.subscribers.set(target, set);
+          }
+          set.add(sock);
         }
-        set.add(sock);
         try {
           sock.send(
-            JSON.stringify({ type: "tab_attached", cid: msg.cid, tab_id: target, ok: true }),
+            JSON.stringify({
+              type: "tab_attached",
+              cid: msg.cid,
+              tab_id: target,
+              ok: valid,
+              ...(valid ? {} : { error: "no such desktop tab" }),
+            }),
           );
         } catch {
           /* socket died */
@@ -567,7 +578,9 @@ export class UiBridge {
         return;
       }
       if (msg.type === "detach_tab") {
-        for (const set of this.subscribers.values()) set.delete(sock);
+        for (const [tid, set] of this.subscribers) {
+          if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
+        }
         return;
       }
 
@@ -858,7 +871,10 @@ export class UiBridge {
     // Mirror fan-out: also deliver a tab-scoped frame to any phones mirroring this
     // tab (remote control). No-op when nothing is subscribed → existing panel
     // behavior unchanged. The primary is already in `targets`, so skip it here.
-    if (tabId) {
+    // NEVER fan out a correlated reply — those carry a `cid` and belong to the ONE
+    // socket that made the request (e.g. tool_result); mirroring them would leak
+    // another client's result to viewers.
+    if (tabId && frame.cid === undefined) {
       const subs = this.subscribers.get(tabId);
       if (subs) {
         const primarySock = this.conns.get(tabId)?.sock;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -96,7 +96,18 @@ export class UiBridge {
    *  through the same tab/rid logic as the primary bridge; the primary loopback
    *  listener stays token-less so the local browser panel is unaffected. */
   private readonly extraServers: WebSocketServer[] = [];
-  private conns = new Map<string, Conn>(); // tabId -> connection
+  private conns = new Map<string, Conn>(); // tabId -> connection (canvas-owning primary)
+  /** Mobile "mirror" viewers subscribed to a tab's live output (remote control):
+   *  push()-path frames for a tabId fan out to these IN ADDITION to the primary,
+   *  so a phone sees the desktop tab's agent activity/renders. They NEVER receive
+   *  canvas send()-commands (owner-only) and their own correlated replies are
+   *  socket-scoped. Keyed by the mirrored (primary) tabId. Empty in the normal
+   *  case → zero effect on existing panel behavior. */
+  private subscribers = new Map<string, Set<BridgeSocket>>();
+  /** Injected by the orchestrator: does this tabId have a live agent session?
+   *  (SessionStore/PanelAgentManager live there.) Flags desktopTabs() for the
+   *  mobile mirror picker's green "session attached" dot. */
+  private hasSessionPredicate: ((tabId: string) => boolean) | null = null;
   /**
    * Tab-id migrations (oldTabId → newTabId). When a panel socket re-hellos under
    * a NEW tab id (e.g. after a panel update that changed the id scheme from
@@ -441,6 +452,15 @@ export class UiBridge {
           // re-hello — the ONLY safe rebind trigger; title matching is not).
           (msg as Record<string, unknown>).migrated_from = tabId;
           this.conns.delete(tabId);
+          // Move mirror subscribers to the migrated tab id so viewers keep this
+          // tab's live feed across a same-socket re-hello.
+          const migSubs = this.subscribers.get(tabId);
+          if (migSubs) {
+            this.subscribers.delete(tabId);
+            const dest = this.subscribers.get(msg.tab_id as string) ?? new Set<BridgeSocket>();
+            for (const s of migSubs) dest.add(s);
+            this.subscribers.set(msg.tab_id as string, dest);
+          }
         }
         tabId = msg.tab_id;
         const existing = this.conns.get(tabId);
@@ -460,6 +480,7 @@ export class UiBridge {
           headless: (msg as { headless?: unknown }).headless === true,
         });
         if ((msg as { headless?: unknown }).headless === true) this.headlessSeen.add(tabId);
+        this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
         // Log a real connect ONCE per tab id. A reconnect/ping-pong loop (a new
         // socket every couple seconds — e.g. two browser contexts sharing one tab
         // id) would otherwise spam this; dedup by tab id so churn stays at debug.
@@ -513,6 +534,40 @@ export class UiBridge {
       if (msg.type === "title" && tabId) {
         const conn = this.conns.get(tabId);
         if (conn && typeof msg.title === "string" && msg.title) conn.title = msg.title;
+        this.broadcastTabList(); // a title changed — refresh mirror pickers
+        return;
+      }
+
+      // Desktop-tab mirroring (mobile remote control). Handled HERE (we hold the
+      // requesting socket) so the replies are socket-scoped — never fanned out to
+      // other viewers or the primary. Additive: unknown to the desktop panel.
+      if (msg.type === "list_tabs") {
+        try {
+          sock.send(JSON.stringify({ type: "tab_list", cid: msg.cid, tabs: this.desktopTabs() }));
+        } catch {
+          /* socket died — the caller times out */
+        }
+        return;
+      }
+      if (msg.type === "attach_tab" && typeof msg.target_tab_id === "string") {
+        const target = msg.target_tab_id;
+        let set = this.subscribers.get(target);
+        if (!set) {
+          set = new Set();
+          this.subscribers.set(target, set);
+        }
+        set.add(sock);
+        try {
+          sock.send(
+            JSON.stringify({ type: "tab_attached", cid: msg.cid, tab_id: target, ok: true }),
+          );
+        } catch {
+          /* socket died */
+        }
+        return;
+      }
+      if (msg.type === "detach_tab") {
+        for (const set of this.subscribers.values()) set.delete(sock);
         return;
       }
 
@@ -534,13 +589,20 @@ export class UiBridge {
       for (const [from, entry] of this.tabMigrations) {
         if (entry.sock === sock) this.tabMigrations.delete(from);
       }
+      // Drop this socket from any mirror subscriptions (it was a viewer).
+      for (const [tid, set] of this.subscribers) {
+        if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
+      }
+      let wasPrimary = false;
       if (tabId && this.conns.get(tabId)?.sock === sock) {
+        wasPrimary = true;
         this.conns.delete(tabId);
         if (this.lastActiveTabId === tabId) this.lastActiveTabId = null;
         logger.info(
           `[ui-bridge] panel tab disconnected: ${tabId.slice(0, 8)} — ${this.conns.size} tab(s) remain`,
         );
       }
+      if (wasPrimary) this.broadcastTabList(); // a desktop tab left — refresh pickers
       // Reject any in-flight commands that were bound to this socket.
       for (const [rid, p] of this.pending) {
         if ((p as Pending & { sock?: BridgeSocket }).sock === sock) {
@@ -725,6 +787,45 @@ export class UiBridge {
    *  Truly fire-and-forget: if the target tab has gone, this no-ops (returns 0)
    *  rather than throwing — a throw here becomes an unhandled rejection in the
    *  async push call sites and would crash the orchestrator. */
+  /** Inject the "does this tab have a live session?" predicate (SessionStore lives
+   *  in the orchestrator). */
+  setHasSessionPredicate(fn: (tabId: string) => boolean): void {
+    this.hasSessionPredicate = fn;
+  }
+
+  /** The open DESKTOP tabs (non-headless primaries) for the mobile mirror picker. */
+  desktopTabs(): Array<{ tab_id: string; title: string; has_session: boolean }> {
+    const out: Array<{ tab_id: string; title: string; has_session: boolean }> = [];
+    for (const [tabId, conn] of this.conns) {
+      if (this.headlessSeen.has(tabId)) continue; // skip mobile/remote viewers
+      out.push({
+        tab_id: tabId,
+        title: conn.title ?? "",
+        has_session: this.hasSessionPredicate ? this.hasSessionPredicate(tabId) : false,
+      });
+    }
+    return out;
+  }
+
+  /** Push the current desktop-tab list to every mirror subscriber — call when the
+   *  connected-tab set or a session's live state changes so phones stay in sync. */
+  broadcastTabList(): void {
+    if (this.subscribers.size === 0) return;
+    const frame = JSON.stringify({ type: "tab_list", tabs: this.desktopTabs() });
+    const seen = new Set<BridgeSocket>();
+    for (const set of this.subscribers.values()) {
+      for (const sock of set) {
+        if (seen.has(sock) || sock.readyState !== WebSocket.OPEN) continue;
+        seen.add(sock);
+        try {
+          sock.send(frame);
+        } catch {
+          /* socket mid-disconnect — drop */
+        }
+      }
+    }
+  }
+
   push(frame: Record<string, unknown>, tabId?: string): number {
     let sent = 0;
     let targets: Conn[];
@@ -744,13 +845,32 @@ export class UiBridge {
     } else {
       targets = Array.from(this.conns.values());
     }
+    const payload = JSON.stringify(frame);
     for (const conn of targets) {
       if (conn.sock.readyState !== WebSocket.OPEN) continue;
       try {
-        conn.sock.send(JSON.stringify(frame));
+        conn.sock.send(payload);
         sent += 1;
       } catch {
         // Tab mid-disconnect — drop.
+      }
+    }
+    // Mirror fan-out: also deliver a tab-scoped frame to any phones mirroring this
+    // tab (remote control). No-op when nothing is subscribed → existing panel
+    // behavior unchanged. The primary is already in `targets`, so skip it here.
+    if (tabId) {
+      const subs = this.subscribers.get(tabId);
+      if (subs) {
+        const primarySock = this.conns.get(tabId)?.sock;
+        for (const sock of subs) {
+          if (sock === primarySock || sock.readyState !== WebSocket.OPEN) continue;
+          try {
+            sock.send(payload);
+            sent += 1;
+          } catch {
+            /* viewer mid-disconnect — drop */
+          }
+        }
       }
     }
     return sent;


### PR DESCRIPTION
Two mobile-facing changes, shipped together. Codex-reviewed across 5 rounds (final verdict GO).

## Task A — direct call_tool follows a panel retarget (fix, reporter-confirmed)
`applyComfyuiUrl` retargeted the agents but left the orchestrator's own in-process ComfyUI client (`getClient()`, the direct `call_tool` path — `list_workflows`, `get_image`, …) pinned to the process-start host, so a mobile `call_tool` silently queried the old/empty ComfyUI. Adds `config.setComfyuiTarget(url)` + `resetClient()` on retarget; `setComfyuiTarget` also re-classifies remote/local (mutable `remoteUrlActive`) and re-resolves `comfyuiPath` so a retarget across the loopback boundary can't leave FS tools misclassed. **Reporter confirmed the mobile Workflows tab now loads over the tunnel.**

## Task B — desktop-tab mirror + remote control (multi-viewer fan-out)
A phone can enumerate the open desktop ComfyUI tabs and **mirror + drive** one:
- **Fan-out**: a `subscribers` map alongside `conns`; `push(frame, tabId)` fans out to viewers — but only frames on an **allowlist** of shared-session activity types (`say/stream/thinking/echo/turn/turn_anchor/session/agent_status/action/download_progress`), default-deny, so no correlated/secret/config frame (acks, `pair_url`, `secret_saved`, OAuth, `tool_result`, history replies) can ever reach a viewer. No-op when nothing subscribes → existing panel behavior unchanged. Canvas `send()`/rid-commands stay primary-only.
- **Remote control**: an attached viewer's inbound events (`user_message`/`interrupt`/`new_session`) route to the **mirrored** tab's session (server-authoritative stamping) — that's what makes the phone and desktop mirror each other. Re-pointed across migration; reverts on detach / when the mirrored desktop closes.
- **Security hardening** (Codex): socket kind is **pinned on first hello**, so a headless viewer can't forge `headless:false` to hello-hijack a desktop tab's id; re-attach drops the prior subscription (one tab at a time); primary close detaches its viewers (no dangling driver / buffered-forever output).
- `list_tabs`/`attach_tab`/`detach_tab` handled in-bridge with socket-scoped replies; `attach` validates a real non-headless tab; `has_session` predicate + `broadcastTabList` on every reset path (green dot never sticks).

**Verified**: 38 bridge tests (fan-out allowlist incl. `cid:undefined`, drive routing, takeover-refused incl. forged flag, re-attach, revert-on-close, migration continuity) + full suite **1404 pass**; `tsc` clean; live against the real orchestrator (`list_tabs` real tabs, headless excluded, ghost + hijack rejected, panel reconnected no regression); CI green on all platforms.

**v1 scope**: live mirror + remote control. Transcript **hydration on attach is deliberately deferred to v2** — it needs an on-device UX decision (does mirroring replace or overlay the phone's own chat?) that wants the user's input first. The attach path is live-only by design.