### PR TITLE
feat(orchestrator): live queue_status broadcast + mobile one-tap render cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ All notable changes to this project are documented here. This project adheres to
   mobile LoRA hub) can link back to the source and check CivitAI for newer
   versions. Purely additive; no whitelist change — `list_local_models` is
   already mobile-callable.
+- **live `queue_status` bridge frame** — the orchestrator now broadcasts
+  ComfyUI's live render/queue state (running, queue depth, current node,
+  sampler progress, prompt_id) to every connected tab, riding the existing
+  QueueMonitor watchdog so browser-queued jobs are covered too. Change-only
+  and capped at 1 frame/sec: an idle rig broadcasts nothing. Each tab is also
+  seeded with the current state on `hello`, so a client connecting mid-render
+  sees the running job immediately. Powers the mobile app's live queue monitor
+- **`cancel_job` on the mobile call_tool whitelist** — one-tap cancel of the
+  running render from the phone's queue monitor. Narrowly scoped: the client
+  passes the `prompt_id` it observed, cancel_job only interrupts a still-matching
+  running job, and pending jobs are never touched
 
 #### Docs
 - mobile app (beta) page — Android (Firebase App Distribution) + iOS

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -75,6 +75,10 @@ import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./pane
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
+import {
+  buildQueueStatusFrame,
+  createQueueStatusBroadcaster,
+} from "../services/queue-status-broadcast.js";
 import { unloadAllOllama, warmOllama, resolveOllamaHost } from "../services/ollama-vram.js";
 import {
   isLocalLmstudio,
@@ -632,6 +636,13 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // API-format graphs to canvas-openable UI format); overwrites same-filename,
   // so the client generates a unique name. No model/system mutation.
   "save_workflow",
+  // One-tap cancel of the RUNNING render (the mobile queue monitor's stop
+  // button). User-initiated and narrowly scoped: the client passes the
+  // prompt_id it saw in `queue_status`, and cancel_job only interrupts when the
+  // running job still matches — it can never kill a job that started after the
+  // tap, and (without clear_pending, which the mobile client never sends) it
+  // never touches other pending jobs in a shared queue.
+  "cancel_job",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,
@@ -2102,6 +2113,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       pushReadiness(panelTab);
       if (backend === "claude") pushCommands(panelTab);
       bridge.push({ type: "workflow_target", target: workflowTargets.get(panelTab) }, panelTab);
+      // Seed this tab's live queue monitor right away: queue_status broadcasts
+      // are change-only, so a tab connecting MID-render would otherwise wait for
+      // the next state transition to learn a job is already running.
+      bridge.push(buildQueueStatusFrame(QueueMonitor.snapshot()), panelTab);
       // Re-push the last usage so the context meter isn't blank after a reload.
       const lastStatus = manager.lastStatusFor(key);
       if (lastStatus) pushStatus(panelTab, lastStatus);
@@ -3084,6 +3099,20 @@ export async function runPanelOrchestrator(): Promise<void> {
   const downloadTimer = setInterval(pollDownloads, 700);
   downloadTimer.unref?.();
 
+  // ---- Queue-status watcher ----
+  // Live render/queue state for every connected tab (the mobile app's live
+  // queue monitor). Reuses the QueueMonitor watchdog's snapshot — which covers
+  // EVERY ComfyUI job, including browser-queued ones — and broadcasts a
+  // `queue_status` frame at most once per second, and ONLY when the state
+  // changed, so an idle rig costs the tabs nothing (see
+  // services/queue-status-broadcast.ts for the frame shape + throttle contract).
+  const queueStatusBroadcaster = createQueueStatusBroadcaster(
+    () => QueueMonitor.snapshot(),
+    (frame) => void bridge.push(frame),
+  );
+  const queueStatusTimer = setInterval(() => queueStatusBroadcaster.tick(), 1000);
+  queueStatusTimer.unref?.();
+
   // Keep the pod's stored bridge URL fresh so a ComfyUI RESTART self-heals fast.
   // The panel's advertised wss:// URL/token lives in the pod ComfyUI process's
   // MEMORY (the panel __init__'s advertise store). A restart — which the agent
@@ -3131,6 +3160,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     logger.info("[panel-orchestrator] shutting down — stopping agents…");
     selfRestarter?.stop();
     clearInterval(downloadTimer);
+    clearInterval(queueStatusTimer);
     if (readvertiseTimer) clearInterval(readvertiseTimer);
     QueueMonitor.stop();
     unsubscribeSecrets();

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -7,9 +7,12 @@
 // once let the agent stack three more behind it before anyone noticed.
 //
 // This service opens its OWN lightweight WebSocket to COMFYUI_URL. ComfyUI
-// broadcasts execution events (status / executing / progress / execution_*) to
-// every connected client, so we receive the live stream for ANY job — including
-// the browser-queued ones — without touching the panel or the agent subprocess.
+// broadcasts `status`, `progress`, and `progress_state` to every connected
+// client, so we receive the live stream for ANY job — including the
+// browser-queued ones — without touching the panel or the agent subprocess.
+// (The legacy execution_start / executing / execution_* events are sid-scoped
+// to the QUEUING client on modern ComfyUI — verified live on 0.28 — so the
+// handlers below also derive the run state from the broadcast-safe frames.)
 // It holds the last-known run state and derives a stall/backlog report the
 // orchestrator surfaces to the agent as a turn-start note (the same channel as
 // the crash-dump injector).
@@ -57,6 +60,11 @@ export interface QueueSnapshot {
   running: boolean;
   runningPromptId: string | null;
   queueDepth: number;
+  /** The node id currently executing (ComfyUI graph node id), null when idle. */
+  currentNode: string | null;
+  /** Progress of the current node (sampler steps), null before the first tick. */
+  progressValue: number | null;
+  progressMax: number | null;
 }
 
 const RECONNECT_MS = 5000;
@@ -194,6 +202,16 @@ class QueueMonitorImpl {
     this.state.lastActivityTs = Date.now();
   }
 
+  /** Adopt [promptId] as the running prompt when it's new — the broadcast-safe
+   *  substitute for the sid-scoped execution_start this client never receives
+   *  on modern ComfyUI. Fires the start transition exactly once per run. */
+  private adoptRunningPrompt(promptId: unknown): void {
+    if (typeof promptId !== "string" || promptId === this.state.runningPromptId) return;
+    this.state.runningPromptId = promptId;
+    this.touchActivity();
+    this.emitStart();
+  }
+
   private clearRunning(): void {
     this.state.runningPromptId = null;
     this.state.currentNode = null;
@@ -217,9 +235,15 @@ class QueueMonitorImpl {
         const qr = execInfo?.queue_remaining;
         if (typeof qr === "number") {
           this.state.queueRemaining = qr;
-          // A status frame arriving with an empty queue after a run is the
-          // authoritative "fully idle" signal — flush a pending end transition.
-          if (qr === 0) this.emitEndIfIdle();
+          // A status frame with an empty queue is ComfyUI's authoritative
+          // "fully idle" signal. On modern ComfyUI (0.2x) the sid-scoped
+          // executing/execution_success events never reach this passive
+          // watchdog (see the progress_state case), so a run learned from
+          // progress frames would otherwise never clear — drain it here.
+          if (qr === 0) {
+            if (this.state.runningPromptId !== null) this.clearRunning();
+            this.emitEndIfIdle();
+          }
         }
         break;
       }
@@ -255,6 +279,31 @@ class QueueMonitorImpl {
         this.state.progressValue = value;
         this.state.progressMax = max;
         if (typeof data.node === "string") this.state.currentNode = data.node;
+        // progress IS broadcast to every client and carries the prompt_id —
+        // adopt it, since the sid-scoped execution_start may never have arrived
+        // (see the progress_state case below).
+        this.adoptRunningPrompt(data.prompt_id);
+        break;
+      }
+      case "progress_state": {
+        // Modern ComfyUI (verified live on 0.28): execution_start / executing /
+        // execution_success are sent ONLY to the client that queued the prompt,
+        // so this passive watchdog never sees them — but progress_state IS
+        // broadcast, fires from the first node on, and names the running
+        // prompt + node. Derive the run state from it so browser-/agent-queued
+        // renders stay visible here (running flag, prompt_id, current node).
+        this.adoptRunningPrompt(data.prompt_id);
+        const nodes = data.nodes;
+        if (nodes && typeof nodes === "object") {
+          for (const entry of Object.values(nodes as Record<string, unknown>)) {
+            if (!entry || typeof entry !== "object") continue;
+            const n = entry as { state?: unknown; node_id?: unknown };
+            if (n.state === "running" && typeof n.node_id === "string") {
+              if (n.node_id !== this.state.currentNode) this.touchActivity(); // node advanced
+              this.state.currentNode = n.node_id;
+            }
+          }
+        }
         break;
       }
       case "execution_success":
@@ -269,13 +318,17 @@ class QueueMonitorImpl {
     }
   }
 
-  /** Cheap snapshot for backpressure (panel_run): is anything already in flight? */
+  /** Cheap snapshot for backpressure (panel_run) and the live `queue_status`
+   *  broadcast (queue-status-broadcast.ts): is anything in flight, and where? */
   snapshot(): QueueSnapshot {
     return {
       connected: this.state.connected,
       running: this.state.runningPromptId !== null,
       runningPromptId: this.state.runningPromptId,
       queueDepth: Math.max(0, this.state.queueRemaining),
+      currentNode: this.state.currentNode,
+      progressValue: this.state.progressValue,
+      progressMax: this.state.progressMax,
     };
   }
 

--- a/src/services/queue-status-broadcast.test.ts
+++ b/src/services/queue-status-broadcast.test.ts
@@ -1,0 +1,224 @@
+// queue-status-broadcast.test.ts — the live `queue_status` bridge frame and its
+// change-only throttle (the mobile app's live queue monitor rides on this).
+// Contract under test:
+//   • buildQueueStatusFrame maps a QueueMonitor snapshot 1:1 onto the wire shape;
+//   • tick() pushes ONLY when the frame differs from the last one pushed — an
+//     idle rig broadcasts nothing, a running render costs ≤ 1 frame per tick;
+//   • current() always returns the live frame (the on-hello seed for a tab that
+//     connects mid-render).
+import { describe, expect, it } from "vitest";
+import type { QueueSnapshot } from "./queue-monitor.js";
+import {
+  buildQueueStatusFrame,
+  createQueueStatusBroadcaster,
+  type QueueStatusFrame,
+} from "./queue-status-broadcast.js";
+
+const idle = (): QueueSnapshot => ({
+  connected: true,
+  running: false,
+  runningPromptId: null,
+  queueDepth: 0,
+  currentNode: null,
+  progressValue: null,
+  progressMax: null,
+});
+
+const running = (progress: number): QueueSnapshot => ({
+  connected: true,
+  running: true,
+  runningPromptId: "p-123",
+  queueDepth: 2,
+  currentNode: "3",
+  progressValue: progress,
+  progressMax: 20,
+});
+
+describe("buildQueueStatusFrame", () => {
+  it("maps a running snapshot onto the wire shape", () => {
+    expect(buildQueueStatusFrame(running(7))).toEqual({
+      type: "queue_status",
+      connected: true,
+      running: true,
+      queue_depth: 2,
+      prompt_id: "p-123",
+      node: "3",
+      progress_value: 7,
+      progress_max: 20,
+    });
+  });
+
+  it("maps an idle snapshot with nulls, not zeros", () => {
+    const f = buildQueueStatusFrame(idle());
+    expect(f.running).toBe(false);
+    expect(f.queue_depth).toBe(0);
+    expect(f.prompt_id).toBeNull();
+    expect(f.node).toBeNull();
+    expect(f.progress_value).toBeNull();
+    expect(f.progress_max).toBeNull();
+  });
+});
+
+describe("createQueueStatusBroadcaster", () => {
+  it("pushes the first frame, then stays silent while nothing changes", () => {
+    let snap = idle();
+    const pushed: QueueStatusFrame[] = [];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+    );
+
+    b.tick();
+    expect(pushed).toHaveLength(1); // first observation always goes out
+
+    b.tick();
+    b.tick();
+    b.tick();
+    expect(pushed).toHaveLength(1); // idle rig: zero further frames
+
+    snap = running(0);
+    b.tick();
+    expect(pushed).toHaveLength(2);
+    expect(pushed[1].running).toBe(true);
+    expect(pushed[1].prompt_id).toBe("p-123");
+  });
+
+  it("pushes once per progress change, not per tick", () => {
+    let snap = running(5);
+    const pushed: QueueStatusFrame[] = [];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+    );
+
+    b.tick(); // 5/20
+    b.tick(); // unchanged (a wedged step re-emits the same value)
+    expect(pushed).toHaveLength(1);
+
+    snap = running(6);
+    b.tick();
+    snap = running(7);
+    b.tick();
+    b.tick(); // unchanged again
+    expect(pushed).toHaveLength(3);
+    expect(pushed.map((f) => f.progress_value)).toEqual([5, 6, 7]);
+  });
+
+  it("pushes the running→idle transition (the render-finished edge)", () => {
+    let snap = running(19);
+    const pushed: QueueStatusFrame[] = [];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+    );
+    b.tick();
+    snap = idle();
+    b.tick();
+    expect(pushed).toHaveLength(2);
+    expect(pushed[1].running).toBe(false);
+    expect(pushed[1].queue_depth).toBe(0);
+  });
+
+  it("current() returns the live frame without affecting the throttle", () => {
+    let snap = idle();
+    const pushed: QueueStatusFrame[] = [];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+    );
+
+    expect(b.current().running).toBe(false);
+    snap = running(1);
+    expect(b.current().running).toBe(true); // live, not cached
+    expect(pushed).toHaveLength(0); // current() never pushes
+
+    b.tick();
+    expect(pushed).toHaveLength(1); // and never consumed the change either
+  });
+});
+
+describe("QueueMonitor snapshot plumbing", () => {
+  // Drive the real singleton's (private) WS message handler with captured
+  // ComfyUI frames, and assert the NEW snapshot fields carry node + progress —
+  // the exact plumbing queue_status broadcasts to the phone.
+  it("exposes currentNode + progress from live ComfyUI frames", async () => {
+    const { QueueMonitor } = await import("./queue-monitor.js");
+    const onMessage = (
+      QueueMonitor as unknown as { onMessage(text: string): void }
+    ).onMessage.bind(QueueMonitor);
+
+    onMessage(JSON.stringify({ type: "execution_start", data: { prompt_id: "p-9" } }));
+    onMessage(JSON.stringify({ type: "executing", data: { node: "3", prompt_id: "p-9" } }));
+    onMessage(JSON.stringify({ type: "progress", data: { value: 4, max: 20, node: "3" } }));
+
+    let snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(true);
+    expect(snap.runningPromptId).toBe("p-9");
+    expect(snap.currentNode).toBe("3");
+    expect(snap.progressValue).toBe(4);
+    expect(snap.progressMax).toBe(20);
+
+    // Success clears everything back to idle (leave the singleton clean).
+    onMessage(JSON.stringify({ type: "execution_success", data: { prompt_id: "p-9" } }));
+    snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(false);
+    expect(snap.currentNode).toBeNull();
+    expect(snap.progressValue).toBeNull();
+  });
+
+  // Modern ComfyUI (verified live on 0.28) sends execution_start / executing /
+  // execution_success ONLY to the client that queued the prompt. A passive
+  // watchdog sees just the broadcast frames: status / progress / progress_state.
+  // The run state must be derivable from those alone.
+  it("derives running state from broadcast-only frames (modern ComfyUI)", async () => {
+    const { QueueMonitor } = await import("./queue-monitor.js");
+    const onMessage = (
+      QueueMonitor as unknown as { onMessage(text: string): void }
+    ).onMessage.bind(QueueMonitor);
+
+    // Frames captured verbatim from a live ComfyUI 0.28 as a NON-originating
+    // client (trimmed): status → progress_state → progress → status(0).
+    onMessage(
+      JSON.stringify({
+        type: "status",
+        data: { status: { exec_info: { queue_remaining: 1 } } },
+      }),
+    );
+    onMessage(
+      JSON.stringify({
+        type: "progress_state",
+        data: {
+          prompt_id: "612c9766",
+          nodes: { "4": { value: 0, max: 1, state: "running", node_id: "4", prompt_id: "612c9766" } },
+        },
+      }),
+    );
+    let snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(true);
+    expect(snap.runningPromptId).toBe("612c9766");
+    expect(snap.currentNode).toBe("4");
+
+    onMessage(
+      JSON.stringify({
+        type: "progress",
+        data: { value: 5, max: 12, prompt_id: "612c9766", node: "5" },
+      }),
+    );
+    snap = QueueMonitor.snapshot();
+    expect(snap.currentNode).toBe("5");
+    expect(snap.progressValue).toBe(5);
+    expect(snap.progressMax).toBe(12);
+
+    // The drained status frame is the only "done" signal a passive client gets.
+    onMessage(
+      JSON.stringify({
+        type: "status",
+        data: { status: { exec_info: { queue_remaining: 0 } } },
+      }),
+    );
+    snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(false);
+    expect(snap.runningPromptId).toBeNull();
+    expect(snap.queueDepth).toBe(0);
+  });
+});

--- a/src/services/queue-status-broadcast.ts
+++ b/src/services/queue-status-broadcast.ts
@@ -1,0 +1,78 @@
+// Live queue-status fan-out for panel/mobile tabs.
+//
+// The QueueMonitor watchdog (queue-monitor.ts) already tracks ComfyUI's live
+// execution state — for EVERY job, including browser-queued ones — but until
+// now that state never left the orchestrator process. This module turns its
+// snapshot into a `queue_status` bridge frame so a connected tab (the mobile
+// app's live queue monitor) can show queue depth + render progress in real
+// time.
+//
+// Throttle contract: the orchestrator ticks the broadcaster on a 1-second
+// interval, and `tick()` pushes ONLY when the frame differs from the last one
+// sent. An idle rig therefore broadcasts nothing at all, and a running render
+// costs at most one frame per second.
+
+import type { QueueSnapshot } from "./queue-monitor.js";
+
+/** The wire shape of one live queue-status broadcast. */
+export interface QueueStatusFrame extends Record<string, unknown> {
+  type: "queue_status";
+  /** The watchdog WS to ComfyUI is up (false → the rest is last-known/empty). */
+  connected: boolean;
+  /** A prompt is executing right now. */
+  running: boolean;
+  /** running + pending, from ComfyUI's own queue_remaining. */
+  queue_depth: number;
+  /** prompt_id of the running job (null when idle). */
+  prompt_id: string | null;
+  /** The node id currently executing (ComfyUI graph node id, null when idle). */
+  node: string | null;
+  /** Sampler-step progress of the current node (null before the first tick). */
+  progress_value: number | null;
+  progress_max: number | null;
+}
+
+/** Build the broadcast frame for one monitor snapshot. */
+export function buildQueueStatusFrame(s: QueueSnapshot): QueueStatusFrame {
+  return {
+    type: "queue_status",
+    connected: s.connected,
+    running: s.running,
+    queue_depth: s.queueDepth,
+    prompt_id: s.runningPromptId,
+    node: s.currentNode,
+    progress_value: s.progressValue,
+    progress_max: s.progressMax,
+  };
+}
+
+export interface QueueStatusBroadcaster {
+  /** Poll the snapshot and push a frame IF (and only if) it changed. */
+  tick(): void;
+  /** The current frame (for a targeted push to a tab that just connected). */
+  current(): QueueStatusFrame;
+}
+
+/**
+ * Wire a snapshot source to a push sink with change-only semantics. The sink
+ * is the bridge's broadcast push; it must never throw into the timer (the
+ * bridge's own push already guarantees that, see ui-bridge.ts).
+ */
+export function createQueueStatusBroadcaster(
+  snapshot: () => QueueSnapshot,
+  push: (frame: QueueStatusFrame) => void,
+): QueueStatusBroadcaster {
+  let last = "";
+  return {
+    tick(): void {
+      const frame = buildQueueStatusFrame(snapshot());
+      const key = JSON.stringify(frame);
+      if (key === last) return;
+      last = key;
+      push(frame);
+    },
+    current(): QueueStatusFrame {
+      return buildQueueStatusFrame(snapshot());
+    },
+  };
+}


### PR DESCRIPTION
## What

Community request from Discord thread `1527136427853221898` (seanmcmagic): *"Show a live queue monitor with output image preview as soon as a render finishes"* — plus the follow-up ask for *"a one-tap interrupt button to cancel the current running job."* This is the orchestrator half; the mobile UI lands in comfyui-mcp-mobile PR (linked below).

- **New `queue_status` bridge frame** — broadcasts ComfyUI's live render/queue state (`running`, `queue_depth`, `prompt_id`, current `node`, sampler `progress_value/max`) to every connected tab, riding the existing QueueMonitor watchdog so browser-queued jobs are covered too.
  - **Throttled by contract:** 1-second tick + change-only push (`src/services/queue-status-broadcast.ts`). An idle rig broadcasts **zero** frames; a running render costs ≤ 1 frame/sec.
  - Each tab is seeded with the current state on `hello`, so a phone connecting mid-render shows the running job immediately.
- **QueueMonitor: derive run state from broadcast-safe frames.** On modern ComfyUI (verified live on 0.28) the legacy `execution_start` / `executing` / `execution_*` events are **sid-scoped to the queueing client** — a passive watchdog never receives them, so `running` stayed `false` and `prompt_id` `null` for every job it didn't queue itself. Now `progress` / `progress_state` (both broadcast, both carry `prompt_id`) set the running state, and a drained `status` frame clears it. Side benefit: the busy edge-tracking the Ollama VRAM pause relies on works again on 0.28.
- **`cancel_job` added to the mobile `call_tool` whitelist** — the phone's one-tap cancel. Narrowly scoped: user-initiated, the client passes the `prompt_id` it observed in `queue_status`, `cancel_job` only interrupts a still-matching running job, and pending jobs are never touched (shared queue safe).

## Verification

- `npm test` — 129 files / 1446 tests green (7 new tests in `queue-status-broadcast.test.ts`, incl. frames captured verbatim from a live ComfyUI 0.28 as a non-originating client).
- Live E2E against real ComfyUI 0.28 + this orchestrator on an alternate port, with a throwaway headless tab:
  ```
  [+0.0s] queue_status {...,"running":false,"queue_depth":0}        ← hello seed
  [+11.8s] queue_status {...,"running":true,"queue_depth":1,"prompt_id":"5a4b…","node":"5"}
  [+12.8s] queue_status {...,"progress_value":12,"progress_max":60}
  [+12.8s] → call_tool cancel_job prompt_id=5a4b… (own job)
  [+13.8s] queue_status {...,"running":false,"queue_depth":0}       ← drained
  [+14.3s] tool_result {"tool":"cancel_job","ok":true,"result":[…"Interrupted the running job…"]}
  ```
  Idle observation windows produced no frames at all (throttle contract).
- Verified on a real S22 through the mobile PR's UI (screencaps there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)