### PR TITLE
docs: mobile app (beta) page — Android + iOS beta-tester links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project are documented here. This project adheres to
   versions. Purely additive; no whitelist change — `list_local_models` is
   already mobile-callable.
 
+#### Docs
+- mobile app (beta) page — Android (Firebase App Distribution) + iOS
+  (TestFlight) beta-tester links, pairing walkthrough, wired into the docs nav
+
 ## [0.36.0] - 2026-07-15
 
 ### MCP

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -57,6 +57,7 @@
               "concepts",
               "plugin",
               "panel",
+              "mobile",
               "backends",
               "local-llms",
               "arena",

--- a/docs/mobile.mdx
+++ b/docs/mobile.mdx
@@ -1,0 +1,62 @@
+---
+title: "Mobile app (beta)"
+description: "ComfyUI-MCP Mobile — chat with your ComfyUI agent from your phone. Pair with the Agent Panel's QR code and drive generations, workflows, and models from anywhere on your network. Now in closed beta on Android and iOS."
+icon: "mobile"
+---
+
+<Note>
+**Join the beta.** The ComfyUI-MCP mobile app is in closed beta — install a
+build for your platform:
+
+- **Android** — [Firebase App Distribution](https://appdistribution.firebase.dev/i/27a5cccde72ffb42)
+- **iOS** — [TestFlight](https://testflight.apple.com/join/ws65s4a2)
+</Note>
+
+The mobile app is a phone-native front end to the same agent that powers the
+[Sidebar Panel](/panel). It connects to the panel orchestrator's bridge, so
+everything the panel can do — generate images, run and inspect workflows, switch
+models — is available from your phone, with your desktop's ComfyUI doing the
+work.
+
+## Pairing
+
+The app talks to the agent host over the panel bridge, so you pair once and
+you're in:
+
+1. Install and run [comfyui-mcp](/quickstart) with the
+   [Agent Panel](/panel) on your desktop.
+2. Open the panel in ComfyUI and show the **pairing QR**.
+3. In the mobile app, tap **Scan QR from panel** — or paste the bridge URL
+   (`ws://…?token=…`) by hand.
+
+The QR encodes a lander URL whose pairing data rides the URL fragment, so the
+host and token never leave your devices. The app also registers the
+`comfyui-mcp://pair` deep link for the lander's **Open in app** button.
+
+<Note>
+Phone and desktop need a network path between them — the same LAN in the
+simple case, or a [secure relay](/self-hosted-relay) /
+[cloud deployment](/cloud-deployment) when the host isn't directly reachable.
+</Note>
+
+## What's in the app
+
+- **Agent chat** — the same conversation you'd have in the panel sidebar,
+  from your phone.
+- **Model picker** — live model catalog from the orchestrator; switch models
+  mid-session.
+- **Civitai browsing** — search models and creators, likes and favorites.
+- **Remote control** — mirror the desktop panel tab and check workflow
+  diagnostics on the go.
+
+## Feedback
+
+Beta feedback and bug reports are welcome on
+[Discord](https://discord.gg/cW9arBhzCu) or the
+[issue tracker](https://github.com/artokun/comfyui-mcp/issues).
+
+## See also
+
+- [Sidebar Panel](/panel) — the in-ComfyUI agent the app pairs with
+- [Cloud deployment](/cloud-deployment) — drive a remote ComfyUI pod
+- [Self-hosted relay](/self-hosted-relay) — own the secure bridge path

--- a/docs/panel.mdx
+++ b/docs/panel.mdx
@@ -317,6 +317,7 @@ hide and resumes the typewriter on return. Foreground animation is unchanged.
 
 ## See also
 
+- [Mobile app (beta)](/mobile) — pair your phone with the panel and chat with the agent on the go
 - [Backends / providers](/backends) — Claude vs ChatGPT, the picker, capability parity
 - [Skills, Packs & Runtime Cost](/tools/skills-knowledge) — knowledge parity + the cost guardrail
 - [Bridge configuration](/configuration)


### PR DESCRIPTION
## Summary
- New Mintlify page **`docs/mobile.mdx`** — "Mobile app (beta)": what the app is, how it pairs with the Agent Panel (QR / bridge URL / `comfyui-mcp://pair` deep link), feature rundown, and a beta-install `<Note>` callout with both tester links:
  - **Android (Firebase App Distribution):** https://appdistribution.firebase.dev/i/27a5cccde72ffb42
  - **iOS (TestFlight):** https://testflight.apple.com/join/ws65s4a2
- Wired into `docs/docs.json` nav (Guides → Configuration, right after `panel`).
- Cross-link from `docs/panel.mdx` "See also".
- CHANGELOG `Unreleased` → MCP → Docs entry.

## Verification
- `docs.json` parses (`node -e JSON.parse`).
- `npx mint broken-links` — no broken links introduced (the 8 reported are pre-existing `/packs/*` links in `blog/z-image-comfyui.mdx`).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)