### PR TITLE
feat(models): CivitAI provenance line (model+version ids) in list_local_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Added
+- **`list_local_models` CivitAI provenance line** — entries whose
+  `<file>.civitai.json` sidecar (written by `download_civitai_model`) carries
+  ids now render a `civitai: <page URL>` line (the sidecar's `sourceUrl`, or
+  reconstructed from `modelId`/`versionId` for older sidecars). The URL
+  carries the modelId + INSTALLED modelVersionId, so agents and clients (the
+  mobile LoRA hub) can link back to the source and check CivitAI for newer
+  versions. Purely additive; no whitelist change — `list_local_models` is
+  already mobile-callable.
+
 ## [0.36.0] - 2026-07-15
 
 ### MCP

--- a/src/__tests__/services/list-local-models.test.ts
+++ b/src/__tests__/services/list-local-models.test.ts
@@ -15,12 +15,14 @@ vi.mock("../../comfyui/client.js", () => ({
   getClient: (...args: unknown[]) => getClient(...args),
 }));
 
-// Filesystem fallback hooks.
+// Filesystem fallback hooks (readFile feeds the CivitAI sidecar enrichment).
 const readdir = vi.fn();
 const stat = vi.fn();
+const readFile = vi.fn();
 vi.mock("node:fs/promises", () => ({
   readdir: (...a: unknown[]) => readdir(...a),
   stat: (...a: unknown[]) => stat(...a),
+  readFile: (...a: unknown[]) => readFile(...a),
   // Unused by listLocalModels but required by other functions in the module.
   copyFile: vi.fn(),
   link: vi.fn(),
@@ -38,6 +40,9 @@ beforeEach(() => {
   fetchApi.mockReset();
   readdir.mockReset();
   stat.mockReset();
+  readFile.mockReset();
+  // Default: no sidecar next to any model file (enrichment is best-effort).
+  readFile.mockRejectedValue(new Error("ENOENT"));
   config.comfyuiPath = "/comfy";
 });
 
@@ -87,6 +92,52 @@ describe("listLocalModels — HTTP-first with FS fallback", () => {
       size: 1024 * 1024 * 50,
       modified: "2026-06-01T12:00:00.000Z",
     });
+  });
+
+  it("enriches entries from the CivitAI sidecar: trigger words, base, and the source URL", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/models/loras"
+        ? new Response(JSON.stringify(["detail.safetensors"]), { status: 200 })
+        : new Response("[]", { status: 200 }),
+    );
+    readFile.mockResolvedValue(
+      JSON.stringify({
+        modelId: 162967,
+        versionId: 183635,
+        trainedWords: ["more detail"],
+        baseModel: "SDXL 1.0",
+        sourceUrl: "https://civitai.com/models/162967?modelVersionId=183635",
+      }),
+    );
+    const result = await listLocalModels("loras");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "detail.safetensors",
+      triggerWords: ["more detail"],
+      baseModel: "SDXL 1.0",
+      civitaiUrl: "https://civitai.com/models/162967?modelVersionId=183635",
+    });
+  });
+
+  it("reconstructs the CivitAI URL from ids when the sidecar predates sourceUrl", async () => {
+    getClient.mockReturnValue({ fetchApi });
+    fetchApi.mockImplementation(async (path: string) =>
+      path === "/models/loras"
+        ? new Response(JSON.stringify(["a.safetensors", "b.safetensors"]), { status: 200 })
+        : new Response("[]", { status: 200 }),
+    );
+    // a: version-only sidecar (no modelId, no sourceUrl); b: both ids, no sourceUrl.
+    readFile.mockImplementation(async (p: string) =>
+      String(p).includes("a.safetensors")
+        ? JSON.stringify({ versionId: 28907 })
+        : JSON.stringify({ modelId: 211726, versionId: 3101597 }),
+    );
+    const result = await listLocalModels("loras");
+    expect(result.map((m) => m.civitaiUrl)).toEqual([
+      "https://civitai.com/model-versions/28907",
+      "https://civitai.com/models/211726?modelVersionId=3101597",
+    ]);
   });
 
   it("returns empty (no throw) in cloud mode when no comfyuiPath is set", async () => {

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const downloadModelMock = vi.fn();
+const listLocalModelsMock = vi.fn();
 vi.mock("../../services/model-resolver.js", async () => {
   const actual = await vi.importActual<typeof import("../../services/model-resolver.js")>(
     "../../services/model-resolver.js",
@@ -8,6 +9,7 @@ vi.mock("../../services/model-resolver.js", async () => {
   return {
     ...actual,
     downloadModel: (...a: unknown[]) => downloadModelMock(...a),
+    listLocalModels: (...a: unknown[]) => listLocalModelsMock(...a),
   };
 });
 
@@ -28,11 +30,13 @@ function makeServer() {
   registerModelManagementTools(server as never);
   return {
     downloadModel: handlers.get("download_model")!,
+    listLocalModels: handlers.get("list_local_models")!,
   };
 }
 
 beforeEach(() => {
   downloadModelMock.mockReset();
+  listLocalModelsMock.mockReset();
 });
 
 describe("download_model tool", () => {
@@ -59,5 +63,44 @@ describe("download_model tool", () => {
       auth,
     );
     expect(res.isError).toBeFalsy();
+  });
+});
+
+describe("list_local_models rendering", () => {
+  it("renders sidecar hints: trigger words + base, and the civitai provenance line", async () => {
+    listLocalModelsMock.mockResolvedValueOnce([
+      {
+        name: "detail.safetensors",
+        path: "loras/detail.safetensors",
+        size: 0,
+        modified: "",
+        type: "loras",
+        triggerWords: ["more detail", "hdr"],
+        baseModel: "SDXL 1.0",
+        civitaiUrl: "https://civitai.com/models/162967?modelVersionId=183635",
+      },
+      {
+        name: "plain.safetensors",
+        path: "loras/plain.safetensors",
+        size: 0,
+        modified: "",
+        type: "loras",
+      },
+    ]);
+
+    const { listLocalModels } = makeServer();
+    const res = await listLocalModels({ model_type: "loras" });
+    const text = res.content[0].text;
+
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("## loras (2)");
+    expect(text).toContain("- detail.safetensors");
+    expect(text).toContain("    trigger words: more detail, hdr  ·  base: SDXL 1.0");
+    expect(text).toContain(
+      "    civitai: https://civitai.com/models/162967?modelVersionId=183635",
+    );
+    // The un-enriched entry stays a bare name — no stray metadata lines.
+    expect(text).toContain("- plain.safetensors");
+    expect(text).not.toContain("plain.safetensors (");
   });
 });

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -117,6 +117,10 @@ export interface LocalModel {
   triggerWords?: string[];
   /** Base model from the CivitAI sidecar (e.g. "SDXL 1.0"), when present. */
   baseModel?: string;
+  /** Canonical CivitAI page URL from the sidecar (carries the modelId and the
+   *  INSTALLED modelVersionId) — provenance for humans and the anchor clients
+   *  use to check whether a newer version exists on CivitAI. */
+  civitaiUrl?: string;
 }
 
 /**
@@ -285,12 +289,27 @@ async function enrichWithCivitaiMetadata(models: LocalModel[]): Promise<void> {
         const j = JSON.parse(raw) as {
           trainedWords?: unknown;
           baseModel?: unknown;
+          modelId?: unknown;
+          versionId?: unknown;
+          sourceUrl?: unknown;
         };
         if (Array.isArray(j.trainedWords) && j.trainedWords.length > 0) {
           m.triggerWords = j.trainedWords.map(String);
         }
         if (typeof j.baseModel === "string" && j.baseModel) {
           m.baseModel = j.baseModel;
+        }
+        // Provenance: prefer the sidecar's canonical sourceUrl; reconstruct it
+        // from the ids for older sidecars that predate sourceUrl. Both shapes
+        // exist in the wild: /models/<id>?modelVersionId=<vid> (model known)
+        // and /model-versions/<vid> (version-only downloads).
+        if (typeof j.sourceUrl === "string" && isCivitaiUrl(j.sourceUrl)) {
+          m.civitaiUrl = j.sourceUrl;
+        } else if (typeof j.versionId === "number") {
+          m.civitaiUrl =
+            typeof j.modelId === "number"
+              ? `https://civitai.com/models/${j.modelId}?modelVersionId=${j.versionId}`
+              : `https://civitai.com/model-versions/${j.versionId}`;
         }
       } catch {
         // No sidecar (or unreadable) — leave the model un-enriched.

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -138,7 +138,7 @@ export function registerModelManagementTools(server: McpServer): void {
 
   server.tool(
     "list_local_models",
-    "List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them. For models fetched via download_civitai_model, any CivitAI trigger/activation words and base model are shown inline (read from the `<file>.civitai.json` sidecar) — apply those trigger words in your prompt when generating with that model.",
+    "List model files available to the connected ComfyUI, grouped by type. Read-only. Queries ComfyUI's /models REST endpoint first (works with remote ComfyUI and respects extra_model_paths.yaml — symlinked / mounted dirs the install-path filesystem scan would miss), then falls back to a filesystem scan of COMFYUI_PATH/models/ when the REST endpoint is unavailable. Size and modified time are only available on the filesystem fallback path. Use to see which models are already available before generating or downloading; use search_models to discover new models on HuggingFace, then download_model to fetch them. For models fetched via download_civitai_model, any CivitAI trigger/activation words and base model are shown inline (read from the `<file>.civitai.json` sidecar) — apply those trigger words in your prompt when generating with that model. A `civitai:` line under an entry is that model's CivitAI page URL (modelId + INSTALLED modelVersionId, from the same sidecar) — use it to reference the source or check for newer versions.",
     {
       model_type: modelTypeEnum
         .optional()
@@ -187,6 +187,12 @@ export function registerModelManagementTools(server: McpServer): void {
               );
             } else if (m.baseModel) {
               lines.push(`    base: ${m.baseModel}`);
+            }
+            // Provenance: the sidecar's CivitAI page URL carries the modelId
+            // and the INSTALLED modelVersionId — link back to the source, and
+            // let clients check whether a newer version exists on CivitAI.
+            if (m.civitaiUrl) {
+              lines.push(`    civitai: ${m.civitaiUrl}`);
             }
           }
           lines.push("");


### PR DESCRIPTION
## What

`list_local_models` entries that have a `<file>.civitai.json` sidecar (written by `download_civitai_model`) now render one extra indented line:

```
- XDetail_light.safetensors
    base: SDXL 1.0
    civitai: https://civitai.com/models/162967?modelVersionId=183635
```

The URL is the sidecar's canonical `sourceUrl`; for older sidecars that predate `sourceUrl` it is reconstructed from `modelId`/`versionId` (version-only sidecars get the `/model-versions/<id>` shape).

## Why

The mobile **LoRA hub** (companion PR in comfyui-mcp-mobile) needs the INSTALLED `modelVersionId` to flag "update available" against CivitAI, and agents get source provenance for free. `list_local_models` is already on the mobile `call_tool` whitelist, so this additive output line is the entire server-side change — **no whitelist edit**.

## Verification

- `npm run build` clean; full suite green (128 files / 1441 tests)
- New unit tests: sidecar enrichment (sourceUrl passthrough + id reconstruction, both shapes) and tool rendering (`civitai:` line present, bare entries untouched)
- Live-verified against the real rig: 15/102 installed loras emit the line, both URL shapes observed

## Notes

- Output is purely additive; existing indented-line consumers (e.g. the checkpoint-switcher parser) skip unknown metadata lines by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)