### PR TITLE
fix(queue-monitor): reconnect watchdog WS after ComfyUI retarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ All notable changes to this project are documented here. This project adheres to
   passes the `prompt_id` it observed, cancel_job only interrupts a still-matching
   running job, and pending jobs are never touched
 
+#### Fixed
+- **QueueMonitor stayed disconnected after a ComfyUI retarget** — the watchdog
+  WS never reconnected once the orchestrator retargeted ComfyUI (e.g. the
+  `127.0.0.1`→`localhost` swap on a local panel `hello`), because `start()`
+  early-returned on the stale URL after the retarget's `stop()`. That left
+  `queue_status` permanently `connected:false` (so the mobile queue bar never
+  appeared) and silently disabled the local-Ollama VRAM pause. `start()` now
+  reconnects on a URL change or after `stop()`, and the WS handlers are guarded
+  against a superseded socket so the retarget's async close can't null the new
+  connection. Latent since the watchdog landed (2026-06-27); surfaced by the
+  `queue_status` broadcast above
+
 #### Docs
 - mobile app (beta) page — Android (Firebase App Distribution) + iOS
   (TestFlight) beta-tester links, pairing walkthrough, wired into the docs nav

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -151,6 +151,11 @@ class QueueMonitorImpl {
       /* ignore */
     }
     this.ws = null;
+    // Clear the flag here rather than relying on the old socket's `close`: once
+    // we null `this.ws`, that socket's now-superseded close handler early-returns
+    // (this.ws !== ws) and would otherwise leave `connected` stuck true — through
+    // a retarget's stop()+start() gap, or indefinitely if the reconnect fails.
+    this.state.connected = false;
   }
 
   private wsUrl(): string {

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -91,9 +91,14 @@ class QueueMonitorImpl {
     lastActivityTs: null,
   };
 
-  /** Open the watchdog WS to ComfyUI. Idempotent; best-effort (never throws). */
+  /** Open the watchdog WS to ComfyUI. Idempotent per-URL; best-effort (never
+   *  throws). A retarget (new URL) or a prior stop() must re-open the socket:
+   *  the orchestrator calls stop()+start(newUrl) when ComfyUI is retargeted
+   *  (e.g. 127.0.0.1→localhost from a panel hello), so a stale `this.url` must
+   *  NOT early-return — that left the watchdog permanently disconnected. */
   start(comfyuiUrl: string): void {
-    if (this.url) return; // already started
+    if (this.url === comfyuiUrl && !this.stopped) return; // already live on this URL
+    this.stop(); // tear down any prior socket/reconnect timer (also on URL change)
     this.url = comfyuiUrl;
     this.stopped = false;
     this.connect();
@@ -165,15 +170,22 @@ class QueueMonitorImpl {
       return;
     }
     this.ws = ws;
+    // Guard every handler against a superseded socket: on retarget, stop()+start()
+    // opens a new socket while the old one is still async-closing. Without the
+    // `this.ws !== ws` check the old socket's late `close` would null out the NEW
+    // socket and schedule a spurious reconnect.
     ws.on("open", () => {
+      if (this.ws !== ws) return;
       this.state.connected = true;
       logger.debug("[queue-monitor] watchdog WS connected");
     });
     ws.on("message", (raw: WebSocket.RawData, isBinary: boolean) => {
+      if (this.ws !== ws) return;
       if (isBinary) return; // preview image frames — ignore
       this.onMessage(raw.toString());
     });
     ws.on("close", () => {
+      if (this.ws !== ws) return; // a superseded socket closing — ignore
       this.state.connected = false;
       this.ws = null;
       this.scheduleReconnect();


### PR DESCRIPTION
## What

`QueueMonitor` stayed disconnected from ComfyUI after the orchestrator retargets ComfyUI on a local panel `hello` (`127.0.0.1` → `localhost`). Root cause: `start()` early-returned whenever `this.url` was already set, but `stop()` never cleared it. The retarget path calls `stop()` + `start(newUrl)` (`orchestrator/index.ts`), so `start()` saw the stale URL and never reconnected.

## Impact

- `queue_status` broadcast (#229) reported **`connected:false` forever** → the mobile app's live queue bar never appeared.
- The local-Ollama **VRAM pause** (`onRunStart`/`onRunEnd`) silently stopped firing after the first retarget.

Latent since the watchdog landed (`783787c`, 2026-06-27) — **not** a #229 regression; #229's `queue_status` broadcast is what surfaced it. #229's own E2E harness used a direct URL with no retarget, so it passed.

## Fix

- `start()` reconnects on a URL change or after a `stop()` (idempotent only for the same live URL).
- WS handlers guarded with `this.ws !== ws` so the retarget's async close of the *old* socket can't null the freshly-opened one or schedule a spurious reconnect (a race the old early-return masked).

## Verification

- Isolated dist test — `start(127.0.0.1)` → `stop()` → `start(localhost)` → `snapshot().connected === true` (was `false`).
- Live orchestrator — after the real `127.0.0.1`→`localhost` retarget, the bridge now broadcasts `queue_status connected=true` (was `connected=false`).
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)