### PR TITLE
feat: add Moonshot (Kimi K3) as a first-class provider

### DIFF
--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -50,6 +50,12 @@ placeholder follows the active backend ("Ask Claude…" / "Ask Ollama…").
   offered too.
 - **GLM** — set `ZAI_API_KEY` (Z.AI Coding Plan; `GLM_API_KEY` /
   `ZHIPUAI_API_KEY` also accepted). No CLI.
+- **Kimi K3 (Moonshot)** — set `MOONSHOT_API_KEY` from
+  [platform.kimi.ai](https://platform.kimi.ai/console/api-keys). No CLI. This is
+  the Moonshot **platform** key (default model `kimi-k3`, base
+  `https://api.moonshot.ai/v1`) — distinct from the **Kimi** provider above,
+  which is the Kimi Code coding subscription. Override the model with
+  `COMFYUI_MCP_MOONSHOT_MODEL` and the base with `COMFYUI_MCP_MOONSHOT_BASE_URL`.
 - **Copilot (experimental)** — sign in from the panel's experimental provider
   row. Off by default; enable experimental backends in Settings first.
 - **Ollama (local)** — no sign-in. Install Ollama and pull a tool-calling

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -118,6 +118,18 @@ describe("backendReadiness", () => {
     delete process.env.KIMI_SHARE_DIR;
   });
 
+  it("moonshot: ready when MOONSHOT_API_KEY is set (distinct from kimi)", () => {
+    const real = process.env.MOONSHOT_API_KEY;
+    delete process.env.MOONSHOT_API_KEY;
+    expect(backendReadiness("moonshot", { home: tmp }).ready).toBe(false);
+    process.env.MOONSHOT_API_KEY = "sk-moonshot-test";
+    const r = backendReadiness("moonshot", { home: tmp });
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+    if (real === undefined) delete process.env.MOONSHOT_API_KEY;
+    else process.env.MOONSHOT_API_KEY = real;
+  });
+
   it("unknown backend is never ready", () => {
     expect(backendReadiness("bogus").ready).toBe(false);
   });

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import {
   resolveGlmCodeCredentials,
   resolveKimiCodeOAuth,
+  resolveMoonshotCredentials,
   resolveOpenAICodexOAuth,
   __testing,
 } from "../../services/code-provider-auth.js";
@@ -26,6 +27,30 @@ describe("resolveGlmCodeCredentials", () => {
 
   it("throws when no GLM key is set", () => {
     expect(() => resolveGlmCodeCredentials()).toThrow(/ZAI_API_KEY/);
+  });
+});
+
+describe("resolveMoonshotCredentials", () => {
+  afterEach(() => {
+    delete process.env.MOONSHOT_API_KEY;
+    delete process.env.COMFYUI_MCP_MOONSHOT_BASE_URL;
+  });
+
+  it("reads MOONSHOT_API_KEY and default base URL", () => {
+    process.env.MOONSHOT_API_KEY = "sk-moonshot-test";
+    const creds = resolveMoonshotCredentials();
+    expect(creds.apiKey).toBe("sk-moonshot-test");
+    expect(creds.baseUrl).toBe(__testing.MOONSHOT_DEFAULT_BASE);
+  });
+
+  it("honors a base URL override (trailing slash stripped)", () => {
+    process.env.MOONSHOT_API_KEY = "sk-moonshot-test";
+    process.env.COMFYUI_MCP_MOONSHOT_BASE_URL = "https://api.moonshot.cn/v1/";
+    expect(resolveMoonshotCredentials().baseUrl).toBe("https://api.moonshot.cn/v1");
+  });
+
+  it("throws when MOONSHOT_API_KEY is not set", () => {
+    expect(() => resolveMoonshotCredentials()).toThrow(/MOONSHOT_API_KEY/);
   });
 });
 

--- a/src/__tests__/services/panel-secrets-slots.test.ts
+++ b/src/__tests__/services/panel-secrets-slots.test.ts
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 describe("panel-secrets credential slots", () => {
   beforeEach(() => {
     process.env.COMFYUI_MCP_PANEL_SECRETS = join(tmpdir(), `secrets-${randomUUID()}.json`);
-    for (const k of ["OPENROUTER_API_KEY","XAI_API_KEY","GEMINI_API_KEY","GOOGLE_API_KEY","GOOGLE_GENERATIVE_AI_API_KEY","HF_TOKEN","HUGGINGFACE_TOKEN","GLM_API_KEY","ZHIPU_API_KEY","ZHIPUAI_API_KEY","ZAI_API_KEY","KIMI_API_KEY","RUNCOMFY_API_KEY","REGISTRY_ACCESS_TOKEN","CIVITAI_API_TOKEN"]) delete process.env[k];
+    for (const k of ["OPENROUTER_API_KEY","XAI_API_KEY","GEMINI_API_KEY","GOOGLE_API_KEY","GOOGLE_GENERATIVE_AI_API_KEY","HF_TOKEN","HUGGINGFACE_TOKEN","GLM_API_KEY","ZHIPU_API_KEY","ZHIPUAI_API_KEY","ZAI_API_KEY","KIMI_API_KEY","MOONSHOT_API_KEY","RUNCOMFY_API_KEY","REGISTRY_ACCESS_TOKEN","CIVITAI_API_TOKEN"]) delete process.env[k];
   });
 
   it("fans a slot out to all its env keys in the right store file", async () => {
@@ -24,6 +24,14 @@ describe("panel-secrets credential slots", () => {
     const file = JSON.parse(readFileSync(process.env.COMFYUI_MCP_PANEL_SECRETS!, "utf-8"));
     expect(file.agentEnv.GLM_API_KEY).toBe("glm-secret-xyz789");
     expect(process.env.GLM_API_KEY).toBe("glm-secret-xyz789");
+  });
+
+  it("routes the moonshot slot to MOONSHOT_API_KEY in the agent store", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("moonshot", "sk-moonshot-abc123");
+    const file = JSON.parse(readFileSync(process.env.COMFYUI_MCP_PANEL_SECRETS!, "utf-8"));
+    expect(file.agentEnv.MOONSHOT_API_KEY).toBe("sk-moonshot-abc123");
+    expect(process.env.MOONSHOT_API_KEY).toBe("sk-moonshot-abc123");
   });
 
   it("rejects an unknown slot", async () => {

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -17,6 +17,7 @@ export type BackendId =
   | "grok"
   | "glm"
   | "kimi"
+  | "moonshot"
   | "ollama"
   | "openrouter"
   | "copilot";
@@ -290,6 +291,13 @@ export const GLM_CAPABILITIES: AgentCapabilities = {
 
 /** Kimi Code subscription OAuth or KIMI_API_KEY — OpenAI-compatible coding API. */
 export const KIMI_CAPABILITIES: AgentCapabilities = {
+  ...OLLAMA_CAPABILITIES,
+};
+
+/** Moonshot platform API (Kimi K3) — MOONSHOT_API_KEY, OpenAI-compatible
+ *  /v1/chat/completions. Distinct from the `kimi` backend (Kimi Code coding
+ *  subscription): a general pay-per-token platform key, its own host + model. */
+export const MOONSHOT_CAPABILITIES: AgentCapabilities = {
   ...OLLAMA_CAPABILITIES,
 };
 

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -186,6 +186,13 @@ export function backendReadiness(
     const auth = !!apiKey || oauth;
     return { backend: "kimi", cli: true, auth, ready: auth };
   }
+  if (b === "moonshot") {
+    // Moonshot platform (Kimi K3) — hosted, no CLI. Readiness = MOONSHOT_API_KEY
+    // in the orchestrator's env (a bad key still surfaces via the connect ack's
+    // model probe → degraded). Distinct from `kimi` (Kimi Code subscription).
+    const auth = !!process.env.MOONSHOT_API_KEY?.trim();
+    return { backend: "moonshot", cli: true, auth, ready: auth };
+  }
   if (b === "gemini") {
     const cli = onPath(CLI_NAMES.gemini);
     // The gemini CLI caches its Google OAuth at <home>/.gemini/oauth_creds.json

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1801,9 +1801,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   // without a reconnect.
   const unsubscribeAgentSecrets = onAgentSecretsChanged(() => {
     hydrateAgentSecretsIntoEnv();
-    // A key change can affect either keyed endpoint provider — drop both
-    // caches so the next probe carries the fresh credentials.
-    for (const b of ["openrouter", "custom"]) {
+    // A key change can affect ANY keyed provider (OpenRouter/Custom endpoints and
+    // the hosted API-key backends GLM / Kimi / Moonshot) — drop each one's cached
+    // probe backend + model list so the next probe carries the fresh credentials
+    // (and a revoked key immediately stops reading as "ready" from a stale cache).
+    for (const b of ["openrouter", "custom", "glm", "kimi", "moonshot"]) {
       modelsByBackend.delete(b);
       const pb = probeBackends.get(b);
       if (pb?.close) void pb.close().catch(() => {});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -64,6 +64,7 @@ import { OllamaBackend, OLLAMA_SYSTEM_PROMPT } from "./ollama-backend.js";
 import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-backend.js";
 import { GlmBackend, GLM_DEFAULT_MODEL } from "./glm-backend.js";
 import { KimiBackend, KIMI_DEFAULT_MODEL } from "./kimi-backend.js";
+import { MoonshotBackend, MOONSHOT_DEFAULT_MODEL } from "./moonshot-backend.js";
 import { CopilotBackend, COPILOT_DEFAULT_MODEL } from "./copilot-backend.js";
 import { SYSTEM as MODEL_CARD_SYSTEM } from "./ai-proposer.js";
 import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/prompt-overrides.js";
@@ -1075,7 +1076,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     const hydrated = new Set(hydratedSecrets);
     const src = (k: string) => (process.env[k] ? (hydrated.has(k) ? "store" : "env") : "none");
     logger.info(
-      `[panel-orchestrator] keyed providers: openrouter=${src("OPENROUTER_API_KEY")}, glm=${src("GLM_API_KEY")}, kimi=${src("KIMI_API_KEY")}`,
+      `[panel-orchestrator] keyed providers: openrouter=${src("OPENROUTER_API_KEY")}, glm=${src("GLM_API_KEY")}, kimi=${src("KIMI_API_KEY")}, moonshot=${src("MOONSHOT_API_KEY")}`,
     );
   }
   const persistedAgent = getAgentSettings();
@@ -1084,6 +1085,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   const chatgptModel = process.env.COMFYUI_MCP_CHATGPT_MODEL ?? CHATGPT_DEFAULT_MODEL;
   const glmModel = process.env.COMFYUI_MCP_GLM_MODEL ?? GLM_DEFAULT_MODEL;
   const kimiModel = process.env.COMFYUI_MCP_KIMI_MODEL ?? KIMI_DEFAULT_MODEL;
+  const moonshotModel = process.env.COMFYUI_MCP_MOONSHOT_MODEL ?? MOONSHOT_DEFAULT_MODEL;
   // EXPERIMENTAL (ToS risk) — off by default, only reachable once the user has
   // signed in via the panel's experimental row (oauth-bridge.ts's
   // allow_experimental gate); never the defaultBackend/auto-pick.
@@ -1183,6 +1185,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     "grok",
     "glm",
     "kimi",
+    "moonshot",
     "ollama",
     "openrouter",
     "lmstudio",
@@ -1479,6 +1482,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         mcpServers: makeHttpBackendMcpServers(panelTabId),
       });
     }
+    if (backend === "moonshot") {
+      return new MoonshotBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        model: moonshotModel,
+        systemAppend: panelSystemAppend,
+        comfyuiUrl,
+        mcpServers: makeHttpBackendMcpServers(panelTabId),
+      });
+    }
     if (backend === "copilot") {
       // EXPERIMENTAL (ToS risk) — prepare() throws a clear re-sign-in error if
       // no ~/.comfyui-mcp/copilot-auth.json exists yet (resolveCopilotOAuth),
@@ -1523,6 +1535,8 @@ export async function runPanelOrchestrator(): Promise<void> {
             ? new GlmBackend({ cwd: comfyuiPath ?? process.cwd(), model: glmModel })
           : backend === "kimi"
             ? new KimiBackend({ cwd: comfyuiPath ?? process.cwd(), model: kimiModel })
+          : backend === "moonshot"
+            ? new MoonshotBackend({ cwd: comfyuiPath ?? process.cwd(), model: moonshotModel })
           : backend === "ollama"
             ? new OllamaBackend({ cwd: comfyuiPath ?? process.cwd(), model: ollamaModel, ...ollamaDeps() })
             : backend === "grok"
@@ -1909,6 +1923,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "chatgpt") return chatgptModel;
     if (backend === "glm") return glmModel;
     if (backend === "kimi") return kimiModel;
+    if (backend === "moonshot") return moonshotModel;
     if (backend === "copilot") return copilotModel;
     return model;
   }
@@ -2114,6 +2129,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const isGk = backend === "grok";
       const isGl = backend === "glm";
       const isKm = backend === "kimi";
+      const isMs = backend === "moonshot";
       const isOl = backend === "ollama";
       const isOr = backend === "openrouter";
       const isLs = backend === "lmstudio";
@@ -2175,6 +2191,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                   ? (glmModel ?? (models[0] as { value?: string }).value ?? "GLM")
                 : isKm
                   ? (kimiModel ?? (models[0] as { value?: string }).value ?? "Kimi")
+                : isMs
+                  ? (moonshotModel ?? (models[0] as { value?: string }).value ?? "Kimi K3")
                 : isOl
                   ? (ollamaModel ?? (models[0] as { value?: string }).value ?? "Ollama")
                   : isLs
@@ -2235,6 +2253,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Z.AI GLM Coding Plan. Ask away.`
                   : isKm
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Kimi Code subscription. Ask away.`
+                  : isMs
+                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Moonshot platform (Kimi K3) API key. Ask away.`
                   : isOl
                     ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
                     : isLs
@@ -2265,6 +2285,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                   ? "⚠️ The background agent isn't responding — GLM Code API couldn't start. Set ZAI_API_KEY (Z.AI Coding Plan), then Disconnect → Connect to retry."
                 : isKm
                   ? "⚠️ The background agent isn't responding — Kimi Code couldn't start. Run Kimi Code login (~/.kimi/credentials/kimi-code.json) or set KIMI_API_KEY, then Disconnect → Connect to retry."
+                : isMs
+                  ? "⚠️ The background agent isn't responding — Moonshot (Kimi K3) couldn't start. Set MOONSHOT_API_KEY from platform.kimi.ai, then Disconnect → Connect to retry."
                 : isOl
                   ? "⚠️ The background agent isn't responding — Ollama isn't reachable. Start it with `ollama serve` and pull our fine-tuned model (`ollama pull artokun/gemma4-comfyui-mcp:e4b` — gemma4 trained on the comfyui-mcp tool suite — arena-best local model; `:12b` for ~8 GB VRAM), then Disconnect → Connect to retry."
                   : isLs

--- a/src/orchestrator/moonshot-backend.ts
+++ b/src/orchestrator/moonshot-backend.ts
@@ -1,0 +1,25 @@
+import { MOONSHOT_CAPABILITIES } from "./agent-backend.js";
+import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
+import { resolveMoonshotCredentials } from "../services/code-provider-auth.js";
+
+export const MOONSHOT_DEFAULT_MODEL =
+  process.env.COMFYUI_MCP_MOONSHOT_MODEL?.trim() || "kimi-k3";
+
+/** Moonshot platform API (Kimi K3) — OpenAI-compatible chat/completions + 6-tool
+ *  router. A general pay-per-token platform key (MOONSHOT_API_KEY, api.moonshot.ai),
+ *  distinct from the `kimi` backend's Kimi Code coding subscription. */
+export class MoonshotBackend extends OllamaBackend {
+  readonly capabilities = MOONSHOT_CAPABILITIES;
+
+  constructor(deps: Omit<OllamaBackendDeps, "api" | "host" | "apiKey" | "backendId"> = {}) {
+    const creds = resolveMoonshotCredentials();
+    super({
+      ...deps,
+      backendId: "moonshot",
+      api: "openai",
+      host: creds.baseUrl,
+      apiKey: creds.apiKey,
+      model: deps.model ?? MOONSHOT_DEFAULT_MODEL,
+    });
+  }
+}

--- a/src/orchestrator/panel-console-http.ts
+++ b/src/orchestrator/panel-console-http.ts
@@ -22,6 +22,7 @@ const KNOWN_BACKENDS = [
   "grok",
   "glm",
   "kimi",
+  "moonshot",
   "ollama",
   "copilot", // EXPERIMENTAL — see orchestrator/index.ts's copilotModel comment
 ] as const;

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -20,6 +20,7 @@ const KIMI_OAUTH_TOKEN_URL = "https://api.kimi.com/oauth/token";
 
 export const GLM_CODE_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4";
 export const KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1";
+export const MOONSHOT_DEFAULT_BASE = "https://api.moonshot.ai/v1";
 
 const TOKEN_REFRESH_SKEW_MS = 120_000;
 
@@ -36,6 +37,11 @@ export type OpenAICodexOAuthCredentials = {
 };
 
 export type GlmCodeCredentials = {
+  apiKey: string;
+  baseUrl: string;
+};
+
+export type MoonshotCredentials = {
   apiKey: string;
   baseUrl: string;
 };
@@ -474,6 +480,23 @@ export function resolveGlmCodeCredentials(): GlmCodeCredentials {
 }
 
 /**
+ * Moonshot platform API key (Kimi K3). Env: MOONSHOT_API_KEY. This is the
+ * general Moonshot/Kimi PLATFORM key (api.moonshot.ai), distinct from the
+ * Kimi Code coding subscription resolved by `resolveKimiCodeOAuth` above.
+ */
+export function resolveMoonshotCredentials(): MoonshotCredentials {
+  const apiKey = process.env.MOONSHOT_API_KEY?.trim();
+  if (!apiKey) {
+    throw new ValidationError(
+      "Moonshot (Kimi K3) requires MOONSHOT_API_KEY from platform.kimi.ai (https://platform.kimi.ai/console/api-keys).",
+    );
+  }
+  const baseUrl =
+    process.env.COMFYUI_MCP_MOONSHOT_BASE_URL?.trim().replace(/\/$/, "") || MOONSHOT_DEFAULT_BASE;
+  return { apiKey, baseUrl };
+}
+
+/**
  * Resolve Kimi Code subscription OAuth from ~/.kimi/credentials/kimi-code.json.
  * Falls back to KIMI_API_KEY when set (pay-per-token / CI).
  */
@@ -699,6 +722,7 @@ export const __testing = {
   KIMI_CODE_CLIENT_ID,
   GLM_CODE_DEFAULT_BASE,
   KIMI_CODE_DEFAULT_BASE,
+  MOONSHOT_DEFAULT_BASE,
   codexAuthPath,
   kimiCodeAuthPath,
   grokAuthPath,

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -90,6 +90,7 @@ export const AGENT_SECRET_ENV_ALLOWLIST = [
   "ZHIPUAI_API_KEY",
   "ZAI_API_KEY",
   "KIMI_API_KEY",
+  "MOONSHOT_API_KEY",
 ] as const;
 const AGENT_ALLOWLIST_SET = new Set<string>(AGENT_SECRET_ENV_ALLOWLIST);
 
@@ -352,6 +353,7 @@ export const CREDENTIAL_SLOTS: CredentialSlot[] = [
   { id: "openrouter", label: "OpenRouter", envKeys: ["OPENROUTER_API_KEY"], store: "agent", help: "Hosted models (MiMo, MiniMax, GPT, Claude…)" },
   { id: "glm", label: "GLM / Zhipu", envKeys: ["GLM_API_KEY", "ZHIPU_API_KEY", "ZHIPUAI_API_KEY", "ZAI_API_KEY"], store: "agent", help: "GLM provider" },
   { id: "kimi", label: "Kimi (API)", envKeys: ["KIMI_API_KEY"], store: "agent", help: "Kimi via API key (vs its OAuth)" },
+  { id: "moonshot", label: "Kimi K3 (Moonshot)", envKeys: ["MOONSHOT_API_KEY"], store: "agent", help: "Kimi K3 via the Moonshot platform API key" },
   { id: "civitai", label: "Civitai", envKeys: ["CIVITAI_API_TOKEN"], store: "comfyui", help: "Model downloads" },
   { id: "huggingface", label: "HuggingFace", envKeys: ["HF_TOKEN", "HUGGINGFACE_TOKEN"], store: "comfyui", help: "Model downloads" },
   { id: "google", label: "Google / Gemini", envKeys: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"], store: "comfyui", help: "Nano Banana concept images" },


### PR DESCRIPTION
## What

Hooks up **Kimi K3** ([platform.kimi.ai](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart)) as a dedicated `moonshot` provider in the single-port multi-provider orchestrator.

Kimi K3 lives on Moonshot's **platform** API (`api.moonshot.ai/v1`, `MOONSHOT_API_KEY`, default model `kimi-k3`, OpenAI-compatible). That's a different product from the existing `kimi` backend, which is the **Kimi Code** coding subscription (OAuth or `KIMI_API_KEY`, `api.kimi.com/coding/v1`, `kimi-for-coding`). So this adds a clean sibling of `GlmBackend` rather than folding into `kimi` — both Kimi products are now selectable side by side.

## Wiring (every surface a provider touches)

- `agent-backend.ts` — `BackendId` union + `MOONSHOT_CAPABILITIES`
- `moonshot-backend.ts` (new) — `MoonshotBackend extends OllamaBackend` (openai dialect)
- `code-provider-auth.ts` — `resolveMoonshotCredentials()` + `MOONSHOT_DEFAULT_BASE`
- `index.ts` — model var, `makeBackend`, probe, `KNOWN_BACKENDS`, current-model label, connect-ack ready/degraded messages
- `panel-console-http.ts` — `KNOWN_BACKENDS`
- `backend-readiness.ts` — ready iff `MOONSHOT_API_KEY` is set
- `panel-secrets.ts` — credential slot **Kimi K3 (Moonshot)** + agent-secret allowlist
- `docs/backends.mdx` — sign-in bullet

## Config

| Var | Purpose | Default |
|---|---|---|
| `MOONSHOT_API_KEY` | Platform key from platform.kimi.ai | — (required) |
| `COMFYUI_MCP_MOONSHOT_MODEL` | Model id | `kimi-k3` |
| `COMFYUI_MCP_MOONSHOT_BASE_URL` | Base URL | `https://api.moonshot.ai/v1` |

## Testing

- Full suite green: **1443 tests pass**; `tsc` clean.
- New tests: `resolveMoonshotCredentials`, `backendReadiness("moonshot")`, and moonshot credential-slot routing.
- **Verified live** against the Moonshot API: `kimi-k3` is present in `/v1/models` and answers `chat/completions`; `MoonshotBackend.listModels()` returns it through our own code path.

## Notes / follow-ups

- K3 returns `reasoning_content` (always-on thinking). Content is handled correctly; surfacing the reasoning stream in the panel is a nice-to-have, not done here.
- The panel UI chip lives in the separate `comfyui-mcp-panel` repo — this PR is the server side only.
- The per-provider wiring is duplicated across ~10 sites; a **provider-registry consolidation** is proposed as a separate draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)