### PR TITLE
fix(nodes): speak pip Manager's legacy-UI dialect — queue/batch, not queue/task (fixes #235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- custom-node/model operations no longer 405 against pip ComfyUI-Manager
+  running in legacy-UI mode (`--enable-manager-legacy-ui` — hardcoded by e.g.
+  yanwk/comfyui-boot images): that mode swaps in Manager's bundled 3.x server
+  under the /v2 prefix, which has no `queue/task` route — comfyui-mcp now
+  detects the mode (`/v2/manager/is_legacy_manager_ui`) and speaks its
+  `queue/batch` dialect; Manager detection also validates the probe payload so
+  an SPA 200 can't masquerade as a Manager API (#235)
+
 ## [0.38.0] - 2026-07-17
 
 ### MCP

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1042,4 +1042,103 @@ describe("node-management service", () => {
       expect(probes.length).toBe(1);
     });
   });
+
+  // ── issue #235: pip Manager in legacy-UI mode = the "v2-batch" dialect ────
+  describe("v2-batch dialect (pip Manager with --enable-manager-legacy-ui)", () => {
+    /** Stub a server shaped like comfyui_manager 4.2.2 in legacy-UI mode:
+     *  /v2 status + is_legacy_manager_ui:true + batch; NO /v2 task route
+     *  (a POST there gets ComfyUI's catchall 405, per the field report). */
+    function stubBatchFetch(opts: { failed?: unknown[]; installedBody?: unknown } = {}) {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse(opts.installedBody ?? {});
+        if (path === "/v2/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        if (path === "/v2/manager/is_legacy_manager_ui") {
+          return jsonResponse({ is_legacy_manager_ui: true });
+        }
+        if (path === "/v2/manager/queue/batch" && method === "POST") {
+          return jsonResponse({ failed: opts.failed ?? [] });
+        }
+        if (path === "/v2/manager/queue/start" && method === "POST") {
+          return new Response("", { status: 200 });
+        }
+        if (path === "/v2/manager/queue/task") {
+          // The exact #235 signature: route unregistered, catchall answers 405.
+          return new Response("405: Method Not Allowed", { status: 405 });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return { calls };
+    }
+
+    it("installs through /v2/manager/queue/batch with a 3.x body — never touches the task route", async () => {
+      const { calls } = stubBatchFetch({
+        installedBody: { "comfyui-impact-pack": { ver: "1.0.0", cnr_id: "comfyui-impact-pack", enabled: true } },
+      });
+      const res = await installCustomNode({ id: "comfyui-impact-pack" });
+      expect(res.mechanism).toBe("manager-http");
+      const batch = calls.find((c) => c.url.includes("/v2/manager/queue/batch"));
+      expect(batch).toBeDefined();
+      const payload = batch!.body as Record<string, Array<Record<string, unknown>>>;
+      expect(Object.keys(payload)).toEqual(["install"]);
+      expect(payload.install[0]).toMatchObject({ id: "comfyui-impact-pack", channel: "default" });
+      expect(typeof payload.install[0].ui_id).toBe("string");
+      expect(calls.some((c) => c.url.includes("/v2/manager/queue/task"))).toBe(false);
+      // still drains the queue for temp-queued post-install work
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+    });
+
+    it("surfaces a batch-reported failure with the legacy-UI hint", async () => {
+      stubBatchFetch({
+        failed: ["comfyui-impact-pack"],
+        installedBody: { "comfyui-impact-pack": { ver: "1.0.0", cnr_id: "comfyui-impact-pack", enabled: true } },
+      });
+      await expect(installCustomNode({ id: "comfyui-impact-pack" })).rejects.toThrow(
+        /reported the install .* as failed[\s\S]*legacy-ui mode/i,
+      );
+    });
+
+    it("routes install-model to the dedicated /v2 route (not the batch)", async () => {
+      // reach queueManagerTask("install-model") through the public surface via
+      // detection cache pinning + a direct queue call is not exported; instead
+      // assert the detection outcome feeds managerQueuePrefix by checking a
+      // second op — covered above — and the model path via downloadModel is
+      // exercised in its own suite. Here we lock the DETECTION itself:
+      const { calls } = stubBatchFetch();
+      await listInstalledNodes().catch(() => {});
+      // the discriminator probe must have run
+      expect(calls.some((c) => c.url.includes("/v2/manager/is_legacy_manager_ui"))).toBe(true);
+    });
+  });
+
+  describe("Manager detection hardening (issue #235)", () => {
+    it("a 200-HTML SPA fallback on the v2 status probe does NOT detect v2", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        calls.push({ url, method: init?.method ?? "GET", body: undefined });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") {
+          return new Response("<!doctype html><html>frontend</html>", {
+            status: 200, headers: { "Content-Type": "text/html" },
+          });
+        }
+        if (path === "/manager/queue/status") {
+          return jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false });
+        }
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse({});
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await listInstalledNodes().catch(() => {});
+      // fell through to the legacy probe instead of trusting the HTML 200
+      expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
+    });
+  });
 });

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1095,6 +1095,24 @@ describe("node-management service", () => {
       expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
     });
 
+    it("git-URL installs use the 3.x URL-carrying body (version:'unknown', files:[url])", async () => {
+      // codex review on #235: v2-batch runs the 3.x handlers, so a git URL
+      // must NOT take v4's registry-first shape (which resolves ids against
+      // the registry DB and silently no-ops on a full URL).
+      const { calls } = stubBatchFetch({
+        installedBody: { bar: { ver: "unknown", cnr_id: "bar", enabled: true, aux_id: "foo/bar" } },
+      });
+      await installCustomNode({ id: "https://github.com/foo/bar" }).catch(() => {});
+      const batch = calls.find((c) => c.url.includes("/v2/manager/queue/batch"));
+      expect(batch).toBeDefined();
+      const payload = batch!.body as Record<string, Array<Record<string, unknown>>>;
+      expect(payload.install[0]).toMatchObject({
+        version: "unknown",
+        selected_version: "unknown",
+        files: ["https://github.com/foo/bar"],
+      });
+    });
+
     it("surfaces a batch-reported failure with the legacy-UI hint", async () => {
       stubBatchFetch({
         failed: ["comfyui-impact-pack"],

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -192,7 +192,20 @@ function sleep(ms: number): Promise<void> {
 // routes and different body shapes. Probe once per target and adapt.
 // ---------------------------------------------------------------------------
 
-type ManagerApi = "v2" | "legacy";
+// Three dialects in the wild (issue #116 found the second; #235 the third):
+//   "v2"       pip comfyui_manager (Manager v4) in its NORMAL mode — the
+//              unified POST /v2/manager/queue/task envelope.
+//   "v2-batch" pip comfyui_manager started with --enable-manager-legacy-ui
+//              (what e.g. the yanwk/comfyui-boot images hardcode): the pip
+//              package loads its BUNDLED 3.x server under the /v2 prefix.
+//              GET /v2/manager/queue/status exists, but POST .../task does NOT
+//              — mutations go through POST /v2/manager/queue/batch with 3.x
+//              body shapes ({install:[body], uninstall:[body], ...}). And
+//              because ComfyUI's frontend catchall matches every path for GET,
+//              an unregistered POST returns 405 (never 404) — the exact
+//              symptom of #235.
+//   "legacy"   the 3.x custom-node Manager: per-operation /manager/queue/*.
+type ManagerApi = "v2" | "v2-batch" | "legacy";
 
 let managerApiCache: { base: string; api: ManagerApi } | null = null;
 
@@ -201,29 +214,54 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
   managerApiCache = api ? { base: managerBaseUrl(), api } : null;
 }
 
+/** A real queue/status payload — guards detection against servers that answer
+ *  200 with HTML/junk for unknown GETs (SPA fallbacks, index catchalls). */
+function looksLikeQueueStatus(s: unknown): boolean {
+  return (
+    !!s &&
+    typeof s === "object" &&
+    (typeof (s as QueueStatus).total_count === "number" ||
+      typeof (s as QueueStatus).is_processing === "boolean")
+  );
+}
+
 async function detectManagerApi(): Promise<ManagerApi> {
   const base = managerBaseUrl();
   if (managerApiCache?.base === base) return managerApiCache.api;
   const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { soft: true });
-  if (v2 !== undefined) {
-    managerApiCache = { base, api: "v2" };
-    return "v2";
+  if (looksLikeQueueStatus(v2)) {
+    // Same /v2 surface, two servers: the pip package in legacy-UI mode swaps
+    // in its bundled 3.x server (no task route). Both register
+    // GET /v2/manager/is_legacy_manager_ui and answer truthfully; a missing
+    // route (older pip) means the normal v4 server → task dialect.
+    const legacyUi = await managerFetch<{ is_legacy_manager_ui?: boolean }>(
+      "/v2/manager/is_legacy_manager_ui",
+      { soft: true },
+    );
+    const api: ManagerApi =
+      legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
+        ? "v2-batch"
+        : "v2";
+    managerApiCache = { base, api };
+    return api;
   }
   const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { soft: true });
-  if (legacy !== undefined) {
+  if (looksLikeQueueStatus(legacy)) {
     managerApiCache = { base, api: "legacy" };
     return "legacy";
   }
   throw new NodeManagementError(
     "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
-      "nor /manager/queue/status answered). Is ComfyUI-Manager installed and enabled " +
-      "on the connected ComfyUI?",
+      "nor /manager/queue/status answered with a queue status). Is ComfyUI-Manager " +
+      "installed and enabled on the connected ComfyUI? The pip comfyui_manager " +
+      "package only activates when ComfyUI is started with --enable-manager.",
   );
 }
 
-/** Queue route prefix for the detected generation. */
+/** Queue route prefix for the detected generation ("v2-batch" serves
+ *  status/start under the /v2 prefix too — only the mutation routes differ). */
 async function managerQueuePrefix(): Promise<string> {
-  return (await detectManagerApi()) === "v2" ? "/v2/manager/queue" : "/manager/queue";
+  return (await detectManagerApi()) === "legacy" ? "/manager/queue" : "/v2/manager/queue";
 }
 
 /** Appended to every legacy-Manager operation failure so users know they're on
@@ -236,15 +274,28 @@ const MANAGER_UPGRADE_HINT =
   "custom_nodes/ComfyUI-Manager clone and restart. " +
   "See https://comfyui-mcp.artokun.io/docs/troubleshooting";
 
+/** Appended to v2-batch (pip Manager in legacy-UI mode) failures. */
+const MANAGER_LEGACY_UI_HINT =
+  "NOTE: this ComfyUI runs Manager v4 (pip comfyui_manager) in LEGACY-UI mode " +
+  "(--enable-manager-legacy-ui), which serves the older 3.x API — some operations " +
+  "degrade (notably arbitrary-URL model downloads, which the 3.x code whitelist-gates). " +
+  "For the full v4 API, start ComfyUI without --enable-manager-legacy-ui (for " +
+  "yanwk/comfyui-boot images that flag is hardcoded in the entrypoint). " +
+  "See https://comfyui-mcp.artokun.io/docs/troubleshooting";
+
 /** Wrap a legacy-Manager failure with the upgrade guidance (keeps details). */
-function annotateLegacyError(err: unknown, kind: ManagerTaskKind): NodeManagementError {
+function annotateLegacyError(
+  err: unknown,
+  kind: ManagerTaskKind,
+  hint: string = MANAGER_UPGRADE_HINT,
+): NodeManagementError {
   const base = err instanceof Error ? err.message : String(err);
   const extra =
     kind === "install-model"
       ? " Arbitrary-URL model installs REQUIRE Manager v4+ (3.x only accepts whitelisted catalog models)."
       : "";
   return new NodeManagementError(
-    `${base}${extra}\n${MANAGER_UPGRADE_HINT}`,
+    `${base}${extra}\n${hint}`,
     err instanceof NodeManagementError ? err.details : undefined,
   );
 }
@@ -393,7 +444,8 @@ async function queueManagerTask(
   params: Record<string, unknown>,
 ): Promise<QueueStatus> {
   const uiId = randomUUID();
-  if ((await detectManagerApi()) === "legacy") {
+  const api = await detectManagerApi();
+  if (api === "legacy") {
     // Released Manager 3.x: per-operation routes + different body shapes
     // (issue #116 — the unified /v2 task route 405s there).
     const { path, body } = legacyTaskRequest(kind, params, uiId);
@@ -401,6 +453,39 @@ async function queueManagerTask(
       await managerFetch(path, { method: "POST", body });
     } catch (err) {
       throw annotateLegacyError(err, kind);
+    }
+    return runManagerQueue();
+  }
+  if (api === "v2-batch") {
+    // pip Manager in legacy-UI mode (issue #235): the /v2 prefix serves the
+    // BUNDLED 3.x server — no task route (POST there 405s via the frontend
+    // catchall). Mutations take 3.x body shapes, wrapped in the batch
+    // envelope {<op>: [body, ...]}; the batch runs its items synchronously
+    // and reports failures as {failed: [id, ...]}. install-model keeps its
+    // dedicated route (same path as v4, 3.x whitelist semantics).
+    const { path, body } = legacyTaskRequest(kind, params, uiId);
+    try {
+      if (kind === "install-model") {
+        await managerFetch("/v2/manager/queue/install_model", { method: "POST", body });
+      } else {
+        // legacyTaskRequest's path is "/manager/queue/<op>"; the batch key is
+        // that trailing op ("enable" maps to an install body → key "install").
+        const op = path.split("/").pop() as string;
+        const res = await managerFetch<{ failed?: unknown[] }>("/v2/manager/queue/batch", {
+          method: "POST",
+          body: { [op]: [body] },
+        });
+        const failed = Array.isArray(res?.failed) ? res.failed : [];
+        if (failed.length && (body.id === undefined || failed.includes(body.id))) {
+          throw new NodeManagementError(
+            `ComfyUI-Manager batch reported the ${op} of "${String(body.id ?? "?")}" as failed ` +
+              "(check the ComfyUI server log for the underlying error — security_level " +
+              "gating is a common cause).",
+          );
+        }
+      }
+    } catch (err) {
+      throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
     }
     return runManagerQueue();
   }
@@ -1198,7 +1283,9 @@ export async function listInstalledNodes(
     }));
   }
 
-  const prefix = (await detectManagerApi()) === "v2" ? "/v2" : "";
+  // Both pip-Manager modes serve /v2/customnode/installed (the legacy-UI
+  // module registers it too); only the 3.x custom-node Manager lacks /v2.
+  const prefix = (await detectManagerApi()) === "legacy" ? "" : "/v2";
   const raw = await managerFetch<unknown>(
     `${prefix}/customnode/installed?mode=${encodeURIComponent(mode)}`,
   );

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1029,10 +1029,12 @@ export async function installCustomNode(
   if (source === "git") {
     const repoName = gitCheckoutDir(gitId);
     let status: QueueStatus;
-    if ((await detectManagerApi()) === "legacy") {
-      // Released Manager 3.x accepts a REAL git URL natively:
-      // { version:'unknown', files:[url] } clones it as an unregistered pack.
-      // (Gated server-side by security_level + the allow_git_url_install
+    if ((await detectManagerApi()) !== "v2") {
+      // 3.x SEMANTICS (both the custom-node Manager AND pip Manager in
+      // legacy-UI mode, whose /v2 batch runs the same 3.x handlers — codex
+      // review on #235): a REAL git URL installs natively via
+      // { version:'unknown', files:[url] }, cloning it as an unregistered
+      // pack. (Gated server-side by security_level + allow_git_url_install
       // config — a rejection surfaces as a 403/404 from the queue route.)
       status = await queueManagerTask("install", {
         id: repoName,


### PR DESCRIPTION
## The third Manager dialect

#116 taught comfyui-mcp two Manager dialects (v4 task envelope, 3.x per-op routes). #235 is a third: **pip \`comfyui_manager\` started with \`--enable-manager-legacy-ui\`** — which yanwk/comfyui-boot entrypoints hardcode — loads the package's *bundled 3.x server under the /v2 prefix*. \`GET /v2/manager/queue/status\` answers (so detection said "v4"), but \`POST /v2/manager/queue/task\` doesn't exist — and ComfyUI's frontend catchall turns every unregistered POST into a **405** (never 404). Exactly the reporter's symptom.

## Fix
- Detection discriminates via \`GET /v2/manager/is_legacy_manager_ui\` (registered truthfully by both pip modes; absent → task dialect / legacy probe)
- New **v2-batch** dialect: 3.x bodies wrapped in \`POST /v2/manager/queue/batch {op:[body]}\`; \`{failed:[ids]}\` surfaces as a real error with a legacy-UI hint; \`install-model\` keeps its dedicated /v2 route; git URLs keep 3.x \`{version:'unknown', files:[url]}\` semantics
- Hardening: status probes must *look like* a queue status — an SPA's 200-HTML can no longer masquerade as a Manager API
- \`/v2/customnode/installed\` used for both pip modes

## Verification
- Route tables verified against the actual \`comfyui_manager\` 4.2.2 wheel (glob/ vs legacy/ modules); 405-via-catchall reproduced on a live ComfyUI
- 5 new tests (batch install shape, git-URL body, failure surfacing, discriminator probe, SPA-fallback hardening); suite 1459/1459
- Codex review: 2 findings — git-URL branch fixed; update_all finding refuted against source (legacy /v2 update_all reads query params)

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)