### PR TITLE
feat(training): CLI LoRA trainer P1 — character LoRA on FLUX.1-dev via GPU-Docker train_* tools (E2E-proven)

### DIFF
--- a/docker/trainer/Dockerfile
+++ b/docker/trainer/Dockerfile
@@ -12,14 +12,15 @@
 # Run (bind config + dataset + output + HF cache; --gpus all is required):
 #   docker run --rm --gpus all \
 #     -v /path/config.yml:/config.yml:ro \
-#     -v /path/dataset:/dataset:ro \
+#     -v /path/dataset:/dataset \
 #     -v /path/output:/output \
 #     -v $HOME/.cache/huggingface:/root/.cache/huggingface \
 #     -e HF_TOKEN=$HF_TOKEN \
 #     comfyui-mcp-trainer:latest /config.yml
 #
 # The config's training_folder must be /output and datasets[].folder_path /dataset
-# (the driver in src/services/ai-toolkit.ts wires these paths).
+# (the driver in src/services/ai-toolkit.ts wires these paths). /dataset must be
+# writable: ai-toolkit caches (.aitk_size.json, latents) inside it.
 
 FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 

--- a/docker/trainer/Dockerfile
+++ b/docker/trainer/Dockerfile
@@ -1,0 +1,64 @@
+# Headless GPU LoRA-training image — runs ostris ai-toolkit's `run.py` directly.
+#
+# Derived from ai-toolkit's own Dockerfile (same CUDA base, torch, arch list) but
+# STRIPPED of the Next.js UI: we drive training via the CLI + a generated YAML
+# config, so no Node/UI layers. One image, two future targets — local `docker run`
+# now, the same image on a RunPod pod later.
+#
+# Build (from repo root):
+#   docker build -t comfyui-mcp-trainer:latest \
+#     --build-arg AI_TOOLKIT_REF=<commit-or-tag> docker/trainer
+#
+# Run (bind config + dataset + output + HF cache; --gpus all is required):
+#   docker run --rm --gpus all \
+#     -v /path/config.yml:/config.yml:ro \
+#     -v /path/dataset:/dataset:ro \
+#     -v /path/output:/output \
+#     -v $HOME/.cache/huggingface:/root/.cache/huggingface \
+#     -e HF_TOKEN=$HF_TOKEN \
+#     comfyui-mcp-trainer:latest /config.yml
+#
+# The config's training_folder must be /output and datasets[].folder_path /dataset
+# (the driver in src/services/ai-toolkit.ts wires these paths).
+
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PYTHONUTF8=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    # Ampere (30xx) through Blackwell (50xx/GB) — 8.9 = RTX 4090.
+    TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0 10.0 12.0"
+
+# 1) System packages (heaviest, most cache-stable layer).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-pip python3-dev \
+        git git-lfs cmake build-essential ffmpeg libgl1 libglib2.0-0 ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
+
+# 2) PyTorch (cu128) — pinned to ai-toolkit's tested versions, before source so a
+#    code bump doesn't re-download torch.
+RUN pip install --break-system-packages --no-cache-dir \
+        torch==2.9.1 torchvision==0.24.1 torchaudio==2.9.1 \
+        --index-url https://download.pytorch.org/whl/cu128 \
+    && pip install --break-system-packages --no-cache-dir hf_transfer
+
+# 3) ai-toolkit source (pin AI_TOOLKIT_REF for reproducible builds) + its
+#    requirements. Requirements are installed from the cloned file so they layer
+#    after torch.
+ARG AI_TOOLKIT_REPO=https://github.com/ostris/ai-toolkit.git
+ARG AI_TOOLKIT_REF=main
+WORKDIR /opt
+RUN git clone --recurse-submodules "${AI_TOOLKIT_REPO}" ai-toolkit \
+    && cd ai-toolkit \
+    && git checkout "${AI_TOOLKIT_REF}" \
+    && git submodule update --init --recursive \
+    && pip install --break-system-packages --no-cache-dir -r requirements.txt
+
+WORKDIR /opt/ai-toolkit
+
+# Fail fast + loud if the container is started without a GPU.
+# run.py takes the config path as its single positional arg.
+ENTRYPOINT ["python", "run.py"]

--- a/docker/trainer/Dockerfile
+++ b/docker/trainer/Dockerfile
@@ -50,7 +50,11 @@ RUN pip install --break-system-packages --no-cache-dir \
 #    requirements. Requirements are installed from the cloned file so they layer
 #    after torch.
 ARG AI_TOOLKIT_REPO=https://github.com/ostris/ai-toolkit.git
-ARG AI_TOOLKIT_REF=main
+# Pinned to the commit the P1 end-to-end run was validated against (200-step
+# character LoRA on a 4090). `main` moves, so an unpinned default silently
+# rebuilds a DIFFERENT trainer than the one we tested — override with
+# --build-arg AI_TOOLKIT_REF=<sha> to move deliberately.
+ARG AI_TOOLKIT_REF=a0224793
 WORKDIR /opt
 RUN git clone --recurse-submodules "${AI_TOOLKIT_REPO}" ai-toolkit \
     && cd ai-toolkit \

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "plugin",
     "packs",
     "scripts",
+    "docker",
     "model-settings.json",
     "model-settings.user.jsonc.example"
   ],

--- a/plugin/skills/train-character-lora/SKILL.md
+++ b/plugin/skills/train-character-lora/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: train-character-lora
+description: Train a character/identity LoRA locally on FLUX.1-dev via the comfyui-mcp train_* tools (GPU Docker + ostris ai-toolkit). Use when the user wants to train a LoRA of a person/character from their photos on the local GPU — covers dataset prep, launch, monitoring, and using the result in ComfyUI. For WAN/Z-Image training via the ai-toolkit UI see ai-toolkit-trainer.
+globs:
+  - "**/*.json"
+---
+
+# Train a Character LoRA (local, Flux.1-dev)
+
+## Overview
+
+The trainer runs **ostris ai-toolkit's `run.py` inside a headless GPU Docker container**,
+driven entirely through `train_*` MCP tools — you (the LLM) are the UI. You generate the
+dataset, launch the job, watch progress, and the finished LoRA lands in ComfyUI
+`models/loras/` + the LoRA catalog automatically.
+
+- Base model: **FLUX.1-dev** (best proven character consistency; needs ~24GB VRAM with
+  quantization — RTX 4090 class).
+- Phase-1 scope: **character LoRAs only**. Style/slider/edit and other bases come later.
+
+## The flow (tool sequence)
+
+1. **`train_doctor`** — preflight once per session. Checks docker daemon, `--gpus all`
+   GPU passthrough, trainer image, HF_TOKEN. If `image:false` → run **`train_build_image`**
+   (one-time, several minutes — CUDA + torch + ai-toolkit). If `hfTokenSet:false`, warn the
+   user: the first run downloads FLUX.1-dev (gated HF repo) and needs `HF_TOKEN` in the MCP
+   server env.
+2. **`train_prepare_dataset`** — stage the images. See "Dataset" below.
+3. **`train_start`** — launch. Returns a job id immediately; training runs detached.
+4. **`train_status {id}`** — poll progress (`progress.step/totalSteps/loss`, recent
+   `samples`, `log` tail). Poll on a slow cadence (every few minutes) — a 2000-step run is
+   roughly an hour on a 4090. Don't block on it.
+5. **Done** — `status:"completed"` means the `.safetensors` was copied to
+   `models/loras/<name>.safetensors` and upserted into the LoRA catalog (`result` has the
+   paths + catalog id). Verify by loading it in a Flux workflow (`LoraLoaderModelOnly`,
+   strength 1.0) with the trigger word in the prompt.
+
+## Dataset guidance
+
+Call `train_prepare_dataset` with `items: [{path, caption?}, ...]` and a `defaultCaption`.
+
+- **10–30 varied images** of the subject: different angles, expressions, lighting,
+  backgrounds, distances (close-up + half-body + full-body). Variety beats count.
+- **Trigger word**: pick something rare and stable (e.g. `ohwx`, `zxc_person`) — NOT a
+  real word. Use it as `defaultCaption` and pass it as `trigger` to `train_start`.
+- **Captions**: describe what *changes* between images (pose, setting, clothing,
+  expression); the constant identity is learned from the images themselves. Start each
+  caption with the trigger word, e.g. `ohwx person sitting in a cafe, laughing, natural
+  light`. Keep them short and factual. When in doubt, the trigger word alone
+  (`defaultCaption`) is a workable baseline.
+- Images are copied and renamed `img_00001.<ext>` etc. — source files are never modified.
+
+## Params (sane defaults — override sparingly)
+
+| Param | Default | When to change |
+|-------|---------|----------------|
+| steps | 2000 | 200 for a smoke test; 1500–3000 real runs. More ≠ better (overbake = plasticky). |
+| lr | 1e-4 | 5e-5 for a tighter/subtler identity. |
+| rank | 16 | 32 for very detailed characters. |
+| resolution | [512,768,1024] | [512] if VRAM-constrained. |
+| quantize | true | Keep true on 24GB. |
+| saveEvery / sampleEvery | 250 | Lower (100) to watch early progress. |
+
+## Monitoring & judgement
+
+- `train_status.progress.samples` are host paths — **look at them**. (ai-toolkit prints no
+  saved-sample lines, so they populate at finalize from the output dir; mid-run you can look
+  directly in the job's `output/<name>/samples/` folder.) Identity should be
+  recognizable by ~1/3 of the run; if samples stay generic past halfway, the run will
+  likely underfit — cancel (`train_cancel`) and check captions/trigger.
+- Loss should trend down and stabilize (~0.1–0.3); wild spikes usually mean lr too high.
+- Checkpoints save every `saveEvery` steps under the job's `output/` dir, so a cancelled
+  run isn't a total loss.
+
+## Failure modes
+
+- **`no_docker` / `no_image` from train_start** → run `train_doctor`, follow its hints.
+- **OOM / CUDA errors in the log tail** → drop `resolution` to `[512]`, keep `quantize:true`,
+  batch stays 1.
+- **`handoff failed` in job error** → training itself finished; the LoRA is still under the
+  job's `output/<name>/` dir — copy it into `models/loras/` manually and upsert the catalog.
+- **First run is slow before step 1** — FLUX.1-dev download (~24GB) + latent caching. As
+  long as the log tail moves, it's fine. The HF cache persists across runs.

--- a/src/__tests__/services/ai-toolkit.test.ts
+++ b/src/__tests__/services/ai-toolkit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseTrainingProgress, TRAINER_IMAGE, resolveDocker } from "../../services/ai-toolkit.js";
+
+describe("parseTrainingProgress", () => {
+  it("parses a tqdm-style line with step/total + loss", () => {
+    const line = "my_lora:  12%|#2        | 240/2000 [01:03<07:41,  4.2it/s, lr: 1.0e-04 loss: 3.9e-01]";
+    const t = parseTrainingProgress(line);
+    expect(t).not.toBeNull();
+    expect(t!.step).toBe(240);
+    expect(t!.totalSteps).toBe(2000);
+    expect(t!.loss).toBeCloseTo(0.39, 5);
+  });
+
+  it("parses loss with = separator", () => {
+    const t = parseTrainingProgress("step 500/2000 loss=0.215");
+    expect(t!.step).toBe(500);
+    expect(t!.loss).toBeCloseTo(0.215, 5);
+  });
+
+  it("captures a saved sample image path", () => {
+    const t = parseTrainingProgress("Saved sample to /output/my_lora/samples/1727890_000000250.png");
+    expect(t).not.toBeNull();
+    expect(t!.sample).toMatch(/000000250\.png$/);
+  });
+
+  it("returns null for a non-progress line", () => {
+    expect(parseTrainingProgress("Loading model black-forest-labs/FLUX.1-dev ...")).toBeNull();
+    expect(parseTrainingProgress("   ")).toBeNull();
+  });
+
+  it("always keeps the raw line", () => {
+    const t = parseTrainingProgress("100/200 loss: 0.5");
+    expect(t!.raw).toBe("100/200 loss: 0.5");
+  });
+});
+
+describe("trainer config surface", () => {
+  it("has a default image tag and resolves a docker binary", () => {
+    expect(TRAINER_IMAGE).toContain("comfyui-mcp-trainer");
+    expect(typeof resolveDocker()).toBe("string");
+    expect(resolveDocker().length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/services/ai-toolkit.test.ts
+++ b/src/__tests__/services/ai-toolkit.test.ts
@@ -28,6 +28,14 @@ describe("parseTrainingProgress", () => {
     expect(parseTrainingProgress("   ")).toBeNull();
   });
 
+  it("ignores bare dataset/download bars without a loss reading", () => {
+    // Real E2E artifact: the dataset-scan bar "6/6" was misparsed as step 6/6.
+    expect(parseTrainingProgress("100%|##########| 6/6 [00:00<00:00, 15.00it/s]")).toBeNull();
+    expect(parseTrainingProgress(" 33%|###       | 2/6 [00:00<00:00, 14.54it/s]")).toBeNull();
+    const t = parseTrainingProgress("Loading weights: 100%|###| 196/196 [00:00<00:00, 2669.35it/s]");
+    expect(t).toBeNull();
+  });
+
   it("always keeps the raw line", () => {
     const t = parseTrainingProgress("100/200 loss: 0.5");
     expect(t!.raw).toBe("100/200 loss: 0.5");

--- a/src/__tests__/services/training-config.test.ts
+++ b/src/__tests__/services/training-config.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  buildTrainingConfig,
+  DEFAULT_PARAMS,
+  type TrainingConfigInput,
+} from "../../services/training-config.js";
+
+const base: TrainingConfigInput = {
+  name: "Ciri LoRA",
+  flow: "character",
+  model: "flux1-dev",
+  datasetPath: "/dataset",
+  outputDir: "/output",
+  trigger: "ohwx",
+};
+
+/** Reach into the single sd_trainer process block. */
+function proc(input: TrainingConfigInput) {
+  const { config } = buildTrainingConfig(input);
+  const cfg = config.config as { name: string; process: Record<string, unknown>[] };
+  return { name: cfg.name, p: cfg.process[0] };
+}
+
+describe("buildTrainingConfig (character / flux1-dev)", () => {
+  it("emits the ai-toolkit job/config/process skeleton", () => {
+    const { config } = buildTrainingConfig(base);
+    expect(config.job).toBe("extension");
+    const cfg = config.config as { name: string; process: unknown[] };
+    expect(cfg.name).toBe("Ciri_LoRA"); // sanitized (space → _)
+    expect(cfg.process).toHaveLength(1);
+    expect((cfg.process[0] as { type: string }).type).toBe("sd_trainer");
+  });
+
+  it("maps flux1-dev to the right model + scheduler + optimizer", () => {
+    const { p } = proc(base);
+    const model = p.model as Record<string, unknown>;
+    expect(model.name_or_path).toBe("black-forest-labs/FLUX.1-dev");
+    expect(model.is_flux).toBe(true);
+    expect(model.quantize).toBe(true);
+    const train = p.train as Record<string, unknown>;
+    expect(train.noise_scheduler).toBe("flowmatch");
+    expect(train.optimizer).toBe("adamw8bit");
+    expect(train.dtype).toBe("bf16");
+    expect(train.train_text_encoder).toBe(false);
+    expect((p.sample as Record<string, unknown>).sampler).toBe("flowmatch"); // must match scheduler
+  });
+
+  it("applies default params + wires the LoRA rank into network", () => {
+    const { p } = proc(base);
+    const net = p.network as Record<string, unknown>;
+    expect(net.type).toBe("lora");
+    expect(net.linear).toBe(DEFAULT_PARAMS.rank);
+    expect(net.linear_alpha).toBe(DEFAULT_PARAMS.rank);
+    const train = p.train as Record<string, unknown>;
+    expect(train.steps).toBe(DEFAULT_PARAMS.steps);
+    expect(train.batch_size).toBe(1);
+    expect((p.datasets as Record<string, unknown>[])[0].resolution).toEqual([512, 768, 1024]);
+  });
+
+  it("honors param overrides", () => {
+    const { p } = proc({ ...base, params: { steps: 200, rank: 32, resolution: [512], quantize: false } });
+    expect((p.train as Record<string, unknown>).steps).toBe(200);
+    expect((p.network as Record<string, unknown>).linear).toBe(32);
+    expect((p.datasets as Record<string, unknown>[])[0].resolution).toEqual([512]);
+    expect((p.model as Record<string, unknown>).quantize).toBe(false);
+  });
+
+  it("sets trigger_word and substitutes [trigger] in sample prompts", () => {
+    const { p } = proc(base);
+    expect(p.trigger_word).toBe("ohwx");
+    const prompts = (p.sample as { prompts: string[] }).prompts;
+    expect(prompts.every((pr) => pr.startsWith("ohwx "))).toBe(true);
+    expect(prompts.some((pr) => pr.includes("[trigger]"))).toBe(false);
+  });
+
+  it("strips [trigger] cleanly when no trigger is given", () => {
+    const { trigger, ...noTrigger } = base;
+    void trigger;
+    const { p } = proc(noTrigger);
+    expect(p.trigger_word).toBeUndefined();
+    const prompts = (p.sample as { prompts: string[] }).prompts;
+    expect(prompts.some((pr) => pr.includes("[trigger]"))).toBe(false);
+    expect(prompts[0].startsWith("a photo")).toBe(true);
+  });
+
+  it("points datasets + training_folder at the given paths", () => {
+    const { p } = proc(base);
+    expect(p.training_folder).toBe("/output");
+    expect((p.datasets as Record<string, unknown>[])[0].folder_path).toBe("/dataset");
+  });
+
+  it("produces valid YAML that round-trips", () => {
+    const { yaml, config } = buildTrainingConfig(base);
+    expect(yaml).toContain("job: extension");
+    expect(parse(yaml)).toEqual(config);
+  });
+
+  it("rejects unsupported flow/model", () => {
+    // @ts-expect-error - exercising the runtime guard with a bad flow
+    expect(() => buildTrainingConfig({ ...base, flow: "style" })).toThrow(/unsupported training flow/);
+    // @ts-expect-error - exercising the runtime guard with a bad model
+    expect(() => buildTrainingConfig({ ...base, model: "sdxl" })).toThrow(/unsupported base model/);
+  });
+});

--- a/src/__tests__/services/training-config.test.ts
+++ b/src/__tests__/services/training-config.test.ts
@@ -96,6 +96,33 @@ describe("buildTrainingConfig (character / flux1-dev)", () => {
     expect(parse(yaml)).toEqual(config);
   });
 
+  it("never lets a dots-only name escape the output dir (codex #1)", () => {
+    expect(proc({ ...base, name: ".." }).name).toBe("lora");
+    expect(proc({ ...base, name: "." }).name).toBe("lora");
+    // "/" collapses to "_" → ".._evil": no longer a ".." segment, harmless dir name.
+    expect(proc({ ...base, name: "../evil" }).name).toBe(".._evil");
+    expect(proc({ ...base, name: "  " }).name).toBe("lora");
+  });
+
+  it("inserts a trigger containing replace special sequences literally (codex #2)", () => {
+    const { p } = proc({ ...base, trigger: "$&" });
+    const prompts = (p.sample as { prompts: string[] }).prompts;
+    expect(prompts[0].startsWith("$& ")).toBe(true);
+    expect(prompts.some((pr) => pr.includes("[trigger]"))).toBe(false);
+  });
+
+  it("ignores undefined param overrides instead of erasing defaults (codex #3)", () => {
+    const { p } = proc({ ...base, params: { steps: undefined, rank: undefined } });
+    expect((p.train as Record<string, unknown>).steps).toBe(DEFAULT_PARAMS.steps);
+    expect((p.network as Record<string, unknown>).linear).toBe(DEFAULT_PARAMS.rank);
+  });
+
+  it("rejects non-positive or empty params", () => {
+    expect(() => buildTrainingConfig({ ...base, params: { steps: 0 } })).toThrow(/must be positive/);
+    expect(() => buildTrainingConfig({ ...base, params: { resolution: [] } })).toThrow(/resolution/);
+    expect(() => buildTrainingConfig({ ...base, params: { resolution: [0] } })).toThrow(/resolution/);
+  });
+
   it("rejects unsupported flow/model", () => {
     // @ts-expect-error - exercising the runtime guard with a bad flow
     expect(() => buildTrainingConfig({ ...base, flow: "style" })).toThrow(/unsupported training flow/);

--- a/src/__tests__/services/training-jobs.test.ts
+++ b/src/__tests__/services/training-jobs.test.ts
@@ -1,0 +1,752 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The registry is module-level state keyed off COMFYUI_MCP_TRAINING_DIR, so each
+// test gets a fresh module (vi.resetModules) pointed at a fresh temp dir. All
+// docker/catalog seams are injected fakes — no docker daemon or ComfyUI needed.
+
+let root: string;
+let mod: typeof import("../../services/training-jobs.js");
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function fakeHandle(d: ReturnType<typeof deferred<{ code: number; tail: string }>>) {
+  return {
+    containerName: "fake",
+    done: d.promise,
+    child: {} as never,
+  };
+}
+
+/** A catalog fake capturing upsert/setPreview calls. */
+function fakeCatalog() {
+  const upserts: unknown[] = [];
+  const previews: { id: string; src: string }[] = [];
+  return {
+    upserts,
+    previews,
+    upsert(partial: Record<string, unknown>) {
+      upserts.push(partial);
+      return { id: "loras-test-job", previewFile: undefined, ...partial } as never;
+    },
+    setPreview(id: string, src: string) {
+      previews.push({ id, src });
+      return { id, previewFile: `${id}.png` } as never;
+    },
+  };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  root = mkdtempSync(join(tmpdir(), "training-jobs-test-"));
+  process.env.COMFYUI_MCP_TRAINING_DIR = join(root, "training");
+  mod = await import("../../services/training-jobs.js");
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_TRAINING_DIR;
+  rmSync(root, { recursive: true, force: true });
+});
+
+function makeImage(dir: string, name: string): string {
+  const p = join(dir, name);
+  writeFileSync(p, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  return p;
+}
+
+describe("prepareDataset", () => {
+  it("stages images with captions and a defaultCaption fallback", async () => {
+    const src = join(root, "src");
+    mkdirSync(src);
+    const a = makeImage(src, "a photo.png");
+    const b = makeImage(src, "b.jpg");
+    const out = await mod.prepareDataset({
+      name: "My Character!",
+      items: [{ path: a, caption: "ohwx smiling, park" }, { path: b }],
+      defaultCaption: "ohwx person",
+    });
+    expect(out.imageCount).toBe(2);
+    expect(out.captionedCount).toBe(2);
+    expect(out.warnings).toHaveLength(0);
+    expect(existsSync(join(out.datasetPath, "img_00001.png"))).toBe(true);
+    expect(readFileSync(join(out.datasetPath, "img_00001.txt"), "utf-8")).toBe("ohwx smiling, park");
+    expect(readFileSync(join(out.datasetPath, "img_00002.txt"), "utf-8")).toBe("ohwx person");
+  });
+
+  it("warns when neither item caption nor defaultCaption is set", async () => {
+    const src = join(root, "src");
+    mkdirSync(src);
+    const a = makeImage(src, "a.png");
+    const out = await mod.prepareDataset({ name: "d", items: [{ path: a }] });
+    expect(out.captionedCount).toBe(0);
+    expect(out.warnings).toHaveLength(1);
+    expect(existsSync(join(out.datasetPath, "img_00001.png"))).toBe(true);
+  });
+
+  it("rejects empty items, missing files, and non-image extensions", async () => {
+    await expect(mod.prepareDataset({ name: "d", items: [] })).rejects.toThrow(/at least one image/);
+    await expect(mod.prepareDataset({ name: "d", items: [{ path: join(root, "nope.png") }] })).rejects.toThrow(/image not found/);
+    const txt = join(root, "notes.txt");
+    writeFileSync(txt, "hi");
+    await expect(mod.prepareDataset({ name: "d", items: [{ path: txt }] })).rejects.toThrow(/not a supported image/);
+  });
+
+  it("replaces a previously staged dataset of the same name (no stale files)", async () => {
+    const src = join(root, "src");
+    mkdirSync(src);
+    const a = makeImage(src, "a.png");
+    const b = makeImage(src, "b.png");
+    const first = await mod.prepareDataset({ name: "same", items: [{ path: a }, { path: b }], defaultCaption: "ohwx" });
+    expect(readdirSync(first.datasetPath).filter((f) => f.endsWith(".png"))).toHaveLength(2);
+    const second = await mod.prepareDataset({ name: "same", items: [{ path: a }], defaultCaption: "ohwx" });
+    expect(second.datasetPath).toBe(first.datasetPath);
+    const files = readdirSync(second.datasetPath);
+    expect(files.filter((f) => f.endsWith(".png"))).toHaveLength(1);
+    expect(files).not.toContain("img_00002.png");
+    expect(files).not.toContain("img_00002.txt");
+  });
+
+  it("keeps the previous dataset intact when the replacement has a bad item", async () => {
+    const src = join(root, "src");
+    mkdirSync(src);
+    const a = makeImage(src, "a.png");
+    const b = makeImage(src, "b.png");
+    const first = await mod.prepareDataset({ name: "swap", items: [{ path: a }, { path: b }], defaultCaption: "ohwx" });
+    await expect(
+      mod.prepareDataset({ name: "swap", items: [{ path: a }, { path: join(root, "gone.png") }] }),
+    ).rejects.toThrow(/image not found/);
+    // Old staging untouched, no staging temp left behind.
+    expect(readdirSync(first.datasetPath).filter((f) => f.endsWith(".png"))).toHaveLength(2);
+    expect(existsSync(`${first.datasetPath}.staging-${process.pid}`)).toBe(false);
+  });
+
+  it("refuses to restage a dataset a running job is training from", async () => {
+    const src = join(root, "src");
+    mkdirSync(src);
+    const a = makeImage(src, "a.png");
+    const staged = await mod.prepareDataset({ name: "busy", items: [{ path: a }] });
+    // A running job pointing at this dataset dir (persisted record, foreign process).
+    mkdirSync(mod.jobsRoot(), { recursive: true });
+    const jobFile = join(mod.jobsRoot(), "tbusy1.json");
+    writeFileSync(jobFile, JSON.stringify({
+      id: "tbusy1", name: "busy_lora", flow: "character", model: "flux1-dev",
+      status: "running", progress: { samples: [] }, containerName: "comfyui-train-tbusy1",
+      datasetPath: staged.datasetPath, jobDir: join(mod.jobsRoot(), "tbusy1"),
+      outputDir: join(mod.jobsRoot(), "tbusy1", "output"), log: [],
+      createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+    }));
+    await expect(
+      mod.prepareDataset({ name: "busy", items: [{ path: a }] }, { containerRunning: async () => true }),
+    ).rejects.toThrow(/in use by running job tbusy1/);
+    // Once the job is terminal, restaging works again.
+    writeFileSync(jobFile, JSON.stringify({ ...JSON.parse(readFileSync(jobFile, "utf-8")), status: "completed" }));
+    await expect(mod.prepareDataset({ name: "busy", items: [{ path: a }] })).resolves.toMatchObject({ imageCount: 1 });
+  });
+});
+
+describe("findProducedLora", () => {
+  it("prefers the exact final save over checkpoints", () => {
+    const dir = join(root, "output", "job1");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "job1_000000250.safetensors"), "a");
+    writeFileSync(join(dir, "job1.safetensors"), "b");
+    expect(mod.findProducedLora(join(root, "output"), "job1")).toBe(join(dir, "job1.safetensors"));
+  });
+
+  it("falls back to the highest-step checkpoint", () => {
+    const dir = join(root, "output", "job1");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "job1_000000250.safetensors"), "a");
+    writeFileSync(join(dir, "job1_000001000.safetensors"), "b");
+    expect(mod.findProducedLora(join(root, "output"), "job1")).toBe(join(dir, "job1_000001000.safetensors"));
+  });
+
+  it("returns null when nothing was produced", () => {
+    expect(mod.findProducedLora(join(root, "output"), "ghost")).toBeNull();
+  });
+});
+
+describe("startTrainingJob", () => {
+  async function startWith(deps: Parameters<typeof mod.startTrainingJob>[1], name = "test_job") {
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    writeFileSync(join(dataset, "img_00001.txt"), "ohwx person");
+    return mod.startTrainingJob(
+      { name, flow: "character", model: "flux1-dev", datasetPath: dataset, trigger: "ohwx", params: { steps: 200 } },
+      deps,
+    );
+  }
+
+  it("runs to completion: config written, progress tracked, LoRA handed off + cataloged", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const catalog = fakeCatalog();
+    const lorasDir = join(root, "loras");
+    const seen: { containerName?: string; configPath?: string } = {};
+    const job = await startWith({
+      startTraining: (opts) => {
+        seen.containerName = opts.containerName;
+        seen.configPath = opts.configPath;
+        // Simulate ai-toolkit writing its outputs, then exiting 0.
+        const outDir = join(opts.outputDir, "test_job");
+        mkdirSync(join(outDir, "samples"), { recursive: true });
+        writeFileSync(join(outDir, "test_job.safetensors"), "weights");
+        writeFileSync(join(outDir, "samples", "0001.png"), "sample");
+        opts.onProgress?.({ step: 199, totalSteps: 200, loss: 0.12, raw: "199/200 loss: 0.12" });
+        // Resolve on a timer (not a microtask) so the job is still running when
+        // startTrainingJob returns, matching real long-running behavior.
+        setTimeout(() => d.resolve({ code: 0, tail: "" }), 5);
+        return fakeHandle(d);
+      },
+      lorasDir: () => lorasDir,
+      catalog,
+    });
+
+    expect(job.status).toBe("running");
+    expect(job.progress.step).toBe(199);
+    expect(job.containerName).toMatch(/^comfyui-train-/);
+    // The generated config exists and points at the container mount points.
+    const yaml = readFileSync(seen.configPath!, "utf-8");
+    expect(yaml).toContain("folder_path: /dataset");
+    expect(yaml).toContain("training_folder: /output");
+    expect(yaml).toContain("trigger_word: ohwx");
+
+    // Let handle.done + finalizeJob run.
+    await new Promise((r) => setTimeout(r, 20));
+    const done = (await mod.getJob(job.id))!;
+    expect(done.status).toBe("completed");
+    // Completed jobs normalize the last bar (199/200) to the full count.
+    expect(done.progress.step).toBe(200);
+    // Samples are picked up from the output dir at finalize (ai-toolkit prints
+    // no saved-sample lines for onProgress to catch).
+    expect(done.progress.samples).toHaveLength(1);
+    expect(done.progress.samples[0]).toContain("0001.png");
+    expect(done.result!.loraPath).toBe(join(lorasDir, "test_job.safetensors"));
+    expect(existsSync(done.result!.loraPath)).toBe(true);
+    expect(done.result!.loraRelPath).toBe("loras/test_job.safetensors");
+    expect(catalog.upserts).toHaveLength(1);
+    const upsert = catalog.upserts[0] as Record<string, unknown>;
+    expect(upsert.keywords).toEqual(["ohwx"]);
+    expect(upsert.baseModels).toEqual(["FLUX.1-dev"]);
+    expect(upsert.missing).toBe(false);
+    expect(catalog.previews).toHaveLength(1);
+    expect(done.result!.previewFile).toBe("loras-test-job.png");
+  });
+
+  it("marks the job failed when the container exits non-zero", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const job = await startWith({
+      startTraining: () => {
+        queueMicrotask(() => d.resolve({ code: 1, tail: "CUDA OOM" }));
+        return fakeHandle(d);
+      },
+      lorasDir: () => join(root, "loras"),
+      catalog: fakeCatalog(),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const done = (await mod.getJob(job.id))!;
+    expect(done.status).toBe("failed");
+    expect(done.error).toContain("exited 1");
+    expect(done.error).toContain("CUDA OOM");
+  });
+
+  it("fails the job when training succeeded but produced no LoRA", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const job = await startWith({
+      startTraining: () => {
+        queueMicrotask(() => d.resolve({ code: 0, tail: "" }));
+        return fakeHandle(d);
+      },
+      lorasDir: () => join(root, "loras"),
+      catalog: fakeCatalog(),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await mod.getJob(job.id))!.status).toBe("failed");
+    expect((await mod.getJob(job.id))!.error).toContain("handoff");
+  });
+
+  it("rejects a dataset with no images", async () => {
+    const empty = join(root, "empty");
+    mkdirSync(empty);
+    await expect(
+      mod.startTrainingJob({ name: "x", flow: "character", model: "flux1-dev", datasetPath: empty }),
+    ).rejects.toThrow(/no images/);
+  });
+
+  it("fails BEFORE launching the container when the loras destination is unresolvable", async () => {
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    let containerStarted = false;
+    await expect(
+      mod.startTrainingJob(
+        { name: "x", flow: "character", model: "flux1-dev", datasetPath: dataset },
+        {
+          startTraining: () => {
+            containerStarted = true;
+            return fakeHandle(deferred<{ code: number; tail: string }>());
+          },
+          lorasDir: () => {
+            throw new Error("No local ComfyUI path configured");
+          },
+          catalog: fakeCatalog(),
+        },
+      ),
+    ).rejects.toThrow(/No local ComfyUI path/);
+    expect(containerStarted).toBe(false);
+  });
+
+  it("persists throttled progress snapshots so other processes see live state", async () => {
+    vi.useFakeTimers();
+    try {
+      const d = deferred<{ code: number; tail: string }>();
+      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      const dataset = join(root, "dataset");
+      mkdirSync(dataset, { recursive: true });
+      makeImage(dataset, "img_00001.png");
+      const job = await mod.startTrainingJob(
+        { name: "snap_me", flow: "character", model: "flux1-dev", datasetPath: dataset, params: { steps: 200 } },
+        {
+          startTraining: (opts) => {
+            tick = opts.onProgress;
+            return fakeHandle(d);
+          },
+          lorasDir: () => join(root, "loras"),
+          catalog: fakeCatalog(),
+        },
+      );
+      const file = join(mod.jobsRoot(), `${job.id}.json`);
+      const readStep = () => (JSON.parse(readFileSync(file, "utf-8")) as { progress: { step?: number } }).progress.step;
+
+      tick!({ step: 10, totalSteps: 200, raw: "10/200" });
+      expect(readStep()).toBe(10); // first tick always persists
+      tick!({ step: 20, totalSteps: 200, raw: "20/200" });
+      expect(readStep()).toBe(10); // inside the 5s throttle window
+      vi.setSystemTime(Date.now() + 6000);
+      tick!({ step: 30, totalSteps: 200, raw: "30/200" });
+      expect(readStep()).toBe(30); // past the window → snapshot written
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("cancelJob", () => {
+  it("stops the container and keeps 'cancelled' even when done resolves later", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const stopped: string[] = [];
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    const job = await mod.startTrainingJob(
+      { name: "cancel_me", flow: "character", model: "flux1-dev", datasetPath: dataset },
+      {
+        startTraining: () => fakeHandle(d),
+        stopTraining: async (name) => {
+          stopped.push(name);
+          return { ok: true, command: "train_cancel", data: { stopped: name } };
+        },
+        lorasDir: () => join(root, "loras"),
+        catalog: fakeCatalog(),
+      },
+    );
+    const cancelled = await mod.cancelJob(job.id, {
+      stopTraining: async (name) => {
+        stopped.push(name);
+        return { ok: true, command: "train_cancel", data: { stopped: name } };
+      },
+      containerRunning: async () => false,
+    });
+    expect(cancelled.status).toBe("cancelled");
+    expect(stopped).toEqual([job.containerName]);
+    // Container exits (killed) afterwards — finalize must not resurrect it.
+    d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await mod.getJob(job.id))!.status).toBe("cancelled");
+  });
+
+  it("ignores progress ticks that arrive after a cancel (no resurrection)", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    const job = await mod.startTrainingJob(
+      { name: "zombie", flow: "character", model: "flux1-dev", datasetPath: dataset },
+      {
+        startTraining: (opts) => {
+          tick = opts.onProgress;
+          return fakeHandle(d);
+        },
+        lorasDir: () => join(root, "loras"),
+        catalog: fakeCatalog(),
+      },
+    );
+    await mod.cancelJob(job.id, {
+      stopTraining: async (name) => ({ ok: true, command: "train_cancel", data: { stopped: name } }),
+      containerRunning: async () => false,
+    });
+    // A late tqdm line flushes while docker stop is in flight — must be ignored.
+    tick!({ step: 42, totalSteps: 200, loss: 0.3, raw: "42/200 loss: 0.3" });
+    expect(job.status).toBe("cancelled");
+    expect(job.progress.step).toBeUndefined();
+    const disk = JSON.parse(readFileSync(join(mod.jobsRoot(), `${job.id}.json`), "utf-8")) as { status: string };
+    expect(disk.status).toBe("cancelled");
+  });
+
+  it("adopts a foreign cancel seen on disk instead of clobbering it at persist", async () => {
+    vi.useFakeTimers();
+    try {
+      const d = deferred<{ code: number; tail: string }>();
+      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      const dataset = join(root, "dataset");
+      mkdirSync(dataset, { recursive: true });
+      makeImage(dataset, "img_00001.png");
+      const job = await mod.startTrainingJob(
+        { name: "foreign_cancel", flow: "character", model: "flux1-dev", datasetPath: dataset },
+        {
+          startTraining: (opts) => {
+            tick = opts.onProgress;
+            return fakeHandle(d);
+          },
+          lorasDir: () => join(root, "loras"),
+          catalog: fakeCatalog(),
+        },
+      );
+      // Another process cancels: only the DISK record shows it; our memory
+      // still says running. The next throttled persist must adopt, not clobber.
+      const file = join(mod.jobsRoot(), `${job.id}.json`);
+      const record = JSON.parse(readFileSync(file, "utf-8")) as { status: string; finishedAt?: string };
+      record.status = "cancelled";
+      record.finishedAt = new Date().toISOString();
+      writeFileSync(file, JSON.stringify(record, null, 2));
+      vi.setSystemTime(Date.now() + 6000); // past the persist throttle window
+      tick!({ step: 10, totalSteps: 200, loss: 0.5, raw: "10/200 loss: 0.5" });
+      expect(job.status).toBe("cancelled");
+      const disk = JSON.parse(readFileSync(file, "utf-8")) as { status: string };
+      expect(disk.status).toBe("cancelled");
+      // And when the container finally exits, no handoff happens.
+      d.resolve({ code: 0, tail: "" });
+      await Promise.resolve();
+      vi.useRealTimers();
+      await new Promise((r) => setTimeout(r, 20));
+      expect((await mod.getJob(job.id))!.status).toBe("cancelled");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes when a foreign cancel is rolled back after a failed stop", async () => {
+    vi.useFakeTimers();
+    try {
+      const d = deferred<{ code: number; tail: string }>();
+      let tick: ((p: { step?: number; totalSteps?: number; raw: string }) => void) | undefined;
+      const catalog = fakeCatalog();
+      const lorasDir = join(root, "loras");
+      const dataset = join(root, "dataset");
+      mkdirSync(dataset, { recursive: true });
+      makeImage(dataset, "img_00001.png");
+      const job = await mod.startTrainingJob(
+        { name: "rollback", flow: "character", model: "flux1-dev", datasetPath: dataset },
+        {
+          startTraining: (opts) => {
+            tick = opts.onProgress;
+            return fakeHandle(d);
+          },
+          lorasDir: () => lorasDir,
+          catalog,
+        },
+      );
+      const file = join(mod.jobsRoot(), `${job.id}.json`);
+      const record = JSON.parse(readFileSync(file, "utf-8")) as { status: string };
+      record.status = "cancelled";
+      writeFileSync(file, JSON.stringify(record, null, 2));
+      vi.setSystemTime(Date.now() + 6000);
+      tick!({ step: 10, totalSteps: 200, loss: 0.5, raw: "10/200 loss: 0.5" });
+      expect(job.status).toBe("cancelled"); // adopted from disk
+      // The cancelling process's docker stop FAILED → it reverts the record.
+      record.status = "running";
+      writeFileSync(file, JSON.stringify(record, null, 2));
+      tick!({ step: 11, totalSteps: 200, loss: 0.4, raw: "11/200 loss: 0.4" });
+      expect(job.status).toBe("running"); // reconciled, not stuck cancelled
+      // A later successful completion now finalizes + hands off normally.
+      const outDir = join(job.outputDir, "rollback");
+      mkdirSync(outDir, { recursive: true });
+      writeFileSync(join(outDir, "rollback.safetensors"), "weights");
+      d.resolve({ code: 0, tail: "" });
+      await Promise.resolve();
+      vi.useRealTimers();
+      await new Promise((r) => setTimeout(r, 20));
+      const final = (await mod.getJob(job.id))!;
+      expect(final.status).toBe("completed");
+      expect(final.result!.loraPath).toBe(join(lorasDir, "rollback.safetensors"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reverts to running when the container genuinely fails to stop", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    const job = await mod.startTrainingJob(
+      { name: "cant_stop", flow: "character", model: "flux1-dev", datasetPath: dataset },
+      { startTraining: () => fakeHandle(d), lorasDir: () => join(root, "loras"), catalog: fakeCatalog() },
+    );
+    const after = await mod.cancelJob(job.id, {
+      stopTraining: async () => ({ ok: false, command: "train_cancel", error: { code: "stop_failed", message: "daemon unreachable" } }),
+      containerRunning: async () => true,
+    });
+    expect(after.status).toBe("running");
+    expect(after.error).toContain("cancel failed");
+    // And a later successful finalize still completes the job normally.
+    const outDir = join(job.outputDir, "cant_stop");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "cant_stop.safetensors"), "weights");
+    d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 20));
+    expect((await mod.getJob(job.id))!.status).toBe("completed");
+  });
+
+  it("respects a cancel written by ANOTHER process (disk record) at finalize", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    const catalog = fakeCatalog();
+    const job = await mod.startTrainingJob(
+      { name: "cross_cancel", flow: "character", model: "flux1-dev", datasetPath: dataset },
+      { startTraining: () => fakeHandle(d), lorasDir: () => join(root, "loras"), catalog },
+    );
+    // Another process (e.g. orchestrator call_tool client) cancels via disk:
+    // its cancelJob persists status=cancelled, unseen by this process's memory.
+    const file = join(mod.jobsRoot(), `${job.id}.json`);
+    const record = JSON.parse(readFileSync(file, "utf-8")) as { status: string; finishedAt?: string };
+    record.status = "cancelled";
+    record.finishedAt = new Date().toISOString();
+    writeFileSync(file, JSON.stringify(record, null, 2));
+    // The killed container then exits 0 (docker stop can be a clean exit) —
+    // finalize must keep 'cancelled' and skip the handoff.
+    d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 20));
+    const final = (await mod.getJob(job.id))!;
+    expect(final.status).toBe("cancelled");
+    expect(final.result).toBeUndefined();
+    expect(catalog.upserts).toHaveLength(0);
+  });
+
+  it("retries docker stop for an already-cancelled job whose container is still alive", async () => {
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    mkdirSync(mod.jobsRoot(), { recursive: true });
+    // A cancelled-on-disk job left behind by a process that died mid-stop.
+    const file = join(mod.jobsRoot(), "tzombie1.json");
+    writeFileSync(file, JSON.stringify({
+      id: "tzombie1", name: "zombie_lora", flow: "character", model: "flux1-dev",
+      status: "cancelled", progress: { samples: [] }, containerName: "comfyui-train-tzombie1",
+      datasetPath: dataset, jobDir: join(mod.jobsRoot(), "tzombie1"),
+      outputDir: join(mod.jobsRoot(), "tzombie1", "output"), log: [],
+      createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    }));
+    const stopped: string[] = [];
+    let alive = true;
+    const after = await mod.cancelJob("tzombie1", {
+      containerRunning: async () => alive, // still burning GPU until stopped
+      stopTraining: async (name) => {
+        stopped.push(name);
+        alive = false;
+        return { ok: true, command: "train_cancel", data: { stopped: name } };
+      },
+    });
+    expect(stopped).toEqual(["comfyui-train-tzombie1"]);
+    expect(after.status).toBe("cancelled");
+
+    // And when the retry ALSO fails, the job goes back to running (honest).
+    const after2 = await mod.cancelJob("tzombie1", {
+      containerRunning: async () => true,
+      stopTraining: async () => ({ ok: false, command: "train_cancel", error: { code: "stop_failed", message: "timeout" } }),
+    });
+    expect(after2.status).toBe("running");
+    expect(after2.error).toContain("cancel retry failed");
+  });
+
+  it("leaves an already-cancelled job alone when its container is gone", async () => {
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    mkdirSync(mod.jobsRoot(), { recursive: true });
+    const file = join(mod.jobsRoot(), "tgone1.json");
+    writeFileSync(file, JSON.stringify({
+      id: "tgone1", name: "gone_lora", flow: "character", model: "flux1-dev",
+      status: "cancelled", progress: { samples: [] }, containerName: "comfyui-train-tgone1",
+      datasetPath: dataset, jobDir: join(mod.jobsRoot(), "tgone1"),
+      outputDir: join(mod.jobsRoot(), "tgone1", "output"), log: [],
+      createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    }));
+    let stops = 0;
+    const after = await mod.cancelJob("tgone1", {
+      containerRunning: async () => false,
+      stopTraining: async (name) => {
+        stops++;
+        return { ok: true, command: "train_cancel", data: { stopped: name } };
+      },
+    });
+    expect(after.status).toBe("cancelled");
+    expect(stops).toBe(0);
+  });
+
+  it("attempts the stop when cancelled-job liveness is UNKNOWN (daemon flapping)", async () => {
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    mkdirSync(mod.jobsRoot(), { recursive: true });
+    const file = join(mod.jobsRoot(), "tunknown1.json");
+    writeFileSync(file, JSON.stringify({
+      id: "tunknown1", name: "unknown_lora", flow: "character", model: "flux1-dev",
+      status: "cancelled", progress: { samples: [] }, containerName: "comfyui-train-tunknown1",
+      datasetPath: dataset, jobDir: join(mod.jobsRoot(), "tunknown1"),
+      outputDir: join(mod.jobsRoot(), "tunknown1", "output"), log: [],
+      createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    }));
+    let stops = 0;
+    const after = await mod.cancelJob("tunknown1", {
+      containerRunning: async () => null, // daemon unreachable — can't tell
+      stopTraining: async (name) => {
+        stops++;
+        return { ok: false, command: "train_cancel", error: { code: "stop_failed", message: "daemon unreachable" } };
+      },
+    });
+    expect(stops).toBe(1); // stop attempted, not skipped on "unknown"
+    expect(after.status).toBe("running"); // unconfirmed → honest revert
+  });
+});
+
+describe("registry persistence", () => {
+  async function startRestartedJob() {
+    const d = deferred<{ code: number; tail: string }>();
+    const dataset = join(root, "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    const job = await mod.startTrainingJob(
+      { name: "restart_me", flow: "character", model: "flux1-dev", datasetPath: dataset },
+      { startTraining: () => fakeHandle(d), lorasDir: () => join(root, "loras"), catalog: fakeCatalog() },
+    );
+    expect(existsSync(join(mod.jobsRoot(), `${job.id}.json`))).toBe(true);
+    // Simulate an MCP restart: fresh module, same training dir, no live handle.
+    vi.resetModules();
+    const mod2 = await import("../../services/training-jobs.js");
+    return { job, mod2 };
+  }
+
+  it("marks an in-flight job failed when its container is definitively gone", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    const revived = (await mod2.getJob(job.id, { containerRunning: async () => false }))!;
+    expect(revived).not.toBeNull();
+    expect(revived.status).toBe("failed");
+    expect(revived.error).toContain("no longer running");
+  });
+
+  it("does NOT mislabel another process's live job as failed", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    const revived = (await mod2.getJob(job.id, { containerRunning: async () => true }))!;
+    expect(revived.status).toBe("running");
+  });
+
+  it("keeps status when liveness is unknown (docker daemon down)", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    const revived = (await mod2.getJob(job.id, { containerRunning: async () => null }))!;
+    expect(revived.status).toBe("running");
+  });
+
+  it("recovers a FINISHED run whose owner died (handoff runs on next read)", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    // ai-toolkit finished and wrote the final save before the owner died. No
+    // log marker exists (nothing streams after owner death) — the final
+    // <name>.safetensors is the durable success signal.
+    const outDir = join(job.outputDir, "restart_me");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "restart_me.safetensors"), "weights");
+    const lorasDir = join(root, "loras");
+    const catalog = fakeCatalog();
+    const revived = (await mod2.getJob(job.id, {
+      containerRunning: async () => false,
+      lorasDir: () => lorasDir,
+      catalog,
+    }))!;
+    expect(revived.status).toBe("completed");
+    expect(revived.result!.loraPath).toBe(join(lorasDir, "restart_me.safetensors"));
+    expect(existsSync(revived.result!.loraPath)).toBe(true);
+    expect(catalog.upserts).toHaveLength(1);
+  });
+
+  it("does NOT recover a crashed run that left only checkpoints behind", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    const outDir = join(job.outputDir, "restart_me");
+    mkdirSync(outDir, { recursive: true });
+    // A periodic checkpoint without the final save = training never finished.
+    writeFileSync(join(outDir, "restart_me_000000100.safetensors"), "partial");
+    const lorasDir = join(root, "loras");
+    const revived = (await mod2.getJob(job.id, {
+      containerRunning: async () => false,
+      lorasDir: () => lorasDir,
+      catalog: fakeCatalog(),
+    }))!;
+    expect(revived.status).toBe("failed");
+    expect(revived.result).toBeUndefined();
+    expect(existsSync(join(lorasDir, "restart_me.safetensors"))).toBe(false);
+  });
+
+  it("on retarget: copies the LoRA to the ORIGINAL loras dir but skips the catalog", async () => {
+    const { job, mod2 } = await startRestartedJob();
+    const outDir = join(job.outputDir, "restart_me");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "restart_me.safetensors"), "weights");
+    // Job was started against a DIFFERENT ComfyUI instance than this process
+    // currently targets (simulating a mid-run retarget).
+    const originalLoras = join(root, "original-loras");
+    const record = JSON.parse(readFileSync(join(mod2.jobsRoot(), `${job.id}.json`), "utf-8")) as Record<string, unknown>;
+    record.lorasDir = originalLoras;
+    record.instanceSlug = "some_other_instance_9000";
+    writeFileSync(join(mod2.jobsRoot(), `${job.id}.json`), JSON.stringify(record, null, 2));
+    const catalog = fakeCatalog();
+    const revived = (await mod2.getJob(job.id, {
+      containerRunning: async () => false,
+      lorasDir: () => join(root, "WRONG-new-instance-loras"),
+      catalog,
+    }))!;
+    expect(revived.status).toBe("completed");
+    // File lands in the ORIGINAL dir; the (new-instance) catalog stays untouched.
+    expect(revived.result!.loraPath).toBe(join(originalLoras, "restart_me.safetensors"));
+    expect(existsSync(revived.result!.loraPath)).toBe(true);
+    expect(revived.result!.catalogId).toBeUndefined();
+    expect(catalog.upserts).toHaveLength(0);
+  });
+
+  it("re-reads disk on every poll so a fresh process sees later jobs", async () => {
+    const { mod2 } = await startRestartedJob();
+    // A SECOND job created after mod2's first read must appear on the next one.
+    await mod2.listJobs({ containerRunning: async () => true });
+    const d2 = deferred<{ code: number; tail: string }>();
+    const job2 = await mod.startTrainingJob(
+      { name: "created_later", flow: "character", model: "flux1-dev", datasetPath: join(root, "dataset") },
+      { startTraining: () => fakeHandle(d2), lorasDir: () => join(root, "loras"), catalog: fakeCatalog() },
+    );
+    const jobs = await mod2.listJobs({ containerRunning: async () => true });
+    expect(jobs.some((j) => j.id === job2.id)).toBe(true);
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -656,6 +656,13 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // mobile Training tab (train_start/cancel stay agent-side for now).
   "train_list_flows",
   "train_status",
+  // User-initiated training ops (panel/mobile Training wizard): stage a dataset,
+  // launch a GPU-container training run, cancel one. All validation lives in the
+  // tools themselves (dataset checks, docker/image preflight, liveness-verified
+  // cancel); the whitelist only gates reachability.
+  "train_prepare_dataset",
+  "train_start",
+  "train_cancel",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -652,10 +652,11 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // the same story server-side from history + re-validating the graph that ran.
   // Read-only.
   "diagnose_run",
-  // Read-only training surface: flow/model discovery + progress polling for the
-  // mobile Training tab (train_start/cancel stay agent-side for now).
+  // Read-only training surface: flow/model discovery + progress polling +
+  // docker/GPU/image preflight for the panel/mobile Training tab.
   "train_list_flows",
   "train_status",
+  "train_doctor",
   // User-initiated training ops (panel/mobile Training wizard): stage a dataset,
   // launch a GPU-container training run, cancel one. All validation lives in the
   // tools themselves (dataset checks, docker/image preflight, liveness-verified

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -652,6 +652,10 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // the same story server-side from history + re-validating the graph that ran.
   // Read-only.
   "diagnose_run",
+  // Read-only training surface: flow/model discovery + progress polling for the
+  // mobile Training tab (train_start/cancel stay agent-side for now).
+  "train_list_flows",
+  "train_status",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,

--- a/src/services/ai-toolkit.ts
+++ b/src/services/ai-toolkit.ts
@@ -1,0 +1,255 @@
+// Drives the headless GPU trainer container (docker/trainer/Dockerfile) that runs
+// ostris ai-toolkit's `run.py`. This is the runtime half of the trainer: preflight
+// docker + GPU, build the image once, then `docker run --gpus all` a generated
+// config and stream ai-toolkit's progress back out.
+//
+// Modeled on src/services/comfy-cli.ts (external-CLI wrapper): quick probes via
+// execFile, the long training run via spawn with streamed stdout, and results
+// normalized into a small envelope so callers/tools get a uniform shape.
+
+import childProcess from "node:child_process";
+import { logger } from "../utils/logger.js";
+
+/** Uniform result shape for trainer operations (mirrors the comfy-cli envelope). */
+export interface TrainerEnvelope<T = unknown> {
+  ok: boolean;
+  command: string;
+  data?: T;
+  error?: { code: string; message: string };
+  stderr?: string;
+}
+
+/** Image tag we build/run. */
+export const TRAINER_IMAGE = process.env.COMFYUI_MCP_TRAINER_IMAGE?.trim() || "comfyui-mcp-trainer:latest";
+
+/** Docker executable — env override, else PATH. */
+export function resolveDocker(): string {
+  return process.env.COMFYUI_MCP_DOCKER?.trim() || "docker";
+}
+
+function ok<T>(command: string, data?: T): TrainerEnvelope<T> {
+  return { ok: true, command, data };
+}
+function fail(command: string, code: string, message: string, stderr?: string): TrainerEnvelope<never> {
+  return { ok: false, command, error: { code, message }, stderr };
+}
+
+/** Run a short docker command, capturing stdout/stderr. Never throws. */
+function execDocker(args: string[], timeoutMs = 20_000): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    childProcess.execFile(
+      resolveDocker(),
+      args,
+      { timeout: timeoutMs, windowsHide: true, maxBuffer: 4 * 1024 * 1024, env: { ...process.env } },
+      (err, stdout, stderr) => {
+        const code = err && typeof (err as { code?: unknown }).code === "number" ? (err as { code: number }).code : err ? 1 : 0;
+        resolve({ code, stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+      },
+    );
+  });
+}
+
+/** Is the docker daemon reachable? */
+export async function dockerAvailable(): Promise<boolean> {
+  const r = await execDocker(["version", "--format", "{{.Server.Version}}"]);
+  return r.code === 0 && r.stdout.trim().length > 0;
+}
+
+/** Is `--gpus all` usable (NVIDIA Container Toolkit present)? Runs a tiny CUDA
+ *  image's `nvidia-smi`; slower, so callers cache the result. */
+export async function gpuDockerAvailable(): Promise<boolean> {
+  const r = await execDocker(
+    ["run", "--rm", "--gpus", "all", "nvidia/cuda:12.8.1-base-ubuntu24.04", "nvidia-smi", "-L"],
+    120_000,
+  );
+  return r.code === 0 && /GPU \d+/.test(r.stdout);
+}
+
+/** Does our trainer image exist locally? */
+export async function trainerImageExists(): Promise<boolean> {
+  const r = await execDocker(["image", "inspect", TRAINER_IMAGE]);
+  return r.code === 0;
+}
+
+/**
+ * Preflight report for `train_doctor`: docker daemon, GPU passthrough, image
+ * presence. Returns an envelope with a per-check breakdown so the UI/LLM can
+ * give the user precise setup guidance instead of a cryptic run failure.
+ */
+export async function trainerDoctor(): Promise<TrainerEnvelope<{
+  docker: boolean;
+  gpu: boolean;
+  image: boolean;
+  image_tag: string;
+  hints: string[];
+}>> {
+  const docker = await dockerAvailable();
+  const hints: string[] = [];
+  if (!docker) {
+    hints.push("Docker daemon not reachable — install/start Docker Desktop (Windows) or the docker engine.");
+    return ok("train_doctor", { docker, gpu: false, image: false, image_tag: TRAINER_IMAGE, hints });
+  }
+  const [gpu, image] = await Promise.all([gpuDockerAvailable(), trainerImageExists()]);
+  if (!gpu) hints.push("`docker run --gpus all` failed — install the NVIDIA Container Toolkit and enable GPU support in Docker.");
+  if (!image) hints.push(`Trainer image ${TRAINER_IMAGE} not built yet — run train_build_image (one-time, several minutes).`);
+  return ok("train_doctor", { docker, gpu, image, image_tag: TRAINER_IMAGE, hints });
+}
+
+/**
+ * Build the trainer image from docker/trainer/Dockerfile. Long-running; streams
+ * build output via onLog. `contextDir` is the docker/trainer dir.
+ */
+export function buildTrainerImage(opts: {
+  contextDir: string;
+  aiToolkitRef?: string;
+  onLog?: (line: string) => void;
+}): Promise<TrainerEnvelope<{ image: string }>> {
+  const args = ["build", "-t", TRAINER_IMAGE];
+  if (opts.aiToolkitRef) args.push("--build-arg", `AI_TOOLKIT_REF=${opts.aiToolkitRef}`);
+  args.push(opts.contextDir);
+  return streamDocker(args, opts.onLog).then((r) =>
+    r.code === 0 ? ok("train_build_image", { image: TRAINER_IMAGE }) : fail("train_build_image", "build_failed", `docker build exited ${r.code}`, r.tail),
+  );
+}
+
+/** Handle to a running training container. */
+export interface TrainingHandle {
+  /** `--name` we assigned (also used to stop it). */
+  containerName: string;
+  /** The spawned `docker run` child (resolves when training exits). */
+  done: Promise<{ code: number; tail: string }>;
+  child: childProcess.ChildProcess;
+}
+
+/** A parsed progress tick from ai-toolkit's training stdout. */
+export interface TrainingProgress {
+  step?: number;
+  totalSteps?: number;
+  loss?: number;
+  /** A saved sample-image path/line, when seen. */
+  sample?: string;
+  /** The raw line (always present). */
+  raw: string;
+}
+
+/**
+ * Parse one stdout line from ai-toolkit into a progress tick. ai-toolkit prints a
+ * tqdm-style bar with the job name, `<step>/<total>` and a `loss: <n>` postfix,
+ * e.g. `my_lora:  12%|#2 | 240/2000 [01:03<07:41, ... loss: 3.9e-01]`.
+ */
+export function parseTrainingProgress(line: string): TrainingProgress | null {
+  const raw = line.trim();
+  if (!raw) return null;
+  const stepMatch = raw.match(/(\d+)\s*\/\s*(\d+)/);
+  const lossMatch = raw.match(/loss[:=]\s*([\d.eE+-]+)/);
+  const sampleMatch = raw.match(/(?:saved|sample).*?([^\s'"]+\.(?:png|jpg|jpeg))/i);
+  if (!stepMatch && !lossMatch && !sampleMatch) return null;
+  const tick: TrainingProgress = { raw };
+  if (stepMatch) {
+    tick.step = Number(stepMatch[1]);
+    tick.totalSteps = Number(stepMatch[2]);
+  }
+  if (lossMatch) {
+    const n = Number(lossMatch[1]);
+    if (Number.isFinite(n)) tick.loss = n;
+  }
+  if (sampleMatch) tick.sample = sampleMatch[1];
+  return tick;
+}
+
+/**
+ * Start a training run: `docker run --gpus all` with the config/dataset/output/HF
+ * mounts. Returns immediately with a handle; caller awaits `handle.done`. Progress
+ * ticks are delivered via onProgress. Paths are host paths; the container sees the
+ * fixed mount points `/config.yml`, `/dataset`, `/output`.
+ */
+export function startTraining(opts: {
+  containerName: string;
+  configPath: string;
+  datasetPath: string;
+  outputDir: string;
+  hfCacheDir?: string;
+  hfToken?: string;
+  onProgress?: (p: TrainingProgress) => void;
+  onLog?: (line: string) => void;
+}): TrainingHandle {
+  const args = [
+    "run", "--rm", "--gpus", "all", "--name", opts.containerName,
+    "-v", `${opts.configPath}:/config.yml:ro`,
+    "-v", `${opts.datasetPath}:/dataset:ro`,
+    "-v", `${opts.outputDir}:/output`,
+  ];
+  if (opts.hfCacheDir) args.push("-v", `${opts.hfCacheDir}:/root/.cache/huggingface`);
+  if (opts.hfToken) args.push("-e", `HF_TOKEN=${opts.hfToken}`);
+  args.push(TRAINER_IMAGE, "/config.yml");
+
+  const child = childProcess.spawn(resolveDocker(), args, { windowsHide: true, env: { ...process.env } });
+  const tailLines: string[] = [];
+  const pushTail = (s: string) => {
+    tailLines.push(s);
+    if (tailLines.length > 200) tailLines.shift();
+  };
+  const onLine = (line: string) => {
+    pushTail(line);
+    opts.onLog?.(line);
+    const tick = parseTrainingProgress(line);
+    if (tick && opts.onProgress) opts.onProgress(tick);
+  };
+  lineStream(child.stdout, onLine);
+  lineStream(child.stderr, onLine);
+
+  const done = new Promise<{ code: number; tail: string }>((resolve) => {
+    child.on("close", (code) => resolve({ code: code ?? 0, tail: tailLines.slice(-40).join("\n") }));
+    child.on("error", (err) => {
+      logger.debug(`[ai-toolkit] docker run spawn error: ${err instanceof Error ? err.message : String(err)}`);
+      resolve({ code: 1, tail: tailLines.slice(-40).join("\n") });
+    });
+  });
+  return { containerName: opts.containerName, done, child };
+}
+
+/** Stop a running training container (best-effort). `docker stop` on an
+ *  already-gone container is idempotent success for us. */
+export async function stopTraining(containerName: string): Promise<TrainerEnvelope<{ stopped: string }>> {
+  await execDocker(["stop", "-t", "10", containerName], 30_000);
+  return ok("train_cancel", { stopped: containerName });
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+/** Spawn a docker command, streaming output through onLog, resolving on close. */
+function streamDocker(
+  args: string[],
+  onLog?: (line: string) => void,
+): Promise<{ code: number; tail: string }> {
+  const child = childProcess.spawn(resolveDocker(), args, { windowsHide: true, env: { ...process.env } });
+  const tail: string[] = [];
+  const onLine = (line: string) => {
+    tail.push(line);
+    if (tail.length > 200) tail.shift();
+    onLog?.(line);
+  };
+  lineStream(child.stdout, onLine);
+  lineStream(child.stderr, onLine);
+  return new Promise((resolve) => {
+    child.on("close", (code) => resolve({ code: code ?? 0, tail: tail.slice(-40).join("\n") }));
+    child.on("error", () => resolve({ code: 1, tail: tail.slice(-40).join("\n") }));
+  });
+}
+
+/** Split a readable stream into trimmed lines. */
+function lineStream(stream: NodeJS.ReadableStream | null, onLine: (line: string) => void): void {
+  if (!stream) return;
+  let buf = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => {
+    buf += chunk;
+    // ai-toolkit's tqdm bar uses \r; treat both \r and \n as line breaks.
+    const parts = buf.split(/\r\n|\r|\n/);
+    buf = parts.pop() ?? "";
+    for (const line of parts) if (line.trim()) onLine(line);
+  });
+  stream.on("end", () => {
+    if (buf.trim()) onLine(buf);
+  });
+}

--- a/src/services/ai-toolkit.ts
+++ b/src/services/ai-toolkit.ts
@@ -136,6 +136,11 @@ export interface TrainingProgress {
  * Parse one stdout line from ai-toolkit into a progress tick. ai-toolkit prints a
  * tqdm-style bar with the job name, `<step>/<total>` and a `loss: <n>` postfix,
  * e.g. `my_lora:  12%|#2 | 240/2000 [01:03<07:41, ... loss: 3.9e-01]`.
+ *
+ * A bare `<n>/<total>` is NOT trusted as training progress: ai-toolkit also
+ * prints dataset-scan / download / weight-loading bars (e.g. `6/6`) that would
+ * otherwise masquerade as steps (found by the first real E2E run). Step/total
+ * is only assigned when the line also carries a loss reading.
  */
 export function parseTrainingProgress(line: string): TrainingProgress | null {
   const raw = line.trim();
@@ -145,7 +150,7 @@ export function parseTrainingProgress(line: string): TrainingProgress | null {
   const sampleMatch = raw.match(/(?:saved|sample).*?([^\s'"]+\.(?:png|jpg|jpeg))/i);
   if (!stepMatch && !lossMatch && !sampleMatch) return null;
   const tick: TrainingProgress = { raw };
-  if (stepMatch) {
+  if (stepMatch && lossMatch) {
     tick.step = Number(stepMatch[1]);
     tick.totalSteps = Number(stepMatch[2]);
   }
@@ -154,6 +159,8 @@ export function parseTrainingProgress(line: string): TrainingProgress | null {
     if (Number.isFinite(n)) tick.loss = n;
   }
   if (sampleMatch) tick.sample = sampleMatch[1];
+  // A line with ONLY a bare step/total (no loss, no sample) is not progress.
+  if (tick.step === undefined && tick.loss === undefined && tick.sample === undefined) return null;
   return tick;
 }
 
@@ -176,7 +183,10 @@ export function startTraining(opts: {
   const args = [
     "run", "--rm", "--gpus", "all", "--name", opts.containerName,
     "-v", `${opts.configPath}:/config.yml:ro`,
-    "-v", `${opts.datasetPath}:/dataset:ro`,
+    // Dataset is mounted READ-WRITE: ai-toolkit writes cache files into it
+    // (.aitk_size.json, latent caches) — a read-only mount fails the run
+    // ([Errno 30] on .aitk_size.json, found by the first real E2E run).
+    "-v", `${opts.datasetPath}:/dataset`,
     "-v", `${opts.outputDir}:/output`,
   ];
   if (opts.hfCacheDir) args.push("-v", `${opts.hfCacheDir}:/root/.cache/huggingface`);
@@ -208,11 +218,26 @@ export function startTraining(opts: {
   return { containerName: opts.containerName, done, child };
 }
 
-/** Stop a running training container (best-effort). `docker stop` on an
- *  already-gone container is idempotent success for us. */
+/** Stop a running training container. The envelope is honest about failure:
+ *  a non-zero `docker stop` (daemon down, timeout) yields ok:false so callers
+ *  don't report a container as stopped while it keeps burning GPU. An
+ *  already-gone container counts as stopped. */
 export async function stopTraining(containerName: string): Promise<TrainerEnvelope<{ stopped: string }>> {
-  await execDocker(["stop", "-t", "10", containerName], 30_000);
+  const r = await execDocker(["stop", "-t", "10", containerName], 30_000);
+  if (r.code !== 0 && !/no such (object|container)/i.test(r.stderr)) {
+    return fail("train_cancel", "stop_failed", `docker stop ${containerName} failed: ${r.stderr.trim() || `exit ${r.code}`}`, r.stderr);
+  }
   return ok("train_cancel", { stopped: containerName });
+}
+
+/** Is this training container currently running? `false` when it definitively
+ *  does not exist, `null` when we can't tell (docker daemon down, etc.) — the
+ *  registry uses this to avoid mis-marking a live foreign-process job failed. */
+export async function containerRunning(containerName: string): Promise<boolean | null> {
+  const r = await execDocker(["inspect", "-f", "{{.State.Running}}", containerName]);
+  if (r.code === 0) return r.stdout.trim() === "true";
+  if (/no such (object|container)/i.test(r.stderr)) return false;
+  return null;
 }
 
 // ---- helpers ---------------------------------------------------------------

--- a/src/services/training-config.ts
+++ b/src/services/training-config.ts
@@ -116,10 +116,14 @@ export interface BuiltTrainingConfig {
   yaml: string;
 }
 
-/** ai-toolkit uses the job name as a filesystem path — keep it safe. */
+/** ai-toolkit uses the job name as a filesystem path segment (it joins
+ *  training_folder/name and writes there) — keep it safe. Dots-only names like
+ *  "." / ".." would escape or collapse the per-job directory, so they fall back
+ *  to "lora" (codex review finding #1). */
 function sanitizeName(name: string): string {
   const cleaned = name.trim().replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
-  return cleaned || "lora";
+  if (!cleaned || /^\.+$/.test(cleaned)) return "lora";
+  return cleaned;
 }
 
 /**
@@ -137,10 +141,24 @@ export function buildTrainingConfig(input: TrainingConfigInput): BuiltTrainingCo
   }
 
   const jobName = sanitizeName(input.name);
-  const p: TrainParams = { ...DEFAULT_PARAMS, ...input.params };
+  // Drop undefined overrides so `{steps: undefined}` can't erase a default
+  // (codex finding #3), then validate the merged values.
+  const overrides = Object.fromEntries(
+    Object.entries(input.params ?? {}).filter(([, v]) => v !== undefined),
+  ) as Partial<TrainParams>;
+  const p: TrainParams = { ...DEFAULT_PARAMS, ...overrides };
+  if (!(p.steps > 0) || !(p.lr > 0) || !(p.rank > 0) || !(p.batchSize > 0) || !(p.saveEvery > 0) || !(p.sampleEvery > 0)) {
+    throw new Error("invalid training params: steps/lr/rank/batchSize/saveEvery/sampleEvery must be positive");
+  }
+  if (!Array.isArray(p.resolution) || p.resolution.length === 0 || p.resolution.some((r) => !(r > 0))) {
+    throw new Error("invalid training params: resolution must be a non-empty list of positive sizes");
+  }
   const device = input.device ?? "cuda:0";
+  // Function replacer: a trigger like "$&" must be inserted literally, not
+  // interpreted as a String.replace special sequence (codex finding #2).
+  const trigger = input.trigger;
   const prompts = (input.samplePrompts ?? DEFAULT_CHARACTER_PROMPTS).map((s) =>
-    input.trigger ? s.replace(/\[trigger\]/g, input.trigger) : s.replace(/\[trigger\]\s*/g, ""),
+    trigger ? s.replace(/\[trigger\]/g, () => trigger) : s.replace(/\[trigger\]\s*/g, ""),
   );
 
   const process: Record<string, unknown> = {

--- a/src/services/training-config.ts
+++ b/src/services/training-config.ts
@@ -1,0 +1,204 @@
+// Generates ostris ai-toolkit training configs (the YAML `run.py` consumes) from
+// a high-level request. This is the "derived from AI Toolkit" core: we own the
+// mapping (flow + base model + dataset + params) → ai-toolkit's config schema,
+// and ai-toolkit does the actual training unchanged.
+//
+// Schema mirrors ai-toolkit's example configs / notebooks:
+//   job: extension
+//   config: { name, process: [ { type: sd_trainer, training_folder, device,
+//     trigger_word, network{lora}, save, datasets[], train{}, model{}, sample{} } ] }
+// Defaults come from the `ai-toolkit-trainer` SKILL param tables + character-
+// consistency research (rank 16, quantize on 24GB, batch 1, 512/768/1024 buckets).
+//
+// Phase 1 ships ONE flow (character) on ONE model (Flux.1-dev). The MODEL_SPECS
+// and FLOW map are structured so later phases add Z-Image / WAN / edit without
+// reshaping callers.
+
+import { stringify } from "yaml";
+
+/** Base models we can train against. P1 = flux1-dev only; others are capability-
+ *  gated until verified against the installed ai-toolkit (see plan). */
+export type TrainerModel = "flux1-dev";
+
+/** Training flow. P1 = character; style/slider/edit/video come later. */
+export type TrainerFlow = "character";
+
+/** Tunables a caller (or the LLM) may override. All optional — sane defaults below. */
+export interface TrainParams {
+  /** Total training steps. 500–4000 is the useful range; 200 for a smoke test. */
+  steps: number;
+  /** Learning rate. */
+  lr: number;
+  /** LoRA rank (linear + linear_alpha). 16 simple, 16–32 detailed. */
+  rank: number;
+  /** Resolution buckets. Flux likes multiple; drop to [512] to save VRAM. */
+  resolution: number[];
+  /** Micro-batch. 1 unless you have VRAM to spare. */
+  batchSize: number;
+  /** Checkpoint cadence (steps). */
+  saveEvery: number;
+  /** Sample-image cadence (steps). */
+  sampleEvery: number;
+  /** 8-bit mixed precision to fit Flux on a 24GB card. */
+  quantize: boolean;
+}
+
+export const DEFAULT_PARAMS: TrainParams = {
+  steps: 2000,
+  lr: 1e-4,
+  rank: 16,
+  resolution: [512, 768, 1024],
+  batchSize: 1,
+  saveEvery: 250,
+  sampleEvery: 250,
+  quantize: true,
+};
+
+/** Per-model ai-toolkit knobs. Keyed by TrainerModel so new bases are additive. */
+interface ModelSpec {
+  /** HF repo id (or local path) ai-toolkit loads. */
+  nameOrPath: string;
+  /** Extra `model` block flags for this arch. */
+  modelFlags: Record<string, unknown>;
+  /** Scheduler used for both train + sample (must match). */
+  scheduler: string;
+  /** Optimizer that fits this arch on consumer VRAM. */
+  optimizer: string;
+  /** Compute dtype. */
+  dtype: string;
+  /** train_text_encoder — off for Flux. */
+  trainTextEncoder: boolean;
+}
+
+const MODEL_SPECS: Record<TrainerModel, ModelSpec> = {
+  "flux1-dev": {
+    nameOrPath: "black-forest-labs/FLUX.1-dev",
+    modelFlags: { is_flux: true, quantize: true },
+    scheduler: "flowmatch",
+    optimizer: "adamw8bit",
+    dtype: "bf16",
+    trainTextEncoder: false,
+  },
+};
+
+export interface TrainingConfigInput {
+  /** Job name — becomes the output folder + `.safetensors` basename. */
+  name: string;
+  flow: TrainerFlow;
+  model: TrainerModel;
+  /** Path to the dataset folder (images + same-basename `.txt` captions), as the
+   *  training process will see it (a container path when run in Docker). */
+  datasetPath: string;
+  /** Root the trainer writes checkpoints/samples into (`training_folder`). */
+  outputDir: string;
+  /** Optional trigger word — injected into captions / usable as `[trigger]`. */
+  trigger?: string;
+  /** GPU selector. */
+  device?: string;
+  /** Optional param overrides. */
+  params?: Partial<TrainParams>;
+  /** Optional sample prompts; `[trigger]` is substituted. Defaults provided. */
+  samplePrompts?: string[];
+}
+
+const DEFAULT_CHARACTER_PROMPTS = [
+  "[trigger] a photo of the person, natural lighting, looking at the camera",
+  "[trigger] the person in a city street, candid, golden hour",
+  "[trigger] a close-up portrait of the person, soft studio lighting",
+];
+
+export interface BuiltTrainingConfig {
+  /** ai-toolkit job name (== input.name, sanitized). */
+  jobName: string;
+  /** The config object (ordered to match ai-toolkit's examples). */
+  config: Record<string, unknown>;
+  /** YAML text to write and pass to `run.py`. */
+  yaml: string;
+}
+
+/** ai-toolkit uses the job name as a filesystem path — keep it safe. */
+function sanitizeName(name: string): string {
+  const cleaned = name.trim().replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+  return cleaned || "lora";
+}
+
+/**
+ * Build an ai-toolkit training config for the given request.
+ * Throws on an unsupported flow/model so callers surface a clear error rather
+ * than emitting a config ai-toolkit will choke on.
+ */
+export function buildTrainingConfig(input: TrainingConfigInput): BuiltTrainingConfig {
+  if (input.flow !== "character") {
+    throw new Error(`unsupported training flow "${input.flow}" (phase 1 supports: character)`);
+  }
+  const spec = MODEL_SPECS[input.model];
+  if (!spec) {
+    throw new Error(`unsupported base model "${input.model}" (phase 1 supports: flux1-dev)`);
+  }
+
+  const jobName = sanitizeName(input.name);
+  const p: TrainParams = { ...DEFAULT_PARAMS, ...input.params };
+  const device = input.device ?? "cuda:0";
+  const prompts = (input.samplePrompts ?? DEFAULT_CHARACTER_PROMPTS).map((s) =>
+    input.trigger ? s.replace(/\[trigger\]/g, input.trigger) : s.replace(/\[trigger\]\s*/g, ""),
+  );
+
+  const process: Record<string, unknown> = {
+    type: "sd_trainer",
+    training_folder: input.outputDir,
+    device,
+    ...(input.trigger ? { trigger_word: input.trigger } : {}),
+    network: { type: "lora", linear: p.rank, linear_alpha: p.rank },
+    save: { dtype: "float16", save_every: p.saveEvery, max_step_saves_to_keep: 4 },
+    datasets: [
+      {
+        folder_path: input.datasetPath,
+        caption_ext: "txt",
+        caption_dropout_rate: 0.05,
+        shuffle_tokens: false,
+        cache_latents_to_disk: true,
+        resolution: p.resolution,
+      },
+    ],
+    train: {
+      batch_size: p.batchSize,
+      steps: p.steps,
+      gradient_accumulation_steps: 1,
+      train_unet: true,
+      train_text_encoder: spec.trainTextEncoder,
+      content_or_style: "balanced",
+      gradient_checkpointing: true,
+      noise_scheduler: spec.scheduler,
+      optimizer: spec.optimizer,
+      lr: p.lr,
+      ema_config: { use_ema: true, ema_decay: 0.99 },
+      dtype: spec.dtype,
+    },
+    model: {
+      name_or_path: spec.nameOrPath,
+      ...spec.modelFlags,
+      // Honor an explicit quantize override (e.g. off on a big card).
+      quantize: p.quantize,
+    },
+    sample: {
+      sampler: spec.scheduler,
+      sample_every: p.sampleEvery,
+      width: 1024,
+      height: 1024,
+      prompts,
+      neg: "",
+      seed: 42,
+      walk_seed: true,
+      guidance_scale: 4,
+      sample_steps: 20,
+    },
+  };
+
+  const config: Record<string, unknown> = {
+    job: "extension",
+    config: { name: jobName, process: [process] },
+    meta: { name: "[name]", version: "1.0" },
+  };
+
+  return { jobName, config, yaml: stringify(config) };
+}

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -1,0 +1,776 @@
+// Training job registry for the LoRA trainer — the state layer between the
+// train_* MCP tools and the ai-toolkit container driver.
+//
+// A job ties together: a dataset dir (staged by prepareDataset), a generated
+// ai-toolkit config (training-config.ts), and a running docker container
+// (ai-toolkit.ts). Jobs persist a small JSON record under
+// <trainingRoot>/jobs/<id>.json so `train_status`/`train_cancel` still work
+// after an MCP restart (the container keeps running; we re-read the record).
+//
+// On success the final `.safetensors` is copied into ComfyUI models/loras/ and
+// upserted into the LoRA catalog (trigger keyword + base model) so it shows in
+// the mobile LoRA hub immediately. Live step/loss progress is also mirrored
+// onto the cross-process download-progress channel for the panel/mobile tray.
+
+import {
+  appendFileSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, extname, join, resolve } from "node:path";
+import {
+  containerRunning,
+  startTraining,
+  stopTraining,
+  type TrainingHandle,
+  type TrainingProgress,
+} from "./ai-toolkit.js";
+import {
+  buildTrainingConfig,
+  type TrainParams,
+  type TrainerFlow,
+  type TrainerModel,
+} from "./training-config.js";
+import { reportDownloadProgress } from "./download-progress.js";
+import { getLoraCatalog } from "./lora-catalog.js";
+import { resolveModelSubfolder } from "./model-resolver.js";
+import { getInstanceSlug } from "../config.js";
+import { logger } from "../utils/logger.js";
+
+export type TrainingJobStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+
+export interface TrainingJob {
+  id: string;
+  /** Job/LoRA name — becomes the output folder + .safetensors basename. */
+  name: string;
+  flow: TrainerFlow;
+  model: TrainerModel;
+  trigger?: string;
+  status: TrainingJobStatus;
+  progress: {
+    step?: number;
+    totalSteps?: number;
+    loss?: number;
+    /** Host paths of the most recent sample images (max 4). */
+    samples: string[];
+  };
+  containerName?: string;
+  /** Host dataset dir mounted at /dataset (writable — ai-toolkit caches into it). */
+  datasetPath: string;
+  /** Per-job dir holding config.yml, train.log, output/. */
+  jobDir: string;
+  /** Host output dir mounted at /output. */
+  outputDir: string;
+  /** Recent log lines (ring buffer, max 50) for train_status. */
+  log: string[];
+  error?: string;
+  /** models/loras dir resolved at START — persisted so a mid-run ComfyUI
+   *  retarget can't redirect the handoff to the wrong instance. */
+  lorasDir?: string;
+  /** ComfyUI instance slug at START — the catalog upsert is skipped when the
+   *  active instance at handoff time differs (retargeted mid-run). */
+  instanceSlug?: string;
+  result?: {
+    /** Absolute path of the LoRA copied into models/loras/. */
+    loraPath: string;
+    /** models/-relative path, e.g. "loras/my_lora.safetensors". */
+    loraRelPath: string;
+    /** Absent when the catalog upsert was skipped (instance changed mid-run). */
+    catalogId?: string;
+    previewFile?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  finishedAt?: string;
+}
+
+/** Injectable seams so tests can run without docker / a ComfyUI install. */
+export interface TrainingJobDeps {
+  startTraining?: typeof startTraining;
+  stopTraining?: typeof stopTraining;
+  /** Container liveness probe (false = definitively gone, null = unknown). */
+  containerRunning?: typeof containerRunning;
+  /** Where the finished LoRA is copied. Default: ComfyUI models/loras. */
+  lorasDir?: () => string;
+  catalog?: Pick<ReturnType<typeof getLoraCatalog>, "upsert" | "setPreview">;
+  now?: () => number;
+}
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+const LOG_RING = 50;
+/** Container-side mount points (must match ai-toolkit.ts startTraining). */
+const CONTAINER_DATASET = "/dataset";
+const CONTAINER_OUTPUT = "/output";
+
+// ---- paths -----------------------------------------------------------------
+
+function dataBaseDir(): string {
+  return process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp");
+}
+
+/** Root for datasets, job dirs, and the shared HF cache. */
+export function trainingRoot(): string {
+  return process.env.COMFYUI_MCP_TRAINING_DIR?.trim() || join(dataBaseDir(), "training");
+}
+
+export function datasetsRoot(): string {
+  return join(trainingRoot(), "datasets");
+}
+
+export function jobsRoot(): string {
+  return join(trainingRoot(), "jobs");
+}
+
+/** Shared HF cache mounted into every training container (models persist
+ *  across runs so Flux isn't re-downloaded each job). */
+export function hfCacheRoot(): string {
+  return join(trainingRoot(), "hf-cache");
+}
+
+// ---- registry ---------------------------------------------------------------
+
+const jobs = new Map<string, TrainingJob>();
+const handles = new Map<string, TrainingHandle>();
+/** Throttle for persisting live progress (codex finding: cross-process readers
+ *  only see what's on disk, so running jobs must snapshot, not just finalize). */
+const lastProgressPersistAt = new Map<string, number>();
+const PROGRESS_PERSIST_MS = 5000;
+
+function jobFile(id: string): string {
+  return join(jobsRoot(), `${id}.json`);
+}
+
+function persist(job: TrainingJob): void {
+  try {
+    mkdirSync(jobsRoot(), { recursive: true });
+    writeFileSync(jobFile(job.id), JSON.stringify(job, null, 2));
+  } catch (err) {
+    logger.warn(`[training-jobs] could not persist ${job.id}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** True when the ON-DISK record says cancelled — i.e. another process issued a
+ *  cancel this process hasn't seen (its memory still says running). */
+function diskCancelled(job: TrainingJob): boolean {
+  try {
+    const disk = JSON.parse(readFileSync(jobFile(job.id), "utf-8")) as TrainingJob;
+    return disk?.status === "cancelled";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist a live progress/log snapshot WITHOUT clobbering a foreign cancel:
+ * if the disk record was cancelled by another process since we last looked,
+ * adopt that state into memory and skip the write (codex finding: the owner's
+ * throttled persist overwrote the cross-process cancel, then finalize ran the
+ * handoff anyway).
+ */
+function persistLiveState(job: TrainingJob): void {
+  if (job.status === "cancelled") return;
+  if (diskCancelled(job)) {
+    job.status = "cancelled";
+    job.finishedAt = new Date().toISOString();
+    job.updatedAt = job.finishedAt;
+    return;
+  }
+  persist(job);
+}
+
+/**
+ * Merge the on-disk records into the in-memory map. Runs on EVERY read: the
+ * orchestrator's long-lived in-process client (mobile `train_status`) is a
+ * different process from the one running `train_start`, so a load-once
+ * registry would show stale/empty state forever (codex finding #1).
+ *
+ * Merge rules:
+ *  - A job with a live in-process handle is authoritative in memory (fresher
+ *    than disk between throttled persists) — disk never overwrites it.
+ *  - Anything else takes the disk record (new, updated, or absent in memory).
+ *  - A record persisted as running/queued with NO live handle here belongs to
+ *    another process (or a crashed one): probe the container. Definitively
+ *    gone → mark failed; running or unknown → report as recorded, never
+ *    mislabel a live foreign job as failed (codex finding #2).
+ */
+async function refreshRegistry(deps: TrainingJobDeps = {}): Promise<void> {
+  let files: string[] = [];
+  try {
+    files = readdirSync(jobsRoot()).filter((f) => f.endsWith(".json"));
+  } catch {
+    return; // no jobs dir yet
+  }
+  for (const f of files) {
+    let job: TrainingJob;
+    try {
+      job = JSON.parse(readFileSync(join(jobsRoot(), f), "utf-8")) as TrainingJob;
+    } catch {
+      continue; // skip a garbled record
+    }
+    if (!job || typeof job.id !== "string") continue;
+    if (handles.has(job.id)) continue; // live in this process — memory wins
+    if ((job.status === "running" || job.status === "queued") && job.containerName) {
+      const probe = deps.containerRunning ?? containerRunning;
+      const running = await probe(job.containerName).catch(() => null);
+      if (running === false) {
+        // Container gone with no live handle anywhere: the owning process died.
+        // Recover ONLY a proven-successful run — artifact presence alone is not
+        // enough (a crashed run leaves periodic checkpoints behind, and handing
+        // those off would publish partial weights as a finished LoRA; codex
+        // finding). Proof = the FINAL save exists AND ai-toolkit's own summary
+        // in train.log reports completed jobs.
+        try {
+          if (recoveredSuccessfully(job)) {
+            handoffToComfyUI(job, deps);
+            job.status = "completed";
+            const samples = findSamples(job.outputDir, job.name, 4);
+            if (samples.length > 0) job.progress.samples = samples;
+            if (job.progress.totalSteps !== undefined) job.progress.step = job.progress.totalSteps;
+            job.finishedAt = new Date().toISOString();
+            persist(job);
+            jobs.set(job.id, job);
+            continue;
+          }
+        } catch (err) {
+          job.status = "failed";
+          job.error = `recovered output but handoff failed: ${err instanceof Error ? err.message : String(err)}`;
+          job.finishedAt = new Date().toISOString();
+          persist(job);
+          jobs.set(job.id, job);
+          continue;
+        }
+        job.status = "failed";
+        job.error = "training container is no longer running (the MCP process that started it exited or the container died); any output (checkpoints, samples) is under the job's output/ dir.";
+        job.finishedAt = new Date().toISOString();
+        persist(job);
+      }
+    }
+    jobs.set(job.id, job);
+  }
+}
+
+export async function getJob(id: string, deps: TrainingJobDeps = {}): Promise<TrainingJob | null> {
+  await refreshRegistry(deps);
+  return jobs.get(id) ?? null;
+}
+
+export async function listJobs(deps: TrainingJobDeps = {}): Promise<TrainingJob[]> {
+  await refreshRegistry(deps);
+  return [...jobs.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+// ---- dataset staging ----------------------------------------------------------
+
+export interface DatasetItem {
+  /** Host path to a source image. */
+  path: string;
+  /** Caption text. Falls back to defaultCaption (usually the trigger word). */
+  caption?: string;
+}
+
+export interface PreparedDataset {
+  datasetPath: string;
+  imageCount: number;
+  captionedCount: number;
+  warnings: string[];
+}
+
+function sanitizeDirName(name: string): string {
+  const cleaned = name.trim().replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+  if (!cleaned || /^\.+$/.test(cleaned)) return "dataset";
+  return cleaned;
+}
+
+/**
+ * Stage images + same-basename .txt captions into a dataset dir ai-toolkit can
+ * consume. Images are copied in as img_00001.<ext> etc. (stable, caption-safe
+ * names); a missing caption falls back to defaultCaption, and if that's also
+ * absent the image is staged uncaptioned with a warning (ai-toolkit trains on
+ * it with an empty caption).
+ *
+ * Re-staging the same name REPLACES the old dir — but refuses when a
+ * non-terminal job currently trains from it (the dir is bind-mounted into the
+ * running container; wiping it mid-run would corrupt the job — codex finding).
+ */
+export async function prepareDataset(opts: {
+  name: string;
+  items: DatasetItem[];
+  defaultCaption?: string;
+}, deps: TrainingJobDeps = {}): Promise<PreparedDataset> {
+  if (!Array.isArray(opts.items) || opts.items.length === 0) {
+    throw new Error("dataset needs at least one image");
+  }
+  const dir = join(datasetsRoot(), sanitizeDirName(opts.name));
+  const resolvedDir = resolve(dir);
+  const active = await listJobs(deps);
+  const inUse = active.find(
+    (j) => (j.status === "running" || j.status === "queued") && resolve(j.datasetPath) === resolvedDir,
+  );
+  if (inUse) {
+    throw new Error(`dataset "${opts.name}" is in use by ${inUse.status} job ${inUse.id} — pick another name or cancel the job first`);
+  }
+  // Validate EVERY item first and stage into a temp sibling, then swap — an
+  // invalid item or a copy failure must not destroy the previously valid
+  // dataset or leave a partial replacement (codex finding).
+  const resolvedItems = opts.items.map((item) => {
+    const src = item.path?.trim();
+    if (!src || !existsSync(src)) throw new Error(`image not found: ${item.path}`);
+    const ext = extname(src).toLowerCase();
+    if (!IMAGE_EXTS.has(ext)) throw new Error(`not a supported image (${[...IMAGE_EXTS].join("/")}): ${src}`);
+    return { src, ext, caption: (item.caption ?? opts.defaultCaption)?.trim() };
+  });
+  const tmp = `${dir}.staging-${process.pid}`;
+  rmSync(tmp, { recursive: true, force: true });
+  mkdirSync(tmp, { recursive: true });
+  const warnings: string[] = [];
+  let captionedCount = 0;
+  try {
+    resolvedItems.forEach((item, i) => {
+      const base = `img_${String(i + 1).padStart(5, "0")}`;
+      copyFileSync(item.src, join(tmp, `${base}${item.ext}`));
+      if (item.caption) {
+        writeFileSync(join(tmp, `${base}.txt`), item.caption);
+        captionedCount++;
+      } else {
+        warnings.push(`${basename(item.src)}: no caption (defaultCaption not set)`);
+      }
+    });
+  } catch (err) {
+    rmSync(tmp, { recursive: true, force: true });
+    throw err;
+  }
+  rmSync(dir, { recursive: true, force: true });
+  renameSync(tmp, dir);
+  return { datasetPath: dir, imageCount: resolvedItems.length, captionedCount, warnings };
+}
+
+// ---- job lifecycle ------------------------------------------------------------
+
+export interface StartJobInput {
+  name: string;
+  flow: TrainerFlow;
+  model: TrainerModel;
+  /** Host dataset dir (images + .txt captions). */
+  datasetPath: string;
+  trigger?: string;
+  params?: Partial<TrainParams>;
+  device?: string;
+}
+
+function countDatasetImages(datasetPath: string): number {
+  try {
+    return readdirSync(datasetPath).filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase())).length;
+  } catch {
+    return 0;
+  }
+}
+
+function pushLog(job: TrainingJob, line: string): void {
+  job.log.push(line);
+  if (job.log.length > LOG_RING) job.log.shift();
+  try {
+    appendFileSync(join(job.jobDir, "train.log"), line + "\n");
+  } catch {
+    // log file is best-effort
+  }
+}
+
+/** Map a container-side /output path (from a sample line) back to its host path. */
+function toHostOutputPath(job: TrainingJob, p: string): string {
+  if (p.startsWith(CONTAINER_OUTPUT + "/")) return join(job.outputDir, p.slice(CONTAINER_OUTPUT.length + 1));
+  return p;
+}
+
+function reportProgress(job: TrainingJob, status: "downloading" | "done" | "error", force = false): void {
+  reportDownloadProgress(
+    {
+      id: `train-${job.id}`,
+      name: `LoRA ${job.name}`,
+      downloaded: job.progress.step ?? 0,
+      total: job.progress.totalSteps ?? 0,
+      bytes_per_sec: 0,
+      status,
+    },
+    force,
+  );
+}
+
+/** Pick the LoRA ai-toolkit produced: the exact <name>.safetensors final save,
+ *  else the highest-step <name>_NNNNNNN.safetensors checkpoint. */
+export function findProducedLora(outputDir: string, jobName: string): string | null {
+  const dir = join(outputDir, jobName);
+  if (!existsSync(dir)) return null;
+  const finalPath = join(dir, `${jobName}.safetensors`);
+  if (existsSync(finalPath)) return finalPath;
+  let best: { step: number; path: string } | null = null;
+  for (const f of readdirSync(dir)) {
+    const m = f.match(new RegExp(`^${jobName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}_(\\d+)\\.safetensors$`));
+    if (m) {
+      const step = Number(m[1]);
+      if (!best || step > best.step) best = { step, path: join(dir, f) };
+    }
+  }
+  return best?.path ?? null;
+}
+
+/**
+ * Durable proof an owner-less job actually FINISHED training: the FINAL save
+ * (<name>.safetensors) exists. ai-toolkit writes it only after the training
+ * loop completes — periodic <name>_NNNN.safetensors checkpoints prove nothing
+ * (a crash leaves those too), and stdout markers can't help: after the owner
+ * process dies, nothing appends its end-of-run summary to train.log (codex
+ * finding). The residual risk — a crash in the sampling phase AFTER the final
+ * save — still yields a complete LoRA, so handing it off is correct.
+ */
+export function recoveredSuccessfully(job: TrainingJob): boolean {
+  return existsSync(join(job.outputDir, job.name, `${job.name}.safetensors`));
+}
+
+/** Latest sample images from <output>/<name>/samples/, newest first. */
+function findSamples(outputDir: string, jobName: string, limit = 4): string[] {
+  const dir = join(outputDir, jobName, "samples");
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir)
+      .filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()))
+      .map((f) => ({ f, mtime: statSync(join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, limit)
+      .map((x) => join(dir, x.f));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Success handoff: copy the produced LoRA into models/loras/ and upsert the
+ * catalog (trigger as keyword, base model from the trained arch) so the LoRA
+ * is immediately usable in workflows and visible in the mobile LoRA hub.
+ */
+function handoffToComfyUI(job: TrainingJob, deps: TrainingJobDeps): void {
+  const produced = findProducedLora(job.outputDir, job.name);
+  if (!produced) {
+    throw new Error(`training exited cleanly but no .safetensors found under ${join(job.outputDir, job.name)}`);
+  }
+  // The destination resolved at job START wins (codex finding): if the ComfyUI
+  // target changed mid-run, re-resolving now would copy the LoRA to the new
+  // instance's models dir.
+  const lorasDir = job.lorasDir ?? (deps.lorasDir ? deps.lorasDir() : resolveModelSubfolder("loras"));
+  mkdirSync(lorasDir, { recursive: true });
+  const dest = join(lorasDir, `${job.name}.safetensors`);
+  copyFileSync(produced, dest);
+
+  // The catalog is per-instance: after a mid-run retarget, upserting here
+  // would register the LoRA in the WRONG instance's catalog. Copy still
+  // happened (into the original dir, above); skip the catalog honestly.
+  if (job.instanceSlug && job.instanceSlug !== getInstanceSlug()) {
+    logger.warn(
+      `[training-jobs] ComfyUI instance changed mid-run (${job.instanceSlug} → ${getInstanceSlug()}); ` +
+        `LoRA copied to ${dest} but the catalog upsert was skipped — re-run lora_catalog_upsert on the original instance.`,
+    );
+    job.result = { loraPath: dest, loraRelPath: `loras/${job.name}.safetensors` };
+    return;
+  }
+
+  const catalog = deps.catalog ?? getLoraCatalog();
+  const entry = catalog.upsert({
+    relPath: `loras/${job.name}.safetensors`,
+    displayName: job.name.replace(/_/g, " "),
+    description: `Character LoRA trained locally on FLUX.1-dev via ostris ai-toolkit (comfyui-mcp trainer, job ${job.id}).`,
+    setupInstructions:
+      "Load with LoraLoaderModelOnly on a FLUX.1-dev checkpoint" +
+      (job.trigger ? ` and include the trigger word "${job.trigger}" in the prompt.` : "."),
+    keywords: job.trigger ? [job.trigger] : [],
+    baseModels: ["FLUX.1-dev"],
+    strengthDefault: 1.0,
+    tags: ["trained-locally", "character"],
+    // Explicitly clear the flag — retraining a LoRA whose entry was marked
+    // missing must become visible again (upsert otherwise preserves it).
+    missing: false,
+  });
+
+  // Best-effort: newest sample image becomes the catalog preview.
+  let previewFile: string | undefined;
+  const samples = findSamples(job.outputDir, job.name, 1);
+  if (samples.length > 0) {
+    try {
+      previewFile = catalog.setPreview(entry.id, samples[0]).previewFile;
+    } catch (err) {
+      logger.debug(`[training-jobs] preview copy skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  job.result = { loraPath: dest, loraRelPath: `loras/${job.name}.safetensors`, catalogId: entry.id, previewFile };
+}
+
+async function finalizeJob(job: TrainingJob, code: number, tail: string, deps: TrainingJobDeps): Promise<void> {
+  // A cancel marks the job before the container exits — don't overwrite it.
+  // Check BOTH this process's memory and the on-disk record: a cancel issued
+  // from another process (e.g. the orchestrator's call_tool client) only shows
+  // up on disk (codex finding: cross-process cancel was clobbered by finalize).
+  if (job.status === "cancelled") {
+    if (diskCancelled(job)) return;
+    // Memory says cancelled but disk doesn't: the cancel was rolled back after
+    // a failed stop — reconcile and finalize normally (codex finding).
+    job.status = "running";
+    job.finishedAt = undefined;
+    job.error = undefined;
+  }
+  if (diskCancelled(job)) {
+    job.status = "cancelled";
+    job.finishedAt = new Date().toISOString();
+    job.updatedAt = job.finishedAt;
+    return;
+  }
+  job.finishedAt = new Date().toISOString();
+  // Surface the generated samples in train_status regardless of outcome —
+  // ai-toolkit prints only "Generating Images" bars (no saved-file lines), so
+  // onProgress never sees sample paths (codex finding; confirmed by the E2E).
+  const samples = findSamples(job.outputDir, job.name, 4);
+  if (samples.length > 0) job.progress.samples = samples;
+  if (code === 0) {
+    try {
+      handoffToComfyUI(job, deps);
+      job.status = "completed";
+      // The last training bar can read e.g. 199/200 before the final save +
+      // sampling phases — normalize so a completed job shows a complete count
+      // (codex finding).
+      if (job.progress.totalSteps !== undefined) job.progress.step = job.progress.totalSteps;
+      reportProgress(job, "done", true);
+    } catch (err) {
+      job.status = "failed";
+      job.error = `output handoff failed: ${err instanceof Error ? err.message : String(err)}`;
+      reportProgress(job, "error", true);
+    }
+  } else {
+    job.status = "failed";
+    job.error = `training container exited ${code}${tail ? ` — last output:\n${tail}` : ""}`;
+    reportProgress(job, "error", true);
+  }
+  job.updatedAt = new Date().toISOString();
+  persist(job);
+}
+
+/**
+ * Build the config, launch the container, and register the job. Returns as
+ * soon as the container is up; completion is handled by the handle's `done`
+ * promise (finalizeJob). Preflight (docker/image) belongs to the caller — the
+ * train_start tool runs trainerDoctor checks first.
+ *
+ * The LoRA handoff destination is resolved BEFORE launch (codex finding): in
+ * remote mode / with no local workspace, resolveModelSubfolder throws — better
+ * here than after an hours-long run.
+ */
+export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDeps = {}): Promise<TrainingJob> {
+  const start = deps.startTraining ?? startTraining;
+  const now = deps.now ?? (() => Date.now());
+  const datasetPath = resolve(input.datasetPath);
+  if (!existsSync(datasetPath)) throw new Error(`dataset not found: ${input.datasetPath}`);
+  const imageCount = countDatasetImages(datasetPath);
+  if (imageCount === 0) throw new Error(`dataset has no images (${[...IMAGE_EXTS].join("/")}): ${datasetPath}`);
+  // Pre-launch handoff check — throws early when no local ComfyUI is resolvable.
+  const lorasDir = deps.lorasDir ?? (() => resolveModelSubfolder("loras"));
+  const resolvedLorasDir = lorasDir();
+  const effDeps: TrainingJobDeps = { ...deps, lorasDir };
+
+  const id = `t${now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  const jobDir = join(jobsRoot(), id);
+  const outputDir = join(jobDir, "output");
+  mkdirSync(outputDir, { recursive: true });
+
+  // Config sees CONTAINER paths; the driver bind-mounts the host dirs there.
+  const built = buildTrainingConfig({
+    name: input.name,
+    flow: input.flow,
+    model: input.model,
+    datasetPath: CONTAINER_DATASET,
+    outputDir: CONTAINER_OUTPUT,
+    trigger: input.trigger,
+    device: input.device,
+    params: input.params,
+  });
+  const configPath = join(jobDir, "config.yml");
+  writeFileSync(configPath, built.yaml);
+
+  const job: TrainingJob = {
+    id,
+    name: built.jobName,
+    flow: input.flow,
+    model: input.model,
+    trigger: input.trigger,
+    status: "queued",
+    progress: { samples: [] },
+    containerName: `comfyui-train-${id}`,
+    datasetPath,
+    jobDir,
+    outputDir,
+    log: [],
+    lorasDir: resolvedLorasDir,
+    instanceSlug: getInstanceSlug(),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  jobs.set(id, job);
+  persist(job);
+
+  const handle = start({
+    containerName: job.containerName!,
+    configPath,
+    datasetPath,
+    outputDir,
+    hfCacheDir: hfCacheRoot(),
+    hfToken: process.env.HF_TOKEN?.trim() || undefined,
+    onProgress: (p: TrainingProgress) => {
+      // Terminal jobs ignore ticks — a progress line arriving while a cancel's
+      // docker stop is in flight must not resurrect the job (codex finding).
+      if (job.status === "cancelled") {
+        // …but a FOREIGN cancel can be rolled back: the cancelling process
+        // reverts the disk record to running when its docker stop fails. If the
+        // disk no longer says cancelled, resume — otherwise stay cancelled
+        // (codex finding: permanent adoption suppressed a later completion).
+        if (!diskCancelled(job)) {
+          job.status = "running";
+          job.finishedAt = undefined;
+          job.error = undefined;
+        } else {
+          return;
+        }
+      }
+      if (job.status === "completed" || job.status === "failed") return;
+      if (job.status !== "running") {
+        job.status = "running";
+        reportProgress(job, "downloading", true);
+      }
+      if (p.step !== undefined) job.progress.step = p.step;
+      if (p.totalSteps !== undefined) job.progress.totalSteps = p.totalSteps;
+      if (p.loss !== undefined) job.progress.loss = p.loss;
+      if (p.sample) {
+        job.progress.samples.unshift(toHostOutputPath(job, p.sample));
+        job.progress.samples = job.progress.samples.slice(0, 4);
+      }
+      job.updatedAt = new Date().toISOString();
+      reportProgress(job, "downloading");
+      // Throttled disk snapshot so OTHER processes (orchestrator call_tool
+      // client → mobile train_status) see live progress, not just the final
+      // state (codex finding: progress was memory-only until finalize).
+      const last = lastProgressPersistAt.get(id) ?? 0;
+      if (Date.now() - last >= PROGRESS_PERSIST_MS) {
+        lastProgressPersistAt.set(id, Date.now());
+        persistLiveState(job);
+      }
+    },
+    onLog: (line) => {
+      pushLog(job, line);
+      // Log lines also snapshot (same throttle): during the long first-run
+      // model download there are NO progress ticks, so without this a
+      // cross-process train_status sees an empty, apparently stalled record
+      // (codex finding).
+      const last = lastProgressPersistAt.get(id) ?? 0;
+      if (Date.now() - last >= PROGRESS_PERSIST_MS) {
+        lastProgressPersistAt.set(id, Date.now());
+        persistLiveState(job);
+      }
+    },
+  });
+  handles.set(id, handle);
+
+  handle.done
+    .then(({ code, tail }) => finalizeJob(job, code, tail, effDeps))
+    .catch((err) => {
+      logger.warn(`[training-jobs] finalize ${id} failed: ${err instanceof Error ? err.message : String(err)}`);
+    })
+    .finally(() => {
+      handles.delete(id);
+      lastProgressPersistAt.delete(id);
+      // NOTE: the terminal download-progress row is intentionally NOT cleared —
+      // the orchestrator watcher lingers done/error rows ~8s (so completion is
+      // visible in the tray) and then prunes them itself (codex finding).
+    });
+
+  job.status = "running";
+  job.updatedAt = new Date().toISOString();
+  persist(job);
+  return job;
+}
+
+/** Stop the container and mark the job cancelled. Idempotent. Works
+ *  cross-process: the container name is persisted, so a cancel from another
+ *  process (orchestrator call_tool) still reaches `docker stop`.
+ *
+ *  Ordering matters (codex findings): the cancelled state is persisted BEFORE
+ *  awaiting `docker stop` — otherwise a clean-exit container can finalize
+ *  (handoff + catalog) while the stop is in flight. After the stop we verify
+ *  with a liveness probe; if the container is genuinely still alive the job
+ *  reverts to running with an error instead of lying about being cancelled. */
+export async function cancelJob(id: string, deps: TrainingJobDeps = {}): Promise<TrainingJob> {
+  const job = await getJob(id, deps);
+  if (!job) throw new Error(`no training job ${id}`);
+  if (job.status === "completed" || job.status === "failed") return job;
+  if (job.status === "cancelled") {
+    // Already cancelled — but if a previous cancel died between persisting the
+    // state and finishing `docker stop`, the container may still be alive.
+    // Retry the stop instead of blindly returning (codex finding).
+    if (!job.containerName) return job;
+    const probe = deps.containerRunning ?? containerRunning;
+    const alive = await probe(job.containerName).catch(() => null);
+    // Only a definitive "gone" short-circuits; unknown (daemon temporarily
+    // unreachable) still attempts the stop so a live container can't keep
+    // burning GPU behind a stale cancelled record (codex finding).
+    if (alive === false) return job;
+    const stop = deps.stopTraining ?? stopTraining;
+    const res = await stop(job.containerName);
+    // Always probe after a stop attempt: a CLI timeout can fire AFTER the
+    // daemon honored the stop (codex finding). Only when liveness is unknown
+    // do we fall back to the stop command's own result.
+    const probed = await probe(job.containerName).catch(() => null);
+    const stillRunning = probed ?? res.ok === false;
+    if (stillRunning === true) {
+      job.status = "running";
+      job.finishedAt = undefined;
+      job.updatedAt = new Date().toISOString();
+      job.error = `cancel retry failed — container ${job.containerName} is still running${res.error ? `: ${res.error.message}` : ""}`;
+      persist(job);
+    }
+    return job;
+  }
+
+  job.status = "cancelled";
+  job.finishedAt = new Date().toISOString();
+  job.updatedAt = job.finishedAt;
+  job.error = undefined;
+  persist(job);
+
+  if (job.containerName) {
+    const stop = deps.stopTraining ?? stopTraining;
+    const res = await stop(job.containerName);
+    const probe = deps.containerRunning ?? containerRunning;
+    // Probe after the stop regardless of its exit status (see above).
+    const probed = await probe(job.containerName).catch(() => null);
+    const stillRunning = probed ?? res.ok === false;
+    if (stillRunning === true) {
+      // Stop genuinely failed — the container is still training.
+      job.status = "running";
+      job.finishedAt = undefined;
+      job.updatedAt = new Date().toISOString();
+      job.error = `cancel failed — container ${job.containerName} is still running${res.error ? `: ${res.error.message}` : ""}`;
+      persist(job);
+      return job;
+    }
+  }
+  reportProgress(job, "error", true);
+  persist(job);
+  return job;
+}
+
+/** Public, JSON-safe view of a job (drops nothing — TrainingJob is already
+ *  plain data; exposed so tools/tests have one obvious shape). */
+export function toJobSummary(job: TrainingJob): TrainingJob {
+  return job;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -53,6 +53,7 @@ import { registerCalculateTools } from "./calculate.js";
 import { registerComfyUISettingsTools } from "./comfyui-settings.js";
 import { registerNodeDevTools } from "./node-dev.js";
 import { registerComfyCliTools } from "./comfy-cli.js";
+import { registerTrainTools } from "./train.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -115,6 +116,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["diagnostics", registerCalculateTools],
   ["server", registerComfyUISettingsTools],
   ["custom-nodes", registerNodeDevTools],
+  ["training", registerTrainTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -1,0 +1,236 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildTrainerImage,
+  dockerAvailable,
+  trainerDoctor,
+  trainerImageExists,
+  TRAINER_IMAGE,
+} from "../services/ai-toolkit.js";
+import { DEFAULT_PARAMS } from "../services/training-config.js";
+import {
+  cancelJob,
+  getJob,
+  hfCacheRoot,
+  listJobs,
+  prepareDataset,
+  startTrainingJob,
+  trainingRoot,
+} from "../services/training-jobs.js";
+import { errorToToolResult } from "../utils/errors.js";
+
+function textEnvelope(envelope: unknown) {
+  const failed = typeof envelope === "object" && envelope !== null && "ok" in envelope && envelope.ok === false;
+  return {
+    ...(failed ? { isError: true } : {}),
+    content: [{ type: "text" as const, text: JSON.stringify(envelope, null, 2) }],
+  };
+}
+
+/** Package root — dist/tools/train.js → ../../ (ships docker/trainer). */
+function packageRoot(): string {
+  return fileURLToPath(new URL("../../", import.meta.url));
+}
+
+function trainerContextDir(): string {
+  return join(packageRoot(), "docker", "trainer");
+}
+
+const paramsSchema = z
+  .object({
+    steps: z.number().int().min(1).optional().describe("Total training steps (200 = smoke test, 1500-3000 real)."),
+    lr: z.number().positive().optional().describe("Learning rate."),
+    rank: z.number().int().min(1).optional().describe("LoRA rank (16 simple, 16-32 detailed)."),
+    resolution: z.array(z.number().int().positive()).min(1).optional().describe("Resolution buckets, e.g. [512,768,1024]."),
+    batchSize: z.number().int().min(1).optional(),
+    saveEvery: z.number().int().min(1).optional().describe("Checkpoint cadence (steps)."),
+    sampleEvery: z.number().int().min(1).optional().describe("Sample-image cadence (steps)."),
+    quantize: z.boolean().optional().describe("8-bit mixed precision — needed to fit Flux on 24GB."),
+  })
+  .optional();
+
+export function registerTrainTools(server: McpServer): void {
+  server.tool(
+    "train_list_flows",
+    "List the LoRA training flows and base models the local trainer supports (phase 1: character LoRA on FLUX.1-dev), with the default training params. Read-only — call this first to see what train_start accepts.",
+    {},
+    async () => {
+      try {
+        return textEnvelope({
+          ok: true,
+          flows: [
+            {
+              id: "character",
+              kind: "image",
+              description: "Character/identity LoRA from ~10-30 images with captions + a unique trigger word.",
+              models: [
+                {
+                  id: "flux1-dev",
+                  hfRepo: "black-forest-labs/FLUX.1-dev",
+                  vram: "24GB with quantize=true (RTX 4090 class)",
+                  notes: "Proven character-consistency base (ai-toolkit presets tuned for it).",
+                },
+              ],
+            },
+          ],
+          defaultParams: DEFAULT_PARAMS,
+          image: TRAINER_IMAGE,
+        });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_prepare_dataset",
+    "Stage training images + captions into a dataset dir the trainer consumes. Each item is an image path with an optional caption (a missing caption falls back to defaultCaption — typically the trigger word). Returns the datasetPath to pass to train_start. Character LoRA guidance: 10-30 varied images; caption what changes between images, keep the trigger word constant.",
+    {
+      name: z.string().min(1).describe("Dataset name (becomes the staging dir name)."),
+      items: z
+        .array(
+          z.object({
+            path: z.string().min(1).describe("Absolute path to a source image (png/jpg/jpeg/webp)."),
+            caption: z.string().optional().describe("Caption for this image."),
+          }),
+        )
+        .min(1),
+      defaultCaption: z.string().optional().describe("Fallback caption for items without one — usually the trigger word."),
+    },
+    async (args) => {
+      try {
+        const prepared = await prepareDataset({ name: args.name, items: args.items, defaultCaption: args.defaultCaption });
+        return textEnvelope({ ok: true, ...prepared });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_start",
+    "Start a LoRA training job in the GPU trainer container: builds the ai-toolkit config, launches `docker run --gpus all`, and returns a job id for train_status/train_cancel. Long-running — this returns immediately; poll train_status for step/loss/samples. On completion the LoRA is copied into ComfyUI models/loras/ and added to the LoRA catalog automatically. Run train_doctor first if unsure the image/docker/GPU are ready.",
+    {
+      name: z.string().min(1).describe("Job name — becomes the output .safetensors basename (e.g. 'aria_character')."),
+      flow: z.enum(["character"]).optional().default("character"),
+      model: z.enum(["flux1-dev"]).optional().default("flux1-dev"),
+      datasetPath: z.string().min(1).describe("Dataset dir from train_prepare_dataset (images + same-basename .txt captions)."),
+      trigger: z.string().optional().describe("Unique trigger word (e.g. 'ohwx person') — injected as trigger_word and usable in prompts."),
+      params: paramsSchema,
+      device: z.string().optional().describe("GPU selector, default cuda:0."),
+    },
+    async (args) => {
+      try {
+        if (!(await dockerAvailable())) {
+          return textEnvelope({ ok: false, error: { code: "no_docker", message: "Docker daemon not reachable — start Docker Desktop / the docker engine, then re-run. See train_doctor." } });
+        }
+        if (!(await trainerImageExists())) {
+          return textEnvelope({ ok: false, error: { code: "no_image", message: `Trainer image ${TRAINER_IMAGE} not built yet — run train_build_image once (several minutes), then re-run train_start.` } });
+        }
+        const job = await startTrainingJob({
+          name: args.name,
+          flow: args.flow,
+          model: args.model,
+          datasetPath: args.datasetPath,
+          trigger: args.trigger,
+          params: args.params,
+          device: args.device,
+        });
+        return textEnvelope({ ok: true, job });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_status",
+    "Check training progress: pass an id for one job (step/total, loss, recent samples, log tail, result paths when done) or omit for all jobs newest-first.",
+    {
+      id: z.string().optional().describe("Job id from train_start. Omit to list all jobs."),
+    },
+    async (args) => {
+      try {
+        if (args.id) {
+          const job = await getJob(args.id);
+          if (!job) throw new Error(`no training job ${args.id}`);
+          return textEnvelope({ ok: true, job });
+        }
+        const jobs = await listJobs();
+        return textEnvelope({ ok: true, count: jobs.length, jobs });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_cancel",
+    "Stop a running training job (docker stop) and mark it cancelled. Checkpoints already saved stay in the job's output dir; no LoRA is handed off to models/loras. Returns ok:false when the container could not be confirmed stopped (the job reverts to running).",
+    {
+      id: z.string().min(1).describe("Job id from train_start."),
+    },
+    async (args) => {
+      try {
+        const job = await cancelJob(args.id);
+        // A failed cancel returns the job as RUNNING with an error — that must
+        // not surface as a successful cancellation (codex finding): clients
+        // keying on the envelope/isError would think the GPU is free.
+        if (job.status !== "cancelled") {
+          return textEnvelope({ ok: false, error: { code: "cancel_failed", message: job.error ?? `job is ${job.status}` }, job });
+        }
+        return textEnvelope({ ok: true, job });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_build_image",
+    `Build the headless GPU trainer image (${TRAINER_IMAGE}) from docker/trainer/Dockerfile — one-time, several minutes (CUDA + torch + ai-toolkit). Requires a reachable docker daemon. aiToolkitRef pins the ai-toolkit commit/tag for reproducibility.`,
+    {
+      aiToolkitRef: z.string().optional().describe("ai-toolkit git ref (commit/tag) to build against. Default: the Dockerfile's pinned ref."),
+    },
+    async (args) => {
+      try {
+        if (!(await dockerAvailable())) {
+          return textEnvelope({ ok: false, error: { code: "no_docker", message: "Docker daemon not reachable — start Docker Desktop / the docker engine first." } });
+        }
+        const contextDir = trainerContextDir();
+        if (!existsSync(join(contextDir, "Dockerfile"))) {
+          return textEnvelope({ ok: false, error: { code: "no_dockerfile", message: `Trainer Dockerfile not found at ${contextDir} — the docker/ dir may not be shipped in this install.` } });
+        }
+        const result = await buildTrainerImage({ contextDir, aiToolkitRef: args.aiToolkitRef });
+        return textEnvelope(result);
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_doctor",
+    "Preflight the local trainer: docker daemon reachable, `--gpus all` GPU passthrough working (NVIDIA Container Toolkit), trainer image built. Returns per-check booleans + setup hints. Also reports the training data root and whether HF_TOKEN is set (needed to download FLUX.1-dev on first run).",
+    {},
+    async () => {
+      try {
+        const doctor = await trainerDoctor();
+        return textEnvelope({
+          ...doctor,
+          data: {
+            ...doctor.data,
+            trainingRoot: trainingRoot(),
+            hfCache: hfCacheRoot(),
+            hfTokenSet: !!process.env.HF_TOKEN?.trim(),
+          },
+        });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+}

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -21,6 +21,7 @@ import {
   trainingRoot,
 } from "../services/training-jobs.js";
 import { errorToToolResult } from "../utils/errors.js";
+import { isRemoteMode } from "../config.js";
 
 function textEnvelope(envelope: unknown) {
   const failed = typeof envelope === "object" && envelope !== null && "ok" in envelope && envelope.ok === false;
@@ -226,6 +227,10 @@ export function registerTrainTools(server: McpServer): void {
             trainingRoot: trainingRoot(),
             hfCache: hfCacheRoot(),
             hfTokenSet: !!process.env.HF_TOKEN?.trim(),
+            // Dataset staging + the LoRA handoff need a LOCAL ComfyUI filesystem
+            // on this MCP's machine — false in remote mode, so panel/mobile can
+            // warn before a doomed launch instead of failing at staging.
+            localFs: !isRemoteMode(),
           },
         });
       } catch (error) {


### PR DESCRIPTION
# CLI LoRA trainer — P1: local character-LoRA slice (train_* tools + GPU Docker + E2E-proven)

Plan: `~/.claude/plans/eager-hatching-cerf.md`. Wraps **ostris ai-toolkit's `run.py`** (unchanged, upstream) in a **headless GPU Docker image**; the **LLM drives training through `train_*` MCP tools + a purpose-built skill**. Local-first (RunPod = P4, deferred), narrow first slice: **character LoRA on FLUX.1-dev**.

## What lands in P1

- **`docker/trainer/Dockerfile`** — lean headless image (CUDA 12.8.1 devel, torch 2.9.1/cu128, ai-toolkit pinned via `AI_TOOLKIT_REF`, `ENTRYPOINT ["python","run.py"]`). No Node/UI.
- **`src/services/ai-toolkit.ts`** — container driver: docker/GPU preflight (`trainerDoctor`), `buildTrainerImage`, `startTraining` (`docker run --gpus all` + bind mounts, streamed stdout → progress ticks), `stopTraining` (honest envelope), `containerRunning` liveness probe.
- **`src/services/training-config.ts`** — ai-toolkit YAML generator (schema confirmed by codex review against the official `train_lora_flux_24gb.yaml`).
- **`src/services/training-jobs.ts`** — job registry + lifecycle:
  - Per-job JSON under `~/.comfyui-mcp/training/jobs/`; **refreshed from disk on every read** so the orchestrator's cross-process `call_tool` client (mobile `train_status`) sees live state; throttled progress+log snapshots.
  - Dataset staging: validate-all-then-atomic-swap; refuses to restage a dir an active job trains from.
  - Cancel: pre-persisted state (no finalize race), liveness-verified stop, honest revert-to-running on failure, retry for stale cancelled records, rollback reconcile.
  - Owner-death recovery keyed on the **final save** (periodic checkpoints prove nothing).
  - **Output handoff:** final `.safetensors` → ComfyUI `models/loras/` + LoRA catalog upsert (trigger keyword, FLUX.1-dev base, sample preview, `missing:false`) — skipped honestly if the ComfyUI instance changed mid-run.
- **`src/tools/train.ts`** — `train_list_flows` / `train_prepare_dataset` / `train_start` / `train_status` / `train_cancel` / `train_build_image` / `train_doctor`. Registered as the `training` TOOL_GROUP (appended; order preserved). `train_list_flows` + `train_status` whitelisted for mobile `call_tool` (read-only). `train_cancel` returns `ok:false` when the container isn't confirmed stopped.
- **`plugin/skills/train-character-lora/SKILL.md`** — teaches the LLM the whole flow (dataset guidance, trigger word, defaults, monitoring, failure modes).
- **`package.json`** — ships `docker/` so `train_build_image` works from the npm package.

## E2E proof (RTX 4090, this branch's code)

Real run, not a mock: built `comfyui-mcp-trainer:latest` (ai-toolkit `a0224793`), staged a 6-image character dataset, `train_start` → 200 steps on FLUX.1-dev.

- `train_doctor` all green (docker 29.6.1, `--gpus all` → RTX 4090, image, HF_TOKEN).
- Live `train_status` from a **separate process** reported the running job correctly (cross-process path).
- Job **completed** (final loss 0.196) → `e2e_smoke.safetensors` (172 MB, rank-16 Flux LoRA, `ss_base_model_version: flux.1`, trigger `ohwx`) copied to `models/loras/`; catalog entry `loras-e2e-smoke` + sample preview.
- LoRA **loaded in a live ComfyUI Flux workflow** (`LoraLoaderModelOnly`) and steered the output — A/B vs strength-0 control (control render confirms fp8 softness is settings, not the LoRA).

The E2E caught two real bugs, both fixed in this branch: `/dataset` must be mounted **rw** (ai-toolkit writes `.aitk_size.json` into it) and the progress parser needs a **loss reading** to trust step counts (dataset bars like `6/6` masqueraded as training steps).

## Review & tests

- **6 rounds of codex review, 19 findings addressed** (cross-process registry freshness/liveness, cancel/finalize races in both directions, recovery misclassification, mid-run retarget guard, cancel retry, terminal progress linger, cancel envelope honesty).
- 51 trainer tests (config gen, progress parse, dataset staging, registry/cancel/recovery lifecycle). `tsc` clean. Full suite: 1504 passing, 1 **pre-existing unrelated** `node-dev` failure (verified it fails without this branch's changes too).

## Deferred (per plan)

- P2: broaden flows/models (Z-Image Turbo, style/slider/edit).
- P3: mobile Training tab + panel wiring to `train_*` over `call_tool`.
- P4: RunPod — same image on a pod, `src/services/runpod.ts`. **No cloud spend yet.**

Note: the E2E artifacts remain on the rig — `models/loras/e2e_smoke.safetensors` (+ catalog entry), the training dataset/jobs under `~/.comfyui-mcp/training/`, and Flux support models downloaded for the validation render (`flux1-dev-fp8`, `clip_l`, `t5xxl_fp8`, `ae`). Delete `e2e_smoke*` freely; the rest is generally useful.
