### PR TITLE
fix(gemini): API-key auth over stale OAuth + refresh the dead model catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,13 @@ COMFYUI_PORT=8188
 # COMFYUI_MCP_AUTORESTART=1           # set 0 to keep update checks but never restart
 # COMFYUI_MCP_UPDATE_CHECK_MS=3600000 # registry re-check period
 
+# Gemini agent backend auth. The free "Sign in with Google" / Code-Assist login
+# for individuals was retired 2026-06-18, so the Gemini backend now needs an API
+# key. Set a RESTRICTED Gemini API key (from Google AI Studio) here — unrestricted
+# standard keys are rejected as of 2026-06-19. The backend forwards it to the
+# spawned `gemini --acp` CLI and picks the API-key (USE_GEMINI) auth method.
+# GEMINI_API_KEY=
+
 HUGGINGFACE_TOKEN=
 GITHUB_TOKEN=
 CIVITAI_API_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project are documented here. This project adheres to
   boundary wrapper replaces image blocks with an honest "withheld" note — on
   both the full MCP surface and the compact call_tool router; toggling Blind
   live respawns the tab's tool server at idle (panel issue #90)
+- **Gemini model catalog was dead on arrival** — both catalog entries
+  (`gemini-2.5-pro`, the default, and `gemini-2.5-flash`) now return 404 *"no
+  longer available to new users"* from Google, so every new Gemini user hit a
+  failing turn on the very first prompt. The catalog now leads with Google's
+  floating aliases (`gemini-pro-latest`, `gemini-flash-latest`) so it stops
+  rotting, plus the pinned models they currently resolve to (`gemini-3.1-pro-preview`,
+  `gemini-3.5-flash`). Default is now `gemini-pro-latest`. Verified live against
+  the Gemini API on 2026-07-20.
 - **Gemini backend auth** — on an ACP `auth_required`, the backend now selects the
   API-key auth method (`USE_GEMINI`) when `GEMINI_API_KEY` is set, instead of
   blindly retrying `authMethods[0]` (the Google/Code-Assist OAuth method). Google

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project are documented here. This project adheres to
   boundary wrapper replaces image blocks with an honest "withheld" note — on
   both the full MCP surface and the compact call_tool router; toggling Blind
   live respawns the tab's tool server at idle (panel issue #90)
+- **Gemini backend auth** — on an ACP `auth_required`, the backend now selects the
+  API-key auth method (`USE_GEMINI`) when `GEMINI_API_KEY` is set, instead of
+  blindly retrying `authMethods[0]` (the Google/Code-Assist OAuth method). Google
+  retired the free "Sign in with Google" login for individuals on 2026-06-18, which
+  turned that blind retry into an infinite auth loop and took the whole backend
+  down. API keys still work; set a restricted Gemini API key (Google AI Studio) in
+  `~/.comfyui-mcp/.env`. Failure messages now point at the key path rather than a
+  dead sign-in flow.
 
 ## [0.41.0] - 2026-07-20
 

--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -28,7 +28,17 @@ const hoisted = vi.hoisted(() => ({
   received: [] as Array<Record<string, unknown>>,
   // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
   // "cancel" streams a bit then WAITS for session/cancel before resolving.
-  config: { mode: "complete" as "complete" | "cancel" },
+  config: {
+    mode: "complete" as "complete" | "cancel",
+    // authMethods advertised in the initialize result (empty = none).
+    authMethods: [] as Array<{ id?: string; name?: string; description?: string }>,
+    // When true, session/new fails with an `auth_required` error until the client
+    // has sent an `authenticate` request (models the CLI being signed out).
+    requireAuth: false,
+    // Flipped by the authenticate handler; the last methodId the client sent.
+    authenticated: false,
+    lastAuthMethodId: undefined as string | undefined,
+  },
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -139,14 +149,24 @@ vi.mock("node:child_process", async (importOriginal) => {
                 mcpCapabilities: { http: true, sse: false },
               },
               agentInfo: { name: "gemini", title: "Gemini", version: "test" },
-              authMethods: [],
+              authMethods: hoisted.config.authMethods,
             },
           });
         } else if (method === "session/new" && id !== undefined) {
-          write({ jsonrpc: "2.0", id, result: { sessionId: SESSION_ID } });
+          if (hoisted.config.requireAuth && !hoisted.config.authenticated) {
+            write({
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32000, message: "auth required", data: { reason: "auth_required" } },
+            });
+          } else {
+            write({ jsonrpc: "2.0", id, result: { sessionId: SESSION_ID } });
+          }
         } else if (method === "session/load" && id !== undefined) {
           write({ jsonrpc: "2.0", id, result: {} });
         } else if (method === "authenticate" && id !== undefined) {
+          hoisted.config.authenticated = true;
+          hoisted.config.lastAuthMethodId = (msg.params as { methodId?: string } | undefined)?.methodId;
           write({ jsonrpc: "2.0", id, result: {} });
         } else if (method === "session/prompt" && id !== undefined) {
           // Stream on the next tick so the request is registered first.
@@ -183,6 +203,11 @@ beforeEach(async () => {
   hoisted.spawnArgs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
+  hoisted.config.authMethods = [];
+  hoisted.config.requireAuth = false;
+  hoisted.config.authenticated = false;
+  hoisted.config.lastAuthMethodId = undefined;
+  delete process.env.GEMINI_API_KEY;
   ({ GeminiBackend } = await import("../../orchestrator/gemini-backend.js"));
 });
 
@@ -299,6 +324,82 @@ describe("GeminiBackend (ACP over stdio)", () => {
     expect(promptBlocks[0].text).toContain("<system>");
     expect(promptBlocks[0].text).toContain("BE NICE.");
     expect(promptBlocks[0].text).toContain("hi there");
+
+    await backend.close();
+  });
+
+  it("on auth_required, authenticates with the API-KEY method when GEMINI_API_KEY is set (not method[0])", async () => {
+    // The free Google/Code-Assist OAuth login was retired 2026-06-18; the fix must
+    // pick the API-key method, not blindly authMethods[0] (the OAuth one).
+    process.env.GEMINI_API_KEY = "AIza-test-key";
+    hoisted.config.requireAuth = true;
+    hoisted.config.authMethods = [
+      { id: "oauth-personal", name: "Log in with Google" },
+      { id: "gemini-api-key", name: "Gemini API Key" },
+    ];
+
+    const backend = new GeminiBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    // It authenticated with the API-key method id, then completed a normal turn.
+    expect(hoisted.config.lastAuthMethodId).toBe("gemini-api-key");
+    expect(events.some((e) => e.type === "result" && e.ok === true)).toBe(true);
+
+    await backend.close();
+  });
+
+  it("on auth_required, falls back to the first advertised method when no GEMINI_API_KEY", async () => {
+    delete process.env.GEMINI_API_KEY;
+    hoisted.config.requireAuth = true;
+    hoisted.config.authMethods = [
+      { id: "oauth-personal", name: "Log in with Google" },
+      { id: "gemini-api-key", name: "Gemini API Key" },
+    ];
+
+    const backend = new GeminiBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    expect(hoisted.config.lastAuthMethodId).toBe("oauth-personal");
+
+    await backend.close();
+  });
+
+  it("prefers the real gemini-api-key method over a Vertex decoy that mentions 'API key'", async () => {
+    process.env.GEMINI_API_KEY = "AIza-test-key";
+    hoisted.config.requireAuth = true;
+    // Vertex is advertised FIRST and its blurb mentions "API key" — the strong
+    // match must still pick the canonical gemini-api-key method, not the decoy.
+    hoisted.config.authMethods = [
+      { id: "vertex-ai", name: "Vertex AI", description: "Use a Google Cloud project or API key" },
+      { id: "gemini-api-key", name: "Gemini API Key" },
+      { id: "oauth-personal", name: "Log in with Google" },
+    ];
+
+    const backend = new GeminiBackend({ cwd: process.cwd() });
+    const channel = makeChannel();
+    const events: AgentEvent[] = [];
+    const run = consume(backend.run({ channel: channel.iterable }), events);
+
+    channel.push({ text: "hi" });
+    await waitFor(() => events.some((e) => e.type === "result"));
+    channel.close();
+    await run;
+
+    expect(hoisted.config.lastAuthMethodId).toBe("gemini-api-key");
 
     await backend.close();
   });

--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -437,7 +437,12 @@ describe("GeminiBackend (ACP over stdio)", () => {
   it("listModels returns the static Gemini catalog (no effort metadata)", async () => {
     const backend = new GeminiBackend();
     const models = await backend.listModels();
-    expect(models.map((m) => m.id)).toEqual(["gemini-2.5-pro", "gemini-2.5-flash"]);
+    expect(models.map((m) => m.id)).toEqual([
+      "gemini-pro-latest",
+      "gemini-flash-latest",
+      "gemini-3.1-pro-preview",
+      "gemini-3.5-flash",
+    ]);
     // Gemini has no discrete effort scale → no effort metadata (panel hides picker).
     expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
   });
@@ -448,7 +453,7 @@ describe("GeminiBackend (ACP over stdio)", () => {
     const backend = new GeminiBackend({ cwd: process.cwd() });
     const channel = makeChannel();
     const events: AgentEvent[] = [];
-    const run = consume(backend.run({ channel: channel.iterable, model: "gemini-2.5-flash" }), events);
+    const run = consume(backend.run({ channel: channel.iterable, model: "gemini-flash-latest" }), events);
 
     channel.push({ text: "hi" });
     await waitFor(() => events.some((e) => e.type === "result"));
@@ -458,13 +463,13 @@ describe("GeminiBackend (ACP over stdio)", () => {
     expect(hoisted.spawnArgs).toHaveLength(1);
     expect(hoisted.spawnArgs[0]).toContain("--acp");
     expect(hoisted.spawnArgs[0]).toContain("--model");
-    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-2.5-flash");
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-flash-latest");
 
     await backend.close();
   });
 
   it("a live setModel() respawns the CLI with the new --model and a fresh session", async () => {
-    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-2.5-pro" });
+    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-pro-latest" });
     const channel = makeChannel();
     const events: AgentEvent[] = [];
     const run = consume(backend.run({ channel: channel.iterable }), events);
@@ -473,10 +478,10 @@ describe("GeminiBackend (ACP over stdio)", () => {
     channel.push({ text: "turn one" });
     await waitFor(() => events.filter((e) => e.type === "result").length >= 1);
     expect(hoisted.spawnArgs).toHaveLength(1);
-    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-2.5-pro");
+    expect(hoisted.spawnArgs[0][hoisted.spawnArgs[0].indexOf("--model") + 1]).toBe("gemini-pro-latest");
 
     // Live model switch (panel picker → PanelAgent.setOptions → agent.setModel).
-    await backend.setModel("gemini-2.5-flash");
+    await backend.setModel("gemini-flash-latest");
 
     // Next turn must transparently respawn with the new --model + a fresh session.
     channel.push({ text: "turn two" });
@@ -487,7 +492,7 @@ describe("GeminiBackend (ACP over stdio)", () => {
     // A SECOND `gemini --acp` was spawned, pinned to the new model.
     expect(hoisted.spawnArgs).toHaveLength(2);
     expect(hoisted.spawnArgs[1]).toContain("--acp");
-    expect(hoisted.spawnArgs[1][hoisted.spawnArgs[1].indexOf("--model") + 1]).toBe("gemini-2.5-flash");
+    expect(hoisted.spawnArgs[1][hoisted.spawnArgs[1].indexOf("--model") + 1]).toBe("gemini-flash-latest");
 
     // The respawn opened a fresh session → a second `session` event was emitted.
     expect(events.filter((e) => e.type === "session").length).toBe(2);
@@ -498,7 +503,7 @@ describe("GeminiBackend (ACP over stdio)", () => {
   });
 
   it("ignores a non-Gemini model id passed to setModel (e.g. the Claude panel model)", async () => {
-    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-2.5-pro" });
+    const backend = new GeminiBackend({ cwd: process.cwd(), model: "gemini-pro-latest" });
     const channel = makeChannel();
     const events: AgentEvent[] = [];
     const run = consume(backend.run({ channel: channel.iterable }), events);

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -408,12 +408,26 @@ interface AcpInitializeResult {
 // Gemini's "thinking" is a token BUDGET, not a discrete effort scale, so we do
 // NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
 // then hides the effort dropdown (omission is the documented "no effort control"
-// signal). gemini-2.5-pro is the default.
+// signal).
+//
+// PIN THE FLOATING ALIASES FIRST. A static catalog rots: as of 2026-07-20 Google
+// returns 404 "no longer available to new users" for BOTH former entries
+// (gemini-2.5-pro AND gemini-2.5-flash) on a newly-issued API key, so the old
+// default was dead on arrival for every new user. `gemini-pro-latest` /
+// `gemini-flash-latest` are Google's floating aliases (verified resolving to
+// gemini-3.1-pro-preview / gemini-3.5-flash) and keep tracking the current
+// generation without another code change. The pinned ids below are the concrete
+// models those aliases resolved to, kept for reproducibility.
+// Verified against generativelanguage.googleapis.com on 2026-07-20: the four
+// entries below return 200; gemini-2.5-pro / gemini-2.5-flash / gemini-3-pro-preview
+// return 404.
 const GEMINI_MODELS: ModelChoice[] = [
-  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  { id: "gemini-pro-latest", label: "Gemini Pro (latest)" },
+  { id: "gemini-flash-latest", label: "Gemini Flash (latest)" },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro (preview)" },
+  { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
 ];
-const GEMINI_DEFAULT_MODEL = "gemini-2.5-pro";
+const GEMINI_DEFAULT_MODEL = "gemini-pro-latest";
 
 /** Does this id look like a Gemini model (vs. the Claude panel model PanelAgent
  *  unconditionally passes as opts.model)? Used so the configured Gemini model
@@ -664,6 +678,27 @@ export class GeminiBackend implements AgentBackend {
       if (!res?.sessionId) throw new Error("gemini --acp session/new returned no sessionId.");
       return res.sessionId;
     };
+    // PROACTIVE API-key auth. When GEMINI_API_KEY is set we authenticate up front
+    // rather than only reacting to `auth_required`. Why: a CLI that was previously
+    // signed in keeps `security.auth.selectedType: "oauth-personal"` + cached OAuth
+    // creds, which OUTRANK GEMINI_API_KEY — so `session/new` SUCCEEDS via the (now
+    // dead, post-2026-06-18) individual OAuth without ever raising `auth_required`,
+    // then fails at request time ("session keeps ending"). Authenticating with the
+    // API-key method here switches the CLI to USE_GEMINI and clears the stale creds
+    // (the ACP `authenticate` handler drops cached creds when the method changes),
+    // so the reactive retry below only matters for a never-signed-in CLI.
+    if (process.env.GEMINI_API_KEY?.trim()) {
+      const apiKeyMethod = this.pickAuthMethod();
+      if (apiKeyMethod) {
+        try {
+          await client.request("authenticate", { methodId: apiKeyMethod });
+        } catch (err) {
+          logger.warn(
+            `[gemini-backend] proactive API-key authenticate failed (${msgOf(err)}) — continuing to session/new`,
+          );
+        }
+      }
+    }
     try {
       this.sessionId = await createNew();
     } catch (err) {

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -38,13 +38,15 @@
 //                            no model enumeration; the model is selected at SPAWN via
 //                            the CLI `--model` flag (see resolveBin/spawn below)
 //
-// AUTH (NO API KEY — the CLI owns auth): Gemini CLI authenticates itself via
-// Google OAuth / Code Assist (the user runs `gemini` once to sign in). This
-// backend NEVER passes an API key; it just spawns the already-authenticated CLI.
-// If the CLI is signed out, `session/new` returns an `auth_required` error — we
-// attempt one `authenticate` with the first advertised auth method, then surface
-// a clear "run `gemini` and sign in" message (the OAuth browser flow itself is
-// owned by the CLI and cannot be completed headlessly).
+// AUTH (the CLI owns auth): Gemini CLI authenticates either via a Gemini API key
+// (USE_GEMINI — read from GEMINI_API_KEY, which we forward through the spawned
+// process.env) or via Google OAuth / Code Assist (paid/enterprise only — the free
+// individual login was retired 2026-06-18). If the CLI is unauthenticated,
+// `session/new` returns an `auth_required` error — we then call `authenticate`
+// with the API-key method when GEMINI_API_KEY is set (see pickAuthMethod), else
+// the first advertised method, and on failure surface a clear message pointing at
+// the GEMINI_API_KEY path. API-key auth completes headlessly; the OAuth browser
+// flow does not and must be done once by running `gemini` directly.
 //
 // PARITY with Codex/Claude: the Gemini backend gets the SAME tool surface — the
 // headless `comfyui` stdio MCP plus the `panel` HTTP MCP for live-graph panel_*
@@ -637,9 +639,10 @@ export class GeminiBackend implements AgentBackend {
 
   /** Ensure a live ACP session exists, creating (session/new) or resuming
    *  (session/load) one. Handles an `auth_required` error from session/new by
-   *  attempting a single `authenticate` with the first advertised method, then
-   *  retrying — surfacing a clear sign-in message if it still fails. Returns the
-   *  session id. */
+   *  attempting a single `authenticate` with the API-key method when GEMINI_API_KEY
+   *  is set (else the first advertised method — see pickAuthMethod), then retrying
+   *  — surfacing a clear sign-in message if it still fails. Returns the session
+   *  id. */
   private async ensureSession(client: AcpClient, cwd: string, resumeId: string | null): Promise<string> {
     const mcpServers = this.deps.mcpServers ? buildAcpMcpServers(this.deps.mcpServers) : [];
     const canLoad = this.agentCaps?.loadSession === true;
@@ -664,27 +667,69 @@ export class GeminiBackend implements AgentBackend {
     try {
       this.sessionId = await createNew();
     } catch (err) {
-      if (this.isAuthRequired(err) && this.authMethods[0]?.id) {
-        // The CLI owns auth (Google OAuth). Try the first advertised method once;
-        // if the CLI isn't already signed in this cannot complete headlessly.
-        try {
-          await client.request("authenticate", { methodId: this.authMethods[0].id });
-          this.sessionId = await createNew();
-        } catch {
-          throw new Error(
-            "Gemini CLI is not signed in. Run `gemini` once and complete the Google sign-in, then reconnect.",
-          );
-        }
-      } else if (this.isAuthRequired(err)) {
-        throw new Error(
-          "Gemini CLI is not signed in. Run `gemini` once and complete the Google sign-in, then reconnect.",
-        );
-      } else {
-        throw err;
+      if (!this.isAuthRequired(err)) throw err;
+      // The CLI owns auth. The free "Sign in with Google" / Code-Assist login for
+      // individuals was retired 2026-06-18; API keys (USE_GEMINI) still work. Pick
+      // the API-key auth method when GEMINI_API_KEY is set rather than blindly the
+      // first advertised method (OAuth — now a dead loop for individuals). The key
+      // itself already reaches the CLI via the spawned process.env.
+      const methodId = this.pickAuthMethod();
+      if (!methodId) throw new Error(this.authFailureMessage());
+      try {
+        await client.request("authenticate", { methodId });
+        this.sessionId = await createNew();
+      } catch {
+        throw new Error(this.authFailureMessage());
       }
     }
     this.needsSystemPreamble = !!this.deps.systemAppend; // fresh session → persona on first turn
     return this.sessionId!;
+  }
+
+  /** Choose the ACP auth method for the `authenticate` retry. Prefers the Gemini
+   *  API-key method (USE_GEMINI) when GEMINI_API_KEY is set — the free Google /
+   *  Code-Assist OAuth login for individuals was retired 2026-06-18, so blindly
+   *  taking authMethods[0] (OAuth) now dead-loops. Falls back to the first
+   *  advertised method when no key is set or no API-key method is advertised. The
+   *  methodId is the CLI's AuthType value (e.g. "gemini-api-key"); we match against
+   *  the CLI's own advertised methods rather than hardcode the literal, so this
+   *  survives AuthType value changes across gemini-cli versions. */
+  private pickAuthMethod(): string | undefined {
+    const methods = this.authMethods;
+    if (methods.length === 0) return undefined;
+    if (process.env.GEMINI_API_KEY?.trim()) {
+      const hay = (m: AcpAuthMethod) =>
+        `${m.id ?? ""} ${m.name ?? ""} ${m.description ?? ""}`.toLowerCase();
+      // Strong match: the canonical AuthType value, or a method naming BOTH gemini
+      // and api-key (so a Vertex/OAuth method that merely mentions "api key" in its
+      // blurb can't win).
+      const strong = methods.find(
+        (m) =>
+          m.id === "gemini-api-key" ||
+          m.id === "use_gemini" ||
+          (/gemini/.test(hay(m)) && /api.?key/.test(hay(m))),
+      );
+      if (strong?.id) return strong.id;
+      // Loose fallback: an api-key-ish method that is clearly NOT oauth/vertex.
+      const loose = methods.find((m) => {
+        const h = hay(m);
+        return /api.?key|use_gemini/.test(h) && !/oauth|vertex|sign.?in|log.?in/.test(h);
+      });
+      if (loose?.id) return loose.id;
+    }
+    return methods[0]?.id;
+  }
+
+  /** A clear sign-in error reflecting the 2026-06-18 individual-OAuth sunset:
+   *  points key-holders at a likely bad/unrestricted key, and everyone else at the
+   *  GEMINI_API_KEY path (the free Google login no longer works for individuals). */
+  private authFailureMessage(): string {
+    return process.env.GEMINI_API_KEY?.trim()
+      ? "Gemini CLI rejected the API key. Ensure GEMINI_API_KEY is a valid, API-restricted key " +
+          "(unrestricted standard keys are rejected as of 2026-06-19), then reconnect."
+      : "Gemini CLI is not authenticated. The free Google / Code-Assist login for individuals ended " +
+          "2026-06-18 — set GEMINI_API_KEY (a restricted AI Studio key) in ~/.comfyui-mcp/.env, or run " +
+          "`gemini` once and sign in with a paid / enterprise account, then reconnect.";
   }
 
   /** Does this error look like an ACP `auth_required`? Reads the JSON-RPC error


### PR DESCRIPTION
Restores the Gemini backend for individual users after Google's **2026-06-18** retirement of the free "Sign in with Google" / Code-Assist login — then fixes two further blockers that only showed up under live testing.

## Three defects, all confirmed live

### 1. Blind `authMethods[0]` retry (the original bug)
On an ACP `auth_required` from `session/new`, the backend retried `authenticate({ methodId: authMethods[0].id })`. `authMethods[0]` is the Google OAuth method — dead for individuals — so it dead-looped and took the whole backend down. Reported by bunnykillerv2.

**Fix:** `pickAuthMethod()` selects the advertised **API-key** method when `GEMINI_API_KEY` is set, matched against the CLI's own `authMethods` (not a hardcoded enum literal, so it survives AuthType changes), with a strong-match pass so a Vertex/OAuth entry that merely mentions "api key" can't win. Falls back to `authMethods[0]` otherwise.

### 2. Stale OAuth silently bypasses the fix ← *found by live testing*
A CLI that was previously signed in keeps `security.auth.selectedType: "oauth-personal"` + cached creds, and **that setting outranks `GEMINI_API_KEY`**. So `session/new` *succeeds* via the dead OAuth and **never raises `auth_required`** — the reactive retry never fires — then the turn fails at request time ("session keeps ending"). The unit tests passed while the real thing was broken.

**Fix:** when `GEMINI_API_KEY` is set, authenticate with the API-key method **up front**, which switches the CLI to `USE_GEMINI` and drops the stale creds. The reactive retry stays for a never-signed-in CLI.

### 3. The model catalog was dead on arrival ← *found by live testing*
Google now returns 404 *"no longer available to new users"* for **both** former catalog entries — `gemini-2.5-pro` (**the default**) and `gemini-2.5-flash`. Every new Gemini user hit a failing turn on their first prompt, regardless of auth.

**Fix:** lead with Google's floating aliases `gemini-pro-latest` / `gemini-flash-latest` so the catalog stops rotting, plus the pinned models they resolve to today (`gemini-3.1-pro-preview`, `gemini-3.5-flash`). Default → `gemini-pro-latest`.

## Verification

- `tsc --noEmit` clean; **10 tests green** (4 new: API-key method chosen, fallback to `[0]`, Vertex-decoy guard, refreshed catalog).
- **Live API check (2026-07-20):** the four catalog entries return **200**; `gemini-2.5-pro` / `gemini-2.5-flash` / `gemini-3-pro-preview` return **404**.
- **Live end-to-end:** Gemini replied correctly in the ComfyUI panel over the bridge using an API key.
- Auth mechanics verified against gemini-cli source via context7: ACP `authenticate` methodId is the `AuthType` value; CLI priority is settings → `GEMINI_DEFAULT_AUTH_TYPE` → `GEMINI_API_KEY` → OAuth.

## Notes for users

`gemini-cli` itself is **not** dead — still Apache-2.0, still shipping, still `--acp`; only the free consumer OAuth was sunset. Set a **restricted** Gemini API key (`GEMINI_API_KEY`, now documented in `.env.example`). New keys use Google's `AQ.` auth-key format; unrestricted standard keys are rejected as of 2026-06-19 and standard keys retire entirely in Sept 2026.

If your CLI was previously signed in with Google, this PR switches it to the key automatically — no manual `~/.gemini/settings.json` edit needed.

Antigravity CLI (`agy`) was evaluated as the successor but is **not** programmatically drivable yet (no ACP — feature request #31; `-p` silently drops stdout under non-TTY — bug #76). Revisit when native ACP lands.

🤖 Draft — do not merge without artokun's OK.
