### PR TITLE
feat(diagnostics): diagnose_run — canvas-less "why did my render fail?" (mobile parity with panel_view_errored_nodes)

### DIFF
--- a/src/__tests__/tools/diagnose-run.test.ts
+++ b/src/__tests__/tools/diagnose-run.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Mock the client + validator so diagnose_run is tested in isolation: we care about
+// WHICH run it picks, and how it turns a history entry + validation issues into the
+// "why did it fail / what's missing" answer a canvas-less client needs.
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getLogs: vi.fn(),
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+}));
+
+const validateWorkflowMock = vi.fn();
+vi.mock("../../services/workflow-validator.js", () => ({
+  validateWorkflow: (...a: unknown[]) => validateWorkflowMock(...a),
+}));
+
+import { registerDiagnosticsTools } from "../../tools/diagnostics.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerDiagnosticsTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+/** A history entry; `messages` carries the execution_error when the run failed. */
+const entry = (
+  queueNumber: number,
+  id: string,
+  opts: {
+    graph?: Record<string, unknown>;
+    error?: Record<string, unknown>;
+    status?: string;
+  } = {},
+) => ({
+  prompt: [queueNumber, id, opts.graph ?? { "1": { class_type: "KSampler", inputs: {} } }, {}, []],
+  outputs: {},
+  status: {
+    status_str: opts.status ?? (opts.error ? "error" : "success"),
+    completed: !opts.error,
+    messages: opts.error ? [["execution_error", opts.error]] : [],
+  },
+});
+
+const clean = { valid: true, issues: [], summary: "ok" };
+
+beforeEach(() => {
+  getHistoryMock.mockReset();
+  validateWorkflowMock.mockReset();
+  validateWorkflowMock.mockResolvedValue(clean);
+});
+
+describe("diagnose_run — run selection", () => {
+  it("prefers the most recent FAILED run over a newer successful one", async () => {
+    // The user asks "why did it fail?" after kicking off something that worked —
+    // the failure is what they mean, even though it isn't the newest entry.
+    getHistoryMock.mockResolvedValue({
+      "old-fail": entry(1, "old-fail", { error: { node_id: 7, node_type: "VAEDecode" } }),
+      "new-ok": entry(2, "new-ok"),
+    });
+    const res = await getHandler("diagnose_run")({});
+    expect(res.content[0].text).toContain("old-fail");
+    expect(res.content[0].text).toContain("VAEDecode");
+  });
+
+  it("falls back to the most recent run when nothing failed", async () => {
+    getHistoryMock.mockResolvedValue({
+      a: entry(1, "a"),
+      b: entry(2, "b"),
+    });
+    const res = await getHandler("diagnose_run")({});
+    expect(res.content[0].text).toContain("Diagnosis: b");
+    expect(res.content[0].text).toContain("No runtime error recorded");
+  });
+
+  it("honors an explicit prompt_id", async () => {
+    getHistoryMock.mockResolvedValue({ specific: entry(1, "specific") });
+    const res = await getHandler("diagnose_run")({ prompt_id: "specific" });
+    expect(getHistoryMock).toHaveBeenCalledWith("specific");
+    expect(res.content[0].text).toContain("Diagnosis: specific");
+  });
+
+  it("reports cleanly when there is no history at all", async () => {
+    getHistoryMock.mockResolvedValue({});
+    const res = await getHandler("diagnose_run")({});
+    expect(res.content[0].text).toContain("No execution history");
+  });
+});
+
+describe("diagnose_run — failure explanation", () => {
+  it("names the failed node, exception type/message, and trims a long traceback", async () => {
+    const traceback = Array.from({ length: 40 }, (_, i) => `frame ${i}\n`);
+    getHistoryMock.mockResolvedValue({
+      p: entry(1, "p", {
+        error: {
+          node_id: 12,
+          node_type: "CheckpointLoaderSimple",
+          exception_type: "FileNotFoundError",
+          exception_message: "model.safetensors not found",
+          traceback,
+        },
+      }),
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("Failed node**: 12 (CheckpointLoaderSimple)");
+    expect(text).toContain("FileNotFoundError");
+    expect(text).toContain("model.safetensors not found");
+    // Only the tail is included — a full traceback would flood the agent's context.
+    expect(text).toContain("frame 39");
+    expect(text).not.toContain("frame 0\n");
+  });
+
+  it("surfaces missing models with the exact file and the widget holding it", async () => {
+    getHistoryMock.mockResolvedValue({ p: entry(1, "p", { error: { node_id: 3 } }) });
+    validateWorkflowMock.mockResolvedValue({
+      valid: false,
+      summary: "bad",
+      issues: [
+        {
+          severity: "error",
+          kind: "missing_model",
+          node_id: "3",
+          node_type: "CheckpointLoaderSimple",
+          input: "ckpt_name",
+          value: "sdxl_base.safetensors",
+          message: "not in list",
+        },
+      ],
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("Missing models");
+    expect(text).toContain("sdxl_base.safetensors");
+    expect(text).toContain("ckpt_name");
+    expect(text).toContain("search_civitai_models"); // actionable next step
+  });
+
+  it("surfaces missing node types, de-duplicated", async () => {
+    getHistoryMock.mockResolvedValue({ p: entry(1, "p") });
+    validateWorkflowMock.mockResolvedValue({
+      valid: false,
+      summary: "bad",
+      issues: [
+        { severity: "error", kind: "missing_node_type", node_id: "1", node_type: "IPAdapter", message: "x" },
+        { severity: "error", kind: "missing_node_type", node_id: "2", node_type: "IPAdapter", message: "x" },
+      ],
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("Missing node types");
+    // De-duplicated: one bullet for the pack, not one per node.
+    expect(text.match(/- \*\*IPAdapter\*\*/g)?.length).toBe(1);
+    expect(text).toContain("install_custom_node");
+  });
+
+  it("separates other validation errors from missing models/nodes", async () => {
+    getHistoryMock.mockResolvedValue({ p: entry(1, "p") });
+    validateWorkflowMock.mockResolvedValue({
+      valid: false,
+      summary: "bad",
+      issues: [
+        { severity: "error", kind: "value_not_in_list", node_id: "5", node_type: "KSampler", message: "bad sampler" },
+        { severity: "warning", kind: "disconnected", node_id: "9", node_type: "Note", message: "ignored" },
+      ],
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("Validation errors");
+    expect(text).toContain("bad sampler");
+    expect(text).not.toContain("ignored"); // warnings aren't errors
+  });
+
+  it("says the graph validates clean when the failure was purely runtime", async () => {
+    getHistoryMock.mockResolvedValue({
+      p: entry(1, "p", { error: { node_id: 1, exception_type: "RuntimeError" } }),
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("validates clean");
+  });
+
+  it("handles a history entry with no recorded graph", async () => {
+    getHistoryMock.mockResolvedValue({
+      p: { prompt: [1, "p"], outputs: {}, status: { status_str: "error", completed: false, messages: [] } },
+    });
+    const text = (await getHandler("diagnose_run")({})).content[0].text;
+    expect(text).toContain("no recorded graph");
+    expect(validateWorkflowMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -212,7 +212,10 @@ const HEADLESS_DIRECTIVE =
   "There is NO panel to auto-deliver a finished render, so you MUST deliver the result YOURSELF IN THIS SAME TURN: " +
   "enqueuing returns a prompt_id immediately, so wait for it with get_job_status(prompt_id) — poll it briefly until " +
   "it reports completion (this is the ONE case where polling IS correct) — then fetch the output with get_history and " +
-  "show it with panel_show_media. Do NOT end your turn expecting an automatic notification; none will arrive.";
+  "show it with panel_show_media. Do NOT end your turn expecting an automatic notification; none will arrive. " +
+  "If the run FAILED — or the user asks why a render failed / what's missing — call diagnose_run: it names the failed " +
+  "node with its exception, plus any missing models (exact file + the widget holding it) and missing node types, in one " +
+  "call. It is the canvas-less equivalent of the panel's \"why is this red?\", so do NOT try panel_view_errored_nodes here.";
 
 /** Live stall threshold (seconds) pushed from the panel setting via a `set_config`
  *  frame — applies WITHOUT a reconnect. null = not set, fall back to env then the
@@ -644,6 +647,11 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // tap, and (without clear_pending, which the mobile client never sends) it
   // never touches other pending jobs in a shared queue.
   "cancel_job",
+  // "Why did my render fail?" for canvas-less clients. The panel answers this from
+  // live canvas state (panel_view_errored_nodes); a phone has no canvas, so it reads
+  // the same story server-side from history + re-validating the graph that ran.
+  // Read-only.
+  "diagnose_run",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -8,8 +8,15 @@ export interface ValidationIssue {
   node_id: string;
   node_type: string;
   message: string;
-  /** Health-finding kind (disconnected, duplicate_model_load, …) when the issue came from graph-health. */
+  /** Health-finding kind (disconnected, duplicate_model_load, …) when the issue came from
+   *  graph-health, OR a validation kind — "missing_node_type" / "missing_model" /
+   *  "value_not_in_list" — so callers can partition issues without parsing `message`
+   *  (diagnose_run groups by this). */
   kind?: string;
+  /** The input/widget the issue is about, when it's input-scoped. */
+  input?: string;
+  /** The offending value (e.g. the model filename that isn't installed). */
+  value?: string;
 }
 
 export interface ValidationResult {
@@ -69,6 +76,7 @@ export async function validateWorkflow(
         severity: "error",
         node_id: nodeId,
         node_type: classType,
+        kind: "missing_node_type",
         message: `Unknown node type "${classType}". This node may not be installed.`,
       });
       continue; // Can't validate inputs without the definition
@@ -255,6 +263,9 @@ function checkComboValues(
       severity: "error",
       node_id: nodeId,
       node_type: classType,
+      kind: isModel ? "missing_model" : "value_not_in_list",
+      input: inputName,
+      value,
       message: `"${inputName}" = "${value}" is not in the list of valid options (value_not_in_list).${hint}`,
     });
   }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -5,8 +5,38 @@ import {
   getHistory,
   type HistoryEntry,
 } from "../comfyui/client.js";
-import { selectNewestHistoryEntry } from "../services/history-select.js";
+import { selectNewestHistoryEntry, extractWorkflowGraph } from "../services/history-select.js";
+import { validateWorkflow } from "../services/workflow-validator.js";
 import { errorToToolResult } from "../utils/errors.js";
+
+/** The `execution_error` payload ComfyUI records in a history entry's status.messages. */
+interface ExecutionErrorInfo {
+  node_id?: string | number;
+  node_type?: string;
+  exception_type?: string;
+  exception_message?: string;
+  traceback?: string[];
+}
+
+function findExecutionError(entry: HistoryEntry): ExecutionErrorInfo | null {
+  const msg = (entry.status?.messages ?? []).find((m) => m[0] === "execution_error");
+  return msg ? (msg[1] as ExecutionErrorInfo) : null;
+}
+
+/**
+ * Pick the run to diagnose. An explicit id wins; otherwise prefer the most recent
+ * FAILED run over a newer successful one — "why did it fail?" should land on the
+ * failure even when the user has since kicked off something that worked.
+ */
+function selectRunToDiagnose(
+  history: Record<string, HistoryEntry>,
+  promptId?: string,
+): [string, HistoryEntry] | undefined {
+  if (promptId) return selectNewestHistoryEntry(history, promptId);
+  const failed = Object.entries(history).filter(([, e]) => findExecutionError(e));
+  if (failed.length > 0) return selectNewestHistoryEntry(Object.fromEntries(failed));
+  return selectNewestHistoryEntry(history);
+}
 
 function formatHistoryEntry(
   promptId: string,
@@ -189,6 +219,134 @@ export function registerDiagnosticsTools(server: McpServer): void {
         const [promptId, entry] = selected;
         const text = formatHistoryEntry(promptId, entry);
         return { content: [{ type: "text", text }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "diagnose_run",
+    "WHY DID MY RENDER FAIL / WHAT'S MISSING? Explains a failed run in ONE call, without needing a canvas — the headless counterpart to the panel's panel_view_errored_nodes (\"why is this red?\"), so mobile/remote sessions get the same answer. Returns: the failed node (id, type) with its `exception_type` + message and a trimmed traceback; **missing_models** (the exact model file that isn't installed and the widget holding it — feed the filename to search_civitai_models/download_model to fix it); **missing_node_types** (node classes this install lacks — feed to search_custom_nodes/install_custom_node); and any other per-input validation errors. Call this whenever a run fails, an enqueue is rejected, or the user asks what's missing — instead of guessing from raw logs. With no prompt_id it diagnoses the most recent FAILED run (falling back to the most recent run). Read-only.",
+    {
+      prompt_id: z
+        .string()
+        .optional()
+        .describe(
+          "Specific run to diagnose (the prompt_id from enqueue_workflow). Omit to diagnose the most recent FAILED run — preferred over a newer successful one — falling back to the most recent run if nothing failed.",
+        ),
+    },
+    async (args) => {
+      try {
+        const history = await getHistory(args.prompt_id);
+        const selected = selectRunToDiagnose(history, args.prompt_id);
+        if (!selected) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: args.prompt_id
+                  ? `No history found for prompt ${args.prompt_id}.`
+                  : "No execution history available — nothing has run yet on this ComfyUI.",
+              },
+            ],
+          };
+        }
+
+        const [promptId, entry] = selected;
+        const lines: string[] = [];
+        lines.push(`## Diagnosis: ${promptId}`);
+        lines.push(`**Status**: ${entry.status?.status_str ?? "unknown"}`);
+
+        // 1. Runtime failure (what actually blew up mid-execution).
+        const execError = findExecutionError(entry);
+        if (execError) {
+          lines.push("");
+          lines.push("### Runtime failure");
+          lines.push(
+            `**Failed node**: ${execError.node_id ?? "?"} (${execError.node_type ?? "unknown type"})`,
+          );
+          if (execError.exception_type) lines.push(`**Type**: ${execError.exception_type}`);
+          if (execError.exception_message) {
+            lines.push(`**Message**: ${execError.exception_message}`);
+          }
+          if (Array.isArray(execError.traceback) && execError.traceback.length > 0) {
+            // Tail only — the last frames carry the cause, and a full traceback can
+            // be hundreds of lines (this reply goes straight into an agent's context).
+            const tail = execError.traceback.slice(-12);
+            lines.push("");
+            lines.push("```");
+            lines.push(tail.join("").trimEnd());
+            lines.push("```");
+          }
+        } else {
+          lines.push("");
+          lines.push(
+            "_No runtime error recorded for this run_ — if the user still sees a problem, it was likely rejected BEFORE execution (see validation below) or the run simply produced an unwanted result.",
+          );
+        }
+
+        // 2. Re-validate the exact graph that ran, so we can name what's missing.
+        //    Reuses the same validator behind validate_workflow — the graph is the
+        //    one ComfyUI recorded, so this reflects what actually executed.
+        const graph = extractWorkflowGraph(entry);
+        if (!graph) {
+          lines.push("");
+          lines.push(
+            "_This history entry has no recorded graph_, so missing models/nodes can't be checked for it.",
+          );
+        } else {
+          const result = await validateWorkflow(graph, { health: false });
+          const errors = result.issues.filter((i) => i.severity === "error");
+          const missingModels = errors.filter((i) => i.kind === "missing_model");
+          const missingNodeTypes = errors.filter((i) => i.kind === "missing_node_type");
+          const otherErrors = errors.filter(
+            (i) => i.kind !== "missing_model" && i.kind !== "missing_node_type",
+          );
+
+          if (missingModels.length > 0) {
+            lines.push("");
+            lines.push("### Missing models");
+            for (const i of missingModels) {
+              lines.push(
+                `- **${i.value ?? "(unknown file)"}** — node ${i.node_id} (${i.node_type}), widget \`${i.input ?? "?"}\``,
+              );
+            }
+            lines.push(
+              "_Fix_: search_civitai_models / search_models by that filename, then download_model (or download_civitai_model) into the loader's directory.",
+            );
+          }
+
+          if (missingNodeTypes.length > 0) {
+            lines.push("");
+            lines.push("### Missing node types (packs this install lacks)");
+            const uniq = [...new Set(missingNodeTypes.map((i) => i.node_type))];
+            for (const t of uniq) lines.push(`- **${t}**`);
+            lines.push(
+              "_Fix_: search_custom_nodes for the owning pack, install_custom_node, then restart ComfyUI to load it.",
+            );
+          }
+
+          if (otherErrors.length > 0) {
+            lines.push("");
+            lines.push("### Validation errors");
+            for (const i of otherErrors.slice(0, 20)) {
+              lines.push(`- node ${i.node_id} (${i.node_type}): ${i.message}`);
+            }
+            if (otherErrors.length > 20) {
+              lines.push(`- …and ${otherErrors.length - 20} more`);
+            }
+          }
+
+          if (errors.length === 0) {
+            lines.push("");
+            lines.push(
+              "_The recorded graph validates clean_ — nothing is missing, so the failure was a runtime one (see above), not a setup problem.",
+            );
+          }
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (err) {
         return errorToToolResult(err);
       }


### PR DESCRIPTION
## The gap

Panel 0.9.2–0.9.5 + #238 added three live-canvas tools. Two are inherently canvas-bound and need no mobile equivalent (`panel_view_selected` reads the *selection*; `panel_view_nodes_in_viewport` reads the *viewport rect*). The third — `panel_view_errored_nodes`, "why is this red?" — answers a question that applies to mobile **just as much**, arguably more, since a phone user can't see the canvas at all.

But it's a `ctx.call({cmd: "graph_view_errored_nodes"})` live-canvas command: a headless client declines it, and `HEADLESS_DIRECTIVE` explicitly tells the mobile agent the `panel_*` tools "are UNAVAILABLE here and will fail." Its data sources are frontend-only (`app.lastNodeErrors`, `execution_error` events, canvas flags), and nothing in `src/tools/` returned structured missing-model/reason data. Net effect: **panel users got a clean answer; mobile users got raw logs and guesswork.**

## The fix

`diagnose_run` — the canvas-less counterpart, built by **composing existing pieces** rather than new plumbing:

- `getHistory` + a selector that prefers the most recent **FAILED** run over a newer successful one (asking "why did it fail?" after kicking off something that worked should still land on the failure)
- `extractWorkflowGraph` (already existed) to recover the graph that actually ran
- `validateWorkflow` (already existed — it already checks missing node types *and* missing models) to name what's missing in that exact graph

Returns:
- **Runtime failure** — failed node id/type, `exception_type`, message, and a **trimmed** traceback (tail only; a full one is hundreds of lines going straight into an agent's context)
- **Missing models** — the exact file *and the widget holding it*, plus the concrete next step (`search_civitai_models` → `download_model`)
- **Missing node types** — de-duplicated per pack, with `install_custom_node` as the next step
- **Other validation errors**, and an explicit "graph validates clean → this was runtime, not setup" verdict

## Supporting change

To partition issues reliably instead of regex-matching message strings, `ValidationIssue` now carries `kind` (`missing_node_type` | `missing_model` | `value_not_in_list`) plus the offending `input`/`value`. `kind` was already an optional field (used by graph-health), so this is backward compatible.

## Wiring

Whitelisted on the mobile `call_tool` channel, and referenced from `HEADLESS_DIRECTIVE` so the agent actually reaches for it on failure instead of poking at raw history.

## Verification

**Live over the real headless bridge path** (same `call_tool` route the phone uses) against an actual failed run — `ok: true`, correctly naming node `3 (CLIPTextEncode)`, `RuntimeError`, the real message, a trimmed traceback, and the "validates clean → runtime failure" verdict.

10 new unit tests (failed-run preference, explicit id, traceback trimming, missing-model file+widget, node-type de-duplication, warnings-aren't-errors, no-graph entry). Full suite **1472 green**, `tsc` clean.

## Scope note

This deliberately covers runs that **entered history and failed**. A prompt rejected at submit never reaches history — `enqueue_workflow` already surfaces those `node_errors` inline.