### PR TITLE
feat(codex): GPT-5.6 family (Sol/Terra/Luna) + max/ultra efforts; deprecate pre-5.6 models (fixes #241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Changed
+- **GPT-5.6 family (Sol / Terra / Luna) with the extended effort scale
+  (`max`, `ultra`)** — the bundled Codex SDK is now 0.145.0-alpha.24 (the
+  stable 0.144.6 crashes renewing a Codex-Desktop 0.145 models cache; the
+  alpha is the field-verified pairing — #241), and pre-5.6 models are
+  DEPRECATED: the picker hides them whenever the account has the 5.6 family
+  (accounts without 5.6 keep their catalog). ChatGPT-direct default is now
+  `gpt-5.6-luna` (successor to the retired `gpt-5.4-mini`); Claude-max→xhigh
+  effort downmapping removed (`max` is native now)
+
 ## [0.40.0] - 2026-07-19
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.197",
         "@aws-sdk/client-s3": "^3.1053.0",
         "@azure/storage-blob": "^12.31.0",
-        "@openai/codex": "~0.141.0",
+        "@openai/codex": "0.145.0-alpha.24",
         "ai": "^6.0.191",
         "cloudflared": "^0.7.1"
       }
@@ -2103,9 +2103,9 @@
       "optional": true
     },
     "node_modules/@openai/codex": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0.tgz",
-      "integrity": "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw==",
+      "version": "0.145.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24.tgz",
+      "integrity": "sha512-S2BAMTUCNPdnHLLI98GlZtBZgaHlkjXdWqf7zKHML413qayy+0nLFrw8a6n5XKIuIGmZrN3zhofcABm3tEk6rg==",
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -2115,19 +2115,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.145.0-alpha.24-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.145.0-alpha.24-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.145.0-alpha.24-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.145.0-alpha.24-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.145.0-alpha.24-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.145.0-alpha.24-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-arm64.tgz",
-      "integrity": "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg==",
+      "version": "0.145.0-alpha.24-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-darwin-arm64.tgz",
+      "integrity": "sha512-H0a+Cb15oTPFP/tKkOXf+gMVglVBBSQ2ZUvuYAInntcIJ5p6rMI4hRHZxHMNS5Hxvx5OWuTFanI92FMi1C3Tkw==",
       "cpu": [
         "arm64"
       ],
@@ -2142,9 +2142,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-x64.tgz",
-      "integrity": "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg==",
+      "version": "0.145.0-alpha.24-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-darwin-x64.tgz",
+      "integrity": "sha512-/dpha6ImJpTLa7NG0knYTpFq65RBUaU+iuzyZC9U/KRbqTgGjPjpo+kypYJ1Vse1EHXclYN/1wno8m12LbP6mA==",
       "cpu": [
         "x64"
       ],
@@ -2159,9 +2159,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-arm64.tgz",
-      "integrity": "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw==",
+      "version": "0.145.0-alpha.24-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-linux-arm64.tgz",
+      "integrity": "sha512-6Zr3HjVXxAU/GdKwzuZvKvyt6ejpQ0eqvsX3VYC8esSncnmUByY9Ep1dcab34K3N823lksPsIcokjCdjFRemhA==",
       "cpu": [
         "arm64"
       ],
@@ -2176,9 +2176,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-x64.tgz",
-      "integrity": "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA==",
+      "version": "0.145.0-alpha.24-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-linux-x64.tgz",
+      "integrity": "sha512-FsyV5Gn6rMuApDIMFGqIHxUv6m2/CgKmb5mp/NI0jEybqnyIvfxrhW27jOcG02Bwk/soiQrvFYYJwXuJW0EUhQ==",
       "cpu": [
         "x64"
       ],
@@ -2193,9 +2193,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-arm64.tgz",
-      "integrity": "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ==",
+      "version": "0.145.0-alpha.24-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-win32-arm64.tgz",
+      "integrity": "sha512-slZ5x2UiOWFYjKk1rvfgH5v/mmCtX9Xi/hRsZVpqMIz8Ok/6PG1UUUmC533qLQg87axMhptJoM7x7kNJnEUURg==",
       "cpu": [
         "arm64"
       ],
@@ -2210,9 +2210,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-x64.tgz",
-      "integrity": "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ==",
+      "version": "0.145.0-alpha.24-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.145.0-alpha.24-win32-x64.tgz",
+      "integrity": "sha512-9tK8qFVtrGxH0JdhqCjrmawTEItQg2iUxmQUSAF6KwSo40S3WCRjkokabFFUgryx1Q4BTCfYAt8+91CkWS35qw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.197",
-    "@openai/codex": "~0.141.0",
+    "@openai/codex": "0.145.0-alpha.24",
     "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/google": "^3.0.79",
     "@ai-sdk/openai": "^3.0.65",

--- a/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
+++ b/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatGptOAuthBackend } from "../../orchestrator/chatgpt-oauth-backend.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "../../orchestrator/chatgpt-oauth-backend.js";
 import type { McpToolClient } from "../../orchestrator/ollama-backend.js";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 
@@ -155,5 +158,63 @@ describe("ChatGptOAuthBackend — Responses-API image delivery (#218)", () => {
   it("text-only turns carry no input_image items", async () => {
     await collect(makeBackend(), turnsOf({ text: "hello" }));
     expect(userContent(responsesRequests[0]).every((c) => c.type === "input_text")).toBe(true);
+  });
+});
+
+describe("GPT-5.6-only model policy (issue #241 + 2026-07-20 deprecation)", () => {
+  it("hides deprecated pre-5.6 ids when the codex cache carries the 5.6 family", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmcp-56-"));
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "models_cache.json"),
+      JSON.stringify({ models: [
+        { id: "gpt-5.6-sol" }, { id: "gpt-5.6-terra" }, { id: "gpt-5.6-luna" },
+        { id: "gpt-5.5" }, { id: "gpt-5.4-mini" },
+      ] }),
+    );
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(home, ".codex");
+    try {
+      const b = new ChatGptOAuthBackend({
+        model: "gpt-5.6-sol",
+        connectToolClients: async () => ({ comfyui: fakeMcpClient() }),
+      });
+      const ids = (await b.listModels()).map((m) => m.id);
+      expect(ids).toContain("gpt-5.6-sol");
+      expect(ids).toContain("gpt-5.6-terra");
+      expect(ids).toContain("gpt-5.6-luna");
+      expect(ids).not.toContain("gpt-5.5");
+      expect(ids).not.toContain("gpt-5.4-mini");
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the full cache when no 5.6 model is present (older plans never brick)", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmcp-56b-"));
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "models_cache.json"),
+      JSON.stringify({ models: [{ id: "gpt-5.5" }, { id: "gpt-5.4-mini" }] }),
+    );
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(home, ".codex");
+    try {
+      const b = new ChatGptOAuthBackend({
+        model: "gpt-5.5",
+        connectToolClients: async () => ({ comfyui: fakeMcpClient() }),
+      });
+      const ids = (await b.listModels()).map((m) => m.id);
+      expect(ids).toContain("gpt-5.5");
+      expect(ids).toContain("gpt-5.4-mini");
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("CHATGPT_DEFAULT_MODEL is gpt-5.6-luna", () => {
+    expect(CHATGPT_DEFAULT_MODEL).toBe("gpt-5.6-luna");
   });
 });

--- a/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
+++ b/src/__tests__/orchestrator/chatgpt-oauth-backend.test.ts
@@ -214,7 +214,35 @@ describe("GPT-5.6-only model policy (issue #241 + 2026-07-20 deprecation)", () =
     }
   });
 
-  it("CHATGPT_DEFAULT_MODEL is gpt-5.6-luna", () => {
+  it.skipIf(!!process.env.COMFYUI_MCP_CHATGPT_MODEL)("CHATGPT_DEFAULT_MODEL is gpt-5.6-luna", () => {
+    // (skipped when COMFYUI_MCP_CHATGPT_MODEL overrides the baked default)
     expect(CHATGPT_DEFAULT_MODEL).toBe("gpt-5.6-luna");
+  });
+
+  it("migrates a deprecated ACTIVE model to the family default instead of re-inserting it", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmcp-56c-"));
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    writeFileSync(
+      join(home, ".codex", "models_cache.json"),
+      JSON.stringify({ models: [
+        { id: "gpt-5.6-sol" }, { id: "gpt-5.6-terra" }, { id: "gpt-5.6-luna" }, { id: "gpt-5.4-mini" },
+      ] }),
+    );
+    const prev = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = join(home, ".codex");
+    try {
+      // A tab that saved the OLD default keeps pushing it on reconnect — the
+      // list must not re-insert it at the head (it 400s every turn now).
+      const b = new ChatGptOAuthBackend({
+        model: "gpt-5.4-mini",
+        connectToolClients: async () => ({ comfyui: fakeMcpClient() }),
+      });
+      const ids = (await b.listModels()).map((m) => m.id);
+      expect(ids).not.toContain("gpt-5.4-mini");
+      expect(ids[0].startsWith("gpt-5.6")).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.CODEX_HOME; else process.env.CODEX_HOME = prev;
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -22,8 +22,10 @@ const CHATGPT_SYSTEM_PROMPT = [
   "Describe a tool before its first call. Finish tasks by running tools, not inventing results.",
 ].join("\n");
 
+// GPT-5.6-only policy (2026-07-20): Luna is the family's cost-conscious
+// variant — the successor default to the retired gpt-5.4-mini.
 export const CHATGPT_DEFAULT_MODEL =
-  process.env.COMFYUI_MCP_CHATGPT_MODEL?.trim() || "gpt-5.4-mini";
+  process.env.COMFYUI_MCP_CHATGPT_MODEL?.trim() || "gpt-5.6-luna";
 
 const MAX_TOOL_ROUNDS = 32;
 
@@ -446,9 +448,14 @@ export class ChatGptOAuthBackend extends OllamaBackend {
 
   override async listModels(): Promise<ModelChoice[]> {
     const cached = await loadCodexModelIds();
-    const ids = cached.length
-      ? cached
-      : [CHATGPT_DEFAULT_MODEL, "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"];
+    // GPT-5.6-only policy: hide deprecated pre-5.6 ids when the cache carries
+    // the 5.6 family; a cache without any 5.6 keeps its full list.
+    const fam = cached.filter((id) => id.startsWith("gpt-5.6"));
+    const ids = fam.length
+      ? fam
+      : cached.length
+        ? cached
+        : ["gpt-5.6-sol", "gpt-5.6-terra", CHATGPT_DEFAULT_MODEL];
     const rest = ids.filter((id) => id !== this.model).slice(0, 40);
     return [this.model, ...rest].map((id) => ({ id, label: id }));
   }

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -456,6 +456,16 @@ export class ChatGptOAuthBackend extends OllamaBackend {
       : cached.length
         ? cached
         : ["gpt-5.6-sol", "gpt-5.6-terra", CHATGPT_DEFAULT_MODEL];
+    // A deprecated ACTIVE model (e.g. a tab that saved the old gpt-5.4-mini
+    // default) must not be re-inserted at the head of the filtered list — that
+    // kept it selected and 400ing every turn (codex review). Migrate the
+    // instance to the family default instead so the next turn works.
+    if (fam.length && this.model && !this.model.startsWith("gpt-5.6")) {
+      logger.info(
+        `[chatgpt-oauth-backend] active model ${this.model} is deprecated — migrating to ${CHATGPT_DEFAULT_MODEL}`,
+      );
+      this.model = ids.includes(CHATGPT_DEFAULT_MODEL) ? CHATGPT_DEFAULT_MODEL : ids[0];
+    }
     const rest = ids.filter((id) => id !== this.model).slice(0, 40);
     return [this.model, ...rest].map((id) => ({ id, label: id }));
   }

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -363,7 +363,9 @@ class AppServerClient {
 // present) AND toCodexEffort() further down (the validity check), to avoid drift.
 // The backend ALREADY applies effort to every turn via toCodexEffort regardless
 // of model, so advertising it for all Codex models matches current behavior.
-const CODEX_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+// GPT-5.6 extends the scale with `max` and `ultra` (verified live per model:
+// sol/terra accept through ultra, luna through max — issue #241's catalog).
+const CODEX_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
 
 // ---- model fallback ----
 // config/read does not enumerate a model CATALOG (it reports the active provider
@@ -371,9 +373,13 @@ const CODEX_EFFORT_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"
 // model family. The panel picker degrades gracefully on an empty list. Each entry
 // advertises the Codex effort scale so the panel enables the reasoning-effort
 // dropdown for these models (the backend applies effort to every turn anyway).
+// GPT-5.6 family ONLY (product decision 2026-07-20): older GPT-5.x are
+// deprecated — the live catalog is filtered to the 5.6 family and these
+// fallbacks match it. Per-variant effort ceilings from the live model/list.
 const CODEX_FALLBACK_MODELS: ModelChoice[] = [
-  { id: "gpt-5.5", label: "GPT-5.5", supportsEffort: true, supportedEffortLevels: [...CODEX_EFFORT_LEVELS] },
-  { id: "gpt-5.5-codex", label: "GPT-5.5 Codex", supportsEffort: true, supportedEffortLevels: [...CODEX_EFFORT_LEVELS] },
+  { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
+  { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
+  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"] },
 ];
 
 /** Does this id look like an OpenAI/Codex model (vs. a Claude panel model)? Used
@@ -398,7 +404,9 @@ function toCodexEffort(effort: string | undefined): string | null {
   if (!effort) return null;
   const e = effort.toLowerCase();
   if ((CODEX_EFFORTS as readonly string[]).includes(e)) return e;
-  if (e === "max") return "xhigh"; // Claude's top level → Codex's nearest valid
+  // ("max" is now a NATIVE Codex level on GPT-5.6 — the old Claude-max→xhigh
+  // downmap is gone; per-model ceilings are enforced by the picker, and an
+  // over-ceiling level is clamped app-server-side.)
   return null; // unknown level → let the app-server pick its default
 }
 
@@ -1195,8 +1203,18 @@ export class CodexBackend implements AgentBackend {
             };
           });
         if (live.length) {
-          this.liveCatalog = live;
-          return live;
+          // GPT-5.6-only policy: hide deprecated 5.x/codex ids from the picker
+          // when the account has the 5.6 family. Accounts WITHOUT any 5.6
+          // model keep their full catalog (never brick an older plan).
+          const fam = live.filter((m) => m.id.startsWith("gpt-5.6"));
+          if (fam.length && fam.length < live.length) {
+            logger.debug(
+              `[codex-backend] hiding ${live.length - fam.length} deprecated pre-5.6 model(s) from the picker`,
+            );
+          }
+          const chosen = fam.length ? fam : live;
+          this.liveCatalog = chosen;
+          return chosen;
         }
       }
     } catch (err) {

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -380,6 +380,11 @@ const CODEX_FALLBACK_MODELS: ModelChoice[] = [
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
   { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max", "ultra"] },
   { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", supportsEffort: true, supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"] },
+  // This static list only surfaces when model/list is UNAVAILABLE — i.e. an
+  // older CLI resolved from PATH (bundled-install failure), which cannot run
+  // any 5.6 model. Keep one runnable pre-5.6 escape hatch there (codex
+  // review); accounts on the pinned bundled CLI never see this list.
+  { id: "gpt-5.5", label: "GPT-5.5 (legacy CLI fallback)", supportsEffort: true, supportedEffortLevels: ["none", "minimal", "low", "medium", "high", "xhigh"] },
 ];
 
 /** Does this id look like an OpenAI/Codex model (vs. a Claude panel model)? Used
@@ -400,14 +405,27 @@ function isCodexModel(id: string): boolean {
 // off-scale source value is Claude "max", which has no Codex equivalent and maps
 // to the nearest valid level (xhigh). Unknown/empty → null (app-server default).
 const CODEX_EFFORTS = CODEX_EFFORT_LEVELS; // single source of truth (advertised == accepted)
-function toCodexEffort(effort: string | undefined): string | null {
+// Low→high rank for ceiling-snapping in toCodexEffort.
+const EFFORT_RANK = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+function toCodexEffort(effort: string | undefined, allowed?: string[]): string | null {
   if (!effort) return null;
   const e = effort.toLowerCase();
-  if ((CODEX_EFFORTS as readonly string[]).includes(e)) return e;
-  // ("max" is now a NATIVE Codex level on GPT-5.6 — the old Claude-max→xhigh
-  // downmap is gone; per-model ceilings are enforced by the picker, and an
-  // over-ceiling level is clamped app-server-side.)
-  return null; // unknown level → let the app-server pick its default
+  if (!(CODEX_EFFORTS as readonly string[]).includes(e)) {
+    return null; // unknown level → let the app-server pick its default
+  }
+  // Snap to the active model's supported list when we know it: "max"/"ultra"
+  // are native on GPT-5.6 but REJECTED by pre-5.6 models and older CLIs —
+  // the old blanket max→xhigh downmap was removed, so the ceiling must be
+  // enforced here (codex review). No list known → conservative xhigh cap.
+  if (allowed && allowed.length) {
+    if (allowed.includes(e)) return e;
+    for (let i = EFFORT_RANK.indexOf(e); i >= 0; i--) {
+      if (allowed.includes(EFFORT_RANK[i])) return EFFORT_RANK[i];
+    }
+    return allowed[allowed.length - 1] ?? null;
+  }
+  if (e === "max" || e === "ultra") return "xhigh";
+  return e;
 }
 
 /**
@@ -563,6 +581,9 @@ export class CodexBackend implements AgentBackend {
   private model: string | undefined;
   /** The Codex reasoning effort for new turns, already mapped to a valid Codex
    *  level (null = let the app-server choose). Captured from run(opts.effort). */
+  /** RAW panel effort for this session — snapped per-turn against the
+   *  RESOLVED model's supported list (the catalog isn't loaded yet when run()
+   *  captures it, and the active model can change via the clamp). */
   private effort: string | null = null;
   /** True until the panel system prompt has been prepended to a turn. The
    *  app-server's thread/start has no instructions field, so the persona rides on
@@ -761,12 +782,12 @@ export class CodexBackend implements AgentBackend {
     // otherwise ignore it and keep the configured Codex model (or the account
     // default when neither is set — model:null lets the app-server choose).
     if (opts.model && isCodexModel(opts.model)) this.model = opts.model;
-    // Map the panel/Claude effort scale onto Codex's and apply it to every turn in
-    // this session (the panel restarts run() on an effort change, so capturing it
-    // here is enough — each new turn reads this.effort). Without this the session
-    // ran at the app-server default regardless of the picker (the effort was
-    // previously hardcoded to null on turn/start).
-    this.effort = toCodexEffort(opts.effort);
+    // Capture the RAW panel effort; each turn maps+snaps it against the model
+    // it actually runs (toCodexEffort with the model's supported list — the
+    // catalog isn't loaded yet here, and max/ultra are only valid on models
+    // that advertise them). The panel restarts run() on an effort change, so
+    // capturing once per session is enough.
+    this.effort = opts.effort ?? null;
 
     // forkAtAnchor is false (CODEX_CAPABILITIES) → ignore opts.rewindAnchor; we
     // only do whole-thread resume.
@@ -1082,13 +1103,22 @@ export class CodexBackend implements AgentBackend {
 
     try {
       // turn/start delivers the user text plus any resolved image input items.
+      const turnModel = this.resolveTurnModel();
       client
         .request<{ turn?: { id?: string } }>("turn/start", {
           threadId,
           input: turnInput,
-          model: this.model ?? null,
-          // Forward the session's mapped Codex effort (null = app-server default).
-          effort: this.effort,
+          // Same clamp as thread/start|resume — sending the raw pin here let
+          // a deprecated/unrunnable model bypass the thread-level clamp on
+          // every turn (codex review on this branch).
+          model: turnModel,
+          // Map+snap the session effort against the model THIS turn runs:
+          // known catalog → the model's own supported list caps it (5.6 keeps
+          // max/ultra; pre-5.6 snaps down); unknown catalog → xhigh cap.
+          effort: toCodexEffort(
+            this.effort ?? undefined,
+            this.liveCatalog?.find((m) => m.id === turnModel)?.supportedEffortLevels,
+          ),
           outputSchema: null,
         })
         .then((res) => {
@@ -1203,6 +1233,12 @@ export class CodexBackend implements AgentBackend {
             };
           });
         if (live.length) {
+          // liveCatalog keeps the FULL account catalog: it answers "can this
+          // account run model X" for resolveTurnModel's clamp. The PICKER gets
+          // the deprecation-filtered view below — hiding a model from new
+          // picks must not force-switch an existing pin/resume that the
+          // account can still legally run (codex review on this branch).
+          this.liveCatalog = live;
           // GPT-5.6-only policy: hide deprecated 5.x/codex ids from the picker
           // when the account has the 5.6 family. Accounts WITHOUT any 5.6
           // model keep their full catalog (never brick an older plan).
@@ -1212,9 +1248,7 @@ export class CodexBackend implements AgentBackend {
               `[codex-backend] hiding ${live.length - fam.length} deprecated pre-5.6 model(s) from the picker`,
             );
           }
-          const chosen = fam.length ? fam : live;
-          this.liveCatalog = chosen;
-          return chosen;
+          return fam.length ? fam : live;
         }
       }
     } catch (err) {


### PR DESCRIPTION
Implements the GPT-5.6-only model policy with the extended effort scale, per the verified matrix in #241.

## What changes
- **SDK**: `@openai/codex` pinned exactly to `0.145.0-alpha.24` — stable 0.144.6 crashes renewing a Codex-Desktop 0.145 `models_cache.json` (missing `supports_reasoning_summaries`); the alpha is the field-verified pairing.
- **Models**: picker shows only `gpt-5.6-sol/terra/luna` whenever the account has the family; accounts without 5.6 keep their full catalog. `liveCatalog` retains the FULL account list so the clamp never force-switches a still-runnable pin or resumed thread; `turn/start` now clamps identically to `thread/start|resume`. ChatGPT-direct default `gpt-5.4-mini` → `gpt-5.6-luna`, with active-model migration for tabs that saved the old default.
- **Efforts**: scale extends with `max`/`ultra`; effort is snapped per-turn against the resolved model's supported list (Sol/Terra through ultra, Luna through max; unknown catalog → conservative xhigh cap). Static fallback keeps a `gpt-5.5` escape hatch for the legacy-CLI-only path.

## Review
Two codex CLI review runs wedged mid-analysis (plausibly the very Desktop-cache bug this fixes); substituted a Claude adversarial review — 3 major + 3 minor findings, all fixed, then a second independent pass verified every fix closed with logic traces: **CLEAN**.

## Verification
- 1463 tests green incl. new migration/policy regressions; tsc clean; branch rebased onto main
- Live over the real bridge: codex models frame = exactly the three variants with per-variant effort ceilings; the account's gpt-5.5 hidden from the picker

Pairs with comfyui-mcp-panel `feat/gpt-5.6-efforts`. Fixes #241 (the legacy_notify Windows warning noted there is unrelated hook noise, tracked separately if it recurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)