### PR TITLE
fix(blind): Blind mechanically gates every image-returning tool (fixes comfyui-mcp-panel#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- the panel's **Blind** toggle now mechanically gates EVERY image-returning
+  tool (get_image, view_image, convert previews, …): blind tabs spawn their
+  comfyui tool server with COMFYUI_MCP_BLIND=1 and a single registration-
+  boundary wrapper replaces image blocks with an honest "withheld" note — on
+  both the full MCP surface and the compact call_tool router; toggling Blind
+  live respawns the tab's tool server at idle (panel issue #90)
+
 ## [0.41.0] - 2026-07-20
 
 ### MCP

--- a/src/__tests__/tools/blind-image-gate.test.ts
+++ b/src/__tests__/tools/blind-image-gate.test.ts
@@ -1,0 +1,82 @@
+// The Blind content-mode gate (panel issue #90): with COMFYUI_MCP_BLIND=1 the
+// tool-registration boundary replaces every image content block with an honest
+// text block — for BOTH the live McpServer path and the compact-mode catalog
+// (call_tool router), so no image-returning tool can leak pixels to the model.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { collectToolCatalog } from "../../tools/index.js";
+
+const PIXELS = Buffer.from("fake-png-bytes-here").toString("base64");
+
+describe("blind image gate (COMFYUI_MCP_BLIND)", () => {
+  const prev = process.env.COMFYUI_MCP_BLIND;
+  beforeEach(() => {
+    process.env.COMFYUI_MCP_BLIND = "1";
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.COMFYUI_MCP_BLIND;
+    else process.env.COMFYUI_MCP_BLIND = prev;
+  });
+
+  it("scrubs image blocks and leaves text blocks intact (wrapper semantics)", async () => {
+    // Exercise the boundary directly: register a synthetic tool through
+    // registerAllTools' gate by reaching the same wrapper via collectToolCatalog
+    // is awkward — the catalog only captures known groups. So assert semantics
+    // on a real captured handler: view_image with a stubbed registry.
+    const { AssetRegistry } = await import("../../services/asset-registry.js");
+    const catalog = await collectToolCatalog();
+    const entry = catalog.get("view_image");
+    expect(entry).toBeTruthy();
+    // Stub fetch so viewAssetImage returns real-looking pixels.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(Buffer.from("fake-png-bytes-here"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      })) as typeof fetch;
+    try {
+      const [rec] = AssetRegistry.register({
+        promptId: "p1",
+        workflow: {},
+        outputs: [{ node_id: "9", images: [{ filename: "blindtest.png", subfolder: "", type: "output" }] }],
+      });
+      const id = rec.assetId;
+      const result = (await entry!.handler({ asset_id: id })) as {
+        content: Array<{ type: string; text?: string; data?: string }>;
+      };
+      expect(result.content.some((b) => b.type === "image")).toBe(false);
+      const note = result.content.find((b) => b.type === "text" && b.text?.includes("Blind mode"));
+      expect(note).toBeTruthy();
+      expect(note!.text).toContain("image withheld");
+      expect(JSON.stringify(result)).not.toContain(PIXELS);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("without the env, pixels pass through unchanged", async () => {
+    delete process.env.COMFYUI_MCP_BLIND;
+    const { AssetRegistry } = await import("../../services/asset-registry.js");
+    const catalog = await collectToolCatalog();
+    const entry = catalog.get("view_image");
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(Buffer.from("fake-png-bytes-here"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      })) as typeof fetch;
+    try {
+      const [rec] = AssetRegistry.register({
+        promptId: "p2",
+        workflow: {},
+        outputs: [{ node_id: "9", images: [{ filename: "cleartest.png", subfolder: "", type: "output" }] }],
+      });
+      const id = rec.assetId;
+      const result = (await entry!.handler({ asset_id: id })) as {
+        content: Array<{ type: string; data?: string }>;
+      };
+      expect(result.content.some((b) => b.type === "image")).toBe(true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1594,7 +1594,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   // (persisted by panel-secrets) lands in the comfyui server's spawn env. The
   // comfyui server is declared LAST so it always wins over any user entry that
   // slipped through (defensive — the reader already filters comfyui-mcp entries).
-  const buildMcpServers = () => ({
+  // `panelTab` (when given) layers per-tab spawn env — the Blind content gate
+  // (panel issue #90). The tab-less form remains for the static fallback.
+  const buildMcpServers = (panelTab?: string) => ({
     // The user's inherited servers first… (re-read so a panel_add_mcp is picked
     // up on the same in-process respawn, mirroring a soft reload).
     ...readUserMcpServers(),
@@ -1609,6 +1611,8 @@ export async function runPanelOrchestrator(): Promise<void> {
         // Local mode → enables download_model, apply_manifest (installer packs),
         // and model scans so the agent installs the right way instead of curl.
         ...(comfyuiPath ? { COMFYUI_PATH: comfyuiPath } : forceRemoteEnv()),
+        // Blind tab (issue #90): this tab's tool server withholds image pixels.
+        ...(panelTab && blindTabs.has(panelTab) ? { COMFYUI_MCP_BLIND: "1" } : {}),
       }),
     },
   });
@@ -1627,6 +1631,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         ? createPanelMcpServer(bridge, panelTabOf(key), workflowTargets)
         : undefined,
     mcpServers: buildMcpServers(),
+    // Per-KEY factory — the CLAUDE path's spawns must also reflect per-tab state
+    // (the Blind gate); the static set above stays as the fallback. Codex-review
+    // F1 on issue #90: without this, the default backend bypassed the gate.
+    makeMcpServers: (key) => buildMcpServers(panelTabOf(key)),
     // NOTE: manager callbacks fire with the composite agent key `tabId::backend`;
     // panelTabOf() recovers the PANEL tab so every push reaches the right socket.
     onSay: (key, text, meta) => {
@@ -2072,10 +2080,25 @@ export async function runPanelOrchestrator(): Promise<void> {
           : undefined;
       const backend = reqBackend && KNOWN_BACKENDS.has(reqBackend) ? reqBackend : defaultBackend;
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
-      // already carries the right tool-server env — a toggle later goes through
-      // set_content_mode below.
-      if ((event as { blind?: unknown }).blind === true) blindTabs.add(panelTab);
-      else if ((event as { blind?: unknown }).blind === false) blindTabs.delete(panelTab);
+      // already carries the right tool-server env. A CHANGE against a live
+      // agent also respawns it (codex-review F2: the set_content_mode frame is
+      // lost when toggled during a socket drop — the re-hello is the recovery
+      // path, so it must enforce, not just record). Absence = no-op (old panels
+      // never send the field; it must not clear a prior state).
+      {
+        const helloBlind = (event as { blind?: unknown }).blind;
+        if (helloBlind === true || helloBlind === false) {
+          const changed = helloBlind !== blindTabs.has(panelTab);
+          if (helloBlind) blindTabs.add(panelTab);
+          else blindTabs.delete(panelTab);
+          if (changed && manager.hasLiveAgent(agentKeyFor(panelTab))) {
+            manager.restartForMcpEnv(agentKeyFor(panelTab));
+            logger.info(
+              `[panel-orchestrator] tab ${panelTab.slice(0, 8)} blind=${String(helloBlind)} via hello — live agent respawn queued`,
+            );
+          }
+        }
+      }
       // Tab-id migration (issue #210): the BRIDGE stamps `migrated_from` on a
       // hello when the SAME socket re-helloed under a new tab id (panel update
       // changed the id scheme, e.g. random UUID → tmp:/wf:). That same-socket
@@ -2826,7 +2849,12 @@ export async function runPanelOrchestrator(): Promise<void> {
         logger.info(`[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run_error → agent (interrupt)`);
         return;
       }
-      const delivered = manager.injectEvent(agentKeyFor(event.tab_id), ev);
+      // Blind tab (issue #90, codex-review F3): strip render pixels at the
+      // SERVER boundary too — the desktop panel already drops them client-side,
+      // but a mirror viewer (mobile has no Blind concept) can inject
+      // agent_event frames with images onto a blinded desktop tab.
+      const evForTab = blindTabs.has(event.tab_id) ? { ...ev, images: [] } : ev;
+      const delivered = manager.injectEvent(agentKeyFor(event.tab_id), evForTab);
       if (delivered) {
         logger.info(`[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} event → agent: ${event.kind}`);
       }
@@ -3081,9 +3109,18 @@ export async function runPanelOrchestrator(): Promise<void> {
         ? ((event as { context?: string }).context as string).trim()
         : "";
     if (replay) outText = `${replay}\n\n${outText}`;
+    // Blind tab (issue #90): the toggle promises the agent NEVER receives
+    // pixels — that includes composer attachments. Withhold them with an
+    // honest note (the user can toggle Blind off to share an image).
+    const attachedImages = (event as { images?: Array<{ filename: string; subfolder?: string; type?: string }> })
+      .images;
+    const tabIsBlind = blindTabs.has(event.tab_id);
+    if (tabIsBlind && attachedImages?.length) {
+      outText += `\n\n[panel note: ${attachedImages.length} image attachment(s) withheld — Blind mode is ON. You cannot see them; ask the user to describe the content or turn Blind off.]`;
+    }
     const sendOpts = {
       title: event.title,
-      images: (event as { images?: Array<{ filename: string; subfolder?: string; type?: string }> }).images,
+      images: tabIsBlind ? undefined : attachedImages,
       mid: userMid,
     };
     // Local-agent VRAM pause: if this tab runs the local Ollama model AND a

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2079,26 +2079,6 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? ((event as { backend?: string }).backend as string).toLowerCase()
           : undefined;
       const backend = reqBackend && KNOWN_BACKENDS.has(reqBackend) ? reqBackend : defaultBackend;
-      // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
-      // already carries the right tool-server env. A CHANGE against a live
-      // agent also respawns it (codex-review F2: the set_content_mode frame is
-      // lost when toggled during a socket drop — the re-hello is the recovery
-      // path, so it must enforce, not just record). Absence = no-op (old panels
-      // never send the field; it must not clear a prior state).
-      {
-        const helloBlind = (event as { blind?: unknown }).blind;
-        if (helloBlind === true || helloBlind === false) {
-          const changed = helloBlind !== blindTabs.has(panelTab);
-          if (helloBlind) blindTabs.add(panelTab);
-          else blindTabs.delete(panelTab);
-          if (changed && manager.hasLiveAgent(agentKeyFor(panelTab))) {
-            manager.restartForMcpEnv(agentKeyFor(panelTab));
-            logger.info(
-              `[panel-orchestrator] tab ${panelTab.slice(0, 8)} blind=${String(helloBlind)} via hello — live agent respawn queued`,
-            );
-          }
-        }
-      }
       // Tab-id migration (issue #210): the BRIDGE stamps `migrated_from` on a
       // hello when the SAME socket re-helloed under a new tab id (panel update
       // changed the id scheme, e.g. random UUID → tmp:/wf:). That same-socket
@@ -2141,6 +2121,28 @@ export async function runPanelOrchestrator(): Promise<void> {
         tabBackends.delete(migratedFrom);
         headlessTabs.delete(migratedFrom);
         workflowTargets.clear(migratedFrom);
+      }
+      // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
+      // already carries the right tool-server env. A CHANGE against a live
+      // agent also respawns it (codex-review F2: the set_content_mode frame is
+      // lost when toggled during a socket drop — the re-hello is the recovery
+      // path, so it must enforce, not just record). Runs AFTER the migrated_from
+      // rebind so a simultaneous lost-toggle + tab-id migration still finds the
+      // (rebound) live agent (review note). Absence = no-op (old panels
+      // never send the field; it must not clear a prior state).
+      {
+        const helloBlind = (event as { blind?: unknown }).blind;
+        if (helloBlind === true || helloBlind === false) {
+          const changed = helloBlind !== blindTabs.has(panelTab);
+          if (helloBlind) blindTabs.add(panelTab);
+          else blindTabs.delete(panelTab);
+          if (changed && manager.hasLiveAgent(agentKeyFor(panelTab))) {
+            manager.restartForMcpEnv(agentKeyFor(panelTab));
+            logger.info(
+              `[panel-orchestrator] tab ${panelTab.slice(0, 8)} blind=${String(helloBlind)} via hello — live agent respawn queued`,
+            );
+          }
+        }
       }
       const prev = tabBackends.get(panelTab);
       if (prev && prev !== backend) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1286,6 +1286,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the same secrets — reach either provider.
   // A FUNCTION (not a frozen object) so it always reflects the CURRENT retargeted
   // comfyuiUrl/comfyuiPath — makeHttpBackendMcpServers calls it per (re)spawn.
+  // Tabs whose panel Blind toggle is ON (issue #90): their comfyui tool-server
+  // spawns get COMFYUI_MCP_BLIND=1 so image-returning tools withhold pixels
+  // mechanically. Seeded from `blind` on hello; toggled live via the
+  // set_content_mode frame (which respawns the tab's agent at idle so the new
+  // env applies). Keyed by tab id (the spawn is per tab, not per backend).
+  const blindTabs = new Set<string>();
+
   const comfyuiBaseEnv = (): Record<string, string> => ({
     COMFYUI_URL: comfyuiUrl,
     COMFYUI_MCP_PROGRESS_DIR: progressDir,
@@ -1353,7 +1360,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       args: [mcpEntry], // dist/index.js
       // Merge persisted tool secrets at SPAWN time so a respawn picks up a
       // just-saved CIVITAI_API_TOKEN / HF_TOKEN without a process restart.
-      env: buildComfyuiMcpEnv(comfyuiBaseEnv()),
+      // Blind tabs (issue #90) add COMFYUI_MCP_BLIND=1 so the tool server
+      // withholds image pixels from the model.
+      env: buildComfyuiMcpEnv({
+        ...comfyuiBaseEnv(),
+        ...(blindTabs.has(tabId) ? { COMFYUI_MCP_BLIND: "1" } : {}),
+      }),
     },
     // Live-graph panel_* tools for THIS tab over the loopback HTTP MCP.
     ...(panelMcpHttp
@@ -2059,6 +2071,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? ((event as { backend?: string }).backend as string).toLowerCase()
           : undefined;
       const backend = reqBackend && KNOWN_BACKENDS.has(reqBackend) ? reqBackend : defaultBackend;
+      // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
+      // already carries the right tool-server env — a toggle later goes through
+      // set_content_mode below.
+      if ((event as { blind?: unknown }).blind === true) blindTabs.add(panelTab);
+      else if ((event as { blind?: unknown }).blind === false) blindTabs.delete(panelTab);
       // Tab-id migration (issue #210): the BRIDGE stamps `migrated_from` on a
       // hello when the SAME socket re-helloed under a new tab id (panel update
       // changed the id scheme, e.g. random UUID → tmp:/wf:). That same-socket
@@ -2721,6 +2738,34 @@ export async function runPanelOrchestrator(): Promise<void> {
     // reaches this handler); the ack echoes it verbatim (plus
     // `requested_model`, the pre-guard id) so the client can resolve exactly
     // the attempt each ack answers. See options-ack.ts.
+    // Blind toggle (issue #90): record the tab's content mode and, when an
+    // agent is live, respawn it at idle so the comfyui tool server restarts
+    // with the new COMFYUI_MCP_BLIND env — the same coalesced restart path a
+    // saved secret uses. The session resumes; only the tool subprocess env
+    // changes.
+    if (event.type === "set_content_mode" && event.tab_id) {
+      const tabId = event.tab_id;
+      const nextBlind = (event as { blind?: unknown }).blind === true;
+      const changed = nextBlind !== blindTabs.has(tabId);
+      if (nextBlind) blindTabs.add(tabId);
+      else blindTabs.delete(tabId);
+      const key = agentKeyFor(tabId);
+      if (changed && manager.hasLiveAgent(key)) {
+        manager.restartForMcpEnv(key);
+        bridge.push(
+          {
+            type: "say",
+            text: nextBlind
+              ? "🕶️ Blind mode ON — the agent's image tools now withhold pixels (applies after the current turn; the session resumes automatically)."
+              : "👁️ Blind mode OFF — the agent's image tools deliver pixels again (applies after the current turn).",
+          },
+          tabId,
+        );
+      }
+      bridge.push({ type: "ack", ok: true, kind: "set_content_mode", blind: nextBlind }, tabId);
+      return;
+    }
+
     if (event.type === "set_options" && event.tab_id) {
       const tabId = event.tab_id;
       const meta = optionsRequestMeta(event as { cid?: unknown; model?: unknown });

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1196,6 +1196,15 @@ export class PanelAgentManager {
     }
   }
 
+  /** Single-tab variant of restartAllForMcpEnv — used when ONE tab's tool-server
+   *  spawn env changed (e.g. the Blind toggle, issue #90). Same coalesced
+   *  at-idle replacement; no-op when the tab has no live agent. */
+  restartForMcpEnv(key: string, nudge?: string): void {
+    if (!this.agents.has(key)) return;
+    this.pendingMcpRestart.set(key, nudge ?? null);
+    this.applyPendingRestarts(key);
+  }
+
   /**
    * Apply any deferred session-restart for a tab once it's idle — COALESCING a
    * pending effort change and a pending comfyui-MCP-env respawn into ONE

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1033,6 +1033,11 @@ export interface PanelAgentManagerOptions {
    *  undefined for a backend that hosts its panel_* tools out-of-process (codex/
    *  gemini use the loopback HTTP MCP instead of this in-process SDK server). */
   makePanelServer?: (tabId: string) => McpSdkServerConfigWithInstance | undefined;
+  /** Per-KEY mcpServers factory (key = tabId::backend). When provided it wins
+   *  over the static `mcpServers` for every spawn — required for per-tab spawn
+   *  env like the Blind content gate (panel issue #90): a static object shared
+   *  across tabs cannot express per-tab COMFYUI_MCP_BLIND. */
+  makeMcpServers?: (key: string) => Options["mcpServers"];
   /** Bundled plugin dir whose skills make the agent an expert (optional). */
   pluginPath?: string;
   /**
@@ -1118,7 +1123,9 @@ export class PanelAgentManager {
     // PanelAgent constructor defaults to ClaudeBackend (existing behavior).
     const backend = this.opts.makeBackend?.(tabId);
     return new PanelAgent(tabId, {
-      mcpServers: this.opts.mcpServers,
+      // The factory (fresh per spawn — re-reads closures AND per-tab state like
+      // the Blind gate) wins over the static set (kept for tests/back-compat).
+      mcpServers: this.opts.makeMcpServers?.(tabId) ?? this.opts.mcpServers,
       comfyuiUrl: this.opts.comfyuiUrl,
       systemAppend: this.opts.systemAppend,
       model: this.modelFor(tabId),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -117,12 +117,69 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["custom-nodes", registerNodeDevTools],
 ];
 
+// ── Blind content mode (panel issue #90) ────────────────────────────────────
+// When COMFYUI_MCP_BLIND=1 (set on the tool-server spawn by the orchestrator
+// for tabs whose panel Blind toggle is ON), NO tool may deliver image pixels
+// to the model. Enforced MECHANICALLY at the single registration boundary both
+// tool paths share — the live McpServer and the compact-mode ToolCatalog both
+// receive handlers wrapped here — so the guarantee holds for every current and
+// future image-returning tool (get_image, view_image, convert_image, color
+// analysis previews, ...) without per-tool opt-ins.
+const blindMode = (): boolean => process.env.COMFYUI_MCP_BLIND === "1";
+
+function scrubImageBlocks(result: unknown): unknown {
+  if (!result || typeof result !== "object") return result;
+  const r = result as { content?: Array<Record<string, unknown>> };
+  if (!Array.isArray(r.content)) return result;
+  let scrubbed = 0;
+  const content = r.content.map((block) => {
+    if (!block || block.type !== "image") return block;
+    scrubbed++;
+    const bytes = typeof block.data === "string" ? Math.round((block.data.length * 3) / 4) : 0;
+    const size = bytes ? `${Math.max(1, Math.round(bytes / 1024))} KB, ` : "";
+    return {
+      type: "text" as const,
+      text:
+        `[Blind mode: image withheld (${size}${String(block.mimeType ?? "image")}). ` +
+        "The user's Blind setting means you NEVER receive image pixels — work from " +
+        "filenames/metadata, and tell the user to inspect the image themselves if it matters.]",
+    };
+  });
+  if (!scrubbed) return result;
+  return { ...r, content };
+}
+
+/** Wrap a registrar so every tool handler enforces Blind mode on its RESULT.
+ *  Works for both the live McpServer and ToolCatalog.asRegistrar() (the compact
+ *  call_tool router) — each captures/registers the wrapped handler. */
+function withBlindImageGate(server: McpServer): McpServer {
+  const orig = (server as unknown as { tool: (...args: unknown[]) => unknown }).tool.bind(server);
+  const tool = (...args: unknown[]): unknown => {
+    const handler = args[args.length - 1];
+    if (typeof handler === "function") {
+      const wrapped = async (...hargs: unknown[]) => {
+        const result = await (handler as (...a: unknown[]) => unknown)(...hargs);
+        return blindMode() ? scrubImageBlocks(result) : result;
+      };
+      return orig(...args.slice(0, -1), wrapped);
+    }
+    return orig(...args);
+  };
+  return new Proxy(server, {
+    get(target, prop, receiver) {
+      if (prop === "tool") return tool;
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as McpServer;
+}
+
 export async function registerAllTools(server: McpServer): Promise<void> {
   // Hydrate persisted defaults before any tool registration so subsequent
   // tools can consult DefaultsManager.apply() against a fully-resolved view.
   await DefaultsManager.load();
-  for (const [, register] of TOOL_GROUPS) register(server);
-  await registerAutoloadedWorkflows(server);
+  const gated = withBlindImageGate(server);
+  for (const [, register] of TOOL_GROUPS) register(gated);
+  await registerAutoloadedWorkflows(gated);
 }
 
 /**
@@ -133,7 +190,7 @@ export async function registerAllTools(server: McpServer): Promise<void> {
 export async function collectToolCatalog(): Promise<ToolCatalog> {
   await DefaultsManager.load();
   const catalog = new ToolCatalog();
-  const registrar = catalog.asRegistrar();
+  const registrar = withBlindImageGate(catalog.asRegistrar());
   for (const [category, register] of TOOL_GROUPS) {
     catalog.setCategory(category);
     register(registrar);


### PR DESCRIPTION
The panel's Blind toggle promised "the agent NEVER receives the image pixels" but only gated the panel's own image feed — `get_image`/`view_image` hit ComfyUI's `/view` directly and returned pixels regardless (panel #90).

## Mechanical enforcement
- Blind tabs spawn their comfyui tool server with `COMFYUI_MCP_BLIND=1`; ONE wrapper at the tool-registration boundary (shared by the live McpServer AND the compact call_tool router) replaces every image content block with an honest "[Blind mode: image withheld (N KB, mime)]" note — every current and future image-returning tool covered, no per-tool opt-ins.
- Panel rides `blind` on hello + a new `set_content_mode` frame; a live toggle respawns the tab's agent at idle via the coalesced pendingMcpRestart path. Server-side strips at the injection boundaries (render events, composer attachments — mirror clients have no Blind concept). Screenshots refuse panel-side.

## Review (2 rounds, Claude adversarial)
Round 1 found a MAJOR: the Claude (default) backend used a static shared mcpServers object and bypassed the gate entirely — fixed with a per-key `makeMcpServers` factory, plus hello-as-recovery-path enforcement, server-side image strips, and an old-orchestrator warning. Round 2: **CLEAN**, with the migration-ordering informational note also fixed.

## Verification
- Unit: boundary wrapper on both registration paths (scrub + control); suites 1465/67 green
- Tool-server E2E: blind spawn → get_image text-only withheld; control spawn → pixels
- Wire E2E: hello blind → compact call_tool withheld → live toggle → ack + at-idle respawn → delivers again
- **Claude-path E2E** (the round-1 leak): withheld note returned through a real Claude agent

Pairs with comfyui-mcp-panel#96. Ships in v0.42.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)