### PR TITLE
fix(diagnostics): steer failure-diagnosis to diagnose_run over get_history

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -213,9 +213,10 @@ const HEADLESS_DIRECTIVE =
   "enqueuing returns a prompt_id immediately, so wait for it with get_job_status(prompt_id) — poll it briefly until " +
   "it reports completion (this is the ONE case where polling IS correct) — then fetch the output with get_history and " +
   "show it with panel_show_media. Do NOT end your turn expecting an automatic notification; none will arrive. " +
-  "If the run FAILED — or the user asks why a render failed / what's missing — call diagnose_run: it names the failed " +
-  "node with its exception, plus any missing models (exact file + the widget holding it) and missing node types, in one " +
-  "call. It is the canvas-less equivalent of the panel's \"why is this red?\", so do NOT try panel_view_errored_nodes here.";
+  "If the run FAILED — or the user asks why a render failed / what's missing — call diagnose_run FIRST, and do NOT use " +
+  "get_history for that: diagnose_run returns everything get_history would (failed node + exception + traceback) PLUS the " +
+  "missing models (exact file + the widget holding it) and missing node types that get_history omits, in one call. It is " +
+  "the canvas-less equivalent of the panel's \"why is this red?\", so also do NOT try panel_view_errored_nodes here.";
 
 /** Live stall threshold (seconds) pushed from the panel setting via a `set_config`
  *  frame — applies WITHOUT a reconnect. null = not set, fall back to env then the

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -189,7 +189,7 @@ export function registerDiagnosticsTools(server: McpServer): void {
 
   server.tool(
     "get_history",
-    "Get execution history for a ComfyUI prompt. Returns status, timing, cached nodes, output details, and full error information including Python tracebacks. Use after a failed enqueue_workflow to diagnose what went wrong.",
+    "Get execution history for a ComfyUI prompt: status, timing, cached nodes, and output details (media filenames for get_image). Also carries the raw error/traceback. To diagnose WHY a run FAILED or what's missing, prefer `diagnose_run` — it returns the same failure info PLUS missing models (with the file + widget) and missing node types, which this tool does not. Use get_history when you need the run's OUTPUTS or timing for a specific prompt_id.",
     {
       prompt_id: z
         .string()


### PR DESCRIPTION
Follow-up to #243. That PR merged the `diagnose_run` tool, but the **steering fix landed on the branch *after* the squash-merge**, so main shipped the tool while the agent still preferred `get_history` for failures — i.e. the feature is in main but effectively dormant.

## Why this matters (found by live testing)

I staged a real failed run and asked the headless agent (the mobile wire path) *"why did my last render fail?"*. It answered correctly — but via **`get_history`, not `diagnose_run`**. Cause: `get_history`'s own description claimed the diagnosis role (*"Use after a failed enqueue_workflow to diagnose what went wrong"*), so the model reached for the tool it already knew.

For that runtime `TypeError` `get_history` sufficed, but a **missing-model** failure would silently lose the download/widget analysis that is the entire reason `diagnose_run` exists.

## The fix

- `get_history` description now **defers failure-diagnosis to `diagnose_run`** and scopes itself to a prompt's outputs/timing.
- `HEADLESS_DIRECTIVE` now says **call `diagnose_run` FIRST, not `get_history`** for a failure (diagnose_run returns everything get_history would PLUS missing models/nodes).

No logic change — description/prompt strings only.

## Verified live

After the change, over the same failed run on the same headless bridge:
- **before:** `actions: ToolSearch, get_history`
- **after:** `actions: diagnose_run` — and the answer carries diagnose_run's signature line: *"the graph validates clean, so this isn't a missing-model or missing-node problem. It's a runtime type mismatch."*

`tsc` clean; the diagnose_run unit tests pass unchanged (this touches only descriptions).