### PR TITLE
fix(outputs): surface text-preview node results to the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### MCP
+
+#### Fixed
+- **Text-preview node results are no longer invisible to the agent.** Nodes like
+  *Preview as Text* / `PreviewAny` / `ShowText` write no file — they publish into
+  the node's `ui` dict, which ComfyUI stores under `outputs[nodeId].text`. We only
+  ever harvested `images` / `videos` from history, so caption, prompt-builder and
+  other LLM-text workflows completed with **nothing for the agent to read**: it
+  would say it was going to report the text back, then have nothing to report.
+  History analysis now also extracts text, and it surfaces as `text_outputs` on
+  both `get_job_status` and the job-watcher completion record (omitted entirely
+  for image-only runs). Tolerates the shapes seen in the wild — `{text:[…]}`,
+  `{text:"…"}`, and packs that use `string` — and the parser is pinned by a
+  regression test using a payload captured verbatim from a live ComfyUI run.
+  (reported by seanmcmagic)
+
 ## [0.43.0] - 2026-07-20
 
 ### MCP

--- a/src/__tests__/services/job-history.test.ts
+++ b/src/__tests__/services/job-history.test.ts
@@ -4,6 +4,7 @@ import {
   analyzeHistoryEntry,
   extractExecutionError,
   extractExecutionStats,
+  extractTextOutputs,
 } from "../../services/job-history.js";
 
 function historyEntry(messages: unknown): HistoryEntry {
@@ -40,5 +41,92 @@ describe("job-history malformed message parsing", () => {
     expect(extractExecutionError(entry)).toBeUndefined();
     expect(extractExecutionStats(entry)).toBeUndefined();
     expect(analyzeHistoryEntry(entry)).toEqual({});
+  });
+});
+
+// ── Text-preview outputs ────────────────────────────────────────────────
+// Text-preview nodes (Preview as Text / ShowText / pack equivalents) write no
+// file — they publish into the node's `ui` dict, which /history stores under
+// outputs[nodeId]. We only harvested images/videos, so text workflows finished
+// with nothing for the agent to report (help-thread report from seanmcmagic).
+
+function outputsEntry(outputs: Record<string, unknown>): HistoryEntry {
+  return {
+    prompt: {},
+    outputs,
+    status: { status_str: "success", completed: true, messages: [] },
+  } as unknown as HistoryEntry;
+}
+
+describe("extractTextOutputs", () => {
+  it("extracts the common { text: [string] } shape", () => {
+    const entry = outputsEntry({ "7": { text: ["a caption"] } });
+    expect(extractTextOutputs(entry)).toEqual([{ node_id: "7", text: ["a caption"] }]);
+  });
+
+  it("accepts a bare string and the `string` key variant", () => {
+    expect(extractTextOutputs(outputsEntry({ "1": { text: "hello" } }))).toEqual([
+      { node_id: "1", text: ["hello"] },
+    ]);
+    expect(extractTextOutputs(outputsEntry({ "2": { string: ["packy"] } }))).toEqual([
+      { node_id: "2", text: ["packy"] },
+    ]);
+  });
+
+  it("stringifies non-string scalars and drops empty strings", () => {
+    const entry = outputsEntry({ "3": { text: ["", 42, true, "keep"] } });
+    expect(extractTextOutputs(entry)).toEqual([{ node_id: "3", text: ["42", "true", "keep"] }]);
+  });
+
+  it("collects text from multiple nodes and ignores image-only nodes", () => {
+    const entry = outputsEntry({
+      "5": { images: [{ filename: "a.png", subfolder: "", type: "output" }] },
+      "6": { text: ["from six"] },
+      "8": { text: ["from eight"] },
+    });
+    expect(extractTextOutputs(entry)).toEqual([
+      { node_id: "6", text: ["from six"] },
+      { node_id: "8", text: ["from eight"] },
+    ]);
+  });
+
+  it("returns nothing for image-only, empty, or malformed outputs", () => {
+    expect(extractTextOutputs(outputsEntry({ "5": { images: [] } }))).toEqual([]);
+    expect(extractTextOutputs(outputsEntry({ "5": { text: [] } }))).toEqual([]);
+    expect(extractTextOutputs(outputsEntry({ "5": { text: [""] } }))).toEqual([]);
+    expect(extractTextOutputs(outputsEntry({ "5": null as unknown as object }))).toEqual([]);
+    expect(extractTextOutputs({ prompt: {}, status: {} } as unknown as HistoryEntry)).toEqual([]);
+  });
+});
+
+describe("analyzeHistoryEntry text_outputs", () => {
+  it("surfaces text_outputs when the run produced text", () => {
+    const entry = outputsEntry({ "7": { text: ["reported back"] } });
+    expect(analyzeHistoryEntry(entry).text_outputs).toEqual([
+      { node_id: "7", text: ["reported back"] },
+    ]);
+  });
+
+  it("omits text_outputs entirely for an image-only run", () => {
+    const entry = outputsEntry({
+      "9": { images: [{ filename: "a.png", subfolder: "", type: "output" }] },
+    });
+    expect(analyzeHistoryEntry(entry).text_outputs).toBeUndefined();
+    expect("text_outputs" in analyzeHistoryEntry(entry)).toBe(false);
+  });
+});
+
+describe("extractTextOutputs — real ComfyUI payload", () => {
+  // Captured verbatim from a live ComfyUI run (StringConstant -> PreviewAny) on
+  // 2026-07-20. Locks the on-the-wire shape so a future refactor can't silently
+  // stop reading text-preview results.
+  it("reads the exact /history payload PreviewAny produces", () => {
+    const entry = outputsEntry({ "2": { text: ["TEXT-PREVIEW-PROOF-42"] } });
+    expect(extractTextOutputs(entry)).toEqual([
+      { node_id: "2", text: ["TEXT-PREVIEW-PROOF-42"] },
+    ]);
+    expect(analyzeHistoryEntry(entry).text_outputs).toEqual([
+      { node_id: "2", text: ["TEXT-PREVIEW-PROOF-42"] },
+    ]);
   });
 });

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -19,9 +19,18 @@ export interface ExecutionStats {
   nodes: Record<string, { duration_ms: number }>;
 }
 
+/** Text produced by a preview/show-text node, keyed by the node that emitted it. */
+export interface TextOutput {
+  node_id: string;
+  text: string[];
+}
+
 export interface HistoryAnalysis {
   error?: ExecutionErrorDetails;
   execution_stats?: ExecutionStats;
+  /** Present only when the run actually produced text (omitted otherwise so
+   *  image-only runs don't carry an empty array around). */
+  text_outputs?: TextOutput[];
 }
 
 export type HistoryStatusMessage = readonly [string, Record<string, unknown>];
@@ -165,9 +174,56 @@ export function extractExecutionStats(
   };
 }
 
+/**
+ * Pull TEXT results out of a finished run.
+ *
+ * Text-preview nodes (ComfyUI's "Preview as Text", ShowText, and the many pack
+ * equivalents) have no file on disk — they publish their result into the node's
+ * `ui` dict, which is exactly what /history stores under
+ * `outputs[nodeId]`. We only ever harvested `images` / `videos` there, so an
+ * LLM-caption / prompt-builder / text workflow completed with the agent seeing
+ * NOTHING — it would say it was going to report back and then have nothing to
+ * report (help-thread report from seanmcmagic).
+ *
+ * Shapes in the wild: `{ text: ["hi"] }` (the common one), `{ text: "hi" }`, and
+ * packs that use `string` instead of `text`. Non-string scalars are stringified;
+ * empty strings are dropped so a node that emitted nothing stays absent.
+ */
+export function extractTextOutputs(entry: HistoryEntry): TextOutput[] {
+  const results: TextOutput[] = [];
+  const outputs = (entry as { outputs?: Record<string, unknown> }).outputs;
+  if (!outputs || typeof outputs !== "object") return results;
+
+  for (const [nodeId, nodeOutput] of Object.entries(outputs)) {
+    if (!nodeOutput || typeof nodeOutput !== "object") continue;
+    const record = nodeOutput as Record<string, unknown>;
+    const text: string[] = [];
+
+    for (const key of ["text", "string"] as const) {
+      const value = record[key];
+      if (typeof value === "string") {
+        if (value.length > 0) text.push(value);
+      } else if (Array.isArray(value)) {
+        for (const item of value) {
+          if (typeof item === "string") {
+            if (item.length > 0) text.push(item);
+          } else if (typeof item === "number" || typeof item === "boolean") {
+            text.push(String(item));
+          }
+        }
+      }
+    }
+
+    if (text.length > 0) results.push({ node_id: nodeId, text });
+  }
+  return results;
+}
+
 export function analyzeHistoryEntry(entry: HistoryEntry): HistoryAnalysis {
+  const text_outputs = extractTextOutputs(entry);
   return {
     error: extractExecutionError(entry),
     execution_stats: extractExecutionStats(entry),
+    ...(text_outputs.length > 0 ? { text_outputs } : {}),
   };
 }

--- a/src/services/job-watcher.ts
+++ b/src/services/job-watcher.ts
@@ -21,6 +21,7 @@ import {
   normalizeHistoryMessages,
   type ExecutionStats,
   type ExecutionErrorDetails,
+  type TextOutput,
 } from "./job-history.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -63,6 +64,9 @@ export interface CompletionNotification {
     node_id: string;
     videos: MediaOutput[];
   }>;
+  /** Text emitted by preview/show-text nodes — no file on disk, so it would
+   *  otherwise be invisible to whoever reads this completion record. */
+  text_outputs?: TextOutput[];
   cached_nodes: string[];
   execution_stats?: ExecutionStats;
 }
@@ -234,6 +238,7 @@ export function buildCompletionNotification(
     error,
     outputs,
     video_outputs,
+    ...(analysis.text_outputs ? { text_outputs: analysis.text_outputs } : {}),
     cached_nodes: cachedNodes,
     execution_stats: analysis.execution_stats,
   };
@@ -334,6 +339,7 @@ async function handleCompletion(
         (n, o) => n + o.videos.length,
         0,
       ),
+      text_nodes: notification.text_outputs?.length ?? 0,
     });
   } catch (err) {
     logger.error("Failed to write completion file", {

--- a/src/services/queue-manager.ts
+++ b/src/services/queue-manager.ts
@@ -13,7 +13,12 @@ import { isCloudMode } from "../config.js";
 import type { QueueItem, WorkflowJSON } from "../comfyui/types.js";
 import { logger } from "../utils/logger.js";
 import { ComfyUIError, ValidationError } from "../utils/errors.js";
-import { analyzeHistoryEntry, type ExecutionErrorDetails, type ExecutionStats } from "./job-history.js";
+import {
+  analyzeHistoryEntry,
+  type ExecutionErrorDetails,
+  type ExecutionStats,
+  type TextOutput,
+} from "./job-history.js";
 import { JobWatcher } from "./job-watcher.js";
 
 export interface QueueSummary {
@@ -49,6 +54,10 @@ export interface JobStatus {
   status_str?: string;
   error?: ExecutionErrorDetails;
   execution_stats?: ExecutionStats;
+  /** Text emitted by preview/show-text nodes (Preview as Text, ShowText, …).
+   *  These write no file, so without this a text-producing workflow finishes
+   *  with nothing for the agent to report. Omitted when the run produced none. */
+  text_outputs?: TextOutput[];
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -287,6 +296,7 @@ export async function getJobStatus(
       status_str: entry.status.status_str,
       error: analysis.error,
       execution_stats: analysis.execution_stats,
+      ...(analysis.text_outputs ? { text_outputs: analysis.text_outputs } : {}),
     };
   } catch (err) {
     logger.warn("Could not enrich job status from history", {

--- a/src/tools/queue-management.ts
+++ b/src/tools/queue-management.ts
@@ -114,7 +114,7 @@ export function registerQueueManagementTools(server: McpServer): void {
 
   server.tool(
     "get_job_status",
-    "Check the status of ONE ComfyUI job by its prompt_id (the id returned by enqueue_workflow). Queries the connected ComfyUI server; requires it to be running. Returns JSON with running, pending, and done booleans, plus optional status_str, error details, and execution_stats from ComfyUI history once the job is done. Use get_queue to see the whole queue at once, and get_history for full output filenames.",
+    "Check the status of ONE ComfyUI job by its prompt_id (the id returned by enqueue_workflow). Queries the connected ComfyUI server; requires it to be running. Returns JSON with running, pending, and done booleans, plus optional status_str, error details, and execution_stats from ComfyUI history once the job is done. Also returns text_outputs when the workflow contained text-preview nodes (Preview as Text, ShowText, …) — those produce no image file, so this is the ONLY way to read their result; report that text back to the user. Use get_queue to see the whole queue at once, and get_history for full output filenames.",
     {
       prompt_id: z.string().describe("The prompt ID returned by enqueue_workflow"),
     },


### PR DESCRIPTION
## The bug

Text-preview nodes — *Preview as Text*, core `PreviewAny`, `ShowText|pysssss`, and the many pack equivalents — **write no file**. They publish their result into the node's `ui` dict, which ComfyUI stores in `/history` under `outputs[<nodeId>].text`.

We only ever harvested `images` and `videos` from that structure. So a caption / prompt-builder / LLM-text workflow ran to completion and the agent saw **nothing** — it would tell the user it was going to report the text back, then have nothing to report.

Reported by **seanmcmagic** in the help channel.

## The fix

Extraction goes into `analyzeHistoryEntry()`, which is the shared history analyzer already feeding *both* agent-facing readers — so one change surfaces text on both:

- **`get_job_status`** → new `text_outputs` field (and the tool description now tells the agent to report that text back to the user)
- **job-watcher completion record** → same `text_outputs` field, plus a `text_nodes` count in the completion log

`text_outputs` is **omitted entirely** when a run produced no text, so image-only runs don't start carrying an empty array around.

Tolerates the shapes actually seen in the wild:

| shape | source |
|---|---|
| `{ text: ["…"] }` | the common one (PreviewAny, ShowText) |
| `{ text: "…" }` | bare string |
| `{ string: […] }` | some packs |

Non-string scalars are stringified; empty strings are dropped so a node that emitted nothing stays absent.

## Verification

Rather than trusting the docs, I ran it against a **live ComfyUI**: a `StringConstant → PreviewAny` workflow, which returned exactly

```json
{ "2": { "text": ["TEXT-PREVIEW-PROOF-42"] } }
```

That payload is pinned as a regression test so a future refactor can't silently stop reading text-preview results.

- 8 new tests (shape variants, multi-node, image-only omission, malformed input, real-payload fixture)
- Full suite **134 files / 1537 tests green**, `tsc --noEmit` clean