### PR TITLE
fix(orchestrator): a per-tab start failure can never self-exit the orchestrator

### DIFF
--- a/src/__tests__/orchestrator/start-failure-per-tab.test.ts
+++ b/src/__tests__/orchestrator/start-failure-per-tab.test.ts
@@ -1,0 +1,226 @@
+// Issue #250 — a backend whose prepare() rejects at agent start (e.g. an
+// OpenAI-dialect provider 401ing on an invalid API key) must degrade THAT TAB
+// ONLY. Before the fix, the manager routed every start failure to onAgentFatal,
+// which the orchestrator wires to a process-wide self-exit ("closing the bridge
+// so a fresh orchestrator can take over") — killing every OTHER tab too,
+// including healthy sessions on different providers.
+//
+// Contract under test:
+//  (a) a start failure must NOT fire onAgentFatal (no self-exit) and must not
+//      disturb another tab's live agent;
+//  (b) it produces the per-tab degraded notification (onStartFailure when
+//      wired, else the onSay fallback);
+//  (c) the tab's slot stays RECOVERABLE: after the user fixes the key, a new
+//      send on the SAME tab spawns a fresh agent that works;
+//  (d) the genuinely process-level path is preserved: the bounded self-restart
+//      give-up ("session keeps ending immediately") still fires onAgentFatal.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A backend whose prepare() rejects — the #250 repro: OllamaBackend.prepare()
+ *  throwing `endpoint ... rejected the key (http 401)` on an invalid key. */
+class Rejecting401Backend implements AgentBackend {
+  readonly id = "moonshot" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  prepareCalls = 0;
+
+  async prepare(): Promise<void> {
+    this.prepareCalls += 1;
+    throw new Error("endpoint https://api.moonshot.ai/v1 rejected the key (http 401)");
+  }
+
+  // eslint-disable-next-line require-yield
+  async *run(): AsyncGenerator<AgentEvent> {
+    throw new Error("run() must never be reached when prepare() rejects");
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** A healthy backend that records turns and completes them immediately. */
+class HealthyBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+  turnTexts: string[] = [];
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    yield { type: "session", sessionId: `sess-${this.runCount}` };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** A backend whose session ends IMMEDIATELY every time — drives the bounded
+ *  self-restart loop to its give-up threshold (the genuinely fatal path). */
+class InstantlyDroppingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+
+  // eslint-disable-next-line require-yield
+  async *run(): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    // Return immediately: "session ended" with zero events.
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+interface Recorded {
+  says: Array<{ tab: string; text: string }>;
+  startFailures: Array<{ tab: string; message: string }>;
+  fatals: Array<{ tab: string; reason: string }>;
+}
+
+function makeManager(
+  makeBackend: (key: string) => AgentBackend | undefined,
+  opts: { wireStartFailure?: boolean } = {},
+): { manager: InstanceType<typeof PanelAgentManager>; rec: Recorded } {
+  const rec: Recorded = { says: [], startFailures: [], fatals: [] };
+  const manager = new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: (tab: string, text: string) => rec.says.push({ tab, text }),
+    onTurn: () => {},
+    makeBackend,
+    ...(opts.wireStartFailure === false
+      ? {}
+      : {
+          onStartFailure: (tab: string, message: string) =>
+            rec.startFailures.push({ tab, message }),
+        }),
+    onAgentFatal: (tab: string, reason: string) => rec.fatals.push({ tab, reason }),
+  } as never);
+  return { manager, rec };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("per-tab start failure (issue #250)", () => {
+  it("a 401 in prepare() degrades ONLY that tab: onStartFailure fires, onAgentFatal does NOT, and another tab keeps working", async () => {
+    const bad = new Rejecting401Backend();
+    const good = new HealthyBackend();
+    const badTab = "tab-moonshot::moonshot";
+    const goodTab = "tab-claude::claude";
+    const { manager, rec } = makeManager((key) => (key === badTab ? bad : good));
+
+    // Healthy tab first — it must survive the other tab's start failure.
+    manager.send(goodTab, "hello healthy");
+    await waitFor(() => good.turnTexts.length >= 1);
+
+    // Bad-key tab: prepare() rejects with the 401.
+    manager.send(badTab, "hello moonshot");
+    await waitFor(() => rec.startFailures.length >= 1);
+
+    // (b) the per-tab degraded notification carries the honest error…
+    expect(rec.startFailures[0]!.tab).toBe(badTab);
+    expect(rec.startFailures[0]!.message).toMatch(/rejected the key \(http 401\)/);
+    // …and (a) NOTHING escalated to the process-fatal path (the old behavior
+    // called onAgentFatal("agent failed to start") → orchestrator self-exit).
+    expect(rec.fatals).toHaveLength(0);
+    // The dead agent was dropped — the slot is empty, not wedged.
+    expect(manager.hasLiveAgent(badTab)).toBe(false);
+
+    // The HEALTHY tab is untouched: still live, still processes turns.
+    expect(manager.hasLiveAgent(goodTab)).toBe(true);
+    manager.send(goodTab, "still alive?");
+    await waitFor(() => good.turnTexts.length >= 2);
+    expect(good.turnTexts).toContain("still alive?");
+    expect(rec.fatals).toHaveLength(0);
+
+    await manager.stopAll();
+  });
+
+  it("without onStartFailure wired, falls back to a per-tab onSay — still no onAgentFatal", async () => {
+    const bad = new Rejecting401Backend();
+    const { manager, rec } = makeManager(() => bad, { wireStartFailure: false });
+    const tab = "tab-glm::glm";
+
+    manager.send(tab, "hi");
+    await waitFor(() => rec.says.some((s) => s.text.includes("could not start")));
+
+    const say = rec.says.find((s) => s.text.includes("could not start"))!;
+    expect(say.tab).toBe(tab);
+    expect(say.text).toMatch(/^⚠️/);
+    expect(say.text).toMatch(/http 401/);
+    expect(rec.fatals).toHaveLength(0);
+
+    await manager.stopAll();
+  });
+
+  it("the tab is RECOVERABLE: after the key is fixed, a new send on the SAME tab starts a working agent", async () => {
+    const bad = new Rejecting401Backend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const tab = "tab-moonshot::moonshot";
+
+    // First attempt: bad key → per-tab failure, slot cleared.
+    manager.send(tab, "first try");
+    await waitFor(() => rec.startFailures.length >= 1);
+    expect(manager.hasLiveAgent(tab)).toBe(false);
+
+    // User fixes the key (factory now builds a healthy backend) and retries.
+    keyFixed = true;
+    manager.send(tab, "second try");
+    await waitFor(() => good.turnTexts.length >= 1);
+    expect(good.turnTexts).toContain("second try");
+    expect(manager.hasLiveAgent(tab)).toBe(true);
+    // Still no fatal escalation anywhere in the sequence.
+    expect(rec.fatals).toHaveLength(0);
+
+    await manager.stopAll();
+  });
+
+  it("PRESERVED: the bounded self-restart give-up still routes to onAgentFatal (process-level)", async () => {
+    const dropping = new InstantlyDroppingBackend();
+    const { manager, rec } = makeManager(() => dropping);
+    const tab = "tab-drop::claude";
+
+    manager.send(tab, "hello");
+    // 4 immediate session drops (~250ms apart) trip the give-up threshold.
+    await waitFor(() => rec.fatals.length >= 1, 10_000);
+
+    expect(rec.fatals[0]!.tab).toBe(tab);
+    expect(rec.fatals[0]!.reason).toMatch(/self-restart gave up/);
+    // The give-up is NOT a start failure — the per-tab path must not have fired.
+    expect(rec.startFailures).toHaveLength(0);
+
+    await manager.stopAll();
+  }, 15_000);
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1745,6 +1745,11 @@ export async function runPanelOrchestrator(): Promise<void> {
         panelTab,
       );
       bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
+      // The user_message path already pushed turn:"working", and the panel
+      // clears its thinking spinner ONLY on turn:"done" — without this the
+      // degraded tab sits on a live spinner for the 120s safety timeout
+      // (adversarial review of #253, finding 1).
+      bridge.push({ type: "turn", state: "done" }, panelTab);
       logger.warn(
         `[panel-orchestrator] tab ${panelTab.slice(0, 8)} (${backend}) agent failed to start — degraded THIS tab only, other tabs unaffected (${message})`,
       );

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1719,13 +1719,45 @@ export async function runPanelOrchestrator(): Promise<void> {
     onSeen: (key, mid) => {
       bridge.push({ type: "ack", ok: true, kind: "seen", mid }, panelTabOf(key));
     },
+    // PER-TAB start failure (issue #250): a backend that rejects at
+    // prepare()/first-connect — an invalid API key 401ing on an OpenAI-dialect
+    // provider (moonshot/glm/custom/openrouter), an unreachable endpoint — is a
+    // tab-local configuration error, the same class as the keyless ctor path
+    // (#209), one step later. Degrade THAT tab only: an honest say naming the
+    // provider with check-your-key guidance, plus a degraded ack so the panel
+    // shows the real state. The manager already dropped the dead agent, so
+    // fixing the key and Disconnect → Connect (or just re-sending) retries
+    // cleanly. This must NOT self-exit — a bad moonshot key on one tab was
+    // killing healthy sessions on every other tab.
+    onStartFailure: (key, message) => {
+      const backend = backendOf(key);
+      const panelTab = panelTabOf(key);
+      const reg = openAiKeyProvider(backend);
+      const hint = reg
+        ? `Check your ${reg.slotLabel} API key in the API Keys card (${reg.envKeys[0]}), then Disconnect → Connect to retry.`
+        : backend === "openrouter"
+          ? "Check your OpenRouter API key in the API Keys card (OPENROUTER_API_KEY), then Disconnect → Connect to retry."
+          : backend === "custom"
+            ? "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry."
+            : "Check the provider's credentials/login, then Disconnect → Connect to retry.";
+      bridge.push(
+        { type: "say", text: `⚠️ The ${backend} agent could not start: ${message} — ${hint}` },
+        panelTab,
+      );
+      bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
+      logger.warn(
+        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} (${backend}) agent failed to start — degraded THIS tab only, other tabs unaffected (${message})`,
+      );
+    },
     // ROOT-CAUSE self-exit (the "bridge open but no panel agent responded" wedge):
-    // a tab's agent died fatally (couldn't start, or its bounded self-restart gave
-    // up). The orchestrator is alive and the bridge is up, but no agent will ever
-    // handshake — exactly the wedge. Exit cleanly so the panel pack's bridge-death
-    // → reclaim + sticky-reconnect respawns a FRESH orchestrator, instead of
-    // leaving the user staring at the manual "fully restart ComfyUI" warning.
-    // Mirrors the uncaughtException exit above (Node's own default on a fatal).
+    // a tab's agent died fatally — its bounded self-restart loop gave up (the
+    // session kept dropping immediately). The orchestrator is alive and the
+    // bridge is up, but no agent will ever handshake — exactly the wedge. Exit
+    // cleanly so the panel pack's bridge-death → reclaim + sticky-reconnect
+    // respawns a FRESH orchestrator, instead of leaving the user staring at the
+    // manual "fully restart ComfyUI" warning. Mirrors the uncaughtException exit
+    // above (Node's own default on a fatal). Start failures no longer route here
+    // (issue #250) — they degrade per-tab via onStartFailure above.
     onAgentFatal: (tabId, reason) => {
       requestSelfExit(`tab ${tabId.slice(0, 8)} ${reason}`);
     },

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1048,14 +1048,28 @@ export interface PanelAgentManagerOptions {
    */
   makeBackend?: (tabId: string) => AgentBackend | undefined;
   /**
-   * Fired when a tab's agent dies FATALLY — either it failed to start (hard
-   * reject from backend.prepare/run) or its bounded self-restart loop gave up
+   * Fired when a tab's agent FAILED TO START — a hard reject from
+   * backend.prepare()/run before any session existed (e.g. an OpenAI-dialect
+   * provider rejecting an invalid API key with a 401, or an unreachable
+   * endpoint). This is a PER-TAB, recoverable condition (issue #250): the
+   * manager has already dropped the dead agent, so once the user fixes the
+   * credentials the next message / Disconnect → Connect on the SAME tab spawns
+   * a fresh agent. The orchestrator should degrade THAT tab (honest say +
+   * degraded ack) and must NOT self-exit — a bad key on one tab used to take
+   * down every other tab. When absent, the manager falls back to a generic
+   * onSay notice (still per-tab, still no fatal escalation).
+   */
+  onStartFailure?: (tabId: string, message: string) => void;
+  /**
+   * Fired when a tab's agent dies FATALLY: its bounded self-restart loop gave up
    * (the session kept dropping immediately). This is the "agent backend is dead"
    * signal: the orchestrator is alive and the bridge is up, but no agent will
    * ever handshake. The orchestrator wires this to a clean self-exit so the panel
    * pack's bridge-death → reclaim + sticky-reconnect path respawns a FRESH
    * orchestrator, instead of leaving the user wedged on "bridge open but no panel
    * agent responded". `reason` is a short human label for the log.
+   * NOTE (issue #250): plain start failures no longer route here — they are
+   * per-tab configuration errors handled by onStartFailure above.
    */
   onAgentFatal?: (tabId: string, reason: string) => void;
   /**
@@ -1313,11 +1327,16 @@ export class PanelAgentManager {
       if (err) {
         const m = msgOf(err);
         logger.error(`[panel-agent ${tabId.slice(0, 8)}] failed to start: ${m}`);
-        this.opts.onSay(tabId, `⚠️ The panel agent could not start: ${m}`);
-        // Hard start failure (e.g. the codex app-server can't spawn/handshake, the
-        // Claude SDK can't init) → fatal: the orchestrator should exit so a fresh
-        // one is respawned rather than serving a dead agent.
-        this.opts.onAgentFatal?.(tabId, `agent failed to start: ${m}`);
+        // PER-TAB degradation (issue #250): a hard start failure is almost
+        // always a tab-local configuration error — an invalid API key (the
+        // endpoint 401s in prepare()), an unreachable base URL, a missing CLI
+        // login. It must degrade THIS tab only. The old escalation
+        // (onAgentFatal → orchestrator self-exit) killed every OTHER tab too,
+        // including healthy sessions on different providers. The agent slot was
+        // cleared above, so after the user fixes the key, the next message /
+        // Disconnect → Connect spawns a fresh agent on the same tab.
+        if (this.opts.onStartFailure) this.opts.onStartFailure(tabId, m);
+        else this.opts.onSay(tabId, `⚠️ The panel agent could not start: ${m}`);
       } else if (gaveUp) {
         // The bounded self-restart loop gave up — the session keeps dropping. Same
         // fatal signal: let the orchestrator self-exit + respawn.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1337,6 +1337,11 @@ export class PanelAgentManager {
         // Disconnect → Connect spawns a fresh agent on the same tab.
         if (this.opts.onStartFailure) this.opts.onStartFailure(tabId, m);
         else this.opts.onSay(tabId, `⚠️ The panel agent could not start: ${m}`);
+        // Insurance, not correctness: every current backend self-cleans when
+        // prepare() throws, but that's per-backend convention — stop() makes
+        // backend.close?.() a guarantee now that the process SURVIVES this
+        // path (it used to exit, which mooted cleanup).
+        void agent.stop().catch(() => {});
       } else if (gaveUp) {
         // The bounded self-restart loop gave up — the session keeps dropping. Same
         // fatal signal: let the orchestrator self-exit + respawn.


### PR DESCRIPTION
## What / why

Fixes #250.

An invalid API key on an OpenAI-dialect provider (moonshot/glm/custom/openrouter) killed the WHOLE orchestrator at agent start, taking down every other tab.

**Repro (from the issue):** set `MOONSHOT_API_KEY=sk-fake` (readiness flips ready — key *presence* is all it can check), select moonshot on a tab, send any message. `OllamaBackend.prepare()` throws (`endpoint ... rejected the key (http 401)`) → PanelAgent "failed to start" → `onAgentFatal` → `requestSelfExit` ("closing the bridge so a fresh orchestrator can take over") → every other tab dies, including healthy sessions on other providers.

This is the same class of failure as the keyless ctor path fixed in #209 (ValidationError → `brokenBackend` → degraded ack + visible say), just one step later — in `prepare()`/first-connect instead of the constructor.

## How the fix routes start-failures

- **`src/orchestrator/panel-agent.ts`** — the manager's `settle()` on a start reject no longer fires `onAgentFatal`. It routes to a new optional **`onStartFailure(tabId, message)`** callback (falling back to a per-tab `onSay` notice when unwired). The dead agent slot was already cleared, so the tab stays recoverable: fix the key → re-send or Disconnect → Connect spawns a fresh agent.
- **`src/orchestrator/index.ts`** — wires `onStartFailure`: pushes an honest say naming the provider (`⚠️ The <backend> agent could not start: <error> — Check your <provider> API key in the API Keys card (<ENV_VAR>), then Disconnect → Connect to retry.`, registry-driven for glm/kimi/moonshot, bespoke copy for openrouter/custom) plus a `degraded` ack to THAT panel tab only, and logs it as tab-local. **No `requestSelfExit`.**

## Self-exit deliberately preserved

Checked every route into `requestSelfExit` (it has exactly one caller: `onAgentFatal`):
- **Kept fatal:** the bounded self-restart give-up (`agent session kept dropping (self-restart gave up)`) — the "bridge open but no panel agent responded" wedge that the self-exit was built for.
- Unrelated paths (uncaughtException handler, connect-time degraded acks) untouched.

## Test evidence

New: `src/__tests__/orchestrator/start-failure-per-tab.test.ts` (follows the restart-coalesce harness pattern) —
1. a backend whose `prepare()` rejects with a fake 401 fires `onStartFailure` with the honest error, does **not** fire `onAgentFatal`, and a second tab's healthy agent keeps processing turns;
2. the `onSay` fallback (manager without `onStartFailure`) is still per-tab, still no fatal;
3. **recovery:** after the factory starts returning a healthy backend ("key fixed"), a new send on the SAME tab spawns a working agent;
4. **preserved:** the instantly-dropping-session backend still trips the give-up threshold → `onAgentFatal`.

Gates:
- `npx tsc --noEmit` — clean
- `npx vitest run` — **135 files / 1541 tests passed** (incl. the 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)