### PR TITLE
fix(orchestrator): start-failure follow-ups — rebind-safe settle, held mail, real spinner clear

### DIFF
--- a/src/__tests__/orchestrator/start-failure-notice.test.ts
+++ b/src/__tests__/orchestrator/start-failure-notice.test.ts
@@ -1,0 +1,87 @@
+// Issue #255 (review finding 5) — the orchestrator's onStartFailure wiring had
+// no test coverage. The frame construction now lives in start-failure-notice.ts
+// (extracted from index.ts's inline handler) so this can pin down:
+//   • hint selection via the OpenAI-key provider registry (openAiKeyProvider),
+//     with the openrouter / custom / generic fallbacks;
+//   • composite-key (`panelTabId::backend`) → panel tab mapping, including the
+//     split-on-LAST-separator rule and the bare-key fallback;
+//   • the exact frame sequence pushed to the panel: honest say → degraded ack →
+//     turn:"done" (NOT "idle" — the panel's turn handler only recognizes
+//     working/done, so an idle frame never clears the spinner; issue #257).
+
+import { describe, expect, it } from "vitest";
+import {
+  backendOfKey,
+  buildStartFailureNotice,
+  panelTabOfKey,
+  startFailureHint,
+} from "../../orchestrator/start-failure-notice.js";
+
+describe("composite agent key → panel tab mapping", () => {
+  it("splits `panelTabId::backend` on the LAST separator", () => {
+    expect(panelTabOfKey("tab-1::moonshot")).toBe("tab-1");
+    expect(backendOfKey("tab-1::moonshot", "claude")).toBe("moonshot");
+  });
+
+  it("a bare key (no separator) maps to itself + the default backend", () => {
+    expect(panelTabOfKey("tab-plain")).toBe("tab-plain");
+    expect(backendOfKey("tab-plain", "claude")).toBe("claude");
+  });
+
+  it("a tab id that itself contains '::'-free prefixes still splits correctly", () => {
+    // Deterministic panel ids look like "wf:abc" / "tmp:abc" — the colon inside
+    // the tab half must not confuse the split.
+    expect(panelTabOfKey("wf:abc123::glm")).toBe("wf:abc123");
+    expect(backendOfKey("wf:abc123::glm", "claude")).toBe("glm");
+  });
+});
+
+describe("startFailureHint provider selection", () => {
+  it("names a registered OpenAI-key provider's slot + primary env key", () => {
+    // moonshot / glm / kimi live in the openai-provider-registry.
+    expect(startFailureHint("moonshot")).toContain("MOONSHOT_API_KEY");
+    expect(startFailureHint("glm")).toContain("GLM_API_KEY");
+    expect(startFailureHint("kimi")).toContain("KIMI_API_KEY");
+    expect(startFailureHint("moonshot")).toContain("API Keys card");
+  });
+
+  it("falls back for openrouter, custom, and unknown backends", () => {
+    expect(startFailureHint("openrouter")).toContain("OPENROUTER_API_KEY");
+    expect(startFailureHint("custom")).toContain("Custom endpoint");
+    expect(startFailureHint("claude")).toBe(
+      "Check the provider's credentials/login, then Disconnect → Connect to retry.",
+    );
+  });
+});
+
+describe("buildStartFailureNotice frames", () => {
+  it("pushes say → degraded ack → turn:done to the PANEL tab", () => {
+    const { panelTab, backend, frames } = buildStartFailureNotice(
+      "tab-abc::moonshot",
+      "endpoint https://api.moonshot.ai/v1 rejected the key (http 401)",
+      "claude",
+    );
+    expect(panelTab).toBe("tab-abc");
+    expect(backend).toBe("moonshot");
+    expect(frames).toHaveLength(3);
+
+    const [say, ack, turn] = frames;
+    expect(say!.type).toBe("say");
+    expect(say!.text).toContain("The moonshot agent could not start");
+    expect(say!.text).toContain("rejected the key (http 401)");
+    expect(say!.text).toContain("MOONSHOT_API_KEY");
+
+    expect(ack).toEqual({ type: "ack", ok: false, kind: "degraded" });
+
+    // The panel clears its thinking spinner ONLY on turn:"done" — "idle" is a
+    // no-op in the panel's handler (issue #257), so this must stay "done".
+    expect(turn).toEqual({ type: "turn", state: "done" });
+  });
+
+  it("a bare (non-composite) key degrades under the default backend's generic hint", () => {
+    const { panelTab, backend, frames } = buildStartFailureNotice("tab-solo", "boom", "claude");
+    expect(panelTab).toBe("tab-solo");
+    expect(backend).toBe("claude");
+    expect(frames[0]!.text).toContain("The claude agent could not start: boom");
+  });
+});

--- a/src/__tests__/orchestrator/start-failure-per-tab.test.ts
+++ b/src/__tests__/orchestrator/start-failure-per-tab.test.ts
@@ -199,7 +199,12 @@ describe("per-tab start failure (issue #250)", () => {
     keyFixed = true;
     manager.send(tab, "second try");
     await waitFor(() => good.turnTexts.length >= 1);
-    expect(good.turnTexts).toContain("second try");
+    const delivered = good.turnTexts.join("\n\n");
+    expect(delivered).toContain("second try");
+    // Held mail (issue #256): the message that hit the FAILED start is no
+    // longer dropped — the fresh agent re-delivers it ahead of the retry.
+    expect(delivered).toContain("first try");
+    expect(delivered.indexOf("first try")).toBeLessThan(delivered.indexOf("second try"));
     expect(manager.hasLiveAgent(tab)).toBe(true);
     // Still no fatal escalation anywhere in the sequence.
     expect(rec.fatals).toHaveLength(0);

--- a/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
+++ b/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
@@ -60,6 +60,43 @@ class GatedPrepareBackend implements AgentBackend {
   }
 }
 
+/** A backend whose turn stays IN FLIGHT until the test releases it — for
+ *  pinning isTurnActive() (the predicate the orchestrator's held-during-gen
+ *  branch checks before pushing a spinner-clearing turn:"done"). */
+class HoldingTurnBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turnStarted = false;
+  private released = false;
+  private releaseTurn: (() => void) | null = null;
+
+  /** Open the gate PERMANENTLY: the held turn completes, and any turns queued
+   *  behind it complete immediately too (so the tab can settle to idle). */
+  release(): void {
+    this.released = true;
+    this.releaseTurn?.();
+    this.releaseTurn = null;
+  }
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-hold" };
+    for await (const _turn of opts.channel) {
+      this.turnStarted = true;
+      if (!this.released) {
+        await new Promise<void>((resolve) => {
+          this.releaseTurn = resolve;
+        });
+      }
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
 /** A healthy backend that records the turns it receives and completes them. */
 class HealthyBackend implements AgentBackend {
   readonly id = "claude" as const;
@@ -201,6 +238,96 @@ describe("held mail across a failed start (issue #256)", () => {
     await manager.stopAll();
   });
 
+  it("held mail BLOCKS the self-restart gate: hasHeldMail()/allIdle() refuse until re-delivery lands (#260 review, finding 1)", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const key = "tab-gate::moonshot";
+
+    // Nothing held yet — the gate is open.
+    expect(manager.hasHeldMail()).toBe(false);
+
+    manager.send(key, "parked by the failed start");
+    await waitFor(() => bad.prepareCalls === 1);
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+
+    // Mail is parked and there is NO live agent — the old agent-only allIdle()
+    // returned true here, letting an auto-restart tear down (stopAll erases the
+    // held-mail map) and silently drop the parked message.
+    expect(manager.hasHeldMail()).toBe(true);
+    expect(manager.allIdle()).toBe(false);
+
+    // Successful retry re-delivers; once the turn completes the gate reopens.
+    keyFixed = true;
+    manager.send(key, "retry");
+    await waitFor(() => good.turnTexts.length >= 1);
+    expect(good.turnTexts.join("\n\n")).toContain("parked by the failed start");
+    expect(manager.hasHeldMail()).toBe(false);
+    await waitFor(() => manager.allIdle());
+
+    await manager.stopAll();
+  });
+
+  it("cancel-by-mid reaches HELD mail: a deleted prompt is NOT re-delivered on the retry (#260 review, finding 2)", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const key = "tab-cancel::moonshot";
+
+    manager.send(key, "keep me", { mid: "mid-keep" });
+    await waitFor(() => bad.prepareCalls === 1);
+    manager.send(key, "delete me", { mid: "mid-del" });
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+    expect(manager.hasLiveAgent(key)).toBe(false);
+
+    // With no live agent, cancel must reach the held-mail map by mid.
+    expect(manager.cancelQueued(key, "mid-del")).toBe(true);
+    expect(manager.cancelQueued(key, "mid-unknown")).toBe(false);
+
+    keyFixed = true;
+    manager.send(key, "the retry", { mid: "mid-retry" });
+    await waitFor(() => good.turnTexts.length >= 1);
+    const delivered = good.turnTexts.join("\n\n");
+    expect(delivered).toContain("keep me");
+    expect(delivered).toContain("the retry");
+    expect(delivered).not.toContain("delete me");
+    // The cancelled message is never dequeued, so it gets no seen ack.
+    await waitFor(() => rec.seen.length >= 2);
+    expect(rec.seen.map((s) => s.mid)).toEqual(["mid-keep", "mid-retry"]);
+
+    await manager.stopAll();
+  });
+
+  it("reorder-by-mid reaches HELD mail: the retry re-delivers in the panel's new order", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const key = "tab-reorder::moonshot";
+
+    manager.send(key, "alpha", { mid: "mid-a" });
+    await waitFor(() => bad.prepareCalls === 1);
+    manager.send(key, "beta", { mid: "mid-b" });
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+
+    // No live agent — the reorder must land on the held-mail entries.
+    expect(manager.reorderQueue(key, ["mid-b", "mid-a"])).toBe(true);
+
+    keyFixed = true;
+    manager.send(key, "gamma", { mid: "mid-c" });
+    await waitFor(() => good.turnTexts.length >= 1);
+    const delivered = good.turnTexts.join("\n\n");
+    expect(delivered.indexOf("beta")).toBeLessThan(delivered.indexOf("alpha"));
+    expect(delivered.indexOf("alpha")).toBeLessThan(delivered.indexOf("gamma"));
+
+    await manager.stopAll();
+  });
+
   it("held mail follows a rebind: a failed-start message re-delivers under the tab's NEW key", async () => {
     const bad = new GatedPrepareBackend();
     const good = new HealthyBackend();
@@ -225,6 +352,39 @@ describe("held mail across a failed start (issue #256)", () => {
     const delivered = good.turnTexts.join("\n\n");
     expect(delivered).toContain("message into the doomed start");
     expect(delivered).toContain("retry on the new key");
+
+    await manager.stopAll();
+  });
+});
+
+describe("isTurnActive — the held-during-gen spinner-clear guard (#260 review, finding 3)", () => {
+  // The orchestrator's VRAM-hold branch (index.ts) pushes turn:"done" to clear
+  // the optimistic working spinner ONLY when !manager.isTurnActive(key): a
+  // tab-wide "done" during an ACTIVE earlier turn would hide that turn's
+  // spinner and disarm its resume nudge. This pins the predicate the branch
+  // gates on: active while a turn is in flight (or queued behind one), inactive
+  // when the tab is idle or has no agent at all.
+  it("is true while a turn is in flight (and while messages queue behind it), false when idle or absent", async () => {
+    const holding = new HoldingTurnBackend();
+    const { manager } = makeManager(() => holding);
+    const key = "tab-active::claude";
+
+    // No agent at all → inactive (the held branch MAY clear the spinner).
+    expect(manager.isTurnActive(key)).toBe(false);
+
+    // A turn in flight → ACTIVE (the held branch must NOT push turn:"done").
+    manager.send(key, "long turn");
+    await waitFor(() => holding.turnStarted);
+    expect(manager.isTurnActive(key)).toBe(true);
+
+    // Still active while a follow-up waits behind the live turn — that queued
+    // message will drive its own working→done cycle.
+    manager.send(key, "queued behind the live turn");
+    expect(manager.isTurnActive(key)).toBe(true);
+
+    // Release both turns → the tab settles back to inactive.
+    holding.release();
+    await waitFor(() => !manager.isTurnActive(key), 5000);
 
     await manager.stopAll();
   });

--- a/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
+++ b/src/__tests__/orchestrator/start-failure-rebind-heldmail.test.ts
@@ -1,0 +1,231 @@
+// Issues #255 + #256 — follow-ups to the per-tab start-failure work (#250/#253).
+//
+// #255: settle() used a KEY-based guard (`agents.get(tabId) !== agent`), so when
+// rebindAgent() moved a still-starting agent to a new key (panel tab-id
+// migration) and prepare() then rejected, settle early-returned — the dead
+// agent stayed mapped under the NEW key forever: hasLiveAgent true, queue never
+// drained, no onStartFailure, tab wedged until reset. settle must locate the
+// agent by IDENTITY and clean up / report under the CURRENT key.
+//
+// #256: messages queued into a doomed agent between spawn and prepare()-reject
+// died silently with it (no seen ack, no failure ack). settle(err) now captures
+// the agent's still-queued mail into the manager's held-mail map, and the next
+// spawn on the same key re-delivers it — NO silent drop.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A backend whose prepare() BLOCKS until the test releases it — so the test
+ *  can rebind / queue messages inside the spawn → prepare()-settle window,
+ *  then reject (or resolve) deterministically. */
+class GatedPrepareBackend implements AgentBackend {
+  readonly id = "moonshot" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  prepareCalls = 0;
+  private release!: (err?: Error) => void;
+  private gate = new Promise<void>((resolve, reject) => {
+    this.release = (err?: Error) => (err ? reject(err) : resolve());
+  });
+
+  async prepare(): Promise<void> {
+    this.prepareCalls += 1;
+    await this.gate;
+  }
+
+  /** Reject the pending prepare() (the 401-during-start repro). */
+  failPrepare(message = "endpoint rejected the key (http 401)"): void {
+    this.release(new Error(message));
+  }
+
+  // eslint-disable-next-line require-yield
+  async *run(): AsyncGenerator<AgentEvent> {
+    throw new Error("run() must never be reached when prepare() rejects");
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** A healthy backend that records the turns it receives and completes them. */
+class HealthyBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turnTexts: string[] = [];
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-healthy" };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+interface Recorded {
+  says: Array<{ tab: string; text: string }>;
+  startFailures: Array<{ tab: string; message: string }>;
+  fatals: Array<{ tab: string; reason: string }>;
+  seen: Array<{ tab: string; mid: string }>;
+}
+
+function makeManager(makeBackend: (key: string) => AgentBackend | undefined): {
+  manager: InstanceType<typeof PanelAgentManager>;
+  rec: Recorded;
+} {
+  const rec: Recorded = { says: [], startFailures: [], fatals: [], seen: [] };
+  const manager = new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: (tab: string, text: string) => rec.says.push({ tab, text }),
+    onTurn: () => {},
+    onSeen: (tab: string, mid: string) => rec.seen.push({ tab, mid }),
+    makeBackend,
+    onStartFailure: (tab: string, message: string) => rec.startFailures.push({ tab, message }),
+    onAgentFatal: (tab: string, reason: string) => rec.fatals.push({ tab, reason }),
+  } as never);
+  return { manager, rec };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("rebind during a failing start (issue #255)", () => {
+  it("settle finds the rebound agent by IDENTITY: slot cleaned under the NEW key, onStartFailure fires for the NEW key", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const oldKey = "tmp:old-tab::moonshot";
+    const newKey = "wf:new-tab::moonshot";
+
+    // Spawn: prepare() is now pending (gated), the agent is mapped under oldKey.
+    manager.send(oldKey, "hello while starting");
+    await waitFor(() => bad.prepareCalls === 1);
+    expect(manager.hasLiveAgent(oldKey)).toBe(true);
+
+    // Panel tab-id migration lands while the agent is STILL starting.
+    expect(manager.rebindAgent(oldKey, newKey)).toBe(true);
+    expect(manager.hasLiveAgent(newKey)).toBe(true);
+    expect(manager.hasLiveAgent(oldKey)).toBe(false);
+
+    // Now the start fails (401). The old key-based guard early-returned here,
+    // stranding the dead agent under newKey with no warning.
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+
+    // The failure is reported under the CURRENT (new) key…
+    expect(rec.startFailures[0]!.tab).toBe(newKey);
+    expect(rec.startFailures[0]!.message).toMatch(/http 401/);
+    // …the slot is CLEANED under both keys (not wedged, hasLiveAgent honest)…
+    expect(manager.hasLiveAgent(newKey)).toBe(false);
+    expect(manager.hasLiveAgent(oldKey)).toBe(false);
+    // …and nothing escalated to the process-fatal path.
+    expect(rec.fatals).toHaveLength(0);
+
+    // The tab stays RECOVERABLE under its new key: fix the key, resend, works —
+    // and the message queued into the doomed start is re-delivered first (#256).
+    keyFixed = true;
+    manager.send(newKey, "after fix");
+    await waitFor(() => good.turnTexts.length >= 1);
+    expect(good.turnTexts.join("\n\n")).toContain("hello while starting");
+    expect(good.turnTexts.join("\n\n")).toContain("after fix");
+
+    await manager.stopAll();
+  });
+});
+
+describe("held mail across a failed start (issue #256)", () => {
+  it("messages queued between spawn and prepare()-reject are re-delivered, in order, after a successful retry", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const key = "tab-held::moonshot";
+
+    // First message triggers the spawn; the second lands in the doomed agent's
+    // queue while prepare() is still pending.
+    manager.send(key, "first (triggered the spawn)", { mid: "mid-1" });
+    await waitFor(() => bad.prepareCalls === 1);
+    manager.send(key, "second (queued into the doomed window)", { mid: "mid-2" });
+
+    // The start fails — before the fix, both messages died silently here.
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+    expect(manager.hasLiveAgent(key)).toBe(false);
+    // NOT silently seen: neither message was consumed by the dead agent.
+    expect(rec.seen).toHaveLength(0);
+
+    // User fixes the key and retries — the retry message spawns a fresh agent,
+    // which must re-deliver the held mail FIRST (chronological order).
+    keyFixed = true;
+    manager.send(key, "third (the retry)", { mid: "mid-3" });
+    await waitFor(() => good.turnTexts.length >= 1);
+
+    const delivered = good.turnTexts.join("\n\n");
+    expect(delivered).toContain("first (triggered the spawn)");
+    expect(delivered).toContain("second (queued into the doomed window)");
+    expect(delivered).toContain("third (the retry)");
+    expect(delivered.indexOf("first")).toBeLessThan(delivered.indexOf("second"));
+    expect(delivered.indexOf("second")).toBeLessThan(delivered.indexOf("third"));
+
+    // The re-delivery is VISIBLE: each original mid gets its seen ack when the
+    // fresh agent dequeues it, so the panel bubbles flip from queued to read.
+    await waitFor(() => rec.seen.length >= 3);
+    expect(rec.seen.map((s) => s.mid)).toEqual(["mid-1", "mid-2", "mid-3"]);
+
+    await manager.stopAll();
+  });
+
+  it("held mail follows a rebind: a failed-start message re-delivers under the tab's NEW key", async () => {
+    const bad = new GatedPrepareBackend();
+    const good = new HealthyBackend();
+    let keyFixed = false;
+    const { manager, rec } = makeManager(() => (keyFixed ? good : bad));
+    const oldKey = "tmp:before::moonshot";
+    const newKey = "wf:after::moonshot";
+
+    manager.send(oldKey, "message into the doomed start");
+    await waitFor(() => bad.prepareCalls === 1);
+    bad.failPrepare();
+    await waitFor(() => rec.startFailures.length >= 1);
+    expect(manager.hasLiveAgent(oldKey)).toBe(false);
+
+    // Tab-id migration AFTER the failure — no live agent, but the held mail is
+    // durable state and must move with the tab.
+    manager.rebindAgent(oldKey, newKey);
+
+    keyFixed = true;
+    manager.send(newKey, "retry on the new key");
+    await waitFor(() => good.turnTexts.length >= 1);
+    const delivered = good.turnTexts.join("\n\n");
+    expect(delivered).toContain("message into the doomed start");
+    expect(delivered).toContain("retry on the new key");
+
+    await manager.stopAll();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -76,6 +76,7 @@ import { SYSTEM as MODEL_CARD_SYSTEM } from "./ai-proposer.js";
 import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/prompt-overrides.js";
 import { allBackendReadiness } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
+import { buildStartFailureNotice } from "./start-failure-notice.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
@@ -1730,26 +1731,11 @@ export async function runPanelOrchestrator(): Promise<void> {
     // cleanly. This must NOT self-exit — a bad moonshot key on one tab was
     // killing healthy sessions on every other tab.
     onStartFailure: (key, message) => {
-      const backend = backendOf(key);
-      const panelTab = panelTabOf(key);
-      const reg = openAiKeyProvider(backend);
-      const hint = reg
-        ? `Check your ${reg.slotLabel} API key in the API Keys card (${reg.envKeys[0]}), then Disconnect → Connect to retry.`
-        : backend === "openrouter"
-          ? "Check your OpenRouter API key in the API Keys card (OPENROUTER_API_KEY), then Disconnect → Connect to retry."
-          : backend === "custom"
-            ? "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry."
-            : "Check the provider's credentials/login, then Disconnect → Connect to retry.";
-      bridge.push(
-        { type: "say", text: `⚠️ The ${backend} agent could not start: ${message} — ${hint}` },
-        panelTab,
-      );
-      bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
-      // The user_message path already pushed turn:"working", and the panel
-      // clears its thinking spinner ONLY on turn:"done" — without this the
-      // degraded tab sits on a live spinner for the 120s safety timeout
-      // (adversarial review of #253, finding 1).
-      bridge.push({ type: "turn", state: "done" }, panelTab);
+      // Frame construction (hint selection via the key-provider registry,
+      // composite-key → panel-tab split, say + degraded ack + turn:done) lives
+      // in start-failure-notice.ts so it is unit-testable (issue #255).
+      const { panelTab, backend, frames } = buildStartFailureNotice(key, message, defaultBackend);
+      for (const frame of frames) bridge.push(frame, panelTab);
       logger.warn(
         `[panel-orchestrator] tab ${panelTab.slice(0, 8)} (${backend}) agent failed to start — degraded THIS tab only, other tabs unaffected (${message})`,
       );
@@ -3210,7 +3196,13 @@ export async function runPanelOrchestrator(): Promise<void> {
         },
         event.tab_id,
       );
-      bridge.push({ type: "turn", state: "idle" }, event.tab_id); // clear the working spinner
+      // Clear the working spinner. MUST be state:"done" — the panel's turn
+      // handler only recognizes "working" and "done", so the old "idle" frame
+      // was a no-op and the spinner ran until the 120s safety timeout (issue
+      // #257). "done" also disarms the panel's mid-task resume nudge, which is
+      // correct here: no turn is in flight — the message is held orchestrator-
+      // side and its re-delivery (onRunEnd) pushes a fresh turn:"working".
+      bridge.push({ type: "turn", state: "done" }, event.tab_id);
       return;
     }
     manager.send(agentKeyFor(event.tab_id), outText, sendOpts);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3196,13 +3196,17 @@ export async function runPanelOrchestrator(): Promise<void> {
         },
         event.tab_id,
       );
-      // Clear the working spinner. MUST be state:"done" — the panel's turn
-      // handler only recognizes "working" and "done", so the old "idle" frame
-      // was a no-op and the spinner ran until the 120s safety timeout (issue
-      // #257). "done" also disarms the panel's mid-task resume nudge, which is
-      // correct here: no turn is in flight — the message is held orchestrator-
-      // side and its re-delivery (onRunEnd) pushes a fresh turn:"working".
-      bridge.push({ type: "turn", state: "done" }, event.tab_id);
+      // Clear the working spinner — the panel's turn handler only recognizes
+      // "working" and "done", so the old "idle" frame never cleared it and the
+      // spinner ran until the 120s safety timeout (issue #257). But ONLY when no
+      // agent turn is actually in flight for this tab: a tab-wide "done" during
+      // an ACTIVE earlier turn would hide THAT turn's spinner and disarm its
+      // resume nudge (the idle frame was a load-bearing no-op in that case —
+      // #260 review). When a turn IS active we push nothing: the live turn's own
+      // turn:"done" clears the spinner at the right moment.
+      if (!manager.isTurnActive(key)) {
+        bridge.push({ type: "turn", state: "done" }, event.tab_id);
+      }
       return;
     }
     manager.send(agentKeyFor(event.tab_id), outText, sendOpts);
@@ -3367,6 +3371,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   selfRestarter = new SelfRestarter({
     allIdle: () =>
       manager.allIdle() &&
+      // Failed-start held mail (issue #256): teardown erases it, so a restart
+      // while it's parked would silently drop the messages awaiting re-delivery.
+      // (allIdle() already covers this; kept explicit alongside heldDuringGen so
+      // the gate reads as the full "nothing queued or held" contract.)
+      !manager.hasHeldMail() &&
       ![...heldDuringGen.values()].some((msgs) => msgs.length > 0) &&
       !QueueMonitor.isBusy(),
     announce: (text) => void bridge.push({ type: "say", text }),

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1274,9 +1274,23 @@ export class PanelAgentManager {
   }
 
   /** Cancel a still-queued message for a tab (user edited/deleted it before the
-   *  agent read it). Returns true if it was removed from the queue. */
+   *  agent read it). Returns true if it was removed from the queue. Also reaches
+   *  HELD mail (issue #256 follow-up): after a failed start parks messages in
+   *  heldMessages there is no live agent, but the user can still delete/edit the
+   *  bubble — without this the cancelled prompt would execute on the next spawn
+   *  (possibly alongside its replacement). */
   cancelQueued(tabId: string, mid: string): boolean {
-    return this.agents.get(tabId)?.cancelQueued(mid) ?? false;
+    if (this.agents.get(tabId)?.cancelQueued(mid)) return true;
+    const held = this.heldMessages.get(tabId);
+    if (held) {
+      const i = held.findIndex((item) => item.mid === mid);
+      if (i >= 0) {
+        held.splice(i, 1);
+        if (held.length === 0) this.heldMessages.delete(tabId);
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Replace a tab's agent with a fresh one (picks up the manager's current
@@ -1415,10 +1429,21 @@ export class PanelAgentManager {
     return true;
   }
 
-  /** Reorder a tab's still-queued messages to the panel's desired flush order. */
+  /** Reorder a tab's still-queued messages to the panel's desired flush order.
+   *  Also applies to HELD mail (a failed start parked the queue — the panel can
+   *  still drag bubbles while the tab is degraded), with the same stable-sort
+   *  semantics as PanelAgent.reorderQueue. */
   reorderQueue(tabId: string, order: string[]): boolean {
+    let applied = false;
+    const held = this.heldMessages.get(tabId);
+    if (Array.isArray(order) && held && held.length >= 2) {
+      const rank = new Map(order.map((mid, i) => [mid, i]));
+      const at = (mid?: string) => (mid && rank.has(mid) ? rank.get(mid)! : Number.MAX_SAFE_INTEGER);
+      held.sort((a, b) => at(a.mid) - at(b.mid));
+      applied = true;
+    }
     const agent = this.agents.get(tabId);
-    if (!agent || agent.isStopped) return false;
+    if (!agent || agent.isStopped) return applied;
     agent.reorderQueue(order);
     return true;
   }
@@ -1626,13 +1651,36 @@ export class PanelAgentManager {
     return this.agents.size;
   }
 
-  /** True when NO agent is mid-turn or holding queued messages — the only
-   *  moment a self-restart may replace the process without eating a reply. */
+  /** True when any message is parked in the held-mail map (a start failure
+   *  captured a doomed agent's queue for re-delivery, issue #256). Surfaced so
+   *  the self-restart gate can refuse to restart while mail is parked —
+   *  teardown (stopAll) ERASES held mail, so an auto-restart while it exists
+   *  would silently drop the very messages the hold protects. */
+  hasHeldMail(): boolean {
+    for (const msgs of this.heldMessages.values()) {
+      if (msgs.length > 0) return true;
+    }
+    return false;
+  }
+
+  /** True when this key's agent has a turn in flight (or messages queued to
+   *  start one imminently) — i.e. the panel's working spinner belongs to a REAL
+   *  turn that will push its own turn:"done". The orchestrator's held-during-gen
+   *  branch checks this before clearing the spinner, so a tab-wide turn:"done"
+   *  can never hide an ACTIVE turn's spinner or disarm its resume nudge. */
+  isTurnActive(key: string): boolean {
+    const agent = this.agents.get(key);
+    return !!agent && !agent.isStopped && (agent.isBusy || agent.hasPending);
+  }
+
+  /** True when NO agent is mid-turn or holding queued messages AND no failed-
+   *  start mail is parked for re-delivery — the only moment a self-restart may
+   *  replace the process without eating a reply (or erasing held mail). */
   allIdle(): boolean {
     for (const a of this.agents.values()) {
       if (a.isBusy || a.hasPending) return false;
     }
-    return true;
+    return !this.hasHeldMail();
   }
 
   get defaults(): { model: string; effort?: Effort } {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -445,8 +445,9 @@ export class PanelAgent {
     return this.queue.length > 0;
   }
   /** Remove and return any unsent queued messages — so a session restart can hand
-   *  them to the replacement agent instead of dropping them. */
-  takePending(): Array<{ text: string; images?: ImageRef[] }> {
+   *  them to the replacement agent instead of dropping them. Items keep their
+   *  panel `mid`, so re-delivery still flips the right bubble on dequeue (seen). */
+  takePending(): Array<{ text: string; images?: ImageRef[]; mid?: string }> {
     const items = this.queue;
     this.queue = [];
     return items;
@@ -1087,6 +1088,12 @@ export class PanelAgentManager {
   private opts: PanelAgentManagerOptions;
   /** Per-tab session id to resume on the next spawn (reload restore). */
   private pendingResume = new Map<string, string>();
+  /** Held mail (issue #256): messages queued into an agent that then FAILED to
+   *  start (prepare() rejected before the channel was ever consumed) are
+   *  captured here at settle(err) instead of dying with the agent — the next
+   *  spawn on the same composite key re-delivers them, so nothing sent into the
+   *  spawn → prepare()-reject window is silently dropped. */
+  private heldMessages = new Map<string, Array<{ text: string; images?: ImageRef[]; mid?: string }>>();
   /** Tabs whose effort changed mid-turn — the session restart is deferred to the
    *  next idle moment so we never interrupt (and silently drop) a live reply. */
   private pendingEffortRestart = new Set<string>();
@@ -1280,7 +1287,7 @@ export class PanelAgentManager {
     const resume = oldAgent.sessionId ?? undefined;
     const pending = oldAgent.takePending();
     const fresh = this.spawn(tabId, resume); // new agent owns the tab now
-    for (const item of pending) fresh.send(item.text, { images: item.images });
+    for (const item of pending) fresh.send(item.text, { images: item.images, mid: item.mid });
     if (nudge) fresh.send(nudge);
     void oldAgent.stop(); // retire the old one; it's no longer mapped
     return pending.length;
@@ -1315,18 +1322,58 @@ export class PanelAgentManager {
     logger.info(
       `[panel-orchestrator] spawning agent for tab ${tabId.slice(0, 8)}${resume ? " (resume)" : ""} (${this.agents.size} active)`,
     );
+    // Re-deliver mail orphaned by a previous FAILED start on this key (issue
+    // #256): the doomed agent's still-queued messages were captured at
+    // settle(err) below; queue them into the fresh agent FIRST so they run
+    // ahead of whatever message triggered this spawn (chronological order).
+    // If this start fails too, settle(err) captures them right back — no loss.
+    const held = this.heldMessages.get(tabId);
+    if (held?.length) {
+      this.heldMessages.delete(tabId);
+      for (const item of held) agent.send(item.text, { images: item.images, mid: item.mid });
+      logger.info(
+        `[panel-orchestrator] tab ${tabId.slice(0, 8)} re-delivering ${held.length} message(s) held from the previous failed start`,
+      );
+    }
     // start() now SELF-RESTARTS internally on session-end, so it only settles on
     // an intentional stop() or after it gives up (repeated immediate failures),
     // or it rejects on a hard start failure. In the give-up / reject cases, drop
     // the dead agent (if still mapped and not stopped on purpose) so the next
     // user message spawns a fresh one.
     const settle = (err?: unknown) => {
-      if (this.agents.get(tabId) !== agent || agent.isStopped) return;
+      if (agent.isStopped) return;
+      // Locate the agent by IDENTITY, not by its spawn-time key (issue #255):
+      // rebindAgent() may have moved a still-starting agent to a NEW key (panel
+      // tab-id migration), and the old key-based guard (agents.get(tabId) !==
+      // agent) early-returned in that case — a prepare()-rejected agent then
+      // stayed mapped under the new key forever: hasLiveAgent true, queue never
+      // drained, no warning, tab wedged until reset. The failure must clean up
+      // (and report onStartFailure for) whatever key CURRENTLY maps this agent.
+      let key: string | undefined;
+      for (const [k, a] of this.agents) {
+        if (a === agent) {
+          key = k;
+          break;
+        }
+      }
+      if (key === undefined) return; // already replaced/dropped — nothing to settle
       const gaveUp = agent.gaveUp;
-      this.agents.delete(tabId);
+      this.agents.delete(key);
       if (err) {
         const m = msgOf(err);
-        logger.error(`[panel-agent ${tabId.slice(0, 8)}] failed to start: ${m}`);
+        logger.error(`[panel-agent ${key.slice(0, 8)}] failed to start: ${m}`);
+        // Held mail (issue #256): prepare() rejected before the channel was
+        // ever consumed, so EVERY message sent since the spawn is still in the
+        // agent's queue — including the one that triggered it. Capture them
+        // (BEFORE stop(), which closes the agent) for re-delivery by the next
+        // spawn on this key, so nothing dies silently with the doomed agent.
+        const orphaned = agent.takePending();
+        if (orphaned.length) {
+          this.heldMessages.set(key, [...(this.heldMessages.get(key) ?? []), ...orphaned]);
+          logger.warn(
+            `[panel-orchestrator] tab ${key.slice(0, 8)} holding ${orphaned.length} undelivered message(s) — re-delivered on the next successful start`,
+          );
+        }
         // PER-TAB degradation (issue #250): a hard start failure is almost
         // always a tab-local configuration error — an invalid API key (the
         // endpoint 401s in prepare()), an unreachable base URL, a missing CLI
@@ -1335,8 +1382,11 @@ export class PanelAgentManager {
         // including healthy sessions on different providers. The agent slot was
         // cleared above, so after the user fixes the key, the next message /
         // Disconnect → Connect spawns a fresh agent on the same tab.
-        if (this.opts.onStartFailure) this.opts.onStartFailure(tabId, m);
-        else this.opts.onSay(tabId, `⚠️ The panel agent could not start: ${m}`);
+        // Report under the CURRENT key (not the spawn-time tabId) so the
+        // orchestrator's composite-key → panel-tab split reaches the tab that
+        // owns the agent NOW, even after a rebind (issue #255).
+        if (this.opts.onStartFailure) this.opts.onStartFailure(key, m);
+        else this.opts.onSay(key, `⚠️ The panel agent could not start: ${m}`);
         // Insurance, not correctness: every current backend self-cleans when
         // prepare() throws, but that's per-backend convention — stop() makes
         // backend.close?.() a guarantee now that the process SURVIVES this
@@ -1345,7 +1395,7 @@ export class PanelAgentManager {
       } else if (gaveUp) {
         // The bounded self-restart loop gave up — the session keeps dropping. Same
         // fatal signal: let the orchestrator self-exit + respawn.
-        this.opts.onAgentFatal?.(tabId, "agent session kept dropping (self-restart gave up)");
+        this.opts.onAgentFatal?.(key, "agent session kept dropping (self-restart gave up)");
       }
     };
     void agent.start(resume).then(
@@ -1401,6 +1451,15 @@ export class PanelAgentManager {
       const persisted = this.opts.sessionStore?.get(oldKey);
       if (persisted) this.opts.sessionStore?.set(newKey, persisted);
       this.opts.sessionStore?.clear(oldKey);
+      // Held mail from a failed start migrates too (issue #256) — it exists
+      // precisely when NO live agent does, so it must move in the durable pass
+      // for the rebound tab's next spawn to re-deliver it. Old-key mail is
+      // older, so it goes ahead of anything already held under the new key.
+      const heldOld = this.heldMessages.get(oldKey);
+      if (heldOld?.length) {
+        this.heldMessages.set(newKey, [...heldOld, ...(this.heldMessages.get(newKey) ?? [])]);
+      }
+      this.heldMessages.delete(oldKey);
     };
     const agent = this.agents.get(oldKey);
     if (!agent || agent.isStopped) {
@@ -1540,6 +1599,7 @@ export class PanelAgentManager {
     this.opts.sessionStore?.clear(tabId);
     this.pendingEffortRestart.delete(tabId); // a reset supersedes any deferred restart
     this.pendingMcpRestart.delete(tabId);
+    this.heldMessages.delete(tabId); // a reset is an explicit fresh start — drop held mail
     // Drop this key's picker override so a provider switch (which reset()s the old
     // key) can't carry the old provider's model/effort into the new backend's spawn.
     this.modelByKey.delete(tabId);
@@ -1557,6 +1617,7 @@ export class PanelAgentManager {
   async stopAll(): Promise<void> {
     this.pendingEffortRestart.clear();
     this.pendingMcpRestart.clear();
+    this.heldMessages.clear();
     await Promise.all([...this.agents.values()].map((a) => a.stop()));
     this.agents.clear();
   }

--- a/src/orchestrator/start-failure-notice.ts
+++ b/src/orchestrator/start-failure-notice.ts
@@ -1,0 +1,80 @@
+/**
+ * PER-TAB start-failure notice (issue #250, extracted for testability — issue
+ * #255 review finding 5): when a tab's agent backend rejects at
+ * prepare()/first-connect (an invalid API key 401ing on an OpenAI-dialect
+ * provider, an unreachable endpoint), the orchestrator degrades THAT tab only.
+ * This module builds the exact bridge frames the orchestrator pushes:
+ *
+ *   1. an honest `say` naming the provider, with check-your-key guidance
+ *      (hint selected via the OpenAI-key provider registry when the backend is
+ *      a registered key provider, with openrouter/custom/generic fallbacks);
+ *   2. a degraded `ack` so the panel shows the real state;
+ *   3. `turn: done` — the user_message path already pushed turn:"working", and
+ *      the panel clears its thinking spinner ONLY on turn:"done"; without this
+ *      the degraded tab sits on a live spinner for the 120s safety timeout
+ *      (adversarial review of #253, finding 1).
+ *
+ * The manager reports failures under the COMPOSITE agent key
+ * (`panelTabId::backend`); frames must go to the PANEL tab, so the composite
+ * key is split here on its LAST separator (a panel tab id never contains "::";
+ * backend names never do).
+ */
+import { openAiKeyProvider } from "../services/openai-provider-registry.js";
+
+export const AGENT_KEY_SEP = "::";
+
+/** The panel tab id half of a composite agent key (the whole key when bare). */
+export function panelTabOfKey(key: string): string {
+  const i = key.lastIndexOf(AGENT_KEY_SEP);
+  return i >= 0 ? key.slice(0, i) : key;
+}
+
+/** The backend half of a composite agent key (`fallback` when bare). */
+export function backendOfKey(key: string, fallback: string): string {
+  const i = key.lastIndexOf(AGENT_KEY_SEP);
+  return i >= 0 ? key.slice(i + AGENT_KEY_SEP.length) : fallback;
+}
+
+/** Check-your-credentials guidance for a backend that failed to start. */
+export function startFailureHint(backend: string): string {
+  const reg = openAiKeyProvider(backend);
+  if (reg) {
+    return `Check your ${reg.slotLabel} API key in the API Keys card (${reg.envKeys[0]}), then Disconnect → Connect to retry.`;
+  }
+  if (backend === "openrouter") {
+    return "Check your OpenRouter API key in the API Keys card (OPENROUTER_API_KEY), then Disconnect → Connect to retry.";
+  }
+  if (backend === "custom") {
+    return "Check the base URL and API key in Settings → Custom endpoint, then Disconnect → Connect to retry.";
+  }
+  return "Check the provider's credentials/login, then Disconnect → Connect to retry.";
+}
+
+export interface StartFailureNotice {
+  /** The PANEL tab the frames must be pushed to (composite key split). */
+  panelTab: string;
+  /** The backend half of the composite key (names the provider in the say). */
+  backend: string;
+  /** Bridge frames, in push order: say → degraded ack → turn done. */
+  frames: Array<Record<string, unknown>>;
+}
+
+/** Build the per-tab degradation frames for a start failure on `key`. */
+export function buildStartFailureNotice(
+  key: string,
+  message: string,
+  defaultBackend: string,
+): StartFailureNotice {
+  const backend = backendOfKey(key, defaultBackend);
+  const panelTab = panelTabOfKey(key);
+  const hint = startFailureHint(backend);
+  return {
+    panelTab,
+    backend,
+    frames: [
+      { type: "say", text: `⚠️ The ${backend} agent could not start: ${message} — ${hint}` },
+      { type: "ack", ok: false, kind: "degraded" },
+      { type: "turn", state: "done" },
+    ],
+  };
+}


### PR DESCRIPTION
Follow-ups from the adversarial review of #253 (findings 2, 4, 5, 7).

## #255 — rebind race stranded a prepare-failing agent under its new key

**What:** `settle()` in `PanelAgentManager.spawn()` guarded on its spawn-time key (`agents.get(tabId) !== agent`). If `rebindAgent()` moved a still-starting agent to a new key (panel tab-id migration) and `prepare()` then rejected, settle early-returned: the dead agent stayed mapped under the new key — `hasLiveAgent` true, queue never drained, no `onStartFailure`, tab wedged until reset.

**Fix:** settle now locates the agent by **identity** (scan of the agents map) and cleans up / fires `onStartFailure` / `onAgentFatal` under whatever key **currently** maps the agent. If the agent is no longer mapped at all (replaced by `restartAgentResume`), settle is still a no-op.

**Also (finding 5):** the orchestrator's inline `onStartFailure` wiring had zero test coverage. The frame construction — hint selection via `openAiKeyProvider`, composite-key → panel-tab split, `say` + degraded `ack` + `turn:done` push order — is extracted to `src/orchestrator/start-failure-notice.ts` (index.ts now just pushes the built frames) and unit-tested in `start-failure-notice.test.ts`.

## #256 — messages into a failing start died silently

**What:** anything queued into a doomed agent between spawn and `prepare()`-reject died with it: no seen ack, no failure ack, bubble stuck muted-queued forever.

**Fix:** `prepare()` rejects **before the channel is ever consumed**, so every message since the spawn is still in the agent's queue. `settle(err)` captures them (via `takePending()`, before `stop()`) into a manager-level held-mail map; the **next spawn on the same key re-delivers them first**, in order, with their original `mid`s — so the fresh agent's dequeue fires the normal `seen` acks and the panel bubbles flip from queued to read. Redelivery semantics were chosen over nacking to match the existing held-mail precedent (`heldDuringGen` / `restartAgentResume` carry-over): the message is answered, not bounced. If the retry fails too, settle re-captures — no loss loop. Held mail migrates on `rebindAgent()` (in the durable pass — it exists precisely when no live agent does), and is dropped on explicit `reset()` / `stopAll()`.

`takePending()`'s return type now includes `mid` (the runtime items always carried it), so `restartAgentResume` carry-over also preserves seen-tracking.

## #257 — `turn state:'idle'` was a no-op

**What:** the local-VRAM hold path (`index.ts`, held-during-gen branch) pushed `{ type: 'turn', state: 'idle' }` to clear the working spinner, but the panel's `onTurn` handler only recognizes `'working'` and `'done'` — the spinner ran until the 120s safety timeout.

**Fix:** push `state: 'done'`. Verified read-only against the panel repo (`web/js/comfyui-mcp-panel.js`, `onTurn`): `'done'` hides the spinner, disarms the mid-task resume nudge (correct here — no turn is in flight; the held message re-delivers on render end with a fresh `'working'`), and snapshots the graph in a try/catch (harmless).

Fixes #255
Fixes #256
Fixes #257

## Test evidence

- `npx tsc --noEmit` — clean
- `npx vitest run` — **137 files / 1551 tests passed**
- New: `start-failure-rebind-heldmail.test.ts` — rebind-during-failing-start → slot cleaned under the new key + `onStartFailure(newKey)` fired + recoverable; queued-during-failing-start → re-delivered in order after a successful retry with seen acks for the original mids; held mail follows a rebind.
- New: `start-failure-notice.test.ts` — hint selection (moonshot/glm/kimi via registry, openrouter/custom/generic fallbacks), composite-key → panel tab split (incl. `wf:`-prefixed ids and bare keys), exact frame sequence say → degraded ack → `turn:done` (pinning that it is not `idle`).
- Updated: `start-failure-per-tab.test.ts` recoverability case — the retry turn now (correctly) also contains the re-delivered first message, ordered ahead of the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)