### PR TITLE
fix(queue-status): foreign-run attribution + sub-tick run completions in the queue_status broadcast

### DIFF
--- a/src/__tests__/tools/diagnose-run.test.ts
+++ b/src/__tests__/tools/diagnose-run.test.ts
@@ -194,3 +194,61 @@ describe("diagnose_run — failure explanation", () => {
     expect(validateWorkflowMock).not.toHaveBeenCalled();
   });
 });
+
+describe("diagnose_run — interrupted runs (mobile#23)", () => {
+  // ComfyUI records an interrupted run with status_str "error" plus an
+  // execution_interrupted message and NO execution_error. Echoing the raw
+  // "error" made cancelled runs read as failures downstream (mobile's
+  // classifier keys on the exact word "error" → "Render failed").
+  const interruptedEntry = (queueNumber: number, id: string) => ({
+    prompt: [queueNumber, id, { "1": { class_type: "KSampler", inputs: {} } }, {}, []],
+    outputs: {},
+    status: {
+      status_str: "error",
+      completed: false,
+      messages: [
+        ["execution_start", { prompt_id: id, timestamp: 1 }],
+        ["execution_interrupted", { prompt_id: id, node_id: "5", node_type: "KSampler" }],
+      ],
+    },
+  });
+
+  it("reports Status: interrupted (not error) with an Interrupted section, no Runtime-failure section", async () => {
+    getHistoryMock.mockResolvedValue({ p: interruptedEntry(1, "p") });
+    const text = (await getHandler("diagnose_run")({ prompt_id: "p" })).content[0].text;
+    expect(text).toContain("**Status**: interrupted");
+    expect(text).not.toContain("**Status**: error");
+    expect(text).toContain("### Interrupted");
+    expect(text).toContain("interrupted/cancelled at node 5 (KSampler)");
+    expect(text).not.toContain("### Runtime failure");
+    expect(text).not.toContain("_No runtime error recorded");
+  });
+
+  it("a genuine execution_error wins over an interrupted marker in the same entry", async () => {
+    const e = interruptedEntry(1, "p") as { status: { messages: unknown[] } };
+    e.status.messages.push([
+      "execution_error",
+      { node_id: 7, node_type: "VAEDecode", exception_type: "RuntimeError", exception_message: "boom" },
+    ]);
+    getHistoryMock.mockResolvedValue({ p: e });
+    const text = (await getHandler("diagnose_run")({ prompt_id: "p" })).content[0].text;
+    expect(text).toContain("**Status**: error");
+    expect(text).toContain("### Runtime failure");
+    expect(text).not.toContain("### Interrupted");
+  });
+
+  it("formatRunOutcome maps an interrupted entry without node info too", async () => {
+    const { formatRunOutcome } = await import("../../tools/diagnostics.js");
+    const lines = formatRunOutcome({
+      prompt: {},
+      outputs: {},
+      status: {
+        status_str: "error",
+        completed: false,
+        messages: [["execution_interrupted", {}]],
+      },
+    } as never);
+    expect(lines[0]).toBe("**Status**: interrupted");
+    expect(lines.join("\n")).toContain("### Interrupted");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3282,8 +3282,16 @@ export async function runPanelOrchestrator(): Promise<void> {
   const queueStatusBroadcaster = createQueueStatusBroadcaster(
     () => QueueMonitor.snapshot(),
     (frame) => void bridge.push(frame),
+    () => QueueMonitor.drainCompletions(),
   );
-  const queueStatusTimer = setInterval(() => queueStatusBroadcaster.tick(), 1000);
+  // Each tick first refreshes the monitor over HTTP (GET /queue + /history
+  // tail): on modern ComfyUI (0.28+) the passive watchdog WS carries no
+  // prompt_id and no completion events for foreign runs, so the poll is what
+  // restores run attribution (#258) and catches runs shorter than the tick
+  // (#259). poll() never rejects and self-guards against overlap.
+  const queueStatusTimer = setInterval(() => {
+    void QueueMonitor.poll().finally(() => queueStatusBroadcaster.tick());
+  }, 1000);
   queueStatusTimer.unref?.();
 
   // Keep the pod's stored bridge URL fresh so a ComfyUI RESTART self-heals fast.

--- a/src/services/queue-monitor.poll.test.ts
+++ b/src/services/queue-monitor.poll.test.ts
@@ -1,0 +1,190 @@
+// queue-monitor.poll.test.ts — the HTTP poll that restores run attribution on
+// modern ComfyUI (issues #258/#259).
+//
+// Wire-level fact (verified live on ComfyUI 0.28.0): a passive, non-originating
+// WS client receives ONLY `status` frames — execution_start / executing /
+// execution_* / progress / progress_state are all sid-scoped to the client that
+// queued the prompt. So for foreign runs the watchdog's WS carries no prompt_id
+// and no completion signal at all. poll() supplies both over HTTP:
+//   • GET /queue → queue_running[0][1] is the running prompt_id (#258);
+//   • GET /history tail diff → completions with success/error status, including
+//     runs that started AND finished entirely between polls (#259).
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueueMonitor, type CompletionEvent } from "./queue-monitor.js";
+
+// Reach into the singleton the same way queue-status-broadcast.test.ts does —
+// no real WS is opened (start() is never called here).
+type Priv = {
+  url: string | null;
+  stopped: boolean;
+  busy: boolean;
+  pollInFlight: boolean;
+  historyPrimed: boolean;
+  historySeen: Set<string>;
+  completedReported: Set<string>;
+  pendingCompletions: CompletionEvent[];
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    currentNode: string | null;
+    progressValue: number | null;
+    progressMax: number | null;
+    queueRemaining: number;
+    lastActivityTs: number | null;
+    lastCompleted: CompletionEvent | null;
+  };
+  onMessage(text: string): void;
+};
+const priv = QueueMonitor as unknown as Priv;
+
+/** Route fetches by path fragment; anything unmatched 404s. */
+function mockFetch(routes: { queue?: unknown; history?: unknown }): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      const body = url.includes("/history")
+        ? routes.history
+        : url.includes("/queue")
+          ? routes.queue
+          : undefined;
+      if (body === undefined) return { ok: false, json: async () => ({}) };
+      return { ok: true, json: async () => body };
+    }),
+  );
+}
+
+const emptyQueue = { queue_running: [], queue_pending: [] };
+const historyEntry = (statusStr: string, messages: unknown[][] = []) => ({
+  status: { status_str: statusStr, completed: statusStr === "success", messages },
+});
+
+beforeEach(() => {
+  priv.url = "http://127.0.0.1:9999";
+  priv.stopped = false;
+  priv.busy = false;
+  priv.pollInFlight = false;
+  priv.historyPrimed = false;
+  priv.historySeen = new Set();
+  priv.completedReported = new Set();
+  priv.pendingCompletions.length = 0;
+  priv.state.runningPromptId = null;
+  priv.state.currentNode = null;
+  priv.state.progressValue = null;
+  priv.state.progressMax = null;
+  priv.state.queueRemaining = 0;
+  priv.state.lastActivityTs = null;
+  priv.state.lastCompleted = null;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  priv.stopped = true;
+  priv.url = null;
+});
+
+describe("poll() /queue attribution (#258)", () => {
+  it("adopts the running prompt_id and true depth from GET /queue", async () => {
+    mockFetch({
+      queue: {
+        queue_running: [[5, "p-foreign", { "1": {} }, {}, ["7"]]],
+        queue_pending: [[6, "p-next", {}, {}, []]],
+      },
+      history: {},
+    });
+    await QueueMonitor.poll();
+    const snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(true);
+    expect(snap.runningPromptId).toBe("p-foreign");
+    expect(snap.queueDepth).toBe(2);
+  });
+
+  it("clears the adopted run once GET /queue reports empty", async () => {
+    mockFetch({ queue: { queue_running: [[5, "p-foreign", {}, {}, []]], queue_pending: [] }, history: {} });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.snapshot().running).toBe(true);
+
+    mockFetch({ queue: emptyQueue, history: {} });
+    await QueueMonitor.poll();
+    const snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(false);
+    expect(snap.runningPromptId).toBeNull();
+    expect(snap.queueDepth).toBe(0);
+  });
+
+  it("survives a fetch failure without touching state", async () => {
+    priv.state.runningPromptId = "p-keep";
+    priv.state.queueRemaining = 1;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+    );
+    await QueueMonitor.poll(); // must not reject
+    expect(QueueMonitor.snapshot().runningPromptId).toBe("p-keep");
+  });
+});
+
+describe("poll() /history tail diff (#259)", () => {
+  it("primes on the first look, then reports a sub-tick run that never showed in /queue", async () => {
+    // Tick 1: idle, one pre-existing history entry — primes, emits nothing.
+    mockFetch({ queue: emptyQueue, history: { "h-old": historyEntry("success") } });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()).toEqual([]);
+    expect(QueueMonitor.snapshot().lastCompleted).toBeNull();
+
+    // Tick 2: still idle on /queue (the run started AND failed between ticks),
+    // but the history tail gained an errored entry.
+    mockFetch({
+      queue: emptyQueue,
+      history: { "h-old": historyEntry("success"), "h-flash": historyEntry("error") },
+    });
+    await QueueMonitor.poll();
+    const events = QueueMonitor.drainCompletions();
+    expect(events).toHaveLength(1);
+    expect(events[0].promptId).toBe("h-flash");
+    expect(events[0].status).toBe("error");
+    expect(QueueMonitor.snapshot().lastCompleted?.promptId).toBe("h-flash");
+
+    // Tick 3: same tail — nothing new, no replay.
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()).toEqual([]);
+  });
+
+  it("maps an interrupted run distinctly", async () => {
+    mockFetch({ queue: emptyQueue, history: {} });
+    await QueueMonitor.poll(); // prime
+    mockFetch({
+      queue: emptyQueue,
+      history: { "h-int": historyEntry("error", [["execution_interrupted", { prompt_id: "h-int" }]]) },
+    });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()[0]?.status).toBe("interrupted");
+  });
+
+  it("completing the tracked running prompt also clears the run state", async () => {
+    mockFetch({ queue: { queue_running: [[1, "p-run", {}, {}, []]], queue_pending: [] }, history: {} });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.snapshot().running).toBe(true);
+
+    mockFetch({ queue: emptyQueue, history: { "p-run": historyEntry("success") } });
+    await QueueMonitor.poll();
+    const snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(false);
+    expect(snap.lastCompleted?.promptId).toBe("p-run");
+    expect(QueueMonitor.drainCompletions().map((e) => e.promptId)).toEqual(["p-run"]);
+  });
+
+  it("dedupes a completion seen by BOTH the WS event and the history diff", async () => {
+    mockFetch({ queue: emptyQueue, history: {} });
+    await QueueMonitor.poll(); // prime
+    // Own run: on older ComfyUI (or the originating client) the WS event lands first…
+    priv.onMessage(JSON.stringify({ type: "execution_success", data: { prompt_id: "p-own" } }));
+    expect(QueueMonitor.drainCompletions().map((e) => e.promptId)).toEqual(["p-own"]);
+    // …then the next poll sees the same finish in history. Must not re-emit.
+    mockFetch({ queue: emptyQueue, history: { "p-own": historyEntry("success") } });
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()).toEqual([]);
+  });
+});

--- a/src/services/queue-monitor.poll.test.ts
+++ b/src/services/queue-monitor.poll.test.ts
@@ -11,6 +11,7 @@
 //     runs that started AND finished entirely between polls (#259).
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueueMonitor, type CompletionEvent } from "./queue-monitor.js";
+import { logger } from "../utils/logger.js";
 
 // Reach into the singleton the same way queue-status-broadcast.test.ts does —
 // no real WS is opened (start() is never called here).
@@ -19,6 +20,8 @@ type Priv = {
   stopped: boolean;
   busy: boolean;
   pollInFlight: boolean;
+  pollGeneration: number;
+  monitorStartTs: number;
   historyPrimed: boolean;
   historySeen: Set<string>;
   completedReported: Set<string>;
@@ -64,6 +67,7 @@ beforeEach(() => {
   priv.stopped = false;
   priv.busy = false;
   priv.pollInFlight = false;
+  priv.monitorStartTs = Date.now();
   priv.historyPrimed = false;
   priv.historySeen = new Set();
   priv.completedReported = new Set();
@@ -186,5 +190,140 @@ describe("poll() /history tail diff (#259)", () => {
     mockFetch({ queue: emptyQueue, history: { "p-own": historyEntry("success") } });
     await QueueMonitor.poll();
     expect(QueueMonitor.drainCompletions()).toEqual([]);
+  });
+});
+
+describe("poll() hardening (codex review of PR #261)", () => {
+  it("issues the /queue and /history fetches in PARALLEL (worst case one timeout, not two)", async () => {
+    const resolvers: Array<() => void> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (input: unknown) =>
+          new Promise((res) => {
+            const body = String(input).includes("/history") ? {} : emptyQueue;
+            resolvers.push(() => res({ ok: true, json: async () => body }));
+          }),
+      ),
+    );
+    const done = QueueMonitor.poll();
+    await Promise.resolve(); // let poll() issue its requests
+    // BOTH requests must be in flight before either has resolved — a serial
+    // implementation would only have issued /queue at this point.
+    expect(resolvers).toHaveLength(2);
+    for (const r of resolvers) r();
+    await done;
+  });
+
+  it("fetches a 32-entry tail and warns (does not silently claim coverage) when a diff saturates it", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      mockFetch({ queue: emptyQueue, history: {} });
+      await QueueMonitor.poll(); // prime
+      const urls = (fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes("max_items=32"))).toBe(true);
+
+      // 32 brand-new entries — the whole window is unseen: possible gap.
+      const burst = Object.fromEntries(
+        Array.from({ length: 32 }, (_, i) => [
+          `h-${i}`,
+          { ...historyEntry("success"), prompt: [i + 1, `h-${i}`, {}, {}, []] },
+        ]),
+      );
+      mockFetch({ queue: emptyQueue, history: burst });
+      await QueueMonitor.poll();
+      expect(QueueMonitor.drainCompletions()).toHaveLength(32);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("saturated"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("priming does NOT swallow a run that finished during startup (timestamp cutoff)", async () => {
+    priv.monitorStartTs = 1000;
+    mockFetch({
+      queue: emptyQueue,
+      history: {
+        "h-old": {
+          ...historyEntry("success", [["execution_success", { prompt_id: "h-old", timestamp: 500 }]]),
+          prompt: [1, "h-old", {}, {}, []],
+        },
+        "h-during": {
+          ...historyEntry("error", [["execution_error", { prompt_id: "h-during", timestamp: 2000 }]]),
+          prompt: [2, "h-during", {}, {}, []],
+        },
+      },
+    });
+    await QueueMonitor.poll(); // FIRST look — primes, but must keep h-during
+    const events = QueueMonitor.drainCompletions();
+    expect(events.map((e) => e.promptId)).toEqual(["h-during"]);
+    expect(events[0].status).toBe("error");
+    // …and h-during is not double-reported on the next diff.
+    await QueueMonitor.poll();
+    expect(QueueMonitor.drainCompletions()).toEqual([]);
+  });
+
+  it("abandons an in-flight poll's responses when the generation changes (retarget race)", async () => {
+    const resolvers: Array<() => void> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (input: unknown) =>
+          new Promise((res) => {
+            const body = String(input).includes("/history")
+              ? { "h-stale": historyEntry("success") }
+              : { queue_running: [[9, "p-stale", {}, {}, []]], queue_pending: [] };
+            resolvers.push(() => res({ ok: true, json: async () => body }));
+          }),
+      ),
+    );
+    priv.historyPrimed = true; // pretend a diff baseline exists so h-stale WOULD report
+    const done = QueueMonitor.poll();
+    await Promise.resolve();
+    priv.pollGeneration++; // what stop()/start(newUrl) does mid-flight
+    for (const r of resolvers) r();
+    await done;
+    // The old target's responses must not have touched anything.
+    const snap = QueueMonitor.snapshot();
+    expect(snap.running).toBe(false);
+    expect(snap.runningPromptId).toBeNull();
+    expect(QueueMonitor.drainCompletions()).toEqual([]);
+  });
+
+  it("start() resets completion state so nothing leaks across a retarget", () => {
+    priv.state.lastCompleted = { promptId: "p-old", status: "success", at: 1 };
+    priv.pendingCompletions.push({ promptId: "p-old", status: "success", at: 1 });
+    priv.completedReported.add("p-old");
+    priv.historyPrimed = true;
+    const gen = priv.pollGeneration;
+    QueueMonitor.start("http://127.0.0.1:9997"); // different URL → full retarget path
+    try {
+      expect(priv.pollGeneration).toBeGreaterThan(gen);
+      expect(QueueMonitor.snapshot().lastCompleted).toBeNull();
+      expect(priv.pendingCompletions).toHaveLength(0);
+      expect(priv.completedReported.size).toBe(0);
+      expect(priv.historyPrimed).toBe(false);
+    } finally {
+      QueueMonitor.stop();
+    }
+  });
+
+  it("replays a burst in ComfyUI queue-number order (prompt[0]), not /history object order", async () => {
+    mockFetch({ queue: emptyQueue, history: {} });
+    await QueueMonitor.poll(); // prime
+    // Object order deliberately scrambled vs. the queue counter.
+    mockFetch({
+      queue: emptyQueue,
+      history: {
+        "h-b": { ...historyEntry("success"), prompt: [7, "h-b", {}, {}, []] },
+        "h-a": { ...historyEntry("error"), prompt: [5, "h-a", {}, {}, []] },
+        "h-c": { ...historyEntry("success"), prompt: [6, "h-c", {}, {}, []] },
+      },
+    });
+    await QueueMonitor.poll();
+    const events = QueueMonitor.drainCompletions();
+    expect(events.map((e) => e.promptId)).toEqual(["h-a", "h-c", "h-b"]);
+    // lastCompleted is the genuinely newest run, not the last object key.
+    expect(QueueMonitor.snapshot().lastCompleted?.promptId).toBe("h-b");
   });
 });

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -6,13 +6,20 @@
 // for minutes at high resolution) is invisible here — which is how a stalled job
 // once let the agent stack three more behind it before anyone noticed.
 //
-// This service opens its OWN lightweight WebSocket to COMFYUI_URL. ComfyUI
-// broadcasts `status`, `progress`, and `progress_state` to every connected
-// client, so we receive the live stream for ANY job — including the
-// browser-queued ones — without touching the panel or the agent subprocess.
-// (The legacy execution_start / executing / execution_* events are sid-scoped
-// to the QUEUING client on modern ComfyUI — verified live on 0.28 — so the
-// handlers below also derive the run state from the broadcast-safe frames.)
+// This service opens its OWN lightweight WebSocket to COMFYUI_URL, and — on
+// modern ComfyUI — supplements it with a cheap HTTP poll (see poll() below).
+// The WS handlers keep the full event vocabulary for older servers, but on
+// ComfyUI 0.28 a passive (non-originating) client receives ONLY `status`
+// frames: execution_start / executing / execution_* AND progress /
+// progress_state are all sid-scoped to the QUEUING client (verified wire-level
+// on a live 0.28.0 — a foreign run delivers nothing but queue_remaining
+// transitions here). So run ATTRIBUTION for foreign jobs must come from HTTP:
+//   • GET /queue        — queue_running entries are [number, prompt_id, ...],
+//                          which names the running prompt (issue #258);
+//   • GET /history tail — a run that starts AND finishes between polls still
+//                          lands in history, so diffing the newest ids yields a
+//                          completion event with success/error status even when
+//                          no live signal was ever observed (issue #259).
 // It holds the last-known run state and derives a stall/backlog report the
 // orchestrator surfaces to the agent as a turn-start note (the same channel as
 // the crash-dump injector).
@@ -37,6 +44,21 @@ interface MonitorState {
   // progress value ticked up) while a job runs. A stuck step re-emits the same
   // progress value, which must NOT refresh this — that's how we see the stall.
   lastActivityTs: number | null;
+  // The most recent completed run (from the /history tail diff or, on older
+  // ComfyUI, the execution_success/error WS events). Sticky: survives idle so a
+  // tab that connects late still learns what just finished.
+  lastCompleted: CompletionEvent | null;
+}
+
+/** How a finished run ended. `interrupted` = cancelled mid-run. */
+export type CompletionStatus = "success" | "error" | "interrupted";
+
+/** One finished run, observed live (WS) or recovered from the /history tail. */
+export interface CompletionEvent {
+  promptId: string;
+  status: CompletionStatus;
+  /** ms epoch when WE observed the completion (not ComfyUI's own timestamp). */
+  at: number;
 }
 
 export interface StallReport {
@@ -65,6 +87,8 @@ export interface QueueSnapshot {
   /** Progress of the current node (sampler steps), null before the first tick. */
   progressValue: number | null;
   progressMax: number | null;
+  /** The most recent completed run (sticky; null until one completes). */
+  lastCompleted: CompletionEvent | null;
 }
 
 const RECONNECT_MS = 5000;
@@ -89,7 +113,20 @@ class QueueMonitorImpl {
     progressMax: null,
     queueRemaining: 0,
     lastActivityTs: null,
+    lastCompleted: null,
   };
+  // ---- HTTP-poll bookkeeping (the broadcast-safe channel on modern ComfyUI) ----
+  private pollInFlight = false;
+  // /history tail diff: the ids seen on the previous poll. Primed (no events
+  // emitted) on the first successful fetch after start(), so pre-existing
+  // history never replays as fresh completions.
+  private historyPrimed = false;
+  private historySeen = new Set<string>();
+  // Prompt ids already reported as completed — dedupes the WS event vs. the
+  // history diff observing the same finish. Bounded FIFO.
+  private completedReported = new Set<string>();
+  // Completions not yet drained by the broadcaster. Bounded.
+  private pendingCompletions: CompletionEvent[] = [];
 
   /** Open the watchdog WS to ComfyUI. Idempotent per-URL; best-effort (never
    *  throws). A retarget (new URL) or a prior stop() must re-open the socket:
@@ -101,6 +138,10 @@ class QueueMonitorImpl {
     this.stop(); // tear down any prior socket/reconnect timer (also on URL change)
     this.url = comfyuiUrl;
     this.stopped = false;
+    // A (re)start may target a DIFFERENT ComfyUI whose history tail is all new
+    // to us — re-prime the diff so its backlog doesn't replay as completions.
+    this.historyPrimed = false;
+    this.historySeen.clear();
     this.connect();
   }
 
@@ -326,6 +367,16 @@ class QueueMonitorImpl {
       case "execution_success":
       case "execution_error":
       case "execution_interrupted": {
+        // Older ComfyUI broadcasts these to every client; modern 0.28 scopes
+        // them to the originator (own runs still pass through here when the
+        // orchestrator queued them). recordCompletion dedupes against the
+        // /history diff seeing the same finish.
+        if (typeof data.prompt_id === "string") {
+          this.recordCompletion(
+            data.prompt_id,
+            msg.type === "execution_success" ? "success" : msg.type === "execution_interrupted" ? "interrupted" : "error",
+          );
+        }
         this.clearRunning();
         this.emitEndIfIdle();
         break;
@@ -333,6 +384,130 @@ class QueueMonitorImpl {
       default:
         break;
     }
+  }
+
+  /** Record one finished run exactly once (WS event and /history diff can both
+   *  observe the same finish). Completing the tracked running prompt also
+   *  clears the run state. Never throws. */
+  private recordCompletion(promptId: string, status: CompletionStatus): void {
+    if (this.completedReported.has(promptId)) return;
+    this.completedReported.add(promptId);
+    // Bounded FIFO — Set iterates in insertion order, so drop the oldest.
+    while (this.completedReported.size > 200) {
+      const oldest = this.completedReported.values().next().value;
+      if (oldest === undefined) break;
+      this.completedReported.delete(oldest);
+    }
+    const ev: CompletionEvent = { promptId, status, at: Date.now() };
+    this.state.lastCompleted = ev;
+    this.pendingCompletions.push(ev);
+    while (this.pendingCompletions.length > 20) this.pendingCompletions.shift();
+    if (this.state.runningPromptId === promptId) {
+      this.clearRunning();
+      this.emitEndIfIdle();
+    }
+  }
+
+  /** Hand the not-yet-broadcast completions to the queue_status broadcaster
+   *  (each drains exactly once). */
+  drainCompletions(): CompletionEvent[] {
+    if (this.pendingCompletions.length === 0) return [];
+    return this.pendingCompletions.splice(0);
+  }
+
+  /** GET a JSON endpoint on the monitored ComfyUI. Best-effort: null on any
+   *  failure, hard 2.5s timeout so a wedged server can't pile up polls. */
+  private async fetchJson(path: string): Promise<unknown> {
+    if (!this.url) return null;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 2500);
+    (timer as { unref?: () => void }).unref?.();
+    try {
+      const res = await fetch(`${this.url.replace(/\/+$/, "")}${path}`, { signal: ctrl.signal });
+      if (!res.ok) return null;
+      return (await res.json()) as unknown;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** One HTTP poll tick — the broadcast-safe channel on modern ComfyUI, where
+   *  the passive WS carries no attribution (see header). Reads GET /queue for
+   *  the running prompt_id + true depth (#258) and diffs GET /history's tail
+   *  for runs that finished since the last poll — including runs that started
+   *  AND finished entirely between polls (#259). Best-effort, never rejects,
+   *  self-guards against overlap. */
+  async poll(): Promise<void> {
+    if (this.stopped || !this.url || this.pollInFlight) return;
+    this.pollInFlight = true;
+    try {
+      await this.pollQueue();
+      await this.pollHistory();
+    } catch (err) {
+      logger.debug(`[queue-monitor] poll failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      this.pollInFlight = false;
+    }
+  }
+
+  private async pollQueue(): Promise<void> {
+    const fetchStart = Date.now();
+    const q = (await this.fetchJson("/queue")) as
+      | { queue_running?: unknown; queue_pending?: unknown }
+      | null;
+    if (!q || typeof q !== "object") return;
+    const running = Array.isArray(q.queue_running) ? q.queue_running : [];
+    const pending = Array.isArray(q.queue_pending) ? q.queue_pending : [];
+    this.state.queueRemaining = running.length + pending.length;
+    // queue_running entries are [number, prompt_id, prompt, extra, outputs] —
+    // the ONLY place a passive observer learns WHICH prompt runs on 0.28.
+    const first = running[0];
+    if (Array.isArray(first) && typeof first[1] === "string") {
+      this.adoptRunningPrompt(first[1]);
+    } else if (running.length === 0 && this.state.runningPromptId !== null) {
+      // Empty queue → the tracked run is over. Skip the clear if a run was
+      // adopted AFTER this fetch began (the response would be stale for it).
+      if ((this.state.lastActivityTs ?? 0) <= fetchStart) {
+        this.clearRunning();
+        this.emitEndIfIdle();
+      }
+    } else if (running.length === 0) {
+      this.emitEndIfIdle();
+    }
+  }
+
+  private async pollHistory(): Promise<void> {
+    // 8 entries of tail: at 1 Hz even a burst of sub-second runs can't scroll
+    // more than that past us between polls.
+    const h = (await this.fetchJson("/history?max_items=8")) as Record<string, unknown> | null;
+    if (!h || typeof h !== "object" || Array.isArray(h)) return;
+    const ids = Object.keys(h);
+    if (!this.historyPrimed) {
+      // First look after (re)start: whatever is already there predates us.
+      this.historyPrimed = true;
+      this.historySeen = new Set(ids);
+      return;
+    }
+    for (const id of ids) {
+      if (this.historySeen.has(id)) continue;
+      const entry = h[id] as { status?: { status_str?: unknown; completed?: unknown; messages?: unknown } } | null;
+      const st = entry && typeof entry === "object" ? entry.status : undefined;
+      let status: CompletionStatus;
+      if (st?.completed === true || st?.status_str === "success" || st === undefined) {
+        status = "success";
+      } else if (
+        Array.isArray(st.messages) &&
+        st.messages.some((m) => Array.isArray(m) && m[0] === "execution_interrupted")
+      ) {
+        status = "interrupted";
+      } else {
+        status = "error";
+      }
+      this.recordCompletion(id, status);
+    }
+    this.historySeen = new Set(ids);
   }
 
   /** Cheap snapshot for backpressure (panel_run) and the live `queue_status`
@@ -346,6 +521,7 @@ class QueueMonitorImpl {
       currentNode: this.state.currentNode,
       progressValue: this.state.progressValue,
       progressMax: this.state.progressMax,
+      lastCompleted: this.state.lastCompleted,
     };
   }
 

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -92,6 +92,11 @@ export interface QueueSnapshot {
 }
 
 const RECONNECT_MS = 5000;
+// /history tail entries fetched per poll. Wide enough that a realistic burst
+// of sub-second runs between 1 Hz polls stays inside the window; when a diff
+// still saturates it (every entry new), we log the potential gap instead of
+// silently claiming coverage.
+const HISTORY_TAIL_ITEMS = 32;
 
 class QueueMonitorImpl {
   private ws: WebSocket | null = null;
@@ -117,9 +122,16 @@ class QueueMonitorImpl {
   };
   // ---- HTTP-poll bookkeeping (the broadcast-safe channel on modern ComfyUI) ----
   private pollInFlight = false;
-  // /history tail diff: the ids seen on the previous poll. Primed (no events
-  // emitted) on the first successful fetch after start(), so pre-existing
-  // history never replays as fresh completions.
+  // Bumped on every start()/stop(). A poll captures it before fetching and
+  // abandons its (now stale) responses if a retarget happened while awaiting —
+  // otherwise an in-flight /queue answer from the OLD ComfyUI could mutate
+  // state for the NEW one.
+  private pollGeneration = 0;
+  // When THIS monitor came up (ms epoch) — the priming cutoff for the history
+  // diff: tail entries that completed before this predate us and are swallowed;
+  // ones that completed after (a run finishing during startup) are reported.
+  private monitorStartTs = Date.now();
+  // /history tail diff: the ids seen on the previous poll.
   private historyPrimed = false;
   private historySeen = new Set<string>();
   // Prompt ids already reported as completed — dedupes the WS event vs. the
@@ -139,9 +151,16 @@ class QueueMonitorImpl {
     this.url = comfyuiUrl;
     this.stopped = false;
     // A (re)start may target a DIFFERENT ComfyUI whose history tail is all new
-    // to us — re-prime the diff so its backlog doesn't replay as completions.
+    // to us — invalidate any in-flight poll (generation bump), re-prime the
+    // diff, and drop completion state that belonged to the old target so its
+    // backlog can neither replay nor leak across the retarget.
+    this.pollGeneration++;
+    this.monitorStartTs = Date.now();
     this.historyPrimed = false;
     this.historySeen.clear();
+    this.completedReported.clear();
+    this.pendingCompletions.length = 0;
+    this.state.lastCompleted = null;
     this.connect();
   }
 
@@ -184,6 +203,7 @@ class QueueMonitorImpl {
 
   stop(): void {
     this.stopped = true;
+    this.pollGeneration++; // strand any in-flight poll's pending responses
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
     try {
@@ -401,7 +421,9 @@ class QueueMonitorImpl {
     const ev: CompletionEvent = { promptId, status, at: Date.now() };
     this.state.lastCompleted = ev;
     this.pendingCompletions.push(ev);
-    while (this.pendingCompletions.length > 20) this.pendingCompletions.shift();
+    // Bound must exceed the history tail (HISTORY_TAIL_ITEMS) so one saturated
+    // diff still reaches the broadcaster whole; beyond that, drop the oldest.
+    while (this.pendingCompletions.length > 2 * HISTORY_TAIL_ITEMS) this.pendingCompletions.shift();
     if (this.state.runningPromptId === promptId) {
       this.clearRunning();
       this.emitEndIfIdle();
@@ -438,13 +460,25 @@ class QueueMonitorImpl {
    *  the running prompt_id + true depth (#258) and diffs GET /history's tail
    *  for runs that finished since the last poll — including runs that started
    *  AND finished entirely between polls (#259). Best-effort, never rejects,
-   *  self-guards against overlap. */
+   *  self-guards against overlap. Both fetches run in PARALLEL so the
+   *  worst-case poll is one timeout, not two — overlapping ticks bail at
+   *  pollInFlight, so a serial 5s worst case would stall attribution. */
   async poll(): Promise<void> {
     if (this.stopped || !this.url || this.pollInFlight) return;
     this.pollInFlight = true;
+    const gen = this.pollGeneration;
+    const fetchStart = Date.now();
     try {
-      await this.pollQueue();
-      await this.pollHistory();
+      const [q, h] = await Promise.all([
+        this.fetchJson("/queue"),
+        this.fetchJson(`/history?max_items=${HISTORY_TAIL_ITEMS}`),
+      ]);
+      // A stop()/start() (retarget) happened while we were awaiting — these
+      // responses belong to the OLD target; writing them would corrupt the
+      // fresh state (and re-seed the old server's completions).
+      if (gen !== this.pollGeneration || this.stopped) return;
+      this.applyQueue(q, fetchStart);
+      this.applyHistory(h);
     } catch (err) {
       logger.debug(`[queue-monitor] poll failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
@@ -452,11 +486,8 @@ class QueueMonitorImpl {
     }
   }
 
-  private async pollQueue(): Promise<void> {
-    const fetchStart = Date.now();
-    const q = (await this.fetchJson("/queue")) as
-      | { queue_running?: unknown; queue_pending?: unknown }
-      | null;
+  private applyQueue(raw: unknown, fetchStart: number): void {
+    const q = raw as { queue_running?: unknown; queue_pending?: unknown } | null;
     if (!q || typeof q !== "object") return;
     const running = Array.isArray(q.queue_running) ? q.queue_running : [];
     const pending = Array.isArray(q.queue_pending) ? q.queue_pending : [];
@@ -478,35 +509,76 @@ class QueueMonitorImpl {
     }
   }
 
-  private async pollHistory(): Promise<void> {
-    // 8 entries of tail: at 1 Hz even a burst of sub-second runs can't scroll
-    // more than that past us between polls.
-    const h = (await this.fetchJson("/history?max_items=8")) as Record<string, unknown> | null;
+  /** Read one /history entry into diff-able facts. `queueNum` is ComfyUI's
+   *  monotonic queue counter (prompt[0]) — /history object order is NOT
+   *  chronological (see history-select.ts), so this is the only real order
+   *  key. `completedTs` is the newest server-side message timestamp (the end
+   *  event is always last), null when the entry carries none. */
+  private parseHistoryEntry(
+    id: string,
+    raw: unknown,
+  ): { id: string; queueNum: number; status: CompletionStatus; completedTs: number | null } {
+    const entry = raw as {
+      prompt?: unknown;
+      status?: { status_str?: unknown; completed?: unknown; messages?: unknown };
+    } | null;
+    const st = entry && typeof entry === "object" ? entry.status : undefined;
+    const messages = Array.isArray(st?.messages) ? (st.messages as unknown[]) : [];
+    let status: CompletionStatus;
+    if (st?.completed === true || st?.status_str === "success" || st === undefined) {
+      status = "success";
+    } else if (messages.some((m) => Array.isArray(m) && m[0] === "execution_interrupted")) {
+      status = "interrupted";
+    } else {
+      status = "error";
+    }
+    let completedTs: number | null = null;
+    for (const m of messages) {
+      if (!Array.isArray(m)) continue;
+      const ts = (m[1] as { timestamp?: unknown } | undefined)?.timestamp;
+      if (typeof ts === "number" && (completedTs === null || ts > completedTs)) completedTs = ts;
+    }
+    const prompt = entry && typeof entry === "object" ? entry.prompt : undefined;
+    const queueNum =
+      Array.isArray(prompt) && typeof prompt[0] === "number" ? prompt[0] : Number.MAX_SAFE_INTEGER;
+    return { id, queueNum, status, completedTs };
+  }
+
+  private applyHistory(raw: unknown): void {
+    const h = raw as Record<string, unknown> | null;
     if (!h || typeof h !== "object" || Array.isArray(h)) return;
     const ids = Object.keys(h);
     if (!this.historyPrimed) {
-      // First look after (re)start: whatever is already there predates us.
+      // First look after (re)start. Entries whose completion predates the
+      // monitor are swallowed — but a run that finished DURING startup
+      // (server-side timestamp after monitorStartTs) is a real completion the
+      // subscribers must still see, not priming noise. (Timestamps are the
+      // server's clock; against a remote host with heavy skew this degrades to
+      // at worst a replayed or swallowed tail entry at startup — best-effort.)
       this.historyPrimed = true;
       this.historySeen = new Set(ids);
+      const fresh = ids
+        .map((id) => this.parseHistoryEntry(id, h[id]))
+        .filter((e) => e.completedTs !== null && e.completedTs > this.monitorStartTs)
+        .sort((a, b) => a.queueNum - b.queueNum);
+      for (const e of fresh) this.recordCompletion(e.id, e.status);
       return;
     }
-    for (const id of ids) {
-      if (this.historySeen.has(id)) continue;
-      const entry = h[id] as { status?: { status_str?: unknown; completed?: unknown; messages?: unknown } } | null;
-      const st = entry && typeof entry === "object" ? entry.status : undefined;
-      let status: CompletionStatus;
-      if (st?.completed === true || st?.status_str === "success" || st === undefined) {
-        status = "success";
-      } else if (
-        Array.isArray(st.messages) &&
-        st.messages.some((m) => Array.isArray(m) && m[0] === "execution_interrupted")
-      ) {
-        status = "interrupted";
-      } else {
-        status = "error";
-      }
-      this.recordCompletion(id, status);
+    const unseen = ids
+      .filter((id) => !this.historySeen.has(id))
+      .map((id) => this.parseHistoryEntry(id, h[id]))
+      // Oldest-first by ComfyUI's monotonic queue number, so the burst replays
+      // in true order and lastCompleted lands on the genuinely newest run.
+      .sort((a, b) => a.queueNum - b.queueNum);
+    // Saturated window: EVERY entry of a full tail is new since the last
+    // successful diff — completions may have scrolled past unobserved. Say so
+    // instead of silently claiming full coverage.
+    if (unseen.length >= HISTORY_TAIL_ITEMS && unseen.length === ids.length) {
+      logger.warn(
+        `[queue-monitor] history tail saturated (${unseen.length} new entries in one diff) — some run completions may have been missed between polls`,
+      );
     }
+    for (const e of unseen) this.recordCompletion(e.id, e.status);
     this.historySeen = new Set(ids);
   }
 

--- a/src/services/queue-status-broadcast.test.ts
+++ b/src/services/queue-status-broadcast.test.ts
@@ -22,6 +22,7 @@ const idle = (): QueueSnapshot => ({
   currentNode: null,
   progressValue: null,
   progressMax: null,
+  lastCompleted: null,
 });
 
 const running = (progress: number): QueueSnapshot => ({
@@ -32,6 +33,7 @@ const running = (progress: number): QueueSnapshot => ({
   currentNode: "3",
   progressValue: progress,
   progressMax: 20,
+  lastCompleted: null,
 });
 
 describe("buildQueueStatusFrame", () => {
@@ -45,7 +47,18 @@ describe("buildQueueStatusFrame", () => {
       node: "3",
       progress_value: 7,
       progress_max: 20,
+      last_completed_prompt_id: null,
+      last_completed_status: null,
+      last_completed_at: null,
     });
+  });
+
+  it("carries the snapshot's lastCompleted onto the additive wire fields", () => {
+    const snap = { ...idle(), lastCompleted: { promptId: "p-done", status: "error" as const, at: 1234 } };
+    const f = buildQueueStatusFrame(snap);
+    expect(f.last_completed_prompt_id).toBe("p-done");
+    expect(f.last_completed_status).toBe("error");
+    expect(f.last_completed_at).toBe(1234);
   });
 
   it("maps an idle snapshot with nulls, not zeros", () => {
@@ -134,6 +147,56 @@ describe("createQueueStatusBroadcaster", () => {
 
     b.tick();
     expect(pushed).toHaveLength(1); // and never consumed the change either
+  });
+
+  // Issue #259: a run that starts AND finishes entirely between ticks leaves
+  // the state idle→idle — only the drained completion can reach subscribers.
+  it("replays drained completions as frames even when the state never changed", () => {
+    const done = { promptId: "p-flash", status: "error" as const, at: 5000 };
+    let snap = idle();
+    let queue: (typeof done)[] = [];
+    const pushed: QueueStatusFrame[] = [];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+      () => queue.splice(0),
+    );
+
+    b.tick(); // idle baseline
+    expect(pushed).toHaveLength(1);
+
+    // A sub-tick run fails: state is already idle again, but the monitor
+    // recorded the completion (snapshot.lastCompleted + drained event).
+    snap = { ...idle(), lastCompleted: done };
+    queue = [done];
+    b.tick();
+    expect(pushed).toHaveLength(2);
+    expect(pushed[1].running).toBe(false);
+    expect(pushed[1].last_completed_prompt_id).toBe("p-flash");
+    expect(pushed[1].last_completed_status).toBe("error");
+
+    b.tick(); // nothing new — the sticky lastCompleted must not re-push
+    expect(pushed).toHaveLength(2);
+  });
+
+  it("replays a BURST of completions as distinct frames, newest deduping into the state frame", () => {
+    const a = { promptId: "p-a", status: "error" as const, at: 1 };
+    const bEv = { promptId: "p-b", status: "success" as const, at: 2 };
+    const snap = { ...idle(), lastCompleted: bEv };
+    const pushed: QueueStatusFrame[] = [];
+    let queue = [a, bEv];
+    const b = createQueueStatusBroadcaster(
+      () => snap,
+      (f) => pushed.push(f),
+      () => queue.splice(0),
+    );
+    b.tick();
+    // Two frames: one per completion; the trailing state frame equals the
+    // p-b frame and dedupes away.
+    expect(pushed).toHaveLength(2);
+    expect(pushed.map((f) => f.last_completed_prompt_id)).toEqual(["p-a", "p-b"]);
+    b.tick();
+    expect(pushed).toHaveLength(2);
   });
 });
 

--- a/src/services/queue-status-broadcast.ts
+++ b/src/services/queue-status-broadcast.ts
@@ -12,7 +12,7 @@
 // sent. An idle rig therefore broadcasts nothing at all, and a running render
 // costs at most one frame per second.
 
-import type { QueueSnapshot } from "./queue-monitor.js";
+import type { CompletionEvent, QueueSnapshot } from "./queue-monitor.js";
 
 /** The wire shape of one live queue-status broadcast. */
 export interface QueueStatusFrame extends Record<string, unknown> {
@@ -30,10 +30,26 @@ export interface QueueStatusFrame extends Record<string, unknown> {
   /** Sampler-step progress of the current node (null before the first tick). */
   progress_value: number | null;
   progress_max: number | null;
+  // ---- Additive fields (issues #258/#259) — existing fields keep their exact
+  // meaning; older consumers simply ignore these. ----
+  /** prompt_id of the most recently FINISHED run (sticky; null until one
+   *  completes). Changes here push a frame even when a run started and finished
+   *  entirely between ticks — the sub-tick-run signal of issue #259. */
+  last_completed_prompt_id: string | null;
+  /** How that run ended. */
+  last_completed_status: "success" | "error" | "interrupted" | null;
+  /** ms epoch when the orchestrator observed the completion (staleness hint
+   *  for tabs that connect late and get this frame as their hello seed). */
+  last_completed_at: number | null;
 }
 
-/** Build the broadcast frame for one monitor snapshot. */
-export function buildQueueStatusFrame(s: QueueSnapshot): QueueStatusFrame {
+/** Build the broadcast frame for one monitor snapshot. `completed` overrides
+ *  the snapshot's own lastCompleted — used to replay a burst of completions
+ *  drained in one tick as distinct frames. */
+export function buildQueueStatusFrame(
+  s: QueueSnapshot,
+  completed: CompletionEvent | null = s.lastCompleted,
+): QueueStatusFrame {
   return {
     type: "queue_status",
     connected: s.connected,
@@ -43,6 +59,9 @@ export function buildQueueStatusFrame(s: QueueSnapshot): QueueStatusFrame {
     node: s.currentNode,
     progress_value: s.progressValue,
     progress_max: s.progressMax,
+    last_completed_prompt_id: completed?.promptId ?? null,
+    last_completed_status: completed?.status ?? null,
+    last_completed_at: completed?.at ?? null,
   };
 }
 
@@ -57,19 +76,32 @@ export interface QueueStatusBroadcaster {
  * Wire a snapshot source to a push sink with change-only semantics. The sink
  * is the bridge's broadcast push; it must never throw into the timer (the
  * bridge's own push already guarantees that, see ui-bridge.ts).
+ *
+ * `drainCompletions` (optional) yields runs that finished since the last tick
+ * — each one is replayed as its own frame BEFORE the change-only state frame,
+ * so even a run that started and completed entirely between ticks reaches
+ * every subscriber exactly once (issue #259). The final state frame carries
+ * the newest completion too, so it usually dedupes away.
  */
 export function createQueueStatusBroadcaster(
   snapshot: () => QueueSnapshot,
   push: (frame: QueueStatusFrame) => void,
+  drainCompletions?: () => CompletionEvent[],
 ): QueueStatusBroadcaster {
   let last = "";
+  const send = (frame: QueueStatusFrame): void => {
+    const key = JSON.stringify(frame);
+    if (key === last) return;
+    last = key;
+    push(frame);
+  };
   return {
     tick(): void {
-      const frame = buildQueueStatusFrame(snapshot());
-      const key = JSON.stringify(frame);
-      if (key === last) return;
-      last = key;
-      push(frame);
+      const snap = snapshot();
+      for (const ev of drainCompletions ? drainCompletions() : []) {
+        send(buildQueueStatusFrame(snap, ev));
+      }
+      send(buildQueueStatusFrame(snap));
     },
     current(): QueueStatusFrame {
       return buildQueueStatusFrame(snapshot());

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -23,6 +23,68 @@ function findExecutionError(entry: HistoryEntry): ExecutionErrorInfo | null {
   return msg ? (msg[1] as ExecutionErrorInfo) : null;
 }
 
+/** The `execution_interrupted` payload (user/agent cancel mid-run). */
+interface ExecutionInterruptedInfo {
+  node_id?: string | number;
+  node_type?: string;
+}
+
+function findExecutionInterrupted(entry: HistoryEntry): ExecutionInterruptedInfo | null {
+  const msg = (entry.status?.messages ?? []).find((m) => m[0] === "execution_interrupted");
+  return msg ? ((msg[1] ?? {}) as ExecutionInterruptedInfo) : null;
+}
+
+/**
+ * The Status line + outcome section of a diagnosis. Exported for tests.
+ *
+ * ComfyUI records an INTERRUPTED run with status_str "error" (plus an
+ * execution_interrupted message and NO execution_error) — echoing that raw
+ * "error" made cancelled runs read as failures ("Render failed" on mobile,
+ * see comfyui-mcp-mobile#23). Report it as interrupted instead; a genuine
+ * execution_error always wins over the interrupted marker.
+ */
+export function formatRunOutcome(entry: HistoryEntry): string[] {
+  const lines: string[] = [];
+  const execError = findExecutionError(entry);
+  const interrupted = execError ? null : findExecutionInterrupted(entry);
+  lines.push(`**Status**: ${interrupted ? "interrupted" : (entry.status?.status_str ?? "unknown")}`);
+
+  if (execError) {
+    lines.push("");
+    lines.push("### Runtime failure");
+    lines.push(`**Failed node**: ${execError.node_id ?? "?"} (${execError.node_type ?? "unknown type"})`);
+    if (execError.exception_type) lines.push(`**Type**: ${execError.exception_type}`);
+    if (execError.exception_message) {
+      lines.push(`**Message**: ${execError.exception_message}`);
+    }
+    if (Array.isArray(execError.traceback) && execError.traceback.length > 0) {
+      // Tail only — the last frames carry the cause, and a full traceback can
+      // be hundreds of lines (this reply goes straight into an agent's context).
+      const tail = execError.traceback.slice(-12);
+      lines.push("");
+      lines.push("```");
+      lines.push(tail.join("").trimEnd());
+      lines.push("```");
+    }
+  } else if (interrupted) {
+    lines.push("");
+    lines.push("### Interrupted");
+    const where =
+      interrupted.node_id !== undefined
+        ? ` at node ${interrupted.node_id}${interrupted.node_type ? ` (${interrupted.node_type})` : ""}`
+        : "";
+    lines.push(
+      `**This run was interrupted/cancelled${where}** — it did not crash. Nothing is broken; re-queue it if the cancellation wasn't intended.`,
+    );
+  } else {
+    lines.push("");
+    lines.push(
+      "_No runtime error recorded for this run_ — if the user still sees a problem, it was likely rejected BEFORE execution (see validation below) or the run simply produced an unwanted result.",
+    );
+  }
+  return lines;
+}
+
 /**
  * Pick the run to diagnose. An explicit id wins; otherwise prefer the most recent
  * FAILED run over a newer successful one — "why did it fail?" should land on the
@@ -256,35 +318,8 @@ export function registerDiagnosticsTools(server: McpServer): void {
         const [promptId, entry] = selected;
         const lines: string[] = [];
         lines.push(`## Diagnosis: ${promptId}`);
-        lines.push(`**Status**: ${entry.status?.status_str ?? "unknown"}`);
-
-        // 1. Runtime failure (what actually blew up mid-execution).
-        const execError = findExecutionError(entry);
-        if (execError) {
-          lines.push("");
-          lines.push("### Runtime failure");
-          lines.push(
-            `**Failed node**: ${execError.node_id ?? "?"} (${execError.node_type ?? "unknown type"})`,
-          );
-          if (execError.exception_type) lines.push(`**Type**: ${execError.exception_type}`);
-          if (execError.exception_message) {
-            lines.push(`**Message**: ${execError.exception_message}`);
-          }
-          if (Array.isArray(execError.traceback) && execError.traceback.length > 0) {
-            // Tail only — the last frames carry the cause, and a full traceback can
-            // be hundreds of lines (this reply goes straight into an agent's context).
-            const tail = execError.traceback.slice(-12);
-            lines.push("");
-            lines.push("```");
-            lines.push(tail.join("").trimEnd());
-            lines.push("```");
-          }
-        } else {
-          lines.push("");
-          lines.push(
-            "_No runtime error recorded for this run_ — if the user still sees a problem, it was likely rejected BEFORE execution (see validation below) or the run simply produced an unwanted result.",
-          );
-        }
+        // 1. Status + outcome: runtime failure, interruption, or clean.
+        lines.push(...formatRunOutcome(entry));
 
         // 2. Re-validate the exact graph that ran, so we can name what's missing.
         //    Reuses the same validator behind validate_workflow — the graph is the


### PR DESCRIPTION
Fixes #258
Fixes #259

## Root cause (#258)

Verified wire-level against the live ComfyUI **0.28.0**: a passive, non-originating WS client receives **only `status` frames** (queue_remaining) — `execution_start` / `executing` / `execution_*` **and** `progress` / `progress_state` are all sid-scoped to the client that queued the prompt. Probe result for a foreign run (frame type counts on the passive socket): `{"status": 4, "crystools.monitor": 11}` — nothing carrying a `prompt_id`. So `QueueMonitor`'s adopt-from-`progress_state` path (its only attribution source; it never polled HTTP) can never fire for foreign runs, leaving frames at `running:false / prompt_id:null` with depth-only transitions. Meanwhile `GET /queue`'s `queue_running` entries do carry the prompt_id (`[number, prompt_id, ...]` — confirmed live).

## Approach

`QueueMonitor` keeps its WS (still the source of node/progress detail for older servers and status/queue_remaining everywhere) and gains a best-effort `poll()` the orchestrator awaits before each 1 Hz broadcast tick:

- **#258 — `GET /queue`**: adopt `queue_running[0][1]` as the running prompt_id + take the true depth (running+pending). Clear the run when the queue reports empty (with a stale-response race guard).
- **#259 — `GET /history?max_items=8` tail diff**: new ids since the last poll are completions — this works **regardless of sid-scoping** (the ws `executing`/`executed` events verifiably do NOT reach foreign clients on 0.28, so history diffing was the only reliable option). Primed on first look so pre-existing history never replays; deduped against the WS `execution_success/error/interrupted` events (older ComfyUI / own runs) via a bounded set. Status mapping: `success` / `error` / `interrupted` (from `status.messages`).

The broadcaster drains completions each tick and replays each as its own frame, so a run that started AND finished entirely between ticks still reaches every subscriber exactly once.

## Wire compat (panel / mobile)

**Additive only** — no existing field changes meaning. New `queue_status` fields:

- `last_completed_prompt_id: string | null` (sticky — also seeds late-connecting tabs)
- `last_completed_status: "success" | "error" | "interrupted" | null`
- `last_completed_at: number | null` (ms epoch observation time, staleness hint)

Checked consumers: `comfyui-mcp-panel/web/js` does **not** consume `queue_status` bridge frames at all (only the unrelated `nodes_queue_status` tool). The mobile app can later replace its anonymous-diagnose burst/baseline dance by keying Diagnose off `last_completed_prompt_id` + `last_completed_status === "error"`, and drop the id-less mode.

## Live verification (ComfyUI 0.28.0, real dist code driving monitor + broadcaster as a passive observer)

- Foreign 20-step run → frame `running:true, prompt_id:"20cb1354-…", queue_depth:1`, then a completion frame `last_completed_status:"success"` ✅ (#258)
- Fully-cached rerun (completes in <100 ms, entirely between ticks; `/queue` observed empty the whole time) → completion frame `last_completed_prompt_id:"542d95ad-…", last_completed_status:"success"` still emitted ✅ (#259)
- Shared queue respected: only self-enqueued 512×512 v1-5 runs, nothing cancelled, running orchestrator untouched.

## Gates

- `npx tsc --noEmit` clean
- `npx vitest run`: 136 files / 1551 tests green (includes new unit tests: /queue adoption + clear + fetch-failure resilience; history prime/diff/dedupe/interrupted mapping; broadcaster completion replay incl. burst + idle→idle sub-tick case)

## Notes

- A long foreign render with zero broadcast progress signal now gets *tracked* (it previously didn't exist to the watchdog); its stall clock only refreshes on real signals, so the stall report stays conservative for foreign runs.
- Burst semantics: up to 8 history-tail entries per tick; each drained completion is replayed as a distinct frame (bounded queue of 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex review hardening (second commit)

Parallel /queue+/history fetches (one-timeout worst case); 32-entry history tail with a visible saturation warning; timestamp-based priming so runs finishing during startup aren't swallowed; poll generation counter + completion-state reset across stop()/start() retargets; completions ordered by ComfyUI's monotonic queue number (prompt[0]).

Also fixes the interrupted false-failure chain server-side (**comfyui-mcp-mobile#23**): `diagnose_run` now reports `Status: interrupted` (with an Interrupted section) for runs with `execution_interrupted` and no `execution_error`, instead of echoing status_str "error" — mobile's classifier will stop showing "Render failed" for cancels.
