### PR TITLE
feat(providers): surface which model an api-key provider is on, and how to change it

### DIFF
--- a/src/__tests__/services/provider-model-hint.test.ts
+++ b/src/__tests__/services/provider-model-hint.test.ts
@@ -1,0 +1,67 @@
+// The panel's API Keys card never told anyone that these providers ship a pinned
+// default model with an env override — so a user on a newer model (e.g. GLM 5.2)
+// had no way to discover they could point at it without reading the source.
+// `providerModelHint` generates that line FROM the registry so it can't drift
+// from the real default, and the credential slot appends it to its help text.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  OPENAI_KEY_PROVIDERS,
+  openAiKeyProvider,
+  providerModelHint,
+} from "../../services/openai-provider-registry.js";
+
+const GLM = openAiKeyProvider("glm")!;
+const saved = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const p of OPENAI_KEY_PROVIDERS) {
+    saved.set(p.modelEnv, process.env[p.modelEnv]);
+    delete process.env[p.modelEnv];
+  }
+});
+afterEach(() => {
+  for (const [k, v] of saved) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("providerModelHint", () => {
+  it("names the default model AND the env var that overrides it", () => {
+    const hint = providerModelHint(GLM);
+    expect(hint).toContain(GLM.defaultModel); // e.g. glm-4.7
+    expect(hint).toContain(GLM.modelEnv); // COMFYUI_MCP_GLM_MODEL
+    expect(hint).toMatch(/default/i);
+  });
+
+  it("reports the ACTIVE model when the env override is set", () => {
+    process.env[GLM.modelEnv] = "glm-5.2";
+    const hint = providerModelHint(GLM);
+    // Answers "why am I not on the model I set?" — shows active + where it came
+    // from + what the default would be.
+    expect(hint).toContain("glm-5.2");
+    expect(hint).toContain(GLM.modelEnv);
+    expect(hint).toContain(GLM.defaultModel);
+  });
+
+  it("is generated for every registry provider (no hand-written drift)", () => {
+    for (const p of OPENAI_KEY_PROVIDERS) {
+      const hint = providerModelHint(p);
+      expect(hint).toContain(p.defaultModel);
+      expect(hint).toContain(p.modelEnv);
+    }
+  });
+});
+
+describe("credential slot help", () => {
+  it("appends the model hint to the GLM slot, and names the Z.AI Coding Plan", async () => {
+    // Imported lazily so the beforeEach env reset applies to the module's
+    // slot construction (CREDENTIAL_SLOTS is built at module load).
+    const { CREDENTIAL_SLOTS } = await import("../../services/panel-secrets.js");
+    const slot = CREDENTIAL_SLOTS.find((s) => s.id === "glm");
+    expect(slot).toBeTruthy();
+    expect(slot!.help).toMatch(/Z\.AI Coding Plan/i);
+    expect(slot!.help).toContain(GLM.modelEnv);
+  });
+});

--- a/src/services/openai-provider-registry.ts
+++ b/src/services/openai-provider-registry.ts
@@ -75,7 +75,7 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
   {
     id: "glm",
     slotLabel: "GLM / Zhipu",
-    slotHelp: "GLM provider",
+    slotHelp: "Z.AI Coding Plan (GLM / Zhipu)",
     envKeys: ["GLM_API_KEY", "ZHIPU_API_KEY", "ZHIPUAI_API_KEY", "ZAI_API_KEY"],
     modelEnv: "COMFYUI_MCP_GLM_MODEL",
     defaultModel: process.env.COMFYUI_MCP_GLM_MODEL?.trim() || "glm-4.7",
@@ -138,4 +138,24 @@ export function simpleKeyProvider(id: string): OpenAiKeyProvider | undefined {
  *  the old `<provider>Model = process.env.<MODEL_ENV> ?? <DEFAULT_MODEL>`. */
 export function openAiKeyProviderModel(p: OpenAiKeyProvider): string {
   return process.env[p.modelEnv] ?? p.defaultModel;
+}
+
+/**
+ * One-line "which model am I on, and how do I change it?" hint for the panel's
+ * API Keys card.
+ *
+ * These providers ship a pinned default (glm-4.7, kimi-for-coding, kimi-k3) and
+ * a `modelEnv` override, but NOTHING in the UI ever said the override existed —
+ * so a user on a newer model (e.g. GLM 5.2) had no way to discover they could
+ * point at it without reading the source. Generated from the registry rather
+ * than hand-written per provider, so it can never drift from the real default.
+ *
+ * Reports the ACTIVE model (env override if set, else the default) and names the
+ * env var either way, so the card also answers "why am I not on the model I set?".
+ */
+export function providerModelHint(p: OpenAiKeyProvider): string {
+  const active = openAiKeyProviderModel(p);
+  return active === p.defaultModel
+    ? `Model ${active} (default) — set ${p.modelEnv} to use another.`
+    : `Model ${active} (via ${p.modelEnv}; default ${p.defaultModel}).`;
 }

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -21,7 +21,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "n
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
-import { OPENAI_KEY_PROVIDERS } from "./openai-provider-registry.js";
+import { OPENAI_KEY_PROVIDERS, providerModelHint } from "./openai-provider-registry.js";
 
 interface PanelSecrets {
   /** Env vars injected into the built-in comfyui MCP server's spawn env. */
@@ -495,7 +495,10 @@ export const CREDENTIAL_SLOTS: CredentialSlot[] = [
       label: p.slotLabel,
       envKeys: p.envKeys,
       store: "agent",
-      help: p.slotHelp,
+      // Append the generated model hint so the card says which model the
+      // provider is actually on and how to change it — the override env var
+      // existed but was invisible outside the source.
+      help: `${p.slotHelp} · ${providerModelHint(p)}`,
     }),
   ),
   { id: "civitai", label: "Civitai", envKeys: ["CIVITAI_API_TOKEN"], store: "comfyui", help: "Model downloads" },


### PR DESCRIPTION
Asked for in the help channel: *"add Z.AI Coding Plan / GLM 5.2 to the providers list"*.

## It's already supported — just undiscoverable

GLM **is** already a provider (`openai-provider-registry`, id `glm`). Its own credential resolver literally expects *"your Z.AI Coding Plan"* key (`ZAI_API_KEY` / `GLM_API_KEY` / `ZHIPUAI_API_KEY`). And each of these providers ships a pinned default model with a `modelEnv` override.

The problem: **nothing in the UI ever said the override existed.** A user wanting GLM 5.2 had no way to discover `COMFYUI_MCP_GLM_MODEL` without reading the source.

## Change

`providerModelHint()` generates the line **from the registry** — never hand-written, so it can't drift from the real default — and the credential slot appends it to its help:

```
GLM / Zhipu
Z.AI Coding Plan (GLM / Zhipu) · Model glm-4.7 (default) — set COMFYUI_MCP_GLM_MODEL to use another.
```

It reports the **active** model (env override if set, else the default) and names the env var either way, so the card also answers *"why am I not on the model I set?"*:

```
Model glm-5.2 (via COMFYUI_MCP_GLM_MODEL; default glm-4.7).
```

Applies to all three api-key providers (GLM, Kimi, Moonshot). Also replaces GLM's unhelpful `"GLM provider"` slot help with wording that names the Z.AI Coding Plan.

**Deliberately does NOT bump any default model** — per request, this is a discoverability fix, not a version bump.

## ⚠️ Needs the paired panel PR

While building this I found the panel **drops `help` for every credential slot** — OpenRouter's, Civitai's, RunPod's, all of them. That field has been sent and silently ignored since it was added; nobody has ever seen any of it.

Paired: **comfyui-mcp-panel#feat/render-credential-slot-help** renders it. **This change is invisible without that one.**

## Verification

- `tsc` clean; **142 files / 1619 tests green**; 4 new tests (default branch, override branch, all-providers generation, slot help wiring).
- Verified against the built dist — all 10 slots now carry help; GLM's reads exactly the string above.