### PR TITLE
fix(antigravity): a Stop pressed during turn startup was silently dropped

### DIFF
--- a/src/__tests__/orchestrator/antigravity-backend.test.ts
+++ b/src/__tests__/orchestrator/antigravity-backend.test.ts
@@ -111,6 +111,22 @@ beforeEach(() => {
   hoisted.procs.length = 0;
   hoisted.killed.length = 0;
   hoisted.script.length = 0;
+  // killProcessTree has TWO platform paths: Windows shells out to `taskkill`
+  // (mocked via spawnSync above), POSIX signals the process group with
+  // process.kill(-pid). Only the Windows path was emulated, so on Linux/macOS
+  // the fake child was never terminated and every interrupt test hung to the
+  // 5s timeout — green on a Windows dev box, red on CI. Emulate the POSIX path
+  // too so these tests assert the same behavior on every platform.
+  vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+    const target = Math.abs(Number(pid)); // POSIX group kill passes -pid
+    hoisted.killed.push(target);
+    const proc = hoisted.procs.find((p) => p.pid === target);
+    if (proc && proc.exitCode === null) {
+      proc.exitCode = 1;
+      (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit("exit", null, "SIGKILL");
+    }
+    return true;
+  }) as unknown as typeof process.kill);
   process.env.COMFYUI_MCP_ANTIGRAVITY_PATH = FAKE_BIN;
   delete process.env.COMFYUI_MCP_ANTIGRAVITY_PRINT_TIMEOUT;
   workDir = mkdtempSync(join(tmpdir(), "agy-test-"));
@@ -119,6 +135,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.COMFYUI_MCP_ANTIGRAVITY_PATH;
   rmSync(workDir, { recursive: true, force: true });
+  vi.mocked(process.kill).mockRestore?.();
 });
 
 describe("parseAgyModels", () => {

--- a/src/__tests__/orchestrator/antigravity-backend.test.ts
+++ b/src/__tests__/orchestrator/antigravity-backend.test.ts
@@ -311,6 +311,34 @@ describe("AntigravityBackend turns", () => {
     ]);
   });
 
+  it("honors an interrupt that lands BEFORE the child is assigned (spawn window)", async () => {
+    // The regression: interrupt() used to bail on `if (!this.child) return`
+    // WITHOUT setting `interrupted`. `this.child` is assigned only after
+    // spawn() returns, so a Stop pressed in that window was silently dropped
+    // and the turn ran forever (CI saw this as a 5s timeout in the interrupt
+    // test; a user sees the stop button do nothing).
+    hoisted.script.push({ hang: true });
+    const backend = new AntigravityBackend({ cwd: workDir });
+    const gen = backend.run({ channel: channelOf([{ text: "long job" }]) });
+    const events: AgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of gen) events.push(ev);
+    })();
+
+    // Interrupt IMMEDIATELY — deliberately without waiting for the spawn, so
+    // this lands in (or before) the spawn window.
+    await backend.interrupt();
+
+    // Must still terminate. Pre-fix this hung until the test timeout.
+    await drain;
+
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "cancelled" },
+    ]);
+    // and the child must not be left running
+    if (hoisted.procs[0]) expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
+  });
+
   it("prepare() fails fast with install guidance when agy is missing", async () => {
     delete process.env.COMFYUI_MCP_ANTIGRAVITY_PATH;
     const savedPath = process.env.PATH;

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -377,7 +377,12 @@ export class AntigravityBackend implements AgentBackend {
       ...(this.model ? ["--model", this.model] : []),
     ];
 
-    this.interrupted = false;
+    // NOTE: `interrupted` is deliberately NOT cleared here. A Stop can land
+    // while this turn is still starting up (run() awaits prepare() and the
+    // channel before reaching runTurn), and clearing at turn START silently
+    // discarded it — the turn then ran with nothing able to stop it. The flag is
+    // cleared when a turn SETTLES instead, so it survives setup and the child
+    // assignment below acts on it.
     const queue: AgentEvent[] = [];
     let wake: (() => void) | null = null;
     let done = false;
@@ -481,10 +486,21 @@ export class AntigravityBackend implements AgentBackend {
         this.continueNext = true;
         push({ type: "result", ok: true, subtype: "end_turn" });
       }
+      // Clear the interrupt HERE (turn end), not at turn start — see the note
+      // where the queue is set up. The flag has now been consumed to pick this
+      // turn's result, so the next turn starts clean.
+      this.interrupted = false;
       finish();
     };
     child.on("error", (err) => settle(null, err));
     child.on("exit", (code) => settle(code));
+
+    // An interrupt can arrive while spawn() is in flight — `this.child` was
+    // still null then, so interrupt() could only raise the flag. Honor it now.
+    // This MUST come after the exit/error listeners above: killing earlier can
+    // deliver the child's death before anything is listening, and then the turn
+    // never settles (exactly what hung the interrupt test).
+    if (this.interrupted) killProcessTree(child.pid);
 
     // Drain the bridged queue until the child settles.
     while (true) {
@@ -500,9 +516,16 @@ export class AntigravityBackend implements AgentBackend {
   /** Stop the current turn: kill the in-flight child's process tree. The next
    *  turn continues the conversation (`-c`) with whatever agy recorded. */
   async interrupt(): Promise<void> {
-    const child = this.child;
-    if (!child) return;
+    // Set the flag FIRST and UNCONDITIONALLY. `this.child` is only assigned
+    // after spawn() returns, so an interrupt landing in that window used to hit
+    // the `if (!child) return` below, leave `interrupted` false, and never kill
+    // anything — the turn then ran to completion with nothing able to stop it.
+    // In the panel that is "hit Stop right after Send and the turn hangs
+    // forever"; in CI it was a 5s timeout in the interrupt test. run() re-checks
+    // this flag the moment it assigns the child, so a kill is never lost.
     this.interrupted = true;
+    const child = this.child;
+    if (!child) return; // spawn window — run() kills it as soon as it exists
     killProcessTree(child.pid);
   }
 


### PR DESCRIPTION
**main's CI has been red since #262** on `interrupt kills the in-flight child tree` — *Test timed out in 5000ms*.

It isn't a flaky test. It's a real race the test caught, with a user-visible symptom: **press Stop right after Send and the turn never ends.**

## Three defects, each of which alone loses the interrupt

**1. `interrupt()` dropped the request during the spawn window**

```js
const child = this.child;
if (!child) return;        // ← returns BEFORE setting the flag
this.interrupted = true;
```

`this.child` is only assigned *after* `spawn()` returns, so a Stop landing in that window set nothing and killed nothing. The flag is now raised **first and unconditionally** — it's the durable signal; the kill is best-effort.

**2. The per-turn reset ran at turn START**

`run()` awaits `prepare()` and the channel before reaching `runTurn`, so a Stop arriving during that setup was cleared moments later by `this.interrupted = false`. It's now cleared when a turn **settles** (after being consumed to pick the result), so it survives startup and the next turn still begins clean.

**3. The catch-up kill fired before anything was listening**

Acting on a pending interrupt at child-assignment time killed the child **before** the `exit`/`error` listeners were attached — the death was delivered to nobody and the turn never settled. The kill now runs immediately *after* those listeners are wired.

(3) is the one that kept the new regression test hanging even after (1) and (2) were fixed. Killing something before you can observe it dying is its own bug, and it would bite in production too — not just against a synchronous test fake.

## Regression test

Interrupts **without** waiting for the spawn, so it deterministically lands in the startup window:

- fails against the previous code (hangs to the 5s timeout)
- passes now, verified **green 5 runs in a row**

## Verification

`tsc` clean; **142 files / 1636 tests green**.

Found while getting CI green for #265 (LTX Director skill) — that PR is docs-only and was failing on this pre-existing breakage, not on its own content.