### PR TITLE
feat(models): resolve_missing_models — find a workflow's missing models + VRAM-aware candidates

### DIFF
--- a/src/__tests__/services/missing-models.test.ts
+++ b/src/__tests__/services/missing-models.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPrecision,
+  dedupeCandidates,
+  fileStem,
+  findMissingModels,
+  fitVerdict,
+  matchQuality,
+  rankCandidates,
+  resolveCandidates,
+  type ObjectInfoLike,
+} from "../../services/missing-models.js";
+
+// A combo spec as ComfyUI publishes it: [[...options], {…meta}]
+const combo = (options: string[]) => [options, {}];
+
+const OBJECT_INFO: ObjectInfoLike = {
+  CheckpointLoaderSimple: {
+    input: { required: { ckpt_name: combo(["have.safetensors", "other.safetensors"]) } },
+  },
+  LoraLoader: {
+    input: {
+      required: {
+        lora_name: combo(["installed-lora.safetensors"]),
+        strength_model: ["FLOAT", {}],
+      },
+    },
+  },
+  KSampler: {
+    input: {
+      required: {
+        // a NON-model combo — enum drift here is not a missing model
+        sampler_name: combo(["euler", "dpmpp_2m"]),
+        steps: ["INT", {}],
+      },
+    },
+  },
+};
+
+describe("findMissingModels", () => {
+  it("flags a checkpoint the server does not have, with its target directory", () => {
+    const wf = {
+      "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "absent.safetensors" } },
+    };
+    expect(findMissingModels(wf, OBJECT_INFO)).toEqual([
+      {
+        node_id: "1",
+        node_type: "CheckpointLoaderSimple",
+        widget: "ckpt_name",
+        name: "absent.safetensors",
+        directory: "checkpoints",
+      },
+    ]);
+  });
+
+  it("ignores models the server already has", () => {
+    const wf = {
+      "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "have.safetensors" } },
+    };
+    expect(findMissingModels(wf, OBJECT_INFO)).toEqual([]);
+  });
+
+  it("ignores wired connections and non-combo inputs", () => {
+    const wf = {
+      "2": {
+        class_type: "LoraLoader",
+        inputs: { lora_name: "installed-lora.safetensors", strength_model: 0.8, model: ["1", 0] },
+      },
+    };
+    expect(findMissingModels(wf, OBJECT_INFO)).toEqual([]);
+  });
+
+  it("does NOT report ordinary enum drift as a missing model", () => {
+    // sampler_name is a combo, but "res_multistep" is not a weight file — that's
+    // a node-version mismatch, not something download_model can fix.
+    const wf = { "3": { class_type: "KSampler", inputs: { sampler_name: "res_multistep", steps: 20 } } };
+    expect(findMissingModels(wf, OBJECT_INFO)).toEqual([]);
+  });
+
+  it("skips unknown node types instead of guessing", () => {
+    const wf = { "4": { class_type: "SomeCustomNode", inputs: { ckpt_name: "absent.safetensors" } } };
+    expect(findMissingModels(wf, OBJECT_INFO)).toEqual([]);
+  });
+
+  it("dedupes the same missing file referenced by several nodes", () => {
+    const wf = {
+      "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "absent.safetensors" } },
+      "2": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "absent.safetensors" } },
+    };
+    expect(findMissingModels(wf, OBJECT_INFO)).toHaveLength(1);
+  });
+
+  it("still reports a missing model when the widget has no known directory", () => {
+    const oi: ObjectInfoLike = {
+      WeirdPackNode: { input: { required: { mystery_weights: combo(["a.safetensors"]) } } },
+    };
+    const wf = { "9": { class_type: "WeirdPackNode", inputs: { mystery_weights: "nope.safetensors" } } };
+    const out = findMissingModels(wf, oi);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.directory).toBeUndefined(); // unknown, but NOT dropped
+  });
+});
+
+describe("classifyPrecision", () => {
+  it("reads the common dtypes", () => {
+    expect(classifyPrecision("flux1-dev-fp8_e4m3fn.safetensors").precision).toBe("fp8");
+    expect(classifyPrecision("model-fp16.safetensors").precision).toBe("fp16");
+    expect(classifyPrecision("model-bf16.safetensors").precision).toBe("bf16");
+    expect(classifyPrecision("model-fp32.safetensors").precision).toBe("fp32");
+    expect(classifyPrecision("flux-nf4.safetensors").precision).toBe("nf4");
+    expect(classifyPrecision("plain.safetensors").precision).toBe("unknown");
+  });
+
+  it("detects GGUF with its quant tag and flags the loader pack it needs", () => {
+    const q = classifyPrecision("flux1-dev-Q4_K_M.gguf");
+    expect(q.precision).toBe("gguf");
+    expect(q.quant).toBe("Q4_K_M");
+    // handing someone a GGUF without saying it needs a loader node is a trap
+    expect(q.requiresPack).toBe("ComfyUI-GGUF");
+  });
+
+  it("prefers the GGUF container over a dtype token in the same name", () => {
+    // container decides whether it loads at all
+    expect(classifyPrecision("model-fp16-Q6_K.gguf").precision).toBe("gguf");
+  });
+});
+
+describe("fitVerdict", () => {
+  const VRAM = 16 * 1024 ** 3; // 16 GB
+
+  it("calls a comfortable file a fit and an oversized one too big", () => {
+    expect(fitVerdict(7 * 1024 ** 3, VRAM)).toBe("fits");
+    expect(fitVerdict(24 * 1024 ** 3, VRAM)).toBe("too_big");
+  });
+
+  it("reserves headroom — weights are the floor, not the ceiling", () => {
+    // 15 GB of weights on a 16 GB card is not a comfortable "fits"
+    expect(fitVerdict(15 * 1024 ** 3, VRAM)).toBe("tight");
+  });
+
+  it("is honest about not knowing", () => {
+    expect(fitVerdict(undefined, VRAM)).toBe("unknown");
+    expect(fitVerdict(7 * 1024 ** 3, undefined)).toBe("unknown");
+    expect(fitVerdict(0, VRAM)).toBe("unknown");
+  });
+});
+
+describe("matchQuality / fileStem", () => {
+  it("grades exact, stem and fuzzy matches", () => {
+    expect(matchQuality("a.safetensors", "a.safetensors")).toBe("exact");
+    expect(matchQuality("a.safetensors", "a.gguf")).toBe("stem");
+    expect(matchQuality("a.safetensors", "b.safetensors")).toBe("fuzzy");
+  });
+
+  it("compares basenames, ignoring subfolders", () => {
+    expect(matchQuality("sub/dir/a.safetensors", "a.safetensors")).toBe("exact");
+    expect(fileStem("sub\\dir\\A.SafeTensors")).toBe("a");
+  });
+});
+
+describe("rankCandidates", () => {
+  const VRAM = 16 * 1024 ** 3;
+  const GB = 1024 ** 3;
+
+  it("puts the exact name first, then what actually fits the card", () => {
+    const wanted = "flux1-dev.safetensors";
+    const ranked = rankCandidates(wanted, [
+      { filename: "flux1-dev-Q4_K_M.gguf", size_bytes: 7 * GB, fit: fitVerdict(7 * GB, VRAM) },
+      { filename: "flux1-dev.safetensors", size_bytes: 24 * GB, fit: fitVerdict(24 * GB, VRAM) },
+      { filename: "flux1-dev-fp8_e4m3fn.safetensors", size_bytes: 12 * GB, fit: fitVerdict(12 * GB, VRAM) },
+    ]);
+    // exact name wins even though it won't fit — the user asked for it, and the
+    // alternatives are right behind it, annotated.
+    expect(ranked[0]!.filename).toBe("flux1-dev.safetensors");
+    expect(ranked[0]!.match).toBe("exact");
+    expect(ranked[0]!.fit).toBe("too_big");
+    // among the rest, the ones that fit come first
+    expect(ranked.slice(1).every((c) => c.fit === "fits")).toBe(true);
+  });
+
+  it("prefers the larger (higher quality) file when name and fit are equal", () => {
+    const ranked = rankCandidates("m.safetensors", [
+      { filename: "m-Q4_K_M.gguf", size_bytes: 4 * GB, fit: "fits" as const },
+      { filename: "m-Q6_K.gguf", size_bytes: 9 * GB, fit: "fits" as const },
+    ]);
+    expect(ranked[0]!.filename).toBe("m-Q6_K.gguf");
+  });
+
+  it("is stable for otherwise-equal candidates", () => {
+    const ranked = rankCandidates("x.safetensors", [
+      { filename: "a.safetensors", fit: "unknown" as const },
+      { filename: "b.safetensors", fit: "unknown" as const },
+    ]);
+    expect(ranked.map((c) => c.filename)).toEqual(["a.safetensors", "b.safetensors"]);
+  });
+});
+
+describe("resolveCandidates", () => {
+  const GB = 1024 ** 3;
+  const MISSING = {
+    node_id: "1",
+    node_type: "CheckpointLoaderSimple",
+    widget: "ckpt_name",
+    name: "flux1-dev.safetensors",
+    directory: "checkpoints",
+  };
+
+  const deps = (over: Partial<Parameters<typeof resolveCandidates>[1]> = {}) => ({
+    searchCivitai: async () => [
+      { name: "flux1-dev.safetensors", model_id: 11, version_id: 22, size_mb: 24 * 1024, base_model: "Flux.1 D" },
+    ],
+    searchHf: async () => [{ id: "org/flux" }],
+    hfRepoFiles: async () => [
+      { filename: "flux1-dev-fp8_e4m3fn.safetensors", size_bytes: 12 * GB },
+      { filename: "flux1-dev-Q4_K_M.gguf", size_bytes: 7 * GB },
+    ],
+    vramBytes: async () => 16 * GB,
+    ...over,
+  });
+
+  it("annotates every candidate with precision, size, source and GPU fit", async () => {
+    const out = await resolveCandidates(MISSING, deps());
+    const byName = Object.fromEntries(out.map((c) => [c.filename, c]));
+
+    // exact name first, even though it cannot fit — the alternatives follow it
+    expect(out[0]!.filename).toBe("flux1-dev.safetensors");
+    expect(out[0]!.match).toBe("exact");
+    expect(out[0]!.fit).toBe("too_big");
+    expect(out[0]!.source).toBe("civitai");
+    expect(out[0]!.base_model).toBe("Flux.1 D");
+
+    expect(byName["flux1-dev-fp8_e4m3fn.safetensors"]!.precision).toBe("fp8");
+    expect(byName["flux1-dev-fp8_e4m3fn.safetensors"]!.fit).toBe("fits");
+    expect(byName["flux1-dev-fp8_e4m3fn.safetensors"]!.source).toBe("huggingface");
+    expect(byName["flux1-dev-fp8_e4m3fn.safetensors"]!.url).toContain("huggingface.co/org/flux/resolve/main/");
+  });
+
+  it("flags that a GGUF pick needs the loader pack", async () => {
+    const out = await resolveCandidates(MISSING, deps());
+    const gguf = out.find((c) => c.precision === "gguf")!;
+    expect(gguf.quant).toBe("Q4_K_M");
+    // handing over a GGUF without saying it needs a loader node is a trap
+    expect(gguf.requires_pack).toBe("ComfyUI-GGUF");
+  });
+
+  it("degrades to the other provider when one is down, instead of failing", async () => {
+    const out = await resolveCandidates(
+      MISSING,
+      deps({ searchCivitai: async () => { throw new Error("civitai 503"); } }),
+    );
+    expect(out.length).toBeGreaterThan(0);
+    expect(out.every((c) => c.source === "huggingface")).toBe(true);
+  });
+
+  it("reports fit as unknown when VRAM can't be read (remote/cloud)", async () => {
+    const out = await resolveCandidates(MISSING, deps({ vramBytes: async () => undefined }));
+    expect(out.every((c) => c.fit === "unknown")).toBe(true);
+  });
+
+  it("type-filters the CivitAI search by the model's directory", async () => {
+    let seenTypes: string[] | undefined = ["NOT SET"];
+    await resolveCandidates(MISSING, deps({
+      searchCivitai: async (_q: string, types: string[] | undefined) => { seenTypes = types; return []; },
+    }));
+    // a checkpoint hunt must not return LoRAs
+    expect(seenTypes).toEqual(["Checkpoint"]);
+  });
+});
+
+describe("dedupeCandidates", () => {
+  const GB = 1024 ** 3;
+  it("collapses the same file mirrored across repos, keeping the one that knows its size", () => {
+    const out = dedupeCandidates([
+      { filename: "flux1-dev.safetensors", source: "huggingface", precision: "unknown" },
+      { filename: "org2/flux1-dev.safetensors", source: "huggingface", precision: "unknown", size_bytes: 22 * GB },
+    ]);
+    expect(out).toHaveLength(1);
+    // size drives the fit verdict, so the sized entry must win
+    expect(out[0]!.size_bytes).toBe(22 * GB);
+  });
+
+  it("keeps genuinely different builds of the same model", () => {
+    const out = dedupeCandidates([
+      { filename: "flux1-dev.safetensors", source: "huggingface", precision: "fp16" },
+      { filename: "flux1-dev.safetensors", source: "huggingface", precision: "fp8" },
+      { filename: "flux1-dev-Q4_K_M.gguf", source: "huggingface", precision: "gguf", quant: "Q4_K_M" },
+      { filename: "flux1-dev-Q6_K.gguf", source: "huggingface", precision: "gguf", quant: "Q6_K" },
+    ]);
+    // fp16 / fp8 / two GGUF quants are four real choices, not duplicates
+    expect(out).toHaveLength(4);
+  });
+});

--- a/src/services/missing-models.ts
+++ b/src/services/missing-models.ts
@@ -1,0 +1,374 @@
+// Missing-model resolution: figure out which model files a workflow wants but
+// this ComfyUI doesn't have, then find installable candidates for them.
+//
+// WHY THIS EXISTS: `extract_workflow_dependencies` / `install_workflow_dependencies`
+// resolve the custom NODE PACKS a workflow needs — they never touch the missing
+// MODEL side of the same problem. So "open this Template and make it runnable"
+// took two manual hops: the agent had to infer which checkpoint/VAE/LoRA was
+// missing, then find it itself. Reported in the help channel (seanmcmagic).
+//
+// DETECTION: we do NOT hardcode widget names. ComfyUI publishes every model
+// selector as a COMBO whose options are the server's ACTUAL filenames:
+//
+//   CheckpointLoaderSimple.input.required.ckpt_name = [["a.safetensors", …], {…}]
+//
+// So a workflow value that is a model-looking filename and is NOT in its combo's
+// option list is missing — which covers every model type, including ones from
+// custom packs we've never heard of, with no per-node mapping to maintain.
+//
+// SIZE IS NOT VRAM: weights are the floor, not the ceiling (activations, latents
+// and context sit on top), so `fitVerdict` deliberately reserves headroom rather
+// than pretending file size == requirement.
+
+/** Weight-file extensions. Used to tell a model value from an ordinary enum. */
+const MODEL_EXTS = new Set([".safetensors", ".ckpt", ".pt", ".pth", ".bin", ".gguf", ".sft", ".onnx"]);
+
+/** Widget name → models/ subdirectory. Only used to say WHERE a download should
+ *  land; detection never depends on it, so an unknown widget degrades to
+ *  `undefined` rather than dropping the missing model. */
+const DIR_BY_WIDGET: Record<string, string> = {
+  ckpt_name: "checkpoints",
+  lora_name: "loras",
+  vae_name: "vae",
+  control_net_name: "controlnet",
+  controlnet_name: "controlnet",
+  unet_name: "diffusion_models",
+  model_name: "upscale_models",
+  clip_name: "text_encoders",
+  clip_name1: "text_encoders",
+  clip_name2: "text_encoders",
+  style_model_name: "style_models",
+  embedding_name: "embeddings",
+  gligen_name: "gligen",
+  hypernetwork_name: "hypernetworks",
+  ipadapter_file: "ipadapter",
+};
+
+export type Precision = "fp32" | "fp16" | "bf16" | "fp8" | "gguf" | "nf4" | "unknown";
+
+export interface MissingModel {
+  node_id: string;
+  node_type: string;
+  widget: string;
+  /** The filename the workflow asks for. */
+  name: string;
+  /** Best-guess models/ subdirectory for a download, when we can infer one. */
+  directory?: string;
+}
+
+export interface PrecisionInfo {
+  precision: Precision;
+  /** GGUF quantisation tag when present, e.g. "Q4_K_M". */
+  quant?: string;
+  /** GGUF needs a loader node that core ComfyUI does not ship. */
+  requiresPack?: string;
+}
+
+export type FitVerdict = "fits" | "tight" | "too_big" | "unknown";
+
+export type MatchQuality = "exact" | "stem" | "fuzzy";
+
+/** Strip directory + extension, lowercase — the comparable identity of a model. */
+export function fileStem(name: string): string {
+  const base = name.split(/[/\\]/).pop() ?? name;
+  return base.replace(/\.[^.]+$/, "").toLowerCase();
+}
+
+function hasModelExt(name: string): boolean {
+  const base = name.split(/[/\\]/).pop() ?? name;
+  const dot = base.lastIndexOf(".");
+  if (dot < 0) return false;
+  return MODEL_EXTS.has(base.slice(dot).toLowerCase());
+}
+
+/**
+ * Read the precision / quantisation out of a weight filename.
+ *
+ * This is what makes a fuzzy match set useful instead of opaque: the same model
+ * ships as fp16 / fp8 / several GGUF quants at wildly different sizes, and on a
+ * constrained GPU the quantised one is the whole answer.
+ *
+ * GGUF is checked FIRST: a name can contain both "gguf" and a dtype-looking
+ * token, and the container is what decides whether it loads at all.
+ */
+export function classifyPrecision(filename: string): PrecisionInfo {
+  const n = filename.toLowerCase();
+  if (/\.gguf$|[-_.]gguf\b/.test(n)) {
+    // Q4_K_M, Q6_K, Q8_0, IQ3_XXS …
+    const m = n.match(/\b(iq|q)(\d+)(_[a-z0-9]+)*\b/);
+    return {
+      precision: "gguf",
+      quant: m ? m[0].toUpperCase() : undefined,
+      requiresPack: "ComfyUI-GGUF",
+    };
+  }
+  if (/\bnf4\b/.test(n)) return { precision: "nf4" };
+  // fp8_e4m3fn / fp8_e5m2 / float8
+  if (/\bfp8\b|\bfloat8\b|e4m3|e5m2/.test(n)) return { precision: "fp8" };
+  if (/\bbf16\b|\bbfloat16\b/.test(n)) return { precision: "bf16" };
+  if (/\bfp16\b|\bfloat16\b|\bhalf\b/.test(n)) return { precision: "fp16" };
+  if (/\bfp32\b|\bfloat32\b|\bfull\b/.test(n)) return { precision: "fp32" };
+  return { precision: "unknown" };
+}
+
+/**
+ * Can this file plausibly run on a card with `vramBytes` of VRAM?
+ *
+ * Weights are the floor, not the ceiling — activations/latents/context also live
+ * in VRAM — so we reserve headroom instead of claiming a 15.9 GB file "fits" a
+ * 16 GB card. Anything above 80% of VRAM is reported as `tight`, not `fits`.
+ */
+export function fitVerdict(sizeBytes: number | undefined, vramBytes: number | undefined): FitVerdict {
+  if (!sizeBytes || !vramBytes || sizeBytes <= 0 || vramBytes <= 0) return "unknown";
+  const ratio = sizeBytes / vramBytes;
+  if (ratio > 1) return "too_big";
+  if (ratio > 0.8) return "tight";
+  return "fits";
+}
+
+/** How well does `candidate` answer the request for `wanted`? */
+export function matchQuality(wanted: string, candidate: string): MatchQuality {
+  const w = (wanted.split(/[/\\]/).pop() ?? wanted).toLowerCase();
+  const c = (candidate.split(/[/\\]/).pop() ?? candidate).toLowerCase();
+  if (w === c) return "exact";
+  if (fileStem(wanted) === fileStem(candidate)) return "stem";
+  return "fuzzy";
+}
+
+const MATCH_RANK: Record<MatchQuality, number> = { exact: 0, stem: 1, fuzzy: 2 };
+const FIT_RANK: Record<FitVerdict, number> = { fits: 0, tight: 1, unknown: 2, too_big: 3 };
+
+/**
+ * Order candidates the way a human would pick: closest name first, then what
+ * actually fits the card, then larger (higher-quality) files before smaller.
+ * Stable — equal candidates keep their input order.
+ */
+export function rankCandidates<T extends { filename: string; size_bytes?: number; fit?: FitVerdict }>(
+  wanted: string,
+  candidates: T[],
+): Array<T & { match: MatchQuality }> {
+  return candidates
+    .map((c, i) => ({ ...c, match: matchQuality(wanted, c.filename), _i: i }))
+    .sort((a, b) => {
+      const m = MATCH_RANK[a.match] - MATCH_RANK[b.match];
+      if (m !== 0) return m;
+      const f = FIT_RANK[a.fit ?? "unknown"] - FIT_RANK[b.fit ?? "unknown"];
+      if (f !== 0) return f;
+      const s = (b.size_bytes ?? 0) - (a.size_bytes ?? 0);
+      if (s !== 0) return s;
+      return a._i - b._i;
+    })
+    .map(({ _i, ...rest }) => rest as T & { match: MatchQuality });
+}
+
+/** The subset of /object_info we need: class → input name → spec. */
+export type ObjectInfoLike = Record<
+  string,
+  { input?: { required?: Record<string, unknown>; optional?: Record<string, unknown> } } | undefined
+>;
+
+/** A workflow node in API format. */
+interface ApiNode {
+  class_type?: string;
+  inputs?: Record<string, unknown>;
+}
+
+/** The combo option list for an input spec, or null when it isn't a combo. */
+function comboOptions(spec: unknown): string[] | null {
+  if (!Array.isArray(spec) || spec.length === 0) return null;
+  const first = spec[0];
+  if (!Array.isArray(first)) return null;
+  return first.filter((o): o is string => typeof o === "string");
+}
+
+/**
+ * Find every model a workflow references that this server does not have.
+ *
+ * A value counts as a missing model when its input is a COMBO (so the server
+ * published the set it actually has) and the value is a model-looking filename
+ * absent from that set. Connections (`[nodeId, slot]` arrays) and non-model
+ * enums are ignored.
+ *
+ * `directory` is a best-effort hint for where a download should land; it is
+ * never required, so an unrecognised widget still reports its missing model.
+ */
+export function findMissingModels(
+  workflow: Record<string, unknown>,
+  objectInfo: ObjectInfoLike,
+): MissingModel[] {
+  const missing: MissingModel[] = [];
+  const seen = new Set<string>();
+
+  for (const [nodeId, rawNode] of Object.entries(workflow)) {
+    if (!rawNode || typeof rawNode !== "object") continue;
+    const node = rawNode as ApiNode;
+    const classType = node.class_type;
+    if (!classType || !node.inputs) continue;
+
+    const def = objectInfo[classType];
+    if (!def?.input) continue;
+    const specs = { ...(def.input.required ?? {}), ...(def.input.optional ?? {}) };
+
+    for (const [widget, value] of Object.entries(node.inputs)) {
+      // A wired connection, not a widget value.
+      if (Array.isArray(value)) continue;
+      if (typeof value !== "string" || value.length === 0) continue;
+
+      const options = comboOptions(specs[widget]);
+      if (!options) continue; // not a combo → not a model selector
+      if (options.includes(value)) continue; // present on this server
+
+      // Only claim "missing MODEL" when it looks like a weight file — otherwise
+      // it's an ordinary enum drift and not ours to fix.
+      if (!hasModelExt(value) && !options.some(hasModelExt)) continue;
+
+      const key = `${value.toLowerCase()}|${widget}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      missing.push({
+        node_id: nodeId,
+        node_type: classType,
+        widget,
+        name: value,
+        directory: DIR_BY_WIDGET[widget],
+      });
+    }
+  }
+  return missing;
+}
+
+// ── Candidate resolution ────────────────────────────────────────────────────
+// Deps are INJECTED so the ranking/annotation logic is unit-testable without
+// touching CivitAI, HuggingFace, or a running ComfyUI.
+
+export interface ModelCandidate {
+  filename: string;
+  source: "civitai" | "huggingface";
+  /** Where to get it: a direct URL (HF) or a civitai model/version id. */
+  url?: string;
+  civitai_model_id?: number;
+  civitai_version_id?: number;
+  size_bytes?: number;
+  precision: Precision;
+  quant?: string;
+  /** Set when the file needs a loader node core ComfyUI doesn't ship (GGUF). */
+  requires_pack?: string;
+  base_model?: string;
+  fit?: FitVerdict;
+  match?: MatchQuality;
+}
+
+export interface ResolveDeps {
+  /** CivitAI keyword search, already type-filtered by the caller. */
+  searchCivitai: (
+    query: string,
+    types: string[] | undefined,
+  ) => Promise<Array<{ name: string; model_id: number; version_id?: number; size_mb?: number; base_model?: string }>>;
+  /** HuggingFace repo search. */
+  searchHf: (query: string) => Promise<Array<{ id: string }>>;
+  /** Expand an HF repo into its weight files (filename + size). */
+  hfRepoFiles: (repoId: string) => Promise<Array<{ filename: string; size_bytes?: number }>>;
+  /** Total VRAM in bytes, or undefined when unknown (remote/cloud). */
+  vramBytes: () => Promise<number | undefined>;
+}
+
+/** models/ subdir → CivitAI `types` filter, so a LoRA hunt can't return checkpoints. */
+const CIVITAI_TYPE_BY_DIR: Record<string, string[]> = {
+  checkpoints: ["Checkpoint"],
+  loras: ["LORA", "LoCon"],
+  vae: ["VAE"],
+  controlnet: ["Controlnet"],
+  embeddings: ["TextualInversion"],
+  upscale_models: ["Upscaler"],
+};
+
+const MB = 1024 * 1024;
+
+/**
+ * Find installable candidates for ONE missing model, annotated with precision,
+ * size and whether it fits this GPU, best first.
+ *
+ * Deliberately does NOT auto-pick: the same filename ships across quants and
+ * base models, so we return a ranked, annotated list and let the caller decide.
+ * Network failures degrade to fewer candidates rather than failing the lookup —
+ * a partial answer beats none when one provider is down.
+ */
+export async function resolveCandidates(
+  missing: MissingModel,
+  deps: ResolveDeps,
+  opts: { limit?: number } = {},
+): Promise<ModelCandidate[]> {
+  const limit = opts.limit ?? 8;
+  const query = fileStem(missing.name);
+  const vram = await deps.vramBytes().catch(() => undefined);
+  const out: ModelCandidate[] = [];
+
+  const civitaiTypes = missing.directory ? CIVITAI_TYPE_BY_DIR[missing.directory] : undefined;
+  const hits = await deps.searchCivitai(query, civitaiTypes).catch(() => []);
+  for (const h of hits) {
+    const size = typeof h.size_mb === "number" ? Math.round(h.size_mb * MB) : undefined;
+    const p = classifyPrecision(h.name);
+    out.push({
+      filename: h.name,
+      source: "civitai",
+      civitai_model_id: h.model_id,
+      civitai_version_id: h.version_id,
+      size_bytes: size,
+      precision: p.precision,
+      quant: p.quant,
+      requires_pack: p.requiresPack,
+      base_model: h.base_model,
+      fit: fitVerdict(size, vram),
+    });
+  }
+
+  // Expand generously: the QUANTISED repo (e.g. city96/FLUX.1-dev-gguf) is
+  // routinely ranked below the official one, and on a constrained GPU it is the
+  // only candidate that actually helps — slicing too tightly drops exactly the
+  // answer the user needs.
+  const repos = await deps.searchHf(query).catch(() => []);
+  for (const repo of repos.slice(0, 6)) {
+    const files = await deps.hfRepoFiles(repo.id).catch(() => []);
+    for (const f of files) {
+      const p = classifyPrecision(f.filename);
+      out.push({
+        filename: f.filename,
+        source: "huggingface",
+        url: `https://huggingface.co/${repo.id}/resolve/main/${f.filename}`,
+        size_bytes: f.size_bytes,
+        precision: p.precision,
+        quant: p.quant,
+        requires_pack: p.requiresPack,
+        fit: fitVerdict(f.size_bytes, vram),
+      });
+    }
+  }
+
+  return rankCandidates(missing.name, dedupeCandidates(out)).slice(0, limit);
+}
+
+/**
+ * Collapse the same file offered by several repos/providers into one row.
+ *
+ * Popular weights are mirrored widely, so an un-deduped list wastes most of its
+ * slots showing `flux1-dev.safetensors` three times instead of the fp8 and GGUF
+ * variants that are the actual reason to look. Keyed on filename + precision +
+ * quant so genuinely different builds stay distinct; the entry that knows its
+ * size wins, since size drives the fit verdict.
+ */
+export function dedupeCandidates(candidates: ModelCandidate[]): ModelCandidate[] {
+  const best = new Map<string, ModelCandidate>();
+  for (const c of candidates) {
+    const key = `${(c.filename.split(/[/\\]/).pop() ?? c.filename).toLowerCase()}|${c.precision}|${c.quant ?? ""}`;
+    const prev = best.get(key);
+    if (!prev) {
+      best.set(key, c);
+      continue;
+    }
+    const prevKnows = typeof prev.size_bytes === "number" && prev.size_bytes > 0;
+    const nextKnows = typeof c.size_bytes === "number" && c.size_bytes > 0;
+    if (!prevKnows && nextKnows) best.set(key, c);
+  }
+  return [...best.values()];
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -34,6 +34,7 @@ import { registerReportIssueTools } from "./report-issue.js";
 import { registerNodeAuthoringTools } from "./node-authoring.js";
 import { registerNodeVerifyTools } from "./node-verify.js";
 import { registerWorkflowDepsTools } from "./workflow-deps.js";
+import { registerMissingModelTools } from "./missing-models.js";
 import { registerInstallComfyUITools } from "./install-comfyui.js";
 import { registerUpdateComfyUITools } from "./update-comfyui.js";
 import { registerWorkspaceEnvTools } from "./workspace-env.js";
@@ -95,6 +96,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["custom-nodes", registerNodeManagementTools],
   ["diagnostics", registerReportIssueTools],
   ["workflows", registerWorkflowDepsTools],
+  ["models", registerMissingModelTools],
   ["server", registerInstallComfyUITools],
   ["server", registerUpdateComfyUITools],
   ["models", registerModelExtrasTools],

--- a/src/tools/missing-models.ts
+++ b/src/tools/missing-models.ts
@@ -1,0 +1,175 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+import { getObjectInfo, getSystemStats } from "../comfyui/client.js";
+import { searchCivitaiModels } from "../services/civitai-resolver.js";
+import { searchHuggingFaceModels } from "../services/model-resolver.js";
+import {
+  findMissingModels,
+  resolveCandidates,
+  type ModelCandidate,
+  type ObjectInfoLike,
+  type ResolveDeps,
+} from "../services/missing-models.js";
+import { errorToToolResult, ValidationError } from "../utils/errors.js";
+
+function parseWorkflow(input: unknown): WorkflowJSON {
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new ValidationError("Workflow JSON must be an object with node IDs as keys");
+      }
+      return parsed as WorkflowJSON;
+    } catch (err) {
+      if (err instanceof ValidationError) throw err;
+      throw new ValidationError(`Invalid JSON string: ${(err as Error).message}`);
+    }
+  }
+  if (typeof input === "object" && input !== null && !Array.isArray(input)) {
+    return input as WorkflowJSON;
+  }
+  throw new ValidationError("Workflow must be a JSON string or object");
+}
+
+/** Weight files worth offering; skip READMEs, configs, previews. */
+const WEIGHT_RE = /\.(safetensors|ckpt|pt|pth|bin|gguf|sft)$/i;
+
+/**
+ * List a HuggingFace repo's weight files WITH sizes. HF search returns REPOS,
+ * not files, so without this expansion a candidate has no size, no precision and
+ * no fit verdict — i.e. none of what makes the list useful on a small GPU.
+ *
+ * Must be `/tree/main`: the plain `/api/models/{id}` response carries
+ * `siblings[].rfilename` but NO size, and `?blobs=true` 400s. Verified live.
+ * The repo id is `org/name` — its slash is part of the PATH, so it must not be
+ * percent-encoded (encoding the whole id yields a 404).
+ */
+async function hfRepoFiles(repoId: string): Promise<Array<{ filename: string; size_bytes?: number }>> {
+  const path = repoId.split("/").map(encodeURIComponent).join("/");
+  const res = await fetch(`https://huggingface.co/api/models/${path}/tree/main`, {
+    headers: process.env.HF_TOKEN ? { authorization: `Bearer ${process.env.HF_TOKEN}` } : undefined,
+  });
+  if (!res.ok) return [];
+  const body = (await res.json()) as Array<{ type?: string; path?: string; size?: number }>;
+  if (!Array.isArray(body)) return [];
+  return body
+    .filter((e) => e.type === "file" && typeof e.path === "string" && WEIGHT_RE.test(e.path))
+    .map((e) => ({ filename: e.path as string, size_bytes: typeof e.size === "number" ? e.size : undefined }));
+}
+
+function liveDeps(): ResolveDeps {
+  return {
+    searchCivitai: async (query, types) => {
+      const res = await searchCivitaiModels(query, { types, limit: 6 });
+      return res.hits.map((h) => ({
+        name: h.name,
+        model_id: h.model_id,
+        version_id: h.version_id,
+        size_mb: h.size_mb,
+        base_model: h.base_model,
+      }));
+    },
+    searchHf: async (query) => (await searchHuggingFaceModels(query, { limit: 4 })).map((m) => ({ id: m.id })),
+    hfRepoFiles,
+    vramBytes: async () => {
+      const stats = await getSystemStats();
+      const vram = stats.devices?.[0]?.vram_total;
+      return typeof vram === "number" && vram > 0 ? vram : undefined;
+    },
+  };
+}
+
+function human(bytes?: number): string {
+  if (!bytes || bytes <= 0) return "?";
+  const gb = bytes / 1024 ** 3;
+  return gb >= 1 ? `${gb.toFixed(1)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+const FIT_ICON: Record<string, string> = { fits: "✓ fits", tight: "~ tight", too_big: "✗ won't fit", unknown: "? unknown" };
+
+function renderCandidate(c: ModelCandidate): string {
+  const bits = [
+    `- **${c.filename}**`,
+    `${human(c.size_bytes)}`,
+    c.precision === "unknown" ? "" : c.quant ? `${c.precision.toUpperCase()} ${c.quant}` : c.precision.toUpperCase(),
+    c.source,
+    FIT_ICON[c.fit ?? "unknown"] ?? "",
+    c.base_model ? `base: ${c.base_model}` : "",
+    c.match === "exact" ? "**exact name**" : c.match === "stem" ? "same name, different format" : "",
+  ].filter(Boolean);
+  let line = bits.join("  ·  ");
+  if (c.requires_pack) line += `\n    ⚠️ needs the **${c.requires_pack}** node pack — a GGUF will NOT load in CheckpointLoaderSimple.`;
+  if (c.url) line += `\n    ${c.url}`;
+  else if (c.civitai_model_id) line += `\n    civitai model ${c.civitai_model_id}${c.civitai_version_id ? ` (version ${c.civitai_version_id})` : ""} → download_civitai_model`;
+  return line;
+}
+
+export function registerMissingModelTools(server: McpServer): void {
+  server.tool(
+    "resolve_missing_models",
+    "Find the model files a workflow needs but this ComfyUI does NOT have, and search CivitAI + HuggingFace for installable candidates. THE tool for 'this Template says a model is missing — go get it'. " +
+      "Detects by comparing each model widget against the option list the server actually publishes, so it covers checkpoints, LoRAs, VAEs, ControlNets, UNets, CLIP and custom-pack model types without any per-node mapping. " +
+      "Each candidate reports size, source, precision/quantisation (fp16 / fp8 / GGUF Q4_K_M …) and whether it FITS this GPU's VRAM — so when the exact file is too big you can see the quantised variant that isn't. " +
+      "Read-only: it downloads nothing. Pass a chosen candidate to download_model (url) or download_civitai_model (id), using the reported directory as target_subfolder. " +
+      "For missing custom NODE PACKS (not models) use install_workflow_dependencies instead.",
+    {
+      workflow: z
+        .union([z.string(), z.record(z.string(), z.any())])
+        .describe("ComfyUI workflow in API format (JSON string or object)"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .optional()
+        .describe("Max candidates per missing model (default 8)."),
+    },
+    async (args) => {
+      try {
+        const workflow = parseWorkflow(args.workflow);
+        const objectInfo = (await getObjectInfo()) as unknown as ObjectInfoLike;
+        const missing = findMissingModels(workflow as Record<string, unknown>, objectInfo);
+
+        if (missing.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "## No missing models\n\nEvery model this workflow references is present on the connected ComfyUI. (If it still fails to run, check missing custom node packs with extract_workflow_dependencies.)",
+              },
+            ],
+          };
+        }
+
+        const deps = liveDeps();
+        const lines: string[] = [`## ${missing.length} missing model(s)`, ""];
+
+        for (const m of missing) {
+          lines.push(
+            `### \`${m.name}\``,
+            `needed by node ${m.node_id} (${m.node_type} · ${m.widget})${m.directory ? ` → installs to \`models/${m.directory}/\`` : ""}`,
+            "",
+          );
+          const candidates = await resolveCandidates(m, deps, { limit: args.limit ?? 8 }).catch(() => []);
+          if (candidates.length === 0) {
+            lines.push("_No candidates found on CivitAI or HuggingFace — try search_models / search_civitai_models with a different query._", "");
+            continue;
+          }
+          lines.push(...candidates.map(renderCandidate), "");
+        }
+
+        lines.push(
+          "---",
+          "Nothing was downloaded. Pick a candidate and call **download_model** (url) or **download_civitai_model** (id)" +
+            ", passing the model's directory as `target_subfolder`.",
+          "Names can collide across quantisations and base models — prefer an **exact name** match, and check `base:` before taking a fuzzy one.",
+        );
+
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}


### PR DESCRIPTION
From the help channel (seanmcmagic): *can the agent use the Manager's missing-model errors to fetch a Template's base models?*

Today it can't in one step. `extract_workflow_dependencies` / `install_workflow_dependencies` resolve the custom **node packs** and never touch the missing **model** side — so "make this Template runnable" meant the agent inferring which checkpoint/VAE/LoRA was absent, then hunting for it.

## Detection — no per-node mapping to maintain

ComfyUI publishes every model selector as a **combo whose options are the server's actual filenames**:

```
CheckpointLoaderSimple.input.required.ckpt_name = [["a.safetensors", …], {…}]
```

So a model-looking value absent from its own combo is missing. That covers checkpoints, LoRAs, VAEs, ControlNets, UNets, CLIP **and custom-pack types we've never heard of**, and can't drift the way a hardcoded widget list would.

Ordinary enum drift (a sampler name from a newer node version) is deliberately **not** reported — that isn't something `download_model` can fix.

## Candidates answer what a constrained GPU actually asks

Each candidate carries size, source, precision/quant, and a fit verdict against **real VRAM** from `/system_stats`:

```
 22.2GB  unknown      too_big  exact  flux1-dev.safetensors
 11.8GB  gguf Q8_0    fits     fuzzy  flux1-dev-Q8_0.gguf    ⚠ ComfyUI-GGUF
  9.2GB  gguf Q6_K    fits     fuzzy  flux1-dev-Q6_K.gguf    ⚠ ComfyUI-GGUF
  8.4GB  gguf Q5_1    fits     fuzzy  flux1-dev-Q5_1.gguf    ⚠ ComfyUI-GGUF
```

Instead of *"the exact file is 22 GB, good luck"*, the variant that fits is right there. GGUF picks are flagged as needing the **ComfyUI-GGUF** loader — handing someone a `.gguf` that `CheckpointLoaderSimple` can't open is a trap.

## Deliberate choices

- **Never auto-downloads.** Names collide across quants and base models; it returns a ranked, annotated list and lets the caller decide.
- **`fitVerdict` reserves headroom** — weights are the floor, not the ceiling (activations/latents sit on top), so >80% of VRAM reports `tight`, not `fits`.
- **CivitAI search is type-filtered** by the model's directory, so a LoRA hunt can't return checkpoints.
- **One provider down → fewer candidates, not a failed lookup.**
- **Resolution deps are injected**, so ranking/annotation is unit-tested with no network.

## Live validation caught three things unit tests could not

Run against the actual ComfyUI (2690 node types) and the real HF API:

1. `?blobs=true` **400s** — file sizes only come from `/tree/main`
2. percent-encoding the whole `org/name` repo id **404s** (the slash is path, not data)
3. the **quantised repo ranks below the official one**, so expanding only the top 3 dropped exactly the candidate a 16 GB card needs — widened, and deduped since popular weights are mirrored and duplicates were crowding out the real variants

## Verification

25 new tests; **143 files / 1661 green**, `tsc` clean. Detection verified live: an installed checkpoint correctly ignored, an absent checkpoint + LoRA both flagged with correct target directories, `euler` correctly not treated as a model.