### PR TITLE
fix(runpod): close live secret-leak + billing bugs on 0.44.0

### DIFF
--- a/src/__tests__/orchestrator/antigravity-backend.test.ts
+++ b/src/__tests__/orchestrator/antigravity-backend.test.ts
@@ -227,10 +227,12 @@ describe("resolveAgyBin / readiness", () => {
 });
 
 describe("AntigravityBackend turns", () => {
-  it("spawns agy WITHOUT tool-only secrets in its env, but KEEPS its own Google/Gemini keys", async () => {
-    // SECURITY (PR #251/#270): agy is Google's LLM-vendor CLI — the user's TOOL
-    // secrets (RunPod/CivitAI/HF…) must NOT reach it. The GEMINI/GOOGLE keys are
-    // the SAME vendor's own credential and are kept.
+  it("spawns agy WITHOUT any tool-only secrets in its env (incl. GEMINI/GOOGLE — agy uses OAuth/keyring)", async () => {
+    // SECURITY (PR #270): agy is Google's LLM-vendor CLI — the user's TOOL
+    // secrets (RunPod/CivitAI/HF…) must NOT reach it. Per the official Antigravity
+    // CLI docs agy authenticates via native keyring + browser/SSH OAuth, with NO
+    // documented API-key env auth, so the GEMINI/GOOGLE keys (which panel-secrets
+    // classifies as tool secrets) are ALSO stripped — no keep-list.
     const saved = {
       RUNPOD_API_KEY: process.env.RUNPOD_API_KEY,
       CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN,
@@ -246,7 +248,7 @@ describe("AntigravityBackend turns", () => {
       const env = hoisted.spawns[0]!.opts.env as Record<string, string | undefined>;
       expect(env.RUNPOD_API_KEY).toBeUndefined();
       expect(env.CIVITAI_API_TOKEN).toBeUndefined();
-      expect(env.GEMINI_API_KEY).toBe("AIza-own-key"); // Google's own key kept
+      expect(env.GEMINI_API_KEY).toBeUndefined(); // tool secret — stripped, no keep-list
       expect(env.PATH ?? env.Path).toBeDefined();
     } finally {
       for (const [k, v] of Object.entries(saved)) {

--- a/src/__tests__/orchestrator/antigravity-backend.test.ts
+++ b/src/__tests__/orchestrator/antigravity-backend.test.ts
@@ -227,6 +227,35 @@ describe("resolveAgyBin / readiness", () => {
 });
 
 describe("AntigravityBackend turns", () => {
+  it("spawns agy WITHOUT tool-only secrets in its env, but KEEPS its own Google/Gemini keys", async () => {
+    // SECURITY (PR #251/#270): agy is Google's LLM-vendor CLI — the user's TOOL
+    // secrets (RunPod/CivitAI/HF…) must NOT reach it. The GEMINI/GOOGLE keys are
+    // the SAME vendor's own credential and are kept.
+    const saved = {
+      RUNPOD_API_KEY: process.env.RUNPOD_API_KEY,
+      CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN,
+      GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+    };
+    process.env.RUNPOD_API_KEY = "rp-tool-secret";
+    process.env.CIVITAI_API_TOKEN = "civ-tool-secret";
+    process.env.GEMINI_API_KEY = "AIza-own-key";
+    try {
+      hoisted.script.push({ stdout: ["ok"], exit: 0 });
+      const backend = new AntigravityBackend({ cwd: workDir });
+      await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+      const env = hoisted.spawns[0]!.opts.env as Record<string, string | undefined>;
+      expect(env.RUNPOD_API_KEY).toBeUndefined();
+      expect(env.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(env.GEMINI_API_KEY).toBe("AIza-own-key"); // Google's own key kept
+      expect(env.PATH ?? env.Path).toBeDefined();
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+
   it("streams stdout as deltas, commits the text, and continues with -c on turn 2", async () => {
     hoisted.script.push(
       { stdout: ["Hello ", "world"], exit: 0 },

--- a/src/__tests__/orchestrator/claude-spawn-env.test.ts
+++ b/src/__tests__/orchestrator/claude-spawn-env.test.ts
@@ -1,0 +1,94 @@
+// SECURITY regression (PR #270): the Claude Agent SDK spawns a Claude Code
+// subprocess. When `options.env` is omitted the subprocess INHERITS process.env
+// (sdk.d.ts: "When omitted, the subprocess inherits process.env"), so the user's
+// TOOL secrets (RunPod/CivitAI/HF…) would leak into the LLM subprocess. Both the
+// panel Claude backend AND the one-shot ai-proposer must pass
+// `env: buildAgentSpawnEnv()` (a full env MINUS tool-only secrets — the SDK
+// REPLACES the env, so it must be a complete copy).
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  optionsSeen: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (arg: { options?: Record<string, unknown> }) => {
+    hoisted.optionsSeen.push(arg.options ?? {});
+    const iter = (async function* () {
+      yield { type: "result", subtype: "success", result: "{}" };
+    })();
+    return Object.assign(iter, {
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      interrupt: async () => {},
+      setModel: async () => {},
+    });
+  },
+}));
+
+beforeEach(() => {
+  hoisted.optionsSeen.length = 0;
+});
+
+function withToolSecrets<T>(fn: () => Promise<T>): Promise<T> {
+  const saved = {
+    RUNPOD_API_KEY: process.env.RUNPOD_API_KEY,
+    CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN,
+    HF_TOKEN: process.env.HF_TOKEN,
+  };
+  process.env.RUNPOD_API_KEY = "rp-tool-secret";
+  process.env.CIVITAI_API_TOKEN = "civ-tool-secret";
+  process.env.HF_TOKEN = "hf-tool-secret";
+  return fn().finally(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
+function assertScrubbed(env: Record<string, string | undefined> | undefined): void {
+  expect(env, "options.env must be set (omitting it inherits process.env)").toBeDefined();
+  expect(env!.RUNPOD_API_KEY).toBeUndefined();
+  expect(env!.CIVITAI_API_TOKEN).toBeUndefined();
+  expect(env!.HF_TOKEN).toBeUndefined();
+  // Non-secret env still passes through (the subprocess needs PATH etc.).
+  expect(env!.PATH ?? env!.Path).toBeDefined();
+}
+
+describe("Claude backend spawn env (tool-secret scoping)", () => {
+  it("fetchSupportedModels passes an env WITHOUT tool-only secrets", async () => {
+    const { fetchSupportedModels } = await import("../../orchestrator/claude-backend.js");
+    await withToolSecrets(() => fetchSupportedModels("claude-opus-4-8"));
+    expect(hoisted.optionsSeen.length).toBeGreaterThanOrEqual(1);
+    assertScrubbed(hoisted.optionsSeen[0].env as Record<string, string | undefined> | undefined);
+  });
+
+  it("a run() turn passes an env WITHOUT tool-only secrets", async () => {
+    const { ClaudeBackend } = await import("../../orchestrator/claude-backend.js");
+    const backend = new ClaudeBackend({ mcpServers: {}, systemAppend: "" });
+    async function* channel() {
+      yield { text: "hi" };
+    }
+    await withToolSecrets(async () => {
+      try {
+        for await (const _ of backend.run({ channel: channel() as never })) void _;
+      } catch {
+        // The mock's minimal result shape may not fully route — the query()
+        // call (and thus the options.env we assert on) has already happened.
+      }
+    });
+    const runOpts = hoisted.optionsSeen.find((o) => "systemPrompt" in o) ?? hoisted.optionsSeen[0];
+    assertScrubbed(runOpts.env as Record<string, string | undefined> | undefined);
+  });
+});
+
+describe("ai-proposer spawn env (tool-secret scoping)", () => {
+  it("proposeModelCard passes an env WITHOUT tool-only secrets", async () => {
+    const { proposeModelCard } = await import("../../orchestrator/ai-proposer.js");
+    await withToolSecrets(() => proposeModelCard({ filename: "x.safetensors" }));
+    expect(hoisted.optionsSeen.length).toBeGreaterThanOrEqual(1);
+    assertScrubbed(hoisted.optionsSeen[0].env as Record<string, string | undefined> | undefined);
+  });
+});

--- a/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
+++ b/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
@@ -1,0 +1,89 @@
+// SECURITY regression test (PR #251): the codex app-server is an LLM vendor's
+// subprocess — it must NEVER inherit the user's TOOL secrets (RunPod/CivitAI/
+// HuggingFace/Gemini tokens) from process.env. Those belong exclusively to the
+// comfyui MCP tool child (buildComfyuiMcpEnv). CodexBackend.prepare() must spawn
+// with buildAgentSpawnEnv() — process.env minus every tool-only secret key.
+//
+// The fake child dies immediately (we don't need the JSON-RPC handshake) — the
+// spawn env is captured before prepare() rejects, which is all this test needs.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  spawnEnvs: [] as Array<Record<string, string | undefined> | undefined>,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+  return {
+    ...actual,
+    spawn: (_cmd: string, _args: string[], opts?: { env?: Record<string, string | undefined> }) => {
+      hoisted.spawnEnvs.push(opts?.env);
+      const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+      proc.pid = 4243;
+      proc.exitCode = null;
+      proc.stdin = new PassThrough();
+      proc.stdout = new PassThrough();
+      proc.stderr = new PassThrough();
+      proc.kill = () => {
+        if (proc.exitCode === null) {
+          proc.exitCode = 0;
+          proc.emit("exit", 0, null);
+        }
+        return true;
+      };
+      // Die right away: initialize's pending request rejects via handleExit and
+      // prepare() throws its friendly "could not start" error.
+      setImmediate(() => {
+        proc.exitCode = 1;
+        proc.emit("exit", 1, null);
+      });
+      return proc;
+    },
+    // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
+    spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
+  };
+});
+
+import { CodexBackend } from "../../orchestrator/codex-backend.js";
+
+beforeEach(() => {
+  hoisted.spawnEnvs.length = 0;
+});
+
+describe("CodexBackend spawn env (tool-secret scoping)", () => {
+  it("never passes tool-only secrets (RunPod/CivitAI/HF/Gemini keys) to the codex app-server", async () => {
+    const KEYS = [
+      "RUNPOD_API_KEY",
+      "CIVITAI_API_TOKEN",
+      "HF_TOKEN",
+      "HUGGINGFACE_TOKEN",
+      "RUNCOMFY_API_KEY",
+      "REGISTRY_ACCESS_TOKEN",
+      "GEMINI_API_KEY",
+    ];
+    const saved: Record<string, string | undefined> = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+    for (const k of KEYS) process.env[k] = `secret-${k}`;
+    try {
+      const backend = new CodexBackend({});
+      await backend.prepare().catch(() => {
+        // expected: the fake child dies before the handshake — the spawn (and
+        // therefore the env we assert on) already happened.
+      });
+      expect(hoisted.spawnEnvs.length).toBeGreaterThanOrEqual(1);
+      const env = hoisted.spawnEnvs[0]!;
+      for (const k of KEYS) {
+        expect(env[k], `${k} must not reach the codex app-server env`).toBeUndefined();
+      }
+      // Non-secret env still passes through (the child needs PATH etc.).
+      expect(env.PATH ?? env.Path).toBeDefined();
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+});

--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -24,6 +24,8 @@ const hoisted = vi.hoisted(() => ({
   procs: [] as Array<Record<string, unknown>>,
   // The argv passed to spawn() for each spawned proc (to assert --model pinning).
   spawnArgs: [] as string[][],
+  // The env passed to spawn() for each spawned proc (to assert tool-secret scoping).
+  spawnEnvs: [] as Array<Record<string, string | undefined> | undefined>,
   // Every JSON-RPC message the client SENT to the server (requests + notifications).
   received: [] as Array<Record<string, unknown>>,
   // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
@@ -187,8 +189,9 @@ vi.mock("node:child_process", async (importOriginal) => {
 
   return {
     ...actual,
-    spawn: (_cmd: string, args: string[]) => {
+    spawn: (_cmd: string, args: string[], opts?: { env?: Record<string, string | undefined> }) => {
       hoisted.spawnArgs.push(Array.isArray(args) ? args : []);
+      hoisted.spawnEnvs.push(opts?.env);
       return makeFakeProc();
     },
     // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
@@ -201,6 +204,7 @@ let GeminiBackend: typeof import("../../orchestrator/gemini-backend.js").GeminiB
 beforeEach(async () => {
   hoisted.procs.length = 0;
   hoisted.spawnArgs.length = 0;
+  hoisted.spawnEnvs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
   hoisted.config.authMethods = [];
@@ -265,6 +269,32 @@ function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<
 }
 
 describe("GeminiBackend (ACP over stdio)", () => {
+  it("spawns the CLI WITHOUT tool-only secrets in its env, but WITH its own GEMINI_API_KEY", async () => {
+    // SECURITY (PR #251): tool secrets (RunPod/CivitAI/HF…) live in process.env
+    // for the comfyui tool child — they must NOT leak into the Gemini CLI's
+    // spawn env. GEMINI_API_KEY is the provider's OWN credential and must stay.
+    const saved = { RUNPOD_API_KEY: process.env.RUNPOD_API_KEY, CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN };
+    process.env.RUNPOD_API_KEY = "rp-tool-secret";
+    process.env.CIVITAI_API_TOKEN = "civ-tool-secret";
+    process.env.GEMINI_API_KEY = "AIza-own-key";
+    try {
+      const backend = new GeminiBackend({ cwd: process.cwd() });
+      await backend.prepare();
+      await backend.close();
+      expect(hoisted.spawnEnvs).toHaveLength(1);
+      const env = hoisted.spawnEnvs[0]!;
+      expect(env.RUNPOD_API_KEY).toBeUndefined();
+      expect(env.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(env.GEMINI_API_KEY).toBe("AIza-own-key");
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      delete process.env.GEMINI_API_KEY;
+    }
+  });
+
   it("handshake → prompt → streamed updates → result maps to the canonical AgentEvent sequence", async () => {
     const backend = new GeminiBackend({ cwd: process.cwd(), systemAppend: "BE NICE." });
     const channel = makeChannel();

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -208,4 +208,55 @@ describe("panel-secrets (canonical .env store)", () => {
       expect(readFileSync(envPath, "utf-8")).toMatch(/^COMFYUI_MCP_CUSTOM_API_KEY=sk-custom-1$/m);
     });
   });
+
+  describe("buildAgentSpawnEnv (tool secrets NEVER reach agent-provider subprocesses)", () => {
+    it("strips tool-only secrets from the agent spawn env while the tool server still gets them", async () => {
+      const { buildAgentSpawnEnv } = await import("../../services/panel-secrets.js");
+      // A user saves tool secrets via the panel → they land in process.env.
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+      setComfyuiSecret("CIVITAI_API_TOKEN", "civ-secret");
+      setComfyuiSecret("HF_TOKEN", "hf-secret");
+
+      // TOOL SERVER (comfyui MCP child): gets the secrets — that's its job.
+      const toolEnv = buildComfyuiMcpEnv({ COMFYUI_URL: "http://127.0.0.1:8188" });
+      expect(toolEnv.RUNPOD_API_KEY).toBe("rp-secret");
+      expect(toolEnv.CIVITAI_API_TOKEN).toBe("civ-secret");
+      expect(toolEnv.HF_TOKEN).toBe("hf-secret");
+
+      // AGENT SPAWN ENV (codex app-server / gemini / grok CLI): NO tool secrets.
+      const agentEnv = buildAgentSpawnEnv();
+      expect(agentEnv.RUNPOD_API_KEY).toBeUndefined();
+      expect(agentEnv.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(agentEnv.HF_TOKEN).toBeUndefined();
+      expect(agentEnv.HUGGINGFACE_TOKEN).toBeUndefined();
+      expect(agentEnv.RUNCOMFY_API_KEY).toBeUndefined();
+      expect(agentEnv.REGISTRY_ACCESS_TOKEN).toBeUndefined();
+      // Non-secret env passes through untouched (the child still needs PATH etc.).
+      expect(agentEnv.PATH ?? agentEnv.Path).toBeDefined();
+    });
+
+    it("keeps agent-provider keys and honors the per-provider keep list (gemini's own key)", async () => {
+      const { buildAgentSpawnEnv, setAgentSecret } = await import("../../services/panel-secrets.js");
+      setAgentSecret("OPENROUTER_API_KEY", "or-key"); // agent secret — allowed through
+      setComfyuiSecret("GEMINI_API_KEY", "gm-key"); // tool secret, but ALSO gemini's own credential
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+
+      const codexEnv = buildAgentSpawnEnv();
+      expect(codexEnv.OPENROUTER_API_KEY).toBe("or-key");
+      expect(codexEnv.GEMINI_API_KEY).toBeUndefined(); // codex must not see it
+
+      const geminiEnv = buildAgentSpawnEnv(process.env, {
+        keep: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"],
+      });
+      expect(geminiEnv.GEMINI_API_KEY).toBe("gm-key"); // its own vendor's key survives
+      expect(geminiEnv.RUNPOD_API_KEY).toBeUndefined(); // foreign tool secret still stripped
+    });
+
+    it("does not mutate process.env", async () => {
+      const { buildAgentSpawnEnv } = await import("../../services/panel-secrets.js");
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+      buildAgentSpawnEnv();
+      expect(process.env.RUNPOD_API_KEY).toBe("rp-secret");
+    });
+  });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -174,6 +174,28 @@ describe("createPod (GPU fallback + billing safety)", () => {
     expect(deployAttempts).toBe(1); // ambiguous → stop; do NOT try GPU-B or SECURE
   });
 
+  it("an AMBIGUOUS failure with MULTIPLE new same-named pods fails closed (concurrent-create race)", async () => {
+    // Pod NAME is not unique: a concurrent createPod for the same default name
+    // races this one, so >1 new same-named pod may appear. We must NOT guess
+    // which is ours (a wrong guess could auto-stop someone else's pod) → throw.
+    // list-before must be empty so BOTH pods count as "new"; first call is the snapshot.
+    let call = 0;
+    global.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) throw new Error("socket hang up");
+      const i = call++;
+      return gqlResponse(
+        i === 0
+          ? emptyList
+          : listOf([
+              { id: "pod-a", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: null, runtime: null },
+              { id: "pod-b", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: null, runtime: null },
+            ]),
+      );
+    }) as unknown as typeof fetch;
+    await expect(createPod({ gpuTypeIds: ["GPU-A"] })).rejects.toThrow(/concurrent create|2 new pods|can't be determined/i);
+  });
+
   it("reconciliation ignores same-named pods that existed BEFORE the call", async () => {
     // A pre-existing "comfyui-mcp" pod must not be mistaken for the one this
     // call may have created.
@@ -194,5 +216,9 @@ describe("createPod (GPU fallback + billing safety)", () => {
     expect(isProvablyNotCreatedError(new Error("socket hang up"))).toBe(false);
     expect(isProvablyNotCreatedError(new Error("RunPod API HTTP 500"))).toBe(false);
     expect(isProvablyNotCreatedError(new Error("RunPod API request timed out after 10s"))).toBe(false);
+    // CONSERVATIVE: an unrelated error that merely contains the words "there are
+    // no" (e.g. a vague server message) must NOT be treated as safe-to-retry.
+    expect(isProvablyNotCreatedError(new Error("there are no response details available"))).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("Internal error: there are no results"))).toBe(false);
   });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   createPod,
+  isProvablyNotCreatedError,
   runpodDeployLink,
   runpodProxyUrl,
   comfyuiPortExposed,
@@ -25,6 +26,30 @@ function gqlResponse(body: unknown) {
   return { ok: true, status: 200, json: async () => body } as unknown as Response;
 }
 
+type GqlBody = { query: string; variables: Record<string, unknown> };
+
+/** Mock fetch with a per-request handler keyed on the GraphQL body. The handler
+ *  may throw to simulate a network failure. Returns counters for assertions. */
+function mockGql(handler: (body: GqlBody, callIndex: number) => unknown) {
+  const counts = { total: 0, deploys: 0, lists: 0, inits: [] as RequestInit[] };
+  const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse((init as { body: string }).body) as GqlBody;
+    const i = counts.total++;
+    if (body.query.includes("podFindAndDeployOnDemand")) counts.deploys++;
+    if (body.query.includes("myself")) counts.lists++;
+    counts.inits.push(init as RequestInit);
+    return gqlResponse(handler(body, i));
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return { counts, fetchMock };
+}
+
+const emptyList = { data: { myself: { pods: [] } } };
+const listOf = (pods: unknown[]) => ({ data: { myself: { pods } } });
+const deployed = (id: string, gpu = "RTX 4090") => ({
+  data: { podFindAndDeployOnDemand: { id, name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: { gpuDisplayName: gpu } } },
+});
+
 describe("runpod-client helpers", () => {
   it("builds the referral deploy link with our template + ref code", () => {
     expect(runpodDeployLink()).toBe("https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b");
@@ -39,55 +64,135 @@ describe("runpod-client helpers", () => {
   });
 });
 
-describe("createPod (GPU fallback)", () => {
+describe("runpodGql auth + timeout", () => {
+  it("sends the API key as an Authorization: Bearer header, NEVER in the URL", async () => {
+    const fetchMock = vi.fn(async () => gqlResponse(emptyList));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { listPods } = await import("../../services/runpod-client.js");
+    await listPods();
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(String(url)).not.toContain("api_key");
+    expect(String(url)).not.toContain("rp-test-key");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer rp-test-key");
+    // Hung-network protection: every request carries an abort signal.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("createPod (GPU fallback + billing safety)", () => {
   it("returns the pod on the FIRST GPU type that has capacity", async () => {
-    global.fetch = vi.fn(async () =>
-      gqlResponse({ data: { podFindAndDeployOnDemand: { id: "pod1", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: { gpuDisplayName: "RTX 4090" } } } }),
-    ) as unknown as typeof fetch;
+    const { counts } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
     const pod = await createPod();
     expect(pod.id).toBe("pod1");
     expect(pod.runtime).toBeNull(); // deploy returns no runtime yet
-    expect(global.fetch).toHaveBeenCalledTimes(1); // first GPU succeeded → no fallback
+    expect(counts.deploys).toBe(1); // first GPU succeeded → no fallback
   });
 
-  it("falls through to the NEXT GPU when the first has no capacity", async () => {
-    let call = 0;
-    global.fetch = vi.fn(async () => {
-      call++;
-      if (call === 1) return gqlResponse({ errors: [{ message: "no instances available" }] });
-      return gqlResponse({ data: { podFindAndDeployOnDemand: { id: "pod2", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.3, machine: { gpuDisplayName: "RTX A5000" } } } });
-    }) as unknown as typeof fetch;
+  it("falls through to the NEXT GPU when RunPod explicitly reports no capacity", async () => {
+    let deployCall = 0;
+    const { counts } = mockGql((b) => {
+      if (b.query.includes("myself")) return emptyList;
+      deployCall++;
+      if (deployCall === 1) return { errors: [{ message: "no instances available" }] };
+      return deployed("pod2", "RTX A5000");
+    });
     const pod = await createPod();
     expect(pod.id).toBe("pod2");
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(counts.deploys).toBe(2);
   });
 
-  it("throws a descriptive error listing every GPU tried when all fail", async () => {
-    global.fetch = vi.fn(async () => gqlResponse({ errors: [{ message: "no capacity" }] })) as unknown as typeof fetch;
+  it("throws a descriptive error listing every GPU tried when all lack capacity", async () => {
+    const { counts } = mockGql((b) =>
+      b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] },
+    );
     await expect(createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] })).rejects.toThrow(/GPU-A[\s\S]*GPU-B/);
-    // 2 GPU types × 2 cloud types (COMMUNITY then SECURE) = 4 attempts.
-    expect(global.fetch).toHaveBeenCalledTimes(4);
+    // 2 GPU types × 2 cloud types (COMMUNITY then SECURE) = 4 deploy attempts.
+    expect(counts.deploys).toBe(4);
   });
 
   it("pins the cloud type when one is given (no SECURE fallback)", async () => {
-    global.fetch = vi.fn(async () => gqlResponse({ errors: [{ message: "no capacity" }] })) as unknown as typeof fetch;
+    const { counts } = mockGql((b) =>
+      b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] },
+    );
     await expect(createPod({ gpuTypeIds: ["GPU-A"], cloudType: "SECURE" })).rejects.toThrow(/SECURE\/GPU-A/);
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(counts.deploys).toBe(1);
   });
 
   it("sends our template id + community cloud + the ComfyUI port in the deploy input", async () => {
-    const fetchMock = vi.fn(async () => gqlResponse({ data: { podFindAndDeployOnDemand: { id: "p", desiredStatus: "RUNNING" } } }));
-    global.fetch = fetchMock as unknown as typeof fetch;
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("p", "A40")));
     await createPod({ gpuTypeIds: ["NVIDIA A40"] });
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
-    expect(body.variables.input.templateId).toBe("bnqtkvcer3");
-    expect(body.variables.input.cloudType).toBe("COMMUNITY");
-    expect(body.variables.input.gpuTypeId).toBe("NVIDIA A40");
-    expect(body.variables.input.ports).toBe("3000/http");
+    const deployCall = fetchMock.mock.calls
+      .map((c) => JSON.parse((c[1] as { body: string }).body))
+      .find((b) => b.query.includes("podFindAndDeployOnDemand"));
+    expect(deployCall.variables.input.templateId).toBe("bnqtkvcer3");
+    expect(deployCall.variables.input.cloudType).toBe("COMMUNITY");
+    expect(deployCall.variables.input.gpuTypeId).toBe("NVIDIA A40");
+    expect(deployCall.variables.input.ports).toBe("3000/http");
   });
 
   it("has sane default GPU types (24GB+ cards)", () => {
     expect(RUNPOD_DEFAULT_GPU_TYPES.length).toBeGreaterThan(0);
     expect(RUNPOD_DEFAULT_GPU_TYPES).toContain("NVIDIA GeForce RTX 4090");
+  });
+
+  // ── billing safety: a lost create response must NEVER create a second pod ──
+
+  it("an AMBIGUOUS deploy failure where the pod actually EXISTS returns the existing pod (no second create)", async () => {
+    // Sequence: list-before → [], deploy → network drop AFTER the pod was
+    // created server-side, reconcile-list → the new pod appears.
+    let deployAttempts = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) {
+        deployAttempts++;
+        throw new Error("socket hang up"); // response lost — pod fate unknown
+      }
+      // list-before is call 1 (empty); reconcile list returns the created pod.
+      return gqlResponse(
+        deployAttempts === 0 ? emptyList : listOf([{ id: "ghost-pod", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: null, runtime: null }]),
+      );
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const pod = await createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] });
+    expect(pod.id).toBe("ghost-pod"); // reconciled, not re-created
+    expect(deployAttempts).toBe(1); // NEVER retried the billed mutation
+  });
+
+  it("an AMBIGUOUS deploy failure with NO pod found fails WITHOUT trying more GPU types", async () => {
+    let deployAttempts = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) {
+        deployAttempts++;
+        throw new Error("socket hang up");
+      }
+      return gqlResponse(emptyList);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await expect(createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+    expect(deployAttempts).toBe(1); // ambiguous → stop; do NOT try GPU-B or SECURE
+  });
+
+  it("reconciliation ignores same-named pods that existed BEFORE the call", async () => {
+    // A pre-existing "comfyui-mcp" pod must not be mistaken for the one this
+    // call may have created.
+    const preExisting = { id: "old-pod", name: "comfyui-mcp", desiredStatus: "EXITED", costPerHr: 0, machine: null, runtime: null };
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) throw new Error("socket hang up");
+      return gqlResponse(listOf([preExisting])); // same list before and after
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await expect(createPod({ gpuTypeIds: ["GPU-A"] })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+  });
+
+  it("classifies errors: capacity/quota are provably-not-created; network/HTTP are not", () => {
+    expect(isProvablyNotCreatedError(new Error("There are no longer any instances available with the requested specifications."))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("no capacity"))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("quota exceeded"))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("socket hang up"))).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("RunPod API HTTP 500"))).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("RunPod API request timed out after 10s"))).toBe(false);
   });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -220,5 +220,17 @@ describe("createPod (GPU fallback + billing safety)", () => {
     // no" (e.g. a vague server message) must NOT be treated as safe-to-retry.
     expect(isProvablyNotCreatedError(new Error("there are no response details available"))).toBe(false);
     expect(isProvablyNotCreatedError(new Error("Internal error: there are no results"))).toBe(false);
+    // CONSERVATIVE: "no capacity INFORMATION … status is unknown" is AMBIGUOUS —
+    // it must NOT match the capacity-rejection pattern (that would trigger a
+    // billed retry of a possibly-landed create).
+    expect(
+      isProvablyNotCreatedError(
+        new Error("RunPod response contained no capacity information, so creation status is unknown."),
+      ),
+    ).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("insufficient capacity details returned"))).toBe(false);
+    // Still TRUE for the real rejection phrasings.
+    expect(isProvablyNotCreatedError(new Error("no capacity available for this GPU"))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("insufficient capacity"))).toBe(true);
   });
 });

--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -168,6 +168,36 @@ describe("runpod-watch — idle auto-stop", () => {
     expect(getPodMock).toHaveBeenCalledTimes(2);
   });
 
+  it("drops a stale poll result when the watched pod changed mid-flight (no republish of A over B)", async () => {
+    // poll(A) is in flight; watch(B) lands before it resolves. When A's getPod
+    // finally returns, its frame must be DROPPED (generation guard) — otherwise
+    // it republishes pod A's status after B was selected, leaving B unwatched.
+    let resolveA: ((p: unknown) => void) | null = null;
+    getPodMock.mockImplementationOnce(() => new Promise((res) => (resolveA = res)));
+    const podB = runningPod({ id: "podB", name: "B" });
+    getPodMock.mockResolvedValue(podB); // every later getPod → B
+    const frames: RunpodStatusFrame[] = [];
+    const w = createRunpodWatcher({
+      push: (f) => frames.push(f as RunpodStatusFrame),
+      comfyuiIdle: () => false,
+      renderingOnPod: () => false,
+      idleStopMinutes: 0,
+    });
+    w.watch("podA"); // poll #1 (A) — hangs
+    expect(getPodMock).toHaveBeenCalledTimes(1);
+    w.watch("podB"); // switch target while A in flight
+    expect(w.watchedPodId()).toBe("podB");
+    // Resolve A's stale getPod with A's data — it must be dropped, not published.
+    resolveA!(runningPod({ id: "podA", name: "A" }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(frames.some((f) => f.pod_id === "podA")).toBe(false); // A never published
+    expect(w.watchedPodId()).toBe("podB"); // still watching B
+    // The chained poll for B (kicked after A settled) publishes B.
+    await w.poll();
+    expect(frames.at(-1)?.pod_id).toBe("podB");
+  });
+
   it("never auto-stops when disabled (idleStopMinutes = 0)", async () => {
     getPodMock.mockResolvedValue(runningPod());
     const c = clock();

--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -119,6 +119,55 @@ describe("runpod-watch — idle auto-stop", () => {
     expect(stopPodMock).not.toHaveBeenCalled(); // never reached 15m of continuous idle
   });
 
+  it("a FAILED auto-stop keeps watching, broadcasts the TRUE status + autostop_failed, and retries next tick", async () => {
+    getPodMock.mockResolvedValue(runningPod());
+    stopPodMock.mockRejectedValueOnce(new Error("RunPod API HTTP 500")); // first stop attempt fails
+    stopPodMock.mockResolvedValueOnce({ id: "pod1", desiredStatus: "EXITED" }); // retry succeeds
+    const c = clock();
+    const frames: RunpodStatusFrame[] = [];
+    const w = createRunpodWatcher({
+      push: (f) => frames.push(f as RunpodStatusFrame),
+      comfyuiIdle: () => true,
+      renderingOnPod: () => true,
+      idleStopMinutes: 15,
+      now: c.now,
+    });
+    w.watch("pod1");
+    await w.poll(); // t=0: idle clock starts
+    c.advance(16 * 60_000);
+    await w.poll(); // t=16m: auto-stop fires → stopPod FAILS
+    expect(stopPodMock).toHaveBeenCalledTimes(1);
+    // MONEY SAFETY: the pod is still running/billing — we must NOT lie that it
+    // exited, and we must NOT stop watching.
+    const failed = frames.at(-1)!;
+    expect(failed.status).toBe("RUNNING"); // the TRUE status, not a fake EXITED
+    expect(failed.autostop_failed).toBe(true); // the UI gets the failure hint
+    expect(w.watchedPodId()).toBe("pod1"); // still watching
+    // Next tick retries the stop; this time it succeeds → EXITED + unwatch.
+    c.advance(15_000);
+    await w.poll();
+    expect(stopPodMock).toHaveBeenCalledTimes(2);
+    expect(frames.at(-1)?.status).toBe("EXITED");
+    expect(frames.at(-1)?.autostop_failed).toBeUndefined();
+    expect(w.watchedPodId()).toBeNull();
+  });
+
+  it("does not overlap polls: ticks during an in-flight poll join it instead of re-requesting", async () => {
+    let resolveGet: ((p: unknown) => void) | null = null;
+    getPodMock.mockImplementationOnce(() => new Promise((res) => (resolveGet = res)));
+    getPodMock.mockResolvedValue(runningPod()); // subsequent polls resolve normally
+    const w = createRunpodWatcher({ push: () => {}, comfyuiIdle: () => false, renderingOnPod: () => false, idleStopMinutes: 0 });
+    w.watch("pod1"); // kicks poll #1 — hangs on getPod
+    expect(getPodMock).toHaveBeenCalledTimes(1);
+    const joined = w.poll(); // tick while #1 in flight → joins, NO second getPod
+    void w.poll(); // and another
+    expect(getPodMock).toHaveBeenCalledTimes(1);
+    resolveGet!(runningPod());
+    await joined; // resolves when poll #1 finishes
+    await w.poll(); // previous poll done → this one runs a fresh request
+    expect(getPodMock).toHaveBeenCalledTimes(2);
+  });
+
   it("never auto-stops when disabled (idleStopMinutes = 0)", async () => {
     getPodMock.mockResolvedValue(runningPod());
     const c = clock();

--- a/src/orchestrator/ai-proposer.ts
+++ b/src/orchestrator/ai-proposer.ts
@@ -10,6 +10,7 @@
 import { loadQuery } from "./claude-backend.js";
 import { logger } from "../utils/logger.js";
 import { resolvePrompt } from "../services/prompt-overrides.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 
 export interface ModelCardEvidence {
   filename: string;
@@ -98,6 +99,10 @@ export async function proposeModelCard(
       allowedTools: [],
       strictMcpConfig: true,
       maxTurns: 1,
+      // SECURITY: the SDK spawns a Claude Code subprocess; `env` REPLACES its
+      // environment entirely. Pass the agent env (process.env MINUS tool-only
+      // secrets) so RunPod/HF/CivitAI tokens never reach the LLM subprocess.
+      env: buildAgentSpawnEnv(),
     } as unknown as Parameters<typeof query>[0]["options"],
   });
 

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -53,11 +53,16 @@ import type { Readable } from "node:stream";
 type AgyChild = ChildProcessByStdio<null, Readable, Readable>;
 
 // SECURITY: agy is Google's LLM-vendor CLI — its subprocess must NOT inherit the
-// user's TOOL secrets (RunPod/CivitAI/HF/RunComfy/Registry tokens). agy auths via
-// the system keyring + Google Sign-In, but the GEMINI/GOOGLE keys are the SAME
-// vendor's OWN credential (an API-key fallback), so we KEEP them (not a
-// cross-vendor leak) and strip only the foreign tool secrets.
-const ANTIGRAVITY_KEEP_KEYS = ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"] as const;
+// user's TOOL secrets (RunPod/CivitAI/HF/RunComfy/Registry tokens, AND the
+// GEMINI/GOOGLE keys, which panel-secrets classifies as tool secrets). The
+// official Antigravity CLI docs (antigravity.google/docs/cli) say agy
+// authenticates via the native system keyring + browser/SSH OAuth — it does NOT
+// document any API-key env auth — so there is NO confirmed need to re-admit the
+// GEMINI/GOOGLE keys, and doing so would expose tool credentials to the agy
+// subprocess. We therefore strip EVERY tool-only secret (no keep-list).
+//   NOTE: if a future agy version documents API-key env auth (e.g. GEMINI_API_KEY),
+//   re-admit that specific key deliberately here via buildAgentSpawnEnv(..., { keep })
+//   with a justification — do not blanket-keep.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -472,7 +477,7 @@ export class AntigravityBackend implements AgentBackend {
     try {
       child = spawn(bin, args, {
         cwd,
-        env: buildAgentSpawnEnv(process.env, { keep: ANTIGRAVITY_KEEP_KEYS }),
+        env: buildAgentSpawnEnv(), // no keep-list: strip ALL tool-only secrets (agy uses OAuth/keyring)
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
         detached: process.platform !== "win32",
@@ -663,7 +668,7 @@ export class AntigravityBackend implements AgentBackend {
       try {
         child = spawn(bin, ["models"], {
           cwd: this.deps.cwd ?? process.cwd(),
-          env: buildAgentSpawnEnv(process.env, { keep: ANTIGRAVITY_KEEP_KEYS }),
+          env: buildAgentSpawnEnv(), // no keep-list: strip ALL tool-only secrets (agy uses OAuth/keyring)
           stdio: ["ignore", "pipe", "pipe"],
           windowsHide: true,
         }) as AgyChild;

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -51,10 +51,18 @@ import type { Readable } from "node:stream";
 /** The per-turn child: stdin ignored (agy takes the prompt via argv), stdout +
  *  stderr piped. */
 type AgyChild = ChildProcessByStdio<null, Readable, Readable>;
+
+// SECURITY: agy is Google's LLM-vendor CLI — its subprocess must NOT inherit the
+// user's TOOL secrets (RunPod/CivitAI/HF/RunComfy/Registry tokens). agy auths via
+// the system keyring + Google Sign-In, but the GEMINI/GOOGLE keys are the SAME
+// vendor's OWN credential (an API-key fallback), so we KEEP them (not a
+// cross-vendor leak) and strip only the foreign tool secrets.
+const ANTIGRAVITY_KEEP_KEYS = ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"] as const;
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -464,7 +472,7 @@ export class AntigravityBackend implements AgentBackend {
     try {
       child = spawn(bin, args, {
         cwd,
-        env: process.env,
+        env: buildAgentSpawnEnv(process.env, { keep: ANTIGRAVITY_KEEP_KEYS }),
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
         detached: process.platform !== "win32",
@@ -655,7 +663,7 @@ export class AntigravityBackend implements AgentBackend {
       try {
         child = spawn(bin, ["models"], {
           cwd: this.deps.cwd ?? process.cwd(),
-          env: process.env,
+          env: buildAgentSpawnEnv(process.env, { keep: ANTIGRAVITY_KEEP_KEYS }),
           stdio: ["ignore", "pipe", "pipe"],
           windowsHide: true,
         }) as AgyChild;

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -20,6 +20,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -97,6 +98,11 @@ export async function fetchSupportedModels(model: string): Promise<ModelInfo[]> 
       allowDangerouslySkipPermissions: true,
       strictMcpConfig: true,
       mcpServers: {},
+      // SECURITY: the SDK spawns a Claude Code subprocess; `env` REPLACES its
+      // environment entirely. Pass the agent env (process.env MINUS tool-only
+      // secrets) so RunPod/HF/CivitAI tokens never reach the LLM subprocess.
+      // Claude auth is OAuth-file-based (ANTHROPIC_API_KEY is deliberately unset).
+      env: buildAgentSpawnEnv(),
     } as Options,
   });
   // The transport is pumped by iterating the query — do it in the background so
@@ -164,6 +170,8 @@ export async function fetchSupportedCommands(model: string): Promise<SlashComman
       allowDangerouslySkipPermissions: true,
       strictMcpConfig: true,
       mcpServers: {},
+      // SECURITY: agent env only (no tool-only secrets) — see fetchSupportedModels.
+      env: buildAgentSpawnEnv(),
     } as Options,
   });
   const drain = (async () => {
@@ -331,6 +339,11 @@ export class ClaudeBackend implements AgentBackend {
           }
         : {}),
       ...(rewindOpts ?? (resume ? { resume } : {})),
+      // SECURITY: the SDK spawns a Claude Code subprocess; `env` REPLACES its
+      // environment entirely. Pass the agent env (process.env MINUS tool-only
+      // secrets — RunPod/HF/CivitAI tokens) so tool credentials never reach the
+      // LLM subprocess. Claude auth is OAuth-file-based (no env key needed).
+      env: buildAgentSpawnEnv(),
     } as Options;
   }
 

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -42,6 +42,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -710,7 +711,10 @@ export class CodexBackend implements AgentBackend {
       "-c",
       `approval_policy=${JSON.stringify("never")}`,
     ];
-    const client = new AppServerClient(bin, cwd, process.env, extraArgs);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens). Those belong to the comfyui tool child
+    // (buildComfyuiMcpEnv), never to an LLM vendor's subprocess.
+    const client = new AppServerClient(bin, cwd, buildAgentSpawnEnv(), extraArgs);
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it instead of seeing this.client === null and
     // returning early — which would orphan the spawning app-server child (P0-A).

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -65,6 +65,7 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:chil
 import { createRequire } from "node:module";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -612,7 +613,19 @@ export class GeminiBackend implements AgentBackend {
     if (this.client) return;
     const { cmd, args, useShell } = this.resolveSpawn();
     const cwd = this.deps.cwd ?? process.cwd();
-    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens; they belong only to the comfyui tool child).
+    // The GEMINI/GOOGLE keys are kept: they are this provider's OWN credential —
+    // the CLI authenticates with GEMINI_API_KEY from its spawn env (see run()).
+    const client = new AcpClient(
+      cmd,
+      args,
+      cwd,
+      buildAgentSpawnEnv(process.env, {
+        keep: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"],
+      }),
+      useShell,
+    );
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it (P0-A).
     this.preparingClient = client;

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -63,6 +63,7 @@ import readline from "node:readline";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentCapabilities,
@@ -675,7 +676,9 @@ export class GrokBackend implements AgentBackend {
     if (this.client) return;
     const { cmd, args, useShell } = this.resolveSpawn();
     const cwd = this.deps.cwd ?? process.cwd();
-    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens; they belong only to the comfyui tool child).
+    const client = new AcpClient(cmd, args, cwd, buildAgentSpawnEnv(), useShell);
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it (P0-A).
     this.preparingClient = client;

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -443,6 +443,38 @@ export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string,
   return { ...base, ...loadComfyuiSecretEnv() };
 }
 
+// ── Agent-provider spawn env (tool-secret scoping) ───────────────────────────
+// Tool secrets (RunPod/HF/CivitAI/RunComfy/Registry tokens…) live in process.env
+// because config.ts loads ~/.comfyui-mcp/.env at boot and setEnvSecret applies
+// live. That is CORRECT for the comfyui tool child (buildComfyuiMcpEnv), but the
+// agent-provider subprocesses (Codex app-server, Gemini/Grok CLI…) must NEVER
+// inherit them — a tool credential has no business in an LLM vendor's process.
+// buildAgentSpawnEnv is the single spawn-env builder those backends use: a copy
+// of process.env with every TOOL-ONLY secret key stripped.
+
+/** Secret env keys that are TOOL-only (comfyui allowlist minus agent allowlist)
+ *  — these must never reach an agent-provider subprocess's env. */
+export const TOOL_ONLY_SECRET_ENV_KEYS: readonly string[] =
+  COMFYUI_SECRET_ENV_ALLOWLIST.filter((k) => !AGENT_ALLOWLIST_SET.has(k));
+
+/**
+ * Build the env an AGENT-PROVIDER subprocess (Codex/Gemini/Grok CLI…) spawns
+ * with: `base` (default process.env) with all tool-only secret keys removed.
+ * `keep` re-admits specific keys when they double as the provider's OWN
+ * credential (e.g. GEMINI_API_KEY for the Gemini CLI — same vendor, not a leak).
+ */
+export function buildAgentSpawnEnv(
+  base: NodeJS.ProcessEnv = process.env,
+  opts: { keep?: readonly string[] } = {},
+): NodeJS.ProcessEnv {
+  const keep = new Set(opts.keep ?? []);
+  const out: NodeJS.ProcessEnv = { ...base };
+  for (const k of TOOL_ONLY_SECRET_ENV_KEYS) {
+    if (!keep.has(k)) delete out[k];
+  }
+  return out;
+}
+
 export interface CredentialSlot {
   id: string;
   label: string;

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -267,28 +267,54 @@ async function deployOnce(
  *  response, so blindly retrying could spawn a second billable pod. */
 export function isProvablyNotCreatedError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return /no longer any instances available|no (?:gpu )?instances? available|no capacity|not enough .{0,40}(?:capacity|gpus?)|insufficient .{0,40}capacity|out of stock|quota (?:exceeded|reached)|there are no/i.test(
+  // CONSERVATIVE by design: match ONLY explicit capacity/availability/quota
+  // rejections, each anchored on a concrete noun (instances/capacity/gpu/stock/
+  // quota). An error we don't specifically recognize is treated as AMBIGUOUS
+  // (a pod MAY have been created) → the caller must NOT retry. A too-broad
+  // pattern here (e.g. a bare "there are no") would misclassify an ambiguous
+  // failure as safe-to-retry and could double-bill.
+  return /no longer any instances available|no (?:gpu )?instances? available|there are no (?:longer any )?(?:gpu )?instances? available|\bno capacity\b|not enough (?:instances|capacity|gpus?)|insufficient (?:instances|capacity|gpus?)|out of stock|quota (?:exceeded|reached)/i.test(
     msg,
   );
 }
 
+/** Outcome of reconciling an AMBIGUOUS create failure against the live pod list.
+ *  - `unknown`: we couldn't determine (no snapshot, or the reconcile list failed)
+ *  - `none`:    no NEW same-named pod appeared (the mutation likely didn't land)
+ *  - `one`:     exactly ONE new same-named pod → this call created it; return it
+ *  - `ambiguous`: MULTIPLE new same-named pods → cannot attribute one to THIS
+ *                 call (a concurrent create raced us); fail closed, do NOT guess. */
+type ReconcileResult =
+  | { kind: "unknown" }
+  | { kind: "none" }
+  | { kind: "one"; pod: RunpodPod }
+  | { kind: "ambiguous"; count: number };
+
 /** Reconcile after an AMBIGUOUS create failure: did a NEW pod with the requested
  *  name appear (i.e. did the lost mutation actually land)? `priorIds` is the set
  *  of same-named pod ids that existed BEFORE this createPod call — null when we
- *  couldn't snapshot them, in which case we cannot tell new from pre-existing
- *  and must NOT guess. Returns the full pod (re-fetched) or null. */
-async function findPodCreatedByThisCall(
+ *  couldn't snapshot them, in which case we cannot tell new from pre-existing.
+ *
+ *  CONCURRENCY HAZARD: pod name is NOT unique, so two concurrent createPod calls
+ *  for the same default name ("comfyui-mcp") each see the OTHER's pod as "new".
+ *  We therefore only attribute a pod to THIS call when EXACTLY ONE new same-named
+ *  pod appeared; if several did, we fail closed rather than risk claiming (and
+ *  then managing/auto-stopping) a pod a different caller created. */
+async function reconcileCreatedPod(
   name: string,
   priorIds: Set<string> | null,
-): Promise<RunpodPod | null> {
-  if (!priorIds) return null;
+): Promise<ReconcileResult> {
+  if (!priorIds) return { kind: "unknown" };
+  let created: RunpodPod[];
   try {
     const pods = await listPods();
-    const created = pods.find((p) => p.name === name && !priorIds.has(p.id));
-    return created ?? null;
+    created = pods.filter((p) => p.name === name && !priorIds.has(p.id));
   } catch {
-    return null; // reconciliation itself failed — treat as "unknown", never retry
+    return { kind: "unknown" }; // reconcile list failed — never retry blindly
   }
+  if (created.length === 0) return { kind: "none" };
+  if (created.length === 1) return { kind: "one", pod: created[0] };
+  return { kind: "ambiguous", count: created.length };
 }
 
 /** Deploy a fresh on-demand pod from our template. Community GPU capacity is
@@ -337,14 +363,24 @@ export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodP
           continue;
         }
         // AMBIGUOUS failure: the billed mutation may have landed. Reconcile first.
-        const created = await findPodCreatedByThisCall(name, priorIds);
-        if (created) return created;
+        const rec = await reconcileCreatedPod(name, priorIds);
+        if (rec.kind === "one") return rec.pod; // exactly one new pod → it's ours
+        const suffix = attempts.length ? `\nEarlier attempts:\n${attempts.map((a) => `  • ${a}`).join("\n")}` : "";
+        if (rec.kind === "ambiguous") {
+          throw new Error(
+            `RunPod pod creation on ${cloudType}/${gpuTypeId} failed ambiguously (${msg}) and ` +
+              `${rec.count} new pods named "${name}" appeared — likely a concurrent create raced ` +
+              `this one, so which pod belongs to this call can't be determined. NOT retrying and ` +
+              `NOT claiming any of them automatically (a wrong guess could auto-stop someone else's ` +
+              `pod or leak a billable one). Reconcile manually at console.runpod.io (or ` +
+              `runpod_pod_status).` + suffix,
+          );
+        }
         throw new Error(
           `RunPod pod creation failed on ${cloudType}/${gpuTypeId} and it could not be confirmed ` +
             `whether a pod was created (${msg}). NOT retrying automatically — a retry could create ` +
             `a second billable pod. Check your pods at console.runpod.io (or runpod_pod_status) ` +
-            `before trying again.` +
-            (attempts.length ? `\nEarlier attempts:\n${attempts.map((a) => `  • ${a}`).join("\n")}` : ""),
+            `before trying again.` + suffix,
         );
       }
     }

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -267,16 +267,34 @@ async function deployOnce(
  *  response, so blindly retrying could spawn a second billable pod. */
 export function isProvablyNotCreatedError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  // CONSERVATIVE by design: match ONLY explicit capacity/availability/quota
-  // rejections, each anchored on a concrete noun (instances/capacity/gpu/stock/
-  // quota). An error we don't specifically recognize is treated as AMBIGUOUS
-  // (a pod MAY have been created) → the caller must NOT retry. A too-broad
-  // pattern here (e.g. a bare "there are no") would misclassify an ambiguous
-  // failure as safe-to-retry and could double-bill.
-  return /no longer any instances available|no (?:gpu )?instances? available|there are no (?:longer any )?(?:gpu )?instances? available|\bno capacity\b|not enough (?:instances|capacity|gpus?)|insufficient (?:instances|capacity|gpus?)|out of stock|quota (?:exceeded|reached)/i.test(
-    msg,
-  );
+  return NOT_CREATED_RE.test(msg);
 }
+
+// CONSERVATIVE by design: match ONLY RunPod's explicit capacity/availability/
+// quota REJECTION clauses. An error we don't specifically recognize is treated
+// as AMBIGUOUS (a pod MAY have been created) → the caller must NOT retry.
+//
+// The "…capacity" clauses carry a negative lookahead that EXCLUDES the "capacity
+// information / details / data / status" wording used by AMBIGUOUS "status
+// unknown" messages — e.g. "response contained no capacity information, so
+// creation status is unknown" must NOT be read as a capacity rejection, or a
+// lost-but-landed create would be retried and double-bill. Likewise the
+// availability clauses require the concrete "instances available" phrasing, not
+// any sentence containing "there are no …".
+const CAP_NOISE = "(?!\\s+(?:information|informations|data|details?|info|status|unknown))";
+const NOT_CREATED_RE = new RegExp(
+  [
+    "no longer any instances? available",
+    "there are no (?:longer any )?(?:gpu )?instances? available",
+    "no (?:gpu )?instances? (?:currently )?available",
+    `\\bno capacity${CAP_NOISE}`,
+    `(?:not enough|insufficient) (?:gpu )?capacity${CAP_NOISE}`,
+    "(?:not enough|insufficient) (?:gpu instances|gpus|instances)",
+    "out of stock",
+    "quota (?:exceeded|reached)",
+  ].join("|"),
+  "i",
+);
 
 /** Outcome of reconciling an AMBIGUOUS create failure against the live pod list.
  *  - `unknown`: we couldn't determine (no snapshot, or the reconcile list failed)
@@ -298,8 +316,18 @@ type ReconcileResult =
  *  CONCURRENCY HAZARD: pod name is NOT unique, so two concurrent createPod calls
  *  for the same default name ("comfyui-mcp") each see the OTHER's pod as "new".
  *  We therefore only attribute a pod to THIS call when EXACTLY ONE new same-named
- *  pod appeared; if several did, we fail closed rather than risk claiming (and
- *  then managing/auto-stopping) a pod a different caller created. */
+ *  pod appeared; if several did, we fail closed (kind:"ambiguous") rather than
+ *  risk claiming (and then managing/auto-stopping) a pod a different caller made.
+ *
+ *  RESIDUAL LIMITATION (mis-attribution, NOT extra billing): the single-new-pod
+ *  path can still claim a pod created by a CONCURRENT caller if THIS call failed
+ *  before creating anything AND, in the same window, exactly one other same-named
+ *  pod appeared. The claimed pod exists regardless (no extra spend); the only
+ *  harm is that the wrong caller manages/auto-stops it. A fully correct fix needs
+ *  a per-create idempotency token or a unique deploy name (a RunPod-API design
+ *  change owned by the connector author). Tracked in issue #276 — see the note at
+ *  the createPod call site (~line 400). Not blocking: the common single-caller
+ *  path is correct and the multi-new-pod case is already fail-closed. */
 async function reconcileCreatedPod(
   name: string,
   priorIds: Set<string> | null,
@@ -364,7 +392,11 @@ export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodP
         }
         // AMBIGUOUS failure: the billed mutation may have landed. Reconcile first.
         const rec = await reconcileCreatedPod(name, priorIds);
-        if (rec.kind === "one") return rec.pod; // exactly one new pod → it's ours
+        // Exactly one new same-named pod → attribute it to this call. NOTE: a
+        // concurrent same-name create can make this mis-attribute (harm =
+        // wrong owner manages the pod, NOT extra billing); a proper fix needs a
+        // per-create idempotency key / unique deploy name — tracked in issue #276.
+        if (rec.kind === "one") return rec.pod;
         const suffix = attempts.length ? `\nEarlier attempts:\n${attempts.map((a) => `  • ${a}`).join("\n")}` : "";
         if (rec.kind === "ambiguous") {
           throw new Error(

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -3,8 +3,8 @@
 // link so a user creating their own pod credits our account.
 //
 // Auth: RUNPOD_API_KEY (loaded from ~/.comfyui-mcp/.env into process.env by
-// src/config.ts). The key goes in the endpoint query string exactly as RunPod's
-// API expects (`?api_key=…`) — NEVER logged.
+// src/config.ts). The key is sent as an `Authorization: Bearer` header — NEVER
+// in the URL (query strings leak into proxy/server logs) and NEVER logged.
 //
 // Referral: RunPod's referral attaches at signup/deploy via a `?ref=` link, NOT as
 // a per-pod API parameter — so we surface the deploy link for pod CREATION while
@@ -62,6 +62,13 @@ function getApiKey(): string {
   return key;
 }
 
+/** Per-request timeout for RunPod API calls — a hung network must not pile up
+ *  poller ticks or wedge a tool call forever. Override with RUNPOD_HTTP_TIMEOUT_MS. */
+export const RUNPOD_HTTP_TIMEOUT_MS = (() => {
+  const v = Number(process.env.RUNPOD_HTTP_TIMEOUT_MS);
+  return Number.isFinite(v) && v > 0 ? v : 10_000;
+})();
+
 /** POST a GraphQL query to RunPod. Throws RunpodAuthError on 401, a descriptive
  *  Error on GraphQL/HTTP errors. The api_key never appears in thrown messages. */
 export async function runpodGql<T = unknown>(
@@ -71,13 +78,24 @@ export async function runpodGql<T = unknown>(
   const key = getApiKey();
   let res: Response;
   try {
-    res = await fetch(`${RUNPOD_GRAPHQL_ENDPOINT}?api_key=${encodeURIComponent(key)}`, {
+    res = await fetch(RUNPOD_GRAPHQL_ENDPOINT, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        // Bearer header, NOT `?api_key=` in the URL — URLs land in logs.
+        authorization: `Bearer ${key}`,
+      },
       body: JSON.stringify({ query, variables: variables ?? {} }),
+      signal: AbortSignal.timeout(RUNPOD_HTTP_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`Could not reach RunPod (${RUNPOD_GRAPHQL_ENDPOINT}): ${err instanceof Error ? err.message : String(err)}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    const timedOut = err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+    throw new Error(
+      timedOut
+        ? `RunPod API request timed out after ${RUNPOD_HTTP_TIMEOUT_MS / 1000}s (${RUNPOD_GRAPHQL_ENDPOINT}).`
+        : `Could not reach RunPod (${RUNPOD_GRAPHQL_ENDPOINT}): ${msg}`,
+    );
   }
   if (res.status === 401) throw new RunpodAuthError("RunPod rejected the API key (401). Check RUNPOD_API_KEY in ~/.comfyui-mcp/.env.");
   const body = (await res.json().catch(() => ({}))) as { data?: T; errors?: unknown };
@@ -241,15 +259,65 @@ async function deployOnce(
   return pod?.id ? ({ ...pod, runtime: pod.runtime ?? null } as RunpodPod) : null;
 }
 
+/** Does this createPod failure PROVE RunPod did NOT create (and bill) a pod?
+ *  Only an explicit capacity/availability/quota rejection from RunPod's own
+ *  GraphQL layer qualifies — the server processed the mutation and refused it.
+ *  Everything else (network drop, timeout, 5xx, parse failure, rate limit) is
+ *  AMBIGUOUS: the billed mutation may have landed even though we never saw the
+ *  response, so blindly retrying could spawn a second billable pod. */
+export function isProvablyNotCreatedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /no longer any instances available|no (?:gpu )?instances? available|no capacity|not enough .{0,40}(?:capacity|gpus?)|insufficient .{0,40}capacity|out of stock|quota (?:exceeded|reached)|there are no/i.test(
+    msg,
+  );
+}
+
+/** Reconcile after an AMBIGUOUS create failure: did a NEW pod with the requested
+ *  name appear (i.e. did the lost mutation actually land)? `priorIds` is the set
+ *  of same-named pod ids that existed BEFORE this createPod call — null when we
+ *  couldn't snapshot them, in which case we cannot tell new from pre-existing
+ *  and must NOT guess. Returns the full pod (re-fetched) or null. */
+async function findPodCreatedByThisCall(
+  name: string,
+  priorIds: Set<string> | null,
+): Promise<RunpodPod | null> {
+  if (!priorIds) return null;
+  try {
+    const pods = await listPods();
+    const created = pods.find((p) => p.name === name && !priorIds.has(p.id));
+    return created ?? null;
+  } catch {
+    return null; // reconciliation itself failed — treat as "unknown", never retry
+  }
+}
+
 /** Deploy a fresh on-demand pod from our template. Community GPU capacity is
  *  spotty, so unless a cloud type is pinned we try COMMUNITY (cheap) across each
  *  GPU type, then SECURE (reliable, pricier) — the first slot with capacity wins,
  *  so one-tap deploy survives community supply constraints. Throws a descriptive
  *  error listing what RunPod rejected if nothing is available. The returned pod
- *  is fresh (runtime null — still booting; follow with getPod/runpod_pod_connect). */
+ *  is fresh (runtime null — still booting; follow with getPod/runpod_pod_connect).
+ *
+ *  BILLING SAFETY: podFindAndDeployOnDemand is a non-idempotent, BILLED mutation.
+ *  We only move on to the next cloud/GPU slot when RunPod EXPLICITLY rejected the
+ *  deploy (capacity/quota — provably nothing was created). On any AMBIGUOUS
+ *  failure (network/timeout/5xx/parse — the pod may exist even though the
+ *  response was lost) we reconcile by listing pods under the requested name: if
+ *  this call's pod appeared, return it; otherwise fail WITHOUT retrying so a
+ *  lost-response create can never fan out into extra billable pods. Auth errors
+ *  surface immediately. */
 export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodPod> {
   const gpuTypeIds = opts.gpuTypeIds?.length ? opts.gpuTypeIds : RUNPOD_DEFAULT_GPU_TYPES;
   const cloudTypes: Array<"COMMUNITY" | "SECURE"> = opts.cloudType ? [opts.cloudType] : ["COMMUNITY", "SECURE"];
+  const name = opts.name ?? "comfyui-mcp";
+  // Snapshot the ids of pods ALREADY carrying the requested name, so post-failure
+  // reconciliation can tell a pod THIS call created apart from a pre-existing one.
+  let priorIds: Set<string> | null = null;
+  try {
+    priorIds = new Set((await listPods()).filter((p) => p.name === name).map((p) => p.id));
+  } catch {
+    priorIds = null; // snapshot unavailable → ambiguous failures become terminal
+  }
   const attempts: string[] = [];
   for (const cloudType of cloudTypes) {
     for (const gpuTypeId of gpuTypeIds) {
@@ -258,7 +326,26 @@ export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodP
         if (pod) return pod;
         attempts.push(`${cloudType}/${gpuTypeId}: no capacity available`);
       } catch (err) {
-        attempts.push(`${cloudType}/${gpuTypeId}: ${err instanceof Error ? err.message : String(err)}`);
+        const msg = err instanceof Error ? err.message : String(err);
+        // Auth rejection happens before any pod is created — surface it directly
+        // (retrying other slots with the same bad key is pointless).
+        if (err instanceof RunpodAuthError) throw err;
+        if (isProvablyNotCreatedError(err)) {
+          // RunPod itself said "no capacity/quota" → nothing was created; the
+          // next cloud/GPU slot is safe to try.
+          attempts.push(`${cloudType}/${gpuTypeId}: ${msg}`);
+          continue;
+        }
+        // AMBIGUOUS failure: the billed mutation may have landed. Reconcile first.
+        const created = await findPodCreatedByThisCall(name, priorIds);
+        if (created) return created;
+        throw new Error(
+          `RunPod pod creation failed on ${cloudType}/${gpuTypeId} and it could not be confirmed ` +
+            `whether a pod was created (${msg}). NOT retrying automatically — a retry could create ` +
+            `a second billable pod. Check your pods at console.runpod.io (or runpod_pod_status) ` +
+            `before trying again.` +
+            (attempts.length ? `\nEarlier attempts:\n${attempts.map((a) => `  • ${a}`).join("\n")}` : ""),
+        );
       }
     }
   }

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -36,6 +36,9 @@ export interface RunpodStatusFrame extends Record<string, unknown> {
   autostop_minutes: number | null;
   /** Seconds until auto-stop fires (null when disabled / not idle / not running). */
   autostop_in_seconds: number | null;
+  /** True when an idle auto-stop ATTEMPT failed — the pod is still running (and
+   *  billing); the watcher keeps watching and retries next tick. */
+  autostop_failed?: boolean;
 }
 
 const CLEARED_FRAME: RunpodStatusFrame = {
@@ -143,7 +146,20 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     };
   }
 
-  async function poll(): Promise<void> {
+  // In-flight guard: on a hung network a slow poll must not stack up under the
+  // interval — a tick that lands while the previous poll is still running JOINS
+  // it (no second concurrent RunPod request) instead of starting an overlap.
+  let inflight: Promise<void> | null = null;
+
+  function poll(): Promise<void> {
+    if (inflight) return inflight;
+    inflight = pollOnce().finally(() => {
+      inflight = null;
+    });
+    return inflight;
+  }
+
+  async function pollOnce(): Promise<void> {
     if (!podId || autoStopping) return;
     let pod: RunpodPod | null;
     try {
@@ -180,7 +196,14 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
           try {
             await stopPod(podId);
           } catch (err) {
-            logger.warn(`[runpod-watch] auto-stop of ${podId} failed: ${err instanceof Error ? err.message : err}`);
+            // MONEY SAFETY: the stop FAILED — the pod is still RUNNING and still
+            // BILLING. Do NOT pretend it exited and do NOT stop watching: broadcast
+            // the TRUE status with an autostop_failed hint so the UI can warn, keep
+            // the idle clock (remainMs stays ≤ 0), and retry the stop next tick.
+            logger.warn(`[runpod-watch] auto-stop of ${podId} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
+            autoStopping = false;
+            pushIfChanged({ ...frameFor(pod, idleSeconds, 0), autostop_failed: true });
+            return;
           }
           const stopped: RunpodStatusFrame = {
             ...frameFor(pod, idleSeconds, 0),

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -160,18 +160,25 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
   }
 
   async function pollOnce(): Promise<void> {
-    if (!podId || autoStopping) return;
+    // Capture the watched pod at poll START (the "generation"). A watch(other) or
+    // unwatch() can land while we await getPod/stopPod below; if the target moved
+    // off `target` before we resolve, this poll's result is STALE and must be
+    // dropped — otherwise it would republish pod A's status (or null out podId)
+    // after pod B was already selected, leaving B silently unwatched.
+    const target = podId;
+    if (!target || autoStopping) return;
     let pod: RunpodPod | null;
     try {
-      pod = await getPod(podId);
+      pod = await getPod(target);
     } catch (err) {
       // Transient RunPod API blip — keep the last frame, try again next tick.
-      logger.debug(`[runpod-watch] poll failed for ${podId}: ${err instanceof Error ? err.message : err}`);
+      logger.debug(`[runpod-watch] poll failed for ${target}: ${err instanceof Error ? err.message : err}`);
       return;
     }
+    if (podId !== target) return; // target changed while awaiting → stale, drop
     if (!pod) {
       // Pod vanished (terminated) — stop watching.
-      logger.info(`[runpod-watch] pod ${podId} no longer exists — unwatching`);
+      logger.info(`[runpod-watch] pod ${target} no longer exists — unwatching`);
       unwatch();
       return;
     }
@@ -183,7 +190,7 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     const running = pod.desiredStatus === "RUNNING" && !!pod.runtime;
     let idleSeconds: number | null = null;
     let autostopIn: number | null = null;
-    if (running && deps.renderingOnPod(podId) && deps.comfyuiIdle()) {
+    if (running && deps.renderingOnPod(target) && deps.comfyuiIdle()) {
       if (idleSinceMs == null) idleSinceMs = now();
       idleSeconds = Math.floor((now() - idleSinceMs) / 1000);
       if (idleStopMs > 0) {
@@ -192,19 +199,21 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
         if (remainMs <= 0) {
           // Fire auto-stop once; broadcast the reason so the UI can show it.
           autoStopping = true;
-          logger.info(`[runpod-watch] pod ${podId} idle ${idleSeconds}s ≥ ${deps.idleStopMinutes}m — auto-stopping to save cost`);
+          logger.info(`[runpod-watch] pod ${target} idle ${idleSeconds}s ≥ ${deps.idleStopMinutes}m — auto-stopping to save cost`);
           try {
-            await stopPod(podId);
+            await stopPod(target);
           } catch (err) {
             // MONEY SAFETY: the stop FAILED — the pod is still RUNNING and still
             // BILLING. Do NOT pretend it exited and do NOT stop watching: broadcast
             // the TRUE status with an autostop_failed hint so the UI can warn, keep
             // the idle clock (remainMs stays ≤ 0), and retry the stop next tick.
-            logger.warn(`[runpod-watch] auto-stop of ${podId} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
+            logger.warn(`[runpod-watch] auto-stop of ${target} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
             autoStopping = false;
-            pushIfChanged({ ...frameFor(pod, idleSeconds, 0), autostop_failed: true });
+            if (podId === target) pushIfChanged({ ...frameFor(pod, idleSeconds, 0), autostop_failed: true });
             return;
           }
+          autoStopping = false;
+          if (podId !== target) return; // switched target mid-stop → don't touch B
           const stopped: RunpodStatusFrame = {
             ...frameFor(pod, idleSeconds, 0),
             status: "EXITED",
@@ -215,7 +224,6 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
           // EXITED (so the user can restart it) instead of the card vanishing.
           podId = null;
           idleSinceMs = null;
-          autoStopping = false;
           return;
         }
       }
@@ -227,10 +235,18 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
   }
 
   function watch(id: string): void {
+    const switching = podId !== id;
     podId = id;
     idleSinceMs = null;
-    // Kick an immediate poll so the panel doesn't wait a full interval.
-    void poll();
+    // Kick an immediate poll so the panel doesn't wait a full interval. If a poll
+    // for the PREVIOUS target is still in flight, don't overlap it — chain a fresh
+    // poll after it settles (that stale poll drops its own result via the
+    // generation guard), so the NEW target is polled promptly and correctly.
+    if (inflight) {
+      if (switching) void inflight.then(() => { if (podId === id) void poll(); });
+    } else {
+      void poll();
+    }
   }
 
   function unwatch(): void {


### PR DESCRIPTION
Four CONFIRMED-LIVE bugs on `main` (0.44.0), pinpointed by a codex audit. Each was re-applied onto main's actual code (the reference commits `b085dc9`/`5fbf90c` targeted pre-merge connector code, so they were adapted, not cherry-picked).

## 1. SECURITY — tool secrets leaked into agent LLM-vendor subprocesses
`src/services/panel-secrets.ts:62-72` classifies RUNPOD/CIVITAI/HF/HUGGINGFACE/RUNCOMFY/REGISTRY/GEMINI keys as tool secrets and injects them into `process.env`; the agent backends spawned their vendor subprocesses with the FULL `process.env`:
- `src/orchestrator/codex-backend.ts:713` — `new AppServerClient(bin, cwd, process.env, …)`
- `src/orchestrator/gemini-backend.ts:615` — `new AcpClient(…, process.env, …)`
- `src/orchestrator/grok-backend.ts:678` — `new AcpClient(…, process.env, …)`

**Fix:** new `buildAgentSpawnEnv()` in panel-secrets = `process.env` minus `TOOL_ONLY_SECRET_ENV_KEYS` (derived: comfyui allowlist − agent allowlist, not hardcoded). Codex/Gemini/Grok now spawn with it. Gemini re-admits `GEMINI_API_KEY`/`GOOGLE_*` via an explicit keep-list (its OWN credential); Grok's XAI/GROK keys aren't in the tool allowlist so they pass through untouched.

**Evidence:** codex + gemini spawn-env tests prove RUNPOD/CIVITAI/HF absent from the spawn env while the vendor's own key survives; panel-secrets test proves the tool env (`buildComfyuiMcpEnv`) still gets the secret.

## 2. MONEY — non-idempotent billed pod create
`src/services/runpod-client.ts` `createPod`/`deployOnce` (213-256): ANY exception from the BILLED `podFindAndDeployOnDemand` mutation advanced to the next cloud/GPU slot → a lost response (which may have created a pod) could double-bill.

**Fix:** snapshot same-named pod ids before deploying; only an EXPLICIT capacity/quota rejection (`isProvablyNotCreatedError`, exported + unit-tested) advances the slot; any AMBIGUOUS failure reconciles via `listPods()` — returns the pod the lost mutation actually landed, else throws WITHOUT retrying. Auth errors rethrow immediately. The on-main COMMUNITY→SECURE nested fallback is preserved.

**Evidence:** ghost-pod reconciliation returns the existing pod with exactly ONE deploy attempt; ambiguous failure never issues a second create nor tries more GPU types; a pre-existing same-named pod isn't mistaken for the new one; classifier unit test.

## 3. MONEY — failed auto-stop falsely broadcast EXITED
`src/services/runpod-watch.ts:176-193`: when idle `stopPod` threw, the error was swallowed and it still broadcast `status:"EXITED"`, nulled podId, and stopped polling while the pod kept billing.

**Fix:** on stop failure, broadcast the TRUE status (RUNNING) with a new additive `autostop_failed: true` field, KEEP watching + the idle clock, retry next tick; EXITED + unwatch only on stop SUCCESS.

**Evidence:** fail-then-succeed test asserts RUNNING+autostop_failed and still-watching after the failed attempt, then EXITED+unwatch on the retry.

## 4. MEDIUM — URL key + no timeout + overlapping polls
`runpod-client.ts:71-74` — key moved from `?api_key=` (leaks to logs) to `Authorization: Bearer`; every request now carries a 10s `AbortSignal.timeout` (`RUNPOD_HTTP_TIMEOUT_MS` override). `runpod-watch.ts` poll — in-flight guard so a tick during a running poll JOINS it instead of stacking an overlapping request.

**Evidence:** auth test asserts Bearer header present + key absent from URL + `signal instanceof AbortSignal`; overlapping-tick test asserts a single `getPod` while a poll is in flight.

## Gates
- `npx tsc --noEmit`: clean
- `npx vitest run`: **143 files / 1648 tests passed**

## Notes on adaptation from the reference commits
- main's `createPod` uses a NESTED `cloudType (COMMUNITY→SECURE) × gpuTypeId` loop (an already-on-main fix); the reference used a single GPU loop. Billing-safety logic was integrated into the nested loop and its tests updated to count deploy attempts (2 GPU × 2 cloud = 4) rather than raw fetch calls.
- main's ComfyUI proxy port is 3000 (not the reference's 8188); test fixtures/assertions adjusted accordingly.
- main's watcher requires `renderingOnPod` in `RunpodWatcherDeps` (already-on-main "idle-auto-stop only for the rendered pod" fix); the new watch tests supply it, and that guard is not regressed.
- `RUNPOD_HTTP_TIMEOUT_MS` made env-overridable (reference used a fixed const).

DO NOT MERGE without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)