### PR TITLE
fix(runpod): billing-safe pod create, honest auto-stop, Bearer auth + tool-secret scoping (#251 salvage)

### DIFF
--- a/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
+++ b/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
@@ -1,0 +1,89 @@
+// SECURITY regression test (PR #251): the codex app-server is an LLM vendor's
+// subprocess — it must NEVER inherit the user's TOOL secrets (RunPod/CivitAI/
+// HuggingFace/Gemini tokens) from process.env. Those belong exclusively to the
+// comfyui MCP tool child (buildComfyuiMcpEnv). CodexBackend.prepare() must spawn
+// with buildAgentSpawnEnv() — process.env minus every tool-only secret key.
+//
+// The fake child dies immediately (we don't need the JSON-RPC handshake) — the
+// spawn env is captured before prepare() rejects, which is all this test needs.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  spawnEnvs: [] as Array<Record<string, string | undefined> | undefined>,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+  return {
+    ...actual,
+    spawn: (_cmd: string, _args: string[], opts?: { env?: Record<string, string | undefined> }) => {
+      hoisted.spawnEnvs.push(opts?.env);
+      const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+      proc.pid = 4243;
+      proc.exitCode = null;
+      proc.stdin = new PassThrough();
+      proc.stdout = new PassThrough();
+      proc.stderr = new PassThrough();
+      proc.kill = () => {
+        if (proc.exitCode === null) {
+          proc.exitCode = 0;
+          proc.emit("exit", 0, null);
+        }
+        return true;
+      };
+      // Die right away: initialize's pending request rejects via handleExit and
+      // prepare() throws its friendly "could not start" error.
+      setImmediate(() => {
+        proc.exitCode = 1;
+        proc.emit("exit", 1, null);
+      });
+      return proc;
+    },
+    // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
+    spawnSync: () => ({ status: 0, pid: 1, stdout: "", stderr: "", signal: null, output: [] }),
+  };
+});
+
+import { CodexBackend } from "../../orchestrator/codex-backend.js";
+
+beforeEach(() => {
+  hoisted.spawnEnvs.length = 0;
+});
+
+describe("CodexBackend spawn env (tool-secret scoping)", () => {
+  it("never passes tool-only secrets (RunPod/CivitAI/HF/Gemini keys) to the codex app-server", async () => {
+    const KEYS = [
+      "RUNPOD_API_KEY",
+      "CIVITAI_API_TOKEN",
+      "HF_TOKEN",
+      "HUGGINGFACE_TOKEN",
+      "RUNCOMFY_API_KEY",
+      "REGISTRY_ACCESS_TOKEN",
+      "GEMINI_API_KEY",
+    ];
+    const saved: Record<string, string | undefined> = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+    for (const k of KEYS) process.env[k] = `secret-${k}`;
+    try {
+      const backend = new CodexBackend({});
+      await backend.prepare().catch(() => {
+        // expected: the fake child dies before the handshake — the spawn (and
+        // therefore the env we assert on) already happened.
+      });
+      expect(hoisted.spawnEnvs.length).toBeGreaterThanOrEqual(1);
+      const env = hoisted.spawnEnvs[0]!;
+      for (const k of KEYS) {
+        expect(env[k], `${k} must not reach the codex app-server env`).toBeUndefined();
+      }
+      // Non-secret env still passes through (the child needs PATH etc.).
+      expect(env.PATH ?? env.Path).toBeDefined();
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+});

--- a/src/__tests__/orchestrator/gemini-backend.test.ts
+++ b/src/__tests__/orchestrator/gemini-backend.test.ts
@@ -24,6 +24,8 @@ const hoisted = vi.hoisted(() => ({
   procs: [] as Array<Record<string, unknown>>,
   // The argv passed to spawn() for each spawned proc (to assert --model pinning).
   spawnArgs: [] as string[][],
+  // The env passed to spawn() for each spawned proc (to assert tool-secret scoping).
+  spawnEnvs: [] as Array<Record<string, string | undefined> | undefined>,
   // Every JSON-RPC message the client SENT to the server (requests + notifications).
   received: [] as Array<Record<string, unknown>>,
   // Per-test server behavior: "complete" auto-finishes the prompt with end_turn;
@@ -187,8 +189,9 @@ vi.mock("node:child_process", async (importOriginal) => {
 
   return {
     ...actual,
-    spawn: (_cmd: string, args: string[]) => {
+    spawn: (_cmd: string, args: string[], opts?: { env?: Record<string, string | undefined> }) => {
       hoisted.spawnArgs.push(Array.isArray(args) ? args : []);
+      hoisted.spawnEnvs.push(opts?.env);
       return makeFakeProc();
     },
     // killProcessTree calls spawnSync("taskkill", …) on win32 — make it a no-op.
@@ -201,6 +204,7 @@ let GeminiBackend: typeof import("../../orchestrator/gemini-backend.js").GeminiB
 beforeEach(async () => {
   hoisted.procs.length = 0;
   hoisted.spawnArgs.length = 0;
+  hoisted.spawnEnvs.length = 0;
   hoisted.received.length = 0;
   hoisted.config.mode = "complete";
   hoisted.config.authMethods = [];
@@ -265,6 +269,32 @@ function consume(gen: AsyncIterable<AgentEvent>, events: AgentEvent[]): Promise<
 }
 
 describe("GeminiBackend (ACP over stdio)", () => {
+  it("spawns the CLI WITHOUT tool-only secrets in its env, but WITH its own GEMINI_API_KEY", async () => {
+    // SECURITY (PR #251): tool secrets (RunPod/CivitAI/HF…) live in process.env
+    // for the comfyui tool child — they must NOT leak into the Gemini CLI's
+    // spawn env. GEMINI_API_KEY is the provider's OWN credential and must stay.
+    const saved = { RUNPOD_API_KEY: process.env.RUNPOD_API_KEY, CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN };
+    process.env.RUNPOD_API_KEY = "rp-tool-secret";
+    process.env.CIVITAI_API_TOKEN = "civ-tool-secret";
+    process.env.GEMINI_API_KEY = "AIza-own-key";
+    try {
+      const backend = new GeminiBackend({ cwd: process.cwd() });
+      await backend.prepare();
+      await backend.close();
+      expect(hoisted.spawnEnvs).toHaveLength(1);
+      const env = hoisted.spawnEnvs[0]!;
+      expect(env.RUNPOD_API_KEY).toBeUndefined();
+      expect(env.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(env.GEMINI_API_KEY).toBe("AIza-own-key");
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      delete process.env.GEMINI_API_KEY;
+    }
+  });
+
   it("handshake → prompt → streamed updates → result maps to the canonical AgentEvent sequence", async () => {
     const backend = new GeminiBackend({ cwd: process.cwd(), systemAppend: "BE NICE." });
     const channel = makeChannel();

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -208,4 +208,55 @@ describe("panel-secrets (canonical .env store)", () => {
       expect(readFileSync(envPath, "utf-8")).toMatch(/^COMFYUI_MCP_CUSTOM_API_KEY=sk-custom-1$/m);
     });
   });
+
+  describe("buildAgentSpawnEnv (tool secrets NEVER reach agent-provider subprocesses)", () => {
+    it("strips tool-only secrets from the agent spawn env while the tool server still gets them", async () => {
+      const { buildAgentSpawnEnv } = await import("../../services/panel-secrets.js");
+      // A user saves tool secrets via the panel → they land in process.env.
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+      setComfyuiSecret("CIVITAI_API_TOKEN", "civ-secret");
+      setComfyuiSecret("HF_TOKEN", "hf-secret");
+
+      // TOOL SERVER (comfyui MCP child): gets the secrets — that's its job.
+      const toolEnv = buildComfyuiMcpEnv({ COMFYUI_URL: "http://127.0.0.1:8188" });
+      expect(toolEnv.RUNPOD_API_KEY).toBe("rp-secret");
+      expect(toolEnv.CIVITAI_API_TOKEN).toBe("civ-secret");
+      expect(toolEnv.HF_TOKEN).toBe("hf-secret");
+
+      // AGENT SPAWN ENV (codex app-server / gemini / grok CLI): NO tool secrets.
+      const agentEnv = buildAgentSpawnEnv();
+      expect(agentEnv.RUNPOD_API_KEY).toBeUndefined();
+      expect(agentEnv.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(agentEnv.HF_TOKEN).toBeUndefined();
+      expect(agentEnv.HUGGINGFACE_TOKEN).toBeUndefined();
+      expect(agentEnv.RUNCOMFY_API_KEY).toBeUndefined();
+      expect(agentEnv.REGISTRY_ACCESS_TOKEN).toBeUndefined();
+      // Non-secret env passes through untouched (the child still needs PATH etc.).
+      expect(agentEnv.PATH ?? agentEnv.Path).toBeDefined();
+    });
+
+    it("keeps agent-provider keys and honors the per-provider keep list (gemini's own key)", async () => {
+      const { buildAgentSpawnEnv, setAgentSecret } = await import("../../services/panel-secrets.js");
+      setAgentSecret("OPENROUTER_API_KEY", "or-key"); // agent secret — allowed through
+      setComfyuiSecret("GEMINI_API_KEY", "gm-key"); // tool secret, but ALSO gemini's own credential
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+
+      const codexEnv = buildAgentSpawnEnv();
+      expect(codexEnv.OPENROUTER_API_KEY).toBe("or-key");
+      expect(codexEnv.GEMINI_API_KEY).toBeUndefined(); // codex must not see it
+
+      const geminiEnv = buildAgentSpawnEnv(process.env, {
+        keep: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"],
+      });
+      expect(geminiEnv.GEMINI_API_KEY).toBe("gm-key"); // its own vendor's key survives
+      expect(geminiEnv.RUNPOD_API_KEY).toBeUndefined(); // foreign tool secret still stripped
+    });
+
+    it("does not mutate process.env", async () => {
+      const { buildAgentSpawnEnv } = await import("../../services/panel-secrets.js");
+      setComfyuiSecret("RUNPOD_API_KEY", "rp-secret");
+      buildAgentSpawnEnv();
+      expect(process.env.RUNPOD_API_KEY).toBe("rp-secret");
+    });
+  });
 });

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -258,5 +258,21 @@ describe("panel-secrets (canonical .env store)", () => {
       buildAgentSpawnEnv();
       expect(process.env.RUNPOD_API_KEY).toBe("rp-secret");
     });
+
+    it("strips secrets set with NON-canonical casing (Windows $env:runpod_api_key)", async () => {
+      const { buildAgentSpawnEnv } = await import("../../services/panel-secrets.js");
+      // On Windows process.env lookup is case-insensitive, but a key set with
+      // lowercase casing SPREADS as lowercase — deleting only the canonical
+      // casing would leak it (codex finding).
+      const base = { runpod_api_key: "rp-lower", PATH: "x", Other_Key: "y" } as unknown as NodeJS.ProcessEnv;
+      const env = buildAgentSpawnEnv(base);
+      expect(env.runpod_api_key).toBeUndefined();
+      expect(env.RUNPOD_API_KEY).toBeUndefined();
+      expect(env.PATH).toBe("x");
+      expect(env.Other_Key).toBe("y");
+      // keep-list still works case-insensitively for the provider's own key
+      const gem = buildAgentSpawnEnv({ gemini_api_key: "gm-lower" } as unknown as NodeJS.ProcessEnv, { keep: ["GEMINI_API_KEY"] });
+      expect(gem.gemini_api_key).toBe("gm-lower");
+    });
   });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -197,4 +197,29 @@ describe("createPod (GPU fallback + billing safety)", () => {
     expect(isProvablyNotCreatedError(new Error("RunPod API HTTP 500"))).toBe(false);
     expect(isProvablyNotCreatedError(new Error("RunPod API request timed out after 10s"))).toBe(false);
   });
+
+  it("serializes concurrent creates so billed mutations never overlap", async () => {
+    let release: (() => void) | null = null;
+    let deployCall = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) {
+        deployCall++;
+        if (deployCall === 1) await new Promise<void>((r) => (release = r)); // first create hangs mid-mutation
+        return gqlResponse(deployed(`pod${deployCall}`));
+      }
+      return gqlResponse(emptyList); // prior-ids snapshots
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const p1 = createPod({ gpuTypeIds: ["GPU-A"] });
+    await new Promise((r) => setImmediate(r)); // let p1 reach its (hung) mutation
+    const p2 = createPod({ gpuTypeIds: ["GPU-A"] });
+    await new Promise((r) => setImmediate(r));
+    expect(deployCall).toBe(1); // p2 is queued BEHIND p1 — no second in-flight mutation
+    release!();
+    const [pod1, pod2] = await Promise.all([p1, p2]);
+    expect(deployCall).toBe(2); // serialized, then proceeded
+    expect(pod1.id).toBe("pod1");
+    expect(pod2.id).toBe("pod2");
+  });
 });

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   createPod,
+  isProvablyNotCreatedError,
   runpodDeployLink,
   runpodProxyUrl,
   comfyuiPortExposed,
@@ -25,6 +26,30 @@ function gqlResponse(body: unknown) {
   return { ok: true, status: 200, json: async () => body } as unknown as Response;
 }
 
+type GqlBody = { query: string; variables: Record<string, unknown> };
+
+/** Mock fetch with a per-request handler keyed on the GraphQL body. The handler
+ *  may throw to simulate a network failure. Returns counters for assertions. */
+function mockGql(handler: (body: GqlBody, callIndex: number) => unknown) {
+  const counts = { total: 0, deploys: 0, lists: 0, inits: [] as RequestInit[] };
+  const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    const body = JSON.parse((init as { body: string }).body) as GqlBody;
+    const i = counts.total++;
+    if (body.query.includes("podFindAndDeployOnDemand")) counts.deploys++;
+    if (body.query.includes("myself")) counts.lists++;
+    counts.inits.push(init as RequestInit);
+    return gqlResponse(handler(body, i));
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return { counts, fetchMock };
+}
+
+const emptyList = { data: { myself: { pods: [] } } };
+const listOf = (pods: unknown[]) => ({ data: { myself: { pods } } });
+const deployed = (id: string, gpu = "RTX 4090") => ({
+  data: { podFindAndDeployOnDemand: { id, name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: { gpuDisplayName: gpu } } },
+});
+
 describe("runpod-client helpers", () => {
   it("builds the referral deploy link with our template + ref code", () => {
     expect(runpodDeployLink()).toBe("https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b");
@@ -39,55 +64,137 @@ describe("runpod-client helpers", () => {
   });
 });
 
-describe("createPod (GPU fallback)", () => {
+describe("runpodGql auth + timeout", () => {
+  it("sends the API key as an Authorization: Bearer header, NEVER in the URL", async () => {
+    const fetchMock = vi.fn(async () => gqlResponse(emptyList));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { listPods } = await import("../../services/runpod-client.js");
+    await listPods();
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(String(url)).not.toContain("api_key");
+    expect(String(url)).not.toContain("rp-test-key");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer rp-test-key");
+    // Hung-network protection: every request carries an abort signal.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("createPod (GPU fallback + billing safety)", () => {
   it("returns the pod on the FIRST GPU type that has capacity", async () => {
-    global.fetch = vi.fn(async () =>
-      gqlResponse({ data: { podFindAndDeployOnDemand: { id: "pod1", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: { gpuDisplayName: "RTX 4090" } } } }),
-    ) as unknown as typeof fetch;
+    const { counts } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("pod1")));
     const pod = await createPod();
     expect(pod.id).toBe("pod1");
     expect(pod.runtime).toBeNull(); // deploy returns no runtime yet
-    expect(global.fetch).toHaveBeenCalledTimes(1); // first GPU succeeded → no fallback
+    expect(counts.deploys).toBe(1); // first GPU succeeded → no fallback
   });
 
-  it("falls through to the NEXT GPU when the first has no capacity", async () => {
-    let call = 0;
-    global.fetch = vi.fn(async () => {
-      call++;
-      if (call === 1) return gqlResponse({ errors: [{ message: "no instances available" }] });
-      return gqlResponse({ data: { podFindAndDeployOnDemand: { id: "pod2", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.3, machine: { gpuDisplayName: "RTX A5000" } } } });
-    }) as unknown as typeof fetch;
+  it("falls through to the NEXT GPU when RunPod explicitly reports no capacity", async () => {
+    let deployCall = 0;
+    const { counts } = mockGql((b) => {
+      if (b.query.includes("myself")) return emptyList;
+      deployCall++;
+      if (deployCall === 1) return { errors: [{ message: "no instances available" }] };
+      return deployed("pod2", "RTX A5000");
+    });
     const pod = await createPod();
     expect(pod.id).toBe("pod2");
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(counts.deploys).toBe(2);
   });
 
-  it("throws a descriptive error listing every GPU tried when all fail", async () => {
-    global.fetch = vi.fn(async () => gqlResponse({ errors: [{ message: "no capacity" }] })) as unknown as typeof fetch;
+  it("throws a descriptive error listing every GPU tried when all lack capacity", async () => {
+    const { counts } = mockGql((b) =>
+      b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] },
+    );
     await expect(createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] })).rejects.toThrow(/GPU-A[\s\S]*GPU-B/);
-    // 2 GPU types × 2 cloud types (COMMUNITY then SECURE) = 4 attempts.
-    expect(global.fetch).toHaveBeenCalledTimes(4);
+    // 2 GPU types × 2 cloud types (COMMUNITY then SECURE) = 4 deploy attempts
+    // (the pre-create prior-ids list is a separate query, not counted here).
+    expect(counts.deploys).toBe(4);
   });
 
   it("pins the cloud type when one is given (no SECURE fallback)", async () => {
-    global.fetch = vi.fn(async () => gqlResponse({ errors: [{ message: "no capacity" }] })) as unknown as typeof fetch;
+    const { counts } = mockGql((b) =>
+      b.query.includes("myself") ? emptyList : { errors: [{ message: "no capacity" }] },
+    );
     await expect(createPod({ gpuTypeIds: ["GPU-A"], cloudType: "SECURE" })).rejects.toThrow(/SECURE\/GPU-A/);
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(counts.deploys).toBe(1);
   });
 
   it("sends our template id + community cloud + the ComfyUI port in the deploy input", async () => {
-    const fetchMock = vi.fn(async () => gqlResponse({ data: { podFindAndDeployOnDemand: { id: "p", desiredStatus: "RUNNING" } } }));
-    global.fetch = fetchMock as unknown as typeof fetch;
+    const { fetchMock } = mockGql((b) => (b.query.includes("myself") ? emptyList : deployed("p", "A40")));
     await createPod({ gpuTypeIds: ["NVIDIA A40"] });
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
-    expect(body.variables.input.templateId).toBe("bnqtkvcer3");
-    expect(body.variables.input.cloudType).toBe("COMMUNITY");
-    expect(body.variables.input.gpuTypeId).toBe("NVIDIA A40");
-    expect(body.variables.input.ports).toBe("3000/http");
+    // The prior-ids list is the first call — find the DEPLOY among the calls.
+    const deployCall = fetchMock.mock.calls
+      .map((c) => JSON.parse((c[1] as { body: string }).body))
+      .find((b) => b.query.includes("podFindAndDeployOnDemand"));
+    expect(deployCall.variables.input.templateId).toBe("bnqtkvcer3");
+    expect(deployCall.variables.input.cloudType).toBe("COMMUNITY");
+    expect(deployCall.variables.input.gpuTypeId).toBe("NVIDIA A40");
+    expect(deployCall.variables.input.ports).toBe("3000/http");
   });
 
   it("has sane default GPU types (24GB+ cards)", () => {
     expect(RUNPOD_DEFAULT_GPU_TYPES.length).toBeGreaterThan(0);
     expect(RUNPOD_DEFAULT_GPU_TYPES).toContain("NVIDIA GeForce RTX 4090");
+  });
+
+  // ── billing safety: a lost create response must NEVER create a second pod ──
+
+  it("an AMBIGUOUS deploy failure where the pod actually EXISTS returns the existing pod (no second create)", async () => {
+    // Sequence: list-before → [], deploy → network drop AFTER the pod was
+    // created server-side, reconcile-list → the new pod appears.
+    let deployAttempts = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) {
+        deployAttempts++;
+        throw new Error("socket hang up"); // response lost — pod fate unknown
+      }
+      // list-before is call 1 (empty); reconcile list returns the created pod.
+      return gqlResponse(
+        deployAttempts === 0 ? emptyList : listOf([{ id: "ghost-pod", name: "comfyui-mcp", desiredStatus: "RUNNING", costPerHr: 0.44, machine: null, runtime: null }]),
+      );
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const pod = await createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] });
+    expect(pod.id).toBe("ghost-pod"); // reconciled, not re-created
+    expect(deployAttempts).toBe(1); // NEVER retried the billed mutation
+  });
+
+  it("an AMBIGUOUS deploy failure with NO pod found fails WITHOUT trying more GPU types", async () => {
+    let deployAttempts = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) {
+        deployAttempts++;
+        throw new Error("socket hang up");
+      }
+      return gqlResponse(emptyList);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await expect(createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+    expect(deployAttempts).toBe(1); // ambiguous → stop; do NOT try GPU-B
+  });
+
+  it("reconciliation ignores same-named pods that existed BEFORE the call", async () => {
+    // A pre-existing "comfyui-mcp" pod must not be mistaken for the one this
+    // call may have created.
+    const preExisting = { id: "old-pod", name: "comfyui-mcp", desiredStatus: "EXITED", costPerHr: 0, machine: null, runtime: null };
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const body = JSON.parse((init as { body: string }).body) as GqlBody;
+      if (body.query.includes("podFindAndDeployOnDemand")) throw new Error("socket hang up");
+      return gqlResponse(listOf([preExisting])); // same list before and after
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    await expect(createPod({ gpuTypeIds: ["GPU-A"] })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+  });
+
+  it("classifies errors: capacity/quota are provably-not-created; network/HTTP are not", () => {
+    expect(isProvablyNotCreatedError(new Error("There are no longer any instances available with the requested specifications."))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("no capacity"))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("quota exceeded"))).toBe(true);
+    expect(isProvablyNotCreatedError(new Error("socket hang up"))).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("RunPod API HTTP 500"))).toBe(false);
+    expect(isProvablyNotCreatedError(new Error("RunPod API request timed out after 10s"))).toBe(false);
   });
 });

--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -119,6 +119,55 @@ describe("runpod-watch — idle auto-stop", () => {
     expect(stopPodMock).not.toHaveBeenCalled(); // never reached 15m of continuous idle
   });
 
+  it("a FAILED auto-stop keeps watching, broadcasts the TRUE status + autostop_failed, and retries next tick", async () => {
+    getPodMock.mockResolvedValue(runningPod());
+    stopPodMock.mockRejectedValueOnce(new Error("RunPod API HTTP 500")); // first stop attempt fails
+    stopPodMock.mockResolvedValueOnce({ id: "pod1", desiredStatus: "EXITED" }); // retry succeeds
+    const c = clock();
+    const frames: RunpodStatusFrame[] = [];
+    const w = createRunpodWatcher({
+      push: (f) => frames.push(f as RunpodStatusFrame),
+      comfyuiIdle: () => true,
+      renderingOnPod: () => true,
+      idleStopMinutes: 15,
+      now: c.now,
+    });
+    w.watch("pod1");
+    await w.poll(); // t=0: idle clock starts
+    c.advance(16 * 60_000);
+    await w.poll(); // t=16m: auto-stop fires → stopPod FAILS
+    expect(stopPodMock).toHaveBeenCalledTimes(1);
+    // MONEY SAFETY: the pod is still running/billing — we must NOT lie that it
+    // exited, and we must NOT stop watching.
+    const failed = frames.at(-1)!;
+    expect(failed.status).toBe("RUNNING"); // the TRUE status, not a fake EXITED
+    expect(failed.autostop_failed).toBe(true); // the UI gets the failure hint
+    expect(w.watchedPodId()).toBe("pod1"); // still watching
+    // Next tick retries the stop; this time it succeeds → EXITED + unwatch.
+    c.advance(15_000);
+    await w.poll();
+    expect(stopPodMock).toHaveBeenCalledTimes(2);
+    expect(frames.at(-1)?.status).toBe("EXITED");
+    expect(frames.at(-1)?.autostop_failed).toBeUndefined();
+    expect(w.watchedPodId()).toBeNull();
+  });
+
+  it("does not overlap polls: ticks during an in-flight poll join it instead of re-requesting", async () => {
+    let resolveGet: ((p: unknown) => void) | null = null;
+    getPodMock.mockImplementationOnce(() => new Promise((res) => (resolveGet = res)));
+    getPodMock.mockResolvedValue(runningPod()); // subsequent polls resolve normally
+    const w = createRunpodWatcher({ push: () => {}, comfyuiIdle: () => false, renderingOnPod: () => true, idleStopMinutes: 0 });
+    w.watch("pod1"); // kicks poll #1 — hangs on getPod
+    expect(getPodMock).toHaveBeenCalledTimes(1);
+    const joined = w.poll(); // tick while #1 in flight → joins, NO second getPod
+    void w.poll(); // and another
+    expect(getPodMock).toHaveBeenCalledTimes(1);
+    resolveGet!(runningPod());
+    await joined; // resolves when poll #1 finishes
+    await w.poll(); // previous poll done → this one runs a fresh request
+    expect(getPodMock).toHaveBeenCalledTimes(2);
+  });
+
   it("never auto-stops when disabled (idleStopMinutes = 0)", async () => {
     getPodMock.mockResolvedValue(runningPod());
     const c = clock();

--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -168,6 +168,28 @@ describe("runpod-watch — idle auto-stop", () => {
     expect(getPodMock).toHaveBeenCalledTimes(2);
   });
 
+  it("watch(B) during an in-flight poll for A polls B immediately and discards A's late frame", async () => {
+    let resolveA: ((p: unknown) => void) | null = null;
+    const aPod = runningPod({ id: "podA", name: "a" });
+    const bPod = runningPod({ id: "podB", name: "b" });
+    getPodMock.mockImplementation((id: string) => {
+      if (id === "podA" && !resolveA) return new Promise((res) => (resolveA = res));
+      return Promise.resolve(id === "podA" ? aPod : bPod);
+    });
+    const frames: RunpodStatusFrame[] = [];
+    const w = createRunpodWatcher({ push: (f) => frames.push(f as RunpodStatusFrame), comfyuiIdle: () => false, renderingOnPod: () => true, idleStopMinutes: 0 });
+    w.watch("podA"); // poll for A hangs in flight
+    await new Promise((r) => setImmediate(r));
+    w.watch("podB"); // target change — must NOT wait for A's request
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(frames.at(-1)?.pod_id).toBe("podB"); // B was polled + published already
+    resolveA!(aPod); // A's late response arrives → discarded, never published
+    await new Promise((r) => setImmediate(r));
+    expect(frames.filter((f) => f.pod_id === "podA")).toHaveLength(0);
+    expect(w.watchedPodId()).toBe("podB");
+  });
+
   it("never auto-stops when disabled (idleStopMinutes = 0)", async () => {
     getPodMock.mockResolvedValue(runningPod());
     const c = clock();

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -42,6 +42,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -710,7 +711,10 @@ export class CodexBackend implements AgentBackend {
       "-c",
       `approval_policy=${JSON.stringify("never")}`,
     ];
-    const client = new AppServerClient(bin, cwd, process.env, extraArgs);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens). Those belong to the comfyui tool child
+    // (buildComfyuiMcpEnv), never to an LLM vendor's subprocess.
+    const client = new AppServerClient(bin, cwd, buildAgentSpawnEnv(), extraArgs);
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it instead of seeing this.client === null and
     // returning early — which would orphan the spawning app-server child (P0-A).

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -65,6 +65,7 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:chil
 import { createRequire } from "node:module";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentEvent,
@@ -612,7 +613,19 @@ export class GeminiBackend implements AgentBackend {
     if (this.client) return;
     const { cmd, args, useShell } = this.resolveSpawn();
     const cwd = this.deps.cwd ?? process.cwd();
-    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens; they belong only to the comfyui tool child).
+    // The GEMINI/GOOGLE keys are kept: they are this provider's OWN credential —
+    // the CLI authenticates with GEMINI_API_KEY from its spawn env (see run()).
+    const client = new AcpClient(
+      cmd,
+      args,
+      cwd,
+      buildAgentSpawnEnv(process.env, {
+        keep: ["GEMINI_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GOOGLE_API_KEY"],
+      }),
+      useShell,
+    );
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it (P0-A).
     this.preparingClient = client;

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -63,6 +63,7 @@ import readline from "node:readline";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { logger } from "../utils/logger.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
   type AgentCapabilities,
@@ -675,7 +676,9 @@ export class GrokBackend implements AgentBackend {
     if (this.client) return;
     const { cmd, args, useShell } = this.resolveSpawn();
     const cwd = this.deps.cwd ?? process.cwd();
-    const client = new AcpClient(cmd, args, cwd, process.env, useShell);
+    // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
+    // (RunPod/HF/CivitAI… tokens; they belong only to the comfyui tool child).
+    const client = new AcpClient(cmd, args, cwd, buildAgentSpawnEnv(), useShell);
     // Publish the in-flight client BEFORE the startup awaits so a concurrent
     // close() can find and kill it (P0-A).
     this.preparingClient = client;

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -443,6 +443,38 @@ export function buildComfyuiMcpEnv(base: Record<string, string>): Record<string,
   return { ...base, ...loadComfyuiSecretEnv() };
 }
 
+// ── Agent-provider spawn env (tool-secret scoping) ───────────────────────────
+// Tool secrets (RunPod/HF/CivitAI/RunComfy/Registry tokens…) live in process.env
+// because config.ts loads ~/.comfyui-mcp/.env at boot and setEnvSecret applies
+// live. That is CORRECT for the comfyui tool child (buildComfyuiMcpEnv), but the
+// agent-provider subprocesses (Codex app-server, Gemini/Grok CLI…) must NEVER
+// inherit them — a tool credential has no business in an LLM vendor's process.
+// buildAgentSpawnEnv is the single spawn-env builder those backends use: a copy
+// of process.env with every TOOL-ONLY secret key stripped.
+
+/** Secret env keys that are TOOL-only (comfyui allowlist minus agent allowlist)
+ *  — these must never reach an agent-provider subprocess's env. */
+export const TOOL_ONLY_SECRET_ENV_KEYS: readonly string[] =
+  COMFYUI_SECRET_ENV_ALLOWLIST.filter((k) => !AGENT_ALLOWLIST_SET.has(k));
+
+/**
+ * Build the env an AGENT-PROVIDER subprocess (Codex/Gemini/Grok CLI…) spawns
+ * with: `base` (default process.env) with all tool-only secret keys removed.
+ * `keep` re-admits specific keys when they double as the provider's OWN
+ * credential (e.g. GEMINI_API_KEY for the Gemini CLI — same vendor, not a leak).
+ */
+export function buildAgentSpawnEnv(
+  base: NodeJS.ProcessEnv = process.env,
+  opts: { keep?: readonly string[] } = {},
+): NodeJS.ProcessEnv {
+  const keep = new Set(opts.keep ?? []);
+  const out: NodeJS.ProcessEnv = { ...base };
+  for (const k of TOOL_ONLY_SECRET_ENV_KEYS) {
+    if (!keep.has(k)) delete out[k];
+  }
+  return out;
+}
+
 export interface CredentialSlot {
   id: string;
   label: string;

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -468,9 +468,15 @@ export function buildAgentSpawnEnv(
   opts: { keep?: readonly string[] } = {},
 ): NodeJS.ProcessEnv {
   const keep = new Set(opts.keep ?? []);
-  const out: NodeJS.ProcessEnv = { ...base };
-  for (const k of TOOL_ONLY_SECRET_ENV_KEYS) {
-    if (!keep.has(k)) delete out[k];
+  // Case-insensitive match: on Windows process.env lookups ignore case, so a
+  // secret set as $env:runpod_api_key RESOLVES via RUNPOD_API_KEY but spreads
+  // under the lowercase key — deleting only the canonical casing would leak it
+  // into every agent-provider spawn (codex finding).
+  const strip = new Set(TOOL_ONLY_SECRET_ENV_KEYS.filter((k) => !keep.has(k)).map((k) => k.toUpperCase()));
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(base)) {
+    if (strip.has(k.toUpperCase())) continue;
+    out[k] = v;
   }
   return out;
 }

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -3,8 +3,8 @@
 // link so a user creating their own pod credits our account.
 //
 // Auth: RUNPOD_API_KEY (loaded from ~/.comfyui-mcp/.env into process.env by
-// src/config.ts). The key goes in the endpoint query string exactly as RunPod's
-// API expects (`?api_key=…`) — NEVER logged.
+// src/config.ts). The key is sent as an `Authorization: Bearer` header — NEVER
+// in the URL (query strings leak into proxy/server logs) and NEVER logged.
 //
 // Referral: RunPod's referral attaches at signup/deploy via a `?ref=` link, NOT as
 // a per-pod API parameter — so we surface the deploy link for pod CREATION while
@@ -62,6 +62,10 @@ function getApiKey(): string {
   return key;
 }
 
+/** Per-request timeout for RunPod API calls — a hung network must not pile up
+ *  poller ticks or wedge a tool call forever. */
+export const RUNPOD_HTTP_TIMEOUT_MS = 10_000;
+
 /** POST a GraphQL query to RunPod. Throws RunpodAuthError on 401, a descriptive
  *  Error on GraphQL/HTTP errors. The api_key never appears in thrown messages. */
 export async function runpodGql<T = unknown>(
@@ -71,13 +75,24 @@ export async function runpodGql<T = unknown>(
   const key = getApiKey();
   let res: Response;
   try {
-    res = await fetch(`${RUNPOD_GRAPHQL_ENDPOINT}?api_key=${encodeURIComponent(key)}`, {
+    res = await fetch(RUNPOD_GRAPHQL_ENDPOINT, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        // Bearer header, NOT `?api_key=` in the URL — URLs land in logs.
+        authorization: `Bearer ${key}`,
+      },
       body: JSON.stringify({ query, variables: variables ?? {} }),
+      signal: AbortSignal.timeout(RUNPOD_HTTP_TIMEOUT_MS),
     });
   } catch (err) {
-    throw new Error(`Could not reach RunPod (${RUNPOD_GRAPHQL_ENDPOINT}): ${err instanceof Error ? err.message : String(err)}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    const timedOut = err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+    throw new Error(
+      timedOut
+        ? `RunPod API request timed out after ${RUNPOD_HTTP_TIMEOUT_MS / 1000}s (${RUNPOD_GRAPHQL_ENDPOINT}).`
+        : `Could not reach RunPod (${RUNPOD_GRAPHQL_ENDPOINT}): ${msg}`,
+    );
   }
   if (res.status === 401) throw new RunpodAuthError("RunPod rejected the API key (401). Check RUNPOD_API_KEY in ~/.comfyui-mcp/.env.");
   const body = (await res.json().catch(() => ({}))) as { data?: T; errors?: unknown };
@@ -241,24 +256,93 @@ async function deployOnce(
   return pod?.id ? ({ ...pod, runtime: pod.runtime ?? null } as RunpodPod) : null;
 }
 
+/** Does this createPod failure PROVE RunPod did NOT create (and bill) a pod?
+ *  Only an explicit capacity/availability/quota rejection from RunPod's own
+ *  GraphQL layer qualifies — the server processed the mutation and refused it.
+ *  Everything else (network drop, timeout, 5xx, parse failure, rate limit) is
+ *  AMBIGUOUS: the billed mutation may have landed even though we never saw the
+ *  response, so blindly retrying could spawn a second billable pod. */
+export function isProvablyNotCreatedError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /no longer any instances available|no (?:gpu )?instances? available|no capacity|not enough .{0,40}(?:capacity|gpus?)|insufficient .{0,40}capacity|out of stock|quota (?:exceeded|reached)|there are no/i.test(
+    msg,
+  );
+}
+
+/** Reconcile after an AMBIGUOUS create failure: did a NEW pod with the requested
+ *  name appear (i.e. did the lost mutation actually land)? `priorIds` is the set
+ *  of same-named pod ids that existed BEFORE this createPod call — null when we
+ *  couldn't snapshot them, in which case we cannot tell new from pre-existing
+ *  and must NOT guess. Returns the full pod (re-fetched) or null. */
+async function findPodCreatedByThisCall(
+  name: string,
+  priorIds: Set<string> | null,
+): Promise<RunpodPod | null> {
+  if (!priorIds) return null;
+  try {
+    const pods = await listPods();
+    const created = pods.find((p) => p.name === name && !priorIds.has(p.id));
+    return created ?? null;
+  } catch {
+    return null; // reconciliation itself failed — treat as "unknown", never retry
+  }
+}
+
 /** Deploy a fresh on-demand pod from our template. Community GPU capacity is
  *  spotty, so unless a cloud type is pinned we try COMMUNITY (cheap) across each
  *  GPU type, then SECURE (reliable, pricier) — the first slot with capacity wins,
  *  so one-tap deploy survives community supply constraints. Throws a descriptive
  *  error listing what RunPod rejected if nothing is available. The returned pod
- *  is fresh (runtime null — still booting; follow with getPod/runpod_pod_connect). */
+ *  is fresh (runtime null — still booting; follow with getPod/runpod_pod_connect).
+ *
+ *  BILLING SAFETY: podFindAndDeployOnDemand is a non-idempotent, BILLED mutation.
+ *  We only move on to the next cloud/GPU combo when RunPod explicitly rejected
+ *  the deploy (capacity/quota — provably nothing was created, including a null
+ *  pod from a processed mutation). On any AMBIGUOUS failure (network/timeout/
+ *  5xx/parse — the pod may exist even though the response was lost) we reconcile
+ *  by listing pods under the requested name: if this call's pod appeared, return
+ *  it; otherwise fail WITHOUT retrying so a lost-response create can never fan
+ *  out into extra billable pods. */
 export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodPod> {
   const gpuTypeIds = opts.gpuTypeIds?.length ? opts.gpuTypeIds : RUNPOD_DEFAULT_GPU_TYPES;
   const cloudTypes: Array<"COMMUNITY" | "SECURE"> = opts.cloudType ? [opts.cloudType] : ["COMMUNITY", "SECURE"];
+  const name = opts.name ?? "comfyui-mcp";
+  // Snapshot the ids of pods ALREADY carrying the requested name, so post-failure
+  // reconciliation can tell a pod THIS call created apart from a pre-existing one.
+  let priorIds: Set<string> | null = null;
+  try {
+    priorIds = new Set((await listPods()).filter((p) => p.name === name).map((p) => p.id));
+  } catch {
+    priorIds = null; // snapshot unavailable → ambiguous failures become terminal
+  }
   const attempts: string[] = [];
   for (const cloudType of cloudTypes) {
     for (const gpuTypeId of gpuTypeIds) {
       try {
         const pod = await deployOnce(cloudType, gpuTypeId, opts);
         if (pod) return pod;
+        // RunPod processed the mutation and returned nothing — provably not created.
         attempts.push(`${cloudType}/${gpuTypeId}: no capacity available`);
       } catch (err) {
-        attempts.push(`${cloudType}/${gpuTypeId}: ${err instanceof Error ? err.message : String(err)}`);
+        const msg = err instanceof Error ? err.message : String(err);
+        // Auth rejection happens before any pod is created — surface it directly
+        // (retrying other cloud/GPU combos with the same bad key is pointless).
+        if (err instanceof RunpodAuthError) throw err;
+        if (isProvablyNotCreatedError(err)) {
+          // RunPod itself said "no capacity/quota" → nothing was created; the next
+          // combo is safe to try.
+          attempts.push(`${cloudType}/${gpuTypeId}: ${msg}`);
+          continue;
+        }
+        // AMBIGUOUS failure: the billed mutation may have landed. Reconcile first.
+        const created = await findPodCreatedByThisCall(name, priorIds);
+        if (created) return created;
+        throw new Error(
+          `RunPod pod creation failed on ${cloudType}/${gpuTypeId} and it could not be confirmed whether a pod ` +
+            `was created (${msg}). NOT retrying automatically — a retry could create a second ` +
+            `billable pod. Check your pods at console.runpod.io (or runpod_pod_status) before trying again.` +
+            (attempts.length ? `\nEarlier attempts:\n${attempts.map((a) => `  • ${a}`).join("\n")}` : ""),
+        );
       }
     }
   }

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -302,8 +302,20 @@ async function findPodCreatedByThisCall(
  *  5xx/parse — the pod may exist even though the response was lost) we reconcile
  *  by listing pods under the requested name: if this call's pod appeared, return
  *  it; otherwise fail WITHOUT retrying so a lost-response create can never fan
- *  out into extra billable pods. */
+ *  out into extra billable pods.
+ *
+ *  CONCURRENCY: creates are serialized in-process (two concurrent same-name
+ *  calls would snapshot the same priorIds and could cross-attribute a
+ *  reconciled pod — codex finding). Cross-process creates remain name-
+ *  correlated best-effort; the orchestrator is the single issuer in practice. */
+let createChain: Promise<unknown> = Promise.resolve();
 export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodPod> {
+  const run = createChain.then(() => createPodOnce(opts));
+  createChain = run.catch(() => {}); // a failed create must not wedge the queue
+  return run;
+}
+
+async function createPodOnce(opts: RunpodCreateOptions): Promise<RunpodPod> {
   const gpuTypeIds = opts.gpuTypeIds?.length ? opts.gpuTypeIds : RUNPOD_DEFAULT_GPU_TYPES;
   const cloudTypes: Array<"COMMUNITY" | "SECURE"> = opts.cloudType ? [opts.cloudType] : ["COMMUNITY", "SECURE"];
   const name = opts.name ?? "comfyui-mcp";

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -36,6 +36,9 @@ export interface RunpodStatusFrame extends Record<string, unknown> {
   autostop_minutes: number | null;
   /** Seconds until auto-stop fires (null when disabled / not idle / not running). */
   autostop_in_seconds: number | null;
+  /** True when an idle auto-stop ATTEMPT failed — the pod is still running (and
+   *  billing); the watcher keeps watching and retries next tick. */
+  autostop_failed?: boolean;
 }
 
 const CLEARED_FRAME: RunpodStatusFrame = {
@@ -143,7 +146,20 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     };
   }
 
-  async function poll(): Promise<void> {
+  // In-flight guard: on a hung network a slow poll must not stack up under the
+  // interval — a tick that lands while the previous poll is still running JOINS
+  // it (no second concurrent RunPod request) instead of starting an overlap.
+  let inflight: Promise<void> | null = null;
+
+  function poll(): Promise<void> {
+    if (inflight) return inflight;
+    inflight = pollOnce().finally(() => {
+      inflight = null;
+    });
+    return inflight;
+  }
+
+  async function pollOnce(): Promise<void> {
     if (!podId || autoStopping) return;
     let pod: RunpodPod | null;
     try {
@@ -180,7 +196,14 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
           try {
             await stopPod(podId);
           } catch (err) {
-            logger.warn(`[runpod-watch] auto-stop of ${podId} failed: ${err instanceof Error ? err.message : err}`);
+            // MONEY SAFETY: the stop FAILED — the pod is still RUNNING and still
+            // BILLING. Do NOT pretend it exited and do NOT stop watching: broadcast
+            // the TRUE status with an autostop_failed hint so the UI can warn, keep
+            // the idle clock (remainMs stays ≤ 0), and retry the stop next tick.
+            logger.warn(`[runpod-watch] auto-stop of ${podId} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
+            autoStopping = false;
+            pushIfChanged({ ...frameFor(pod, idleSeconds, 0), autostop_failed: true });
+            return;
           }
           const stopped: RunpodStatusFrame = {
             ...frameFor(pod, idleSeconds, 0),

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -149,29 +149,38 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
   // In-flight guard: on a hung network a slow poll must not stack up under the
   // interval — a tick that lands while the previous poll is still running JOINS
   // it (no second concurrent RunPod request) instead of starting an overlap.
-  let inflight: Promise<void> | null = null;
+  // Keyed by pod id: a tick after the target CHANGED (watch(B) while A is in
+  // flight) starts a FRESH poll for the new target, and the stale poll's result
+  // is discarded on arrival (never published, never auto-stops the wrong pod).
+  let inflight: { id: string; promise: Promise<void> } | null = null;
 
   function poll(): Promise<void> {
-    if (inflight) return inflight;
-    inflight = pollOnce().finally(() => {
-      inflight = null;
+    const id = podId;
+    if (!id) return Promise.resolve();
+    if (inflight && inflight.id === id) return inflight.promise;
+    const promise = pollOnce(id).finally(() => {
+      if (inflight?.promise === promise) inflight = null;
     });
-    return inflight;
+    inflight = { id, promise };
+    return promise;
   }
 
-  async function pollOnce(): Promise<void> {
-    if (!podId || autoStopping) return;
+  async function pollOnce(id: string): Promise<void> {
+    if (autoStopping) return;
     let pod: RunpodPod | null;
     try {
-      pod = await getPod(podId);
+      pod = await getPod(id);
     } catch (err) {
       // Transient RunPod API blip — keep the last frame, try again next tick.
-      logger.debug(`[runpod-watch] poll failed for ${podId}: ${err instanceof Error ? err.message : err}`);
+      logger.debug(`[runpod-watch] poll failed for ${id}: ${err instanceof Error ? err.message : err}`);
       return;
     }
+    // The watch target moved on while this request was in flight — drop the
+    // stale result entirely (no publish, no unwatch, no auto-stop).
+    if (id !== podId) return;
     if (!pod) {
       // Pod vanished (terminated) — stop watching.
-      logger.info(`[runpod-watch] pod ${podId} no longer exists — unwatching`);
+      logger.info(`[runpod-watch] pod ${id} no longer exists — unwatching`);
       unwatch();
       return;
     }
@@ -183,7 +192,7 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     const running = pod.desiredStatus === "RUNNING" && !!pod.runtime;
     let idleSeconds: number | null = null;
     let autostopIn: number | null = null;
-    if (running && deps.renderingOnPod(podId) && deps.comfyuiIdle()) {
+    if (running && deps.renderingOnPod(id) && deps.comfyuiIdle()) {
       if (idleSinceMs == null) idleSinceMs = now();
       idleSeconds = Math.floor((now() - idleSinceMs) / 1000);
       if (idleStopMs > 0) {
@@ -192,15 +201,15 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
         if (remainMs <= 0) {
           // Fire auto-stop once; broadcast the reason so the UI can show it.
           autoStopping = true;
-          logger.info(`[runpod-watch] pod ${podId} idle ${idleSeconds}s ≥ ${deps.idleStopMinutes}m — auto-stopping to save cost`);
+          logger.info(`[runpod-watch] pod ${id} idle ${idleSeconds}s ≥ ${deps.idleStopMinutes}m — auto-stopping to save cost`);
           try {
-            await stopPod(podId);
+            await stopPod(id);
           } catch (err) {
             // MONEY SAFETY: the stop FAILED — the pod is still RUNNING and still
             // BILLING. Do NOT pretend it exited and do NOT stop watching: broadcast
             // the TRUE status with an autostop_failed hint so the UI can warn, keep
             // the idle clock (remainMs stays ≤ 0), and retry the stop next tick.
-            logger.warn(`[runpod-watch] auto-stop of ${podId} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
+            logger.warn(`[runpod-watch] auto-stop of ${id} FAILED — pod still running/billing, will retry next tick: ${err instanceof Error ? err.message : err}`);
             autoStopping = false;
             pushIfChanged({ ...frameFor(pod, idleSeconds, 0), autostop_failed: true });
             return;


### PR DESCRIPTION
## What

Salvages the two commits that were stranded when #251 closed unmerged, ported onto main's newer connector (port-3000 convention, COMMUNITY→SECURE cloud fallback), plus a second codex round on top:

**From the stranded commits (ported):**
- **Bearer auth + 10s timeout**: API key moves from the `?api_key=` URL param (leaks into proxy/server logs) to an `Authorization: Bearer` header; every GraphQL call carries an abort signal.
- **Billing-safe `createPod`**: `podFindAndDeployOnDemand` is a non-idempotent BILLED mutation. Retries to the next cloud/GPU combo only on PROVABLE no-capacity rejections (incl. a null pod from a processed mutation); ambiguous failures (network/timeout/5xx) reconcile via a pre-call pod-id snapshot and fail honestly instead of blind-retrying into a second billable pod.
- **Honest auto-stop failure**: a failed idle auto-stop no longer pretends the pod exited — broadcasts the TRUE RUNNING status with `autostop_failed: true`, keeps watching, retries next tick. Plus an in-flight poll guard (no overlapping polls on a hung network).
- **Tool-secret scoping**: `buildAgentSpawnEnv` strips tool-only secrets (RunPod/HF/CivitAI/…) from Codex/Gemini/Grok subprocess envs — they belong exclusively to the comfyui tool child (`buildComfyuiMcpEnv`).

**Codex round 2 (new):**
- Secret stripping is now **case-insensitive** — on Windows `:runpod_api_key` resolves via `RUNPOD_API_KEY` but spreads lowercase; canonical-case deletion leaked it into every agent spawn.
- `createPod` serializes billed mutations in-process — concurrent same-name calls could cross-attribute a reconciled pod (and orphan a second billable one).
- Watcher keys the in-flight poll by pod id — `watch(B)` during A's poll fetches B immediately and discards A's late frame (no stale publish / wrong-pod auto-stop).

Tests: 16 new/updated cases across runpod-client / runpod-watch / panel-secrets / codex-spawn-env; full suite green except a pre-existing environmental `node-dev` failure (ripgrep installed on this rig — fails on main too, unrelated).

Unblocks #263 (rebased onto this branch).

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-code)