### PR TITLE
fix: close deferred RunPod/training/codex review findings (#268/#269/#273/#274/#276/#277)

### DIFF
--- a/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
+++ b/src/__tests__/orchestrator/codex-backend-spawn-env.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   spawnEnvs: [] as Array<Record<string, string | undefined> | undefined>,
+  spawnArgs: [] as string[][],
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -21,6 +22,7 @@ vi.mock("node:child_process", async (importOriginal) => {
     ...actual,
     spawn: (_cmd: string, _args: string[], opts?: { env?: Record<string, string | undefined> }) => {
       hoisted.spawnEnvs.push(opts?.env);
+      hoisted.spawnArgs.push(_args ?? []);
       const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
       proc.pid = 4243;
       proc.exitCode = null;
@@ -51,6 +53,7 @@ import { CodexBackend } from "../../orchestrator/codex-backend.js";
 
 beforeEach(() => {
   hoisted.spawnEnvs.length = 0;
+  hoisted.spawnArgs.length = 0;
 });
 
 describe("CodexBackend spawn env (tool-secret scoping)", () => {
@@ -85,5 +88,18 @@ describe("CodexBackend spawn env (tool-secret scoping)", () => {
         else process.env[k] = v;
       }
     }
+  });
+
+  it("isolates the embedded app-server from the user's global Codex notify hook (#277)", async () => {
+    const backend = new CodexBackend({});
+    await backend.prepare().catch(() => {});
+    expect(hoisted.spawnArgs.length).toBeGreaterThanOrEqual(1);
+    const args = hoisted.spawnArgs[0];
+    // `-c notify=[]` must be present as adjacent argv entries.
+    let found = false;
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-c" && args[i + 1] === "notify=[]") found = true;
+    }
+    expect(found, "app-server args must include `-c notify=[]`").toBe(true);
   });
 });

--- a/src/__tests__/orchestrator/provider-key-rotation.test.ts
+++ b/src/__tests__/orchestrator/provider-key-rotation.test.ts
@@ -1,0 +1,88 @@
+// #278 — rotating an active provider API key must REBUILD the live keyed agent
+// so the new/revoked key takes effect. Keyed backends (OpenRouter/Custom/GLM/
+// Kimi/Moonshot) capture the credential at construction, so a cache-drop alone
+// leaves the old key in use until the backend is rebuilt. restartForProviderKey
+// drives that rebuild at idle WITHOUT a download-retry nudge.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A keyed backend that SNAPSHOTS the credential at construction (like the real
+ *  OpenRouter/GLM backends), so a test can prove a rebuild picks up a new key. */
+class KeyedBackend implements AgentBackend {
+  readonly id = "openrouter" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  readonly capturedKey: string;
+  turnTexts: string[] = [];
+  constructor(readKey: () => string) {
+    this.capturedKey = readKey(); // captured ONCE at construction
+  }
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: `sess-${this.capturedKey}` };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("provider-key rotation rebuilds the live keyed agent (#278)", () => {
+  it("restartForProviderKey rebuilds the backend with the ROTATED key, no nudge", async () => {
+    let currentKey = "key-OLD";
+    const built: KeyedBackend[] = [];
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "or-model",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => {
+        const b = new KeyedBackend(() => currentKey);
+        built.push(b);
+        return b;
+      },
+    } as never);
+    const tab = "tab-key-rotate";
+
+    manager.send(tab, "hello");
+    await waitFor(() => built.length >= 1 && built[0].turnTexts.includes("hello"));
+    expect(built[0].capturedKey).toBe("key-OLD");
+
+    // Rotate the key, then trigger the keyed rebuild (what onAgentSecretsChanged
+    // now does for a live keyed tab).
+    currentKey = "key-NEW";
+    manager.restartForProviderKey(tab);
+
+    // A SECOND backend is constructed — and it captured the NEW key.
+    await waitFor(() => built.length >= 2);
+    expect(built[1].capturedKey).toBe("key-NEW");
+    // No download-retry nudge was injected into the rebuilt agent.
+    expect(built[1].turnTexts).not.toContain(
+      "🔑 The API token you just provided is now active for the comfyui tools — retry the action that needed it (e.g. the download that returned 401).",
+    );
+  });
+});

--- a/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
+++ b/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
@@ -21,19 +21,24 @@ beforeAll(async () => {
 });
 
 /** A backend that FAILS any run resuming a session (simulating a pruned rollout)
- *  and succeeds on a fresh (resume-less) session. */
+ *  and succeeds on a fresh (resume-less) session. When `alwaysThrow` is set it
+ *  throws the error on EVERY run (even fresh) — to prove a fresh-start failure
+ *  still counts toward the rapid-restart give-up bound. */
 class ResumeMissBackend implements AgentBackend {
   readonly id = "claude" as const;
   readonly capabilities = CLAUDE_CAPABILITIES;
   runCount = 0;
   resumes: Array<string | undefined> = [];
   turnTexts: string[] = [];
-  constructor(private readonly errorText: string) {}
+  constructor(
+    private readonly errorText: string,
+    private readonly alwaysThrow = false,
+  ) {}
 
   async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
     this.runCount += 1;
     this.resumes.push(opts.resume);
-    if (opts.resume) {
+    if (opts.resume || this.alwaysThrow) {
       // The resume target is gone — Codex surfaces this as a stream error.
       throw new Error(this.errorText);
     }
@@ -90,4 +95,21 @@ describe("resume-miss self-heal (#277)", () => {
       expect(backend.runCount).toBeLessThanOrEqual(3);
     });
   }
+
+  it("a FRESH start that keeps emitting the rollout error still hits the give-up bound (#278)", async () => {
+    // No resume seeded → every run is a fresh start that throws the same text.
+    // resumeMiss must NOT be set for a fresh start, so the rapid-restart counter
+    // is NOT reset and the loop terminates (gives up) instead of spinning forever.
+    const backend = new ResumeMissBackend("no rollout found for thread id deadbeef", true);
+    const manager = makeManager(backend);
+    const tab = "tab-fresh-fail";
+    manager.send(tab, "hello");
+    // The agent should GIVE UP (drop itself from the live map) within the bound.
+    await waitFor(() => !manager.hasLiveAgent(tab), 6000);
+    // Bounded restarts, not an infinite loop (initial + ~4 rapid restarts).
+    expect(backend.runCount).toBeGreaterThanOrEqual(3);
+    expect(backend.runCount).toBeLessThanOrEqual(6);
+    // Every attempt was a FRESH start (no resume was ever set).
+    expect(backend.resumes.every((r) => r === undefined)).toBe(true);
+  });
 });

--- a/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
+++ b/src/__tests__/orchestrator/resume-miss-selfheal.test.ts
@@ -1,0 +1,93 @@
+// #277 — PanelAgent self-heals a missing resume target. Current Codex reports a
+// pruned/missing resume session as EITHER "No conversation found with session
+// ID: <id>" OR "no rollout found for thread id <uuid>". Both must clear the dead
+// resume target, start a FRESH session, and replay the queued message — instead
+// of retrying the same dead resume until the give-up threshold self-exits the
+// orchestrator.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A backend that FAILS any run resuming a session (simulating a pruned rollout)
+ *  and succeeds on a fresh (resume-less) session. */
+class ResumeMissBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  runCount = 0;
+  resumes: Array<string | undefined> = [];
+  turnTexts: string[] = [];
+  constructor(private readonly errorText: string) {}
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    this.runCount += 1;
+    this.resumes.push(opts.resume);
+    if (opts.resume) {
+      // The resume target is gone — Codex surfaces this as a stream error.
+      throw new Error(this.errorText);
+    }
+    yield { type: "session", sessionId: "fresh-sess" };
+    for await (const turn of opts.channel) {
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeManager(backend: AgentBackend) {
+  return new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+  } as never);
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("resume-miss self-heal (#277)", () => {
+  for (const errorText of [
+    "No conversation found with session ID: dead-sess",
+    "no rollout found for thread id 00000000-0000-4000-8000-000000000000",
+  ]) {
+    it(`clears the dead resume + replays the queued message: "${errorText.slice(0, 24)}…"`, async () => {
+      const backend = new ResumeMissBackend(errorText);
+      const manager = makeManager(backend);
+      const tab = "tab-resume-miss";
+      // Seed a resume target so the FIRST run resumes (and fails).
+      manager.setResume(tab, "dead-sess");
+      manager.send(tab, "hello");
+
+      // The agent must recover: a SECOND run with NO resume that processes "hello".
+      await waitFor(() => backend.turnTexts.includes("hello"));
+      expect(backend.resumes[0]).toBe("dead-sess"); // first run tried the dead resume
+      expect(backend.resumes[1]).toBeUndefined(); // recovery dropped it → fresh session
+      // Did NOT spin to the give-up threshold (would be many runs).
+      expect(backend.runCount).toBeLessThanOrEqual(3);
+    });
+  }
+});

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -192,6 +192,32 @@ describe("panel-secrets (canonical .env store)", () => {
       expect(migrated).not.toContain("CIVITAI_API_TOKEN"); // skipped (already present)
       delete process.env.COMFYUI_MCP_PANEL_SECRETS;
     });
+
+    it("removeEnvSecret PURGES the legacy JSON so a revoked key can't resurrect (#269)", async () => {
+      const { writeFileSync } = require("node:fs");
+      const jsonPath = join(dir, "panel-secrets.json");
+      process.env.COMFYUI_MCP_PANEL_SECRETS = jsonPath;
+      writeFileSync(
+        jsonPath,
+        JSON.stringify({ comfyuiEnv: { CIVITAI_API_TOKEN: "civ-legacy" }, agentEnv: { OPENROUTER_API_KEY: "or-legacy" } }),
+      );
+      writeFileSync(envPath, "CIVITAI_API_TOKEN=civ-legacy\n");
+      process.env.CIVITAI_API_TOKEN = "civ-legacy";
+
+      const { removeEnvSecret, migrateSecretsToEnv } = await import("../../services/panel-secrets.js");
+      expect(removeEnvSecret("CIVITAI_API_TOKEN")).toBe(true);
+      // Gone from .env AND from the JSON map.
+      expect(readFileSync(envPath, "utf-8")).not.toMatch(/CIVITAI_API_TOKEN/);
+      const json = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      expect(json.comfyuiEnv.CIVITAI_API_TOKEN).toBeUndefined();
+      expect(json.agentEnv.OPENROUTER_API_KEY).toBe("or-legacy"); // untouched
+      // A subsequent boot migration must NOT bring the revoked key back.
+      delete process.env.CIVITAI_API_TOKEN;
+      const migrated = migrateSecretsToEnv();
+      expect(migrated).not.toContain("CIVITAI_API_TOKEN");
+      expect(process.env.CIVITAI_API_TOKEN).toBeUndefined();
+      delete process.env.COMFYUI_MCP_PANEL_SECRETS;
+    });
   });
 
   describe("agent-secret allowlist (provider keys)", () => {

--- a/src/__tests__/services/runpod-client.test.ts
+++ b/src/__tests__/services/runpod-client.test.ts
@@ -154,7 +154,9 @@ describe("createPod (GPU fallback + billing safety)", () => {
       );
     });
     global.fetch = fetchMock as unknown as typeof fetch;
-    const pod = await createPod({ gpuTypeIds: ["GPU-A", "GPU-B"] });
+    // Explicit name → the shared-name reconcile path (the default name is now
+    // unique per create; #276). reconcileCreatedPod matches on this name.
+    const pod = await createPod({ gpuTypeIds: ["GPU-A", "GPU-B"], name: "comfyui-mcp" });
     expect(pod.id).toBe("ghost-pod"); // reconciled, not re-created
     expect(deployAttempts).toBe(1); // NEVER retried the billed mutation
   });
@@ -193,7 +195,9 @@ describe("createPod (GPU fallback + billing safety)", () => {
             ]),
       );
     }) as unknown as typeof fetch;
-    await expect(createPod({ gpuTypeIds: ["GPU-A"] })).rejects.toThrow(/concurrent create|2 new pods|can't be determined/i);
+    // Explicit shared name reproduces the concurrent same-name race (the default
+    // is unique now, #276). Both pods carry this name → ambiguous, fail closed.
+    await expect(createPod({ gpuTypeIds: ["GPU-A"], name: "comfyui-mcp" })).rejects.toThrow(/concurrent create|2 new pods|can't be determined/i);
   });
 
   it("reconciliation ignores same-named pods that existed BEFORE the call", async () => {
@@ -206,7 +210,27 @@ describe("createPod (GPU fallback + billing safety)", () => {
       return gqlResponse(listOf([preExisting])); // same list before and after
     });
     global.fetch = fetchMock as unknown as typeof fetch;
-    await expect(createPod({ gpuTypeIds: ["GPU-A"] })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+    await expect(createPod({ gpuTypeIds: ["GPU-A"], name: "comfyui-mcp" })).rejects.toThrow(/could not be confirmed|NOT retrying/i);
+  });
+
+  it("defaults to a UNIQUE deploy name so concurrent creates don't mis-attribute (#276)", async () => {
+    const names: string[] = [];
+    const { fetchMock } = mockGql((b) => {
+      if (b.query.includes("podFindAndDeployOnDemand")) {
+        const name = (b.variables.input as { name: string }).name;
+        names.push(name);
+        return { data: { podFindAndDeployOnDemand: { id: `p${names.length}`, name, desiredStatus: "RUNNING", costPerHr: 0.44, machine: null } } };
+      }
+      return emptyList;
+    });
+    await createPod({ gpuTypeIds: ["GPU-A"] });
+    await createPod({ gpuTypeIds: ["GPU-A"] });
+    expect(names).toHaveLength(2);
+    // Neither is the bare shared default, and the two differ.
+    expect(names[0]).not.toBe("comfyui-mcp");
+    expect(names[0]).toMatch(/^comfyui-mcp-/);
+    expect(names[0]).not.toBe(names[1]);
+    void fetchMock;
   });
 
   it("classifies errors: capacity/quota are provably-not-created; network/HTTP are not", () => {

--- a/src/__tests__/services/training-jobs.test.ts
+++ b/src/__tests__/services/training-jobs.test.ts
@@ -1427,6 +1427,65 @@ describe("pod target (P4)", () => {
     expect(mod.hasActiveTrainingJob("pod")).toBe(false);
   });
 
+  it("hasActiveTrainingJob scopes to the WATCHED pod id (#274)", async () => {
+    const { deps, d } = podDeps();
+    await mod.startTrainingJob(
+      { name: "scoped_pod", flow: "character", model: "flux1-dev", datasetPath: stageDataset(), target: "pod", podEndpoint: EP, podId: "pod-A" },
+      deps,
+    );
+    // Busy for its OWN pod, and for an unscoped query…
+    expect(mod.hasActiveTrainingJob("pod")).toBe(true);
+    expect(mod.hasActiveTrainingJob("pod", "pod-A")).toBe(true);
+    // …but NOT for a different pod — a run on pod-A must not suppress pod-B's
+    // idle auto-stop.
+    expect(mod.hasActiveTrainingJob("pod", "pod-B")).toBe(false);
+    d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mod.hasActiveTrainingJob("pod", "pod-A")).toBe(false);
+  });
+
+  it("serializes two concurrent starts for the SAME pod — exactly one wins (#273)", async () => {
+    const a = podDeps();
+    const b = podDeps();
+    const [r1, r2] = await Promise.allSettled([
+      mod.startTrainingJob(
+        { name: "race_a", flow: "character", model: "flux1-dev", datasetPath: stageDataset(), target: "pod", podEndpoint: EP },
+        a.deps,
+      ),
+      mod.startTrainingJob(
+        { name: "race_b", flow: "character", model: "flux1-dev", datasetPath: stageDataset(), target: "pod", podEndpoint: EP },
+        b.deps,
+      ),
+    ]);
+    const outcomes = [r1, r2];
+    expect(outcomes.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+    const rejected = outcomes.find((r) => r.status === "rejected") as PromiseRejectedResult;
+    expect(String(rejected.reason)).toMatch(/already has an active training job|already reserving/i);
+    a.d.resolve({ code: 0, tail: "" });
+    b.d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 30));
+  });
+
+  it("local LoRA delivery is atomic and leaves no tmp file (#268)", async () => {
+    // Pre-existing same-name LoRA: the retrain must overwrite it with the new
+    // weights via tmp+rename (no half-written file, no leftover tmp).
+    const lorasDir = join(root, "loras");
+    mkdirSync(lorasDir, { recursive: true });
+    writeFileSync(join(lorasDir, "pod_lora.safetensors"), "OLD");
+    const { deps, d } = podDeps();
+    const job = await mod.startTrainingJob(
+      { name: "pod_lora", flow: "character", model: "flux1-dev", datasetPath: stageDataset(), target: "pod", podEndpoint: EP },
+      deps,
+    );
+    d.resolve({ code: 0, tail: "" });
+    await new Promise((r) => setTimeout(r, 50));
+    const done = (await mod.getJob(job.id))!;
+    expect(done.status).toBe("completed");
+    expect(readFileSync(join(lorasDir, "pod_lora.safetensors"), "utf-8")).toBe("weights");
+    const leftovers = readdirSync(lorasDir).filter((f) => f.includes(".tmp-"));
+    expect(leftovers).toHaveLength(0);
+  });
+
   it("a failed staging TERMINALIZES the job (no orphaned queued record)", async () => {
     const { deps } = podDeps({ rsyncToPod: async () => ({ code: 5, stdout: "", stderr: "no space left on device" }) });
     await expect(

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -710,6 +710,13 @@ export class CodexBackend implements AgentBackend {
       `sandbox_mode=${JSON.stringify(this.sandbox)}`,
       "-c",
       `approval_policy=${JSON.stringify("never")}`,
+      // Isolate the embedded app-server from the user's GLOBAL Codex `notify`
+      // config (#277): an inherited legacy_notify hook can fail after a panel
+      // turn on Windows with `os error 206` (filename/extension too long),
+      // emitting a misleading warning alongside a failed turn. The panel owns
+      // its own UI notifications, so the embedded app-server needs no hook.
+      "-c",
+      "notify=[]",
     ];
     // SECURITY: spawn with the agent env — process.env MINUS tool-only secrets
     // (RunPod/HF/CivitAI… tokens). Those belong to the comfyui tool child

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -676,16 +676,18 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "train_start",
   "train_cancel",
   // RunPod control panel (desktop + mobile): the one-tap pod lifecycle + the
-  // local⇄pod host switch. Read-only status/list/troubleshoot plus the
-  // user-initiated lifecycle actions (start/stop/connect/use_local/watch/
-  // unwatch) and the referral deploy link. Each tool validates its own pod
-  // state; the whitelist only gates reachability from a canvas-less client.
-  // NOTE: runpod_pod_create is deliberately EXCLUDED (#269) — deploying a pod
-  // is a BILLED mutation, so it must go through an agent turn / explicit UI
-  // action, never the confirmation-less direct call_tool channel.
+  // local⇄pod host switch. Read-only status/list/troubleshoot, the COST-SAVING
+  // actions (stop/use_local), connect (retarget only — a pod must already be
+  // RUNNING, so it neither spins nor keeps one billing), watch/unwatch, and the
+  // referral deploy link. Each tool validates its own pod state; the whitelist
+  // only gates reachability from a canvas-less client.
+  // NOTE: runpod_pod_create AND runpod_pod_start are deliberately EXCLUDED
+  // (#269/#278) — both put a pod into a BILLING state (create deploys; start
+  // RESUMES billing on a stopped pod). A confirmation-less mirrored/foreign tab
+  // must not be able to spend money, so both go through an agent turn / explicit
+  // UI action. stop is kept (it SAVES money).
   "runpod_pod_status",
   "runpod_list_pods",
-  "runpod_pod_start",
   "runpod_pod_stop",
   "runpod_pod_connect",
   "runpod_pod_troubleshoot",
@@ -1933,23 +1935,35 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the next probe uses the new key, and re-push readiness + models to every
   // live tab so the OpenRouter provider flips to "ready" and lists its models
   // without a reconnect.
+  const KEYED_PROVIDERS = ["openrouter", "custom", "glm", "kimi", "moonshot"];
   const unsubscribeAgentSecrets = onAgentSecretsChanged(() => {
     hydrateAgentSecretsIntoEnv();
     // A key change can affect ANY keyed provider (OpenRouter/Custom endpoints and
     // the hosted API-key backends GLM / Kimi / Moonshot) — drop each one's cached
     // probe backend + model list so the next probe carries the fresh credentials
     // (and a revoked key immediately stops reading as "ready" from a stale cache).
-    for (const b of ["openrouter", "custom", "glm", "kimi", "moonshot"]) {
+    for (const b of KEYED_PROVIDERS) {
       modelsByBackend.delete(b);
       const pb = probeBackends.get(b);
       if (pb?.close) void pb.close().catch(() => {});
       probeBackends.delete(b);
     }
+    // Cache-drop alone does NOT rotate the key on a LIVE agent: keyed backends
+    // capture the credential at construction and keep using the OLD key until
+    // rebuilt (#278). So a live tab running a keyed provider must be restarted
+    // for the new/revoked key to take effect — a SILENT rebuild at idle (no
+    // download-retry nudge; the guard's job was only to stop the spurious nudge
+    // + unrelated Claude/Codex restarts, not to stop key rotation).
+    for (const [tabId, backend] of tabBackends.entries()) {
+      if (KEYED_PROVIDERS.includes(backend)) {
+        manager.restartForProviderKey(agentKeyFor(tabId));
+      }
+    }
     for (const tabId of tabBackends.keys()) {
       pushReadiness(tabId);
       pushModels(tabId);
     }
-    logger.info("[panel-orchestrator] provider key saved → readiness + models refreshed");
+    logger.info("[panel-orchestrator] provider key saved → readiness + models refreshed + keyed agents rebuilt");
   });
 
   // Debounce the connect ack: the panel re-sends `hello` on reconnect and on

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -677,14 +677,16 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "train_cancel",
   // RunPod control panel (desktop + mobile): the one-tap pod lifecycle + the
   // local⇄pod host switch. Read-only status/list/troubleshoot plus the
-  // user-initiated lifecycle actions (create/start/stop/connect/use_local/
-  // watch/unwatch) and the referral deploy link. Each tool validates its own
-  // pod state; the whitelist only gates reachability from a canvas-less client.
+  // user-initiated lifecycle actions (start/stop/connect/use_local/watch/
+  // unwatch) and the referral deploy link. Each tool validates its own pod
+  // state; the whitelist only gates reachability from a canvas-less client.
+  // NOTE: runpod_pod_create is deliberately EXCLUDED (#269) — deploying a pod
+  // is a BILLED mutation, so it must go through an agent turn / explicit UI
+  // action, never the confirmation-less direct call_tool channel.
   "runpod_pod_status",
   "runpod_list_pods",
   "runpod_pod_start",
   "runpod_pod_stop",
-  "runpod_pod_create",
   "runpod_pod_connect",
   "runpod_pod_troubleshoot",
   "runpod_use_local",
@@ -3352,13 +3354,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   })();
   initRunpodWatcher({
     push: (frame) => void bridge.push(frame),
-    comfyuiIdle: () => {
+    comfyuiIdle: (podId) => {
       const s = QueueMonitor.snapshot();
-      // NOT idle while a training job is alive on the pod: training isn't a
+      // NOT idle while a training job is alive on THIS pod: training isn't a
       // ComfyUI queue job, so the queue alone would call an hours-long LoRA
       // run "idle" and auto-stop the pod mid-flight (P4 guard; review finding
-      // on the connector). hasActiveTrainingJob is a probe-free file scan.
-      return s.connected && !s.running && s.queueDepth === 0 && !hasActiveTrainingJob("pod");
+      // on the connector). hasActiveTrainingJob is a probe-free file scan,
+      // scoped to the watched pod so a run on another pod doesn't suppress
+      // this pod's idle-stop (codex #274).
+      return s.connected && !s.running && s.queueDepth === 0 && !hasActiveTrainingJob("pod", podId);
     },
     // Idle auto-stop only applies to a pod we're actually rendering on: the active
     // ComfyUI target is that pod's proxy (its id appears in the URL). A pod we

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -734,12 +734,14 @@ export class PanelAgent {
         logger.error(`[panel-agent ${this.short()}] stream error: ${emsg}`);
         // A resume whose target session no longer exists — e.g. the orchestrator was
         // relaunched from a different cwd, or the session transcript was pruned —
-        // fails with "No conversation found with session ID: <id>". Retrying the SAME
-        // resume just loops until the give-up threshold trips and self-exits the whole
-        // orchestrator (a live bridge left serving a permanently-dead agent). Drop the
-        // dead resume target so the NEXT iteration starts a FRESH session and
+        // fails with "No conversation found with session ID: <id>". Current Codex
+        // can instead report "no rollout found for thread id <uuid>" for the same
+        // pruned/missing-target condition (#277). Retrying the SAME resume just
+        // loops until the give-up threshold trips and self-exits the whole
+        // orchestrator (a live bridge left serving a permanently-dead agent). Drop
+        // the dead resume target so the NEXT iteration starts a FRESH session and
         // self-heals; queued messages (this.queue) survive and replay.
-        if (/No conversation found with session ID/i.test(emsg)) {
+        if (/(?:No conversation found with session ID|no rollout found for thread id)/i.test(emsg)) {
           logger.warn(
             `[panel-agent ${this.short()}] resume target is gone — starting a fresh session`,
           );

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -741,7 +741,12 @@ export class PanelAgent {
         // orchestrator (a live bridge left serving a permanently-dead agent). Drop
         // the dead resume target so the NEXT iteration starts a FRESH session and
         // self-heals; queued messages (this.queue) survive and replay.
-        if (/(?:No conversation found with session ID|no rollout found for thread id)/i.test(emsg)) {
+        // GUARD (#278): only treat this as a recoverable resume-MISS when this
+        // start actually RESUMED something. A FRESH start (no resume) that emits
+        // the same text is a real, non-recoverable failure and MUST count toward
+        // the rapid-restart give-up bound below — otherwise resumeMiss would reset
+        // the counter forever and spin an infinite restart loop.
+        if (resume && /(?:No conversation found with session ID|no rollout found for thread id)/i.test(emsg)) {
           logger.warn(
             `[panel-agent ${this.short()}] resume target is gone — starting a fresh session`,
           );
@@ -1233,6 +1238,16 @@ export class PanelAgentManager {
     if (!this.agents.has(key)) return;
     this.pendingMcpRestart.set(key, nudge ?? null);
     this.applyPendingRestarts(key);
+  }
+
+  /** Rebuild a live agent because its PROVIDER credential rotated (#278): keyed
+   *  backends (OpenRouter/Custom/GLM/Kimi/Moonshot) capture the API key at
+   *  construction, so a rotated/revoked key only takes effect on a fresh spawn.
+   *  Reuses the coalesced at-idle restart (a fresh makeBackend reads the new
+   *  env key) WITHOUT a retry nudge — this is a silent key refresh, not the
+   *  download-401 flow. No-op when the tab has no live agent. */
+  restartForProviderKey(key: string): void {
+    this.restartForMcpEnv(key);
   }
 
   /**

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -239,19 +239,38 @@ export function setEnvSecret(key: string, value: string): void {
   }
   upsertEnvFile(trimmed, value);
   process.env[trimmed] = value; // live in-process effect (env wins over the file)
-  emitter.emit("change"); // comfyui tool secret → re-inject/respawn agent on idle
+  // Only a COMFYUI tool secret should restart the comfyui MCP child + inject the
+  // "retry the download that needed this token" nudge (#269): saving an
+  // agent-ONLY provider key (OPENROUTER/GLM/KIMI…) previously restarted every
+  // agent with that nonsensical download-retry message. Agent-only keys fire
+  // just "agentChange" (readiness/model refresh) below.
+  if (isAllowedComfyuiSecretKey(trimmed)) emitter.emit("change");
   if (isAllowedAgentSecretKey(trimmed)) emitter.emit("agentChange"); // flip provider readiness live
 }
 
-/** Canonical remover: drop a token from .env + process.env + emit. */
+/** Canonical remover: drop a token from .env + process.env + emit. Also PURGES
+ *  the legacy panel-secrets.json maps (#269): without this a key revoked from
+ *  .env would RESURRECT on the next boot, because migrateSecretsToEnv() re-adds
+ *  any key still present in the JSON store that .env no longer provides. */
 export function removeEnvSecret(key: string): boolean {
   const removed = removeEnvFileKey(key);
   if (process.env[key] !== undefined) delete process.env[key];
-  if (removed) {
-    emitter.emit("change");
+  // Purge the legacy JSON maps so a revoked key can't resurrect via migration.
+  const s = read();
+  let purgedJson = false;
+  for (const map of [s.comfyuiEnv, s.agentEnv]) {
+    if (map && Object.prototype.hasOwnProperty.call(map, key)) {
+      delete map[key];
+      purgedJson = true;
+    }
+  }
+  if (purgedJson) write(s);
+  const changed = removed || purgedJson;
+  if (changed) {
+    if (isAllowedComfyuiSecretKey(key)) emitter.emit("change"); // comfyui-only restart (#269)
     if (isAllowedAgentSecretKey(key)) emitter.emit("agentChange");
   }
-  return removed;
+  return changed;
 }
 
 /**

--- a/src/services/runpod-client.ts
+++ b/src/services/runpod-client.ts
@@ -369,7 +369,17 @@ async function reconcileCreatedPod(
 export async function createPod(opts: RunpodCreateOptions = {}): Promise<RunpodPod> {
   const gpuTypeIds = opts.gpuTypeIds?.length ? opts.gpuTypeIds : RUNPOD_DEFAULT_GPU_TYPES;
   const cloudTypes: Array<"COMMUNITY" | "SECURE"> = opts.cloudType ? [opts.cloudType] : ["COMMUNITY", "SECURE"];
-  const name = opts.name ?? "comfyui-mcp";
+  // Mis-attribution mitigation (#276): pod name is NOT unique, so a shared
+  // default ("comfyui-mcp") let a lost-response reconcile claim a CONCURRENT
+  // caller's same-named pod. RunPod exposes no per-create idempotency token, so
+  // instead we default to a UNIQUE deploy name — then reconcileCreatedPod's
+  // `name` filter attributes exactly THIS call's pod and concurrent creates no
+  // longer collide. An explicitly-passed name keeps its old (shared) semantics:
+  // the caller opted in.
+  const name = opts.name ?? `comfyui-mcp-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  // Ensure deployOnce sends the SAME name we reconcile against (its own default
+  // would otherwise be the shared "comfyui-mcp").
+  opts = { ...opts, name };
   // Snapshot the ids of pods ALREADY carrying the requested name, so post-failure
   // reconciliation can tell a pod THIS call created apart from a pre-existing one.
   let priorIds: Set<string> | null = null;

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -61,8 +61,10 @@ const CLEARED_FRAME: RunpodStatusFrame = {
 export interface RunpodWatcherDeps {
   /** Broadcast a frame to all panel/mobile tabs (the bridge's fire-and-forget push). */
   push: (frame: Record<string, unknown>) => void;
-  /** True when the ACTIVE ComfyUI target's queue is empty and nothing is running. */
-  comfyuiIdle: () => boolean;
+  /** True when the ACTIVE ComfyUI target's queue is empty and nothing is
+   *  running. Receives the WATCHED pod id so the predicate can scope
+   *  "busy training" to this exact pod (codex #274). */
+  comfyuiIdle: (podId: string) => boolean;
   /** True only when comfyui-mcp is CURRENTLY rendering on this pod (its ComfyUI is
    *  the active target). Idle auto-stop applies ONLY then — a pod we merely watch
    *  (e.g. while it boots, before connect) must never be stopped on the LOCAL
@@ -190,7 +192,7 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     const running = pod.desiredStatus === "RUNNING" && !!pod.runtime;
     let idleSeconds: number | null = null;
     let autostopIn: number | null = null;
-    if (running && deps.renderingOnPod(target) && deps.comfyuiIdle()) {
+    if (running && deps.renderingOnPod(target) && deps.comfyuiIdle(target)) {
       if (idleSinceMs == null) idleSinceMs = now();
       idleSeconds = Math.floor((now() - idleSinceMs) / 1000);
       if (idleStopMs > 0) {

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -87,6 +87,11 @@ export interface TrainingJob {
   target?: "local" | "pod";
   /** Pod jobs: where the finished LoRA is delivered (default "both"). */
   deliverTo?: "pod" | "local" | "both";
+  /** RunPod pod id this job runs on (target "pod"). Lets the idle auto-stop
+   *  scope "is a pod busy training?" to the SPECIFIC watched pod — a run on
+   *  pod A must not suppress the idle-stop of pod B (codex #274). Absent on
+   *  pre-#274 records → treated as busy-for-any-pod (cost-safe). */
+  podId?: string;
   /** Pid of the MCP process that launched the container — the ONLY process
    *  allowed to finalize it. Other processes may recover an orphaned job only
    *  when this owner is provably dead (train_status stays side-effect-free for
@@ -530,6 +535,16 @@ async function acquireJobLock(id: string, budgetMs = LOCK_WAIT_MS): Promise<bool
   return acquireLock(lockFile(id), budgetMs);
 }
 
+/** Cross-process reservation lock keyed by a POD ENDPOINT (codex #273). Held
+ *  across the one-run-per-pod scan→persist→launch in startTrainingJob so two
+ *  MCP processes can't both pass the disk scan and double-launch run.py on the
+ *  same pod. The endpoint encoding (`pod|user@host|port`) is sanitized into a
+ *  filename-safe key. */
+function podReservationLockFile(endpoint: PodSshEndpoint): string {
+  const key = encodePodContainerName(endpoint).replace(/[^A-Za-z0-9._-]+/g, "_");
+  return join(jobsRoot(), `.pod-reserve-${key}.lock`);
+}
+
 /** Release a lock — delete the file only if it still carries OUR token, and
  *  only through the SAME claim channel stale takeover uses (codex finding: a
  *  preempted-and-resumed holder's token-check → rm otherwise races a takeover
@@ -863,11 +878,19 @@ export function defaultTrainingStop(name: string, remoteConfigPath?: string): Re
  *  those is alive (the pod is busy training even when the ComfyUI queue is
  *  empty). Stale records err toward "busy" (pod stays up — the cost-safe
  *  direction for a false negative would be the expensive one). */
-export function hasActiveTrainingJob(target?: "pod"): boolean {
+export function hasActiveTrainingJob(target?: "pod", podId?: string): boolean {
   return scanJobRecords().some((j) => {
     if (j.status !== "running" && j.status !== "queued") return false;
     if (!target) return true;
-    return j.target === target || j.containerName?.startsWith("pod|") === true;
+    const isPodJob = j.target === "pod" || j.containerName?.startsWith("pod|") === true;
+    if (!isPodJob) return false;
+    // Scope to a SPECIFIC pod when the caller names one AND this record knows
+    // its pod (codex #274): a run on pod A must not suppress pod B's idle-stop.
+    // A record with no podId (pre-#274) can't be attributed to a pod, so it
+    // errs toward "busy" for every pod — the cost-safe direction (never stop a
+    // maybe-live training run mid-flight).
+    if (podId && j.podId) return j.podId === podId;
+    return true;
   });
 }
 
@@ -1053,6 +1076,9 @@ export interface StartJobInput {
   target?: "local" | "pod";
   /** SSH endpoint of the target pod (target "pod"). */
   podEndpoint?: PodSshEndpoint;
+  /** RunPod pod id (target "pod") — persisted so the idle auto-stop can scope
+   *  "busy training" to this exact pod (codex #274). */
+  podId?: string;
   /** Pod jobs: where the finished LoRA lands (default "both"). */
   deliverTo?: "pod" | "local" | "both";
   /** Override for the base model path as the trainer sees it (e.g. a pod-local
@@ -1190,7 +1216,24 @@ async function handoffToComfyUI(job: TrainingJob, deps: TrainingJobDeps): Promis
     const lorasDir = job.lorasDir ?? (deps.lorasDir ? deps.lorasDir() : resolveModelSubfolder("loras"));
     mkdirSync(lorasDir, { recursive: true });
     dest = join(lorasDir, `${job.name}.safetensors`);
-    copyFileSync(produced, dest);
+    // Atomic publish (codex #268): a straight copyFileSync onto dest lets
+    // ComfyUI's models/loras scan observe a HALF-WRITTEN file, and a same-name
+    // collision clobbers an existing LoRA silently. Copy to a tmp sibling on the
+    // SAME volume, then rename over dest — rename is atomic (libuv uses
+    // MOVEFILE_REPLACE_EXISTING on Windows), so a reader sees either the old or
+    // the complete new file, never a partial one. Overwriting an existing name
+    // (a legit retrain) is allowed but logged so it's not silent.
+    if (existsSync(dest)) {
+      logger.warn(`[training-jobs] overwriting existing LoRA ${dest} (retrain of "${job.name}")`);
+    }
+    const tmpDest = join(lorasDir, `.${job.name}.safetensors.tmp-${process.pid}-${Date.now()}`);
+    copyFileSync(produced, tmpDest);
+    try {
+      renameSync(tmpDest, dest);
+    } catch (err) {
+      try { rmSync(tmpDest, { force: true }); } catch { /* best effort */ }
+      throw err;
+    }
   }
 
   // Pod-side delivery: the LoRA lands in the pod's own models/loras so it's
@@ -1370,6 +1413,11 @@ async function finalizeJob(job: TrainingJob, code: number, tail: string, deps: T
  * here than after an hours-long run.
  */
 export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDeps = {}): Promise<TrainingJob> {
+  // Pod reservation lock (codex #273): held from the one-run-per-pod scan
+  // through the launch so a second process can't double-launch on this pod.
+  // Released on EVERY exit path by the finally at the end of the function.
+  let podReserveLock: string | null = null;
+  try {
   const start = deps.startTraining ?? startTraining;
   const now = deps.now ?? (() => Date.now());
   const datasetPath = resolve(input.datasetPath);
@@ -1396,6 +1444,15 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
     if (!(await sshWorks(input.podEndpoint))) {
       throw new Error(`pod SSH unreachable at ${input.podEndpoint.userHost}:${input.podEndpoint.port} (key-only auth must be set up — the pod template injects $PUBLIC_KEY at boot)`);
     }
+    // Cross-process serialization (codex #273): acquire a pod-scoped lock BEFORE
+    // the scan and hold it through persist+launch, so two MCP processes can't
+    // both pass the disk scan (scan→persist has no in-process yield, so the race
+    // is purely cross-process) and double-launch run.py on this pod.
+    const reserveFile = podReservationLockFile(input.podEndpoint);
+    if (!(await acquireLock(reserveFile, deps.lockBudgetMs ?? LOCK_WAIT_MS))) {
+      throw new Error(`another train_start is already reserving pod ${input.podEndpoint.userHost}:${input.podEndpoint.port} — retry in a moment`);
+    }
+    podReserveLock = reserveFile;
     // One training run per pod at a time (its GPU saturates; a second run.py
     // would also make the remote pkill pattern ambiguous). Probe-free DISK
     // scan scoped to THIS pod's endpoint — a restart or a second MCP process
@@ -1448,6 +1505,7 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
     containerName: isPod ? encodePodContainerName(input.podEndpoint!) : `comfyui-train-${id}`,
     target,
     deliverTo: input.deliverTo ?? "both",
+    podId: input.podId,
     ownerPid: process.pid,
     datasetPath,
     jobDir,
@@ -1608,6 +1666,9 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
   job.updatedAt = new Date().toISOString();
   persist(job);
   return job;
+  } finally {
+    if (podReserveLock) releaseLock(podReserveLock);
+  }
 }
 
 /** Stop the container and mark the job cancelled. Idempotent. Works

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -318,6 +318,13 @@ export function registerRunpodTools(server: McpServer): void {
         if (!probeRes.ok) {
           return { content: [{ type: "text", text: `Pod \`${pod.id}\` exposes ComfyUI but it isn't answering yet at ${url} (${probeRes.status ?? probeRes.error}). It may still be booting — wait ~30s, or run runpod_pod_troubleshoot.` }] };
         }
+        // Readiness needs MORE than /system_stats (#269): a ComfyUI whose core is
+        // up but whose queue/prompt endpoint is broken would answer /system_stats
+        // yet fail every render. Verify /queue answers too before declaring ready.
+        const queueProbe = await probe(`${url}/queue`);
+        if (!queueProbe.ok) {
+          return { content: [{ type: "text", text: `Pod \`${pod.id}\` answers /system_stats but its queue endpoint isn't ready at ${url} (${queueProbe.status ?? queueProbe.error}) — ComfyUI may still be initializing. Wait ~30s, or run runpod_pod_troubleshoot.` }] };
+        }
         const applied = setComfyuiTarget(url);
         if (!applied) return { content: [{ type: "text", text: `Resolved ${url} but could not retarget (unexpected URL parse failure).` }] };
         resetClient();

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -147,6 +147,7 @@ export function registerTrainTools(server: McpServer): void {
     async (args) => {
       try {
         let podEndpoint: import("../services/runpod-ssh.js").PodSshEndpoint | undefined;
+        let podId: string | undefined;
         if (args.target === "pod") {
           const pod = await resolvePodForTraining(args.pod_id);
           if (typeof pod === "string") return textEnvelope({ ok: false, error: { code: "no_pod", message: pod } });
@@ -156,6 +157,7 @@ export function registerTrainTools(server: McpServer): void {
             return textEnvelope({ ok: false, error: { code: "no_ssh", message: `Pod ${pod.id} has no public SSH endpoint (not running, or the template doesn't expose port 22/tcp).` } });
           }
           podEndpoint = ep;
+          podId = pod.id;
         } else {
           if (!(await dockerAvailable())) {
             return textEnvelope({ ok: false, error: { code: "no_docker", message: "Docker daemon not reachable — start Docker Desktop / the docker engine, then re-run. See train_doctor." } });
@@ -174,6 +176,7 @@ export function registerTrainTools(server: McpServer): void {
           device: args.device,
           target: args.target,
           podEndpoint,
+          podId,
           deliverTo: args.deliverTo,
           modelPath: args.model_path,
         });


### PR DESCRIPTION
Zeroes out the deferred follow-up review findings, verified against merged `#263` (pod training) and `#270` (connector security/billing).

## Fully fixed (closed by this PR)
- **#273** — `train_start`: pod-scoped cross-process reservation lock across the one-run-per-pod scan→persist→launch, so two MCP processes can't double-launch `run.py` on one pod.
- **#274** — idle auto-stop's "busy training?" check is now scoped to the WATCHED pod (podId persisted per job; `hasActiveTrainingJob(target, podId)`; watcher threads its pod id into `comfyuiIdle`). A run on pod A no longer keeps pod B billing.
- **#276** — `createPod` defaults to a UNIQUE deploy name. RunPod exposes no per-create idempotency token on `podFindAndDeployOnDemand`, so a unique name is the mitigation: lost-response reconciliation attributes exactly this call's pod; concurrent same-name creates can't mis-attribute. Explicit names keep the old shared semantics.
- **#277** — embedded Codex app-server: `-c notify=[]` (isolate the user's global `legacy_notify` hook → no misleading os-error-206 after a panel turn) + resume self-heal also matches `no rollout found for thread id <uuid>`.

Fixes #273
Fixes #274
Fixes #276
Fixes #277

## Bundles — handled here, dispositioned in comments
- **#268** (pod-training deferred bundle) — all items now resolved: items 1/2 split into #273/#274 (fixed here), item 3 (pkill/liveness) already addressed by #263's config-path-scoped stop, item 4 (non-atomic overwrite) fixed here (tmp+rename). To be **closed** as done/superseded.
- **#269** (connector deferred bundle) — cheap/high-value items fixed here: **#269.1** removeEnvSecret purges legacy `panel-secrets.json` (revoked-key resurrection — security), **#269.5** `runpod_pod_create` removed from the confirmation-less call_tool whitelist (billed mutation), **#269.11** comfyui-only restart/nudge guard, **#269.12** connect readiness also probes `/queue`. Remaining items left open with notes (queue-monitor retarget cluster 2/3/7, dead-man switch 4, GraphQL validation 6, use_local LAN 9, status-machine 10) — see issue comment.

## Left open (not in this PR)
- **#275** — wire native (dockerless) local start into `train_start`. Genuine feature: `startNativeTraining` exists and is handle-compatible, but train_start still needs native-vs-docker path selection, real-host-path config, native stop routing (cross-process docker-stop-by-name doesn't apply), and `nativeToolkitReady` gating. Scoped note left on the issue.

## Gates
- `npx tsc --noEmit`: clean
- `npx vitest run`: 148 files, 1748 passed, 1 skipped

Do not merge — owner runs codex review + merges.