### PR TITLE
fix(training): pod reservation race, per-pod idle-stop, native local start (#273/#274/#275)

### DIFF
--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -235,3 +235,17 @@ describe("runpod-watch — idle auto-stop", () => {
     expect(frames.at(-1)?.autostop_in_seconds).toBeNull();
   });
 });
+
+it("passes the watched pod's id to comfyuiIdle (per-pod idle veto, #274)", async () => {
+  getPodMock.mockResolvedValue(runningPod());
+  const seen: string[] = [];
+  const w = createRunpodWatcher({
+    push: () => {},
+    comfyuiIdle: (podId: string) => { seen.push(podId); return false; },
+    renderingOnPod: () => true,
+    idleStopMinutes: 15,
+  });
+  w.watch("podXYZ");
+  await w.poll();
+  expect(seen).toContain("podXYZ");
+});

--- a/src/__tests__/services/training-jobs.test.ts
+++ b/src/__tests__/services/training-jobs.test.ts
@@ -1647,3 +1647,74 @@ describe("pod target (P4)", () => {
     await new Promise((r) => setTimeout(r, 30));
   });
 });
+
+describe("native local start (#275)", () => {
+  function stageDataset() {
+    const dataset = join(mod.datasetsRoot(), "dataset");
+    mkdirSync(dataset, { recursive: true });
+    makeImage(dataset, "img_00001.png");
+    return dataset;
+  }
+
+  it("native local start — real host paths in config, native-* name, native driver used", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const nativeStart = vi.fn(() => fakeHandle(d));
+    const dataset = stageDataset();
+    const job = await mod.startTrainingJob(
+      { name: "nat_lora", flow: "character", model: "flux1-dev", datasetPath: dataset, native: true },
+      { startNativeTraining: nativeStart as never, lorasDir: () => join(root, "loras"), catalog: fakeCatalog() } as never,
+    );
+    expect(job.containerName).toBe(`native-${job.id}`);
+    expect(nativeStart).toHaveBeenCalledTimes(1);
+    const { parse } = await import("yaml");
+    const cfg = parse(readFileSync(join(job.jobDir, "config.yml"), "utf-8")) as {
+      config: { process: Array<{ datasets: Array<{ folder_path: string }>; training_folder: string }> };
+    };
+    expect(cfg.config.process[0].datasets[0].folder_path).toBe(dataset);
+    expect(cfg.config.process[0].training_folder).toBe(join(job.jobDir, "output"));
+    d.resolve({ code: 1, tail: "cleanup" });
+    await new Promise((r) => setTimeout(r, 30));
+  });
+
+  it("cancel routes a native job's stop to its LOCAL config path", async () => {
+    const d = deferred<{ code: number; tail: string }>();
+    const stopCalls: unknown[][] = [];
+    const deps = {
+      startNativeTraining: () => fakeHandle(d),
+      stopTraining: async (...a: unknown[]) => { stopCalls.push(a); return { ok: true, command: "train_cancel" }; },
+      containerRunning: async () => true,
+      lorasDir: () => join(root, "loras"),
+      catalog: fakeCatalog(),
+    };
+    const job = await mod.startTrainingJob(
+      { name: "nat_cancel", flow: "character", model: "flux1-dev", datasetPath: stageDataset(), native: true },
+      deps as never,
+    );
+    await mod.cancelJob(job.id, deps as never);
+    expect(stopCalls[0]?.[0]).toBe(`native-${job.id}`);
+    expect(stopCalls[0]?.[1]).toBe(join(job.jobDir, "config.yml"));
+    d.resolve({ code: 1, tail: "cleanup" });
+    await new Promise((r) => setTimeout(r, 30));
+  });
+
+  it("an orphaned native job terminalizes via the config-scoped probe (dead owner + no live run.py)", async () => {
+    const id = "tnat1";
+    const jobDir = join(mod.jobsRoot(), id);
+    mkdirSync(join(jobDir, "output"), { recursive: true });
+    writeFileSync(join(jobDir, "config.yml"), "job: extension\n");
+    writeFileSync(join(mod.jobsRoot(), `${id}.json`), JSON.stringify({
+      id, name: "nat_orphan", status: "running", target: "local",
+      containerName: `native-${id}`, ownerPid: 999999,
+      datasetPath: mod.datasetsRoot(), jobDir, outputDir: join(jobDir, "output"),
+      lorasDir: join(root, "loras"),
+      createdAt: "2026-01-01T00:00:00.000Z", updatedAt: new Date(Date.now() - 3600_000).toISOString(),
+      progress: { samples: [] }, log: [],
+    }));
+    // No containerRunning dep → the REAL nativeProcessRunning probe runs.
+    const n = await mod.reconcileStaleTrainingJobs({ lockBudgetMs: 300 } as never);
+    expect(n).toBe(1);
+    const after = JSON.parse(readFileSync(join(mod.jobsRoot(), `${id}.json`), "utf-8")) as { status: string; error?: string };
+    expect(after.status).toBe("failed");
+    expect(after.error).toMatch(/no longer running|container/i);
+  });
+});

--- a/src/services/ai-toolkit.ts
+++ b/src/services/ai-toolkit.ts
@@ -8,8 +8,9 @@
 // normalized into a small envelope so callers/tools get a uniform shape.
 
 import childProcess from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
 
 /** Uniform result shape for trainer operations (mirrors the comfy-cli envelope). */
@@ -228,11 +229,69 @@ export function resolveAiToolkitPython(): string {
     : join(dir, "venv", "bin", "python");
 }
 
-/** Is a native training environment present (checkout + venv python)? */
+/** Is a native training environment present AND complete? run.py + venv python
+ *  alone are NOT enough: a bootstrap whose pip steps died midway still has both
+ *  (codex finding — an incomplete env was selected, then failed asynchronously
+ *  on missing imports). A completed bootstrap writes `.bootstrap-ok` — trusted
+ *  ONLY for the bundled venv it was created against. Anything else (pre-marker
+ *  envs, a COMFYUI_MCP_AI_TOOLKIT_PYTHON override) must show the full critical
+ *  package set in the CONFIGURED interpreter's site-packages (codex findings:
+ *  torch alone let a torch-but-no-requirements env through; the venv-only
+ *  probe broke the override both ways). */
 export async function nativeToolkitReady(): Promise<boolean> {
   try {
-    const { existsSync } = await import("node:fs");
-    return existsSync(join(resolveAiToolkitDir(), "run.py")) && existsSync(resolveAiToolkitPython());
+    const dir = resolveAiToolkitDir();
+    const python = resolveAiToolkitPython();
+    if (!existsSync(join(dir, "run.py")) || !existsSync(python)) return false;
+    const bundled = process.platform === "win32" ? join(dir, "venv", "Scripts", "python.exe") : join(dir, "venv", "bin", "python");
+    // Marker trusted ONLY when it was written for the CURRENT pinned ref — an
+    // install that survives an app upgrade (new AI_TOOLKIT_REF) must re-verify
+    // via the package probe below instead of inheriting "ready" (codex).
+    if (python === bundled && existsSync(join(dir, ".bootstrap-ok"))) {
+      try {
+        const marker = readFileSync(join(dir, ".bootstrap-ok"), "utf-8").trim().split(/\s+/)[0];
+        if (marker === AI_TOOLKIT_REF) return true;
+      } catch { /* unreadable marker → fall through to the probe */ }
+    }
+    return pythonEnvComplete(python) && checkoutMatchesRef(dir);
+  } catch {
+    return false;
+  }
+}
+
+/** Is the ai-toolkit checkout on the pinned ref? Unverifiable WITHOUT .git
+ *  (a plain copy) → trust the package probe; a git checkout on the WRONG ref
+ *  (stale after an app upgrade changed AI_TOOLKIT_REF) → not ready, so
+ *  train_bootstrap re-pins it (codex finding: package-only probing selected
+ *  the stale checkout). */
+function checkoutMatchesRef(dir: string): boolean {
+  if (!existsSync(join(dir, ".git"))) return true;
+  try {
+    const head = childProcess.execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], { encoding: "utf-8", timeout: 5_000 }).trim();
+    return head === AI_TOOLKIT_REF;
+  } catch {
+    return false;
+  }
+}
+
+/** The critical packages a native FLUX LoRA run imports — a pip step that died
+ *  midway through ANY of torch / requirements / hf_transfer leaves at least one
+ *  missing, so the set can't false-positive on an incomplete env. */
+const REQUIRED_NATIVE_PACKAGES = ["torch", "diffusers", "transformers", "accelerate", "hf_transfer"];
+
+/** Every REQUIRED_NATIVE_PACKAGES module resolvable by the CONFIGURED
+ *  interpreter itself, via importlib find_spec (no module execution — ~200ms).
+ *  Path-derived probes can't model sys.path for system pythons, pyenv shims,
+ *  dist-packages or user-site layouts (codex finding). An interpreter that
+ *  can't answer is not a usable trainer → false. */
+function pythonEnvComplete(python: string): boolean {
+  try {
+    childProcess.execFileSync(
+      python,
+      ["-c", `import importlib.util as u, sys; sys.exit(0 if all(u.find_spec(m) for m in ${JSON.stringify(REQUIRED_NATIVE_PACKAGES)}) else 1)`],
+      { timeout: 20_000, stdio: "ignore", windowsHide: true },
+    );
+    return true;
   } catch {
     return false;
   }
@@ -281,6 +340,115 @@ export async function stopNativeTraining(child: childProcess.ChildProcess): Prom
     return ok("train_cancel", { stopped: String(child.pid ?? "unknown") });
   } catch (err) {
     return fail("train_cancel", "stop_failed", `could not stop native training (pid ${child.pid}): ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Escape a literal string for use inside a POSIX ERE (pgrep/pkill -f): config
+ *  paths can contain regex metacharacters ([ ( . + …) from COMFYUI_MCP_TRAINING_DIR,
+ *  which would otherwise make the pattern invalid or mis-match (codex finding). */
+function escapeEre(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Escape a literal string for a PowerShell -like wildcard pattern (`*?[]`). */
+function escapePsLike(s: string): string {
+  return s.replace(/([[\]?*])/g, "`$1");
+}
+
+/** The process-image filter for Windows probes. We deliberately match the
+ *  COMMAND LINE ONLY (no image-name filter): the configured interpreter may be
+ *  python.exe, python3.exe, or a renamed launcher — and a DIFFERENT MCP process
+ *  than the launcher may run this probe, so any name filter risks making a live
+ *  trainer invisible (codex finding: cancelled-on-paper, still-burning-GPU).
+ *  The cmdline match (run.py + the job's unique id dir) is already specific;
+ *  the trade is a full-table CIM scan (~1s). */
+function nativeCmdlinePredicate(jobKey: string): string {
+  // `-ne $PID` excludes the probing PowerShell itself: its own command line
+  // carries this predicate text (which contains "run.py" AND the job key), so
+  // without the exclusion the probe ALWAYS matches itself (codex finding).
+  return `($_.ProcessId -ne $PID) -and $_.CommandLine -like '*run.py*' -and $_.CommandLine -like '*${escapePsLike(jobKey)}*'`;
+}
+
+/** Stop a NATIVE training process WITHOUT a handle, by its config path (the
+ *  cross-process cancel path — e.g. a second MCP process canceling a job whose
+ *  owner died). Matches the run.py cmdline against the config's job-id dir
+ *  (unique per job) so unrelated python/run.py processes survive. The [r]
+ *  bracket keeps the probe's own cmdline from self-matching on posix. */
+export async function stopNativeByConfig(configPath: string): Promise<TrainerEnvelope<{ stopped: string }>> {
+  const jobKey = basename(dirname(configPath));
+  try {
+    if (process.platform === "win32") {
+      const script =
+        `Get-CimInstance Win32_Process | Where-Object { ${nativeCmdlinePredicate(jobKey)} } | ` +
+        `ForEach-Object { & taskkill /PID $_.ProcessId /T /F | Out-Null; Write-Output $_.ProcessId }`;
+      const out = childProcess.execFileSync("powershell.exe", ["-NoProfile", "-Command", script], { timeout: 15_000, windowsHide: true, encoding: "utf-8" });
+      // taskkill is synchronous, but the CIM scan can lag the actual teardown —
+      // confirm exit so an immediate liveness re-probe can't see a zombie
+      // (codex finding: cancel reverted to running, then finalized as failed).
+      await waitNativeGone(configPath, 7_000);
+      return ok("train_cancel", { stopped: out.trim() || jobKey });
+    }
+    // POSIX: signal the trainer's whole PROCESS GROUP, not just cmdline
+    // matches — spawnTrainer detaches (the trainer is its group leader) and
+    // ai-toolkit workers carry different cmdlines, so a cmdline-only pkill
+    // leaves them burning GPU after "cancel" (codex finding).
+    const pg = childProcess.execFileSync("pgrep", ["-f", `[r]un.py ${escapeEre(configPath)}`], { timeout: 10_000, encoding: "utf-8" });
+    const pids = pg.split(/\s+/).filter(Boolean);
+    for (const pid of pids) {
+      try {
+        childProcess.execFileSync("kill", ["-TERM", `-${pid}`], { timeout: 5_000 }); // negative = the process group
+      } catch {
+        try { childProcess.execFileSync("kill", ["-TERM", pid], { timeout: 5_000 }); } catch { /* already gone */ }
+      }
+    }
+    // SIGTERM delivery is not exit: a cancel that reports success while the
+    // trainer is still dying gets probed as "still running" and wrongly
+    // reverts to running (codex finding) — wait for disappearance.
+    if (await waitNativeGone(configPath, 7_000)) {
+      return ok("train_cancel", { stopped: jobKey });
+    }
+    return fail("train_cancel", "still_running", `SIGTERM sent but the trainer for ${jobKey} is still alive after 7s`);  } catch (err) {
+    // pkill exits 1 on no match — that is success for an idempotent cancel.
+    const code = (err as { status?: number })?.status;
+    if (process.platform !== "win32" && code === 1) return ok("train_cancel", { stopped: `${jobKey} (already gone)` });
+    return fail("train_cancel", "stop_failed", `could not stop native training for ${jobKey}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Poll until no native run.py for this config remains (true) or the budget
+ *  runs out (false). Probe failures count as "gone" — matching the unknown-is-
+ *  not-running semantics of the liveness probe's callers. */
+async function waitNativeGone(configPath: string, budgetMs: number): Promise<boolean> {
+  const start = Date.now();
+  for (;;) {
+    const alive = await nativeProcessRunning(configPath);
+    if (alive !== true) return true;
+    if (Date.now() - start > budgetMs) return false;
+    await new Promise((r) => setTimeout(r, 400));
+  }
+}
+
+/** Is a NATIVE training process for this config path still alive? Config-scoped
+ *  like stopNativeByConfig (the job-id dir is the match key). Returns false only
+ *  when the process is DEFINITIVELY gone — null on probe failure (unknown).
+ *  Without this the registry's dead-owner recovery can never fire for native
+ *  jobs (it recovers only on a definitive false) and a finished-but-orphaned
+ *  run would sit "running" forever, never handing off its LoRA (codex finding). */
+export async function nativeProcessRunning(configPath: string): Promise<boolean | null> {
+  const jobKey = basename(dirname(configPath));
+  try {
+    if (process.platform === "win32") {
+      const script =
+        `@(Get-CimInstance Win32_Process | Where-Object { ${nativeCmdlinePredicate(jobKey)} }).Count`;
+      const out = childProcess.execFileSync("powershell.exe", ["-NoProfile", "-Command", script], { timeout: 15_000, windowsHide: true, encoding: "utf-8" });
+      return Number(out.trim()) > 0;
+    }
+    childProcess.execFileSync("pgrep", ["-f", `[r]un.py ${escapeEre(configPath)}`], { timeout: 10_000, stdio: "ignore" });
+    return true;
+  } catch (err) {
+    const code = (err as { status?: number })?.status;
+    if (process.platform !== "win32" && code === 1) return false; // pgrep: no match
+    return null; // probe itself failed — unknown
   }
 }
 

--- a/src/services/trainer-bootstrap.ts
+++ b/src/services/trainer-bootstrap.ts
@@ -8,7 +8,7 @@
 // persistent /workspace only pays the ~10min install ONCE across restarts.
 
 import childProcess from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -117,6 +117,13 @@ export async function bootstrapToolkit(opts: { onLog?: (line: string) => void } 
     r = await stream("git", ["submodule", "update", "--init", "--recursive"], dir, log);
     if (r.code !== 0) return fail("train_bootstrap", "submodule_failed", `submodule update exited ${r.code}`, r.tail);
 
+    // Invalidate any previous completion marker BEFORE the install steps: a
+    // recreated venv whose pip steps now fail must NOT inherit the old env's
+    // "ready" (codex finding — the stale marker let a partial env launch).
+    // It is rewritten only after every step below succeeds.
+    const { rmSync: rmMarker } = await import("node:fs");
+    rmMarker(join(dir, ".bootstrap-ok"), { force: true });
+
     if (!existsSync(resolveAiToolkitPython())) {
       r = await stream(basePython(), ["-m", "venv", "venv"], dir, log);
       if (r.code !== 0) return fail("train_bootstrap", "venv_failed", `venv creation exited ${r.code}`, r.tail);
@@ -134,6 +141,10 @@ export async function bootstrapToolkit(opts: { onLog?: (line: string) => void } 
     if (!status.ready) {
       return fail("train_bootstrap", "verify_failed", "bootstrap finished but run.py/venv python are still missing");
     }
+    // Completion marker: every pip step exited 0 to get here. nativeToolkitReady
+    // requires it (or a torch presence check for pre-marker envs) so a checkout
+    // whose dependency install FAILED is never selected as "ready" (codex).
+    writeFileSync(join(dir, ".bootstrap-ok"), `${AI_TOOLKIT_REF} ${new Date().toISOString()}\n`);
     return ok("train_bootstrap", status);
   } catch (err) {
     return fail("train_bootstrap", "error", err instanceof Error ? err.message : String(err));

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -31,7 +31,10 @@ import { homedir } from "node:os";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import {
   containerRunning,
+  nativeProcessRunning,
+  startNativeTraining,
   startTraining,
+  stopNativeByConfig,
   stopTraining,
   type TrainingHandle,
   type TrainingProgress,
@@ -133,6 +136,8 @@ export interface TrainingJob {
 /** Injectable seams so tests can run without docker / a ComfyUI install. */
 export interface TrainingJobDeps {
   startTraining?: typeof startTraining;
+  /** Native (dockerless) local start seam — used when StartJobInput.native. */
+  startNativeTraining?: typeof startNativeTraining;
   stopTraining?: typeof defaultTrainingStop;
   /** Container liveness probe (false = definitively gone, null = unknown).
    *  The optional 2nd arg scopes pod probes to a job's config path (see
@@ -851,25 +856,38 @@ export async function listJobs(deps: TrainingJobDeps = {}): Promise<TrainingJob[
 /** The default container liveness probe, pod-aware: `pod|…` names go over ssh.
  *  The probe MUST be scoped to the job's own config path (same as the stop),
  *  or an unrelated `run.py` alive on the pod makes this job's cancel falsely
- *  report still-running (codex finding). */
+ *  report still-running (codex finding). `native-…` (dockerless local) jobs
+ *  probe their local `run.py <config>` process the same way — WITHOUT a
+ *  definitive false the dead-owner recovery can never fire and orphaned
+ *  native runs would sit "running" forever (#275). No config path → null. */
 export function defaultContainerProbe(name: string, remoteConfigPath?: string): Promise<boolean | null> {
-  return name.startsWith("pod|") ? sshProcessRunning(name, remoteConfigPath) : containerRunning(name);
+  if (name.startsWith("pod|")) return sshProcessRunning(name, remoteConfigPath);
+  if (name.startsWith("native-")) return remoteConfigPath ? nativeProcessRunning(remoteConfigPath) : Promise.resolve(null);
+  return containerRunning(name);
 }
 
 /** The remote config path a pod job's kill AND liveness probe must both scope
  *  to (undefined for docker jobs, which ignore it). Keeps the probe and the
  *  stop pointed at the SAME `run.py <config>` so a cancel can't be fooled by an
- *  unrelated run.py on the pod. */
+ *  unrelated run.py on the pod. Native jobs scope to their LOCAL config.yml. */
 function jobProbeConfigPath(job: TrainingJob): string | undefined {
-  return job.containerName?.startsWith("pod|") ? podJobPaths(job.id, job.name).configPath : undefined;
+  if (job.containerName?.startsWith("pod|")) return podJobPaths(job.id, job.name).configPath;
+  if (job.containerName?.startsWith("native-")) return join(job.jobDir, "config.yml");
+  return undefined;
 }
 
 /** The default stop, pod-aware. Pod stops are SCOPED to the job's own config
  *  path (pkill 'run.py <config>'): an unscoped pattern kills EVERY ai-toolkit
  *  run.py on the pod — including runs from other registries/processes (codex
- *  finding). */
+ *  finding). Native (dockerless local) jobs stop by their LOCAL config path. */
 export function defaultTrainingStop(name: string, remoteConfigPath?: string): ReturnType<typeof stopTraining> {
-  return name.startsWith("pod|") ? stopSshTraining(name, remoteConfigPath) : stopTraining(name);
+  if (name.startsWith("pod|")) return stopSshTraining(name, remoteConfigPath);
+  if (name.startsWith("native-")) {
+    return remoteConfigPath
+      ? stopNativeByConfig(remoteConfigPath)
+      : Promise.resolve({ ok: false as const, command: "train_cancel", error: { code: "no_config", message: `native job stop needs the job's config path (got none for ${name})` } });
+  }
+  return stopTraining(name);
 }
 
 /** Any job currently running/queued — FILE SCAN ONLY, no liveness probes (ssh
@@ -1084,6 +1102,10 @@ export interface StartJobInput {
   /** Override for the base model path as the trainer sees it (e.g. a pod-local
    *  HF snapshot dir) — bypasses downloading the default HF repo id. */
   modelPath?: string;
+  /** Local only: run the NATIVE (dockerless) trainer instead of the docker
+   *  image — the tool layer sets this when docker is unavailable but the
+   *  native bootstrap is ready (issue #275). Config uses real host paths. */
+  native?: boolean;
 }
 
 function countDatasetImages(datasetPath: string): number {
@@ -1476,16 +1498,18 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
   mkdirSync(outputDir, { recursive: true });
 
   const isPod = target === "pod";
+  const isNative = !isPod && input.native === true;
   // Config paths: docker sees CONTAINER mount points; a pod-native run sees
   // REAL pod paths (no mount rewrite) — built from the SANITIZED job name
-  // (raw input could traverse or break the pod fs layout; codex finding).
+  // (raw input could traverse or break the pod fs layout; codex finding). A
+  // LOCAL native run (dockerless) sees REAL host paths the same way (#275).
   const podPaths = isPod ? podJobPaths(id, sanitizeJobName(input.name)) : null;
   const built = buildTrainingConfig({
     name: input.name,
     flow: input.flow,
     model: input.model,
-    datasetPath: isPod ? podPaths!.datasetDir : CONTAINER_DATASET,
-    outputDir: isPod ? podPaths!.outputDir : CONTAINER_OUTPUT,
+    datasetPath: isPod ? podPaths!.datasetDir : isNative ? datasetPath : CONTAINER_DATASET,
+    outputDir: isPod ? podPaths!.outputDir : isNative ? outputDir : CONTAINER_OUTPUT,
     trigger: input.trigger,
     device: input.device,
     params: input.params,
@@ -1502,7 +1526,7 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
     trigger: input.trigger,
     status: "queued",
     progress: { samples: [] },
-    containerName: isPod ? encodePodContainerName(input.podEndpoint!) : `comfyui-train-${id}`,
+    containerName: isPod ? encodePodContainerName(input.podEndpoint!) : isNative ? `native-${id}` : `comfyui-train-${id}`,
     target,
     deliverTo: input.deliverTo ?? "both",
     podId: input.podId,
@@ -1625,6 +1649,19 @@ export async function startTrainingJob(input: StartJobInput, deps: TrainingJobDe
       });
       if ("error" in h) throw new Error(h.error);
       handle = h;
+    } else if (isNative) {
+      // Dockerless local run: the venv's python executes run.py directly with
+      // REAL host paths (the config above points at them). Issue #275.
+      handle = (deps.startNativeTraining ?? startNativeTraining)({
+        containerName: job.containerName!,
+        configPath,
+        datasetPath,
+        outputDir,
+        hfCacheDir: hfCacheRoot(),
+        hfToken: process.env.HF_TOKEN?.trim() || undefined,
+        onProgress,
+        onLog,
+      });
     } else {
       handle = start({
         containerName: job.containerName!,

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -148,6 +148,7 @@ export function registerTrainTools(server: McpServer): void {
       try {
         let podEndpoint: import("../services/runpod-ssh.js").PodSshEndpoint | undefined;
         let podId: string | undefined;
+        let nativeLocal = false;
         if (args.target === "pod") {
           const pod = await resolvePodForTraining(args.pod_id);
           if (typeof pod === "string") return textEnvelope({ ok: false, error: { code: "no_pod", message: pod } });
@@ -159,11 +160,32 @@ export function registerTrainTools(server: McpServer): void {
           podEndpoint = ep;
           podId = pod.id;
         } else {
-          if (!(await dockerAvailable())) {
-            return textEnvelope({ ok: false, error: { code: "no_docker", message: "Docker daemon not reachable — start Docker Desktop / the docker engine, then re-run. See train_doctor." } });
-          }
-          if (!(await trainerImageExists())) {
-            return textEnvelope({ ok: false, error: { code: "no_image", message: `Trainer image ${TRAINER_IMAGE} not built yet — run train_build_image once (several minutes), then re-run train_start.` } });
+          // Local: docker preferred; the NATIVE (dockerless) trainer is the
+          // fallback when docker/image is missing but train_bootstrap already
+          // prepared the local venv (issue #275 — native bootstrap used to be
+          // a dead end: ready, but train_start still demanded docker).
+          const dockerOk = (await dockerAvailable()) && (await trainerImageExists());
+          if (!dockerOk) {
+            const { nativeToolkitReady } = await import("../services/ai-toolkit.js");
+            if (await nativeToolkitReady()) {
+              // model_path was documented as the CONTAINER-visible path — under
+              // the native fallback it must be a HOST-absolute, EXISTING path;
+              // a container-style value (/root/.cache/…) would silently not
+              // exist for the host process (codex).
+              if (args.model_path) {
+                const isWin = process.platform === "win32";
+                const hostAbsolute = isWin ? /^[a-zA-Z]:[\\/]|^[\\/]{2}/.test(args.model_path) : args.model_path.startsWith("/");
+                const { existsSync } = await import("node:fs");
+                if (!hostAbsolute || !existsSync(args.model_path)) {
+                  return textEnvelope({ ok: false, error: { code: "model_path_native", message: `model_path "${args.model_path}" ${hostAbsolute ? "does not exist on this machine" : "isn't a HOST-absolute path"} — the native (dockerless) fallback runs locally, so supply an existing absolute host path${isWin ? " (e.g. C:/...)" : ""} or omit it to use the default HF repo.` } });
+                }
+              }
+              nativeLocal = true;
+            } else if (!(await dockerAvailable())) {
+              return textEnvelope({ ok: false, error: { code: "no_docker", message: "No docker daemon AND no native trainer — either start docker + run train_build_image, or run train_bootstrap (target local) for the dockerless trainer. See train_doctor." } });
+            } else {
+              return textEnvelope({ ok: false, error: { code: "no_image", message: `Trainer image ${TRAINER_IMAGE} not built and no native trainer ready — run train_build_image (docker) or train_bootstrap (native, target local), then re-run train_start.` } });
+            }
           }
         }
         const job = await startTrainingJob({
@@ -177,6 +199,7 @@ export function registerTrainTools(server: McpServer): void {
           target: args.target,
           podEndpoint,
           podId,
+          native: nativeLocal,
           deliverTo: args.deliverTo,
           modelPath: args.model_path,
         });


### PR DESCRIPTION
## What (updated 2026-07-22 — now #275-only)

#273 and #274 landed on main via #278 (a parallel implementation of the same design), so this PR was rebuilt to carry only **#275 — wire the native (dockerless) local start into `train_start`**.

`train_bootstrap` target local used to be a dead end: it could report ready, but `train_start` still required docker+image and never called `startNativeTraining`. `train_start` now falls back to the native trainer when docker/image is missing — gated on a COMPLETE bootstrap:

- `.bootstrap-ok` marker (ref-validated, invalidated before reinstalls); otherwise a full `find_spec` probe of the *configured* interpreter + a pinned-checkout check.
- Native jobs use real host paths in the config and get full lifecycle parity: config-scoped cancel (process-group kill on posix — cmdline-only pkill leaked ai-toolkit workers; Windows taskkill with the probe's own PID excluded) and a config-scoped liveness probe, so dead-owner recovery actually fires (a null probe never recovered — orphaned runs sat "running" forever, LoRA never handed off).
- `model_path` under the fallback must be host-absolute AND exist.

**Tests:** 3 new regression tests (host paths/driver, cancel routing, orphan recovery via the real probe). Full suite green (1 pre-existing environmental `node-dev` failure, red on main too). Codex rounds 1-8 on the earlier series converged clean; the watcher podId flow test rides along.

Closes #275.

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-code)
