### PR TITLE
feat(agent-drive): panel_* tools to drive the CivitAI browser + training wizard

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -555,6 +555,152 @@ describe("panel_connect slot aliases (live panel finding: stripped aliases → a
   });
 });
 
+describe("panel-tools: agent-driven CivitAI + training modals", () => {
+  it("registers every new drive tool in the shared def list", () => {
+    const names = buildPanelToolDefs().map((d) => d.name);
+    for (const expected of [
+      "panel_civitai_results",
+      "panel_civitai_highlight",
+      "panel_civitai_clear_highlight",
+      "panel_civitai_switch_tab",
+      "panel_civitai_search",
+      "panel_civitai_open_lightbox",
+      "panel_training_open",
+      "panel_training_set_field",
+      "panel_training_goto_step",
+      "panel_training_set_target",
+      "panel_training_highlight",
+    ]) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  it("panel_open_civitai forwards a dock flag alongside the existing args", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_open_civitai").handler({ query: "flux", dock: true }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "open_civitai", query: "flux", dock: true });
+  });
+
+  it("panel_civitai_results forwards civitai_results with limit and clamps the range", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "civitai_results", limit: 20 });
+    const limit = defByName("panel_civitai_results").schema.limit as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(limit.safeParse(0).success).toBe(false);
+    expect(limit.safeParse(51).success).toBe(false);
+    expect(limit.safeParse(undefined).success).toBe(true);
+  });
+
+  it("panel_civitai_highlight forwards ids + kind, and requires at least one id", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_civitai_highlight").handler({ ids: [1, "abc"], kind: "media" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "civitai_highlight", ids: [1, "abc"], kind: "media" });
+    const ids = defByName("panel_civitai_highlight").schema.ids as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(ids.safeParse([]).success).toBe(false);
+    const kind = defByName("panel_civitai_highlight").schema.kind as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(kind.safeParse("model").success).toBe(true);
+    expect(kind.safeParse("nope").success).toBe(false);
+  });
+
+  it("panel_civitai_clear_highlight forwards civitai_clear_highlight with no args", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    expect(Object.keys(defByName("panel_civitai_clear_highlight").schema)).toEqual([]);
+    await defByName("panel_civitai_clear_highlight").handler({}, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "civitai_clear_highlight" });
+  });
+
+  it("panel_civitai_switch_tab forwards civitai_switch_tab with a real tab enum", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_civitai_switch_tab").handler({ tab: "loras" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "civitai_switch_tab", tab: "loras" });
+    const tab = defByName("panel_civitai_switch_tab").schema.tab as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(tab.safeParse("favorites").success).toBe(true);
+    expect(tab.safeParse("nope").success).toBe(false);
+  });
+
+  it("panel_civitai_search forwards query + filters", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_civitai_search").handler(
+      { query: "ghibli", filters: { baseModels: ["Flux.1 D"] } },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({
+      cmd: "civitai_search",
+      query: "ghibli",
+      filters: { baseModels: ["Flux.1 D"] },
+    });
+  });
+
+  it("panel_civitai_open_lightbox forwards civitai_open_lightbox with a string|number id", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_civitai_open_lightbox").handler({ id: 42 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "civitai_open_lightbox", id: 42 });
+    const id = defByName("panel_civitai_open_lightbox").schema.id as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(id.safeParse("abc").success).toBe(true);
+    expect(id.safeParse(1).success).toBe(true);
+  });
+
+  it("panel_training_open forwards open_training with an optional dock flag", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_training_open").handler({ dock: false }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "open_training", dock: false });
+  });
+
+  it("panel_training_set_field forwards name + value (string|number|boolean)", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_training_set_field").handler({ name: "learning_rate", value: 0.0004 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_set_field", name: "learning_rate", value: 0.0004 });
+    const value = defByName("panel_training_set_field").schema.value as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(value.safeParse("adamw").success).toBe(true);
+    expect(value.safeParse(true).success).toBe(true);
+    expect(value.safeParse({}).success).toBe(false);
+  });
+
+  it("panel_training_goto_step forwards a 0-based int step", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_training_goto_step").handler({ step: 2 }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_goto_step", step: 2 });
+    const step = defByName("panel_training_goto_step").schema.step as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(step.safeParse(-1).success).toBe(false);
+    expect(step.safeParse(1.5).success).toBe(false);
+  });
+
+  it("panel_training_set_target forwards a local|pod enum", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_training_set_target").handler({ target: "pod" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_set_target", target: "pod" });
+    const target = defByName("panel_training_set_target").schema.target as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(target.safeParse("local").success).toBe(true);
+    expect(target.safeParse("cloud").success).toBe(false);
+  });
+
+  it("panel_training_highlight forwards refs and requires at least one", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_training_highlight").handler({ refs: ["step:2", "field:lr"] }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_highlight", refs: ["step:2", "field:lr"] });
+    const refs = defByName("panel_training_highlight").schema.refs as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(refs.safeParse([]).success).toBe(false);
+  });
+});
+
 describe("panel-tools: strip/slice read the live canvas by default", () => {
   const CANVAS_GRAPH = {
     nodes: [

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -665,26 +665,39 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     expect(calls[0]).toMatchObject({ cmd: "open_training", dock: false });
   });
 
-  it("panel_training_set_field forwards name + value (string|number|boolean)", async () => {
+  it("panel_training_set_field forwards an allowlisted name + value, rejecting others", async () => {
     const { ctx, calls } = makeFakeCtx();
-    await defByName("panel_training_set_field").handler({ name: "learning_rate", value: 0.0004 }, ctx);
-    expect(calls[0]).toMatchObject({ cmd: "training_set_field", name: "learning_rate", value: 0.0004 });
+    await defByName("panel_training_set_field").handler({ name: "datasetName", value: "my-lora" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_set_field", name: "datasetName", value: "my-lora" });
+    // name is a real enum: only the four allowlisted fields pass.
+    const name = defByName("panel_training_set_field").schema.name as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    for (const ok of ["datasetName", "trigger", "preset", "target"]) {
+      expect(name.safeParse(ok).success).toBe(true);
+    }
+    for (const bad of ["learning_rate", "name", "steps", "dataset_path"]) {
+      expect(name.safeParse(bad).success).toBe(false);
+    }
     const value = defByName("panel_training_set_field").schema.value as {
       safeParse: (v: unknown) => { success: boolean };
     };
-    expect(value.safeParse("adamw").success).toBe(true);
+    expect(value.safeParse("standard").success).toBe(true);
     expect(value.safeParse(true).success).toBe(true);
     expect(value.safeParse({}).success).toBe(false);
   });
 
-  it("panel_training_goto_step forwards a 0-based int step", async () => {
+  it("panel_training_goto_step forwards a 1-based int step clamped to 1..4", async () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_training_goto_step").handler({ step: 2 }, ctx);
     expect(calls[0]).toMatchObject({ cmd: "training_goto_step", step: 2 });
     const step = defByName("panel_training_goto_step").schema.step as {
       safeParse: (v: unknown) => { success: boolean };
     };
-    expect(step.safeParse(-1).success).toBe(false);
+    expect(step.safeParse(1).success).toBe(true);
+    expect(step.safeParse(4).success).toBe(true);
+    expect(step.safeParse(0).success).toBe(false);
+    expect(step.safeParse(5).success).toBe(false);
     expect(step.safeParse(1.5).success).toBe(false);
   });
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -7,10 +7,11 @@
 // panel JS executors implement), and that the McpServer HTTP path registers the
 // identical set.
 
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setNsfwConsent } from "../../services/panel-settings.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   buildPanelToolDefs,
@@ -566,6 +567,7 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
       "panel_civitai_search",
       "panel_civitai_open_lightbox",
       "panel_training_open",
+      "panel_training_get_state",
       "panel_training_set_field",
       "panel_training_goto_step",
       "panel_training_set_target",
@@ -639,6 +641,13 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     });
   });
 
+  it("panel_training_get_state forwards training_get_state with no args", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    expect(Object.keys(defByName("panel_training_get_state").schema)).toEqual([]);
+    await defByName("panel_training_get_state").handler({}, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "training_get_state" });
+  });
+
   it("panel_civitai_open_lightbox forwards civitai_open_lightbox with a string|number id", async () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_civitai_open_lightbox").handler({ id: 42 }, ctx);
@@ -698,6 +707,89 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
       safeParse: (v: unknown) => { success: boolean };
     };
     expect(refs.safeParse([]).success).toBe(false);
+  });
+});
+
+describe("panel-tools: NSFW consent enforced server-side on CivitAI browsing levels", () => {
+  const origSettings = process.env.COMFYUI_MCP_PANEL_SETTINGS;
+
+  beforeAll(() => {
+    // Isolate the persistent consent store to a throwaway file for this suite.
+    const dir = mkdtempSync(join(tmpdir(), "nsfw-consent-"));
+    process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
+  });
+  afterAll(() => {
+    if (origSettings === undefined) delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
+    else process.env.COMFYUI_MCP_PANEL_SETTINGS = origSettings;
+  });
+  beforeEach(() => {
+    setNsfwConsent(false); // default: no consent
+  });
+
+  it("panel_open_civitai clamps adult levels out when un-consented, keeping SFW", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_open_civitai").handler(
+      { query: "x", browsingLevels: [1, 2, 4, 8, 16] },
+      ctx,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].browsingLevels).toEqual([1, 2]);
+  });
+
+  it("panel_open_civitai REJECTS an all-adult request when un-consented (no bridge call)", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const res = await defByName("panel_open_civitai").handler({ browsingLevels: [16] }, ctx);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("panel_open_civitai passes adult levels through when consent IS granted", async () => {
+    setNsfwConsent(true);
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_open_civitai").handler({ browsingLevels: [1, 16] }, ctx);
+    expect(calls[0].browsingLevels).toEqual([1, 16]);
+  });
+
+  it("panel_open_civitai rejects an unknown level value", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const res = await defByName("panel_open_civitai").handler({ browsingLevels: [3] }, ctx);
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("panel_open_civitai leaves omitted browsingLevels undefined (panel default applies)", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_open_civitai").handler({ query: "cats" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "open_civitai", query: "cats" });
+    expect(calls[0].browsingLevels).toBeUndefined();
+  });
+
+  it("panel_civitai_search enforces the SAME gate on its post-open browsingLevels", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    // Un-consented: adult stripped, SFW kept.
+    await defByName("panel_civitai_search").handler(
+      { query: "y", browsingLevels: [2, 8] },
+      ctx,
+    );
+    expect(calls[0].browsingLevels).toEqual([2]);
+
+    // Consented: passes through.
+    setNsfwConsent(true);
+    await defByName("panel_civitai_search").handler(
+      { query: "y", browsingLevels: [8] },
+      ctx,
+    );
+    expect(calls[1].browsingLevels).toEqual([8]);
+  });
+
+  it("panel_civitai_search rejects an all-adult un-consented search (no bridge call)", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const res = await defByName("panel_civitai_search").handler(
+      { query: "z", browsingLevels: [8, 16] },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1172,6 +1172,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           })
           .optional()
           .describe("Optional filter hints: period, a sort, and base-model names (e.g. ['Flux.1 D'])."),
+        dock: z
+          .boolean()
+          .optional()
+          .describe(
+            "Side-dock the browser beside the chat instead of a centered overlay, so chat and results stay visible together while you drive it. Default true (agent-opened browsers dock). Set false to force the old full-screen centered overlay.",
+          ),
       },
       async (args: A, ctx) =>
         ctx.call(
@@ -1181,9 +1187,131 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             tab: args.tab,
             browsingLevels: args.browsingLevels,
             filters: args.filters,
+            dock: args.dock,
           },
           10000,
         ),
+    ),
+    def(
+      "panel_civitai_results",
+      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). Open the browser first with panel_open_civitai. Returns, per result: id, kind (media|model), title, creator, baseModel|type, stats, prompt/description, and the media URL(s). Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. If a fetch is still in flight the panel reports what it has so far. The browser must be open — otherwise the panel replies with an honest error.",
+      {
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe("Max results to serialize (1–50, default 20). The grid is ordered as shown to the user."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "civitai_results", limit: args.limit }, 10000),
+    ),
+    def(
+      "panel_civitai_highlight",
+      "Draw the user's attention to specific results by wrapping their cards in a glowing green outline (and scrolling the first into view) — this is how you say 'these are the ones I mean.' Call panel_civitai_results FIRST to get the ids. Pass a LIST of ids to light up several at once ('these three'). The browser must be open — otherwise the panel replies with an honest error. Non-destructive; it only changes what's highlighted, never downloads or selects.",
+      {
+        ids: z
+          .array(z.union([z.string(), z.number()]))
+          .min(1)
+          .describe("Result ids to glow green (from panel_civitai_results). Pass several to highlight a set."),
+        kind: z
+          .enum(["media", "model"])
+          .optional()
+          .describe("Which result kind these ids refer to (media = images/videos, model = checkpoints/loras/workflows). Match the active tab if omitted."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "civitai_highlight", ids: args.ids, kind: args.kind }, 10000),
+    ),
+    def(
+      "panel_civitai_clear_highlight",
+      "Remove any green highlight glow from the CivitAI results — clears what panel_civitai_highlight set. The browser must be open — otherwise the panel replies with an honest error.",
+      {},
+      async (_args: A, ctx) => ctx.call({ cmd: "civitai_clear_highlight" }, 10000),
+    ),
+    def(
+      "panel_civitai_switch_tab",
+      "Switch the OPEN CivitAI browser to a different tab (crossfades and re-fetches that tab's results). Use to move between images, videos, checkpoints, loras, workflows, or the user's favorites while driving the browse. Follow with panel_civitai_results to read what loaded. The browser must be open — otherwise the panel replies with an honest error.",
+      {
+        tab: z
+          .enum(["images", "videos", "checkpoints", "loras", "workflows", "favorites"])
+          .describe("The tab to switch to."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "civitai_switch_tab", tab: args.tab }, 10000),
+    ),
+    def(
+      "panel_civitai_search",
+      "Run a NEW search inside the already-open CivitAI browser (re-queries the current tab with a fresh term and optional filters). Use this to refine or pivot the browse after reading results — e.g. narrow by base model or change the sort. Follow with panel_civitai_results to read the new results. To open the browser in the first place, use panel_open_civitai instead. The browser must be open — otherwise the panel replies with an honest error.",
+      {
+        query: z.string().describe("The new search term (e.g. 'ghibli background', 'Flux portrait')."),
+        filters: z
+          .object({
+            period: z.string().optional().describe("Time window filter (e.g. 'Week', 'Month', 'AllTime')."),
+            modelSort: z.string().optional().describe("Sort for model tabs (e.g. 'Most Downloaded')."),
+            imageSort: z.string().optional().describe("Sort for image/video tabs (e.g. 'Most Reactions')."),
+            baseModels: z.array(z.string()).optional().describe("Base-model names to filter to (e.g. ['Flux.1 D'])."),
+          })
+          .optional()
+          .describe("Optional filters applied to this search."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "civitai_search", query: args.query, filters: args.filters }, 10000),
+    ),
+    def(
+      "panel_civitai_open_lightbox",
+      "Open the full-size lightbox viewer for one result by id, so the user gets a big look at that specific image/video. Get the id from panel_civitai_results. Use sparingly — as the finishing flourish after you've highlighted your pick. The browser must be open — otherwise the panel replies with an honest error.",
+      {
+        id: z
+          .union([z.string(), z.number()])
+          .describe("The result id to open in the lightbox (from panel_civitai_results)."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "civitai_open_lightbox", id: args.id }, 10000),
+    ),
+    def(
+      "panel_training_open",
+      "Open the in-panel LoRA/model TRAINING wizard for the user, so they can configure and launch a training run visually while you guide them. Opens side-docked beside the chat by default so the wizard and chat stay visible together. After it's open, drive it with panel_training_set_field, panel_training_goto_step, panel_training_set_target, and panel_training_highlight. This only OPENS and configures the wizard — it never starts a run; the user confirms and launches training themselves.",
+      {
+        dock: z
+          .boolean()
+          .optional()
+          .describe("Side-dock the wizard beside chat (default true). Set false for the centered overlay."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "open_training", dock: args.dock }, 10000),
+    ),
+    def(
+      "panel_training_set_field",
+      "Set one field in the OPEN training wizard (e.g. a name, base model, learning rate, step count, dataset path). Use this to fill the form for the user as you walk them through setup. Open the wizard first with panel_training_open. This configures only — it never launches training. The wizard must be open — otherwise the panel replies with an honest error.",
+      {
+        name: z.string().describe("The field name/key to set (as the wizard labels it, e.g. 'learning_rate', 'name')."),
+        value: z
+          .union([z.string(), z.number(), z.boolean()])
+          .describe("The value to set (string, number, or boolean depending on the field)."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "training_set_field", name: args.name, value: args.value }, 10000),
+    ),
+    def(
+      "panel_training_goto_step",
+      "Navigate the OPEN training wizard to a specific step (0-based) — move the user forward/back through the setup flow as you explain each stage. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
+      {
+        step: z.number().int().min(0).describe("The step index to jump to (0-based)."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "training_goto_step", step: args.step }, 10000),
+    ),
+    def(
+      "panel_training_set_target",
+      "Set WHERE the training run will execute — 'local' (this machine) or 'pod' (a remote GPU pod). Use this in the wizard to steer the user toward the right compute for their job. Open the wizard first with panel_training_open. This only configures the target; it never launches the run. The wizard must be open — otherwise the panel replies with an honest error.",
+      {
+        target: z.enum(["local", "pod"]).describe("Execution target: 'local' machine or remote 'pod'."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "training_set_target", target: args.target }, 10000),
+    ),
+    def(
+      "panel_training_highlight",
+      "Draw the user's attention to specific parts of the OPEN training wizard (steps or fields) with a glowing green outline — this is how you point at 'set this here.' Pass a LIST of refs to light up several. Open the wizard first with panel_training_open. Non-destructive. The wizard must be open — otherwise the panel replies with an honest error.",
+      {
+        refs: z
+          .array(z.string())
+          .min(1)
+          .describe("Wizard step/field refs to glow green (as the wizard labels them). Pass several to highlight a set."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "training_highlight", refs: args.refs }, 10000),
     ),
     def(
       "panel_ask",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -83,6 +83,49 @@ function fail(err: unknown): ToolResult {
 
 const slotRef = z.union([z.string(), z.number().int().min(0)]);
 
+// CivitAI browsing-level bitmask values: PG=1, PG-13=2, R=4, X=8, XXX=16.
+const KNOWN_BROWSING_LEVELS = [1, 2, 4, 8, 16];
+// R/X/XXX are adult and gated behind the persistent NSFW consent (getNsfwConsent()).
+const ADULT_BROWSING_LEVELS = [4, 8, 16];
+
+/**
+ * SERVER-SIDE enforcement of the persistent NSFW consent gate on any
+ * agent-supplied browsing levels. The agent can pass arbitrary bitmask values;
+ * this walls them before they reach the panel so adult content is never
+ * surfaced without consent (matching panel_get_content_mode / the consent gate).
+ *
+ * - Rejects unknown levels (not in the PG..XXX enum).
+ * - Rejects a supplied-but-empty array.
+ * - When consent is NOT granted, strips R/X/XXX (4/8/16); if that leaves nothing,
+ *   THROWS so the agent gets an honest, actionable error instead of silent SFW.
+ * - Returns the sanitized, de-duped levels, or undefined when none were supplied
+ *   (preserving the panel's own default, currently [1] = PG).
+ */
+function sanitizeBrowsingLevels(levels: unknown): number[] | undefined {
+  if (levels === undefined || levels === null) return undefined;
+  if (!Array.isArray(levels) || levels.length === 0) {
+    throw new Error(
+      "browsingLevels must be a non-empty array of level values (PG=1, PG-13=2, R=4, X=8, XXX=16).",
+    );
+  }
+  const nums = levels.map((l) => Number(l));
+  for (const n of nums) {
+    if (!KNOWN_BROWSING_LEVELS.includes(n)) {
+      throw new Error(
+        `Unknown browsing level ${String(n)}. Allowed: 1 (PG), 2 (PG-13), 4 (R), 8 (X), 16 (XXX).`,
+      );
+    }
+  }
+  if (getNsfwConsent().allowed) return [...new Set(nums)];
+  const safe = [...new Set(nums.filter((n) => !ADULT_BROWSING_LEVELS.includes(n)))];
+  if (safe.length === 0) {
+    throw new Error(
+      "Adult content (R/X/XXX) requires consent, which the user hasn't granted. Call panel_request_adult_consent first, or request SFW levels only (PG=1, PG-13=2).",
+    );
+  }
+  return safe;
+}
+
 // ---- server-side pack workflow resolution (for panel_load_workflow) --------
 // Read a bundled pack's UI workflow.json on the SERVER so the (large) graph
 // never has to shuttle through the agent's conversation. Mirrors the package-
@@ -1162,7 +1205,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         browsingLevels: z
           .array(z.number())
           .optional()
-          .describe("Content levels to show, as a set of bitmask values: PG=1, PG-13=2, R=4, X=8, XXX=16. e.g. [1,2] for SFW only, [1,2,4,8,16] for everything. Default [1]. Match the user's stated comfort."),
+          .describe("Content levels to show, as a set of bitmask values: PG=1, PG-13=2, R=4, X=8, XXX=16. e.g. [1,2] for SFW only, [1,2,4,8,16] for everything. Default [1]. Match the user's stated comfort. Adult levels (R/X/XXX = 4/8/16) are enforced server-side against the persistent NSFW consent gate and stripped/rejected unless the user has consented (panel_request_adult_consent)."),
         filters: z
           .object({
             period: z.string().optional(),
@@ -1179,22 +1222,28 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             "Side-dock the browser beside the chat instead of a centered overlay, so chat and results stay visible together while you drive it. Default true (agent-opened browsers dock). Set false to force the old full-screen centered overlay.",
           ),
       },
-      async (args: A, ctx) =>
-        ctx.call(
-          {
-            cmd: "open_civitai",
-            query: args.query,
-            tab: args.tab,
-            browsingLevels: args.browsingLevels,
-            filters: args.filters,
-            dock: args.dock,
-          },
-          10000,
-        ),
+      async (args: A, ctx) => {
+        try {
+          const browsingLevels = sanitizeBrowsingLevels(args.browsingLevels);
+          return await ctx.call(
+            {
+              cmd: "open_civitai",
+              query: args.query,
+              tab: args.tab,
+              browsingLevels,
+              filters: args.filters,
+              dock: args.dock,
+            },
+            10000,
+          );
+        } catch (err) {
+          return fail(err);
+        }
+      },
     ),
     def(
       "panel_civitai_results",
-      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). Open the browser first with panel_open_civitai. Returns, per result: id, kind (media|model), title, creator, baseModel|type, stats, prompt/description, and the media URL(s). Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. If a fetch is still in flight the panel reports what it has so far. The browser must be open — otherwise the panel replies with an honest error.",
+      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). Open the browser first with panel_open_civitai. Returns exactly these fields per result and NOTHING else: a MEDIA item is { id, kind:'media', author, prompt (length-capped), modelName, reactions, url }; a MODEL item is { id, kind:'model', name, creator, type, baseModel, downloadCount, thumbsUp, coverUrl }. There is no title, and model descriptions are NOT included (they require a separate detail fetch) — do not expect them. Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. If a fetch is still in flight the panel reports what it has so far. The browser must be open — otherwise the panel replies with an honest error.",
       {
         limit: z
           .number()
@@ -1251,8 +1300,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           })
           .optional()
           .describe("Optional filters applied to this search."),
+        browsingLevels: z
+          .array(z.number())
+          .optional()
+          .describe("Content levels for this search, as bitmask values: PG=1, PG-13=2, R=4, X=8, XXX=16. Omit to keep the browser's current levels. Adult levels (R/X/XXX = 4/8/16) are enforced server-side against the persistent NSFW consent gate and stripped/rejected unless the user has consented (panel_request_adult_consent)."),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "civitai_search", query: args.query, filters: args.filters }, 10000),
+      async (args: A, ctx) => {
+        try {
+          const browsingLevels = sanitizeBrowsingLevels(args.browsingLevels);
+          return await ctx.call(
+            { cmd: "civitai_search", query: args.query, filters: args.filters, browsingLevels },
+            10000,
+          );
+        } catch (err) {
+          return fail(err);
+        }
+      },
     ),
     def(
       "panel_civitai_open_lightbox",
@@ -1266,7 +1329,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_training_open",
-      "Open the in-panel LoRA/model TRAINING wizard for the user, so they can configure and launch a training run visually while you guide them. Opens side-docked beside the chat by default so the wizard and chat stay visible together. After it's open, drive it with panel_training_set_field, panel_training_goto_step, panel_training_set_target, and panel_training_highlight. This only OPENS and configures the wizard — it never starts a run; the user confirms and launches training themselves.",
+      "Open the in-panel LoRA/model TRAINING wizard for the user, so they can configure a training run visually while you guide them. Opens side-docked beside the chat by default so the wizard and chat stay visible together. After it's open, read it with panel_training_get_state and drive it with panel_training_set_field, panel_training_goto_step, panel_training_set_target, and panel_training_highlight. This only OPENS and configures the wizard — you have NO command to start a run; the user reviews the setup and launches training themselves from the wizard's Launch control.",
       {
         dock: z
           .boolean()
@@ -1276,10 +1339,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       async (args: A, ctx) => ctx.call({ cmd: "open_training", dock: args.dock }, 10000),
     ),
     def(
+      "panel_training_get_state",
+      "READ the OPEN training wizard's current state so you can drive it SAFELY. Returns the current view/step, which transitions are allowed right now (so you know if a step's prerequisites are met), the current field values, target availability (e.g. whether a remote pod is SSH-ready), and any async/loading status. Call this BEFORE panel_training_goto_step or panel_training_set_target — the wizard enforces the same gates as its own buttons and will reject a premature move, so check readiness here first. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
+      {},
+      async (_args: A, ctx) => ctx.call({ cmd: "training_get_state" }, 10000),
+    ),
+    def(
       "panel_training_set_field",
-      "Set one field in the OPEN training wizard (e.g. a name, base model, learning rate, step count, dataset path). Use this to fill the form for the user as you walk them through setup. Open the wizard first with panel_training_open. This configures only — it never launches training. The wizard must be open — otherwise the panel replies with an honest error.",
+      "Set one field in the OPEN training wizard (e.g. a name, base model, learning rate, step count, dataset path). Use this to fill the form for the user as you walk them through setup. Only known wizard fields are accepted (the panel applies a per-field allowlist and rejects anything else). Open the wizard first with panel_training_open. This configures only — you have no command to launch training. The wizard must be open — otherwise the panel replies with an honest error.",
       {
-        name: z.string().describe("The field name/key to set (as the wizard labels it, e.g. 'learning_rate', 'name')."),
+        name: z.string().describe("The field name/key to set (as the wizard labels it, e.g. 'learning_rate', 'name'). Must be a known wizard field; unknown names are rejected server-side."),
         value: z
           .union([z.string(), z.number(), z.boolean()])
           .describe("The value to set (string, number, or boolean depending on the field)."),
@@ -1288,7 +1357,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_training_goto_step",
-      "Navigate the OPEN training wizard to a specific step (0-based) — move the user forward/back through the setup flow as you explain each stage. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
+      "Navigate the OPEN training wizard to a specific step (0-based) — move the user forward/back through the setup flow as you explain each stage. This enforces the SAME gates as the wizard's Next button (backend capability, a valid name, uploads settled, images present); if the step's prerequisites aren't met the panel rejects it and throws honestly, so call panel_training_get_state first to check readiness. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
       {
         step: z.number().int().min(0).describe("The step index to jump to (0-based)."),
       },
@@ -1296,7 +1365,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_training_set_target",
-      "Set WHERE the training run will execute — 'local' (this machine) or 'pod' (a remote GPU pod). Use this in the wizard to steer the user toward the right compute for their job. Open the wizard first with panel_training_open. This only configures the target; it never launches the run. The wizard must be open — otherwise the panel replies with an honest error.",
+      "Set WHERE the training run will execute — 'local' (this machine) or 'pod' (a remote GPU pod). Use this in the wizard to steer the user toward the right compute for their job. Choosing 'pod' runs the same preflight as the wizard's own button (a train_doctor check) and is REJECTED if there is no SSH-ready pod — call panel_training_get_state first to confirm pod availability. Open the wizard first with panel_training_open. This only configures the target; you have no command to launch the run. The wizard must be open — otherwise the panel replies with an honest error.",
       {
         target: z.enum(["local", "pod"]).describe("Execution target: 'local' machine or remote 'pod'."),
       },

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1243,7 +1243,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_civitai_results",
-      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). Open the browser first with panel_open_civitai. Returns exactly these fields per result and NOTHING else: a MEDIA item is { id, kind:'media', author, prompt (length-capped), modelName, reactions, url }; a MODEL item is { id, kind:'model', name, creator, type, baseModel, downloadCount, thumbsUp, coverUrl }. There is no title, and model descriptions are NOT included (they require a separate detail fetch) — do not expect them. Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. If a fetch is still in flight the panel reports what it has so far. The browser must be open — otherwise the panel replies with an honest error.",
+      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). Open the browser first with panel_open_civitai. Returns { items, total, loading }. Each item carries EXACTLY these fields and nothing else — a MEDIA item is { id, kind:'image'|'video', title:null, creator, baseModel, type, stats:{ reactions }, prompt (length-capped ~600 chars), urls:[] }; a MODEL item is { id, kind:'model', title (the model's name), creator, baseModel, type, stats:{ downloadCount, thumbsUp }, prompt:null, urls:[] }. Note: stats is a NESTED object (reactions for media; downloadCount+thumbsUp for models), urls is an ARRAY of media URL(s), and media items have title:null while models have prompt:null. Model descriptions are NOT included (they require a separate detail fetch) — do not expect them. Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. `loading:true` means a fetch is still in flight and the panel is reporting what it has so far. The browser must be open — otherwise the panel replies with an honest error.",
       {
         limit: z
           .number()
@@ -1346,20 +1346,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_training_set_field",
-      "Set one field in the OPEN training wizard (e.g. a name, base model, learning rate, step count, dataset path). Use this to fill the form for the user as you walk them through setup. Only known wizard fields are accepted (the panel applies a per-field allowlist and rejects anything else). Open the wizard first with panel_training_open. This configures only — you have no command to launch training. The wizard must be open — otherwise the panel replies with an honest error.",
+      "Set one field in the OPEN training wizard. The panel applies a strict per-field ALLOWLIST — the ONLY accepted `name` values are: 'datasetName' (string — the LoRA/dataset name), 'trigger' (string — the trigger word), 'preset' (one of 'smoke' | 'standard' | 'custom'), and 'target' (one of 'local' | 'pod', same as panel_training_set_target). Any other name is rejected server-side. There is NO learning-rate/step-count/base-model/dataset-path field here — those come from the chosen preset. Open the wizard first with panel_training_open. This configures only — you have no command to launch training. The wizard must be open — otherwise the panel replies with an honest error.",
       {
-        name: z.string().describe("The field name/key to set (as the wizard labels it, e.g. 'learning_rate', 'name'). Must be a known wizard field; unknown names are rejected server-side."),
+        name: z
+          .enum(["datasetName", "trigger", "preset", "target"])
+          .describe("The wizard field to set. Only these four are accepted; anything else is rejected."),
         value: z
           .union([z.string(), z.number(), z.boolean()])
-          .describe("The value to set (string, number, or boolean depending on the field)."),
+          .describe("The value: datasetName/trigger are strings; preset is 'smoke'|'standard'|'custom'; target is 'local'|'pod'."),
       },
       async (args: A, ctx) => ctx.call({ cmd: "training_set_field", name: args.name, value: args.value }, 10000),
     ),
     def(
       "panel_training_goto_step",
-      "Navigate the OPEN training wizard to a specific step (0-based) — move the user forward/back through the setup flow as you explain each stage. This enforces the SAME gates as the wizard's Next button (backend capability, a valid name, uploads settled, images present); if the step's prerequisites aren't met the panel rejects it and throws honestly, so call panel_training_get_state first to check readiness. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
+      "Navigate the OPEN training wizard to one of its four steps (1-based): 1 = dataset (gather images), 2 = label (caption them), 3 = launch (choose target + start), 4 = monitor (watch progress). Move the user forward/back as you explain each stage. This enforces the SAME gates as the wizard's Next button (backend capability, a valid name, uploads settled, images present); if the step's prerequisites aren't met the panel rejects it and throws honestly, so call panel_training_get_state first to check readiness. Open the wizard first with panel_training_open. The wizard must be open — otherwise the panel replies with an honest error.",
       {
-        step: z.number().int().min(0).describe("The step index to jump to (0-based)."),
+        step: z.number().int().min(1).max(4).describe("The step to jump to: 1=dataset, 2=label, 3=launch, 4=monitor."),
       },
       async (args: A, ctx) => ctx.call({ cmd: "training_goto_step", step: args.step }, 10000),
     ),


### PR DESCRIPTION
## What

The agent side of **agent-driven CivitAI + training modals** — the panel agent can now *drive* the CivitAI browser and training wizard, not just open them: run a search, read results, highlight interesting ones, switch tabs, and step the wizard. Pairs with **comfyui-mcp-panel PR (feat/agent-drive-modals)** — both must land together (this repo emits the bridge cmds; the panel implements them).

New `panel_*` tools in `buildPanelToolDefs` (auto-register on both SDK + HTTP transports; no `CALL_TOOL_WHITELIST` change — that gates only the canvas-less `call_tool` path):

- **CivitAI:** `panel_civitai_results` (metadata + image **URLs** only — never image inputs), `panel_civitai_highlight` / `panel_civitai_clear_highlight` (glowing-green outline by result id), `panel_civitai_switch_tab`, `panel_civitai_search`, `panel_civitai_open_lightbox`. `panel_open_civitai` gained `dock`.
- **Training:** `panel_training_open`, `panel_training_get_state` (readiness/allowed-transitions — call before driving), `panel_training_set_field` (allowlist `datasetName|trigger|preset|target`), `panel_training_goto_step` (1..4, enforces the wizard's own gates), `panel_training_set_target`, `panel_training_highlight`.

## Safety

- **NSFW consent enforced server-side:** `sanitizeBrowsingLevels()` validates levels ⊆ the known enum and strips adult (R/X/XXX) unless `getNsfwConsent().allowed`, on **both** `panel_open_civitai` and `panel_civitai_search`; an all-adult unconsented request errors without calling the bridge.
- The agent has **no command** for account-mutating actions (like/download/enqueue/train_start) — the mutation boundary is the absence of a bridge verb, not confirmation.
- Tool descriptions match the panel serializer's real output exactly (no invented fields); prompts length-capped.

## Review

Codex-hardened across **four passes**: plan-design audit (found a design-level NSFW-bypass + handle/highlight lifecycle holes), code review, cross-repo contract review, and a delta pass — **verdict CLEAN TO MERGE** for this repo; all findings closed.

## Gates
- `npx tsc --noEmit` clean; `npx vitest run` — 149 files / 1771 passed / 1 skipped.

**Live-pass pending:** merge gated on the paired live Claude-in-Chrome verification against a running ComfyUI (dock behavior + the visual drive loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
