### PR TITLE
feat: add Grok 4.5 to Agent Panel catalog

### DIFF
--- a/src/__tests__/orchestrator/grok-backend.test.ts
+++ b/src/__tests__/orchestrator/grok-backend.test.ts
@@ -355,7 +355,7 @@ describe("GrokBackend (ACP over stdio)", () => {
   it("listModels returns the static Grok catalog (no effort metadata)", async () => {
     const backend = new GrokBackend();
     const models = await backend.listModels();
-    expect(models.map((m) => m.id)).toEqual(["grok-composer-2.5-fast", "grok-build"]);
+    expect(models.map((m) => m.id)).toEqual(["grok-4.5", "grok-composer-2.5-fast", "grok-build"]);
     // Grok has no discrete effort scale → no effort metadata (panel hides picker).
     expect(models.every((m) => m.supportsEffort === undefined && m.supportedEffortLevels === undefined)).toBe(true);
   });

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -411,16 +411,17 @@ interface AcpInitializeResult {
 
 // ---- model catalog ----
 // ACP exposes no model enumeration, and the model is fixed at SPAWN via the CLI
-// `--model` flag — so we surface a static catalog of the current Gemini family.
-// Gemini's "thinking" is a token BUDGET, not a discrete effort scale, so we do
+// `--model` flag — so we surface a static catalog matching the current Grok CLI.
+// Grok's reasoning control is not exposed as a discrete effort scale here, so we do
 // NOT advertise supportsEffort/supportedEffortLevels: the panel's normalizeModels
 // then hides the effort dropdown (omission is the documented "no effort control"
-// signal). gemini-2.5-pro is the default.
+// signal). grok-4.5 is the current CLI default.
 const GROK_MODELS: ModelChoice[] = [
+  { id: "grok-4.5", label: "Grok 4.5" },
   { id: "grok-composer-2.5-fast", label: "Grok Composer 2.5 Fast" },
   { id: "grok-build", label: "Grok Build" },
 ];
-const GROK_DEFAULT_MODEL = "grok-composer-2.5-fast";
+const GROK_DEFAULT_MODEL = "grok-4.5";
 
 /** Does this id look like a Grok model (vs. the Claude panel model PanelAgent
  *  unconditionally passes as opts.model)? Used so the configured Grok model


### PR DESCRIPTION
## Summary

- add `grok-4.5` to the static Grok ACP model catalog
- make `grok-4.5` the default Grok model
- update the catalog test to cover the new ordering

## Why

The Grok CLI accepts `grok-4.5`, but the Agent Panel catalog could not expose or select it because Grok ACP does not provide model enumeration and the integration relies on a static catalog. Adding the model here makes the available CLI model selectable through the existing picker without changing the effort-control contract.

## Impact

New Grok sessions default to `grok-4.5`. Existing alternatives (`grok-composer-2.5-fast` and `grok-build`) remain available and can still be selected explicitly.

## Validation

- `npm run build`
- `npm test` — 149 files passed, 1775 tests passed, 1 skipped
- live Agent Panel bridge smoke: catalog advertised `grok-4.5` as current and a real Grok 4.5 turn completed successfully
