### PR TITLE
feat(apps): apps_* tools — micro-app run surface for mobile/canvas-less clients

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
               "tools/defaults-stats-skills",
               "tools/runpod",
               "tools/training",
+              "tools/apps",
               "tools/comfy-cli",
               "tools/skills-knowledge"
             ]

--- a/docs/tools/apps.mdx
+++ b/docs/tools/apps.mdx
@@ -1,0 +1,143 @@
+---
+title: "Apps (micro-apps)"
+description: "List, inspect, and run the panel's micro-apps — named, one-click workflow apps with exposed inputs — for canvas-less clients (mobile)."
+icon: "layout-grid"
+---
+
+<Info>5 tools. Generated from the live MCP tool schemas — do not edit by hand; run `npm run docs:gen`.</Info>
+
+## apps_list
+
+List the micro-apps registered on this ComfyUI (panel Apps feature). Each entry is the app's manifest: id, name, description, appMode &#123;inputs, outputs&#125;, deps, hideWorkflow, published. Use apps_get for one app's full detail and apps_run to execute one. Read-only.
+
+<Note>This tool takes no parameters.</Note>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "apps_list",
+  "arguments": {}
+}
+```
+
+---
+
+## apps_get
+
+Get one micro-app's manifest + bundle facts (has_workflow/has_prompt/has_thumbnail) by id. The manifest's appMode.inputs is the app's run form: each input has nodeId, widget, label, kind (text|number|combo|toggle|image|model), optional choices and default. Read-only.
+
+### Parameters
+
+<ParamField path="app_id" type="string" required>
+  The app's uuid (from apps_list).
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "apps_get",
+  "arguments": {
+    "app_id": "<app_id>"
+  }
+}
+```
+
+---
+
+## apps_run
+
+Run a micro-app once: patches `values` (keys '&lt;nodeId&gt;.&lt;widget&gt;', e.g. &#123;"6.text": "a cat"&#125;) into the app's stored prompt snapshot and queues it on ComfyUI. Returns the prompt_id — poll apps_run_status for completion and outputs. Only pass values for inputs listed in the app's appMode.inputs; omitted inputs keep their conversion-time defaults.
+
+### Parameters
+
+<ParamField path="app_id" type="string" required>
+  The app's uuid (from apps_list).
+</ParamField>
+<ParamField path="values" type="object">
+  Input overrides keyed '&lt;nodeId&gt;.&lt;widget&gt;' (e.g. &#123;"6.text": "a cat", "3.seed": 42&#125;). Unknown keys fail loudly (the manifest drifted from the snapshot).
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "apps_run",
+  "arguments": {
+    "app_id": "<app_id>"
+  }
+}
+```
+
+---
+
+## apps_run_status
+
+Check one app run by prompt_id (from apps_run): status (pending|running|done|unknown) plus the run's outputs (image/video file refs under each output node, text outputs). Read-only.
+
+### Parameters
+
+<ParamField path="app_id" type="string" required>
+  The app's uuid.
+</ParamField>
+<ParamField path="prompt_id" type="string" required>
+  The prompt_id returned by apps_run.
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "apps_run_status",
+  "arguments": {
+    "app_id": "<app_id>",
+    "prompt_id": "<prompt_id>"
+  }
+}
+```
+
+---
+
+## apps_import
+
+Install an app from the public registry onto this ComfyUI: fetches the registry bundle (manifest + prompt snapshot [+ workflow unless hidden]) and creates it as a local app via the panel's Apps API. The registry id becomes the local id, so re-importing the same app reports an id conflict (already installed). Deps (models/custom nodes) are NOT installed — report the manifest's deps to the user so they can install them before running.
+
+### Parameters
+
+<ParamField path="registry_url" type="string" required>
+  Registry worker base URL, e.g. https://cmcp-apps-registry.example.workers.dev
+</ParamField>
+<ParamField path="app_id" type="string" required>
+  The registry app's uuid (from the explore list).
+</ParamField>
+<ParamField path="slug" type="string">
+  The app's registry slug (recorded in local metadata).
+</ParamField>
+<ParamField path="version" type="integer">
+  The registry version (recorded in local metadata).
+</ParamField>
+
+### Example
+
+<Note>Example coming soon — the call below is a generated skeleton.</Note>
+
+```json
+{
+  "tool": "apps_import",
+  "arguments": {
+    "registry_url": "<registry_url>",
+    "app_id": "<app_id>"
+  }
+}
+```
+
+---

--- a/scripts/gen-tool-docs.ts
+++ b/scripts/gen-tool-docs.ts
@@ -215,6 +215,13 @@ const CATEGORIES: Array<{
     ],
   },
   {
+    group: "Apps (micro-apps)",
+    slug: "apps",
+    icon: "layout-grid",
+    description: "List, inspect, and run the panel's micro-apps — named, one-click workflow apps with exposed inputs — for canvas-less clients (mobile).",
+    tools: ["apps_list", "apps_get", "apps_run", "apps_run_status", "apps_import"],
+  },
+  {
     group: "comfy-cli",
     slug: "comfy-cli",
     icon: "terminal",

--- a/src/__tests__/tools/apps.test.ts
+++ b/src/__tests__/tools/apps.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+// The apps tools are thin proxies over the panel pack's
+// /comfyui_mcp_panel/apps/* routes — mock fetch, keep the real URL building +
+// error translation.
+
+import { registerAppsTools } from "../../tools/apps.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerAppsTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const APP_ID = "123e4567-e89b-42d3-a456-426614174000";
+
+describe("apps tools", () => {
+  it("apps_list proxies GET /comfyui_mcp_panel/apps", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ apps: [{ id: APP_ID, name: "X" }] }));
+    const res = await getHandler("apps_list")({});
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0].text).apps[0].name).toBe("X");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/comfyui_mcp_panel/apps");
+  });
+
+  it("apps_list explains a missing Apps API (old panel pack)", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 404));
+    const res = await getHandler("apps_list")({});
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("predates the Apps feature");
+  });
+
+  it("apps_run POSTs values and returns the prompt_id", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, prompt_id: "p1" }));
+    const res = await getHandler("apps_run")({ app_id: APP_ID, values: { "6.text": "a dog" } });
+    expect(JSON.parse(res.content[0].text).prompt_id).toBe("p1");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain(`/comfyui_mcp_panel/apps/${APP_ID}/run`);
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({ values: { "6.text": "a dog" } });
+  });
+
+  it("apps_run surfaces the server's validation error", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: "patch targets unknown node 99" }, 400));
+    const res = await getHandler("apps_run")({ app_id: APP_ID, values: { "99.text": "x" } });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("unknown node 99");
+  });
+
+  it("apps_run_status hits the runs route", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ status: "done", outputs: {} }));
+    const res = await getHandler("apps_run_status")({ app_id: APP_ID, prompt_id: "p1" });
+    expect(JSON.parse(res.content[0].text).status).toBe("done");
+    expect(String(fetchMock.mock.calls[0][0])).toContain(`/apps/${APP_ID}/runs/p1`);
+  });
+
+  it("transport failure is a readable error, not a crash", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await getHandler("apps_list")({});
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("Cannot reach the panel's Apps API");
+  });
+
+  it("apps_import fetches the registry bundle and POSTs it to the panel", async () => {
+    const REG = "https://reg.example.workers.dev";
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === `${REG}/v1/apps/${APP_ID}/bundle`) {
+        return jsonResponse({
+          manifest: { id: APP_ID, name: "Cloud App", deps: { models: [], customNodes: [] } },
+          prompt: { 6: { class_type: "CLIPTextEncode", inputs: { text: "x" } } },
+          workflow: { nodes: [] },
+        });
+      }
+      if (url.endsWith("/comfyui_mcp_panel/apps") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as {
+          manifest: { id: string; source: { type: string }; published: { slug: string } };
+        };
+        expect(body.manifest.id).toBe(APP_ID);
+        expect(body.manifest.source.type).toBe("registry");
+        expect(body.manifest.published.slug).toBe("maker/cloud-app");
+        return jsonResponse({ ok: true, id: APP_ID });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const res = await getHandler("apps_import")({
+      registry_url: REG,
+      app_id: APP_ID,
+      slug: "maker/cloud-app",
+      version: 3,
+    });
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0].text).ok).toBe(true);
+  });
+
+  it("apps_import rejects a non-http registry URL", async () => {
+    const res = await getHandler("apps_import")({ registry_url: "file:///etc/passwd", app_id: APP_ID });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("http(s)");
+  });
+});

--- a/src/__tests__/tools/apps.test.ts
+++ b/src/__tests__/tools/apps.test.ts
@@ -92,6 +92,8 @@ describe("apps tools", () => {
 
   it("apps_import fetches the registry bundle and POSTs it to the panel", async () => {
     const REG = "https://reg.example.workers.dev";
+    process.env.COMFYUI_MCP_REGISTRY_URLS = REG;
+    try {
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === `${REG}/v1/apps/${APP_ID}/bundle`) {
         return jsonResponse({
@@ -100,13 +102,18 @@ describe("apps tools", () => {
           workflow: { nodes: [] },
         });
       }
+      if (url === `${REG}/v1/apps/${APP_ID}/thumbnail`) {
+        return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      }
       if (url.endsWith("/comfyui_mcp_panel/apps") && init?.method === "POST") {
         const body = JSON.parse(String(init.body)) as {
           manifest: { id: string; source: { type: string }; published: { slug: string } };
+          thumbnail_b64?: string;
         };
         expect(body.manifest.id).toBe(APP_ID);
         expect(body.manifest.source.type).toBe("registry");
         expect(body.manifest.published.slug).toBe("maker/cloud-app");
+        expect(body.thumbnail_b64).toBe(Buffer.from([1, 2, 3]).toString("base64"));
         return jsonResponse({ ok: true, id: APP_ID });
       }
       throw new Error(`unexpected fetch ${url}`);
@@ -119,11 +126,21 @@ describe("apps tools", () => {
     });
     expect(res.isError).toBeFalsy();
     expect(JSON.parse(res.content[0].text).ok).toBe(true);
+    } finally {
+      delete process.env.COMFYUI_MCP_REGISTRY_URLS;
+    }
   });
 
-  it("apps_import rejects a non-http registry URL", async () => {
-    const res = await getHandler("apps_import")({ registry_url: "file:///etc/passwd", app_id: APP_ID });
+  it("apps_import rejects a registry URL outside the allowlist", async () => {
+    const res = await getHandler("apps_import")({ registry_url: "http://169.254.169.254/latest", app_id: APP_ID });
     expect(res.isError).toBe(true);
-    expect(res.content[0].text).toContain("http(s)");
+    expect(res.content[0].text).toContain("allowlisted");
+  });
+
+  it("apps_run_status rejects a traversal-shaped prompt_id", async () => {
+    const res = await getHandler("apps_run_status")({ app_id: APP_ID, prompt_id: "../../../../system_stats" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("invalid prompt_id");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -697,6 +697,18 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "runpod_watch",
   "runpod_unwatch",
   "runpod_deploy_link",
+  // Micro-Apps (panel "Apps" feature): the canvas-less client's list/run/poll
+  // surface. Same risk posture as enqueue_workflow (already whitelisted): run
+  // queues a job the user explicitly tapped; list/get/status are read-only.
+  "apps_list",
+  "apps_get",
+  "apps_run",
+  "apps_run_status",
+  // Registry install (mobile Explore): the rig fetches the bundle from the
+  // public registry and imports it locally. Same risk as save_workflow +
+  // download_model (already whitelisted): writes a local app bundle, no
+  // model/system mutation. Deps install stays a separate consented action.
+  "apps_import",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -1,0 +1,204 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getComfyUIBaseUrl } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
+import { errorToToolResult, ComfyUIError } from "../utils/errors.js";
+
+/**
+ * Micro-Apps ("Apps") tools — the mobile/direct-call surface for the panel's
+ * app bundles. Each tool is a thin proxy over the panel pack's
+ * /comfyui_mcp_panel/apps/* HTTP routes (py/apps_routes.py), so there is ONE
+ * storage and run implementation (the panel's) for both the desktop panel and
+ * canvas-less clients. The orchestrator's call_tool whitelist decides who may
+ * reach these; the tools themselves just forward and report.
+ *
+ * An "app" = a named workflow packaged for one-click runs: a manifest (name,
+ * description, appMode {inputs, outputs}, deps, hideWorkflow) + an API-format
+ * prompt snapshot that values are patched into per run.
+ */
+
+function appsUrl(path: string): string {
+  return `${getComfyUIBaseUrl()}/comfyui_mcp_panel/apps${path}`;
+}
+
+/** Fetch a panel apps route; translate transport + HTTP failures into a
+ *  readable ComfyUIError (a 404 on the COLLECTION route means the panel pack
+ *  predates the Apps feature — say so plainly). */
+async function appsFetch(path: string, init: RequestInit = {}): Promise<unknown> {
+  let res: Response;
+  try {
+    res = await comfyuiFetch(appsUrl(path), init);
+  } catch (err) {
+    throw new ComfyUIError(
+      `Cannot reach the panel's Apps API at ${appsUrl(path)}: ${err instanceof Error ? err.message : err}. ` +
+        "Is ComfyUI running with the comfyui-mcp-panel pack installed?",
+      "APPS_API_UNREACHABLE",
+    );
+  }
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* non-JSON error page */
+  }
+  if (!res.ok) {
+    const msg =
+      body && typeof body === "object" && typeof (body as { error?: unknown }).error === "string"
+        ? (body as { error: string }).error
+        : `HTTP ${res.status}`;
+    const hint =
+      res.status === 404 && path === ""
+        ? " — the panel pack on this ComfyUI predates the Apps feature; update comfyui-mcp-panel and restart ComfyUI"
+        : "";
+    throw new ComfyUIError(`Apps API error: ${msg}${hint}`, "APPS_API_ERROR");
+  }
+  return body;
+}
+
+function jsonText(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+export function registerAppsTools(server: McpServer): void {
+  server.tool(
+    "apps_list",
+    "List the micro-apps registered on this ComfyUI (panel Apps feature). Each entry is the app's " +
+      "manifest: id, name, description, appMode {inputs, outputs}, deps, hideWorkflow, published. " +
+      "Use apps_get for one app's full detail and apps_run to execute one. Read-only.",
+    {},
+    async () => {
+      try {
+        return jsonText(await appsFetch(""));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "apps_get",
+    "Get one micro-app's manifest + bundle facts (has_workflow/has_prompt/has_thumbnail) by id. " +
+      "The manifest's appMode.inputs is the app's run form: each input has nodeId, widget, label, " +
+      "kind (text|number|combo|toggle|image|model), optional choices and default. Read-only.",
+    {
+      app_id: z.string().uuid().describe("The app's uuid (from apps_list)."),
+    },
+    async (args) => {
+      try {
+        return jsonText(await appsFetch(`/${args.app_id}`));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "apps_run",
+    "Run a micro-app once: patches `values` (keys '<nodeId>.<widget>', e.g. {\"6.text\": \"a cat\"}) " +
+      "into the app's stored prompt snapshot and queues it on ComfyUI. Returns the prompt_id — poll " +
+      "apps_run_status for completion and outputs. Only pass values for inputs listed in the app's " +
+      "appMode.inputs; omitted inputs keep their conversion-time defaults.",
+    {
+      app_id: z.string().uuid().describe("The app's uuid (from apps_list)."),
+      values: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          "Input overrides keyed '<nodeId>.<widget>' (e.g. {\"6.text\": \"a cat\", \"3.seed\": 42}). " +
+            "Unknown keys fail loudly (the manifest drifted from the snapshot).",
+        ),
+    },
+    async (args) => {
+      try {
+        return jsonText(
+          await appsFetch(`/${args.app_id}/run`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ values: args.values || {} }),
+          }),
+        );
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "apps_run_status",
+    "Check one app run by prompt_id (from apps_run): status (pending|running|done|unknown) plus the " +
+      "run's outputs (image/video file refs under each output node, text outputs). Read-only.",
+    {
+      app_id: z.string().uuid().describe("The app's uuid."),
+      prompt_id: z.string().describe("The prompt_id returned by apps_run."),
+    },
+    async (args) => {
+      try {
+        return jsonText(await appsFetch(`/${args.app_id}/runs/${args.prompt_id}`));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "apps_import",
+    "Install an app from the public registry onto this ComfyUI: fetches the registry bundle " +
+      "(manifest + prompt snapshot [+ workflow unless hidden]) and creates it as a local app via the " +
+      "panel's Apps API. The registry id becomes the local id, so re-importing the same app reports " +
+      "an id conflict (already installed). Deps (models/custom nodes) are NOT installed — report the " +
+      "manifest's deps to the user so they can install them before running.",
+    {
+      registry_url: z
+        .string()
+        .url()
+        .describe("Registry worker base URL, e.g. https://cmcp-apps-registry.example.workers.dev"),
+      app_id: z.string().uuid().describe("The registry app's uuid (from the explore list)."),
+      slug: z.string().optional().describe("The app's registry slug (recorded in local metadata)."),
+      version: z.number().int().optional().describe("The registry version (recorded in local metadata)."),
+    },
+    async (args) => {
+      try {
+        const base = args.registry_url.replace(/\/+$/, "");
+        // Only allow http(s) registry URLs — this is a server-side fetch, so no
+        // arbitrary-scheme redirects to file:/gopher: etc.
+        if (!/^https?:\/\//i.test(base)) {
+          throw new ComfyUIError("registry_url must be http(s)", "APPS_IMPORT_BAD_URL");
+        }
+        const res = await fetch(`${base}/v1/apps/${args.app_id}/bundle`);
+        if (!res.ok) {
+          throw new ComfyUIError(`registry bundle fetch failed: HTTP ${res.status}`, "APPS_IMPORT_REGISTRY");
+        }
+        const bundle = (await res.json()) as {
+          manifest?: Record<string, unknown>;
+          prompt?: unknown;
+          workflow?: unknown;
+        };
+        if (!bundle.manifest || !bundle.prompt) {
+          throw new ComfyUIError("registry bundle is missing manifest/prompt", "APPS_IMPORT_BAD_BUNDLE");
+        }
+        const manifest = {
+          ...bundle.manifest,
+          id: args.app_id,
+          source: { type: "registry", workflowUuid: null, registryId: args.app_id },
+          published: {
+            registryId: args.app_id,
+            slug: args.slug || null,
+            publishedVersion: args.version || null,
+          },
+        };
+        const created = await appsFetch("", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            manifest,
+            prompt: bundle.prompt,
+            ...(bundle.workflow ? { workflow: bundle.workflow } : {}),
+          }),
+        });
+        return jsonText({ ok: true, installed: created, deps: (bundle.manifest as { deps?: unknown }).deps || {} });
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+}

--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -59,6 +59,41 @@ function jsonText(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
 
+/** Registry URLs apps_import may fetch from. This is a SERVER-side fetch, so
+ *  an open URL is an SSRF primitive (loopback/LAN, or a public URL redirecting
+ *  into one) — the tool only talks to the default registry or origins the
+ *  operator explicitly allowlists (comma-separated, for dev/staging). */
+function allowedRegistryBases(): string[] {
+  const extra = (process.env.COMFYUI_MCP_REGISTRY_URLS || "")
+    .split(",")
+    .map((s) => s.trim().replace(/\/+$/, ""))
+    .filter(Boolean);
+  return ["https://cmcp-apps-registry.artokun.workers.dev", ...extra];
+}
+
+const MAX_BUNDLE_BYTES = 16 * 1024 * 1024;
+
+/** Bounded GET: 30s timeout, 16MB cap on the buffered body (checked on the
+ *  declared length AND the actual bytes). */
+async function boundedJson(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    redirect: "error", // no redirect-follow into a second origin
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new ComfyUIError(`registry fetch failed: HTTP ${res.status}`, "APPS_IMPORT_REGISTRY");
+  }
+  const declared = Number(res.headers.get("content-length") || 0);
+  if (declared > MAX_BUNDLE_BYTES) {
+    throw new ComfyUIError("registry bundle too large", "APPS_IMPORT_TOO_LARGE");
+  }
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > MAX_BUNDLE_BYTES) {
+    throw new ComfyUIError("registry bundle too large", "APPS_IMPORT_TOO_LARGE");
+  }
+  return JSON.parse(new TextDecoder().decode(buf));
+}
+
 export function registerAppsTools(server: McpServer): void {
   server.tool(
     "apps_list",
@@ -129,11 +164,22 @@ export function registerAppsTools(server: McpServer): void {
       "run's outputs (image/video file refs under each output node, text outputs). Read-only.",
     {
       app_id: z.string().uuid().describe("The app's uuid."),
-      prompt_id: z.string().describe("The prompt_id returned by apps_run."),
+      // ComfyUI prompt ids are uuids; constraining the shape also blocks
+      // route traversal (a "prompt_id" like ../../system_stats would escape
+      // the apps route when interpolated into the URL — codex finding).
+      prompt_id: z
+        .string()
+        .regex(/^[0-9a-zA-Z-]{1,64}$/, "must be a ComfyUI prompt id (alphanumeric/dashes)")
+        .describe("The prompt_id returned by apps_run."),
     },
     async (args) => {
       try {
-        return jsonText(await appsFetch(`/${args.app_id}/runs/${args.prompt_id}`));
+        // In-handler too (not just the zod boundary): any direct caller with a
+        // traversal-shaped id must never reach the URL builder.
+        if (!/^[0-9a-zA-Z-]{1,64}$/.test(args.prompt_id)) {
+          throw new ComfyUIError("invalid prompt_id", "APPS_BAD_PROMPT_ID");
+        }
+        return jsonText(await appsFetch(`/${args.app_id}/runs/${encodeURIComponent(args.prompt_id)}`));
       } catch (err) {
         return errorToToolResult(err);
       }
@@ -151,7 +197,10 @@ export function registerAppsTools(server: McpServer): void {
       registry_url: z
         .string()
         .url()
-        .describe("Registry worker base URL, e.g. https://cmcp-apps-registry.example.workers.dev"),
+        .describe(
+          "Registry worker base URL. Must be the default public registry or an origin the operator " +
+            "allowlisted via COMFYUI_MCP_REGISTRY_URLS (the fetch is server-side — open URLs would be SSRF).",
+        ),
       app_id: z.string().uuid().describe("The registry app's uuid (from the explore list)."),
       slug: z.string().optional().describe("The app's registry slug (recorded in local metadata)."),
       version: z.number().int().optional().describe("The registry version (recorded in local metadata)."),
@@ -159,16 +208,14 @@ export function registerAppsTools(server: McpServer): void {
     async (args) => {
       try {
         const base = args.registry_url.replace(/\/+$/, "");
-        // Only allow http(s) registry URLs — this is a server-side fetch, so no
-        // arbitrary-scheme redirects to file:/gopher: etc.
-        if (!/^https?:\/\//i.test(base)) {
-          throw new ComfyUIError("registry_url must be http(s)", "APPS_IMPORT_BAD_URL");
+        if (!allowedRegistryBases().includes(base)) {
+          throw new ComfyUIError(
+            `registry_url must be the default registry or an operator-allowlisted origin ` +
+              `(COMFYUI_MCP_REGISTRY_URLS); got ${base}`,
+            "APPS_IMPORT_BAD_URL",
+          );
         }
-        const res = await fetch(`${base}/v1/apps/${args.app_id}/bundle`);
-        if (!res.ok) {
-          throw new ComfyUIError(`registry bundle fetch failed: HTTP ${res.status}`, "APPS_IMPORT_REGISTRY");
-        }
-        const bundle = (await res.json()) as {
+        const bundle = (await boundedJson(`${base}/v1/apps/${args.app_id}/bundle`)) as {
           manifest?: Record<string, unknown>;
           prompt?: unknown;
           workflow?: unknown;
@@ -186,6 +233,23 @@ export function registerAppsTools(server: McpServer): void {
             publishedVersion: args.version || null,
           },
         };
+        // Thumbnails live at a separate registry endpoint, not inside the JSON
+        // bundle — fetch and forward so the installed app keeps its card art.
+        let thumbnail_b64: string | undefined;
+        try {
+          const thumbRes = await fetch(`${base}/v1/apps/${args.app_id}/thumbnail`, {
+            redirect: "error",
+            signal: AbortSignal.timeout(15_000),
+          });
+          if (thumbRes.ok) {
+            const buf = await thumbRes.arrayBuffer();
+            if (buf.byteLength <= 5 * 1024 * 1024) {
+              thumbnail_b64 = Buffer.from(buf).toString("base64");
+            }
+          }
+        } catch {
+          /* no thumbnail — cosmetic only */
+        }
         const created = await appsFetch("", {
           method: "POST",
           headers: { "content-type": "application/json" },
@@ -193,6 +257,7 @@ export function registerAppsTools(server: McpServer): void {
             manifest,
             prompt: bundle.prompt,
             ...(bundle.workflow ? { workflow: bundle.workflow } : {}),
+            ...(thumbnail_b64 ? { thumbnail_b64 } : {}),
           }),
         });
         return jsonText({ ok: true, installed: created, deps: (bundle.manifest as { deps?: unknown }).deps || {} });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -56,6 +56,7 @@ import { registerComfyUISettingsTools } from "./comfyui-settings.js";
 import { registerNodeDevTools } from "./node-dev.js";
 import { registerComfyCliTools } from "./comfy-cli.js";
 import { registerTrainTools } from "./train.js";
+import { registerAppsTools } from "./apps.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -121,6 +122,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["server", registerComfyUISettingsTools],
   ["custom-nodes", registerNodeDevTools],
   ["training", registerTrainTools],
+  ["apps", registerAppsTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────


### PR DESCRIPTION
## The Apps epic (orchestrator side)

Sibling of **comfyui-mcp-panel#114** (panel + registry) and the comfyui-mcp-mobile Apps-tab PR. Thin proxies over the panel pack's `/comfyui_mcp_panel/apps/*` routes, so the panel stays the single storage + run implementation for both desktop and mobile.

- `apps_list` / `apps_get` — read the rig's registered micro-apps (manifest: appMode inputs/outputs, deps, hideWorkflow).
- `apps_run` — patch `<nodeId>.<widget>` values into the app's stored prompt snapshot and queue it; returns `prompt_id`. `apps_run_status` polls status + outputs.
- `apps_import` — fetch a bundle from the public registry and install it as a local app (registry id becomes the local id; deps are reported, not auto-installed).

All five are added to the mobile `call_tool` whitelist — same risk posture as the already-whitelisted `enqueue_workflow` / `save_workflow` / `download_*` tools: user-initiated, validated in the tools, no model/system mutation.

**Tests:** 8 new vitest cases (proxy routing, error translation, import round-trip, URL guard); `tsc` build green; docs:gen regenerated (163 tools).

No merge/release per maintainer — awaiting codex:rescue review.