### PR TITLE
fix(runpod): retarget cluster, connect:true, LAN fallback, download-aware idle (#269)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -277,3 +277,91 @@ describe("COMFYUI_PATH nested/wrapper self-heal (doubled-path bug)", () => {
     expect(mod.descendToNestedRoot(nested)).toBe(nested);
   });
 });
+
+describe("getLocalComfyuiUrl (#269 LAN fallback)", () => {
+  let fakeHome: string;
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.argv = [...OLD_ARGV];
+    // setComfyuiTarget persists local-target.json under homedir — sandbox it.
+    fakeHome = mkdtempSync(join(tmpdir(), "config-home-"));
+    // vitest workers ignore HOME/USERPROFILE overrides — the persistence path
+    // is env-overridable instead.
+    process.env.COMFYUI_MCP_LOCAL_TARGET_FILE = join(fakeHome, "local-target.json");
+    process.env.COMFYUI_API_KEY = "";
+    process.env.COMFYUI_PATH = "";
+    process.env.COMFYUI_HOST = "";
+    process.env.COMFYUI_PORT = "8188";
+    process.env.COMFYUI_MCP_FORCE_REMOTE = "";
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    process.argv = OLD_ARGV;
+  });
+
+  it("returns the LAN boot URL when local ComfyUI lives on another LAN host", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const mod = await import("../config.js");
+    expect(mod.getLocalComfyuiUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("returns loopback when booted against a RunPod pod proxy", async () => {
+    process.env.COMFYUI_URL = "https://abc123-3000.proxy.runpod.net";
+    const mod = await import("../config.js");
+    expect(mod.getLocalComfyuiUrl()).toBe("http://127.0.0.1:8188");
+  });
+
+  it("returns the loopback boot URL for a loopback boot", async () => {
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    const mod = await import("../config.js");
+    expect(mod.getLocalComfyuiUrl()).toBe("http://127.0.0.1:8188");
+  });
+
+  it("tracks a LAN target learned AFTER boot (hello retarget) as the local fallback", async () => {
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    const mod = await import("../config.js");
+    expect(mod.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true);
+    expect(mod.getLocalComfyuiUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("a pod retarget does NOT overwrite the learned local fallback", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const mod = await import("../config.js");
+    expect(mod.setComfyuiTarget("https://abc123-3000.proxy.runpod.net")).toBe(true);
+    expect(mod.getLocalComfyuiUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("a VPS boot target is NOT a local fallback (falls back to loopback)", async () => {
+    process.env.COMFYUI_URL = "https://comfy.example-vps.com:8188";
+    const mod = await import("../config.js");
+    expect(mod.getLocalComfyuiUrl()).toBe("http://127.0.0.1:8188");
+  });
+
+  it("a VPS target learned later does NOT become the local fallback", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const mod = await import("../config.js");
+    expect(mod.setComfyuiTarget("https://comfy.example-vps.com:8188")).toBe(true);
+    expect(mod.getLocalComfyuiUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("a pod-boot (self-restart) restores the persisted LAN target", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const first = await import("../config.js");
+    expect(first.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true); // writes local-target.json
+    vi.resetModules();
+    process.env.COMFYUI_URL = "https://abc123-3000.proxy.runpod.net"; // restart boots ON the pod
+    const second = await import("../config.js");
+    expect(second.getLocalComfyuiUrl()).toBe("http://192.168.1.50:8188");
+  });
+
+  it("a VPS boot does NOT restore a persisted LAN target", async () => {
+    process.env.COMFYUI_URL = "http://192.168.1.50:8188";
+    const first = await import("../config.js");
+    expect(first.setComfyuiTarget("http://192.168.1.50:8188")).toBe(true);
+    vi.resetModules();
+    process.env.COMFYUI_URL = "https://comfy.example-vps.com:8188";
+    const second = await import("../config.js");
+    expect(second.getLocalComfyuiUrl()).toBe("http://127.0.0.1:8188");
+  });
+});

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// download-progress.ts captures COMFYUI_MCP_PROGRESS_DIR at import — re-import
+// per test with a fresh dir (same resetModules pattern as config tests).
+const OLD_ENV = process.env;
+let dir: string;
+let mod: typeof import("../../services/download-progress.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env = { ...OLD_ENV };
+  dir = mkdtempSync(join(tmpdir(), "dl-progress-test-"));
+  process.env.COMFYUI_MCP_PROGRESS_DIR = dir;
+  mod = await import("../../services/download-progress.js");
+});
+
+afterEach(() => {
+  process.env = OLD_ENV;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function pendingFiles(): string[] {
+  return readdirSync(dir).filter((f) => f.startsWith(mod.CONTROL_PREFIX));
+}
+
+describe("download target stamping (#269)", () => {
+  it("stamps the row with the writer's COMFYUI_URL at write time", () => {
+    process.env.COMFYUI_URL = "https://podabc-3000.proxy.runpod.net";
+    mod.reportDownloadProgress({ id: "a1", name: "m.safetensors", downloaded: 1, total: 2, bytes_per_sec: 1, status: "downloading" }, true);
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("a1-"))!), "utf-8"));
+    expect(row.target).toBe("https://podabc-3000.proxy.runpod.net");
+    expect(row.status).toBe("downloading");
+  });
+});
+
+describe("control channel (#269 MCP child → orchestrator)", () => {
+  it("round-trips a target request as its own file (url + watchPodId)", () => {
+    expect(mod.requestTargetChange({ url: "https://podabc-3000.proxy.runpod.net", watchPodId: "podabc" })).toBeTruthy();
+    expect(pendingFiles()).toHaveLength(1);
+    const list = mod.listTargetChangeRequests(dir);
+    expect(list).toHaveLength(1);
+    expect(list[0].req.url).toBe("https://podabc-3000.proxy.runpod.net");
+    expect(list[0].req.watchPodId).toBe("podabc");
+    expect(typeof list[0].req.updated).toBe("number");
+  });
+
+  it("supports watch-only, unwatch, local-resolve, and connectWhenReady requests", () => {
+    expect(mod.requestTargetChange({ watchPodId: "podX" })).toBeTruthy();
+    expect(mod.requestTargetChange({ local: true, unwatch: true })).toBeTruthy();
+    expect(mod.requestTargetChange({ watchPodId: "podC", connectWhenReady: { url: "https://podc-3000.proxy.runpod.net", podId: "podC" } })).toBeTruthy();
+    const reqs = mod.listTargetChangeRequests(dir).map((p) => p.req);
+    expect(reqs.some((r) => r.watchPodId === "podX" && !r.url)).toBe(true);
+    expect(reqs.some((r) => r.local === true && r.unwatch === true)).toBe(true);
+    expect(reqs.some((r) => r.connectWhenReady?.podId === "podC")).toBe(true);
+  });
+
+  it("consumes exactly the file read — concurrent children can't clobber (codex)", () => {
+    expect(mod.requestTargetChange({ url: "http://127.0.0.1:8188" })).toBeTruthy();
+    expect(mod.requestTargetChange({ url: "https://podz-3000.proxy.runpod.net" })).toBeTruthy();
+    const list = mod.listTargetChangeRequests(dir);
+    expect(list).toHaveLength(2);
+    mod.consumeTargetChange(list[0].file); // consume ONE
+    const rest = mod.listTargetChangeRequests(dir);
+    expect(rest).toHaveLength(1); // the other request survives untouched
+  });
+
+  it("ignores + reaps requests older than the TTL", () => {
+    expect(mod.requestTargetChange({ url: "http://127.0.0.1:8188" })).toBeTruthy();
+    const [file] = pendingFiles();
+    writeFileSync(join(dir, file), JSON.stringify({ url: "http://127.0.0.1:8188", updated: Date.now() - 61_000 }));
+    expect(mod.listTargetChangeRequests(dir)).toHaveLength(0);
+    expect(pendingFiles()).toHaveLength(0); // reaped
+  });
+
+  it("redacts userinfo from stamped/requested target URLs", () => {
+    process.env.COMFYUI_URL = "https://user:secret@podabc-3000.proxy.runpod.net";
+    mod.reportDownloadProgress({ id: "r1", name: "m", downloaded: 1, total: 1, bytes_per_sec: 1, status: "downloading" }, true);
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("r1-"))!), "utf-8"));
+    expect(row.target).not.toContain("secret");
+    expect(mod.requestTargetChange({ url: "https://user:secret@podabc-3000.proxy.runpod.net" })).toBeTruthy();
+    expect(mod.listTargetChangeRequests(dir)[0].req.url).not.toContain("secret");
+  });
+
+  it("is inactive with no progress dir (non-panel mode)", async () => {
+    vi.resetModules();
+    delete process.env.COMFYUI_MCP_PROGRESS_DIR;
+    const bare = await import("../../services/download-progress.js");
+    expect(bare.requestTargetChange({ url: "http://127.0.0.1:8188" })).toBeNull();
+    expect(bare.listTargetChangeRequests(dir)).toHaveLength(0);
+  });
+});

--- a/src/__tests__/services/runpod-watch.test.ts
+++ b/src/__tests__/services/runpod-watch.test.ts
@@ -249,3 +249,56 @@ it("passes the watched pod's id to comfyuiIdle (per-pod idle veto, #274)", async
   await w.poll();
   expect(seen).toContain("podXYZ");
 });
+
+it("fires onPodUnavailable when the watched pod vanishes (#269 dead-target)", async () => {
+  getPodMock.mockResolvedValue(null);
+  const gone: string[] = [];
+  const w = createRunpodWatcher({
+    push: () => {},
+    comfyuiIdle: () => false,
+    renderingOnPod: () => true,
+    idleStopMinutes: 0,
+    onPodUnavailable: (id) => gone.push(id),
+  });
+  w.watch("podGone");
+  await w.poll();
+  expect(gone).toEqual(["podGone"]);
+  expect(w.watchedPodId()).toBeNull();
+});
+
+it("fires onPodUnavailable after a successful auto-stop (#269 dead-target)", async () => {
+  getPodMock.mockResolvedValue(runningPod());
+  stopPodMock.mockResolvedValue({ id: "podIdle", desiredStatus: "EXITED" });
+  const c = clock();
+  const gone: string[] = [];
+  const w = createRunpodWatcher({
+    push: () => {},
+    comfyuiIdle: () => true,
+    renderingOnPod: () => true,
+    idleStopMinutes: 15,
+    now: c.now,
+    onPodUnavailable: (id) => gone.push(id),
+  });
+  w.watch("podIdle");
+  await w.poll(); // idle clock starts
+  c.advance(16 * 60_000);
+  await w.poll(); // auto-stop fires
+  expect(stopPodMock).toHaveBeenCalledWith("podIdle");
+  expect(gone).toEqual(["podIdle"]);
+});
+
+it("fires onPodUnavailable when a watched pod is EXITED externally (retained pod, runtime null)", async () => {
+  getPodMock.mockResolvedValue({ id: "podStop", name: "s", desiredStatus: "EXITED", costPerHr: 0.4, machine: null, runtime: null });
+  const gone: string[] = [];
+  const w = createRunpodWatcher({
+    push: () => {},
+    comfyuiIdle: () => false,
+    renderingOnPod: () => true,
+    idleStopMinutes: 15,
+    onPodUnavailable: (id) => gone.push(id),
+  });
+  w.watch("podStop");
+  await w.poll();
+  expect(gone).toEqual(["podStop"]);
+  expect(w.watchedPodId()).toBeNull();
+});

--- a/src/__tests__/tools/runpod.test.ts
+++ b/src/__tests__/tools/runpod.test.ts
@@ -33,13 +33,17 @@ vi.mock("../../services/runpod-watch.js", () => ({
     watch: (id: string) => watchMock(id),
     unwatch: () => unwatchMock(),
     watchedPodId: () => watcherState.watched,
+    clearConnectFailed: () => {},
   }),
 }));
 
 const setComfyuiTargetMock = vi.fn(() => true);
+// Mutable active-target URL for the stop handler's targetingThisPod check.
+let mockBaseUrl = "http://127.0.0.1:8188";
 vi.mock("../../config.js", () => ({
   setComfyuiTarget: (...a: unknown[]) => setComfyuiTargetMock(...a),
   getLocalComfyuiUrl: () => "http://127.0.0.1:3000",
+  getComfyUIBaseUrl: () => mockBaseUrl,
 }));
 const resetClientMock = vi.fn();
 vi.mock("../../comfyui/client.js", () => ({ resetClient: () => resetClientMock() }));
@@ -72,6 +76,7 @@ const runningPod = (over: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   watcherState.watched = null;
+  mockBaseUrl = "http://127.0.0.1:8188";
   setComfyuiTargetMock.mockReturnValue(true);
   // default probe: ComfyUI answers
   global.fetch = vi.fn(async () => ({ ok: true, status: 200 })) as unknown as typeof fetch;
@@ -132,6 +137,7 @@ describe("runpod_pod_start / stop", () => {
   });
   it("falls back to local ComfyUI when stopping the CONNECTED pod (the swap)", async () => {
     watcherState.watched = "pod123"; // we were connected to it
+    mockBaseUrl = "https://pod123-3000.proxy.runpod.net"; // active target IS the pod
     stopPodMock.mockResolvedValue({ id: "pod123", desiredStatus: "EXITED" });
     const t = (await getHandler("runpod_pod_stop")({ pod_id: "pod123" })).content[0].text;
     expect(unwatchMock).toHaveBeenCalled();
@@ -141,6 +147,7 @@ describe("runpod_pod_start / stop", () => {
   });
   it("does NOT retarget when stopping a pod we weren't connected to", async () => {
     watcherState.watched = "otherpod";
+    mockBaseUrl = "http://127.0.0.1:8188"; // active target is local, not the pod
     stopPodMock.mockResolvedValue({ id: "pod123", desiredStatus: "EXITED" });
     await getHandler("runpod_pod_stop")({ pod_id: "pod123" });
     expect(setComfyuiTargetMock).not.toHaveBeenCalled();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, resolve, join } from "path";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { isIP } from "node:net";
 import { parseComfyUIUrl, type ComfyUITarget } from "./transport/comfyui-url.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -220,10 +221,13 @@ const LOOPBACK_HOSTS = new Set([
   "0.0.0.0",
 ]);
 
-/** True when a hostname is loopback (or absent → assume local). */
+/** True when a hostname is loopback (or absent → assume local). Bracketed IPv6
+ *  (`[::1]`, as URL parsing stores it) is normalized first so every consumer
+ *  classifies it the same (codex finding: is_local frame vs FS gating split). */
 export function isLoopbackHost(host: string | undefined): boolean {
   if (!host) return true; // No URL → assume local
-  return LOOPBACK_HOSTS.has(host.toLowerCase());
+  const h = host.toLowerCase().replace(/^\[|\]$/g, "");
+  return LOOPBACK_HOSTS.has(h);
 }
 
 /**
@@ -476,13 +480,135 @@ const bootComfyui = {
   basePath: config.comfyuiBasePath,
 };
 
-/** The loopback ComfyUI URL to fall back to when leaving a remote pod. */
+/** True when a host is a RunPod proxy (a pod) — the pod/not-pod boundary the
+ *  host indicator + local-fallback logic share. */
+function isRunpodProxyHost(host: string): boolean {
+  return /\.proxy\.runpod\.net$/i.test(host);
+}
+
+/** "Local" for the fallback means THIS machine or a private-LAN rig — NOT an
+ *  arbitrary remote host: booting against a VPS must still fall back to
+ *  loopback (codex finding; the pre-#269 behavior deliberately did). The
+ *  numeric ranges apply ONLY to IP literals — a DNS name like
+ *  `192.168.example.com` or `fd.example.com` is NOT private (codex finding). */
+function isLocalOrLanHost(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  if (isLoopbackHost(h)) return true;
+  // Local DNS forms: bare single-label names (comfybox), mDNS/home suffixes —
+  // only when NOT an IP literal (a public IPv6 like 2001:4860::8888 has no dot
+  // and must not pass as a bare hostname — codex finding).
+  if (!h.includes(".") && isIP(h) === 0) return true;
+  if (h.endsWith(".local") || h.endsWith(".internal") || h.endsWith(".lan") || h.endsWith(".home.arpa")) return true;
+  if (isIP(h) === 0) return false; // other DNS names — only IP literals get range checks
+  return (
+    h.startsWith("10.") ||
+    h.startsWith("192.168.") ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
+    /^f[cd]/.test(h) || // IPv6 ULA fc00::/7 (fc00–fdff)
+    /^fe[89ab][0-9a-f]:/.test(h) // IPv6 link-local fe80::/10 (fe80–febf)
+  );
+}
+
+/** True when the ACTIVE target is a pod. */
+export function isTargetingPod(): boolean {
+  return isRunpodProxyHost(config.comfyuiHost);
+}
+
+/** True when the ACTIVE target is this machine or a private-LAN rig — the
+ *  panels' `is_local` frame predicate (#269): a RunPod pod is false, a
+ *  loopback/LAN rig is true, and a generic remote host (VPS, cloud) is ALSO
+ *  false — neither "local" nor "pod" (codex rounds on both sides of this). */
+export function isTargetingLocalOrLan(): boolean {
+  return isLocalOrLanHost(config.comfyuiHost);
+}
+
+/** The most recent NON-POD target ("local" = this rig or a LAN rig — #269).
+ *  Seeded from the boot target when that IS local/LAN (a VPS/pod boot seeds
+ *  nothing; cloud mode's placeholder port 0 is treated as unknown). When the
+ *  boot is NOT local/LAN — e.g. a self-restart that inherited the POD url
+ *  through the mutated process env — the last learned target is restored from
+ *  disk instead (codex finding: restarts forgot the LAN rig and fell back to
+ *  127.0.0.1). Advanced by setComfyuiTarget + persisted on every change. */
+/** The saved-target path. Default is profile-global; an orchestrator sets
+ *  COMFYUI_MCP_LOCAL_TARGET_FILE to a port-scoped path at startup so parallel
+ *  orchestrators for DIFFERENT rigs never restore each other's rig (codex
+ *  finding). Evaluated per call so the startup assignment takes effect. */
+function localTargetFile(): string {
+  return process.env.COMFYUI_MCP_LOCAL_TARGET_FILE || join(homedir(), ".comfyui-mcp", "local-target.json");
+}
+
+function readSavedLocalTarget(): string | null {
+  try {
+    const v = JSON.parse(readFileSync(localTargetFile(), "utf-8")) as { url?: unknown };
+    return typeof v?.url === "string" ? v.url : null;
+  } catch {
+    return null;
+  }
+}
+
+const bootLocalTarget =
+  isLocalOrLanHost(bootComfyui.host) && bootComfyui.port > 0
+    ? `${bootComfyui.ssl ? "https" : "http"}://${bootComfyui.host}:${bootComfyui.port}${bootComfyui.basePath}`
+    : null;
+// Restore the saved target ONLY for the pod/restart boot (a self-restart
+// inherits the pod URL through the mutated env) — a deliberate boot against a
+// VPS must fall back to loopback, not a stale saved rig (codex finding).
+let lastNonPodTarget: string | null = bootLocalTarget ?? (isRunpodProxyHost(bootComfyui.host) ? readSavedLocalTarget() : null);
+// A deliberate boot against an explicit non-local, non-pod URL invalidates the
+// saved rig for this session (codex finding: the stale LAN file was later
+// restored after a pod retarget + restart, pointing use_local at the old rig).
+// Cloud boots (API key, no explicit URL) leave it alone.
+if (!bootLocalTarget && !isRunpodProxyHost(bootComfyui.host) && process.env.COMFYUI_URL?.trim() && !isLoopbackHost(bootComfyui.host)) {
+  try {
+    rmSync(localTargetFile(), { force: true });
+  } catch {
+    /* no saved file */
+  }
+}
+
+/** The loopback-or-LAN ComfyUI URL to fall back to when leaving a remote pod.
+ *  "Local" means the most recent non-pod target (boot or learned), falling
+ *  back to the loopback default only when nothing non-pod is known (#269:
+ *  forcing 127.0.0.1 broke rigs whose local ComfyUI lives on another LAN host). */
 export function getLocalComfyuiUrl(): string {
-  const local = isLoopbackHost(bootComfyui.host);
-  const host = local ? bootComfyui.host : "127.0.0.1";
-  const port = local && bootComfyui.port ? bootComfyui.port : 8188;
-  const proto = local && bootComfyui.ssl ? "https" : "http";
-  return `${proto}://${host}:${port}${local ? bootComfyui.basePath : ""}`;
+  return lastNonPodTarget ?? "http://127.0.0.1:8188";
+}
+
+/** Orchestrator startup hook: re-point the saved-target file (port-scoped, so
+ *  parallel orchestrators for different rigs never restore each other's rig)
+ *  and re-restore when booted on a pod — the module-init restore ran before
+ *  the scoped path was known (codex finding). */
+export function rescopeLocalTargetFile(path: string): void {
+  process.env.COMFYUI_MCP_LOCAL_TARGET_FILE = path;
+  // The deliberate non-local, non-pod boot invalidation from module init ran
+  // BEFORE this scoped path existed — repeat it here, or the stale scoped file
+  // resurrects the old LAN rig after a pod retarget + restart (codex finding).
+  if (!bootLocalTarget && !isRunpodProxyHost(bootComfyui.host) && process.env.COMFYUI_URL?.trim() && !isLoopbackHost(bootComfyui.host)) {
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      /* no saved file */
+    }
+    lastNonPodTarget = null;
+    return;
+  }
+  if (isRunpodProxyHost(bootComfyui.host)) {
+    // Pod/restart boot: the SCOPED file is THIS orchestrator's rig — it wins
+    // over any profile-global value the module-init restore picked up (codex
+    // finding: a headless session's global save defeated the port isolation).
+    lastNonPodTarget = readSavedLocalTarget();
+  }
+  if (lastNonPodTarget !== null) {
+    // Persist into the scoped file so the next restart restores it — a direct
+    // LAN boot otherwise lives in memory only and the pod-inherited restart
+    // falls back to 127.0.0.1 (codex finding).
+    try {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, JSON.stringify({ url: lastNonPodTarget }));
+    } catch {
+      /* best-effort */
+    }
+  }
 }
 
 /** True when the ACTIVE ComfyUI target is loopback (renders run on this machine
@@ -503,7 +629,10 @@ export function onComfyuiTargetChanged(cb: ComfyuiTargetListener): () => void {
 }
 function emitComfyuiTargetChanged(): void {
   const url = getComfyUIBaseUrl();
-  const local = isTargetingLocal();
+  // is_local = loopback/LAN rig (#269): pod → false, VPS/cloud remote → false
+  // (neither local nor pod), restored LAN rig → true. One predicate for the
+  // seed frame and every change frame.
+  const local = isTargetingLocalOrLan();
   for (const cb of comfyuiTargetListeners) {
     try {
       cb(url, local);
@@ -595,6 +724,24 @@ export function setComfyuiTarget(url: string): boolean {
     cloud: isCloudMode(),
     remoteHost: t.host,
   });
+  // Track the newest local/LAN non-pod target — it is what "Local" means from
+  // now on (boot may have been loopback while the real rig was learned later,
+  // #269). A VPS or other generic remote target is NOT a local fallback.
+  // Persisted: an orchestrator self-restart boots on the POD url (env was
+  // mutated) and would otherwise forget the rig (codex finding).
+  if (isLocalOrLanHost(t.host)) {
+    lastNonPodTarget = `${t.ssl ? "https" : "http"}://${t.host}:${t.port}${t.basePath}`;
+    try {
+      mkdirSync(dirname(localTargetFile()), { recursive: true });
+      writeFileSync(localTargetFile(), JSON.stringify({ url: lastNonPodTarget }));
+    } catch {
+      /* best-effort */
+    }
+  }
+  // Keep the process env in step: readers like reportDownloadProgress stamp
+  // from COMFYUI_URL, and a runtime retarget must not leave them pinning the
+  // process-start host (codex finding).
+  process.env.COMFYUI_URL = url;
   // Tell the control panels where renders run now (local ⇄ pod).
   emitComfyuiTargetChanged();
   return true;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -9,10 +9,10 @@
 // panel-agent.ts). Each agent runs on the user's Claude SUBSCRIPTION with no API
 // key. See docs/design/panel-orchestrator.md.
 
-import { existsSync, writeFileSync, unlinkSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, unlinkSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir, networkInterfaces } from "node:os";
-import { join } from "node:path";
+import { tmpdir, homedir, networkInterfaces } from "node:os";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import readline from "node:readline";
@@ -46,7 +46,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerAllTools } from "../tools/index.js";
-import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, getComfyUIBaseUrl } from "../config.js";
+import { isForceRemoteFlagSet, isLoopbackHost, detectLocalComfyUIPath, setComfyuiTarget, onComfyuiTargetChanged, isTargetingLocal, isTargetingLocalOrLan, isTargetingPod, getComfyUIBaseUrl, getLocalComfyuiUrl, rescopeLocalTargetFile, getComfyUIAuthHeaders } from "../config.js";
 import {
   buildComfyuiMcpEnv,
   comfyuiSecretKeys,
@@ -84,7 +84,9 @@ import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./pane
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
-import { initRunpodWatcher, getRunpodWatcher } from "../services/runpod-watch.js";
+import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
+import { getPod } from "../services/runpod-client.js";
+import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX } from "../services/download-progress.js";
 import { hasActiveTrainingJob, reconcileStaleTrainingJobs } from "../services/training-jobs.js";
 import {
   buildQueueStatusFrame,
@@ -818,13 +820,21 @@ export async function runPanelOrchestrator(): Promise<void> {
   const bridgeHost = (process.env.COMFYUI_MCP_BRIDGE_HOST ?? "127.0.0.1").trim() || "127.0.0.1";
   const lanBridge = !isLoopbackBindHost(bridgeHost);
   const envBridgeToken = process.env.COMFYUI_MCP_BRIDGE_TOKEN?.trim() || null;
-  const bridgeToken =
+  // Provisioned eagerly for secure/LAN boots, LAZILY on the first remote
+  // retarget (a loopback boot must not permanently rule out the secure bridge
+  // the pod's HTTPS panel needs — codex finding).
+  let bridgeToken =
     envBridgeToken ?? (wantSecureBridge || lanBridge ? randomBytes(24).toString("hex") : null);
 
   // Dedicated PANEL bridge port (default 9180). Token-gated in secure/LAN mode.
   const lockPort = Number(process.env.COMFYUI_MCP_BRIDGE_PORT) || 9180;
   const lockPath = orchLockPath(lockPort);
   const bridge = startUiBridge(lockPort, bridgeToken, bridgeHost);
+  // The LISTENER'S auth was fixed at construction: a null boot token means a
+  // tokenless listener FOREVER — lazily provisioning a token later would
+  // advertise a tunnel whose token is not enforced (codex finding). The lazy
+  // secure-bridge path must refuse in that case, not expose it publicly.
+  const bridgeListenerTokenless = bridgeToken === null;
 
   // On-demand phone pairing (the panel "Remote control" button). Off by default:
   // the FIRST pair request lazily binds a SECOND, token-gated listener on all
@@ -1049,10 +1059,31 @@ export async function runPanelOrchestrator(): Promise<void> {
     }
   }
 
-  // Cross-process download-progress channel: each tab's comfyui MCP subprocess
-  // writes per-download JSON here; the watcher below broadcasts it to the panel
-  // tray. Port-scoped so parallel orchestrators don't cross streams.
-  const progressDir = join(tmpdir(), `comfyui-mcp-progress-${bridgePort}`);
+  // Cross-process download-progress + control channel: each tab's comfyui MCP
+  // subprocess writes per-download JSON (and runpod_* target requests) here;
+  // the watcher below broadcasts downloads to the panel tray and applies
+  // control requests. Port-scoped so parallel orchestrators don't cross
+  // streams, NONCED + mode-0700 so another local user can't pre-create the
+  // predictable path and inject a hostile retarget (codex finding — the
+  // applied URL receives configured auth headers on later requests).
+  const progressNonce = randomBytes(12).toString("hex");
+  const progressDir = join(tmpdir(), `comfyui-mcp-progress-${bridgePort}-${progressNonce}`);
+  // Reap dirs from dead processes on this port (auto-restarts would otherwise
+  // accumulate them forever — codex finding). Same port ⇒ same orchestrator,
+  // so any other dir with the prefix belongs to a previous life.
+  try {
+    for (const d of readdirSync(tmpdir())) {
+      if (d.startsWith(`comfyui-mcp-progress-${bridgePort}-`) && join(tmpdir(), d) !== progressDir) {
+        rmSync(join(tmpdir(), d), { recursive: true, force: true });
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  mkdirSync(progressDir, { recursive: true, mode: 0o700 });
+  // Late-bind the channel dir so the control channel works IN-PROCESS too
+  // (direct/mobile tool calls — codex finding: it was dead without the env var).
+  setProgressDir(progressDir);
 
   // The bundled plugin (skills) ships alongside dist/ in the package root. Load
   // it so the background agents are ComfyUI experts out of the box.
@@ -1879,7 +1910,19 @@ export async function runPanelOrchestrator(): Promise<void> {
     } catch {
       return false; // not a valid URL — ignore (keep current target)
     }
-    if (!host || next === comfyuiUrl) return false;
+    // Same-URL check is DEFAULT-PORT-INSENSITIVE but SCHEME-AWARE: strip only
+    // the scheme's actual default (:443 for https, :80 for http) — http://h:443
+    // and http://h are NOT the same endpoint (codex finding).
+    const canon = (u: string): string => {
+      try {
+        const p = new URL(u);
+        if ((p.protocol === "https:" && p.port === "443") || (p.protocol === "http:" && p.port === "80")) p.port = "";
+        return p.toString().replace(/\/+$/, "");
+      } catch {
+        return u.replace(/\/+$/, "");
+      }
+    };
+    if (!host || canon(next) === canon(comfyuiUrl)) return false;
     const prev = comfyuiUrl;
     comfyuiUrl = next;
     comfyuiPath = localPathForTarget(next);
@@ -1891,21 +1934,11 @@ export async function runPanelOrchestrator(): Promise<void> {
     // forces getClient() to rebuild against the new host on its next use.
     setComfyuiTarget(next);
     resetClient();
-    // Point every provider at the new target: Claude via its rebuilt MCP env, the
-    // manager's image-fetch URL, then respawn active agents so the live comfyui MCP
-    // subprocess is recreated with the new COMFYUI_URL (no-op if none are running —
-    // the next spawn picks it up from the now-updated closures).
-    manager.setMcpServers(buildMcpServers());
-    manager.setComfyuiUrl(comfyuiUrl);
-    manager.restartAllForMcpEnv();
-    // Re-point the render watchdog and re-probe the env (remote vs local differs).
-    try {
-      QueueMonitor.stop();
-    } catch {
-      /* best-effort */
-    }
-    QueueMonitor.start(comfyuiUrl);
-    void refreshEnvCapabilities();
+    // The heavy retarget work (QueueMonitor restart, agent MCP-env respawn,
+    // env-capability re-probe) runs in the onComfyuiTargetChanged listener
+    // fired by setComfyuiTarget above — ONE fan-out for every retarget path
+    // (hello, runpod tools, watcher auto-stop/vanish), so they can't drift
+    // split-brained again (#269).
     logger.info(
       `[panel-orchestrator] retargeted ComfyUI ${prev} → ${comfyuiUrl} (${isLoopbackUrl(next) ? "local" : "remote"} mode) from panel hello`,
     );
@@ -2299,8 +2332,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // current pod-status frame (or a cleared one when nothing is watched).
       const rpFrame = getRunpodWatcher()?.current();
       if (rpFrame) bridge.push(rpFrame, panelTab);
+      // Seed any failed auto-connect warnings too — they live SEPARATELY from
+      // the watched frame so this tab sees every still-billing failure (codex).
+      for (const f of getRunpodWatcher()?.failedFrames() ?? []) bridge.push(f, panelTab);
       // Seed the honest host indicator: tell this tab where renders run now.
-      bridge.push({ type: "comfyui_target", url: getComfyUIBaseUrl(), is_local: isTargetingLocal() }, panelTab);
+      bridge.push({ type: "comfyui_target", url: getComfyUIBaseUrl(), is_local: isTargetingLocalOrLan() }, panelTab);
       // Re-push the last usage so the context meter isn't blank after a reload.
       const lastStatus = manager.lastStatusFor(key);
       if (lastStatus) pushStatus(panelTab, lastStatus);
@@ -3287,6 +3323,78 @@ export async function runPanelOrchestrator(): Promise<void> {
   // a downloading row that stops updating for 60s is treated as a dead writer.
   const DOWNLOAD_LINGER_MS = 8000;
   const downloadRemoveAt = new Map<string, number>();
+  /** Boolean URL probe with a timeout — readiness checks for pending pod connects. */
+  const probeOk = async (url: string, timeoutMs = 8_000): Promise<boolean> => {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), timeoutMs);
+    try {
+      // Carry configured auth (COMFYUI_AUTH_TOKEN / custom header) — a
+      // protected pod's ComfyUI 401s otherwise and connect:true always times
+      // out (codex finding).
+      const res = await fetch(url, { signal: ctl.signal, headers: getComfyUIAuthHeaders() });
+      return res.ok;
+    } catch {
+      return false;
+    } finally {
+      clearTimeout(t);
+    }
+  };
+  // Genuinely-in-flight download rows (set by pollDownloads) — read by the pod
+  // idle-stop veto, SCOPED per pod via each row's stamped target (#269).
+  let downloadingRows: Array<Record<string, unknown>> = [];
+  // create-with-connect pending boot: per-pod pending connects (a second
+  // create(connect:true) must not silently displace the first's promise —
+  // codex finding: the displaced pod kept billing with no deadline, no
+  // notification, and no auto-stop). Any deliberate target event clears ALL
+  // of them (the user chose something else) — EXCEPT a readiness-driven
+  // completion, which would otherwise wipe its siblings' promises (codex):
+  // machineRetargetInFlight distinguishes machine- from user-driven retargets.
+  // PERSISTED (user-private config dir): an orchestrator self-restart mid-boot
+  // must not strand a promised auto-connect (codex finding — the replacement
+  // process gets a fresh progress dir, so in-memory state alone is lost).
+  const pendingPodConnects = new Map<string, { url: string; deadline: number; lastProbe: number }>();
+  let machineRetargetInFlight = false;
+  const pendingConnectsFile = join(homedir(), ".comfyui-mcp", `runpod-pending-connects-${bridgePort}.json`);
+  // Port-scope the saved-target file too, and re-restore for a pod boot (the
+  // module-init read ran unscoped at import — codex finding).
+  rescopeLocalTargetFile(join(homedir(), ".comfyui-mcp", `local-target-${bridgePort}.json`));
+  const persistPendingConnects = () => {
+    try {
+      if (pendingPodConnects.size === 0) {
+        unlinkSync(pendingConnectsFile);
+        return;
+      }
+      mkdirSync(dirname(pendingConnectsFile), { recursive: true });
+      writeFileSync(pendingConnectsFile, JSON.stringify(Object.fromEntries([...pendingPodConnects].map(([k, v]) => [k, { url: v.url, deadline: v.deadline }]))));
+    } catch {
+      /* best-effort */
+    }
+  };
+  // Restore promises made before a restart; an already-past deadline fires the
+  // honest timeout on the first poll tick. RESTORE on a pod boot OR any
+  // self-restart generation (the common create(connect:true) case restarts
+  // with the target still LOCAL mid-wait — codex finding: requiring a pod
+  // target deleted the promise on the normal self-restart). A deliberate
+  // fresh non-pod boot (gen 0) invalidates old pendings instead.
+  try {
+    const restartGen = Number(process.env.COMFYUI_MCP_RESTART_GEN ?? "0");
+    if (!isTargetingPod() && !(restartGen > 0)) {
+      if (existsSync(pendingConnectsFile)) {
+        logger.info("[panel-orchestrator] discarding saved pending pod auto-connect(s) — this boot selected a non-pod target explicitly");
+        unlinkSync(pendingConnectsFile);
+      }
+    } else {
+      const saved = JSON.parse(readFileSync(pendingConnectsFile, "utf-8")) as Record<string, { url: string; deadline: number }>;
+      for (const [podId, v] of Object.entries(saved)) {
+        if (typeof v?.url === "string" && typeof v?.deadline === "number") {
+          pendingPodConnects.set(podId, { url: v.url, deadline: v.deadline, lastProbe: 0 });
+        }
+      }
+      if (pendingPodConnects.size > 0) logger.info(`[panel-orchestrator] restored ${pendingPodConnects.size} pending pod auto-connect(s) from before the restart`);
+    }
+  } catch {
+    // no saved state
+  }
   let lastDownloadSnapshot = "[]";
   const pollDownloads = () => {
     let files: string[] = [];
@@ -3298,6 +3406,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     const now = Date.now();
     const downloads: Array<Record<string, unknown>> = [];
     for (const f of files) {
+      if (f.startsWith(CONTROL_PREFIX)) continue; // control channel, not a download row
       const full = join(progressDir, f);
       let row: Record<string, unknown>;
       try {
@@ -3326,11 +3435,204 @@ export async function runPanelOrchestrator(): Promise<void> {
       }
       downloads.push(row);
     }
+    // Live-download rows for the idle-stop veto (#269): rows surviving the loop
+    // above are fresh (dead writers >60s are already unlinked), so a
+    // "downloading" row here is genuinely in flight — and a pod mid-download
+    // must not count as idle. Self-healing: a crashed writer's row ages out.
+    downloadingRows = downloads.filter((d) => d.status === "downloading");
     downloads.sort((a, b) => String(a.name ?? "").localeCompare(String(b.name ?? "")));
     const snapshot = JSON.stringify(downloads);
     if (snapshot !== lastDownloadSnapshot) {
       lastDownloadSnapshot = snapshot;
       bridge.push({ type: "download_progress", downloads }); // broadcast to all tabs
+    }
+    // MCP-child control channel (#269): runpod_* tools that ran in spawned
+    // agent children ask the orchestrator to retarget / watch / unwatch /
+    // auto-connect here — through the SAME applyComfyuiUrl fan-out as a panel
+    // hello. Each request is its own file: consumption deletes exactly the
+    // file read, so concurrent children can't clobber each other (codex).
+    try {
+      for (const { req, file } of listTargetChangeRequests(progressDir)) {
+        // Apply EVERY request — per-request files make the old timestamp
+        // watermark both unnecessary and wrong (two same-millisecond requests
+        // — e.g. create's watch + auto-connect — would drop the second, codex
+        // finding). A crash between apply and delete replays an idempotent op
+        // once on restart; a dropped auto-connect bills an unwatched pod.
+        // A `local` request resolves the fallback HERE — the orchestrator owns
+        // the learned-LAN memory; the requesting child (spawned post-connect)
+        // may know nothing but loopback (codex finding). `onlyIfTarget` guards
+        // it: a stale child's stop-fallback applies only when the CURRENT
+        // target really is that pod (codex finding — it dragged the target
+        // off a newer pod). The ack below reports the resulting URL either
+        // way, so the stale child ALIGNS to it.
+        const localGuardOk = !req.onlyIfTarget || getComfyUIBaseUrl().includes(req.onlyIfTarget);
+        // Generation guard for URL retargets: drop the retarget when a NEWER
+        // direct choice moved the target after the child wrote this (codex
+        // finding: a queued pod-A request applied after the user picked pod B).
+        const urlGenOk = !req.expectedCurrentUrl || getComfyUIBaseUrl() === req.expectedCurrentUrl;
+        // Only an APPLIED target/unwatch choice supersedes pending auto-connects
+        // (watch-ONLY isn't a choice; a guarded-OUT or generation-STALE request
+        // applied nothing and must not drop a booting pod's promise — codex
+        // findings on both axes).
+        const appliedChoice = urlGenOk && (!!req.url || ((!!req.local || !!req.unwatch) && localGuardOk));
+        if (!req.connectWhenReady && appliedChoice) { pendingPodConnects.clear(); persistPendingConnects(); }
+        if (req.local && localGuardOk && urlGenOk) applyComfyuiUrl(getLocalComfyuiUrl());
+        else if (req.url && urlGenOk) applyComfyuiUrl(req.url); // dropped when a newer choice superseded it
+        if (req.unwatch && localGuardOk && urlGenOk) {
+          // Scoped for stop-fallbacks: only the stopped pod's own watch dies
+          // (codex finding: stopping A killed unrelated watched B).
+          if (req.unwatchPodId) {
+            const w = getRunpodWatcher();
+            if (w?.watchedPodId() === req.unwatchPodId) w.unwatch();
+          } else {
+            getRunpodWatcher()?.unwatch();
+          }
+        }
+        // A confirmed stop clears the pod's recorded auto-connect failure —
+        // including the spawned-child case, where the caller had no watcher
+        // of its own (codex finding: stopped pods kept "billing" forever).
+        // And it CANCELS any pending auto-connect for it — otherwise the
+        // readiness loop could still retarget to a just-stopped pod, or warn
+        // about a timeout for a pod the user deliberately stopped (codex).
+        if (req.stoppedPodId) {
+          getRunpodWatcher()?.clearConnectFailed(req.stoppedPodId);
+          if (pendingPodConnects.delete(req.stoppedPodId)) persistPendingConnects();
+        }
+        if (req.watchPodId) {
+          // Boot-status arm for a create: never displace the ACTIVE render
+          // target's watch — its idle auto-stop / dead-target cleanup is the
+          // billing guard (codex finding: creating pod B while rendering on
+          // pod A left A unguarded and billing indefinitely). The new pod gets
+          // watched when its pending connect completes (it becomes the target).
+          const w = getRunpodWatcher();
+          const cur = w?.watchedPodId();
+          const curIsActiveTarget = !!cur && !isTargetingLocal() && getComfyUIBaseUrl().includes(cur);
+          if (!(curIsActiveTarget && cur !== req.watchPodId)) w?.watch(req.watchPodId);
+        }
+        // Whether the watch request actually LANDED (the guard above may have
+        // refused it) — computed AFTER the attempt; the ack carries it so the
+        // child's create result can't claim a watch we rejected (codex finding).
+        const watchApplied = !!req.watchPodId && getRunpodWatcher()?.watchedPodId() === req.watchPodId;
+        // Whether a URL retarget landed (generation-guarded): the ack must
+        // confirm the AUTHORITATIVE retarget before the child reports success
+        // (codex finding: rejected writes still read "connected").
+        const connectApplied = !!req.url && urlGenOk && getComfyUIBaseUrl() === req.url;
+        if (req.connectWhenReady && urlGenOk) {
+          // The ORCHESTRATOR waits for boot (the tool call returned inside the
+          // MCP 60s lifetime): probe every ~10s, retarget+watch on ready, and
+          // report honestly on deadline — never block the MCP child (codex).
+          // Per-pod slot: concurrent creates each keep their own deadline.
+          // Generation-guarded: a stale registration must not re-arm after the
+          // user already chose a newer target (codex finding).
+          pendingPodConnects.set(req.connectWhenReady.podId, {
+            url: req.connectWhenReady.url,
+            deadline: Date.now() + 8 * 60_000,
+            lastProbe: 0,
+          });
+          persistPendingConnects();
+        }
+        consumeTargetChange(file);
+        // Ack with the RESULTING target ONLY when the requester is waiting —
+        // fire-and-forget requests would leak ack files (codex finding). The
+        // `applied` flag distinguishes an applied local switch from a guarded
+        // skip (onlyIfTarget didn't match — codex finding).
+        if (req.wantAck) ackTargetChange(file, getComfyUIBaseUrl(), req.onlyIfTarget ? localGuardOk && urlGenOk : req.url ? connectApplied : req.connectWhenReady ? urlGenOk : req.watchPodId ? watchApplied : true);
+      }
+    } catch {
+      /* best-effort — the next tick retries a partially-written file */
+    }
+
+    // Pending create-and-connects: probe each until its pod's ComfyUI answers
+    // BOTH readiness endpoints, then retarget through the shared fan-out.
+    const reportConnectFailed = async (podId: string, supersededBy?: string) => {
+      // HONEST failure frame (codex finding: fabricated watching:true/RUNNING
+      // read as a healthy pod while it bills unguarded). Fetch the real state;
+      // `watching` reflects whether the single watcher actually follows it.
+      let status = "UNKNOWN"; // unconfirmed — never present a terminal state we didn't verify (codex)
+      let name: string | null = null;
+      let gpu: string | null = null;
+      let costPerHr: number | null = null;
+      let uptime: number | null = null;
+      try {
+        const pod = await getPod(podId);
+        status = pod?.desiredStatus ?? "TERMINATED";
+        name = pod?.name ?? null;
+        gpu = pod?.machine?.gpuDisplayName ?? null;
+        costPerHr = pod?.costPerHr ?? null;
+        uptime = pod?.runtime?.uptimeInSeconds ?? null;
+      } catch { /* keep fallbacks */ }
+      // RECHECK before installing: a manual connect/stop during the getPod
+      // await already resolved this — installing now would resurrect a stale
+      // alert on a healthy target (codex finding).
+      if (!isTargetingLocal() && getComfyUIBaseUrl().includes(podId)) return;
+      // Suppress the alert ONLY for proven terminal/gone states — a booting
+      // (CREATED/RESTARTING) or unverifiable (UNKNOWN) pod may still be billing
+      // and keeps its warning (codex finding).
+      if (status === "EXITED" || status === "TERMINATED" || status === "DEAD" || status === "PAUSED") return;
+      const frame = {
+        type: "runpod_alert",
+        pod_id: podId,
+        reason: supersededBy ? "superseded" : "timeout",
+        status,
+        name,
+        gpu,
+        cost_per_hr: costPerHr,
+        uptime_seconds: uptime,
+        ...(supersededBy ? { superseded_by: supersededBy } : {}),
+      } satisfies RunpodAlertFrame;
+      // Route through the watcher so the failure STICKS (seeds to new tabs and
+      // rides later frames until the pod exits — codex finding: a one-shot
+      // push lets the only warning evaporate on the next routine poll). The
+      // alert channel can't clobber the watched pod's status slot (codex).
+      const w = getRunpodWatcher();
+      if (w) w.markConnectFailed(podId, frame);
+      else void bridge.push(frame);
+    };
+    for (const [podId, p] of pendingPodConnects) {
+      if (Date.now() > p.deadline) {
+        pendingPodConnects.delete(podId);
+        persistPendingConnects();
+        logger.warn(`[panel-orchestrator] pod ${podId} was not ready within 8 minutes — NOT auto-connecting (connect manually with runpod_pod_connect)`);
+        // The tool call is long gone and idle auto-stop can't fire on a pod we
+        // never connected to (renderingOnPod is false) — the failed pod keeps
+        // billing with no visible failure unless we say so (codex finding).
+        void reportConnectFailed(podId);
+        continue;
+      }
+      if (Date.now() - p.lastProbe >= 10_000) {
+        p.lastProbe = Date.now();
+        void (async () => {
+          const stats = await probeOk(`${p.url}/system_stats`);
+          const queue = stats ? await probeOk(`${p.url}/queue`) : false;
+          if (!pendingPodConnects.has(podId) || pendingPodConnects.get(podId) !== p) return; // superseded/cleared
+          if (stats && queue) {
+            pendingPodConnects.delete(podId);
+            persistPendingConnects();
+            // A readiness-driven retarget — NOT a user override: siblings'
+            // pending connects stay alive through the listener (codex).
+            machineRetargetInFlight = true;
+            try {
+              applyComfyuiUrl(p.url);
+            } finally {
+              machineRetargetInFlight = false;
+            }
+            // ONE winner: a second readiness would displace this pod's watch
+            // (its idle-stop guard), so competing pending connects are resolved
+            // as SUPERSEDED — with an HONEST frame: the loser is UNWATCHED
+            // (nothing guards its cost) and connect_failed says why (codex).
+            for (const [otherId, other] of pendingPodConnects) {
+              pendingPodConnects.delete(otherId);
+              persistPendingConnects();
+              logger.warn(`[panel-orchestrator] pod ${otherId} auto-connect superseded by pod ${podId} (one active target) — it is UNWATCHED and still billing; stop it to end billing if unused`);
+              void reportConnectFailed(otherId, podId);
+              void other;
+            }
+            getRunpodWatcher()?.watch(podId);
+            logger.info(`[panel-orchestrator] pod ${podId} ready — auto-connected (${p.url})`);
+            void bridge.push({ type: "runpod_connected", pod_id: podId, url: p.url });
+          }
+        })();
+      }
     }
   };
   const downloadTimer = setInterval(pollDownloads, 700);
@@ -3370,6 +3672,9 @@ export async function runPanelOrchestrator(): Promise<void> {
   })();
   initRunpodWatcher({
     push: (frame) => void bridge.push(frame),
+    // Persist unresolved connect-failure alerts per port (restart-proof — a
+    // self-restart must not lose a still-billing warning, codex finding).
+    persistPath: join(homedir(), ".comfyui-mcp", `runpod-connect-failures-${bridgePort}.json`),
     comfyuiIdle: (podId) => {
       const s = QueueMonitor.snapshot();
       // NOT idle while a training job is alive on THIS pod: training isn't a
@@ -3377,14 +3682,39 @@ export async function runPanelOrchestrator(): Promise<void> {
       // run "idle" and auto-stop the pod mid-flight (P4 guard; review finding
       // on the connector). hasActiveTrainingJob is a probe-free file scan,
       // scoped to the watched pod so a run on another pod doesn't suppress
-      // this pod's idle-stop (codex #274).
-      return s.connected && !s.running && s.queueDepth === 0 && !hasActiveTrainingJob("pod", podId);
+      // this pod's idle-stop (codex #274). Also NOT idle while THIS POD is
+      // downloading — rows are target-stamped by their writer (#269; an
+      // unstamped pre-fix row errs toward "busy", the cost-safe direction).
+      const podDownloading = downloadingRows.some((d) => {
+        const t = typeof d.target === "string" ? d.target : "";
+        return t === "" || t.includes(podId);
+      });
+      return s.connected && !s.running && s.queueDepth === 0 && !podDownloading && !hasActiveTrainingJob("pod", podId);
     },
     // Idle auto-stop only applies to a pod we're actually rendering on: the active
     // ComfyUI target is that pod's proxy (its id appears in the URL). A pod we
     // merely watch while it boots stays local-targeted, so this is false and it is
     // never auto-stopped on the local rig's idleness.
     renderingOnPod: (podId) => !isTargetingLocal() && getComfyUIBaseUrl().includes(podId),
+    // The watched pod vanished or was auto-stopped (#269 dead-target cleanup):
+    // when renders were pointing AT it, fall back to the local target — via
+    // setComfyuiTarget, so the shared retarget fan-out (QueueMonitor, agents,
+    // frame) runs too. Not every watched pod is the render target, so guard.
+    onPodUnavailable: (goneId) => {
+      if (isTargetingLocal() || !getComfyUIBaseUrl().includes(goneId)) return;
+      const local = getLocalComfyuiUrl();
+      logger.warn(`[panel-orchestrator] pod ${goneId} unavailable while targeted — retargeting local ComfyUI (${local})`);
+      // A MACHINE-driven fallback (auto-stop/vanish), not a user override:
+      // pending create-and-connects on OTHER pods must survive it — otherwise
+      // a booting pod silently loses its promised auto-connect (codex finding).
+      machineRetargetInFlight = true;
+      try {
+        setComfyuiTarget(local);
+      } finally {
+        machineRetargetInFlight = false;
+      }
+      resetClient();
+    },
     idleStopMinutes: runpodIdleStopMinutes,
   });
 
@@ -3406,12 +3736,48 @@ export async function runPanelOrchestrator(): Promise<void> {
   }, 5 * 60_000);
   trainingReconcileTimer.unref?.();
 
-  // Honest host indicator: whenever the ComfyUI target moves (RunPod connect,
-  // pod stop → local fallback, "Local" switch), broadcast a `comfyui_target`
-  // frame so every control panel truthfully shows where renders run. Seeded per
-  // tab on connect (below) so a fresh tab knows the host without waiting for a
-  // switch.
+  // Honest host indicator + RETARGET FAN-OUT: whenever the ComfyUI target moves
+  // (RunPod connect, pod stop → local fallback, "Local" switch, panel hello),
+  // setComfyuiTarget fires this ONE listener — it repoints everything that was
+  // previously left split-brained (#269): QueueMonitor (its WS/polls keep
+  // talking to the OLD host), the agent subprocesses' MCP env (respawned via
+  // restartAllForMcpEnv), and the env-capability probe, then broadcasts the
+  // `comfyui_target` frame so every panel truthfully shows where renders run.
+  // Same-URL retargets (a repeated connect to the current target) skip the
+  // restart storm and only re-broadcast. Seeded per tab on connect (below) so
+  // a fresh tab knows the host without waiting for a switch.
+  let lastRetargetUrl: string | null = comfyuiUrl; // seeded: a first same-URL event must not restart everything
   onComfyuiTargetChanged((url, isLocal) => {
+    // ANY target event — a change OR a reaffirmation of the current target —
+    // supersedes ALL pending auto-connects (codex findings: direct
+    // setComfyuiTarget callers bypass applyComfyuiUrl, and an explicit
+    // Local/Stop at the SAME target must not let a booting pod steal it back
+    // later) — EXCEPT a readiness-driven completion, which must leave its
+    // siblings' pending promises intact (codex finding).
+    if (!machineRetargetInFlight) { pendingPodConnects.clear(); persistPendingConnects(); }
+    if (url !== lastRetargetUrl) {
+      lastRetargetUrl = url;
+      // Sync the shared target closures FIRST: retargets that did NOT come
+      // through applyComfyuiUrl (runpod tools, watcher callbacks) leave them
+      // holding the OLD host — and buildMcpServers()/refreshEnvCapabilities()
+      // below would rebuild/respawn agents against it (codex finding).
+      comfyuiUrl = url;
+      comfyuiPath = localPathForTarget(url);
+      try {
+        QueueMonitor.stop();
+      } catch {
+        /* best-effort */
+      }
+      QueueMonitor.start(url);
+      manager.setMcpServers(buildMcpServers());
+      manager.setComfyuiUrl(url);
+      manager.restartAllForMcpEnv();
+      void refreshEnvCapabilities();
+    }
+    // The readvertise timer follows the target too (created only at startup
+    // before — a local→pod retarget left the pod unable to learn the bridge
+    // URL, codex finding). Cheap no-op for same-url events.
+    syncReadvertise(url);
     void bridge.push({ type: "comfyui_target", url, is_local: isLocal });
   });
 
@@ -3427,14 +3793,98 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the advertise on a cheap idempotent timer repopulates the pod's store within
   // one interval of any reboot (from any cause: the agent's restart, a Manager
   // UI restart, a crash), so the browser's reclaim poll reconnects promptly.
-  // Only meaningful for a remote https target with a secure bridge.
+  // Only meaningful for a remote https target with a secure bridge. Driven by
+  // syncReadvertise at STARTUP and on every retarget (codex finding: a
+  // local→pod retarget later left the timer nonexistent, so the pod could
+  // never learn the WSS URL/token — the very deadlock it prevents). The
+  // bridge itself is created LAZILY on the first remote target too (a local
+  // boot has wantSecureBridge=false — codex finding).
   let readvertiseTimer: ReturnType<typeof setInterval> | null = null;
-  if (secureBridge && isRemoteHttpsUrl(comfyuiUrl)) {
-    readvertiseTimer = setInterval(() => {
-      if (secureBridge && isRemoteHttpsUrl(comfyuiUrl)) void secureBridge.advertise(comfyuiUrl);
-    }, 5000);
-    readvertiseTimer.unref?.();
-  }
+  // One in-flight setup MAX — concurrent ticks must not each start a tunnel
+  // (codex finding: a slow first attempt spawned multiple cloudflared clients).
+  let secureBridgeSetup: Promise<void> | null = null;
+  // A tokenless primary listener does NOT rule out pod panels: the tunnel gets
+  // its OWN token-gated listener (same addListener mechanism the phone-pair
+  // flow uses) on a dedicated port — never retrofit auth onto the public path
+  // and never open a tunnel in front of an unauthenticated one (codex P1).
+  // Port map: +0 bridge, +1 panel_* HTTP-MCP, +2 phone-pair, +3 console (line
+  // ~1427), +4 tunnel listener (codex finding: +3 was already taken).
+  const tunnelPort = lockPort + 4;
+  let tunnelToken: string | null = null;
+  let tunnelListenerStarted = false;
+  const ensureSecureBridge = async (url: string): Promise<void> => {
+    if (secureBridge) return;
+    if (!secureBridgeSetup) {
+      secureBridgeSetup = (async () => {
+        try {
+          let port = lockPort;
+          let token: string;
+          if (bridgeListenerTokenless) {
+            // Primary listener stays tokenless for local use; the tunnel binds
+            // its own token-gated listener (pair-flow precedent) and advertises
+            // THAT token — enforced, because this listener was built with it.
+            // Bound ONCE: a retried setup must reuse it, not EADDRINUSE (codex).
+            tunnelToken ??= randomBytes(24).toString("hex");
+            if (!tunnelListenerStarted) {
+              await bridge.addListener("0.0.0.0", tunnelPort, tunnelToken);
+              tunnelListenerStarted = true;
+            }
+            port = tunnelPort;
+            token = tunnelToken;
+          } else if (bridgeToken) {
+            token = bridgeToken;
+          } else {
+            return; // unreachable — the tokenless branch above covers this
+          }
+          secureBridge = await setupSecureBridge({
+            bridgePort: port,
+            comfyuiUrl: url,
+            token,
+            bridge,
+            // The setup itself advertises on completion — guard it too: a slow
+            // tunnel must not hand the bridge URL to a pod the user already
+            // left (codex finding: the post-await guard alone couldn't stop it).
+            shouldAdvertise: (t) => comfyuiUrl === t && isRemoteHttpsUrl(t),
+          });
+        } catch (err) {
+          logger.error(
+            `[panel-orchestrator] secure bridge (cloudflared) failed: ${err instanceof Error ? err.message : String(err)}. ` +
+              `Install cloudflared (npm i -g cloudflared), or re-run with --insecure-bridge and open the pod through an ` +
+              `SSH tunnel (ssh -L 3000:localhost:3000 …) at http://localhost:3000.`,
+          );
+        } finally {
+          secureBridgeSetup = null;
+        }
+      })();
+    }
+    return secureBridgeSetup;
+  };
+  const syncReadvertise = (url: string) => {
+    const wanted = !insecureBridge && isRemoteHttpsUrl(url);
+    if (wanted && !readvertiseTimer) {
+      // Immediate first advertise (creating the tunnel on a local→pod
+      // transition), then the interval.
+      void (async () => {
+        await ensureSecureBridge(url);
+        // The user may have moved on while the tunnel came up — advertising an
+        // OLD pod now would let its panel hello steal the newer target (codex).
+        if (secureBridge && comfyuiUrl === url && isRemoteHttpsUrl(url)) void secureBridge.advertise(url);
+      })();
+      readvertiseTimer = setInterval(() => {
+        void (async () => {
+          if (isRemoteHttpsUrl(comfyuiUrl)) {
+            await ensureSecureBridge(comfyuiUrl);
+            if (secureBridge) void secureBridge.advertise(comfyuiUrl);
+          }
+        })();
+      }, 5000);
+      readvertiseTimer.unref?.();
+    } else if (!wanted && readvertiseTimer) {
+      clearInterval(readvertiseTimer);
+      readvertiseTimer = null;
+    }
+  };
+  syncReadvertise(comfyuiUrl);
 
   // The no-path suffix must not read as an error when it is BY DESIGN: for a
   // remote target a local path is the wrong filesystem and is deliberately
@@ -3465,6 +3915,13 @@ export async function runPanelOrchestrator(): Promise<void> {
     clearInterval(queueStatusTimer);
     if (readvertiseTimer) clearInterval(readvertiseTimer);
     QueueMonitor.stop();
+    // Remove OUR nonced progress dir (startup reaps previous lives') so the
+    // auto-restart cycle doesn't accumulate temp dirs (codex finding).
+    try {
+      rmSync(progressDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
     unsubscribeSecrets();
     unsubscribeAgentSecrets();
     await manager.stopAll();

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1898,6 +1898,20 @@ export async function runPanelOrchestrator(): Promise<void> {
   // ComfyUI the user actually has open — local OR a RunPod proxy — with no
   // `connect <url>`. Loopback → LOCAL mode (keep COMFYUI_PATH); non-loopback →
   // REMOTE mode (drop the path). No-op if unchanged. Returns true if it retargeted.
+  // Same-URL canonicalization, DEFAULT-PORT-INSENSITIVE but SCHEME-AWARE:
+  // strip only the scheme's actual default (:443 for https, :80 for http) —
+  // http://h:443 and http://h are NOT the same endpoint (codex finding).
+  // Shared by applyComfyuiUrl's dedupe and the control-channel ack check
+  // (runpodProxyUrl omits :443 while getComfyUIBaseUrl includes it — codex).
+  const canonTargetUrl = (u: string): string => {
+    try {
+      const p = new URL(u);
+      if ((p.protocol === "https:" && p.port === "443") || (p.protocol === "http:" && p.port === "80")) p.port = "";
+      return p.toString().replace(/\/+$/, "");
+    } catch {
+      return u.replace(/\/+$/, "");
+    }
+  };
   const applyComfyuiUrl = (rawUrl: unknown): boolean => {
     if (typeof rawUrl !== "string") return false;
     const next = rawUrl.trim().replace(/\/+$/, "");
@@ -1910,19 +1924,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     } catch {
       return false; // not a valid URL — ignore (keep current target)
     }
-    // Same-URL check is DEFAULT-PORT-INSENSITIVE but SCHEME-AWARE: strip only
-    // the scheme's actual default (:443 for https, :80 for http) — http://h:443
-    // and http://h are NOT the same endpoint (codex finding).
-    const canon = (u: string): string => {
-      try {
-        const p = new URL(u);
-        if ((p.protocol === "https:" && p.port === "443") || (p.protocol === "http:" && p.port === "80")) p.port = "";
-        return p.toString().replace(/\/+$/, "");
-      } catch {
-        return u.replace(/\/+$/, "");
-      }
-    };
-    if (!host || canon(next) === canon(comfyuiUrl)) return false;
+    if (!host || canonTargetUrl(next) === canonTargetUrl(comfyuiUrl)) return false;
     const prev = comfyuiUrl;
     comfyuiUrl = next;
     comfyuiPath = localPathForTarget(next);
@@ -3469,7 +3471,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // Generation guard for URL retargets: drop the retarget when a NEWER
         // direct choice moved the target after the child wrote this (codex
         // finding: a queued pod-A request applied after the user picked pod B).
-        const urlGenOk = !req.expectedCurrentUrl || getComfyUIBaseUrl() === req.expectedCurrentUrl;
+        const urlGenOk = !req.expectedCurrentUrl || canonTargetUrl(getComfyUIBaseUrl()) === canonTargetUrl(req.expectedCurrentUrl);
         // Only an APPLIED target/unwatch choice supersedes pending auto-connects
         // (watch-ONLY isn't a choice; a guarded-OUT or generation-STALE request
         // applied nothing and must not drop a booting pod's promise — codex
@@ -3516,7 +3518,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // Whether a URL retarget landed (generation-guarded): the ack must
         // confirm the AUTHORITATIVE retarget before the child reports success
         // (codex finding: rejected writes still read "connected").
-        const connectApplied = !!req.url && urlGenOk && getComfyUIBaseUrl() === req.url;
+        const connectApplied = !!req.url && urlGenOk && canonTargetUrl(getComfyUIBaseUrl()) === canonTargetUrl(req.url);
         if (req.connectWhenReady && urlGenOk) {
           // The ORCHESTRATOR waits for boot (the tool call returned inside the
           // MCP 60s lifetime): probe every ~10s, retarget+watch on ready, and

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -9,8 +9,9 @@
 // This no-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — i.e. for every
 // normal (non-panel) use of the MCP — so it costs nothing outside the panel.
 
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { basename, dirname, join } from "node:path";
 
 export interface DownloadProgress {
   /** Stable id for this download (a hash of the source URL). */
@@ -27,9 +28,25 @@ export interface DownloadProgress {
   status: "downloading" | "done" | "error";
   /** Epoch ms of this snapshot (set on write). */
   updated: number;
+  /** The ComfyUI target this download serves (the writer's own COMFYUI_URL at
+   *  write time — self-scoping, no reporter changes needed). The pod idle-stop
+   *  veto counts ONLY rows for the watched pod: a local download must not
+   *  disable a pod's auto-stop, nor vice versa (#269). Absent on pre-fix rows. */
+  target?: string;
 }
 
 const PROGRESS_DIR = process.env.COMFYUI_MCP_PROGRESS_DIR || "";
+/** Late-bound by the ORCHESTRATOR at startup (its own process has no env var —
+ *  codex finding: the control channel was dead for in-process direct/mobile
+ *  tool calls). progressEnabled() stays env-only on purpose: runpod.ts uses it
+ *  as the spawned-child discriminator, and the orchestrator is NOT a child. */
+let lateBoundDir = "";
+export function setProgressDir(dir: string): void {
+  lateBoundDir = dir;
+}
+function channelDir(): string {
+  return PROGRESS_DIR || lateBoundDir;
+}
 const lastWriteAt = new Map<string, number>();
 
 /** True when running under the panel orchestrator (progress channel is active). */
@@ -37,9 +54,34 @@ export function progressEnabled(): boolean {
   return !!PROGRESS_DIR;
 }
 
-function fileFor(id: string): string {
+function fileFor(id: string, target?: string): string {
   // The id is a hex hash from callers, but stay defensive about the filename.
-  return join(PROGRESS_DIR, `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}.json`);
+  // Include a TARGET discriminator (codex finding: the same URL downloaded for
+  // local AND pod concurrently shared one file — the last writer's target won
+  // the per-pod idle veto and a pod could be auto-stopped mid-transfer).
+  const disc = createHash("sha1")
+    .update(target ?? `pid:${process.pid}`)
+    .digest("hex")
+    .slice(0, 8);
+  return join(PROGRESS_DIR, `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${disc}.json`);
+}
+
+/** Credential-free form of a target URL for persisted rows / control files:
+ *  strips userinfo (https://user:pass@host) before anything hits disk or a
+ *  bridge frame (codex finding — raw COMFYUI_URL was being broadcast). */
+function redactUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    u.username = "";
+    u.password = "";
+    // Query/fragment can carry credentials too (?token=secret) — the contract
+    // is credential-free before disk/broadcast (codex finding).
+    u.search = "";
+    u.hash = "";
+    return u.toString().replace(/\/+$/, "");
+  } catch {
+    return raw.split("@").pop() ?? raw; // unparseable — drop anything before the last @
+  }
 }
 
 /**
@@ -59,18 +101,204 @@ export function reportDownloadProgress(
   lastWriteAt.set(p.id, now);
   try {
     mkdirSync(PROGRESS_DIR, { recursive: true });
-    writeFileSync(fileFor(p.id), JSON.stringify({ ...p, updated: now }));
+    // Stamp the writer's OWN target (the spawned MCP child's COMFYUI_URL): the
+    // idle-stop veto scopes by it, and after a retarget the respawned child
+    // reports against the new host while stale rows age out (codex finding:
+    // a process-wide count let any download disable any pod's auto-stop).
+    // Redacted — target URLs can carry userinfo (codex finding).
+    const rawTarget = p.target ?? (process.env.COMFYUI_URL?.trim() || undefined);
+    const target = rawTarget ? redactUrl(rawTarget) : undefined;
+    writeFileSync(fileFor(p.id, target), JSON.stringify({ ...p, target, updated: now }));
   } catch {
     // best-effort — progress is cosmetic, never fail a download over it
   }
 }
 
-/** Remove a download's progress file (e.g. on cancel). */
+/** Remove a download's progress file(s) (e.g. on cancel). Target-scoped files
+ *  share the id prefix, so clear every variant for the logical download. */
 export function clearDownloadProgress(id: string): void {
   if (!PROGRESS_DIR) return;
   lastWriteAt.delete(id);
   try {
-    rmSync(fileFor(id), { force: true });
+    const prefix = `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-`;
+    for (const f of readdirSync(PROGRESS_DIR)) {
+      if (f.startsWith(prefix) && f.endsWith(".json")) rmSync(join(PROGRESS_DIR, f), { force: true });
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// ── Control channel (MCP child → orchestrator) ──────────────────────────────
+// runpod_* tools invoked by a panel AGENT run in the spawned stdio MCP child:
+// setComfyuiTarget / getRunpodWatcher() there affect only that child — the
+// orchestrator's QueueMonitor, watcher, host indicator and agent envs would
+// stay on the old target while the tool result claims "connected + watched"
+// (#269, codex). This one-file request channel reuses the proven progress-dir
+// plumbing: the child stamps a target request; the orchestrator's 700ms
+// poll loop applies it through the SAME applyComfyuiUrl fan-out as a panel
+// hello. Self-healing (a stale request is ignored after its TTL) and idempotent
+// (in-process callers already applied the change — re-applying dedupes).
+
+export interface TargetChangeRequest {
+  /** Retarget the orchestrator here (omit for a watch/unwatch-only request). */
+  url?: string;
+  /** Generation guard for URL retargets (codex finding): apply ONLY when the
+   *  orchestrator's CURRENT target still equals what the child saw at write
+   *  time — a newer direct choice made during the poll delay must not be
+   *  overwritten by a stale queued request. */
+  expectedCurrentUrl?: string;
+  /** Retarget to the orchestrator's OWN resolved local fallback — the child
+   *  must not guess it: a child spawned AFTER a pod connect has no memory of
+   *  the LAN rig, and would wrongly overwrite it with 127.0.0.1 (codex). */
+  local?: boolean;
+  /** Only retarget local when the orchestrator's CURRENT target is this pod —
+   *  a stale child (left on pod A after another tab moved to B) stopping A
+   *  must not drag the authoritative target off B (codex finding). The ack
+   *  still reports the resulting URL so the stale child ALIGNS to it. */
+  onlyIfTarget?: string;
+  /** A pod the caller just STOPPED — the orchestrator clears its recorded
+   *  auto-connect failure (a spawned child's stop otherwise leaves the
+   *  "still billing" warning up forever — codex finding). */
+  stoppedPodId?: string;
+  /** Wait for this pod's ComfyUI to become READY (stats+queue), THEN retarget
+   *  + watch — the ORCHESTRATOR waits, so the tool call returns inside the
+   *  MCP 60s request lifetime instead of blocking for minutes (codex). */
+  connectWhenReady?: { url: string; podId: string };
+  /** Pod to watch (status broadcast + idle auto-stop) after the retarget. */
+  watchPodId?: string;
+  /** Stop watching entirely (local switch). */
+  unwatch?: boolean;
+  /** Scope the unwatch to THIS pod (stop-fallback): the orchestrator unwatches
+   *  only when it's actually watching this one — an unrelated watched pod must
+   *  survive a different pod's stop (codex finding). */
+  unwatchPodId?: string;
+  /** Set when the requester will block on awaitTargetApplied — the orchestrator
+   *  writes an applied-ack ONLY for these (fire-and-forget requests would leak
+   *  ack files nobody consumes — codex finding). */
+  wantAck?: boolean;
+  updated: number;
+}
+
+const CONTROL_TTL_MS = 60_000; // a request older than this is stale — ignore
+/** Per-request control files are prefixed so the orchestrator consumes EXACTLY
+ *  the file it read (no read-then-delete race between agent children, and no
+ *  timestamp-collision identity problems — codex finding). Kept OUT of
+ *  pollDownloads' tray rows via the "control-" prefix (applied-acks too). */
+export const CONTROL_PREFIX = "control-";
+const REQUEST_PREFIX = `${CONTROL_PREFIX}target-`;
+const APPLIED_PREFIX = `${CONTROL_PREFIX}applied-`;
+let controlSeq = 0;
+
+function controlDirPath(dir: string = channelDir()): string | null {
+  return dir || null;
+}
+
+/** Ask the orchestrator to retarget (+ optionally watch a pod). Returns the
+ *  request file path (for awaitTargetApplied), or null when the channel is
+ *  inactive (no progress dir). */
+export function requestTargetChange(req: Omit<TargetChangeRequest, "updated">): string | null {
+  const dir = controlDirPath();
+  if (!dir) return null;
+  try {
+    mkdirSync(dir, { recursive: true });
+    // Redact any credential-bearing target URL before it touches disk (codex).
+    const safe: Omit<TargetChangeRequest, "updated"> = {
+      ...req,
+      ...(req.url ? { url: redactUrl(req.url) } : {}),
+      ...(req.connectWhenReady ? { connectWhenReady: { ...req.connectWhenReady, url: redactUrl(req.connectWhenReady.url) } } : {}),
+    };
+    // Unique-per-request file: consumption deletes exactly this name — a second
+    // child's request can never be clobbered by the first's delete.
+    const file = join(dir, `${REQUEST_PREFIX}${process.pid}-${Date.now()}-${controlSeq++}.json`);
+    writeFileSync(file, JSON.stringify({ ...safe, updated: Date.now() }));
+    return file;
+  } catch {
+    return null; // best-effort — the caller's own retarget still happened
+  }
+}
+
+/** The ack file the orchestrator writes after applying a given request file. */
+function appliedFileFor(requestFile: string): string {
+  return join(dirname(requestFile), `${APPLIED_PREFIX}${basename(requestFile).slice(REQUEST_PREFIX.length)}`);
+}
+
+/** Child side: wait for the orchestrator to apply our request and report the
+ *  RESULTING target (its own remembered LAN fallback included — the child
+ *  can't compute it, codex finding). Returns the ack, or null on timeout —
+ *  callers must then report honestly rather than guess 127.0.0.1. */
+export async function awaitTargetApplied(requestFile: string, timeoutMs = 4_000): Promise<{ url: string; applied: boolean } | null> {
+  const ack = appliedFileFor(requestFile);
+  const start = Date.now();
+  for (;;) {
+    try {
+      const raw = JSON.parse(readFileSync(ack, "utf-8")) as { url?: string; applied?: boolean };
+      if (typeof raw?.url === "string") {
+        rmSync(ack, { force: true }); // consumed — don't leak it into a later poll
+        return { url: raw.url, applied: raw.applied !== false };
+      }
+    } catch {
+      // not applied yet
+    }
+    if (Date.now() - start > timeoutMs) return null;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+}
+
+export interface PendingTargetChange {
+  req: TargetChangeRequest;
+  file: string;
+}
+
+/** Orchestrator side: all fresh pending requests (within TTL), oldest first.
+ *  The dir is EXPLICIT: the orchestrator computes progressDir itself while the
+ *  module-level env capture is unset in its own process (codex finding — the
+ *  channel was write-only: children stamped, nobody read). */
+export function listTargetChangeRequests(dir: string): PendingTargetChange[] {
+  const out: PendingTargetChange[] = [];
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir).filter((f) => f.startsWith(REQUEST_PREFIX) && f.endsWith(".json"));
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    try {
+      const file = join(dir, f);
+      const raw = JSON.parse(readFileSync(file, "utf-8")) as TargetChangeRequest;
+      if (typeof raw?.updated !== "number") continue;
+      if (!raw.url && !raw.local && !raw.watchPodId && !raw.unwatch && !raw.connectWhenReady && !raw.stoppedPodId) continue;
+      if (Date.now() - raw.updated > CONTROL_TTL_MS) {
+        rmSync(file, { force: true }); // reap stale requests while we're here
+        continue;
+      }
+      out.push({ req: raw, file });
+    } catch {
+      // mid-write or corrupt — retry next tick
+    }
+  }
+  return out.sort((a, b) => a.req.updated - b.req.updated);
+}
+
+/** Orchestrator side: after applying a request, ack it with the RESULTING
+ *  target so the requesting child can align its own process to the TRUE
+ *  fallback/target (it can't compute the orchestrator's remembered LAN URL —
+ *  codex finding). `applied` reports whether a guarded (onlyIfTarget) request
+ *  was actually applied — a guarded-out request must not read as a successful
+ *  local switch (codex finding). Best-effort; the child times out gracefully. */
+export function ackTargetChange(requestFile: string, url: string, applied = true): void {
+  try {
+    writeFileSync(appliedFileFor(requestFile), JSON.stringify({ url, applied, updated: Date.now() }));
+  } catch {
+    // ignore
+  }
+}
+
+/** Orchestrator side: consume one applied request file (exactly the file that
+ *  was read — never a newer replacement, since each request is its own file). */
+export function consumeTargetChange(file: string): void {
+  try {
+    rmSync(file, { force: true });
   } catch {
     // ignore
   }

--- a/src/services/runpod-watch.ts
+++ b/src/services/runpod-watch.ts
@@ -11,6 +11,8 @@
 // configured timeout the pod is stopped automatically (pods bill per running
 // GPU-second even when doing nothing). Off when idleStopMinutes <= 0.
 
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { getPod, stopPod, comfyuiPortExposed, runpodProxyUrl, type RunpodPod } from "./runpod-client.js";
 import { logger } from "../utils/logger.js";
 
@@ -36,9 +38,30 @@ export interface RunpodStatusFrame extends Record<string, unknown> {
   autostop_minutes: number | null;
   /** Seconds until auto-stop fires (null when disabled / not idle / not running). */
   autostop_in_seconds: number | null;
-  /** True when an idle auto-stop ATTEMPT failed — the pod is still running (and
-   *  billing); the watcher keeps watching and retries next tick. */
-  autostop_failed?: boolean;
+  /** True when a promised create-and-auto-connect did NOT happen (readiness
+   *  timeout or superseded by a sibling winner). Decorates ONLY this pod's own
+   *  status frames — failure ALERTS for other pods ride `runpod_alert` so they
+   *  can't clobber the single watched-pod status slot (codex finding). */
+  connect_failed?: boolean;
+  /** The winning pod that superseded this one's auto-connect, when relevant. */
+  superseded_by?: string;
+}
+
+/** A billing-relevant auto-connect FAILURE, on its own channel so it can't
+ *  overwrite the watched pod's status in the single-slot panel store (codex
+ *  finding). `resolved: true` retracts a previous alert (stopped/reconciled). */
+export interface RunpodAlertFrame extends Record<string, unknown> {
+  type: "runpod_alert";
+  pod_id: string;
+  /** "timeout" | "superseded" | "resolved" */
+  reason: string;
+  status: string;
+  name?: string | null;
+  gpu?: string | null;
+  cost_per_hr?: number | null;
+  uptime_seconds?: number | null;
+  superseded_by?: string;
+  resolved?: boolean;
 }
 
 const CLEARED_FRAME: RunpodStatusFrame = {
@@ -70,8 +93,19 @@ export interface RunpodWatcherDeps {
    *  (e.g. while it boots, before connect) must never be stopped on the LOCAL
    *  ComfyUI's idleness, which comfyuiIdle() reports when we haven't connected. */
   renderingOnPod: (podId: string) => boolean;
+  /** The watched pod VANISHED (terminated externally) or was auto-stopped. The
+   *  orchestrator uses this to fall back to the local target when the dead pod
+   *  was the ACTIVE render target — otherwise renders keep failing against a
+   *  dead proxy (#269 dead-target cleanup). Guarded there (not every watched
+   *  pod is the render target). */
+  onPodUnavailable?: (podId: string) => void;
   /** Idle-stop timeout in minutes; <= 0 disables auto-stop. */
   idleStopMinutes: number;
+  /** Optional: persist unresolved connect-failure records here (per-port path)
+   *  so an orchestrator self-restart doesn't lose billing warnings for pods
+   *  that are still running (codex finding). Restored at creation; re-saved on
+   *  every mutation. */
+  persistPath?: string;
   /** Poll interval in ms (default 15000). */
   pollMs?: number;
   /** Injectable clock for tests. */
@@ -87,6 +121,19 @@ export interface RunpodWatcher {
   watchedPodId(): string | null;
   /** The last frame sent (for seeding a tab that just connected). */
   current(): RunpodStatusFrame;
+  /** Failure frames for pods whose auto-connect failed (timeout/superseded) —
+   *  held SEPARATELY from the single watched frame so a routine poll of the
+   *  watched pod can't overwrite the only warning (codex finding). Seeded to
+   *  new tabs alongside current(). */
+  failedFrames(): RunpodAlertFrame[];
+  /** Record a failed auto-connect for a pod: the failure is stored (current()
+ *  seeds it to new tabs) and `connect_failed` rides every later frame for that
+ *  pod until it exits/vanishes (codex finding: a one-shot bridge push lets the
+ *  only warning evaporate on the next routine poll). */
+  markConnectFailed(podId: string, frame: RunpodAlertFrame): void;
+  /** Clear a pod's failure record (e.g. after a successful runpod_pod_stop —
+ *  otherwise an unwatched failed pod reports "still billing" forever). */
+  clearConnectFailed(podId: string): void;
   /** Poll once now (also driven internally by the interval). Exposed for tests. */
   poll(): Promise<void>;
   /** Begin the poll interval. */
@@ -145,7 +192,85 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
       idle_seconds: idleSeconds,
       autostop_minutes: idleStopMs > 0 ? deps.idleStopMinutes : null,
       autostop_in_seconds: autostopIn,
+      // A failed auto-connect STICKS to this pod's frames until it exits or
+      // vanishes (markConnectFailed) — the only warning must not evaporate on
+      // the next routine uptime tick (codex finding).
+      ...(connectFailedPods.has(pod.id) ? { connect_failed: true as const } : {}),
     };
+  }
+
+  /** Pods whose auto-connect failed (timeout/superseded) — failure sticks to
+   *  their frames + the seed until they're gone. */
+  const connectFailedPods = new Set<string>();
+  /** Failure frames by pod — the seed channel, independent of `last`. */
+  const failedById = new Map<string, RunpodAlertFrame>();
+  /** Clear + broadcast "resolved" — every removal path (janitor, stop, connect,
+   *  vanish, terminal) goes through here so panels RETRACT the alert instead of
+   *  keeping a stale billing warning (codex finding). */
+  function clearFailure(id: string): void {
+    const prior = failedById.get(id);
+    connectFailedPods.delete(id);
+    failedById.delete(id);
+    if (prior) deps.push({ ...prior, reason: "resolved", resolved: true });
+    persistFailures();
+  }
+
+  /** Persist unresolved failures across orchestrator self-restarts (pods keep
+   *  billing while the process cycles — codex finding). Best-effort. */
+  function persistFailures(): void {
+    if (!deps.persistPath) return;
+    try {
+      mkdirSync(dirname(deps.persistPath), { recursive: true });
+      if (failedById.size === 0) {
+        rmSync(deps.persistPath, { force: true });
+        return;
+      }
+      writeFileSync(deps.persistPath, JSON.stringify([...failedById.values()]));
+    } catch {
+      /* best-effort */
+    }
+  }
+  // Restore failures recorded before a restart (not re-broadcast — new tabs
+  // seed from failedFrames(); future polls re-decorate via frameFor).
+  if (deps.persistPath) {
+    try {
+      const saved = JSON.parse(readFileSync(deps.persistPath, "utf-8")) as RunpodAlertFrame[];
+      for (const f of saved) {
+        if (f && typeof f.pod_id === "string") {
+          failedById.set(f.pod_id, f);
+          connectFailedPods.add(f.pod_id);
+        }
+      }
+    } catch {
+      // no saved state
+    }
+  }
+  /** Janitor: every ~10 polls, reconcile failure entries for pods we are NOT
+   *  watching (their stop/vanish never reaches our poll paths — codex finding:
+   *  an externally-stopped loser warned "still billing" forever). */
+  let reconcileCounter = 0;
+  async function reconcileFailedPods(): Promise<void> {
+    for (const id of [...failedById.keys()]) {
+      if (id === podId) continue; // the watched pod's own poll paths handle it
+      try {
+        const pod = await getPod(id);
+        if (!pod || pod.desiredStatus === "EXITED" || pod.desiredStatus === "TERMINATED" || pod.desiredStatus === "DEAD" || pod.desiredStatus === "PAUSED") {
+          // Same broadcast correction as clearConnectFailed — the janitor's
+          // delete must not leave the stale failure on panels (codex).
+          const prior = failedById.get(id);
+          failedById.delete(id);
+          connectFailedPods.delete(id);
+          if (prior) {
+            // Retract the alert with the TERMINAL status (the stale RUNNING
+            // line must not live forever — codex finding).
+            deps.push({ ...prior, reason: "resolved", resolved: true, status: pod?.desiredStatus ?? "TERMINATED" });
+          }
+        }
+      } catch {
+        // unknown — keep the warning (cost-safe direction)
+      }
+    }
+    persistFailures();
   }
 
   // In-flight guard: on a hung network a slow poll must not stack up under the
@@ -154,6 +279,13 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
   let inflight: Promise<void> | null = null;
 
   function poll(): Promise<void> {
+    // Janitor tick BEFORE the target check: failures must reconcile even with
+    // NO watched pod (codex finding — an externally-stopped loser warned
+    // "still billing" forever). Cheap: only when failures exist, ~10 polls.
+    if (failedById.size > 0 && ++reconcileCounter >= 10) {
+      reconcileCounter = 0;
+      void reconcileFailedPods();
+    }
     if (inflight) return inflight;
     inflight = pollOnce().finally(() => {
       inflight = null;
@@ -179,9 +311,31 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     }
     if (podId !== target) return; // target changed while awaiting → stale, drop
     if (!pod) {
-      // Pod vanished (terminated) — stop watching.
+      // Pod vanished (terminated) — stop watching, and tell the orchestrator:
+      // if renders were targeting this pod's proxy, the active target is now
+      // DEAD and must fall back to local (#269 dead-target cleanup).
       logger.info(`[runpod-watch] pod ${target} no longer exists — unwatching`);
+      clearFailure(target);
       unwatch();
+      deps.onPodUnavailable?.(target);
+      return;
+    }
+    // A RETAINED pod still answers getPod after being stopped externally
+    // (console / another process): desiredStatus EXITED/TERMINATED/DEAD with
+    // runtime null. Same dead-target cleanup as the vanish path — otherwise
+    // the dead proxy stays the active render target forever (codex finding).
+    // Booting states (CREATED/RESTARTING) merely keep watching.
+    if (pod.desiredStatus === "EXITED" || pod.desiredStatus === "TERMINATED" || pod.desiredStatus === "DEAD" || pod.desiredStatus === "PAUSED") {
+      logger.info(`[runpod-watch] pod ${target} is ${pod.desiredStatus} — unwatching`);
+      // Clear the failure BEFORE the terminal frame is cached as `last` —
+      // otherwise current() seeds a stale connect_failed flag to new tabs even
+      // though the alert was resolved (codex finding).
+      clearFailure(target);
+      pushIfChanged(frameFor(pod, null, null));
+      const goneTarget = target;
+      podId = null;
+      idleSinceMs = null;
+      deps.onPodUnavailable?.(goneTarget);
       return;
     }
 
@@ -224,8 +378,12 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
           pushIfChanged(stopped);
           // Stop watching WITHOUT clearing — the panel keeps showing the pod as
           // EXITED (so the user can restart it) instead of the card vanishing.
+          const goneTarget = target;
           podId = null;
           idleSinceMs = null;
+          // Same dead-target cleanup as the vanish path: if renders pointed at
+          // this pod, fall back to local (#269).
+          deps.onPodUnavailable?.(goneTarget);
           return;
         }
       }
@@ -240,6 +398,11 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     const switching = podId !== id;
     podId = id;
     idleSinceMs = null;
+    // A SUCCESSFUL connect (we're now rendering on this pod) resolves its past
+    // failure — but a watch-ONLY flow (boot monitor, runpod_watch) must not
+    // erase a persisted warning for an unconnected, still-billing pod (codex
+    // finding). clearFailure broadcasts the "resolved" alert.
+    if (deps.renderingOnPod(id)) clearFailure(id);
     // Kick an immediate poll so the panel doesn't wait a full interval. If a poll
     // for the PREVIOUS target is still in flight, don't overlap it — chain a fresh
     // poll after it settles (that stale poll drops its own result via the
@@ -262,6 +425,21 @@ export function createRunpodWatcher(deps: RunpodWatcherDeps): RunpodWatcher {
     unwatch,
     watchedPodId: () => podId,
     current: () => last,
+    markConnectFailed(id, frame) {
+      // Record the failure: stored SEPARATELY from `last` (a routine poll of
+      // the watched pod must not overwrite the only warning — codex finding),
+      // broadcast WITHOUT touching the watched-frame cache (a new tab must
+      // still get the watched pod's real status from current(), not the
+      // loser's failure — codex finding), and stuck to this pod's later
+      // frames (frameFor) until it exits/vanishes or is intentionally
+      // reconnected (watch()).
+      connectFailedPods.add(id);
+      failedById.set(id, frame);
+      deps.push(frame);
+      persistFailures();
+    },
+    failedFrames: () => [...failedById.values()],
+    clearConnectFailed: clearFailure,
     poll,
     start() {
       if (timer) return;

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -66,7 +66,7 @@ function maskToken(url: string): string {
  * Retries a few times — the orchestrator may advertise before the pod route is
  * warm. Returns true on the first 2xx.
  */
-export async function advertiseBridge(comfyuiUrl: string, wssUrl: string): Promise<boolean> {
+export async function advertiseBridge(comfyuiUrl: string, wssUrl: string, shouldAdvertise?: (target: string) => boolean): Promise<boolean> {
   let endpoint: string;
   try {
     endpoint = new URL("/comfyui_mcp_panel/advertise_bridge", comfyuiUrl).toString();
@@ -74,6 +74,9 @@ export async function advertiseBridge(comfyuiUrl: string, wssUrl: string): Promi
     return false;
   }
   for (let attempt = 0; attempt < 3; attempt += 1) {
+    // Re-check per attempt: the target may have moved DURING the retry sequence
+    // — a stale pod must never receive the bridge URL (codex finding).
+    if (shouldAdvertise && !shouldAdvertise(comfyuiUrl)) return false;
     try {
       const res = await fetch(endpoint, {
         method: "POST",
@@ -99,6 +102,10 @@ export interface SetupSecureBridgeOpts {
   /** Needed only by the relay backend, to feed relay-multiplexed panel
    *  connections into the same routing logic a direct loopback socket gets. */
   bridge: UiBridge;
+  /** Optional guard evaluated PER ADVERTISE TARGET (a slow tunnel setup or a
+   *  later retarget must not hand the bridge URL to a stale pod — codex).
+   *  Receives each candidate target URL. */
+  shouldAdvertise?: (target: string) => boolean;
 }
 
 /**
@@ -143,13 +150,20 @@ async function setupRelayBridge(opts: SetupSecureBridgeOpts): Promise<SecureBrid
     onAttach: (sock) => bridge.attachRelayConnection(sock),
   });
   client.start();
-  await client.waitUntilOpen();
+  try {
+    await client.waitUntilOpen();
+  } catch (err) {
+    // A failed setup must not leave a reconnecting client behind — the 5s
+    // retry would pile one on every attempt during a relay outage (codex).
+    client.stop();
+    throw err;
+  }
 
   const wssUrl = `${relayUrl.replace(/\/+$/, "")}/s/${sessionId}?token=${token}`;
   logger.info(`[secure-bridge] bridge exposed via relay at ${maskToken(wssUrl)}`);
 
   const advertise = async (target: string): Promise<boolean> => {
-    const ok = await advertiseBridge(target, wssUrl);
+    const ok = await advertiseBridge(target, wssUrl, opts.shouldAdvertise);
     if (ok) {
       logger.info(`[secure-bridge] advertised the secure bridge URL to the pod panel`);
     } else {
@@ -161,7 +175,9 @@ async function setupRelayBridge(opts: SetupSecureBridgeOpts): Promise<SecureBrid
     return ok;
   };
 
-  await advertise(comfyuiUrl);
+  if (!opts.shouldAdvertise || opts.shouldAdvertise(comfyuiUrl)) {
+    await advertise(comfyuiUrl);
+  }
 
   return {
     wssUrl,
@@ -193,7 +209,7 @@ async function setupCloudflaredBridge(opts: SetupSecureBridgeOpts): Promise<Secu
   logger.info(`[secure-bridge] bridge exposed securely at ${maskToken(wssUrl)}`);
 
   const advertise = async (target: string): Promise<boolean> => {
-    const ok = await advertiseBridge(target, wssUrl);
+    const ok = await advertiseBridge(target, wssUrl, opts.shouldAdvertise);
     if (ok) {
       logger.info(`[secure-bridge] advertised the secure bridge URL to the pod panel`);
     } else {
@@ -205,7 +221,9 @@ async function setupCloudflaredBridge(opts: SetupSecureBridgeOpts): Promise<Secu
     return ok;
   };
 
-  await advertise(comfyuiUrl);
+  if (!opts.shouldAdvertise || opts.shouldAdvertise(comfyuiUrl)) {
+    await advertise(comfyuiUrl);
+  }
 
   return {
     wssUrl,

--- a/src/tools/runpod.ts
+++ b/src/tools/runpod.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { setComfyuiTarget, getLocalComfyuiUrl } from "../config.js";
+import { setComfyuiTarget, getLocalComfyuiUrl, getComfyUIBaseUrl } from "../config.js";
 import { resetClient } from "../comfyui/client.js";
 import { errorToToolResult } from "../utils/errors.js";
 import {
@@ -18,13 +18,39 @@ import {
   type RunpodPod,
 } from "../services/runpod-client.js";
 import { getRunpodWatcher } from "../services/runpod-watch.js";
+import { requestTargetChange, awaitTargetApplied, progressEnabled } from "../services/download-progress.js";
 
-/** Retarget comfyui-mcp back to the local ComfyUI (shared by stop + use_local). */
-function retargetLocal(): string {
+/** Retarget comfyui-mcp back to the local ComfyUI (shared by stop + use_local).
+ *  Returns { url, applied } for display (url null when the channel is down).
+ *  applied=false means the orchestrator SKIPPED the guarded switch (another
+ *  tab/pod owns the target now) — the caller must not claim a local switch
+ *  (codex finding). */
+async function retargetLocal(condOnPodId?: string): Promise<{ url: string | null; applied: boolean }> {
+  if (progressEnabled()) {
+    // condOnPodId: the stop-fallback — fall back ONLY if the orchestrator is
+    // really on that pod (a stale child may lag a newer target, codex). The
+    // unwatch is SCOPED to the stopped pod the same way (an unrelated watched
+    // pod must survive — codex finding).
+    const reqFile = requestTargetChange({ local: true, unwatch: true, wantAck: true, expectedCurrentUrl: getComfyUIBaseUrl(), ...(condOnPodId ? { onlyIfTarget: condOnPodId, unwatchPodId: condOnPodId } : {}) });
+    if (!reqFile) return { url: null, applied: false };
+    const ack = await awaitTargetApplied(reqFile);
+    if (ack) {
+      // Align THIS child's config to the AUTHORITATIVE target either way
+      // (codex finding: a guarded skip left the child on a dead pod for the
+      // rest of the turn). `applied` only narrates whether the requested
+      // local switch actually happened.
+      setComfyuiTarget(ack.url);
+      resetClient();
+    }
+    return { url: ack?.url ?? null, applied: ack?.applied ?? false };
+  }
   const url = getLocalComfyuiUrl();
   setComfyuiTarget(url);
   resetClient();
-  return url;
+  // In-process: the direct path did everything (pending clears ride the target
+  // event; failure clears are direct calls). Do NOT also replay a local
+  // request through the channel — same stale-overwrite race (codex finding).
+  return { url, applied: true };
 }
 
 /** Human-friendly uptime. */
@@ -136,17 +162,35 @@ export function registerRunpodTools(server: McpServer): void {
     async (args) => {
       try {
         const w = getRunpodWatcher();
-        const wasConnected = w?.watchedPodId() === args.pod_id;
         const r = await stopPod(args.pod_id);
-        // Stop live-status/idle-watch if this was the watched pod.
-        if (wasConnected) w?.unwatch();
+        // Clear any recorded auto-connect failure for this pod — it's stopped
+        // now, so "still billing" reports must stop too. Both locally (when
+        // the watcher exists) AND through the control channel (spawned-child
+        // case, where it doesn't — codex finding).
+        getRunpodWatcher()?.clearConnectFailed(args.pod_id);
+        requestTargetChange({ stoppedPodId: args.pod_id });
+        // Unwatch ONLY after the stop succeeded — clearing it first would
+        // leave a possibly-still-running pod unwatched and billing when the
+        // API call times out or is rejected (codex finding).
+        if (w?.watchedPodId() === args.pod_id) w?.unwatch();
         // If comfyui-mcp was pointed at THIS pod, its proxy URL is now dead —
         // fall back to the local ComfyUI so rendering keeps working (the swap
-        // half of the local⇄pod flow). Only when we were connected to it.
+        // half of the local⇄pod flow). The ORCHESTRATOR decides whether its
+        // authoritative target matches (onlyIfTarget) — a spawned child's own
+        // base URL can be a turn stale (codex finding: stopping B while the
+        // child lagged on A left the orchestrator on B's dead proxy).
         let localNote = "";
-        if (wasConnected) {
-          const url = retargetLocal();
-          localNote = ` comfyui-mcp switched back to local ComfyUI (${url}).`;
+        if (progressEnabled()) {
+          const r = await retargetLocal(args.pod_id);
+          localNote = r.applied && r.url
+            ? ` comfyui-mcp switched back to local ComfyUI (${r.url}).`
+            : r.applied
+              ? " comfyui-mcp is switching back to the local ComfyUI (the orchestrator resolves the target)."
+              : " the session's active target moved to another pod in the meantime — leaving it there.";
+        } else if (getComfyUIBaseUrl().includes(args.pod_id)) {
+          // In-process: this IS the orchestrator — the local check is current.
+          const r = await retargetLocal(args.pod_id);
+          localNote = r.applied && r.url ? ` comfyui-mcp switched back to local ComfyUI (${r.url}).` : "";
         }
         return { content: [{ type: "text", text: `Stopped pod \`${r.id}\` → **${r.desiredStatus}**. GPU released; disk kept.${localNote} Start it again with runpod_pod_start.` }] };
       } catch (err) {
@@ -163,7 +207,7 @@ export function registerRunpodTools(server: McpServer): void {
       name: z.string().optional().describe("Pod name (default 'comfyui-mcp')."),
       gpu_type: z.string().optional().describe(`GPU type to prefer, e.g. "NVIDIA GeForce RTX 4090". Default tries: ${RUNPOD_DEFAULT_GPU_TYPES.join(", ")}.`),
       cloud_type: z.enum(["COMMUNITY", "SECURE"]).optional().describe("COMMUNITY (cheaper, default) or SECURE."),
-      connect: z.boolean().optional().describe("After it boots, wait and auto-connect comfyui-mcp to it (default false — deploy returns immediately; the pod still needs ~1-3min to boot)."),
+      connect: z.boolean().optional().describe("Auto-connect when booted: the ORCHESTRATOR waits for ComfyUI to answer (1-3min), then retargets + watches — this call returns immediately (default false: deploy only; connect later with runpod_pod_connect)."),
     },
     async (args) => {
       try {
@@ -174,8 +218,109 @@ export function registerRunpodTools(server: McpServer): void {
         });
         const cost = pod.costPerHr != null ? ` at $${pod.costPerHr.toFixed(3)}/hr` : "";
         const gpu = pod.machine?.gpuDisplayName ? ` on ${pod.machine.gpuDisplayName}` : "";
-        // Broadcast its status to the control panels while it boots.
-        getRunpodWatcher()?.watch(pod.id);
+        // Broadcast its status to the control panels while it boots — including
+        // the spawned-child case: a watch-ONLY control request (no retarget yet)
+        // so the orchestrator starts broadcasting immediately, not just after
+        // the readiness wait (codex finding: boot-time + timeout path were
+        // unwatched while the result claimed live status). NEVER displace an
+        // ACTIVE render target's watch for this — the current pod's idle
+        // auto-stop / dead-target cleanup is its billing guard (codex). Track
+        // whether it actually GOT watched so the result doesn't claim otherwise
+        // (codex finding: guarded-out creates still said "status broadcasting").
+        let watchedNow = false;
+        let activeOtherPod: string | null = null;
+        if (getRunpodWatcher()) {
+          const w = getRunpodWatcher()!;
+          const cur = w.watchedPodId();
+          const curIsActiveTarget = !!cur && getComfyUIBaseUrl().includes(cur);
+          if (curIsActiveTarget && cur !== pod.id) activeOtherPod = cur;
+          if (!activeOtherPod) {
+            w.watch(pod.id);
+            watchedNow = true;
+          }
+        }
+        // Queue the orchestrator watch ONLY when this process has no watcher
+        // (spawned child) — in-process the direct watch above already applied
+        // synchronously, and a delayed duplicate could re-watch after a user's
+        // unwatch; the wantAck would also never be consumed (codex finding).
+        const watchReqFile = getRunpodWatcher() ? null : requestTargetChange({ watchPodId: pod.id, wantAck: true });
+        // In the spawned child the watcher is null — confirm the orchestrator
+        // actually accepted the watch (its active-target guard may REFUSE it
+        // to protect the current pod; claiming otherwise would lie — codex).
+        let watchedEffectively = watchedNow;
+        let watchUnknown = false;
+        if (!watchedEffectively && watchReqFile) {
+          const ack = await awaitTargetApplied(watchReqFile, 3_000);
+          if (ack) watchedEffectively = ack.applied;
+          else watchUnknown = true; // NO ack: unconfirmed — never claim watched (codex)
+        }
+        const watchNote = watchedNow
+          ? "Live status is broadcasting to the control panel (idle auto-stop active)."
+          : watchedEffectively
+            ? "Live status broadcasts on the orchestrator's next poll (idle auto-stop active)."
+            : watchUnknown
+              ? `Live status was requested but is UNCONFIRMED (no orchestrator ack yet) — check \`${pod.id}\` with runpod_pod_status in a moment; idle auto-stop may not be armed yet.`
+              : `NOTE: still rendering on the current pod — \`${pod.id}\` is booting UNWATCHED (its idle auto-stop is NOT armed) so the active pod keeps its billing guard; it gets watched when it becomes the target — or watch it yourself with runpod_watch once the current pod is free.`;
+        if (args.connect) {
+          // connect: true actually connects (#269 — it was a documented no-op),
+          // but the WAIT lives in the orchestrator, not here: an MCP tool call
+          // dies at the SDK's 60s default timeout while a pod takes 1-3min to
+          // boot (codex finding). Ask the orchestrator to probe until ready,
+          // then retarget+watch; this call returns immediately. NO channel
+          // (headless MCP server, no progress dir) → say so honestly instead of
+          // promising an auto-connect nothing will perform (codex).
+          const url = runpodProxyUrl(pod.id);
+          const reqFile = requestTargetChange({ watchPodId: pod.id, connectWhenReady: { url, podId: pod.id }, expectedCurrentUrl: getComfyUIBaseUrl(), wantAck: true });
+          if (!reqFile) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `🚀 Deployed pod \`${pod.id}\` (${pod.name || "comfyui-mcp"})${gpu}${cost}. It's booting (~1-3min) — auto-connect AND live status/idle auto-stop are unavailable in this mode (no panel orchestrator), so connect once it's up with runpod_pod_connect \`${pod.id}\`, watch it with runpod_pod_status, and stop it with runpod_pod_stop when done to end billing.\n\n${GPU_CLI_CREDIT}`,
+                },
+              ],
+            };
+          }
+          // Confirm the registration actually landed (a newer target choice
+          // can generation-reject it — codex finding: the tool still promised
+          // auto-connect while no pending entry existed). A MISSING ack (e.g.
+          // the channel dir rotating under a restart) is UNCONFIRMED, not a
+          // promise (codex finding).
+          const regAck = await awaitTargetApplied(reqFile, 4_000);
+          if (!regAck) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `🚀 Deployed pod \`${pod.id}\` (${pod.name || "comfyui-mcp"})${gpu}${cost}. It's booting — auto-connect is UNCONFIRMED (the orchestrator hasn't acked the registration). Check \`${pod.id}\` with runpod_pod_status in a moment, or connect manually with runpod_pod_connect when it's ready. Stop it with runpod_pod_stop when done to end billing.\n\n${GPU_CLI_CREDIT}`,
+                },
+              ],
+            };
+          }
+          if (!regAck.applied) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    `🚀 Deployed pod \`${pod.id}\` (${pod.name || "comfyui-mcp"})${gpu}${cost}. It's booting, but auto-connect was SKIPPED — a newer target choice won the race. Connect manually when ready: runpod_pod_connect \`${pod.id}\`. Stop it with runpod_pod_stop when done to end billing.\n\n${GPU_CLI_CREDIT}`,
+                },
+              ],
+            };
+          }
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `🚀 Deployed pod \`${pod.id}\` (${pod.name || "comfyui-mcp"})${gpu}${cost}. It's booting — the orchestrator will AUTO-CONNECT when ComfyUI answers (usually 1-3min; it gives up honestly after 8). ` +
+                  `${watchNote} Stop it with runpod_pod_stop when done to end billing.\n\n${GPU_CLI_CREDIT}`,
+              },
+            ],
+          };
+        }
         return {
           content: [
             {
@@ -184,7 +329,7 @@ export function registerRunpodTools(server: McpServer): void {
                 `🚀 Deployed pod \`${pod.id}\` (${pod.name || "comfyui-mcp"})${gpu}${cost}. ` +
                 `It's booting now — ComfyUI takes ~1-3min to come up (model volume warm-up on first boot). ` +
                 `Watch it with runpod_pod_status, then runpod_pod_connect \`${pod.id}\` once ready. ` +
-                `Live status is broadcasting to the control panel (idle auto-stop active). ` +
+                `${watchNote} ` +
                 `Stop it with runpod_pod_stop when done to end billing.\n\n${GPU_CLI_CREDIT}`,
             },
           ],
@@ -205,13 +350,17 @@ export function registerRunpodTools(server: McpServer): void {
         const w = getRunpodWatcher();
         const was = w?.watchedPodId();
         w?.unwatch();
-        const url = retargetLocal();
+        const r = await retargetLocal();
         return {
           content: [
             {
               type: "text",
               text:
-                `✅ comfyui-mcp now targets the local ComfyUI (${url}). Renders run on this machine.` +
+                (r.applied && r.url
+                  ? `✅ comfyui-mcp now targets the local ComfyUI (${r.url}). Renders run on this machine.`
+                  : r.applied
+                    ? `✅ comfyui-mcp is switching back to the local ComfyUI — the orchestrator resolves its remembered target and un-watches the pod.`
+                    : `⚠️ The local switch was skipped — the active target changed in the meantime (check runpod_status / the host pill).`) +
                 (was ? ` Pod \`${was}\` is still running — stop it with runpod_pod_stop to end billing, or reconnect with runpod_pod_connect.` : ""),
             },
           ],
@@ -313,6 +462,11 @@ export function registerRunpodTools(server: McpServer): void {
         if (!comfyuiPortExposed(pod)) {
           return { content: [{ type: "text", text: `Pod \`${pod.id}\` is RUNNING but doesn't expose ComfyUI on port ${RUNPOD_COMFYUI_PORT} — run runpod_pod_troubleshoot for the fix.` }] };
         }
+        // The generation guard needs the PRE-retarget view (the target I
+        // believe the orchestrator is on NOW) — capturing it after
+        // setComfyuiTarget would stamp the NEW url and the orchestrator would
+        // reject its own legitimate request every time (codex finding).
+        const preRetargetUrl = getComfyUIBaseUrl();
         const url = runpodProxyUrl(pod.id);
         const probeRes = await probe(`${url}/system_stats`);
         if (!probeRes.ok) {
@@ -328,6 +482,32 @@ export function registerRunpodTools(server: McpServer): void {
         const applied = setComfyuiTarget(url);
         if (!applied) return { content: [{ type: "text", text: `Resolved ${url} but could not retarget (unexpected URL parse failure).` }] };
         resetClient();
+        // Cover the spawned-child case ONLY: it asks the orchestrator to
+        // retarget + watch through the control channel (#269). In-process the
+        // direct path already did everything synchronously — replaying the
+        // same URL through the channel up to 700ms later could overwrite a
+        // NEWER choice made meanwhile (codex finding). The generation guard
+        // (expectedCurrentUrl) lets the orchestrator drop it if one happened.
+        if (progressEnabled()) {
+          // Confirm the AUTHORITATIVE retarget before reporting success: the
+          // generation guard may have rejected this (a newer target won), and
+          // only the child's private config changed otherwise (codex finding).
+          const reqFile = requestTargetChange({ url, watchPodId: pod.id, expectedCurrentUrl: preRetargetUrl, wantAck: true });
+          const ack = reqFile ? await awaitTargetApplied(reqFile, 4_000) : null;
+          if (!ack?.applied) {
+            // Rejected by the generation guard (a newer target won) — realign
+            // THIS child to the authoritative target too, or it keeps using
+            // the rejected pod for the rest of the turn (codex finding).
+            if (ack?.url) {
+              setComfyuiTarget(ack.url);
+              resetClient();
+            }
+            return { content: [{ type: "text", text: `⚠️ Pod \`${pod.id}\` is ready at ${url}, but the session did NOT retarget — the orchestrator moved to a newer target in the meantime (or the request didn't land). Retry runpod_pod_connect \`${pod.id}\` if that's wrong.` }] };
+          }
+          // Align this child to the confirmed target (its setComfyuiTarget
+          // above already did, but keep it explicit after the ack).
+          return { content: [{ type: "text", text: `✅ Connected to RunPod pod \`${pod.id}\` — comfyui-mcp now targets ${url}. All comfyui tools this session run against the pod. Live status is now broadcasting to the control panel (with idle auto-stop).` }] };
+        }
         // Start live status broadcasts + idle auto-stop for this pod (control panels).
         getRunpodWatcher()?.watch(pod.id);
         return { content: [{ type: "text", text: `✅ Connected to RunPod pod \`${pod.id}\` — comfyui-mcp now targets ${url}. All comfyui tools this session run against the pod. Live status is now broadcasting to the control panel (with idle auto-stop).` }] };


### PR DESCRIPTION
## What

The remaining #269 deferred items, built through **60+ codex review rounds** to a clean converge. Four interlocking pieces:

**1. One retarget fan-out.** `setComfyuiTarget`'s listener now does the full retarget for *every* origin (panel hello, runpod tools, watcher fallback): QueueMonitor restart, agent MCP-env respawn, env-capability re-probe, host-indicator frame — with the closed-over `comfyuiUrl`/`comfyuiPath` synced first (a tool-originated retarget no longer respawns agents against the OLD host). Same-URL events dedupe; the default-port compare is scheme-aware (`:443` hello ≡ normalized target, `http://h:443` ≢ `http://h`).

**2. MCP child → orchestrator control channel.** `runpod_*` tools invoked by a panel agent run in a spawned stdio child where `setComfyuiTarget`/`getRunpodWatcher()` are process-local — the orchestrator's QueueMonitor, watcher, and host indicator stayed blind while results claimed "connected + watched". Now: per-request control files (unique names → race-free consumption) in a **nonced mode-0700** progress dir, applied by the orchestrator's 700ms poll through the same fan-out. Guards everywhere codex found a hole: `onlyIfTarget` (stop-fallback only when the stopped pod is really the target), `expectedCurrentUrl` generation (stale queued requests dropped), applied-acks (children realign to the authoritative target), and **lazy secure-bridge creation** on local→pod transitions — its own token-gated tunnel listener (pair-flow precedent), per-target advertise re-checks, in-flight setup serialization, relay-client cleanup on failed setup.

**3. `connect: true` actually connects.** The wait lives in the orchestrator (a tool call dies at the MCP 60s default): per-pod pending connects with deadlines (one winner, siblings **SUPERSEDED** with visible alerts), readiness probes carrying configured auth, pending state **persisted per bridge port** so self-restarts keep promises (restored only on pod boots / restart generations — an explicit fresh non-pod boot invalidates them). Returns immediately with honest armed / skipped / unconfirmed text.

**4. Failure visibility + idle honesty.** Failures ride a dedicated `runpod_alert` frame (can't clobber the watched pod's single status slot; client rendering is a follow-up — the frames are additive and ignored safely until then), sticky until stopped/connected/gone, janitor-reconciled, persisted per port, seeded to new tabs. Downloads in flight veto idle auto-stop, **scoped per pod** via target-stamped rows (writer's own `COMFYUI_URL`, credential-redacted). The watcher fires `onPodUnavailable` on vanish/auto-stop/EXITED/PAUSED and the orchestrator falls back to local when the dead pod was the render target.

Also: the LAN fallback now tracks the learned LAN rig (boot or hello-learned; IP-literal + local-DNS classification, VPS excluded, persisted per port) instead of forcing `127.0.0.1`; `runpod_pod_stop` unwatches only after a confirmed stop and clears failure/pending state.

**Tests:** 20+ new cases (config LAN/VPS/IPv6/DNS, control-channel roundtrip/race/TTL/redaction/acks, watcher unavailable/vanish/EXITED/failure flows, stop targeting). Full suite green except the pre-existing environmental `node-dev` ripgrep expectation (red on main too, unrelated).

Client-side rendering of `runpod_alert` in panel + mobile is a deliberate follow-up (issues linked below).

Refs #269. Independent of #275 (#280).

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-code)
