### PR TITLE
feat(connect): Cloudflare Access service-token support on every ComfyUI endpoint

### DIFF
--- a/docs/cloud-deployment.mdx
+++ b/docs/cloud-deployment.mdx
@@ -100,7 +100,11 @@ gated by a per-session random token — so it just works everywhere with no prom
 
 <Note>
 If the pod sits behind auth, set `COMFYUI_AUTH_TOKEN` (plus optional
-`COMFYUI_AUTH_HEADER` / `COMFYUI_AUTH_SCHEME`) on the local `connect` command.
+`COMFYUI_AUTH_HEADER` / `COMFYUI_AUTH_SCHEME`) on the local `connect` command. For a
+pod fronted by **Cloudflare Access**, create an Access **service token** and set
+`CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` — both ride every ComfyUI request
+(HTTP + the queue-watcher WebSocket), so the connector passes the gate while the
+human sign-in page stays up for browsers.
 </Note>
 
 ### Keep everything on your machine (no Cloudflare)

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -69,12 +69,26 @@ route, an API gateway, an SSO edge) — this is **not** Comfy Cloud:
 <ParamField path="COMFYUI_AUTH_SCHEME" type="string" default="Bearer for Authorization, else none">
   Scheme prefix on the token value, e.g. `Bearer`, `Token`.
 </ParamField>
+<ParamField path="CF_ACCESS_CLIENT_ID" type="string">
+  Cloudflare Access **service token** Client ID. Set together with
+  `CF_ACCESS_CLIENT_SECRET` to reach a ComfyUI fronted by Cloudflare Access — both
+  are sent (as `CF-Access-Client-Id` / `CF-Access-Client-Secret`) on **every**
+  ComfyUI request (HTTP and the queue-watcher WebSocket), so the connector passes
+  the Access gate instead of getting the interactive sign-in page. Additive to
+  `COMFYUI_AUTH_TOKEN`; both take effect if both are set. Never logged.
+</ParamField>
+<ParamField path="CF_ACCESS_CLIENT_SECRET" type="string">
+  Cloudflare Access service token Client Secret (the pair to `CF_ACCESS_CLIENT_ID`).
+  Only sent when **both** are set — a half-configured token is ignored. Never logged.
+</ParamField>
 
 ```bash
 # Authorization: Bearer <token>, requests under /comfyapi
 COMFYUI_URL=https://gateway.example.com/comfyapi COMFYUI_AUTH_TOKEN=<token> npx -y comfyui-mcp@latest
 # custom header: X-API-Key: <token>
 COMFYUI_URL=https://gateway.example.com/comfyapi COMFYUI_AUTH_HEADER=X-API-Key COMFYUI_AUTH_TOKEN=<token> npx -y comfyui-mcp@latest
+# ComfyUI behind Cloudflare Access — pass a service token (keeps the human sign-in page up)
+COMFYUI_URL=https://comfy.example.com CF_ACCESS_CLIENT_ID=<id>.access CF_ACCESS_CLIENT_SECRET=<secret> npx -y comfyui-mcp@latest
 ```
 
 ## Comfy Cloud

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -135,6 +135,8 @@ describe("remote self-hosted: path prefix + generic auth (#52)", () => {
     process.env.COMFYUI_AUTH_HEADER = "";
     process.env.COMFYUI_AUTH_SCHEME = "";
     process.env.COMFYUI_AUTH_TOKEN = "";
+    process.env.CF_ACCESS_CLIENT_ID = "";
+    process.env.CF_ACCESS_CLIENT_SECRET = "";
   });
 
   afterEach(() => {
@@ -181,6 +183,34 @@ describe("remote self-hosted: path prefix + generic auth (#52)", () => {
     process.env.COMFYUI_AUTH_TOKEN = "abc123";
     const mod = await import("../config.js");
     expect(mod.getComfyUIAuthHeaders()).toEqual({ Authorization: "Token abc123" });
+  });
+
+  it("Cloudflare Access service token → both CF-Access headers (no COMFYUI_AUTH_TOKEN needed)", async () => {
+    process.env.CF_ACCESS_CLIENT_ID = "cid.access";
+    process.env.CF_ACCESS_CLIENT_SECRET = "csecret";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({
+      "CF-Access-Client-Id": "cid.access",
+      "CF-Access-Client-Secret": "csecret",
+    });
+  });
+
+  it("CF Access + COMFYUI_AUTH_TOKEN → both auth schemes coexist", async () => {
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    process.env.CF_ACCESS_CLIENT_ID = "cid.access";
+    process.env.CF_ACCESS_CLIENT_SECRET = "csecret";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({
+      Authorization: "Bearer abc123",
+      "CF-Access-Client-Id": "cid.access",
+      "CF-Access-Client-Secret": "csecret",
+    });
+  });
+
+  it("half-configured CF Access (id only, no secret) → no CF headers", async () => {
+    process.env.CF_ACCESS_CLIENT_ID = "cid.access";
+    const mod = await import("../config.js");
+    expect(mod.getComfyUIAuthHeaders()).toEqual({});
   });
 
   it("generic auth does NOT enable Comfy Cloud mode", async () => {

--- a/src/__tests__/services/secure-bridge-auth.test.ts
+++ b/src/__tests__/services/secure-bridge-auth.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// advertiseBridge is the connect-time "bridge-token update" POST to the pod's
+// panel pack. When that ComfyUI sits behind Cloudflare Access, the POST must
+// carry the CF-Access service-token headers or Access returns its sign-in page
+// instead of the API (the exact failure this wiring fixes). It now shares the
+// single getComfyUIAuthHeaders() source with every other ComfyUI request.
+
+const OLD_ENV = process.env;
+
+function advertiseCall(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.find(([u]) => String(u).includes("/comfyui_mcp_panel/advertise_bridge"));
+  expect(call, "advertise_bridge POST should have been made").toBeTruthy();
+  return call as [string, RequestInit];
+}
+
+describe("advertiseBridge auth headers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    // Pin the target so config.ts's import-time port probe never runs (and can't
+    // pollute the fetch mock).
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    process.env.COMFYUI_AUTH_TOKEN = "";
+    process.env.COMFYUI_AUTH_HEADER = "";
+    process.env.COMFYUI_AUTH_SCHEME = "";
+    process.env.CF_ACCESS_CLIENT_ID = "";
+    process.env.CF_ACCESS_CLIENT_SECRET = "";
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    vi.unstubAllGlobals();
+  });
+
+  it("carries the CF-Access service-token headers on the advertise POST", async () => {
+    process.env.CF_ACCESS_CLIENT_ID = "cid.access";
+    process.env.CF_ACCESS_CLIENT_SECRET = "csecret";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { advertiseBridge } = await import("../../services/secure-bridge.js");
+    const ok = await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
+
+    expect(ok).toBe(true);
+    const [, init] = advertiseCall(fetchMock);
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "CF-Access-Client-Id": "cid.access",
+      "CF-Access-Client-Secret": "csecret",
+    });
+  });
+
+  it("also forwards COMFYUI_AUTH_TOKEN alongside CF Access", async () => {
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    process.env.CF_ACCESS_CLIENT_ID = "cid.access";
+    process.env.CF_ACCESS_CLIENT_SECRET = "csecret";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { advertiseBridge } = await import("../../services/secure-bridge.js");
+    await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
+
+    const [, init] = advertiseCall(fetchMock);
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer abc123",
+      "CF-Access-Client-Id": "cid.access",
+      "CF-Access-Client-Secret": "csecret",
+    });
+  });
+
+  it("no auth configured → advertise POST carries only Content-Type (no regression)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { advertiseBridge } = await import("../../services/secure-bridge.js");
+    await advertiseBridge("https://podid-3000.proxy.runpod.net", "wss://relay/?token=t");
+
+    const [, init] = advertiseCall(fetchMock);
+    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+  });
+});

--- a/src/__tests__/tools/prompt-director.test.ts
+++ b/src/__tests__/tools/prompt-director.test.ts
@@ -37,7 +37,12 @@ describe("prompt_director_inspect tool", () => {
     const inspect = makeServer();
     const result = await inspect({ node_id: "42" });
 
-    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:8188/prompt_director/inspection?node_id=42");
+    // Routed through comfyuiFetch now (so CF Access / COMFYUI_AUTH_* headers reach
+    // this endpoint too); with no auth configured it calls fetch(url, {}).
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8188/prompt_director/inspection?node_id=42",
+      {},
+    );
     expect(result.content[0].text).toContain('"node_id": "42"');
     expect(result.content[0].text).toContain("prompt_director_auto");
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -378,6 +378,13 @@ const configSchema = z.object({
   comfyuiAuthHeader: z.string().optional(),
   comfyuiAuthScheme: z.string().optional(),
   comfyuiAuthToken: z.string().optional(),
+  // Cloudflare Access service token (a Client ID + Client Secret PAIR). When both
+  // are set, every ComfyUI request carries CF-Access-Client-Id / -Secret so a
+  // ComfyUI endpoint fronted by Cloudflare Access lets the connector through
+  // instead of returning the interactive sign-in page. Independent of, and
+  // additive to, COMFYUI_AUTH_TOKEN.
+  cfAccessClientId: z.string().optional(),
+  cfAccessClientSecret: z.string().optional(),
   huggingfaceToken: z.string().optional(),
   githubToken: z.string().optional(),
   civitaiApiToken: z.string().optional(),
@@ -447,6 +454,8 @@ const parsedConfig = configSchema.parse({
   comfyuiAuthHeader: process.env.COMFYUI_AUTH_HEADER,
   comfyuiAuthScheme: process.env.COMFYUI_AUTH_SCHEME,
   comfyuiAuthToken: process.env.COMFYUI_AUTH_TOKEN,
+  cfAccessClientId: process.env.CF_ACCESS_CLIENT_ID,
+  cfAccessClientSecret: process.env.CF_ACCESS_CLIENT_SECRET,
   // HF_TOKEN is the canonical var the huggingface_hub libs read; HUGGINGFACE_TOKEN
   // is a legacy alias we still honor as a fallback.
   huggingfaceToken: process.env.HF_TOKEN || process.env.HUGGINGFACE_TOKEN,
@@ -778,14 +787,27 @@ export function getComfyUIBaseUrl(): string {
  * This is independent of Comfy Cloud mode (COMFYUI_API_KEY / X-API-Key).
  */
 export function getComfyUIAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
   const token = config.comfyuiAuthToken?.trim();
-  if (!token) return {};
-  const header = config.comfyuiAuthHeader?.trim() || "Authorization";
-  // An unset/empty scheme defaults to "Bearer" for the Authorization header and
-  // to none (raw token) for any custom header. Set COMFYUI_AUTH_SCHEME to force
-  // a specific scheme (e.g. "Token").
-  const scheme =
-    config.comfyuiAuthScheme?.trim() ||
-    (header.toLowerCase() === "authorization" ? "Bearer" : "");
-  return { [header]: scheme ? `${scheme} ${token}` : token };
+  if (token) {
+    const header = config.comfyuiAuthHeader?.trim() || "Authorization";
+    // An unset/empty scheme defaults to "Bearer" for the Authorization header and
+    // to none (raw token) for any custom header. Set COMFYUI_AUTH_SCHEME to force
+    // a specific scheme (e.g. "Token").
+    const scheme =
+      config.comfyuiAuthScheme?.trim() ||
+      (header.toLowerCase() === "authorization" ? "Bearer" : "");
+    headers[header] = scheme ? `${scheme} ${token}` : token;
+  }
+  // Cloudflare Access service token — sent as a PAIR (both headers) or not at all,
+  // so a half-configured token never produces a broken request. Additive: works
+  // alongside or instead of COMFYUI_AUTH_TOKEN, and applies to every ComfyUI
+  // endpoint (harmless on endpoints not behind Cloudflare Access — they ignore it).
+  const cfId = config.cfAccessClientId?.trim();
+  const cfSecret = config.cfAccessClientSecret?.trim();
+  if (cfId && cfSecret) {
+    headers["CF-Access-Client-Id"] = cfId;
+    headers["CF-Access-Client-Secret"] = cfSecret;
+  }
+  return headers;
 }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
@@ -1954,7 +1955,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 const base = (process.env.COMFYUI_URL ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
                 const qs = new URLSearchParams({ filename: src.filename, type: src.type ?? "output" });
                 if (src.subfolder) qs.set("subfolder", src.subfolder);
-                const resp = await fetch(`${base}/view?${qs.toString()}`);
+                const resp = await comfyuiFetch(`${base}/view?${qs.toString()}`);
                 if (resp.ok) {
                   const mime = resp.headers.get("content-type") ?? "";
                   const buf = Buffer.from(await resp.arrayBuffer());

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -17,6 +17,7 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
 import { join } from "node:path";
 import { isForceRemoteFlagSet } from "../config.js";
@@ -155,7 +156,7 @@ async function probeManagerGeneration(
 ): Promise<"v4" | "legacy" | "unknown"> {
   const probe = async (path: string): Promise<boolean> => {
     try {
-      const res = await fetch(new URL(path, comfyuiUrl), {
+      const res = await comfyuiFetch(new URL(path, comfyuiUrl), {
         signal: AbortSignal.timeout(timeoutMs),
       });
       return res.ok;
@@ -198,7 +199,7 @@ async function fetchSystemStats(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   timer.unref?.();
   try {
-    const res = await fetch(`${base}/system_stats`, { signal: controller.signal });
+    const res = await comfyuiFetch(`${base}/system_stats`, { signal: controller.signal });
     if (!res.ok) return undefined;
     return (await res.json()) as SystemStatsLike;
   } catch {

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -30,6 +30,8 @@
 
 import WebSocket from "ws";
 import { logger } from "../utils/logger.js";
+import { getComfyUIAuthHeaders } from "../config.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 
 interface MonitorState {
   connected: boolean;
@@ -229,7 +231,14 @@ class QueueMonitorImpl {
     if (this.stopped) return;
     let ws: WebSocket;
     try {
-      ws = new WebSocket(this.wsUrl());
+      // Ride the same auth as HTTP (COMFYUI_AUTH_* + Cloudflare Access service
+      // token) on the WS handshake, so the watchdog reaches a ComfyUI behind a
+      // proxy / CF Access. undefined when unauth'd → identical to `new WebSocket(url)`.
+      const authHeaders = getComfyUIAuthHeaders();
+      ws = new WebSocket(
+        this.wsUrl(),
+        Object.keys(authHeaders).length ? { headers: authHeaders } : undefined,
+      );
     } catch (err) {
       logger.debug(`[queue-monitor] WS construct failed: ${err instanceof Error ? err.message : String(err)}`);
       this.scheduleReconnect();
@@ -445,7 +454,7 @@ class QueueMonitorImpl {
     const timer = setTimeout(() => ctrl.abort(), 2500);
     (timer as { unref?: () => void }).unref?.();
     try {
-      const res = await fetch(`${this.url.replace(/\/+$/, "")}${path}`, { signal: ctrl.signal });
+      const res = await comfyuiFetch(`${this.url.replace(/\/+$/, "")}${path}`, { signal: ctrl.signal });
       if (!res.ok) return null;
       return (await res.json()) as unknown;
     } catch {

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -26,6 +26,7 @@ import { randomBytes } from "node:crypto";
 import { startQuickTunnel, type QuickTunnel } from "./tunnel.js";
 import { RelayClient } from "./relay-client.js";
 import { logger } from "../utils/logger.js";
+import { getComfyUIAuthHeaders } from "../config.js";
 import type { UiBridge } from "./ui-bridge.js";
 
 export interface SecureBridge {
@@ -44,16 +45,6 @@ function toWssUrl(httpsUrl: string, token: string): string {
   u.search = "";
   u.searchParams.set("token", token);
   return u.toString();
-}
-
-/** Auth headers for the pod's ComfyUI, mirroring the connect-time env the docs
- *  document (COMFYUI_AUTH_TOKEN + optional header/scheme). Empty when unset. */
-function comfyuiAuthHeaders(): Record<string, string> {
-  const token = process.env.COMFYUI_AUTH_TOKEN?.trim();
-  if (!token) return {};
-  const header = process.env.COMFYUI_AUTH_HEADER?.trim() || "Authorization";
-  const scheme = process.env.COMFYUI_AUTH_SCHEME?.trim() ?? "Bearer";
-  return { [header]: scheme ? `${scheme} ${token}` : token };
 }
 
 /** Mask the token when logging a wss URL. */
@@ -80,7 +71,7 @@ export async function advertiseBridge(comfyuiUrl: string, wssUrl: string, should
     try {
       const res = await fetch(endpoint, {
         method: "POST",
-        headers: { "Content-Type": "application/json", ...comfyuiAuthHeaders() },
+        headers: { "Content-Type": "application/json", ...getComfyUIAuthHeaders() },
         body: JSON.stringify({ url: wssUrl }),
       });
       if (res.ok) return true;

--- a/src/tools/prompt-director.ts
+++ b/src/tools/prompt-director.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { errorToToolResult } from "../utils/errors.js";
+import { comfyuiFetch } from "../comfyui/fetch.js";
 
 
 function comfyBase(): string {
@@ -25,7 +26,7 @@ export function registerPromptDirectorTools(server: McpServer): void {
     async (args) => {
       try {
         const query = args.node_id ? `?node_id=${encodeURIComponent(args.node_id)}` : "";
-        const response = await fetch(`${comfyBase()}/prompt_director/inspection${query}`);
+        const response = await comfyuiFetch(`${comfyBase()}/prompt_director/inspection${query}`);
         if (!response.ok) {
           return errorToToolResult(
             new Error(


### PR DESCRIPTION
## Problem

A ComfyUI fronted by **Cloudflare Access** returns Access's interactive sign-in page to the CLI instead of the API. That breaks the connect/advertise flow (stale bridge token) and the queue watcher — the `--insecure-bridge` workaround exists only to dodge this. The connector could only ever send **one** auth header, but a CF Access **service token** is a **pair** (`CF-Access-Client-Id` + `CF-Access-Client-Secret`), so it couldn't be passed.

## Fix

Set `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` and both headers ride **every** ComfyUI request. The human sign-in page stays up; the connector passes the gate via the service token.

- **`config.getComfyUIAuthHeaders()`** — the single source of truth — appends the two CF-Access headers when **both** are set (a pair, or nothing; a half-config never sends a broken header). Restructured so CF Access works with *or* without `COMFYUI_AUTH_TOKEN`. **Byte-identical output when the new vars are unset.**
- Routed the stragglers through that one builder so *all* the connect endpoints are covered — no regressions (each `fetch`→`comfyuiFetch` swap is identical when unauth'd):
  - **`secure-bridge` `advertiseBridge`** — the exact endpoint that hit the sign-in page; deduped its private auth-header copy onto `getComfyUIAuthHeaders()` (also fixes a scheme-default drift the copy had).
  - **`queue-monitor`** — WS handshake now carries the auth headers (`undefined` when unauth'd → identical to before); its HTTP probe uses `comfyuiFetch`.
  - **`env-capabilities`**, **`panel-tools` `/view`**, **`prompt-director`** — raw `fetch` → `comfyuiFetch`.
  - **`apps.ts` left as-is** — those calls hit the **external app registry**, not the user's ComfyUI; sending a CF token there would leak it off-host.

## Tests
- `getComfyUIAuthHeaders`: CF pair / CF + token coexist / half-config ignored.
- New `secure-bridge-auth.test.ts`: `advertiseBridge` carries CF headers (+ with token, + none → only Content-Type).
- Full suite green locally: **1790 passed, 1 skipped, 0 failed**; `tsc` clean.

## Docs
`configuration.mdx` (env reference) + `cloud-deployment.mdx` (pod-behind-Access note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)