### PR TITLE
feat(process-control): remote restart_comfyui — reboot a tunnelled ComfyUI via Manager + poll

### DIFF
--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -1,0 +1,157 @@
+// Remote restart: when the orchestrator targets a REMOTE ComfyUI (--comfyui-url,
+// e.g. a Cloudflare-tunnelled Desktop app), restart_comfyui must NOT throw — it
+// fires a ComfyUI-Manager HTTP reboot and polls readiness until the (self-
+// supervised) origin comes back. Everything is exercised through mocked
+// comfyuiFetch + isRemoteMode; no real process/port/network is touched.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remoteMode: { value: true },
+  fetchMock: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+  getSystemStats: vi.fn(async () => ({ system: { argv: [] as string[] } })),
+  execSync: vi.fn(() => ""),
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../config.js", () => ({
+  config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
+  getComfyUIBaseUrl: () => "http://remote.example:8188",
+  isRemoteMode: () => hoisted.remoteMode.value,
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (url: string, init?: RequestInit) => hoisted.fetchMock(url, init),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: hoisted.getSystemStats,
+  resetClient: hoisted.resetClient,
+  resetObjectInfoCache: hoisted.resetObjectInfoCache,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: hoisted.execSync,
+  spawn: hoisted.spawn,
+}));
+
+import {
+  restartComfyUI,
+  __processControlTestHooks,
+} from "../../services/process-control.js";
+
+type FetchCall = [string, RequestInit | undefined];
+const pathOf = (u: string): string => new URL(u).pathname;
+const findCall = (pred: (path: string) => boolean): FetchCall | undefined =>
+  (hoisted.fetchMock.mock.calls as FetchCall[]).find(([u]) => pred(pathOf(u)));
+
+beforeEach(() => {
+  hoisted.remoteMode.value = true;
+  hoisted.fetchMock.mockReset();
+  hoisted.resetClient.mockClear();
+  hoisted.resetObjectInfoCache.mockClear();
+  hoisted.getSystemStats.mockClear();
+  hoisted.execSync.mockReset();
+  hoisted.execSync.mockImplementation(() => "");
+  __processControlTestHooks.reset();
+});
+
+describe("restartComfyUI — remote (Manager reboot)", () => {
+  it("reboot POST 502, then /system_stats errors twice then 200 → started + ready", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    let statsCalls = 0;
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        // Killed origin behind a proxy/tunnel surfaces as a 5xx bad-gateway.
+        return new Response("bad gateway", { status: 502 });
+      }
+      if (path === "/system_stats") {
+        statsCalls++;
+        if (statsCalls <= 2) throw new Error("fetch failed");
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.stopped).toBe(true);
+    expect(res.started).toBe(true);
+    expect(res.ready).toBe(true);
+    expect(res.message).toContain("rebooted via ComfyUI-Manager");
+    expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
+    expect(hoisted.resetObjectInfoCache).toHaveBeenCalledTimes(1);
+    // The 502 on the canonical POST route counts as "fired" — the legacy GET
+    // route must never be tried.
+    expect(findCall((p) => p === "/manager/reboot")).toBeUndefined();
+  });
+
+  it("Manager returns 403 → not started, manager-security note, does NOT throw", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 100,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      // Both routes end in "/manager/reboot"; refuse either with 403.
+      if (pathOf(url).endsWith("/manager/reboot")) {
+        return new Response("forbidden", { status: 403 });
+      }
+      return new Response("", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.started).toBe(false);
+    expect(res.stopped).toBe(false);
+    expect(res.message).toContain("403");
+    expect(res.message).toContain("security");
+    // A refusal must not arm a readiness poll or reset the client.
+    expect(findCall((p) => p === "/system_stats")).toBeUndefined();
+    expect(hoisted.resetClient).not.toHaveBeenCalled();
+  });
+
+  it("reboot fires but readiness never returns within budget → not started, timeout message", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 30,
+      intervalMs: 10,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") throw new Error("ECONNRESET");
+      return new Response("", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.stopped).toBe(true);
+    expect(res.started).toBe(false);
+    expect(res.ready).toBe(false);
+    expect(res.message).toContain("did not come back within 30ms");
+    expect(hoisted.resetClient).not.toHaveBeenCalled();
+  });
+
+  it("local mode routes through stop/start — the remote reboot path is not taken", async () => {
+    hoisted.remoteMode.value = false;
+    // No PID on the port and no Desktop app process → stopComfyUI can't find it.
+    hoisted.execSync.mockImplementation(() => "");
+    hoisted.fetchMock.mockImplementation(async () => new Response("", { status: 200 }));
+
+    const res = await restartComfyUI();
+
+    // Went down the local stop→start path (which reports it couldn't stop),
+    // never the Manager reboot path.
+    expect(res.started).toBe(false);
+    expect(res.message).toContain("Could not stop");
+    expect(findCall((p) => p.endsWith("/manager/reboot"))).toBeUndefined();
+  });
+});

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -807,7 +807,10 @@ const REBOOT_ROUTES: ReadonlyArray<{ path: string; method: "POST" | "GET" }> = [
  */
 function isConnectionDrop(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return /ECONNRESET|socket hang up|fetch failed|network|ECONNREFUSED|ECONNABORTED|EPIPE|terminated|premature close|other side closed|aborted/i.test(
+  // NOTE: ECONNREFUSED is deliberately absent — it means "nothing is listening"
+  // (the origin was ALREADY down before we called), not "we killed it mid-request".
+  // A process reboot we caused surfaces as ECONNRESET / socket-hang-up / terminated.
+  return /ECONNRESET|socket hang up|fetch failed|network|ECONNABORTED|EPIPE|terminated|premature close|other side closed|aborted/i.test(
     msg,
   );
 }
@@ -836,8 +839,8 @@ async function rebootViaManager(): Promise<RebootResult> {
           rebooting: false,
           reason: "manager-security",
           note:
-            "ComfyUI-Manager blocked the reboot (HTTP 403) — its security level " +
-            "forbids remote reboot; lower it or reboot on the host.",
+            "Reboot refused (HTTP 403) — ComfyUI-Manager's security level (or an " +
+            "access proxy in front) forbids it; lower the Manager security level or reboot on the host.",
         };
       }
       if (res.status === 502 || res.status === 503 || res.status === 504) {
@@ -921,11 +924,12 @@ async function restartRemoteViaManager(): Promise<RestartResult> {
   const timing = getRemoteRebootTiming();
   if (timing.settleMs > 0) await sleep(timing.settleMs);
 
-  const maxTries = Math.max(1, Math.ceil(timing.budgetMs / timing.intervalMs));
-  const readiness = await waitForApiReady({
-    intervalMs: timing.intervalMs,
-    maxTries,
-  });
+  // Clamp the interval to a sane floor: a 0 (or tiny) env value would make
+  // maxTries unbounded (ceil(budget/0) = Infinity) and hot-loop the poller,
+  // hanging the tool call if the host never returns.
+  const intervalMs = Math.max(250, timing.intervalMs);
+  const maxTries = Math.max(1, Math.ceil(timing.budgetMs / intervalMs));
+  const readiness = await waitForApiReady({ intervalMs, maxTries });
 
   if (!readiness.ready) {
     return {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -342,8 +342,21 @@ function getRestartPolicy(): RestartPolicy {
   };
 }
 
-async function waitForApiReady(): Promise<StartupReadinessResult> {
-  const { intervalMs, maxTries } = getStartupReadinessConfig();
+/**
+ * Poll `/system_stats` until ComfyUI answers 2xx. This poller is TOLERANT of the
+ * down window: a thrown fetch error (ECONNRESET / socket hang up / fetch failed)
+ * and any non-2xx (including a 502/503/504 from a proxy/tunnel in front of a
+ * killed origin) are all swallowed and treated as "not ready yet — keep polling".
+ * That property is what lets the same routine cover both a locally-spawned start
+ * and a remote ComfyUI-Manager reboot (where ComfyUI briefly disappears).
+ *
+ * `cfg` overrides the interval/try budget — the local start uses the short
+ * env-tuned default; the remote reboot passes a longer budget.
+ */
+async function waitForApiReady(
+  cfg?: { intervalMs: number; maxTries: number },
+): Promise<StartupReadinessResult> {
+  const { intervalMs, maxTries } = cfg ?? getStartupReadinessConfig();
   const probeUrl = `${getComfyUIBaseUrl()}/system_stats`;
   const start = Date.now();
   let attempts = 0;
@@ -760,12 +773,193 @@ export async function startComfyUI(): Promise<StartResult> {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Remote restart — reboot a remote/tunnelled ComfyUI through ComfyUI-Manager.
+//
+// A locally-spawned ComfyUI is restarted by killing + relaunching the process.
+// A REMOTE ComfyUI (reached via --comfyui-url, e.g. a Cloudflare-tunnelled
+// ComfyUI Desktop app) can't be process-controlled from here — but ComfyUI
+// Desktop self-supervises, so a ComfyUI-Manager HTTP reboot DOES bring it back.
+// We fire that reboot and poll readiness instead of throwing.
+// ---------------------------------------------------------------------------
+
+interface RebootResult {
+  rebooting: boolean;
+  endpoint?: string;
+  method?: string;
+  reason?: string;
+  note?: string;
+}
+
+// Match the repo's Manager path convention (node-management.ts appends these to
+// getComfyUIBaseUrl() with no `/api` prefix — the panel's `/api/...` form is only
+// because its browser `api.fetchApi` prepends `/api`). Canonical v4 POST route
+// first, then the legacy GET route for older Manager builds.
+const REBOOT_ROUTES: ReadonlyArray<{ path: string; method: "POST" | "GET" }> = [
+  { path: "/v2/manager/reboot", method: "POST" },
+  { path: "/manager/reboot", method: "GET" },
+];
+
+/**
+ * A dropped/aborted connection is the SUCCESS signal for a reboot: the Manager
+ * handler calls exit(0) the instant it accepts the request, so the origin dies
+ * before it can send an HTTP response and `fetch` rejects.
+ */
+function isConnectionDrop(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /ECONNRESET|socket hang up|fetch failed|network|ECONNREFUSED|ECONNABORTED|EPIPE|terminated|premature close|other side closed|aborted/i.test(
+    msg,
+  );
+}
+
+/**
+ * Fire a ComfyUI-Manager reboot over HTTP against the connected (remote) base URL.
+ * Classification:
+ *   FIRED   (rebooting:true)  — res.ok (2xx) OR a connection drop OR HTTP 502/503/504.
+ *                               A killed origin behind a proxy/Cloudflare surfaces
+ *                               as a 5xx bad-gateway (NOT a raw socket drop), so we
+ *                               must treat those as "reboot fired" too.
+ *   REFUSED (rebooting:false) — HTTP 403 → Manager security forbids remote reboot.
+ *   NO-ENDPOINT (rebooting:false) — every route gave a non-firing failure (e.g. 404).
+ */
+async function rebootViaManager(): Promise<RebootResult> {
+  const base = getComfyUIBaseUrl();
+  const failures: string[] = [];
+
+  for (const { path, method } of REBOOT_ROUTES) {
+    const url = `${base}${path}`;
+    try {
+      const res = await comfyuiFetch(url, { method });
+      if (res.ok) return { rebooting: true, endpoint: path, method };
+      if (res.status === 403) {
+        return {
+          rebooting: false,
+          reason: "manager-security",
+          note:
+            "ComfyUI-Manager blocked the reboot (HTTP 403) — its security level " +
+            "forbids remote reboot; lower it or reboot on the host.",
+        };
+      }
+      if (res.status === 502 || res.status === 503 || res.status === 504) {
+        return {
+          rebooting: true,
+          endpoint: path,
+          method,
+          note: `reboot fired — the origin dropped behind a proxy (HTTP ${res.status}) as it went down`,
+        };
+      }
+      // 404 / other non-OK: wrong route for this Manager build — try the next.
+      failures.push(`${method} ${path} → HTTP ${res.status}`);
+    } catch (err) {
+      if (isConnectionDrop(err)) {
+        return {
+          rebooting: true,
+          endpoint: path,
+          method,
+          note: "connection dropped (origin going down) — reboot fired",
+        };
+      }
+      failures.push(
+        `${method} ${path} → ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return {
+    rebooting: false,
+    reason: "no-endpoint",
+    note: `No reachable ComfyUI-Manager reboot endpoint.${
+      failures.length ? ` Tried: ${failures.join("; ")}` : ""
+    }`,
+  };
+}
+
+interface RemoteRebootTiming {
+  /** Grace pause after firing before we start probing (lets the origin actually go down). */
+  settleMs: number;
+  /** Total readiness budget. */
+  budgetMs: number;
+  /** Interval between readiness probes. */
+  intervalMs: number;
+}
+
+let remoteRebootTimingOverride: RemoteRebootTiming | null = null;
+
+function getRemoteRebootTiming(): RemoteRebootTiming {
+  if (remoteRebootTimingOverride) return remoteRebootTimingOverride;
+  return {
+    settleMs: Math.round(
+      parsePositiveNumberEnv("COMFYUI_REMOTE_REBOOT_SETTLE_S", 3) * 1000,
+    ),
+    budgetMs: Math.round(
+      parsePositiveNumberEnv("COMFYUI_REMOTE_REBOOT_BUDGET_S", 120) * 1000,
+    ),
+    intervalMs: Math.round(
+      parsePositiveNumberEnv("COMFYUI_REMOTE_REBOOT_INTERVAL_S", 2) * 1000,
+    ),
+  };
+}
+
+async function restartRemoteViaManager(): Promise<RestartResult> {
+  logger.info("Restarting remote ComfyUI via ComfyUI-Manager reboot...");
+
+  const reboot = await rebootViaManager();
+  if (!reboot.rebooting) {
+    return {
+      stopped: false,
+      started: false,
+      message: reboot.note ?? "ComfyUI-Manager reboot could not be triggered.",
+    };
+  }
+
+  logger.info("ComfyUI-Manager reboot fired", {
+    endpoint: reboot.endpoint,
+    method: reboot.method,
+    note: reboot.note,
+  });
+
+  const timing = getRemoteRebootTiming();
+  if (timing.settleMs > 0) await sleep(timing.settleMs);
+
+  const maxTries = Math.max(1, Math.ceil(timing.budgetMs / timing.intervalMs));
+  const readiness = await waitForApiReady({
+    intervalMs: timing.intervalMs,
+    maxTries,
+  });
+
+  if (!readiness.ready) {
+    return {
+      stopped: true,
+      started: false,
+      ready: false,
+      readiness,
+      message:
+        `Reboot was triggered but ComfyUI did not come back within ${timing.budgetMs}ms — ` +
+        "check the host (is it the Desktop app / supervised?).",
+    };
+  }
+
+  // Back and ready — refresh the WS client singleton + memoized /object_info,
+  // since a reboot is exactly when the node set may have changed.
+  resetClient();
+  resetObjectInfoCache();
+
+  return {
+    stopped: true,
+    started: true,
+    ready: true,
+    readiness,
+    message:
+      `ComfyUI rebooted via ComfyUI-Manager and came back ready (${readiness.waited_ms}ms) — ` +
+      "remote/supervised restart.",
+  };
+}
+
 export async function restartComfyUI(): Promise<RestartResult> {
   if (isRemoteMode()) {
-    throw new ProcessControlError(
-      "restart_comfyUI operates on the local machine's ComfyUI process and is not " +
-        "available when targeting a remote instance via --comfyui-url.",
-    );
+    // Remote target: can't process-control it, but a Manager HTTP reboot brings
+    // back a self-supervised ComfyUI (e.g. the tunnelled Desktop app).
+    return restartRemoteViaManager();
   }
   logger.info("Restarting ComfyUI...");
 
@@ -813,8 +1007,13 @@ export const __processControlTestHooks = {
     supervisorRestartCount = 0;
     supervisorWindowStartedAt = 0;
     supervisorGaveUp = false;
+    remoteRebootTimingOverride = null;
   },
   setLastProcessInfo(info: ProcessInfo): void {
     lastProcessInfo = info;
+  },
+  /** Inject fast remote-reboot timing so tests don't wait the real ~120s budget. */
+  setRemoteRebootTimingForTests(timing: RemoteRebootTiming | null): void {
+    remoteRebootTimingOverride = timing;
   },
 };

--- a/src/tools/process-control.ts
+++ b/src/tools/process-control.ts
@@ -41,7 +41,7 @@ export function registerProcessControlTools(server: McpServer): void {
 
   server.tool(
     "restart_comfyui",
-    "Restart ComfyUI: stops the running process (capturing its config), waits for the port to free, relaunches with the same arguments, and polls the API for bounded readiness.",
+    "Restart ComfyUI: stops the running process (capturing its config), waits for the port to free, relaunches with the same arguments, and polls the API for bounded readiness. Also works against a REMOTE/tunnelled ComfyUI (via --comfyui-url) by rebooting through ComfyUI-Manager over HTTP and polling for it to come back (requires ComfyUI-Manager present and its security level permitting the reboot).",
     {},
     async () => {
       try {


### PR DESCRIPTION
## Problem
`restart_comfyui` hard-threw in remote mode (`process-control.ts`: *"operates on the local machine's ComfyUI process… not available … via --comfyui-url"*), so an agent connected to a **remote/tunnelled ComfyUI** (e.g. a Cloudflare-fronted ComfyUI **Desktop** app) could not restart it — its only fallback, the Manager HTTP reboot, returns a **502** through the proxy (killed origin) which was read as a failure. That's exactly what stranded a remote agent trying to load a freshly-installed custom node.

## Fix
In remote mode, `restartComfyUI()` now reboots through ComfyUI-Manager over HTTP and polls for the host to come back, instead of throwing:
- `rebootViaManager()` — `POST /v2/manager/reboot` → `GET /manager/reboot` (repo path convention, via the auth-carrying `comfyuiFetch`). **Fired** on 2xx / connection-drop / **502·503·504** (the killed-origin-behind-a-proxy case); **refused** on 403 (Manager security / access proxy); **no-endpoint** otherwise. Never throws.
- Reuses the existing `waitForApiReady()` poller (already tolerant of the down window), with a longer env-tunable budget (`COMFYUI_REMOTE_REBOOT_*`, interval clamped so a `0` can't make the poll unbounded), then `resetClient()`/`resetObjectInfoCache()`. **Local path byte-for-byte unchanged.**

## Live-proven
Fired against the real tunnelled Desktop host: the reboot came back as **HTTP 502**, was classified *"reboot fired,"* polled ~17s, and returned `{stopped:true, started:true, ready:true}` with the full node registry reloaded (2709 → 2709), 21.6s end to end.

## Gates
- `tsc --noEmit` clean; `vitest run` — 1779 passed (+4 new remote-restart tests).
- Independent adversarial review: **CLEAN TO MERGE** (all findings MINOR; the 3 actioned here: interval clamp, ECONNREFUSED classification, 403 wording).

Pairs with comfyui-mcp-panel `feat/remote-restart` (the panel `comfy_reboot` 502 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
