### PR TITLE
docs: Apps reference + blog, 0.46.0 changelog, and correct two stale claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.46.0] - 2026-07-22
+
+### MCP
+
+#### Added
+- **`apps_*` tools — run a micro-app from a canvas-less client.** Sibling to the
+  panel Apps work: thin proxies over the panel pack's
+  `/comfyui_mcp_panel/apps/*` routes, so the panel remains the single storage and
+  run implementation for both desktop and mobile. `apps_list` / `apps_get` read the
+  registered micro-apps (manifest with appMode inputs/outputs, deps, hideWorkflow);
+  `apps_run` patches `<nodeId>.<widget>` values into the app's prompt snapshot and
+  queues it, returning a `prompt_id`; `apps_run_status` polls status and outputs;
+  `apps_import` fetches a bundle from the public registry and installs it. (#285)
+- **Grok 4.5** in the Agent Panel model catalog. (#283)
+- **`restart_comfyui` now works against a remote or tunnelled ComfyUI.** It used to
+  hard-throw in remote mode (`--comfyui-url`), so an agent pointed at a tunnelled
+  ComfyUI Desktop could not restart it — even though Desktop self-supervises and a
+  ComfyUI-Manager HTTP reboot brings it straight back. Remote mode now fires a
+  Manager reboot (`POST /v2/manager/reboot`, falling back to `GET /manager/reboot`)
+  and polls for readiness instead of refusing. (#296)
+
+#### Fixed
+- **RunPod retarget, connection and idle-stop correctness.** Switching the ComfyUI
+  target now performs the full fan-out on *every* path — queue-monitor restart,
+  agent MCP-env respawn, capability probe, host-indicator frame — after syncing the
+  closed-over URL so the hello, tool and watcher origins cannot drift apart. Adds
+  `connect: true` semantics, a LAN fallback, and download-aware idle so a pod is not
+  auto-stopped while a model download is still streaming. Closes the remaining
+  cluster from #269. (#286)
+
+
 ## [0.45.0] - 2026-07-22
 
 ### MCP

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**108 MCP tools** | **32 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
+**163 MCP tools** | **32 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **13 installer packs** | **11 slash commands** | **4 autonomous agents** | **4 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-108 tools across workflow execution, generation, iteration, composition, models, and more:
+163 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/apps.mdx
+++ b/docs/apps.mdx
@@ -1,0 +1,234 @@
+---
+title: "Apps (micro-apps)"
+description: "Turn a workflow into a one-click app: a manifest, an exposed run form, and an API prompt snapshot that values are patched into per run. Convert in the panel, run from the panel, the phone, or an agent, and publish to a public registry."
+icon: "layout-grid"
+---
+
+An **app** is a workflow packaged for one-click runs **without a canvas**. It is a
+directory on your rig holding four things:
+
+| File | What it is |
+|---|---|
+| `manifest.json` | name, description, `appMode {inputs, outputs}`, `deps`, `hideWorkflow`, `published` |
+| `prompt.json` | the API-format prompt **snapshot** — values are patched into this per run |
+| `workflow.json` | the litegraph UI graph — **absent** when `hideWorkflow` is set |
+| `thumbnail.png` | optional card art |
+
+Bundles live under ComfyUI's user dir at
+`<user>/comfyui-mcp-panel/apps/<app-id>/` — deliberately **not** the workflows
+dir, so a hidden app never surfaces in the workflow browser.
+
+```
+workflow ⇄ convert (panel) ⇄ app bundle on disk ⇄ run form ⇄ patch snapshot ⇄ ComfyUI queue
+                                    ⇅
+                        publish / install ⇄ public registry
+```
+
+The reason apps exist as their own layer: the canvas is the wrong interface for
+*running* a workflow you already trust. A form with five labelled fields is the
+right one, and it is the only interface a phone or an agent can drive at all.
+
+<Note>
+  There is **one** storage and run implementation — the panel pack's HTTP routes
+  (`/comfyui_mcp_panel/apps/*`). The desktop panel, the mobile Apps tab, and the
+  `apps_*` MCP tools are all clients of it, so an app behaves identically
+  wherever you launch it from.
+</Note>
+
+## Requirements
+
+Apps are served by the **panel pack** (`comfyui-mcp-panel`), not by the MCP
+server alone. If the pack on your ComfyUI predates the feature, `apps_list`
+fails with an explicit *"the panel pack on this ComfyUI predates the Apps
+feature"* message — update the pack and restart ComfyUI.
+
+## Converting a workflow into an app
+
+In the panel, the **Apps** toolbar button (next to Civitai) opens the app grid.
+Converting the open workflow does three things:
+
+1. **Imports ComfyUI APP-mode config** if the workflow already carries one, and
+   otherwise picks inputs and outputs **heuristically** (prompt widgets, seeds,
+   sampler settings; `SaveImage`-class nodes as outputs). Imported APP-mode
+   inputs are honored on **any** node type, so custom-node endpoints survive the
+   conversion.
+2. **Scans dependencies** — the models and custom-node packs the graph needs —
+   into `manifest.deps`.
+3. **Snapshots the prompt** in API format. Widget values at conversion time
+   become each input's form `default`.
+
+Each input in `appMode.inputs` carries `nodeId`, `widget`, `label`, and a `kind`
+of `text`, `number`, `combo`, `toggle`, `image`, or `model`; combos also carry
+`choices`. That is what the run form renders from — on desktop and on mobile.
+
+### Hiding the workflow
+
+`hideWorkflow` drops `workflow.json` from the bundle entirely, so the graph
+isn't handed to whoever runs or installs the app.
+
+<Warning>
+  **`hideWorkflow` is obfuscation, never security.** The API prompt is still
+  visible to anyone who runs the app via ComfyUI's own `/history`, and the
+  models and custom nodes the app installs reveal the graph's dependencies.
+  Treat it as "don't clutter my workflow browser", not as protection for a graph
+  you can't afford to leak.
+</Warning>
+
+## Running an app
+
+A run patches your form values into the stored snapshot and queues the result.
+Patch keys are `"<nodeId>.<widget>"` — for example `{"6.text": "a cat",
+"3.seed": 42}`. The key splits on the **first** dot only, so widget names that
+themselves contain dots (LoRA stacks, `lora_1.model`) stay intact.
+
+Patching is **strict**: a key addressing a node or an input that doesn't exist
+in the snapshot is a hard error, not a silent skip. A miss means the manifest
+has drifted from the snapshot, and failing loudly beats running with stale
+values. Inputs you omit keep their conversion-time defaults.
+
+The run returns a `prompt_id`; poll it for status (`pending` → `running` →
+`done`, or `unknown` if ComfyUI has never heard of it) and for the outputs
+grouped under each output node.
+
+### Running on a RunPod pod
+
+The panel's **Run on RunPod** path reuses the same patch engine in **dry** mode:
+the panel asks for the patched prompt *without* queueing it locally, pushes any
+pinned dependencies to the pod, and enqueues the prompt there instead.
+
+<Warning>
+  Apps with an **image input** refuse to run on a pod. Uploads land on the
+  **local** ComfyUI, which the pod cannot reach — so the panel declines
+  honestly rather than queueing a run that would fail on a missing file.
+</Warning>
+
+## Publish and Explore
+
+The panel's **Explore** tab is a public registry (a Cloudflare Worker backed by
+D1 + R2) with trending / new / most-starred listings and search. Trending is
+7-day `stars * 3 + runs`. Publishing uploads the bundle — manifest, prompt,
+workflow unless hidden, thumbnail — under a sha256-keyed creator identity.
+
+Installing from Explore shows a **dependency-consent dialog** first: an app's
+`deps` are *reported*, never silently installed. Nothing installs a model or a
+custom-node pack on your rig because you tapped a card.
+
+<Note>
+  `pricing_json` and `hosted_only` exist in the manifest schema and are passed
+  through unchanged, but nothing reads them. They reserve space for a
+  design-only monetization phase — there is no paid-app behavior today.
+</Note>
+
+## The `apps_*` MCP tools
+
+Five tools, all thin proxies over the panel's Apps API. They are the
+**canvas-less** surface: what the mobile app and a directly-driven agent use.
+All five are on the orchestrator's `call_tool` whitelist — `list`/`get`/`status`
+are read-only, and `run` carries the same risk posture as `enqueue_workflow`
+(it queues a job the user explicitly tapped).
+
+| Tool | Effect |
+|---|---|
+| `apps_list` | List every app registered on this ComfyUI — each entry is the full manifest plus `has_workflow` / `has_prompt` / `has_thumbnail`. No parameters. Read-only. |
+| `apps_get` | One app's manifest + bundle facts by id. `appMode.inputs` is the run form. Read-only. |
+| `apps_run` | Patch `values` into the snapshot and queue it. Returns `prompt_id`. |
+| `apps_run_status` | Poll one run by `prompt_id`: `status` plus the run's outputs (image/video file refs per output node, text outputs). Read-only. |
+| `apps_import` | Install an app from the public registry onto this ComfyUI. |
+
+### Parameters
+
+| Tool | Parameter | Type | Notes |
+|---|---|---|---|
+| `apps_get` | `app_id` | `string` (uuid), required | from `apps_list` |
+| `apps_run` | `app_id` | `string` (uuid), required | |
+| | `values` | `object`, optional | keys `"<nodeId>.<widget>"`; unknown keys fail loudly |
+| `apps_run_status` | `app_id` | `string` (uuid), required | |
+| | `prompt_id` | `string`, required | must match `^[0-9a-zA-Z-]{1,64}$` |
+| `apps_import` | `registry_url` | `string` (URL), required | must be the default registry or an allowlisted origin |
+| | `app_id` | `string` (uuid), required | the **registry** app's uuid |
+| | `slug` | `string`, optional | recorded in local metadata |
+| | `version` | `integer`, optional | recorded in local metadata |
+
+The `prompt_id` shape constraint is enforced **twice** — at the schema boundary
+and again inside the handler — because the id is interpolated into a URL path. A
+traversal-shaped "prompt id" must never reach the URL builder even if a caller
+bypasses the schema.
+
+For the generated per-tool schema reference, see
+[Apps tools](/tools/apps).
+
+### Importing from the registry
+
+`apps_import` fetches the registry bundle server-side and creates it as a local
+app. The **registry id becomes the local id**, so re-importing an app you
+already have reports an id conflict rather than duplicating it. The thumbnail
+lives at a separate registry endpoint and is fetched and forwarded separately,
+so an installed app keeps its card art.
+
+Dependencies are **not** installed. The tool returns the manifest's `deps` so
+the caller can report them and let the user install them deliberately.
+
+<Warning>
+  `registry_url` is an allowlist, not a free URL. The fetch happens **on the
+  server**, so an arbitrary URL would be an SSRF primitive — loopback or LAN
+  addresses, or a public URL redirecting into one. Only the default public
+  registry is accepted unless the operator allowlists extra origins via
+  `COMFYUI_MCP_REGISTRY_URLS` (comma-separated, intended for dev/staging).
+  Redirects are refused outright rather than followed.
+</Warning>
+
+## Limits and validation
+
+Things you can actually hit:
+
+| Limit | Value | Where |
+|---|---|---|
+| Bundle / prompt JSON | 16 MB | roomier than a plain graph because a prompt can carry base64 images |
+| Thumbnail | 5 MB | decoded and validated **before** anything is written, so a bad thumbnail can't leave a half-created bundle behind |
+| App name | 120 chars | truncated |
+| Description | 4000 chars | truncated |
+| Combo `choices` | 200 entries | truncated |
+| Registry fetch | 16 MB, 30s | checked on the declared `content-length` **and** the actual bytes |
+
+Validation you'll notice:
+
+- **App ids must be uuids.** Anything else is rejected before a path is built,
+  and the resolved bundle path is re-checked for containment under the apps
+  root.
+- **A prompt must be API format** — numeric node-id keys, each node a
+  `{class_type, inputs}` object. UI-format graphs are rejected.
+- **A UI workflow is required unless `hideWorkflow`** is set.
+- **Creating an app that already exists** is a conflict, not an overwrite.
+- **Partial manifest updates are genuinely partial.** Publishing or hiding an
+  app sends only its own fields and will not wipe your name, description, or
+  `appMode`.
+- **Unknown manifest keys are dropped**, except the reserved pass-through
+  fields, so an older rig ignores fields it doesn't understand instead of
+  failing.
+
+The apps root is overridable with `COMFYUI_MCP_APPS_DIR` (primarily for tests);
+by default it's derived from ComfyUI's own user directory, so it survives
+portable installs.
+
+## On the phone
+
+The mobile app ships a real **Apps** tab — not a preview. It has two halves:
+
+- **My Apps** — the apps installed on your rig, listed over the bridge via
+  `apps_list`. Tapping one opens a generated run form, queues it with
+  `apps_run`, and polls `apps_run_status` every 2s (bounded at 30 minutes)
+  until the outputs render.
+- **Explore** — the public registry, hit **directly over HTTPS** from the phone
+  (no bridge hop, so browsing works before you've paired). Installing goes the
+  other direction: the rig fetches the bundle itself via `apps_import`.
+
+This is the clearest thing the phone can do that chat cannot — run a real
+workflow, with real inputs, without a canvas anywhere in sight.
+
+## See also
+
+- [Apps tools](/tools/apps) — the generated per-tool schema reference
+- [Sidebar Panel](/panel) — where apps are converted, published, and explored
+- [Mobile app](/mobile) — the Apps tab in context
+- [RunPod pods](/tools/runpod) — the pod the "Run on RunPod" path targets
+- [Roadmap](/roadmap)

--- a/docs/blog/micro-apps.mdx
+++ b/docs/blog/micro-apps.mdx
@@ -1,0 +1,195 @@
+---
+title: "Micro-Apps: turn a ComfyUI workflow into a form anyone can run"
+description: "A workflow is a graph, and a graph is a hostile interface for someone who just wants to change three things and hit Go. Apps package a workflow as a manifest plus an API-format prompt snapshot, generate a run form from it, and expose the whole thing over apps_* MCP tools — so the panel, the phone, and the agent all run the same app through one implementation."
+keywords:
+  - ComfyUI micro apps
+  - ComfyUI APP mode
+  - ComfyUI workflow to app
+  - ComfyUI one-click workflow
+  - comfyui-mcp apps tools
+  - ComfyUI app registry
+  - run ComfyUI without the canvas
+  - ComfyUI agent MCP
+---
+
+_by [artokun](https://github.com/artokun) · apps · panel · mobile · registry_
+
+You built the workflow. It works. Now someone else wants to use it — a friend, a
+client, your own self on a phone in a different room — and the thing you have to
+hand them is **a graph**.
+
+That's the whole problem. A ComfyUI workflow is an authoring artifact: 40 nodes,
+a dozen of them wired through loaders you never touch, and exactly three widgets
+that actually matter for the job at hand. Handing someone the canvas means
+handing them every decision you already made, plus the ability to break any of
+them. The honest interface for "run this thing with a different prompt and a
+different seed" is not a node editor. It's **a form**.
+
+Apps are that form.
+
+## What an app actually is
+
+An app is a workflow packaged for one-click runs, stored as a bundle in
+ComfyUI's user dir — deliberately *not* the workflows dir, so hidden apps never
+leak back into the workflow browser:
+
+```
+<user>/comfyui-mcp-panel/apps/<app-id>/
+  manifest.json   # name, description, appMode{inputs,outputs}, deps, flags
+  workflow.json   # litegraph UI format — ABSENT when hideWorkflow is set
+  prompt.json     # API-format snapshot, patched per run
+  thumbnail.png   # optional card art
+```
+
+Two files carry the idea. `prompt.json` is a frozen API-format snapshot of the
+graph — the thing that actually queues. `manifest.json` describes which parts of
+that snapshot a human is allowed to touch: `appMode.inputs`, a list of
+`{nodeId, widget, label, kind, choices?, default?}` entries where `kind` is one
+of `text | number | combo | toggle | image | model`. Running the app means
+patching values keyed `<nodeId>.<widget>` into the snapshot and queueing it.
+Nothing else moves.
+
+That's why an app is not "a workflow with a nicer skin." The graph is *fixed at
+conversion time*. The only degrees of freedom are the ones the author declared.
+
+## Converting: import what the author meant, guess the rest
+
+Conversion happens in the panel, from the live canvas. It reads the workflow's
+**APP-mode config** if the frontend has one — ComfyUI's own app-mode input/output
+selection — and honors those inputs on *any* node type, including custom-node
+endpoints. If the workflow has no app-mode config at all, the builder falls back
+to a heuristic: input-hint nodes' non-link-driven widgets become inputs, output
+nodes (`SaveImage`, `PreviewImage`, `SaveVideo`, `ShowText`, …) become outputs,
+and widget kinds get classified by shape — `LoadImage` becomes an image upload,
+anything matching a loader or a `*_name` widget becomes a model picker, numbers
+become numbers, arrays become combos.
+
+The same pass scans the API prompt for **deps**: model filenames pulled off
+loader widgets, and every `class_type` your ComfyUI doesn't already know, which
+is the custom-node list. Those ride in the manifest so the person installing the
+app finds out what it needs *before* they run it and eat a red node.
+
+There's also a `hideWorkflow` flag, and the copy around it is deliberately
+unflattering. Hiding the workflow drops `workflow.json` from the bundle so the
+graph isn't handed over with the app. It is **best-effort obfuscation, never
+security** — the prompt still runs on the viewer's ComfyUI, which means it's
+visible through `/history`, and the deps list spells out the architecture
+anyway. The UI says exactly that at the point where you'd click it.
+
+## The agent angle
+
+Here's the part that isn't just a nicer front end.
+
+The panel's Apps routes are server-side, not browser fetches, which means the
+same storage and run engine backs a set of MCP tools. The agent gets five:
+
+| Tool | What it does |
+| --- | --- |
+| `apps_list` | Every app registered on this ComfyUI, as manifests |
+| `apps_get` | One app's manifest + bundle facts (`has_workflow`/`has_prompt`/`has_thumbnail`) |
+| `apps_run` | Patch `values` into the snapshot and queue it → `prompt_id` |
+| `apps_run_status` | Poll one run: `pending`/`running`/`done`/`unknown` + outputs |
+| `apps_import` | Install an app from the public registry onto this ComfyUI |
+
+So the agent can read the run form the same way a human does — `appMode.inputs`
+*is* the schema — fill it, queue it, and collect the outputs. No canvas, no
+graph surgery, no guessing which of the 40 nodes holds the positive prompt.
+
+A worked run, end to end:
+
+```jsonc
+// 1. What's installed?
+apps_list {}
+// → [{ id: "6f1c…", name: "Portrait Upscale", appMode: { inputs: [...] }, … }]
+
+// 2. What does it want?
+apps_get { "app_id": "6f1c…" }
+// → appMode.inputs: [
+//     { nodeId: 6,  widget: "text",     label: "Prompt",   kind: "text" },
+//     { nodeId: 3,  widget: "seed",     label: "Seed",     kind: "number" },
+//     { nodeId: 14, widget: "ckpt_name", label: "Checkpoint", kind: "model",
+//       choices: ["flux1-dev.safetensors", …] }
+//   ]
+
+// 3. Run it.
+apps_run {
+  "app_id": "6f1c…",
+  "values": { "6.text": "a tabby cat in a sunbeam", "3.seed": 42 }
+}
+// → { "prompt_id": "a9d3…" }
+
+// 4. Poll.
+apps_run_status { "app_id": "6f1c…", "prompt_id": "a9d3…" }
+// → { "status": "done", "outputs": { "9": { "images": [ … ] } } }
+```
+
+Omitted inputs keep their conversion-time defaults. Unknown keys **fail loudly**
+rather than silently no-op'ing — if a value key doesn't resolve against the
+snapshot, the manifest has drifted from the prompt and you want to hear about it
+immediately, not after a render that ignored half your parameters.
+
+The tools are whitelisted on the orchestrator's `call_tool` path, which is what
+lets **canvas-less clients** drive them. That's the real unlock: a phone has no
+node editor and never will, but it doesn't need one to render a `<nodeId>.<widget>`
+map as a form.
+
+## On the phone
+
+The mobile Apps tab is **real, not a placeholder** — the previous "coming soon"
+stub is gone. It renders My Apps as a card grid with thumbnails (via
+`apps_list`), generates the input form from the manifest on the detail screen —
+text, number, combo, toggle, model pickers, and gallery image upload — fires
+`apps_run` on a tap, polls `apps_run_status` every two seconds, and shows the
+outputs gallery plus any text outputs. Hidden-workflow apps carry the same
+honest best-effort warning the panel shows.
+
+Explore works on the phone too: it browses the public registry over direct
+HTTPS, but **install goes rig-side through `apps_import`** — the phone asks your
+ComfyUI to fetch and install the bundle rather than shipping it over the bridge
+itself.
+
+## Publish and Explore
+
+Published apps live in a registry: a dependency-free Cloudflare Worker on D1 +
+R2. Publishing uploads the manifest, the prompt snapshot, the workflow (unless
+hidden), and a thumbnail, under a creator identity keyed by a sha256 hash.
+Explore gives you **Trending / New / Most starred** plus search, with keyset
+pagination; trending is a 7-day window weighting stars over runs. You can star,
+unstar, and report.
+
+Installing from Explore goes through a **deps-consent dialog** — you see the
+models and custom nodes the app needs before anything lands. Same posture on the
+tool side: `apps_import` does *not* install deps. It returns them, and the agent
+is expected to tell you what's missing so you can decide.
+
+`apps_import` also refuses to fetch from arbitrary origins. The fetch is
+server-side, so an open `registry_url` would be a straightforward SSRF
+primitive — loopback, LAN, or a public URL redirecting into one. It accepts the
+default public registry, plus anything the operator explicitly allowlists via
+`COMFYUI_MCP_REGISTRY_URLS`, with redirects refused outright and a 16MB cap on
+the bundle checked against both the declared length and the actual bytes.
+
+## Running on a pod
+
+Apps run on the local ComfyUI by default. If you have a RunPod pod connected
+through the panel, **Run on RunPod** dry-patches the snapshot locally, pushes
+the pinned deps, and enqueues the resulting prompt on the pod instead.
+
+One case it refuses rather than fudges: apps with an **image input** can't run on
+a pod. Uploads land on the *local* ComfyUI, which the pod can't reach, so the
+button declines with that explanation instead of queueing something that would
+fail confusingly ten seconds later.
+
+## What this is, honestly
+
+Apps don't make workflows easier to build. They make workflows easier to
+*hand off* — to another person, to another device, or to an agent that doesn't
+want to reason about a graph just to change a prompt and a seed. The graph is
+still the source of truth. It's just no longer the interface.
+
+---
+
+Convert your first workflow from the Apps button in the
+[Agent Panel](/panel) toolbar, or ask the agent what's installed with
+`apps_list`. Issues and ideas:
+[artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp/issues).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
               "concepts",
               "plugin",
               "panel",
+              "apps",
               "mobile",
               "backends",
               "local-llms",
@@ -100,6 +101,7 @@
             "group": "Blog",
             "pages": [
               "blog/index",
+              "blog/micro-apps",
               "blog/runpod-comfyui",
               "blog/train-lora-runpod",
               "blog/lora-trainer-p1",

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 32 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 108 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 32 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 163 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -56,6 +56,7 @@ Everything here works today and is covered by the docs.
 | **Models & custom nodes** | Search, install and repair node packs; find and download models — including working out which models a workflow is missing and which quantisation fits your VRAM. |
 | **Civitai browser** | Browse images, videos and models in-panel, filter by base model and creator, and pull a workflow straight onto the canvas. |
 | **Mobile app** | Chat to the agent, watch the queue, browse LoRAs, and mirror a desktop tab to drive your rig from your phone. See [Mobile](/mobile). |
+| **Apps (micro-apps)** | Turn a workflow into a one-click app with a real form: convert and publish in the panel, run it locally or on a pod, install others' apps from the public registry — and run the same apps from the phone's Apps tab or an agent via the `apps_*` tools. See [Apps](/apps). |
 | **Remote & cloud** | Point the panel at a remote ComfyUI, a self-hosted relay, or Comfy Cloud. See [Remote connector](/remote-connector). |
 | **RunPod pods** | Create, connect to and stop RunPod pods from the panel, with billing-safe defaults and an honest host indicator. |
 | **LoRA training (local)** | Character LoRAs on FLUX.1-dev, driven by the agent through `train_*` tools in a GPU Docker container — dataset in, `.safetensors` in `models/loras/` out. |
@@ -75,9 +76,8 @@ Queued and specified, not started. Ordered.
 
 | Item | Why it's here |
 |---|---|
-| **Honest previews in the mobile app** | The app ships **Apps** and **Training** tabs that are placeholders. They read as shipped features and have already misled people into asking how far along they are. Either label them plainly or hide them — the cheapest fix on this list. |
-| **Mobile training** | Wire the mobile Training tab to the trainer that already works. The hard part is done; this is mostly plumbing, and it retires half the item above. |
-| **Apps on mobile** | ComfyUI's workflow-as-form Apps, rendered on the phone — run a workflow without the canvas. The clearest missing capability in the mobile app. |
+| **Honest previews in the mobile app** | The **Training** tab is still inert placeholder UI — six cards that read as a shipped feature and have already misled people into asking how far along it is. Either label it plainly or hide it — the cheapest fix on this list. (The **Apps** tab was the other half of this item and is now real; see [Apps](/apps).) |
+| **Mobile training** | Wire the mobile Training tab to the trainer that already works. The hard part is done; this is mostly plumbing, and it retires the item above. |
 | **Tablet layout** | Real, unglamorous responsive work. Worth doing once the screens above have something worth showing. |
 
 ## Under consideration


### PR DESCRIPTION
Pre-release documentation pass for **0.46.0**. Two agents wrote the Apps material
in parallel; I wrote the changelog and fixed what turned out to be stale.

## Added

- **`docs/apps.mdx`** — the reference page. Bundle layout on disk, conversion,
  patch semantics, `hideWorkflow`, pod runs, registry publish/explore, all five
  `apps_*` tools with params and returns, and the real limits read out of
  `apps_routes.py` (16 MB JSON, 5 MB thumbnail, 120-char name, 200 combo choices).
- **`docs/blog/micro-apps.mdx`** — why a graph is a hostile interface for someone
  who wants to change three things and hit Go.
- **0.46.0 changelog** — `apps_*` tools, Grok 4.5, remote `restart_comfyui` via
  Manager reboot, and the RunPod retarget/connect/LAN-fallback/idle cluster.

## Two things that were wrong

**The roadmap went stale within a day of being written.** Apps sat under *Next*
while it had already shipped. It moves to *Shipped*.

More importantly, the "honest previews" item claimed the mobile **Apps and
Training** tabs were placeholders. That is now false for Apps — the stub was
deleted and replaced with a real implementation in mobile #25
(`lib/features/apps/`, ~1,264 lines: My Apps, generated run form, `apps_run` +
2s status polling, Explore, install via `apps_import`). I verified the old stub
file is gone rather than taking it on trust. Training is now the *only*
remaining placeholder, and the item says so.

**The tool count was a third low.** README and `plugin.mdx` both claimed
**108 MCP tools** — a number last touched at 0.20.9 on 2026-06-27. There are
**163** distinct registrations today.

## One thing deliberately NOT claimed

There is **no MCP tool for workflow→app conversion**. Conversion is panel-UI
only; the agent can list, get, run, poll and import, but cannot *create* an app.
The docs and changelog both stay inside that boundary rather than implying a
round trip that doesn't exist.

## Verification

- Every nav entry checked to resolve to a real `.mdx` file; `docs.json` re-validated
- `tsc --noEmit` clean
- Tool count derived from distinct `server.tool("...")` registrations, not estimated
- Mobile status confirmed by inspecting the mobile repo directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)