### PR TITLE
fix(train): upper-bound train_start params (#104)

### DIFF
--- a/src/__tests__/tools/train.test.ts
+++ b/src/__tests__/tools/train.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { z } from "zod";
+
+// The train tools pull config.js (env/port probes) — stub it the same way the
+// runpod tool tests do so registration is side-effect free.
+vi.mock("../../config.js", () => ({
+  isRemoteMode: () => false,
+}));
+
+import { registerTrainTools } from "../../tools/train.js";
+
+/** Capture the zod SHAPE a tool registered with (server.tool(name, desc, shape, handler)). */
+function getShape(name: string): Record<string, z.ZodType> {
+  let shape: Record<string, z.ZodType> | undefined;
+  const server = { tool: (n: string, _d: string, s: unknown, _h: unknown) => { if (n === name) shape = s as Record<string, z.ZodType>; } };
+  registerTrainTools(server as never);
+  if (!shape) throw new Error(`tool ${name} not registered`);
+  return shape;
+}
+
+describe("train_start params bounds (#104 — a Custom-preset typo must not start a doomed billed run)", () => {
+  const params = () => getShape("train_start").params;
+
+  it("accepts sane custom params (and every preset value)", () => {
+    for (const p of [
+      { steps: 2000, lr: 1e-4, rank: 16, resolution: [512, 768, 1024] },
+      { steps: 1, lr: 0.5, rank: 1024, resolution: [64] },
+      { steps: 100_000, lr: 1, rank: 1, resolution: [4096] },
+      {}, // all-optional
+    ]) {
+      expect(params().safeParse(p).success, JSON.stringify(p)).toBe(true);
+    }
+  });
+
+  it("rejects absurd values that would doom/OOM a run", () => {
+    for (const p of [
+      { steps: 1_000_000_000 },
+      { steps: 100_001 },
+      { steps: 0 },
+      { lr: 10 },
+      { rank: 100_000 },
+      { rank: 1025 },
+      { rank: 0 },
+      { resolution: [100_000] },
+      { resolution: [8192] },
+      { resolution: [32] },
+      { resolution: [0] },
+      { resolution: [] },
+    ]) {
+      expect(params().safeParse(p).success, JSON.stringify(p)).toBe(false);
+    }
+  });
+
+  it("rejects non-integer steps/rank/resolution", () => {
+    expect(params().safeParse({ steps: 200.5 }).success).toBe(false);
+    expect(params().safeParse({ rank: 15.5 }).success).toBe(false);
+    expect(params().safeParse({ resolution: [511.5] }).success).toBe(false);
+  });
+});

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -59,10 +59,14 @@ async function resolvePodForTraining(podId?: string): Promise<import("../service
 
 const paramsSchema = z
   .object({
-    steps: z.number().int().min(1).optional().describe("Total training steps (200 = smoke test, 1500-3000 real)."),
-    lr: z.number().positive().optional().describe("Learning rate."),
-    rank: z.number().int().min(1).optional().describe("LoRA rank (16 simple, 16-32 detailed)."),
-    resolution: z.array(z.number().int().positive()).min(1).optional().describe("Resolution buckets, e.g. [512,768,1024]."),
+    // Upper bounds (panel #104): the Custom preset is free-form, and a typo
+    // like steps=10^9 / rank=100000 / resolution=100000 starts a doomed,
+    // OOM, BILLED run. Ceilings are generous but sane; the panel wizard
+    // mirrors them client-side.
+    steps: z.number().int().min(1).max(100_000).optional().describe("Total training steps (200 = smoke test, 1500-3000 real; max 100000)."),
+    lr: z.number().positive().max(1).optional().describe("Learning rate (max 1)."),
+    rank: z.number().int().min(1).max(1024).optional().describe("LoRA rank (16 simple, 16-32 detailed; max 1024)."),
+    resolution: z.array(z.number().int().min(64).max(4096)).min(1).optional().describe("Resolution buckets, e.g. [512,768,1024] (each 64-4096)."),
     batchSize: z.number().int().min(1).optional(),
     saveEvery: z.number().int().min(1).optional().describe("Checkpoint cadence (steps)."),
     sampleEvery: z.number().int().min(1).optional().describe("Sample-image cadence (steps)."),


### PR DESCRIPTION
Backend half of artokun/comfyui-mcp-panel#104 (client half: comfyui-mcp-panel#127).

## Problem
The Custom preset is free-form, and the `train_start` schema had no upper bounds — steps=10⁹, rank=100000, or resolution=100000 passed validation and started a doomed/OOM **billed** run.

## Fix
Max constraints in `src/tools/train.ts` `paramsSchema` (mirrored client-side by panel #127):
- `steps` ≤ 100,000
- `lr` ≤ 1
- `rank` ≤ 1024
- `resolution` each 64–4096

Deliberately scoped to the four fields the issue names; `batchSize`/`saveEvery`/`sampleEvery` keep `min(1)` (noted, not changed).

## Verification
- New `src/__tests__/tools/train.test.ts` (3 tests): sane values + all preset/default values pass; absurd values (10⁹ steps, lr 10, rank 100000, res 8192/32/0/[]) and non-integers rejected.
- tsc clean; codex review: **no findings** (bounds verified against `training-config.ts` DEFAULT_PARAMS + presets).
- Full suite: only the pre-existing Windows-env `node-dev` ripgrep failure (reproduces on main, unrelated).