### PR TITLE
feat(train): dataset inputs for app clients — json output listing + ref items

### DIFF
--- a/docs/tools/training.mdx
+++ b/docs/tools/training.mdx
@@ -97,7 +97,7 @@ Set up the NATIVE (dockerless) trainer on this machine or a pod: clone ai-toolki
 
 ## train_prepare_dataset
 
-Stage training images + captions into a dataset dir the trainer consumes. Each item is an image path with an optional caption (a missing caption falls back to defaultCaption — typically the trigger word). Returns the datasetPath to pass to train_start. Character LoRA guidance: 10-30 varied images; caption what changes between images, keep the trigger word constant.
+Stage training images + captions into a dataset dir the trainer consumes. Each item is an image (absolute `path`, OR a ComfyUI `ref` &#123;filename,subfolder?,type?&#125; resolved against the connected ComfyUI's output/input dirs — how phone/panel pickers hand over selections) with an optional caption (a missing caption falls back to defaultCaption — typically the trigger word). Returns the datasetPath to pass to train_start. Character LoRA guidance: 10-30 varied images; caption what changes between images, keep the trigger word constant.
 
 ### Parameters
 

--- a/src/__tests__/tools/image-management.test.ts
+++ b/src/__tests__/tools/image-management.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The tool's format:"json" shape is the contract the mobile dataset picker
+// builds on — pin it. The service is mocked; the markdown path must stay
+// byte-for-byte compatible (default when format is omitted).
+const listMock = vi.fn();
+vi.mock("../../services/image-management.js", () => ({
+  extractWorkflowFromImage: vi.fn(),
+  listOutputImages: (...a: unknown[]) => listMock(...a),
+  getOutputImage: vi.fn(),
+  uploadImageAuto: vi.fn(),
+  uploadVideoAuto: vi.fn(),
+  uploadAudioAuto: vi.fn(),
+  stageOutputAsInput: vi.fn(),
+}));
+
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>;
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = { tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => { if (n === name) handler = h; } };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+const sample = [
+  { filename: "a.png", path: "/out/a.png", size: 1024, modified: "2026-07-22T00:00:00.000Z", subfolder: "", kind: "image" },
+  { filename: "b.mp4", path: "/out/video/b.mp4", size: 2048, modified: "2026-07-21T00:00:00.000Z", subfolder: "video", kind: "video" },
+];
+
+describe("list_output_images format param", () => {
+  it("default (markdown) keeps the human/agent-readable list", async () => {
+    listMock.mockResolvedValue(sample);
+    const t = (await getHandler("list_output_images")({ limit: 5 })).content[0].text;
+    expect(t).toContain("Found 2 media file(s) (1 video):");
+    expect(t).toContain("**video/b.mp4** [video]");
+  });
+
+  it("format:json returns a machine-readable array (no prose)", async () => {
+    listMock.mockResolvedValue(sample);
+    const t = (await getHandler("list_output_images")({ limit: 5, format: "json" })).content[0].text;
+    const parsed = JSON.parse(t) as { images: Array<Record<string, unknown>> };
+    expect(parsed.images).toHaveLength(2);
+    expect(parsed.images[0]).toEqual({ filename: "a.png", subfolder: "", kind: "image", size: 1024, modified: "2026-07-22T00:00:00.000Z" });
+    expect(parsed.images[1]).toMatchObject({ filename: "b.mp4", subfolder: "video", kind: "video" });
+  });
+
+  it("format:json with no matches returns an empty array (not a prose message)", async () => {
+    listMock.mockResolvedValue([]);
+    const t = (await getHandler("list_output_images")({ format: "json" })).content[0].text;
+    expect(JSON.parse(t)).toEqual({ images: [] });
+  });
+
+  it("format:json omits size/modified when the scan can't provide them (remote/history path)", async () => {
+    listMock.mockResolvedValue([{ filename: "r.png", path: "", size: 0, modified: "", subfolder: "", kind: "image" }]);
+    const t = (await getHandler("list_output_images")({ format: "json" })).content[0].text;
+    const parsed = JSON.parse(t) as { images: Array<Record<string, unknown>> };
+    expect(parsed.images[0]).toEqual({ filename: "r.png", subfolder: "", kind: "image" });
+  });
+});

--- a/src/__tests__/tools/train-dataset-refs.test.ts
+++ b/src/__tests__/tools/train-dataset-refs.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { resolve } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // train_prepare_dataset items now take path OR a ComfyUI ref — refs are how
 // phone/panel pickers hand over selections. Pin the resolution semantics
@@ -23,11 +26,13 @@ vi.mock("../../services/ai-toolkit.js", () => ({
   trainerImageExists: vi.fn(),
   TRAINER_IMAGE: "trainer:test",
 }));
+let outRoot = "/comfy/output";
+let remote = false;
 vi.mock("../../services/output-dir.js", () => ({
-  resolveOutputDir: () => Promise.resolve("/comfy/output"),
+  resolveOutputDir: () => Promise.resolve(outRoot),
   resolveInputDir: () => Promise.resolve("/comfy/input"),
 }));
-vi.mock("../../config.js", () => ({ isRemoteMode: () => false }));
+vi.mock("../../config.js", () => ({ isRemoteMode: () => remote }));
 
 import { registerTrainTools } from "../../tools/train.js";
 
@@ -44,7 +49,11 @@ function getTool(name: string): { handler: ToolHandler; shape: Record<string, { 
 
 const call = (items: unknown[]) => getTool("train_prepare_dataset").handler({ name: "ds", items });
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  outRoot = "/comfy/output";
+  remote = false;
+});
 
 describe("train_prepare_dataset — path/ref items", () => {
   it("path-only items pass through untouched", async () => {
@@ -89,5 +98,41 @@ describe("train_prepare_dataset — path/ref items", () => {
     expect(items.safeParse([{ caption: "lost" }]).success).toBe(false);
     expect(items.safeParse([{ path: "/x.png" }]).success).toBe(true);
     expect(items.safeParse([{ ref: { filename: "x.png" } }]).success).toBe(true);
+  });
+
+  it("refs are REJECTED in remote mode (the paths would resolve on the wrong machine)", async () => {
+    remote = true;
+    const res = await call([{ ref: { filename: "a.png" } }]);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("LOCAL ComfyUI");
+    expect(prepareMock).not.toHaveBeenCalled();
+  });
+
+  it("a symlinked subfolder pointing OUTSIDE the root is rejected (codex: lexical check bypass)", async () => {
+    const base = mkdtempSync(join(tmpdir(), "dsref-"));
+    const out = join(base, "output");
+    const outside = join(base, "outside");
+    mkdirSync(out, { recursive: true });
+    mkdirSync(outside);
+    writeFileSync(join(outside, "x.png"), "x");
+    symlinkSync(outside, join(out, "link"), "junction");
+    outRoot = out;
+    const res = await call([{ ref: { filename: "x.png", subfolder: "link" } }]);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("escapes");
+    expect(prepareMock).not.toHaveBeenCalled();
+  });
+
+  it("a symlink INSIDE the root pointing inside the root resolves to its real path", async () => {
+    const base = mkdtempSync(join(tmpdir(), "dsref-"));
+    const out = join(base, "output");
+    const real = join(out, "real");
+    mkdirSync(real, { recursive: true });
+    writeFileSync(join(real, "y.png"), "y");
+    symlinkSync(real, join(out, "alias"), "junction");
+    outRoot = out;
+    await call([{ ref: { filename: "y.png", subfolder: "alias" } }]);
+    expect(prepareMock).toHaveBeenCalled();
+    expect(prepareMock.mock.calls[0][0].items[0].path).toBe(realpathSync(join(out, "alias", "y.png")));
   });
 });

--- a/src/__tests__/tools/train-dataset-refs.test.ts
+++ b/src/__tests__/tools/train-dataset-refs.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { resolve } from "node:path";
+
+// train_prepare_dataset items now take path OR a ComfyUI ref — refs are how
+// phone/panel pickers hand over selections. Pin the resolution semantics
+// (output/input roots, containment) and the traversal rejections.
+const prepareMock = vi.fn((opts: { items: Array<{ path: string; caption?: string }> }) =>
+  Promise.resolve({ datasetPath: "/datasets/x", imageCount: opts.items.length, captionedCount: 0, warnings: [] }),
+);
+vi.mock("../../services/training-jobs.js", () => ({
+  cancelJob: vi.fn(),
+  getJob: vi.fn(),
+  hfCacheRoot: vi.fn(),
+  listJobs: vi.fn(() => Promise.resolve([])),
+  prepareDataset: (...a: unknown[]) => prepareMock(...a),
+  startTrainingJob: vi.fn(),
+  trainingRoot: vi.fn(() => "/tmp/training"),
+}));
+vi.mock("../../services/ai-toolkit.js", () => ({
+  buildTrainerImage: vi.fn(),
+  dockerAvailable: vi.fn(),
+  trainerDoctor: vi.fn(),
+  trainerImageExists: vi.fn(),
+  TRAINER_IMAGE: "trainer:test",
+}));
+vi.mock("../../services/output-dir.js", () => ({
+  resolveOutputDir: () => Promise.resolve("/comfy/output"),
+  resolveInputDir: () => Promise.resolve("/comfy/input"),
+}));
+vi.mock("../../config.js", () => ({ isRemoteMode: () => false }));
+
+import { registerTrainTools } from "../../tools/train.js";
+
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text: string }> };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+function getTool(name: string): { handler: ToolHandler; shape: Record<string, { safeParse: (v: unknown) => { success: boolean } }> } {
+  let handler: ToolHandler | undefined;
+  let shape: Record<string, never> | undefined;
+  const server = { tool: (n: string, _d: string, s: unknown, h: ToolHandler) => { if (n === name) { handler = h; shape = s as never; } } };
+  registerTrainTools(server as never);
+  if (!handler || !shape) throw new Error(`tool ${name} not registered`);
+  return { handler, shape: shape as never };
+}
+
+const call = (items: unknown[]) => getTool("train_prepare_dataset").handler({ name: "ds", items });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("train_prepare_dataset — path/ref items", () => {
+  it("path-only items pass through untouched", async () => {
+    await call([{ path: "/host/pic.png", caption: "c" }]);
+    expect(prepareMock.mock.calls[0][0].items).toEqual([{ path: "/host/pic.png", caption: "c" }]);
+  });
+
+  it("an explicit path WINS when ref is also present", async () => {
+    await call([{ path: "/host/pic.png", ref: { filename: "other.png" } }]);
+    expect(prepareMock.mock.calls[0][0].items[0].path).toBe("/host/pic.png");
+  });
+
+  it("ref resolves against the output root by default (top level + subfolder)", async () => {
+    await call([{ ref: { filename: "a.png" } }, { ref: { filename: "b.png", subfolder: "vid" } }]);
+    const items = prepareMock.mock.calls[0][0].items;
+    expect(items[0].path).toBe(resolve("/comfy/output", "a.png"));
+    expect(items[1].path).toBe(resolve("/comfy/output", "vid", "b.png"));
+  });
+
+  it("ref type:'input' resolves against the input root", async () => {
+    await call([{ ref: { filename: "up.png", type: "input" } }]);
+    expect(prepareMock.mock.calls[0][0].items[0].path).toBe(resolve("/comfy/input", "up.png"));
+  });
+
+  it("ref filename with a path separator is rejected", async () => {
+    const res = await call([{ ref: { filename: "sub/a.png" } }]);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("basename");
+    expect(prepareMock).not.toHaveBeenCalled();
+  });
+
+  it("a '..' subfolder escaping the root is rejected (path traversal)", async () => {
+    const res = await call([{ ref: { filename: "secret.txt", subfolder: "../../.." } }]);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("escapes");
+    expect(prepareMock).not.toHaveBeenCalled();
+  });
+
+  it("an item with NEITHER path nor ref fails schema validation", () => {
+    const { shape } = getTool("train_prepare_dataset");
+    const items = shape.items as { safeParse: (v: unknown) => { success: boolean } };
+    expect(items.safeParse([{ caption: "lost" }]).success).toBe(false);
+    expect(items.safeParse([{ path: "/x.png" }]).success).toBe(true);
+    expect(items.safeParse([{ ref: { filename: "x.png" } }]).success).toBe(true);
+  });
+});

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -303,6 +303,10 @@ export function registerImageManagementTools(server: McpServer): void {
         .string()
         .optional()
         .describe("Filter by filename pattern (case-insensitive substring match)"),
+      format: z
+        .enum(["markdown", "json"])
+        .optional()
+        .describe("Response shape: markdown (default, human/agent-readable) or json ({images:[{filename,subfolder,kind,size,modified}]} — for app clients building pick grids)."),
     },
     async (args) => {
       try {
@@ -310,6 +314,26 @@ export function registerImageManagementTools(server: McpServer): void {
           limit: args.limit,
           pattern: args.pattern,
         });
+        if (args.format === "json") {
+          // Machine-readable form for app clients (the mobile dataset picker):
+          // same entries, no prose. Thumbs render client-side via /view URLs.
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  images: images.map((img) => ({
+                    filename: img.filename,
+                    subfolder: img.subfolder,
+                    kind: img.kind,
+                    ...(img.size > 0 ? { size: img.size } : {}),
+                    ...(img.modified ? { modified: img.modified } : {}),
+                  })),
+                }),
+              },
+            ],
+          };
+        }
         if (images.length === 0) {
           return {
             content: [

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -2,7 +2,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
+import { resolveInputDir, resolveOutputDir } from "../services/output-dir.js";
 import {
   buildTrainerImage,
   dockerAvailable,
@@ -57,6 +58,39 @@ async function resolvePodForTraining(podId?: string): Promise<import("../service
   return pod;
 }
 
+/** Map tool items (path | ComfyUI ref) to host-absolute DatasetItems. Refs
+ *  resolve against the connected ComfyUI's output/input root with containment:
+ *  the filename must be a plain basename and the resolved path must stay INSIDE
+ *  the root — otherwise a crafted ref could stage ANY host file into a dataset
+ *  (path traversal). prepareDataset then verifies existence/type per item. */
+async function resolveDatasetItems(
+  items: Array<{
+    path?: string;
+    ref?: { filename: string; subfolder?: string; type?: "output" | "input" };
+    caption?: string;
+  }>,
+): Promise<Array<{ path: string; caption?: string }>> {
+  const norm = (p: string) => (process.platform === "win32" ? p.toLowerCase() : p);
+  return Promise.all(
+    items.map(async (it) => {
+      // An explicit host path always wins over a ref (both are allowed so a
+      // caller can attach a ref for traceability).
+      if (it.path) return { path: it.path, caption: it.caption };
+      const { filename, subfolder, type } = it.ref!;
+      if (filename !== basename(filename)) {
+        throw new Error(`ref filename must be a plain basename, got "${filename}"`);
+      }
+      const kind = type ?? "output";
+      const root = resolve(kind === "input" ? await resolveInputDir() : await resolveOutputDir());
+      const candidate = resolve(root, subfolder ?? "", filename);
+      if (norm(candidate) !== norm(root) && !norm(candidate).startsWith(norm(root) + sep)) {
+        throw new Error(`ref "${subfolder ?? ""}/${filename}" escapes the ${kind} dir`);
+      }
+      return { path: candidate, caption: it.caption };
+    }),
+  );
+}
+
 const paramsSchema = z
   .object({
     steps: z.number().int().min(1).optional().describe("Total training steps (200 = smoke test, 1500-3000 real)."),
@@ -105,22 +139,33 @@ export function registerTrainTools(server: McpServer): void {
 
   server.tool(
     "train_prepare_dataset",
-    "Stage training images + captions into a dataset dir the trainer consumes. Each item is an image path with an optional caption (a missing caption falls back to defaultCaption — typically the trigger word). Returns the datasetPath to pass to train_start. Character LoRA guidance: 10-30 varied images; caption what changes between images, keep the trigger word constant.",
+    "Stage training images + captions into a dataset dir the trainer consumes. Each item is an image (absolute `path`, OR a ComfyUI `ref` {filename,subfolder?,type?} resolved against the connected ComfyUI's output/input dirs — how phone/panel pickers hand over selections) with an optional caption (a missing caption falls back to defaultCaption — typically the trigger word). Returns the datasetPath to pass to train_start. Character LoRA guidance: 10-30 varied images; caption what changes between images, keep the trigger word constant.",
     {
       name: z.string().min(1).describe("Dataset name (becomes the staging dir name)."),
       items: z
         .array(
-          z.object({
-            path: z.string().min(1).describe("Absolute path to a source image (png/jpg/jpeg/webp)."),
-            caption: z.string().optional().describe("Caption for this image."),
-          }),
+          z
+            .object({
+              path: z.string().min(1).optional().describe("Absolute path to a source image (png/jpg/jpeg/webp)."),
+              ref: z
+                .object({
+                  filename: z.string().min(1).describe("Basename only — no path separators."),
+                  subfolder: z.string().optional().describe("Subfolder under the root (default top level)."),
+                  type: z.enum(["output", "input"]).optional().default("output").describe("Which ComfyUI dir to resolve against (default output)."),
+                })
+                .optional()
+                .describe("ComfyUI file ref (e.g. from list_output_images format:json) — resolved server-side with containment checks. Give path OR ref."),
+              caption: z.string().optional().describe("Caption for this image."),
+            })
+            .refine((it) => !!it.path || !!it.ref, { message: "each item needs path or ref" }),
         )
         .min(1),
       defaultCaption: z.string().optional().describe("Fallback caption for items without one — usually the trigger word."),
     },
     async (args) => {
       try {
-        const prepared = await prepareDataset({ name: args.name, items: args.items, defaultCaption: args.defaultCaption });
+        const items = await resolveDatasetItems(args.items);
+        const prepared = await prepareDataset({ name: args.name, items, defaultCaption: args.defaultCaption });
         return textEnvelope({ ok: true, ...prepared });
       } catch (error) {
         return errorToToolResult(error);

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
+import { realpath } from "node:fs/promises";
 import { basename, join, resolve, sep } from "node:path";
 import { resolveInputDir, resolveOutputDir } from "../services/output-dir.js";
 import {
@@ -76,6 +77,12 @@ async function resolveDatasetItems(
       // An explicit host path always wins over a ref (both are allowed so a
       // caller can attach a ref for traceability).
       if (it.path) return { path: it.path, caption: it.caption };
+      // Refs resolve on the ORCHESTRATOR's filesystem — against a remote
+      // ComfyUI (pod/LAN) the root would come from that machine's stats while
+      // prepareDataset checks/copies locally (codex finding). Reject honestly.
+      if (isRemoteMode()) {
+        throw new Error("ref items need a LOCAL ComfyUI (the orchestrator must share its filesystem) — pass absolute paths, or fetch the remote outputs first");
+      }
       const { filename, subfolder, type } = it.ref!;
       if (filename !== basename(filename)) {
         throw new Error(`ref filename must be a plain basename, got "${filename}"`);
@@ -83,10 +90,15 @@ async function resolveDatasetItems(
       const kind = type ?? "output";
       const root = resolve(kind === "input" ? await resolveInputDir() : await resolveOutputDir());
       const candidate = resolve(root, subfolder ?? "", filename);
-      if (norm(candidate) !== norm(root) && !norm(candidate).startsWith(norm(root) + sep)) {
+      // Containment on REAL paths — a symlinked subfolder/file pointing outside
+      // the root must not smuggle the copy across (codex finding). A missing
+      // target keeps its lexical path; prepareDataset reports it not-found.
+      const realRoot = await realpath(root).catch(() => root);
+      const realCandidate = await realpath(candidate).catch(() => candidate);
+      if (norm(realCandidate) !== norm(realRoot) && !norm(realCandidate).startsWith(norm(realRoot) + sep)) {
         throw new Error(`ref "${subfolder ?? ""}/${filename}" escapes the ${kind} dir`);
       }
-      return { path: candidate, caption: it.caption };
+      return { path: realCandidate, caption: it.caption };
     }),
   );
 }


### PR DESCRIPTION
First backend slice of the mobile Training tab (design: `design/mobile-training-tab.md`, PR A). Answer-independent plumbing — every variant of the tab needs these two channels.

## 1. `list_output_images` gains `format: "json"`
Markdown default unchanged. `json` returns `{images:[{filename,subfolder,kind,size?,modified?}]}` so app clients (mobile dataset picker) can build pick grids — thumbs render via existing `/view` URLs, no new media channel. Mobile can't parse the markdown and can't reach the panel's py `/training/list-outputs` route; this is the structured equivalent.

## 2. `train_prepare_dataset` items take `path` OR `ref`
`ref: {filename, subfolder?, type?}` resolves server-side against the connected ComfyUI's output/input dirs — how phone/panel pick selections get into a dataset (the py `resolve-paths` route is panel-only).

Hardening (codex round, 2 P2s fixed):
- **Remote-mode rejection**: against a remote/pod ComfyUI the root would resolve on the wrong machine while `prepareDataset` copies locally → honest error (pass absolute paths or fetch first).
- **Realpath containment**: root + candidate compared after `realpath` — a symlinked subfolder pointing outside the root can't smuggle the copy across; basename-only filenames; explicit `path` wins when both are given.

## Verification
- 14 tests across two new suites (json shape incl. empty/remote-scan omission; resolution semantics; traversal/symlink/remote rejections; schema refine). Full suite green except the pre-existing Windows-env `node-dev` failure (reproduces on main).
- tsc clean; codex review: 2 P2s found → fixed with tests.