### PR TITLE
fix(orchestrator): ignore hello retargets to unreachable instances (zombie tabs)

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2225,8 +2225,23 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (event.type === "hello" && event.tab_id) {
       const panelTab = event.tab_id;
       // Retarget ComfyUI to the URL the browser was served from (window.location),
-      // BEFORE the readiness probe so the "ready" ack reflects the right instance.
-      applyComfyuiUrl((event as { comfyui_url?: unknown }).comfyui_url);
+      // BEFORE the readiness probe so the "ready" ack reflects the right instance —
+      // but a hello can arrive from a STALE browser tab on a DEAD instance (E2E
+      // finding: a zombie :8189 tab kept retargeting the orchestrator to a corpse
+      // and silently breaking every tool that probes the target). Probe
+      // loopback/LAN hellos first; RunPod proxies skip the probe (booting pods
+      // answer late — readiness is the connector's job).
+      const helloUrl = (event as { comfyui_url?: unknown }).comfyui_url;
+      void (async () => {
+        if (typeof helloUrl === "string" && !/\.proxy\.runpod\.net/i.test(helloUrl)) {
+          const base = helloUrl.trim().replace(/\/+$/, "");
+          if (base && !(await probeOk(`${base}/system_stats`, 3_000))) {
+            logger.warn(`[panel-orchestrator] ignoring hello retarget to unreachable ${base} (stale tab on a dead instance?) — keeping ${comfyuiUrl}`);
+            return;
+          }
+        }
+        applyComfyuiUrl(helloUrl);
+      })();
       // Re-advertise the secure bridge on EVERY hello, not just when the URL
       // changes: advertiseBridge's own retries are short (~3s) and can race a
       // pod-side ComfyUI restart, permanently leaving the pod's stored bridge


### PR DESCRIPTION
Found by the on-device training E2E (and hit twice in one hour): a stale desktop tab on a **dead** ComfyUI (:8189) kept saying hello, and the orchestrator dutifully retargeted to the corpse. Symptoms were silent and misleading: `list_output_images` returned `{"images":[]}` from the wrong fallback dir (looked like 'no outputs'), then `train_prepare_dataset` failed on refs that only exist on the live instance (:8188).

**Fix:** loopback/LAN hello retargets probe `/system_stats` (3s) first and are rejected with a warn log when unreachable. RunPod proxy hellos skip the probe — booting pods answer late and readiness is the connector's job. Explicit retarget paths (runpod tools, `use_local`) are untouched.

**Verification:** tsc clean; full suite 1867/1868 (pre-existing Windows-env `node-dev` failure only). No harness exists for the index.ts monolith's hello path — the gate is verified live in the E2E (the zombie tab now logs 'ignoring hello retarget to unreachable' and the target stays put). Merging into the test-on-main flow.