### PR TITLE
fix(train): serialize doctor probes + retry the image check once (cold-docker flake)

### DIFF
--- a/src/services/ai-toolkit.ts
+++ b/src/services/ai-toolkit.ts
@@ -98,7 +98,17 @@ export async function trainerDoctor(): Promise<TrainerEnvelope<{
     hints.push("Docker daemon not reachable — install/start Docker Desktop (Windows) or the docker engine.");
     return ok("train_doctor", { docker, gpu: false, image: false, image_tag: TRAINER_IMAGE, hints });
   }
-  const [gpu, image] = await Promise.all([gpuDockerAvailable(), trainerImageExists()]);
+  // Serial probes, and one retry on the image check: on a cold Docker Desktop
+  // the PARALLEL gpu-run/image-inspect pair intermittently failed the inspect
+  // (on-device E2E flake: the first doctor after an orchestrator start reported
+  // image:false with the image present; later calls true). The image check is
+  // the fast one — run it first, retry once, then the heavy gpu run.
+  let image = await trainerImageExists();
+  if (!image) {
+    await new Promise((r) => setTimeout(r, 2_000));
+    image = await trainerImageExists();
+  }
+  const gpu = await gpuDockerAvailable();
   if (!gpu) hints.push("`docker run --gpus all` failed — install the NVIDIA Container Toolkit and enable GPU support in Docker.");
   if (!image) hints.push(`Trainer image ${TRAINER_IMAGE} not built yet — run train_build_image (one-time, several minutes).`);
   return ok("train_doctor", { docker, gpu, image, image_tag: TRAINER_IMAGE, hints });


### PR DESCRIPTION
Third E2E finding on the backend: `trainerDoctor` ran `gpuDockerAvailable()` (a `docker run --gpus all`) and `trainerImageExists()` in PARALLEL — on a cold Docker Desktop the inspect intermittently failed, so the first preflight after an orchestrator start flapped red ('run train_build_image') with the image present, blocking launch until a refresh.

- Probes now run **serially**: the fast image check first, **one retry after 2s**, then the heavy gpu run.
- No behavior change when docker is warm.

tsc + ai-toolkit tests green. Merging into the test-on-main flow.