### PR TITLE
feat(train): dataset + job-config readers — datasets/detail/job-config/train_file

### DIFF
--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Point the training root at a temp dir (trainingRoot() reads the env per call).
+let root: string;
+let saved: string | undefined;
+beforeAll(() => {
+  saved = process.env.COMFYUI_MCP_TRAINING_DIR;
+  root = mkdtempSync(join(tmpdir(), "train-datasets-test-"));
+  process.env.COMFYUI_MCP_TRAINING_DIR = root;
+});
+afterAll(() => {
+  if (saved === undefined) delete process.env.COMFYUI_MCP_TRAINING_DIR;
+  else process.env.COMFYUI_MCP_TRAINING_DIR = saved;
+  rmSync(root, { recursive: true, force: true });
+});
+
+import { getDataset, getJobConfig, listDatasets, readTrainingFile } from "../../services/training-datasets.js";
+
+function stageDataset(name: string, files: Array<[string, string | null]>) {
+  const dir = join(root, "datasets", name);
+  mkdirSync(dir, { recursive: true });
+  for (const [file, caption] of files) {
+    writeFileSync(join(dir, file), "fakepng");
+    if (caption != null) {
+      writeFileSync(join(dir, file.replace(/\.[^.]+$/, ".txt")), caption);
+    }
+  }
+  return dir;
+}
+
+describe("listDatasets / getDataset", () => {
+  it("lists staged datasets newest-first with image/caption counts (empty dirs excluded)", () => {
+    stageDataset("alpha", [["img_00001.png", "ohwx a person"], ["img_00002.png", null]]);
+    stageDataset("empty", []);
+    mkdirSync(join(root, "datasets", "beta"), { recursive: true });
+    writeFileSync(join(root, "datasets", "beta", "img_00001.png"), "x");
+    const list = listDatasets();
+    expect(list.map((d) => d.name)).toEqual(["beta", "alpha"]);
+    expect(list.find((d) => d.name === "alpha")).toMatchObject({ imageCount: 2, captionedCount: 1 });
+  });
+
+  it("detail returns the items with captions (null when uncaptioned) + the reusable datasetPath", () => {
+    const d = getDataset("alpha");
+    expect(d.datasetPath.replace(/\\/g, "/")).toContain("/datasets/alpha");
+    expect(d.items).toEqual([
+      { file: "img_00001.png", caption: "ohwx a person" },
+      { file: "img_00002.png", caption: null },
+    ]);
+  });
+
+  it("rejects traversal and unknown names", () => {
+    expect(() => getDataset("../secrets")).toThrow(/invalid dataset name/);
+    expect(() => getDataset("no-such-set")).toThrow(/no dataset/);
+  });
+});
+
+describe("readTrainingFile (train_file)", () => {
+  it("inlines an image under the training root with its mime type", () => {
+    const f = readTrainingFile(join(root, "datasets", "alpha", "img_00001.png"));
+    expect(f.mimeType).toBe("image/png");
+    expect(Buffer.from(f.data, "base64").toString()).toBe("fakepng");
+  });
+
+  it("rejects escapes, non-images, and oversize files", () => {
+    expect(() => readTrainingFile(join(tmpdir(), "outside.png"))).toThrow(/escapes/);
+    expect(() => readTrainingFile(join(root, "datasets", "alpha", "img_00001.txt"))).toThrow(/only image files/);
+    const big = join(root, "datasets", "alpha", "big.png");
+    writeFileSync(big, Buffer.alloc(2 * 1024 * 1024 + 1));
+    expect(() => readTrainingFile(big)).toThrow(/too large/);
+  });
+});
+
+describe("getJobConfig", () => {
+  beforeAll(() => {
+    const jobDir = join(root, "jobs", "jobcfg1");
+    mkdirSync(jobDir, { recursive: true });
+    writeFileSync(
+      join(jobDir, "config.yml"),
+      [
+        "job: extension",
+        "config:",
+        "  name: e2e",
+        "  process:",
+        "    - type: sd_trainer",
+        "      network: { type: lora, linear: 16, linear_alpha: 16 }",
+        "      save: { save_every: 250 }",
+        "      datasets:",
+        "        - folder_path: /dataset",
+        "          resolution: [512, 768]",
+        "      train: { steps: 2000, lr: 0.0001, batch_size: 1 }",
+        "      model: { quantize: true }",
+        "      sample: { sample_every: 250 }",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(root, "jobs", "jobcfg1.json"),
+      JSON.stringify({
+        id: "jobcfg1",
+        name: "e2e",
+        flow: "character",
+        model: "flux1-dev",
+        trigger: "e2echar",
+        status: "completed",
+        progress: { samples: [] },
+        datasetPath: join(root, "datasets", "alpha"),
+        jobDir,
+        outputDir: join(jobDir, "output"),
+        log: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+  });
+
+  it("reads the effective settings back from config.yml (steps/lr/rank/resolution/cadences/quantize)", async () => {
+    const v = await getJobConfig("jobcfg1");
+    expect(v).toMatchObject({
+      id: "jobcfg1",
+      name: "e2e",
+      trigger: "e2echar",
+      source: "config.yml",
+      params: {
+        steps: 2000,
+        lr: 0.0001,
+        rank: 16,
+        resolution: [512, 768],
+        batchSize: 1,
+        saveEvery: 250,
+        sampleEvery: 250,
+        quantize: true,
+      },
+    });
+    expect(v.datasetPath).toContain("alpha");
+  });
+
+  it("throws on an unknown job id", async () => {
+    await expect(getJobConfig("nope")).rejects.toThrow(/no training job/);
+  });
+});

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -55,6 +55,20 @@ describe("listDatasets / getDataset", () => {
     expect(() => getDataset("../secrets")).toThrow(/invalid dataset name/);
     expect(() => getDataset("no-such-set")).toThrow(/no dataset/);
   });
+
+  it("excludes internal staging dirs from list AND detail (codex: partial sets must not train)", () => {
+    stageDataset("partial.staging-1234-abcd", [["img_00001.png", "x"]]);
+    expect(listDatasets().map((d) => d.name)).not.toContain("partial.staging-1234-abcd");
+    expect(() => getDataset("partial.staging-1234-abcd")).toThrow(/staging/);
+  });
+
+  it("accepts dot-prefixed dataset names (legal per sanitizeDirName — list and detail must agree)", () => {
+    stageDataset(".portrait", [["img_00001.png", "y"]]);
+    expect(listDatasets().map((d) => d.name)).toContain(".portrait");
+    expect(getDataset(".portrait").items).toHaveLength(1);
+    expect(() => getDataset("..")).toThrow(/invalid dataset name/);
+    expect(() => getDataset(".")).toThrow(/invalid dataset name/);
+  });
 });
 
 describe("readTrainingFile (train_file)", () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -668,10 +668,15 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // Read-only.
   "diagnose_run",
   // Read-only training surface: flow/model discovery + progress polling +
-  // docker/GPU/image preflight for the panel/mobile Training tab.
+  // docker/GPU/image preflight for the panel/mobile Training tab, and the
+  // dataset/job-config/file readers behind its Jobs/Datasets views.
   "train_list_flows",
   "train_status",
   "train_doctor",
+  "train_list_datasets",
+  "train_dataset_detail",
+  "train_job_config",
+  "train_file",
   // User-initiated training ops (panel/mobile Training wizard): stage a dataset,
   // launch a GPU-container training run, cancel one. All validation lives in the
   // tools themselves (dataset checks, docker/image preflight, liveness-verified

--- a/src/services/training-datasets.ts
+++ b/src/services/training-datasets.ts
@@ -43,11 +43,17 @@ function contained(child: string, root: string): boolean {
   return norm(c) === norm(r) || norm(c).startsWith(norm(r) + sep);
 }
 
-/** Resolve a dataset dir by NAME, with traversal + existence checks. */
+/** Resolve a dataset dir by NAME. Rules mirror prepareDataset's sanitizeDirName
+ *  (dot-prefixed names like ".portrait" are legal dataset dirs; dots-only
+ *  collapses and separators are not). Staging dirs from in-flight/crashed
+ *  prepares are internal and never resolve here (codex finding). */
 function datasetDir(name: string): string {
   const clean = name.trim();
-  if (!clean || clean !== basename(clean) || clean.startsWith(".")) {
+  if (!clean || clean !== basename(clean) || /^\.+$/.test(clean)) {
     throw new Error(`invalid dataset name "${name}"`);
+  }
+  if (clean.includes(".staging-")) {
+    throw new Error(`"${clean}" is an internal staging dir, not a dataset`);
   }
   const dir = join(datasetsRoot(), clean);
   if (!contained(dir, datasetsRoot())) {
@@ -81,12 +87,14 @@ function summarize(dir: string, name: string): DatasetSummary {
   };
 }
 
-/** Every staged dataset, newest first. */
+/** Every staged dataset, newest first. Internal staging dirs from in-flight
+ *  or crashed prepares (`<name>.staging-<pid>-<rand>`) are NOT datasets — an
+ *  abandoned partial set must never be advertised as trainable (codex). */
 export function listDatasets(): DatasetSummary[] {
   const root = datasetsRoot();
   if (!existsSync(root)) return [];
   return readdirSync(root, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
+    .filter((d) => d.isDirectory() && !d.name.includes(".staging-"))
     .map((d) => summarize(join(root, d.name), d.name))
     .filter((s) => s.imageCount > 0)
     .sort((a, b) => b.modified.localeCompare(a.modified));

--- a/src/services/training-datasets.ts
+++ b/src/services/training-datasets.ts
@@ -1,0 +1,199 @@
+// Dataset + job-config readers behind the training surfaces (panel Jobs/
+// Datasets tabs, the mobile monitor). READ-ONLY, and bounded to the training
+// root: dataset names are basename-checked, train_file paths are realpath-
+// contained, and inlining is size-capped (a phone is the other end).
+
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { basename, extname, join, resolve, sep } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { datasetsRoot, getJob, trainingRoot } from "./training-jobs.js";
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+/** train_file inlining cap — a sample/dataset photo, not a checkpoint. */
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+
+export interface DatasetSummary {
+  name: string;
+  imageCount: number;
+  captionedCount: number;
+  /** Latest file mtime in the dir (ISO string). */
+  modified: string;
+}
+
+export interface DatasetDetail extends DatasetSummary {
+  datasetPath: string;
+  items: Array<{ file: string; caption: string | null }>;
+}
+
+/** Containment on REAL paths — a symlinked dir must not smuggle reads across
+ *  the root (same lesson as the ref resolver, #302). Missing paths resolve
+ *  lexically and fail later with an honest not-found. */
+function realOrLexical(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+function contained(child: string, root: string): boolean {
+  const c = realOrLexical(child);
+  const r = realOrLexical(root);
+  const norm = (x: string) => (process.platform === "win32" ? x.toLowerCase() : x);
+  return norm(c) === norm(r) || norm(c).startsWith(norm(r) + sep);
+}
+
+/** Resolve a dataset dir by NAME, with traversal + existence checks. */
+function datasetDir(name: string): string {
+  const clean = name.trim();
+  if (!clean || clean !== basename(clean) || clean.startsWith(".")) {
+    throw new Error(`invalid dataset name "${name}"`);
+  }
+  const dir = join(datasetsRoot(), clean);
+  if (!contained(dir, datasetsRoot())) {
+    throw new Error(`dataset "${name}" escapes the datasets root`);
+  }
+  if (!existsSync(dir)) throw new Error(`no dataset "${clean}" (looked in ${datasetsRoot()})`);
+  return dir;
+}
+
+function summarize(dir: string, name: string): DatasetSummary {
+  const files = readdirSync(dir);
+  const images = files.filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()));
+  const captioned = images.filter((f) =>
+    existsSync(join(dir, `${basename(f, extname(f))}.txt`)),
+  );
+  const modified = Math.max(
+    0,
+    ...files.map((f) => {
+      try {
+        return statSync(join(dir, f)).mtimeMs;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+  return {
+    name,
+    imageCount: images.length,
+    captionedCount: captioned.length,
+    modified: new Date(modified || 0).toISOString(),
+  };
+}
+
+/** Every staged dataset, newest first. */
+export function listDatasets(): DatasetSummary[] {
+  const root = datasetsRoot();
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => summarize(join(root, d.name), d.name))
+    .filter((s) => s.imageCount > 0)
+    .sort((a, b) => b.modified.localeCompare(a.modified));
+}
+
+/** One dataset's items with their captions (null when uncaptioned). */
+export function getDataset(name: string): DatasetDetail {
+  const dir = datasetDir(name);
+  const files = readdirSync(dir)
+    .filter((f) => IMAGE_EXTS.has(extname(f).toLowerCase()))
+    .sort();
+  const items = files.map((f) => {
+    const capPath = join(dir, `${basename(f, extname(f))}.txt`);
+    let caption: string | null = null;
+    try {
+      caption = readFileSync(capPath, "utf-8").trim() || null;
+    } catch {
+      /* uncaptioned */
+    }
+    return { file: f, caption };
+  });
+  return { ...summarize(dir, name), datasetPath: dir, items };
+}
+
+// ── train_file: bounded inline reads under the training root ───────────────
+
+/** Read an image under the training root (dataset images, job samples) as
+ *  base64 for the MCP image channel. Contained, image-only, size-capped. */
+export function readTrainingFile(absPath: string): { data: string; mimeType: string } {
+  if (!contained(absPath, trainingRoot())) {
+    throw new Error("path escapes the training root");
+  }
+  const p = realOrLexical(absPath);
+  const ext = extname(p).toLowerCase();
+  if (!IMAGE_EXTS.has(ext)) {
+    throw new Error(`only image files are served (${[...IMAGE_EXTS].join("/")}), not ${ext || "(none)"}`);
+  }
+  const st = statSync(p); // ENOENT surfaces honestly as "no such file"
+  if (st.size > MAX_FILE_BYTES) {
+    throw new Error(`file too large to inline (${(st.size / 1024 / 1024).toFixed(1)} MB > 2 MB) — fetch it on the rig instead`);
+  }
+  const mimeType = ext === ".png" ? "image/png" : ext === ".webp" ? "image/webp" : "image/jpeg";
+  return { data: readFileSync(p).toString("base64"), mimeType };
+}
+
+// ── train_job_config: "what settings did this run use?" ────────────────────
+
+export interface JobConfigView {
+  id: string;
+  name: string;
+  flow: string;
+  model: string;
+  trigger?: string;
+  datasetPath: string;
+  params: {
+    steps?: number;
+    lr?: number;
+    rank?: number;
+    resolution?: number[];
+    batchSize?: number;
+    saveEvery?: number;
+    sampleEvery?: number;
+    quantize?: boolean;
+  };
+  /** Where params were read from. "config.yml" covers every job incl. records
+   *  written before any params-persistence; "unknown" when unreadable. */
+  source: "config.yml" | "unknown";
+}
+
+/** Read a job's effective settings back from the ai-toolkit config.yml we
+ *  wrote for it (the single source of truth run.py consumed). */
+export async function getJobConfig(id: string): Promise<JobConfigView> {
+  const job = await getJob(id);
+  if (!job) throw new Error(`no training job ${id}`);
+  const params: JobConfigView["params"] = {};
+  let source: JobConfigView["source"] = "unknown";
+  try {
+    const doc = parseYaml(readFileSync(join(job.jobDir, "config.yml"), "utf-8")) as {
+      config?: { process?: Array<Record<string, unknown>> };
+    };
+    const proc = (doc?.config?.process?.[0] ?? {}) as Record<string, Record<string, unknown> & { datasets?: Array<Record<string, unknown>> }>;
+    const train = proc.train ?? {};
+    const network = proc.network ?? {};
+    const save = proc.save ?? {};
+    const sample = proc.sample ?? {};
+    const model = proc.model ?? {};
+    const ds = Array.isArray(proc.datasets) ? (proc.datasets[0] ?? {}) : {};
+    if (typeof train.steps === "number") params.steps = train.steps;
+    if (typeof train.lr === "number") params.lr = train.lr;
+    if (typeof network.linear === "number") params.rank = network.linear;
+    if (Array.isArray(ds.resolution)) params.resolution = ds.resolution as number[];
+    if (typeof train.batch_size === "number") params.batchSize = train.batch_size;
+    if (typeof save.save_every === "number") params.saveEvery = save.save_every;
+    if (typeof sample.sample_every === "number") params.sampleEvery = sample.sample_every;
+    if (typeof model.quantize === "boolean") params.quantize = model.quantize;
+    source = "config.yml";
+  } catch {
+    // config.yml missing/unreadable — return the record fields, empty params
+  }
+  return {
+    id: job.id,
+    name: job.name,
+    flow: job.flow,
+    model: job.model,
+    trigger: job.trigger,
+    datasetPath: job.datasetPath,
+    params,
+    source,
+  };
+}

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -22,6 +22,7 @@ import {
   startTrainingJob,
   trainingRoot,
 } from "../services/training-jobs.js";
+import { getDataset, getJobConfig, listDatasets, readTrainingFile } from "../services/training-datasets.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { isRemoteMode } from "../config.js";
 
@@ -328,6 +329,66 @@ export function registerTrainTools(server: McpServer): void {
         }
         const jobs = await listJobs();
         return textEnvelope({ ok: true, count: jobs.length, jobs });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  // ── Datasets + job config (read-only views for the panel/mobile surfaces) ──
+  server.tool(
+    "train_list_datasets",
+    "List staged training datasets (the dirs from train_prepare_dataset), newest-first, with image/caption counts. Read-only — pair with train_dataset_detail to see one dataset's images + captions.",
+    {},
+    async () => {
+      try {
+        return textEnvelope({ ok: true, datasets: listDatasets() });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_dataset_detail",
+    "Show one staged dataset: its dir (datasetPath — reusable as train_start's datasetPath) and every image with its caption (null when uncaptioned). Images render via train_file. Read-only.",
+    {
+      name: z.string().min(1).describe("Dataset name (from train_list_datasets)."),
+    },
+    async (args) => {
+      try {
+        return textEnvelope({ ok: true, ...getDataset(args.name) });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_job_config",
+    "Show the effective settings a training job ran with (steps/lr/rank/resolution/batch/saveEvery/sampleEvery/quantize) read back from the ai-toolkit config.yml it consumed, plus flow/model/trigger/datasetPath — everything needed to run the job again with tweaks. Read-only.",
+    {
+      id: z.string().min(1).describe("Job id from train_start."),
+    },
+    async (args) => {
+      try {
+        return textEnvelope({ ok: true, ...(await getJobConfig(args.id)) });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_file",
+    "Fetch an image under the training root (dataset image, job sample) as an inline image — the tunnel-safe way for a phone/panel to render training files it can't reach over /view. Bounded: image files only, ≤ 2MB.",
+    {
+      path: z.string().min(1).describe("Absolute path under the training root (from train_dataset_detail's datasetPath or train_status's samples)."),
+    },
+    async (args) => {
+      try {
+        const { data, mimeType } = readTrainingFile(args.path);
+        return { content: [{ type: "image" as const, data, mimeType }] };
       } catch (error) {
         return errorToToolResult(error);
       }


### PR DESCRIPTION
Backend for 'see my labeled datasets, job settings, and run it again' (artokun's ask, [screenshot]). Panel PR follows; mobile rides it in PR D.

## New tools (all whitelisted)
- `train_list_datasets` — staged datasets with image/caption counts, newest-first. Internal `.staging-<pid>-<rand>` prepare dirs excluded (a crashed prepare's partial set is never advertised trainable).
- `train_dataset_detail` — items + captions + the `datasetPath` `train_start` reuses directly.
- `train_job_config` — the effective settings a job ran with (steps/lr/rank/resolution/batch/cadences/quantize), read back from the ai-toolkit `config.yml` run.py consumed — the single source of truth, so it covers jobs launched before any params-persistence too.
- `train_file` — bounded (≤2MB, image-only) inline reads under the training root — the tunnel-safe dataset/sample image channel the monitor work needs (a phone can't reach the panel's py `/training/file` route).

Containment per #302 discipline: basename-checked dataset names (dot-prefixed legal, dots-only/separators rejected), realpath-contained file reads (symlink-safe).

## Verification
- 9 service tests (list/detail/traversal/staging-exclusion/dot-names/train_file caps + escapes/job-config parse/unknown-id).
- Live-verified against the real `e2e_smoke` job + 3 staged datasets (counts + parsed params match the actual config.yml).
- codex review: 2 P2s (staging leak, dot-name inconsistency) → fixed with tests.