### PR TITLE
fix(ipadapter): always send weight_type — required by current IPAdapter_plus (#305)

### DIFF
--- a/src/__tests__/services/generate-conditioned.test.ts
+++ b/src/__tests__/services/generate-conditioned.test.ts
@@ -120,6 +120,19 @@ describe("generateWithIpAdapter", () => {
     expect(node(wf, "IPAdapter")!.inputs.weight).toBe(0.8);
   });
 
+  it("always sends weight_type (required by current IPAdapter_plus, #305), honoring an override", async () => {
+    const { deps, enqueued } = makeDeps();
+    await generateWithIpAdapter({ prompt: "p", reference_image: "r.png", checkpoint: "x.safetensors" }, deps);
+    expect(node(enqueued[0], "IPAdapter")!.inputs.weight_type).toBe("standard");
+
+    const { deps: deps2, enqueued: enqueued2 } = makeDeps();
+    await generateWithIpAdapter(
+      { prompt: "p", reference_image: "r.png", weight_type: "style transfer", checkpoint: "x.safetensors" },
+      deps2,
+    );
+    expect(node(enqueued2[0], "IPAdapter")!.inputs.weight_type).toBe("style transfer");
+  });
+
   it("auto-resolves the checkpoint when absent", async () => {
     const { deps, enqueued } = makeDeps();
     await generateWithIpAdapter({ prompt: "p", reference_image: "r.png" }, deps);

--- a/src/services/generate-conditioned.ts
+++ b/src/services/generate-conditioned.ts
@@ -26,6 +26,8 @@ export interface IpAdapterArgs extends CommonArgs {
   reference_image: string;
   weight?: number;
   preset?: string;
+  /** IPAdapter weight mode ('standard' | 'prompt is more important' | 'style transfer'). */
+  weight_type?: string;
 }
 
 export interface ConditionedDeps {
@@ -153,6 +155,7 @@ export async function generateWithIpAdapter(
     reference_image: args.reference_image,
     weight: args.weight,
     preset: args.preset,
+    weight_type: args.weight_type,
   });
 
   const { prompt_id, queue_remaining } = await deps.enqueue(workflow);

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -54,6 +54,9 @@ interface IpAdapterParams extends Txt2ImgParams {
   reference_image?: string;
   weight?: number;
   preset?: string;
+  /** IPAdapter's weight mode — REQUIRED by current IPAdapter_plus (a missing
+   *  key fails prompt validation, issue #305). */
+  weight_type?: string;
 }
 
 type TemplateParams =
@@ -818,6 +821,9 @@ function buildIpAdapter(p: IpAdapterParams): WorkflowJSON {
         ipadapter: conn("3", 1),
         image: conn("2", 0),
         weight,
+        // Required by current IPAdapter_plus — without it the prompt fails
+        // validation with "Required input is missing: weight_type" (#305).
+        weight_type: p.weight_type ?? "standard",
         start_at: 0.0,
         end_at: 1.0,
       },

--- a/src/tools/generate-conditioned.ts
+++ b/src/tools/generate-conditioned.ts
@@ -86,6 +86,10 @@ export function registerConditionedGenerationTools(server: McpServer): void {
       reference_image: z.string().describe("Filename of the (already-uploaded) reference image in ComfyUI's input dir"),
       weight: z.number().optional().describe("IP-Adapter influence on the output, typically 0.0-1.0 (default 0.8); higher = closer to the reference"),
       preset: z.string().optional().describe("IPAdapterUnifiedLoader preset (default 'PLUS (high strength)')"),
+      weight_type: z
+        .enum(["standard", "prompt is more important", "style transfer"])
+        .optional()
+        .describe("IPAdapter weight mode (default 'standard' — required by current IPAdapter_plus builds)"),
       ...commonShape,
     },
     async (args) => {


### PR DESCRIPTION
Closes #305 (community report from dylanstringa — clean diagnosis, verified against the composer).

`buildIpAdapter()` built the `IPAdapter` node with only `model, ipadapter, image, weight, start_at, end_at` — and current `ComfyUI_IPAdapter_plus` requires `weight_type`, so every `generate_with_ip_adapter` failed validation with `Required input is missing: weight_type` before execution.

- Node always sends `weight_type` (default `standard`).
- New optional `weight_type` tool param (`'prompt is more important'` / `'style transfer'`), threaded service → composer.
- Regression test pins default + override; full generate-conditioned suite 11/11, tsc clean.