### PR TITLE
feat(train): dataset workbench API — update/delete, preview config, rawYaml, LLM captioning

### DIFF
--- a/src/__tests__/services/train-caption.test.ts
+++ b/src/__tests__/services/train-caption.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock the Agent SDK before anything imports the caption service — no real
+// subscription calls in tests.
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () =>
+    (async function* () {
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "e2echar, waiting at a rainy bus stop, city lights" }] },
+      };
+      yield { type: "result", subtype: "success" };
+    })(),
+}));
+
+let root: string;
+let saved: string | undefined;
+beforeAll(() => {
+  saved = process.env.COMFYUI_MCP_TRAINING_DIR;
+  root = mkdtempSync(join(tmpdir(), "train-caption-test-"));
+  process.env.COMFYUI_MCP_TRAINING_DIR = root;
+  const dir = join(root, "datasets", "alpha");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "img_00001.png"), "fakepng");
+  writeFileSync(join(dir, "img_00002.png"), "fakepng");
+});
+afterAll(() => {
+  if (saved === undefined) delete process.env.COMFYUI_MCP_TRAINING_DIR;
+  else process.env.COMFYUI_MCP_TRAINING_DIR = saved;
+  rmSync(root, { recursive: true, force: true });
+});
+
+import { captionDataset, captionImage } from "../../services/train-caption.js";
+
+describe("captionImage", () => {
+  it("returns the model's bare caption (quotes stripped)", async () => {
+    const cap = await captionImage({
+      imagePath: join(root, "datasets", "alpha", "img_00001.png"),
+      trigger: "e2echar",
+    });
+    expect(cap).toBe("e2echar, waiting at a rainy bus stop, city lights");
+  });
+});
+
+describe("captionDataset", () => {
+  it("writes every caption into the dataset's .txt files (subset via only)", async () => {
+    const r = await captionDataset("alpha", { trigger: "e2echar" });
+    expect(r).toEqual({ captioned: 2, failed: [] });
+    const txt = readFileSync(join(root, "datasets", "alpha", "img_00001.txt"), "utf-8");
+    expect(txt).toBe("e2echar, waiting at a rainy bus stop, city lights");
+  });
+
+  it("only: restricts which files get captioned", async () => {
+    rmSync(join(root, "datasets", "alpha", "img_00001.txt"), { force: true });
+    rmSync(join(root, "datasets", "alpha", "img_00002.txt"), { force: true });
+    const r = await captionDataset("alpha", { only: ["img_00002.png"] });
+    expect(r).toEqual({ captioned: 1, failed: [] });
+    expect(readFileSync(join(root, "datasets", "alpha", "img_00002.txt"), "utf-8")).toContain("e2echar");
+  });
+});

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -168,6 +168,20 @@ describe("updateDataset / deleteDataset", () => {
     expect(r.warnings).toHaveLength(2);
     const d = getDataset("alpha");
     expect(d.items).toEqual([{ file: "img_00001.png", caption: "ohwx a person, smiling" }]);
+  });
+
+  it("rejects non-image mutation targets (caption sidecars, cache files)", async () => {
+    const dir = join(root, "datasets", "alpha");
+    writeFileSync(join(dir, "img_00001.txt"), "cap");
+    writeFileSync(join(dir, "cache.bin"), "x");
+    const r = await updateDataset("alpha", {
+      setCaptions: { "img_00001.txt": "hijack", "cache.bin": "hijack" },
+      deleteImages: ["img_00001.txt", "cache.bin"],
+    });
+    expect(r.captionsSet).toBe(0);
+    expect(r.imagesDeleted).toBe(0);
+    expect(r.warnings).toHaveLength(4);
+    expect(readFileSync(join(dir, "img_00001.txt"), "utf-8")).toBe("cap"); // untouched
   });
 
   it("rejects edits and deletes while a running job trains from the dataset", async () => {

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -226,7 +226,7 @@ describe("previewConfig", () => {
 });
 
 describe("deleteJob", () => {
-  function writeJob(id: string, status: string) {
+  function writeJob(id: string, status: string, containerName?: string) {
     const jobDir = join(root, "jobs", id);
     mkdirSync(jobDir, { recursive: true });
     writeFileSync(join(jobDir, "config.yml"), "job: extension\n");
@@ -234,6 +234,7 @@ describe("deleteJob", () => {
       join(root, "jobs", `${id}.json`),
       JSON.stringify({
         id, name: id, flow: "character", model: "flux1-dev", status,
+        ...(containerName ? { containerName } : {}),
         progress: { samples: [] }, datasetPath: join(root, "datasets", "alpha"),
         jobDir, outputDir: join(jobDir, "output"), log: [],
         createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
@@ -262,5 +263,29 @@ describe("deleteJob", () => {
     expect(existsSync(join(root, "jobs", "livejob.json"))).toBe(true);
     await expect(deleteJob("no-such-job")).rejects.toThrow(/no training job/);
     rmSync(join(root, "jobs", "livejob.json"), { force: true });
+  });
+
+  it("a CANCELLED job deletes only when its container is verified gone (codex r3 BLOCKER)", async () => {
+    const { deleteJob } = await import("../../services/training-jobs.js");
+    writeJob("cjob", "cancelled", "comfyui-train-cjob");
+    // Container still ALIVE (or unknown) → refuse: the registry must not be
+    // erased while training may be live.
+    await expect(
+      deleteJob("cjob", {}, { containerRunning: () => Promise.resolve(true) }),
+    ).rejects.toThrow(/unconfirmed/);
+    expect(existsSync(join(root, "jobs", "cjob.json"))).toBe(true);
+    // Verified gone → delete proceeds.
+    await deleteJob("cjob", {}, { containerRunning: () => Promise.resolve(false) });
+    expect(existsSync(join(root, "jobs", "cjob.json"))).toBe(false);
+  });
+
+  it("refresh prunes disk-deleted records from the in-memory registry (codex r3 MAJOR)", async () => {
+    const jobs = await import("../../services/training-jobs.js");
+    writeJob("ghost", "completed");
+    // Seed the cache via listJobs, then delete the FILE and re-list.
+    await jobs.listJobs();
+    rmSync(join(root, "jobs", "ghost.json"), { force: true });
+    const after = await jobs.listJobs();
+    expect(after.find((j) => j.id === "ghost")).toBeUndefined();
   });
 });

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -17,7 +17,7 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-import { getDataset, getJobConfig, listDatasets, readTrainingFile } from "../../services/training-datasets.js";
+import { getDataset, getJobConfig, listDatasets, previewConfig, readTrainingFile, deleteDataset, updateDataset } from "../../services/training-datasets.js";
 
 function stageDataset(name: string, files: Array<[string, string | null]>) {
   const dir = join(root, "datasets", name);
@@ -81,7 +81,9 @@ describe("readTrainingFile (train_file)", () => {
   it("rejects escapes, non-images, and oversize files", () => {
     expect(() => readTrainingFile(join(tmpdir(), "outside.png"))).toThrow(/escapes/);
     expect(() => readTrainingFile(join(root, "datasets", "alpha", "img_00001.txt"))).toThrow(/only image files/);
-    const big = join(root, "datasets", "alpha", "big.png");
+    const bigDir = join(root, "datasets", "bigset");
+    mkdirSync(bigDir, { recursive: true });
+    const big = join(bigDir, "big.png");
     writeFileSync(big, Buffer.alloc(2 * 1024 * 1024 + 1));
     expect(() => readTrainingFile(big)).toThrow(/too large/);
   });
@@ -153,5 +155,58 @@ describe("getJobConfig", () => {
 
   it("throws on an unknown job id", async () => {
     await expect(getJobConfig("nope")).rejects.toThrow(/no training job/);
+  });
+});
+
+describe("updateDataset / deleteDataset", () => {
+  it("sets captions atomically, deletes images with their caption files, warns on unknown files", async () => {
+    const r = await updateDataset("alpha", {
+      setCaptions: { "img_00001.png": "ohwx a person, smiling", "ghost.png": "nope" },
+      deleteImages: ["img_00002.png", "ghost2.png"],
+    });
+    expect(r).toMatchObject({ captionsSet: 1, imagesDeleted: 1 });
+    expect(r.warnings).toHaveLength(2);
+    const d = getDataset("alpha");
+    expect(d.items).toEqual([{ file: "img_00001.png", caption: "ohwx a person, smiling" }]);
+  });
+
+  it("rejects edits and deletes while a running job trains from the dataset", async () => {
+    const jobDir = join(root, "jobs", "active1");
+    mkdirSync(jobDir, { recursive: true });
+    writeFileSync(
+      join(root, "jobs", "active1.json"),
+      JSON.stringify({
+        id: "active1", name: "x", flow: "character", model: "flux1-dev", status: "running",
+        progress: { samples: [] }, datasetPath: join(root, "datasets", "alpha"),
+        jobDir, outputDir: join(jobDir, "output"), log: [],
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      }),
+    );
+    await expect(updateDataset("alpha", { setCaptions: { "img_00001.png": "y" } })).rejects.toThrow(/in use/);
+    await expect(deleteDataset("alpha")).rejects.toThrow(/in use/);
+    // cleanup the record so later tests aren't blocked
+    rmSync(join(root, "jobs", "active1.json"));
+  });
+
+  it("deletes an unused dataset wholesale", async () => {
+    stageDataset("doomed", [["img_00001.png", "x"]]);
+    await deleteDataset("doomed");
+    expect(listDatasets().map((d) => d.name)).not.toContain("doomed");
+    expect(() => getDataset("doomed")).toThrow(/no dataset/);
+  });
+});
+
+describe("previewConfig", () => {
+  it("returns the raw ai-toolkit YAML for the settings (no side effects)", () => {
+    const v = previewConfig({
+      name: "prev",
+      datasetPath: join(root, "datasets", "alpha"),
+      trigger: "ohwx",
+      params: { steps: 200, rank: 32 },
+    });
+    expect(v.jobName).toBe("prev");
+    expect(v.yaml).toContain("steps: 200");
+    expect(v.yaml).toContain("linear: 32");
+    expect(v.yaml).toContain("trigger_word: ohwx");
   });
 });

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -222,5 +222,45 @@ describe("previewConfig", () => {
     expect(v.yaml).toContain("steps: 200");
     expect(v.yaml).toContain("linear: 32");
     expect(v.yaml).toContain("trigger_word: ohwx");
+  });
+});
+
+describe("deleteJob", () => {
+  function writeJob(id: string, status: string) {
+    const jobDir = join(root, "jobs", id);
+    mkdirSync(jobDir, { recursive: true });
+    writeFileSync(join(jobDir, "config.yml"), "job: extension\n");
+    writeFileSync(
+      join(root, "jobs", `${id}.json`),
+      JSON.stringify({
+        id, name: id, flow: "character", model: "flux1-dev", status,
+        progress: { samples: [] }, datasetPath: join(root, "datasets", "alpha"),
+        jobDir, outputDir: join(jobDir, "output"), log: [],
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      }),
+    );
+    return jobDir;
+  }
+
+  it("removes the record + job dir (keep_outputs spares the dir)", async () => {
+    const { deleteJob } = await import("../../services/training-jobs.js");
+    const dir = writeJob("oldjob", "completed");
+    await deleteJob("oldjob");
+    expect(existsSync(join(root, "jobs", "oldjob.json"))).toBe(false);
+    expect(existsSync(dir)).toBe(false);
+
+    const dir2 = writeJob("keepme", "completed");
+    await deleteJob("keepme", { keepOutputs: true });
+    expect(existsSync(join(root, "jobs", "keepme.json"))).toBe(false);
+    expect(existsSync(dir2)).toBe(true);
+  });
+
+  it("refuses to delete a running job (cancel first) and unknown ids", async () => {
+    const { deleteJob } = await import("../../services/training-jobs.js");
+    writeJob("livejob", "running");
+    await expect(deleteJob("livejob")).rejects.toThrow(/cancel it first/);
+    expect(existsSync(join(root, "jobs", "livejob.json"))).toBe(true);
+    await expect(deleteJob("no-such-job")).rejects.toThrow(/no training job/);
+    rmSync(join(root, "jobs", "livejob.json"), { force: true });
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -682,6 +682,7 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "train_dataset_delete",
   "train_caption_image",
   "train_caption_dataset",
+  "train_delete_job",
   // User-initiated training ops (panel/mobile Training wizard): stage a dataset,
   // launch a GPU-container training run, cancel one. All validation lives in the
   // tools themselves (dataset checks, docker/image preflight, liveness-verified

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -677,6 +677,11 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   "train_dataset_detail",
   "train_job_config",
   "train_file",
+  "train_preview_config",
+  "train_dataset_update",
+  "train_dataset_delete",
+  "train_caption_image",
+  "train_caption_dataset",
   // User-initiated training ops (panel/mobile Training wizard): stage a dataset,
   // launch a GPU-container training run, cancel one. All validation lives in the
   // tools themselves (dataset checks, docker/image preflight, liveness-verified

--- a/src/services/train-caption.ts
+++ b/src/services/train-caption.ts
@@ -1,0 +1,116 @@
+// LLM captioning for dataset images — one vision turn per image through the
+// user's OWN Claude subscription (the same Agent SDK the panel agent uses),
+// NOT a paid API. Deliberately a direct `query()` call, not the panel's
+// ClaudeBackend: the panel persona/session machinery would bleed chat-flavored
+// prose into what must be a bare caption string.
+//
+// Images come from readTrainingFile (contained to the training root, ≤2MB) so
+// dataset files never touch the /view channel.
+
+import { getDataset, readTrainingFile, updateDataset } from "./training-datasets.js";
+
+// Lazy SDK import (same pattern as claude-backend — the SDK is a heavy optional
+// dependency that must not load at MCP boot).
+let queryFn: typeof import("@anthropic-ai/claude-agent-sdk").query | null = null;
+async function getQuery() {
+  if (!queryFn) {
+    const mod = await import("@anthropic-ai/claude-agent-sdk");
+    queryFn = mod.query;
+  }
+  return queryFn;
+}
+
+/** Model used for captioning — cheap and fast by default (this is a bulk
+ *  utility call on the user's subscription). Override via COMFYUI_MCP_CAPTION_MODEL. */
+const CAPTION_MODEL = process.env.COMFYUI_MCP_CAPTION_MODEL?.trim() || "claude-haiku-4-5";
+
+function captionPrompt(opts: { guide?: string; trigger?: string }): string {
+  const lines = [
+    "Write ONE caption for this image for LoRA training. Rules:",
+    "- Describe what CHANGES between training images: pose, clothing, background, lighting, expression, framing — NOT the subject's identity (the model learns that from the set, not the captions).",
+    "- One or two short comma-separated phrases. No prefix, no quotes, no commentary.",
+  ];
+  if (opts.trigger) lines.push(`- Start the caption EXACTLY with "${opts.trigger}, " (the set's trigger word).`);
+  if (opts.guide) lines.push(`- User guidance: ${opts.guide}`);
+  lines.push("Reply with ONLY the caption.");
+  return lines.join("\n");
+}
+
+/** Caption ONE image (path under the training root). Returns the bare caption. */
+export async function captionImage(opts: {
+  imagePath: string;
+  guide?: string;
+  trigger?: string;
+}): Promise<string> {
+  const { data, mimeType } = readTrainingFile(opts.imagePath);
+  const query = await getQuery();
+  const userContent = [
+    {
+      type: "image" as const,
+      source: {
+        type: "base64" as const,
+        media_type: mimeType as "image/png" | "image/jpeg" | "image/webp" | "image/gif",
+        data,
+      },
+    },
+    { type: "text" as const, text: captionPrompt(opts) },
+  ];
+  async function* turns() {
+    yield {
+      type: "user" as const,
+      message: { role: "user" as const, content: userContent },
+      parent_tool_use_id: null,
+    };
+  }
+  // No tools, single turn — a utility call, not an agent session.
+  const q = query({
+    prompt: turns(),
+    options: { model: CAPTION_MODEL, maxTurns: 1, tools: [] } as never,
+  });
+  let text = "";
+  for await (const msg of q) {
+    const m = msg as { type: string; message?: { content?: Array<{ type: string; text?: string }> } };
+    if (m.type === "assistant" && m.message?.content) {
+      text += m.message.content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text ?? "")
+        .join("");
+    }
+  }
+  const caption = text.trim().replace(/^["']|["']$/g, "");
+  if (!caption) throw new Error("the model returned an empty caption");
+  return caption;
+}
+
+export interface CaptionDatasetResult {
+  captioned: number;
+  failed: Array<{ file: string; error: string }>;
+}
+
+/** Caption a whole staged dataset (or a subset) and WRITE the captions into
+ *  its .txt files. Sequential on purpose — a subscription isn't a rate pool. */
+export async function captionDataset(
+  name: string,
+  opts: { guide?: string; trigger?: string; only?: string[] } = {},
+): Promise<CaptionDatasetResult> {
+  const detail = getDataset(name);
+  const only = opts.only?.length ? new Set(opts.only) : null;
+  const targets = detail.items.filter((it) => !only || only.has(it.file));
+  if (!targets.length) throw new Error(only ? "none of the requested files are in this dataset" : "dataset has no images");
+  const failed: CaptionDatasetResult["failed"] = [];
+  let captioned = 0;
+  for (const it of targets) {
+    try {
+      const caption = await captionImage({
+        imagePath: `${detail.datasetPath}/${it.file}`,
+        guide: opts.guide,
+        trigger: opts.trigger,
+      });
+      await updateDataset(name, { setCaptions: { [it.file]: caption } });
+      captioned++;
+    } catch (err) {
+      failed.push({ file: it.file, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return { captioned, failed };
+}

--- a/src/services/train-caption.ts
+++ b/src/services/train-caption.ts
@@ -7,7 +7,43 @@
 // Images come from readTrainingFile (contained to the training root, ≤2MB) so
 // dataset files never touch the /view channel.
 
-import { getDataset, readTrainingFile, updateDataset } from "./training-datasets.js";
+import { assertDatasetEditable, getDataset, updateDataset } from "./training-datasets.js";
+import { buildAgentSpawnEnv } from "./panel-secrets.js";
+import { trainingRoot } from "./training-jobs.js";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { extname, resolve, sep } from "node:path";
+
+/** Captioning reads staged TRAINING images, not phone-bound display thumbs —
+ *  the 2MB train_file cap is a display budget, not a property of the data
+ *  (codex finding: a valid 8MP training PNG must still caption). 10MB keeps
+ *  the vision context sane without rejecting real sets. Contained + image-only
+ *  like readTrainingFile. */
+const MAX_CAPTION_BYTES = 10 * 1024 * 1024;
+const CAPTION_IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
+
+function readCaptionFile(absPath: string): { data: string; mimeType: string } {
+  let p: string;
+  try {
+    p = realpathSync(absPath);
+  } catch {
+    p = resolve(absPath);
+  }
+  const root = realpathSync(trainingRoot());
+  const norm = (x: string) => (process.platform === "win32" ? x.toLowerCase() : x);
+  if (norm(p) !== norm(root) && !norm(p).startsWith(norm(root) + sep)) {
+    throw new Error("path escapes the training root");
+  }
+  const ext = extname(p).toLowerCase();
+  if (!CAPTION_IMAGE_EXTS.has(ext)) {
+    throw new Error(`only image files can be captioned (${[...CAPTION_IMAGE_EXTS].join("/")})`);
+  }
+  const st = statSync(p);
+  if (st.size > MAX_CAPTION_BYTES) {
+    throw new Error(`image too large to caption (${(st.size / 1024 / 1024).toFixed(1)} MB > 10 MB)`);
+  }
+  const mimeType = ext === ".png" ? "image/png" : ext === ".webp" ? "image/webp" : "image/jpeg";
+  return { data: readFileSync(p).toString("base64"), mimeType };
+}
 
 // Lazy SDK import (same pattern as claude-backend — the SDK is a heavy optional
 // dependency that must not load at MCP boot).
@@ -42,7 +78,7 @@ export async function captionImage(opts: {
   guide?: string;
   trigger?: string;
 }): Promise<string> {
-  const { data, mimeType } = readTrainingFile(opts.imagePath);
+  const { data, mimeType } = readCaptionFile(opts.imagePath);
   const query = await getQuery();
   const userContent = [
     {
@@ -62,10 +98,13 @@ export async function captionImage(opts: {
       parent_tool_use_id: null,
     };
   }
-  // No tools, single turn — a utility call, not an agent session.
+  // No tools, single turn — a utility call, not an agent session. The spawn
+  // env is SCRUBBED of tool-only secrets (RunPod/CivitAI/HF keys) — the
+  // caption subprocess has no business seeing them (codex finding; same
+  // invariant as ClaudeBackend/ai-proposer).
   const q = query({
     prompt: turns(),
-    options: { model: CAPTION_MODEL, maxTurns: 1, tools: [] } as never,
+    options: { model: CAPTION_MODEL, maxTurns: 1, tools: [], env: buildAgentSpawnEnv() } as never,
   });
   let text = "";
   for await (const msg of q) {
@@ -94,6 +133,10 @@ export async function captionDataset(
   opts: { guide?: string; trigger?: string; only?: string[] } = {},
 ): Promise<CaptionDatasetResult> {
   const detail = getDataset(name);
+  // In-use check BEFORE spending subscription turns: a dataset a running job
+  // trains from would reject every write anyway (codex finding — the loop
+  // used to spend one vision turn per image and write zero captions).
+  await assertDatasetEditable(detail.datasetPath, "captioning");
   const only = opts.only?.length ? new Set(opts.only) : null;
   const targets = detail.items.filter((it) => !only || only.has(it.file));
   if (!targets.length) throw new Error(only ? "none of the requested files are in this dataset" : "dataset has no images");

--- a/src/services/training-datasets.ts
+++ b/src/services/training-datasets.ts
@@ -133,7 +133,7 @@ function samePath(a: string, b: string): boolean {
 /** A dataset dir a RUNNING/QUEUED job trains from must not be edited or
  *  deleted (the dir is bind-mounted into the running container — same guard
  *  as prepareDataset's replace check, codex finding lineage). */
-async function assertDatasetEditable(dir: string, what: string): Promise<void> {
+export async function assertDatasetEditable(dir: string, what: string): Promise<void> {
   const active = await listJobs();
   const inUse = active.find(
     (j) => (j.status === "running" || j.status === "queued") && j.datasetPath && samePath(j.datasetPath, dir),
@@ -161,12 +161,12 @@ export async function updateDataset(
   let captionsSet = 0;
   let imagesDeleted = 0;
   for (const [file, caption] of Object.entries(opts.setCaptions ?? {})) {
-    if (file !== basename(file)) {
-      warnings.push(`${file}: skipped (not a plain filename)`);
+    if (file !== basename(file) || !IMAGE_EXTS.has(extname(file).toLowerCase())) {
+      warnings.push(`${file}: skipped (not a supported image file)`);
       continue;
     }
     const img = join(dir, file);
-    if (!existsSync(img)) {
+    if (!existsSync(img) || !statSync(img).isFile()) {
       warnings.push(`${file}: no such image — caption not written`);
       continue;
     }
@@ -177,12 +177,12 @@ export async function updateDataset(
     captionsSet++;
   }
   for (const file of opts.deleteImages ?? []) {
-    if (file !== basename(file)) {
-      warnings.push(`${file}: skipped (not a plain filename)`);
+    if (file !== basename(file) || !IMAGE_EXTS.has(extname(file).toLowerCase())) {
+      warnings.push(`${file}: skipped (not a supported image file)`);
       continue;
     }
     const img = join(dir, file);
-    if (!existsSync(img)) {
+    if (!existsSync(img) || !statSync(img).isFile()) {
       warnings.push(`${file}: no such image`);
       continue;
     }

--- a/src/services/training-datasets.ts
+++ b/src/services/training-datasets.ts
@@ -3,7 +3,7 @@
 // root: dataset names are basename-checked, train_file paths are realpath-
 // contained, and inlining is size-capped (a phone is the other end).
 
-import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join, resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { datasetsRoot, getJob, trainingRoot } from "./training-jobs.js";
@@ -119,6 +119,107 @@ export function getDataset(name: string): DatasetDetail {
   return { ...summarize(dir, name), datasetPath: dir, items };
 }
 
+// ── Dataset mutations (edit captions, delete images, delete datasets) ───────
+
+import { rmSync, renameSync } from "node:fs";
+import { listJobs } from "./training-jobs.js";
+import { buildTrainingConfig, type TrainParams } from "./training-config.js";
+
+function samePath(a: string, b: string): boolean {
+  const norm = (x: string) => (process.platform === "win32" ? x.toLowerCase() : x);
+  return norm(resolve(a)) === norm(resolve(b));
+}
+
+/** A dataset dir a RUNNING/QUEUED job trains from must not be edited or
+ *  deleted (the dir is bind-mounted into the running container — same guard
+ *  as prepareDataset's replace check, codex finding lineage). */
+async function assertDatasetEditable(dir: string, what: string): Promise<void> {
+  const active = await listJobs();
+  const inUse = active.find(
+    (j) => (j.status === "running" || j.status === "queued") && j.datasetPath && samePath(j.datasetPath, dir),
+  );
+  if (inUse) {
+    throw new Error(`dataset is in use by ${inUse.status} job ${inUse.id} — ${what} is blocked until it finishes (or cancel it first)`);
+  }
+}
+
+export interface DatasetUpdateResult {
+  captionsSet: number;
+  imagesDeleted: number;
+  warnings: string[];
+}
+
+/** Edit captions and/or delete images in a staged dataset. Caption writes are
+ *  atomic per file (tmp+rename); unknown files are warnings, never silent. */
+export async function updateDataset(
+  name: string,
+  opts: { setCaptions?: Record<string, string>; deleteImages?: string[] },
+): Promise<DatasetUpdateResult> {
+  const dir = datasetDir(name);
+  await assertDatasetEditable(dir, "editing");
+  const warnings: string[] = [];
+  let captionsSet = 0;
+  let imagesDeleted = 0;
+  for (const [file, caption] of Object.entries(opts.setCaptions ?? {})) {
+    if (file !== basename(file)) {
+      warnings.push(`${file}: skipped (not a plain filename)`);
+      continue;
+    }
+    const img = join(dir, file);
+    if (!existsSync(img)) {
+      warnings.push(`${file}: no such image — caption not written`);
+      continue;
+    }
+    const cap = join(dir, `${basename(file, extname(file))}.txt`);
+    const tmp = `${cap}.tmp-${process.pid}`;
+    writeFileSync(tmp, caption.trim());
+    renameSync(tmp, cap);
+    captionsSet++;
+  }
+  for (const file of opts.deleteImages ?? []) {
+    if (file !== basename(file)) {
+      warnings.push(`${file}: skipped (not a plain filename)`);
+      continue;
+    }
+    const img = join(dir, file);
+    if (!existsSync(img)) {
+      warnings.push(`${file}: no such image`);
+      continue;
+    }
+    rmSync(img, { force: true });
+    rmSync(join(dir, `${basename(file, extname(file))}.txt`), { force: true });
+    imagesDeleted++;
+  }
+  return { captionsSet, imagesDeleted, warnings };
+}
+
+/** Delete a whole staged dataset (dir + captions). In-use guard as above. */
+export async function deleteDataset(name: string): Promise<void> {
+  const dir = datasetDir(name);
+  await assertDatasetEditable(dir, "deleting");
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** The raw YAML train_start would write for these settings — the ostris-UI
+ *  "raw config" preview. NO side effects (nothing is written or started). */
+export function previewConfig(input: {
+  name: string;
+  datasetPath: string;
+  trigger?: string;
+  params?: Partial<TrainParams>;
+}): { jobName: string; yaml: string } {
+  const built = buildTrainingConfig({
+    name: input.name,
+    flow: "character",
+    model: "flux1-dev",
+    datasetPath: input.datasetPath,
+    outputDir: join(trainingRoot(), "jobs", "<job>", "output"),
+    trigger: input.trigger,
+    params: input.params,
+  });
+  return { jobName: built.jobName, yaml: built.yaml };
+}
+
 // ── train_file: bounded inline reads under the training root ───────────────
 
 /** Read an image under the training root (dataset images, job samples) as
@@ -149,6 +250,9 @@ export interface JobConfigView {
   model: string;
   trigger?: string;
   datasetPath: string;
+  /** The raw ai-toolkit config.yml text the job consumed (the ostris-UI "raw
+   *  config" view) — null when the file is gone/unreadable. */
+  rawYaml: string | null;
   params: {
     steps?: number;
     lr?: number;
@@ -171,8 +275,10 @@ export async function getJobConfig(id: string): Promise<JobConfigView> {
   if (!job) throw new Error(`no training job ${id}`);
   const params: JobConfigView["params"] = {};
   let source: JobConfigView["source"] = "unknown";
+  let rawYaml: string | null = null;
   try {
-    const doc = parseYaml(readFileSync(join(job.jobDir, "config.yml"), "utf-8")) as {
+    rawYaml = readFileSync(join(job.jobDir, "config.yml"), "utf-8");
+    const doc = parseYaml(rawYaml) as {
       config?: { process?: Array<Record<string, unknown>> };
     };
     const proc = (doc?.config?.process?.[0] ?? {}) as Record<string, Record<string, unknown> & { datasets?: Array<Record<string, unknown>> }>;
@@ -201,6 +307,7 @@ export async function getJobConfig(id: string): Promise<JobConfigView> {
     model: job.model,
     trigger: job.trigger,
     datasetPath: job.datasetPath,
+    rawYaml,
     params,
     source,
   };

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -745,6 +745,16 @@ async function refreshRegistry(deps: TrainingJobDeps = {}): Promise<void> {
     }
     jobs.set(job.id, job);
   }
+  // Prune ids whose record files are GONE (train_delete_job removed them) —
+  // otherwise every long-lived sibling process keeps serving deleted jobs
+  // from cache and can act on their stale jobDir (codex r3 MAJOR: a later
+  // delete could wipe outputs previously spared with keep_outputs). Ids this
+  // process OWNS (handles) are never pruned — their files exist or are
+  // mid-persist (tmp+rename window).
+  const onDisk = new Set(files.map((f) => f.replace(/\.json$/, "")));
+  for (const id of [...jobs.keys()]) {
+    if (!onDisk.has(id) && !handles.has(id)) jobs.delete(id);
+  }
 }
 
 /** Pod jobs: pull the produced output (checkpoints + samples + LoRA) back to
@@ -1852,25 +1862,47 @@ export function toJobSummary(job: TrainingJob): TrainingJob {
  *  (config/log/checkpoints/samples). Cleanup for the Jobs view — the
  *  DELIVERED LoRA in models/loras is NOT touched. Running/queued jobs refuse:
  *  a deleted record would orphan the container from the cancel/reconcile
- *  machinery (billing!). */
-export async function deleteJob(id: string, opts: { keepOutputs?: boolean } = {}): Promise<void> {
-  const job = await getJob(id);
+ *  machinery (billing!). Cancelled jobs must verify container-gone first —
+ *  "cancelled" persists BEFORE the stop is verified (cancelJob's ordering),
+ *  so a concurrent delete (or a record left by a dead cancel process) could
+ *  otherwise erase the registry while training is still live (codex r3
+ *  BLOCKER). Runs under the per-job CAS lock so a finalize/cancel can't
+ *  interleave. */
+export async function deleteJob(
+  id: string,
+  opts: { keepOutputs?: boolean } = {},
+  deps: TrainingJobDeps = {},
+): Promise<void> {
+  const job = await getJob(id, deps);
   if (!job) throw new Error(`no training job ${id}`);
   if (job.status === "running" || job.status === "queued") {
     throw new Error(`job ${id} is ${job.status} — cancel it first (train_cancel), then delete`);
   }
-  jobs.delete(id);
-  rmSync(jobFile(id), { force: true });
-  // Stale-claim/lock sidecars — a later same-name launch must not trip on them.
-  rmSync(join(jobsRoot(), `${id}.lock`), { force: true });
-  if (!opts.keepOutputs) {
-    // Containment: delete only inside the jobs root — never trust a record's
-    // jobDir blindly (a corrupted record must not reach outside it).
-    const root = resolve(jobsRoot());
-    const dir = resolve(job.jobDir);
-    const norm = (p: string) => (process.platform === "win32" ? p.toLowerCase() : p);
-    if (norm(dir) !== norm(root) && norm(dir).startsWith(norm(root) + sep) && existsSync(dir)) {
-      rmSync(dir, { recursive: true, force: true });
+  if (job.status === "cancelled" && job.containerName) {
+    const probe = deps.containerRunning ?? defaultContainerProbe;
+    const alive = await probe(job.containerName, jobProbeConfigPath(job)).catch(() => null);
+    if (alive !== false) {
+      throw new Error(
+        `job ${id} is marked cancelled but its container state is unconfirmed — it may still be running. ` +
+          `Re-run train_cancel first (it re-stops and verifies), then delete.`,
+      );
     }
+  }
+  const lock = join(jobsRoot(), `${id}.lock`);
+  if (!(await acquireLock(lock, deps.lockBudgetMs ?? LOCK_WAIT_MS, 5 * 60_000))) {
+    throw new Error(`job ${id} is busy (a finalize/cancel is in flight) — try again in a moment`);
+  }
+  try {
+    jobs.delete(id);
+    rmSync(jobFile(id), { force: true });
+    if (!opts.keepOutputs) {
+      // realpath-aware containment (pathWithin) — a symlink/junction inside
+      // the jobs root must not let recursive removal reach outside it.
+      if (existsSync(job.jobDir) && pathWithin(jobsRoot(), job.jobDir)) {
+        rmSync(job.jobDir, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    releaseLock(lock);
   }
 }

--- a/src/services/training-jobs.ts
+++ b/src/services/training-jobs.ts
@@ -1847,3 +1847,30 @@ async function cancelJobBody(id: string, job: TrainingJob, deps: TrainingJobDeps
 export function toJobSummary(job: TrainingJob): TrainingJob {
   return job;
 }
+
+/** Delete an old job's registry record + (unless keepOutputs) its job dir
+ *  (config/log/checkpoints/samples). Cleanup for the Jobs view — the
+ *  DELIVERED LoRA in models/loras is NOT touched. Running/queued jobs refuse:
+ *  a deleted record would orphan the container from the cancel/reconcile
+ *  machinery (billing!). */
+export async function deleteJob(id: string, opts: { keepOutputs?: boolean } = {}): Promise<void> {
+  const job = await getJob(id);
+  if (!job) throw new Error(`no training job ${id}`);
+  if (job.status === "running" || job.status === "queued") {
+    throw new Error(`job ${id} is ${job.status} — cancel it first (train_cancel), then delete`);
+  }
+  jobs.delete(id);
+  rmSync(jobFile(id), { force: true });
+  // Stale-claim/lock sidecars — a later same-name launch must not trip on them.
+  rmSync(join(jobsRoot(), `${id}.lock`), { force: true });
+  if (!opts.keepOutputs) {
+    // Containment: delete only inside the jobs root — never trust a record's
+    // jobDir blindly (a corrupted record must not reach outside it).
+    const root = resolve(jobsRoot());
+    const dir = resolve(job.jobDir);
+    const norm = (p: string) => (process.platform === "win32" ? p.toLowerCase() : p);
+    if (norm(dir) !== norm(root) && norm(dir).startsWith(norm(root) + sep) && existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+}

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -22,7 +22,8 @@ import {
   startTrainingJob,
   trainingRoot,
 } from "../services/training-jobs.js";
-import { getDataset, getJobConfig, listDatasets, readTrainingFile } from "../services/training-datasets.js";
+import { getDataset, getJobConfig, listDatasets, previewConfig, readTrainingFile, deleteDataset, updateDataset } from "../services/training-datasets.js";
+import { captionDataset, captionImage } from "../services/train-caption.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { isRemoteMode } from "../config.js";
 
@@ -389,6 +390,93 @@ export function registerTrainTools(server: McpServer): void {
       try {
         const { data, mimeType } = readTrainingFile(args.path);
         return { content: [{ type: "image" as const, data, mimeType }] };
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_dataset_update",
+    "Edit a staged dataset: set/replace per-image captions and/or delete images (with their caption files). Refuses while a running/queued job trains from it. Returns per-file warnings for unknown files.",
+    {
+      name: z.string().min(1).describe("Dataset name (from train_list_datasets)."),
+      setCaptions: z.record(z.string(), z.string()).optional().describe("{filename: caption} pairs to write (replaces existing captions)."),
+      deleteImages: z.array(z.string()).optional().describe("Image filenames to delete from the dataset (caption files go too)."),
+    },
+    async (args) => {
+      try {
+        return textEnvelope({ ok: true, ...(await updateDataset(args.name, { setCaptions: args.setCaptions, deleteImages: args.deleteImages })) });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_dataset_delete",
+    "Delete a whole staged dataset (images + captions). Refuses while a running/queued job trains from it. Irreversible — confirm with the user first.",
+    {
+      name: z.string().min(1).describe("Dataset name (from train_list_datasets)."),
+    },
+    async (args) => {
+      try {
+        await deleteDataset(args.name);
+        return textEnvelope({ ok: true });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_preview_config",
+    "Show the RAW ai-toolkit config.yml train_start would write for these settings (the ostris-UI 'raw config' view) — no side effects. Use it to review/edit a run before launching; pass the same params to train_start to execute.",
+    {
+      name: z.string().min(1).describe("Job name (becomes the output folder + .safetensors basename)."),
+      datasetPath: z.string().min(1).describe("Staged dataset dir (from train_prepare_dataset or train_dataset_detail)."),
+      trigger: z.string().optional().describe("Trigger word."),
+      params: z.record(z.string(), z.unknown()).optional().describe("Param overrides (steps/lr/rank/resolution/batchSize/saveEvery/sampleEvery/quantize)."),
+    },
+    async (args) => {
+      try {
+        return textEnvelope({ ok: true, ...previewConfig(args) });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_caption_image",
+    "Caption ONE dataset/training image with the user's own Claude subscription (one vision turn through the Agent SDK — not a paid API). Returns the bare caption (does NOT write it — review then save with train_dataset_update, or use train_caption_dataset to write directly). Optional guide text steers the style; optional trigger is prepended by the model.",
+    {
+      path: z.string().min(1).describe("Absolute path of an image under the training root (train_dataset_detail's datasetPath + filename)."),
+      guide: z.string().optional().describe("Extra style guidance for the captioner (e.g. 'focus on outfits and backgrounds')."),
+      trigger: z.string().optional().describe("Trigger word to prepend in the caption."),
+    },
+    async (args) => {
+      try {
+        const caption = await captionImage({ imagePath: args.path, guide: args.guide, trigger: args.trigger });
+        return textEnvelope({ ok: true, caption });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_caption_dataset",
+    "Caption a whole staged dataset (or a subset) with the user's own Claude subscription and WRITE the captions into its .txt files (one vision turn per image, sequential). Use after gathering images, before train_start. Per-file failures are reported without stopping the batch. Optional guide text steers all captions; optional trigger is prepended to each.",
+    {
+      name: z.string().min(1).describe("Dataset name (from train_list_datasets)."),
+      guide: z.string().optional().describe("Extra style guidance applied to every caption."),
+      trigger: z.string().optional().describe("Trigger word prepended to every caption."),
+      only: z.array(z.string()).optional().describe("Subset of filenames to caption (default: all images)."),
+    },
+    async (args) => {
+      try {
+        return textEnvelope({ ok: true, ...(await captionDataset(args.name, { guide: args.guide, trigger: args.trigger, only: args.only })) });
       } catch (error) {
         return errorToToolResult(error);
       }

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -15,6 +15,7 @@ import {
 import { DEFAULT_PARAMS } from "../services/training-config.js";
 import {
   cancelJob,
+  deleteJob,
   getJob,
   hfCacheRoot,
   listJobs,
@@ -477,6 +478,23 @@ export function registerTrainTools(server: McpServer): void {
     async (args) => {
       try {
         return textEnvelope({ ok: true, ...(await captionDataset(args.name, { guide: args.guide, trigger: args.trigger, only: args.only })) });
+      } catch (error) {
+        return errorToToolResult(error);
+      }
+    },
+  );
+
+  server.tool(
+    "train_delete_job",
+    "Delete an old training job's record (+ its output dir with checkpoints/samples unless keep_outputs is true) — cleanup for the Jobs view. The delivered LoRA in models/loras is NOT removed. Running/queued jobs must be cancelled first (train_cancel). Confirm with the user before deleting.",
+    {
+      id: z.string().min(1).describe("Job id from train_start."),
+      keep_outputs: z.boolean().optional().describe("Keep the job's output dir (checkpoints/samples) — delete only the record."),
+    },
+    async (args) => {
+      try {
+        await deleteJob(args.id, { keepOutputs: args.keep_outputs });
+        return textEnvelope({ ok: true });
       } catch (error) {
         return errorToToolResult(error);
       }


### PR DESCRIPTION
Backend half of artokun's dataset-workbench spec (mobile PR follows). All tools whitelisted.

## New tools
- **`train_dataset_update`** — set/replace per-image captions (atomic tmp+rename) and/or delete images (+caption sidecars); per-file warnings; image-files-only enforced. Refuses while a running/queued job trains from the dir.
- **`train_dataset_delete`** — remove a whole staged set (same in-use guard).
- **`train_preview_config`** — the RAW ai-toolkit `config.yml` `train_start` would write for these settings — the ostris-UI 'raw config' view, zero side effects. `train_job_config` now also returns `rawYaml` for past jobs.
- **`train_caption_image` / `train_caption_dataset`** — LLM captioning, ONE vision turn per image via the user's **own Claude subscription** (direct Agent SDK `query()` — deliberately *not* the panel's ClaudeBackend, so the panel persona can't bleed into bare caption strings). Sequential for sets; per-file failures don't stop the batch; guide text + trigger prepend supported.

## codex round (1 P1 + 3 P2, all fixed)
- **P1:** caption subprocesses spawn with `buildAgentSpawnEnv()` — tool-only secrets no longer inherited into every caption call.
- **P2:** caption-specific 10MB contained reader (the 2MB phone-display cap was rejecting valid training images); editability checked *before* spending turns; mutations require supported image files (no sidecar hijack).

## Verification
- 17 tests (mutations, guards, non-image rejection, preview shape, SDK-mocked captioning); full suite green except the pre-existing Windows-env `node-dev` failure.
- Model default `claude-haiku-4-5` (cheap bulk utility), `COMFYUI_MCP_CAPTION_MODEL` override.