### PR TITLE
fix(train): make dataset ordering deterministic (flaky CI + real UI bug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**168 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**174 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-168 tools across workflow execution, generation, iteration, composition, models, and more:
+174 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 168 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 174 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/services/training-datasets.test.ts
+++ b/src/__tests__/services/training-datasets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -36,7 +36,15 @@ describe("listDatasets / getDataset", () => {
     stageDataset("alpha", [["img_00001.png", "ohwx a person"], ["img_00002.png", null]]);
     stageDataset("empty", []);
     mkdirSync(join(root, "datasets", "beta"), { recursive: true });
-    writeFileSync(join(root, "datasets", "beta", "img_00001.png"), "x");
+    const betaImg = join(root, "datasets", "beta", "img_00001.png");
+    writeFileSync(betaImg, "x");
+    // Force beta genuinely newer than alpha, rather than trusting that two writes
+    // in the same test land in different mtime buckets — coarse filesystem mtime
+    // granularity made this "newest-first" assertion flake on CI when alpha and
+    // beta tied. summarize() takes the max file mtime, so stamping beta's only
+    // file into the future is enough.
+    const future = new Date(Date.now() + 60_000);
+    utimesSync(betaImg, future, future);
     const list = listDatasets();
     expect(list.map((d) => d.name)).toEqual(["beta", "alpha"]);
     expect(list.find((d) => d.name === "alpha")).toMatchObject({ imageCount: 2, captionedCount: 1 });

--- a/src/services/training-datasets.ts
+++ b/src/services/training-datasets.ts
@@ -93,11 +93,14 @@ function summarize(dir: string, name: string): DatasetSummary {
 export function listDatasets(): DatasetSummary[] {
   const root = datasetsRoot();
   if (!existsSync(root)) return [];
+  // Newest first; a deterministic name tiebreaker keeps the order STABLE when two
+  // datasets share an mtime (coarse filesystem granularity) — otherwise the order
+  // follows readdir and varies by platform.
   return readdirSync(root, { withFileTypes: true })
     .filter((d) => d.isDirectory() && !d.name.includes(".staging-"))
     .map((d) => summarize(join(root, d.name), d.name))
     .filter((s) => s.imageCount > 0)
-    .sort((a, b) => b.modified.localeCompare(a.modified));
+    .sort((a, b) => b.modified.localeCompare(a.modified) || a.name.localeCompare(b.name));
 }
 
 /** One dataset's items with their captions (null when uncaptioned). */


### PR DESCRIPTION
`training-datasets.test.ts`'s "newest-first" assertion has been flaking on CI —
`['alpha','beta']` vs `['beta','alpha']`, on **both ubuntu and macOS** — and it's
blocking unrelated PRs (it's what turned #310 red twice). It landed in #306,
shipped in 0.47.0.

It's a **real ordering bug**, not just a flaky test:

`listDatasets()` sorted purely by `modified` with **no tiebreaker**:

```ts
.sort((a, b) => b.modified.localeCompare(a.modified));
```

When two datasets share an mtime — coarse filesystem granularity, or two stages
in the same millisecond — the sort is unstable and falls back to `readdir` order,
which varies by platform. **That misorders datasets in the actual UI too**, not
only the test.

## Fix

- **Source:** add a deterministic name tiebreaker, so an mtime tie has a defined,
  stable order instead of a platform-dependent one.
- **Test:** stamp beta's file mtime into the future so it's unambiguously newer,
  asserting the real newest-first behavior instead of hoping two writes land in
  different mtime buckets.

Ran the suite **5× — deterministic** every time (18/18). Typecheck clean.

Merging this unblocks CI for every open PR, #310 included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)