### PR TITLE
feat(orchestrator): whitelist app-dependency tools for panel deps side-panel

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -722,6 +722,18 @@ const CALL_TOOL_WHITELIST = new Set<string>([
   // download_model (already whitelisted): writes a local app bundle, no
   // model/system mutation. Deps install stays a separate consented action.
   "apps_import",
+  // App dependency side-panel (Explore/detail): the ✓/download panel reads what
+  // an app needs vs what's installed and offers per-item fetches. Reads are safe
+  // (missing-model detection + candidate resolution, node-pack presence); model
+  // downloads reuse the already-whitelisted download_civitai_model/download_model.
+  // install_custom_node is a MUTATION that runs the pack's code on install —
+  // reachable for the panel's "install missing node" button, gated behind an
+  // explicit themed confirm client-side. (Revisit if a canvas-less/foreign tab
+  // must not be able to trigger a node install.)
+  "resolve_missing_models",
+  "extract_workflow_dependencies",
+  "list_installed_nodes",
+  "install_custom_node",
 ]);
 
 /** Lazily build ONE in-process MCP client wired to the full comfyui tool surface,


### PR DESCRIPTION
Enables the Apps (micro-apps) **dependency side-panel** (Explore/detail) to reach the dependency-detection + install tools over the panel bridge (`CALL_TOOL_WHITELIST`, `src/orchestrator/index.ts`).

Added:
- `resolve_missing_models` — detect missing model weights + resolve download candidates (read-only)
- `extract_workflow_dependencies` — required/missing custom-node packs for a workflow (read-only)
- `list_installed_nodes` — installed pack presence (read-only)
- `install_custom_node` — **mutation** (runs the pack's code on install); reachable for the panel's "install missing node" button, gated client-side behind an explicit themed confirm

Model downloads reuse the already-whitelisted `download_civitai_model` / `download_model`. No new tools, no behavior change for existing surfaces — only reachability from the canvas-less/bridge `call_tool` path.

Part of the Apps redesign P1 (dependency ✓/download panel). Panel side (the UI that calls these) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)