### PR TITLE
feat(tools): generate_3d — 3D generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**181 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**182 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-181 tools across workflow execution, generation, iteration, composition, models, and more:
+182 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 181 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 182 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/tools/generate-3d.test.ts
+++ b/src/__tests__/tools/generate-3d.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Provide the config-module exports the api-nodes import graph touches.
+const mockConfig = vi.hoisted(() => ({
+  comfyApiKey: undefined as string | undefined,
+  comfyuiSsl: false,
+  comfyuiHost: "127.0.0.1",
+  resolvedPort: 8188,
+}));
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIApiHost: () => "127.0.0.1:8188",
+  getComfyUIProtocol: () => "http",
+}));
+
+import {
+  generate3d,
+  find3dApiNodes,
+  is3dApiNode,
+} from "../../services/generate-3d.js";
+import type { ApiNodesDeps } from "../../services/api-nodes.js";
+import type { ComfyUINodeDef, ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
+import { ValidationError } from "../../utils/errors.js";
+
+beforeEach(() => {
+  mockConfig.comfyApiKey = undefined;
+});
+
+function nodeDef(partial: Partial<ComfyUINodeDef>): ComfyUINodeDef {
+  return {
+    input: {},
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    name: "",
+    display_name: "",
+    description: "",
+    category: "",
+    output_node: false,
+    ...partial,
+  };
+}
+
+/** ObjectInfo mirroring the real partner 3D catalog (Tripo text + image nodes). */
+function objectInfoWith3d(): ObjectInfo {
+  return {
+    TripoTextToModelNode: nodeDef({
+      api_node: true,
+      category: "partner/3d/Tripo",
+      display_name: "Tripo: Text to Model",
+      output_node: true,
+      output: ["STRING", "MODEL_TASK_ID", "FILE_3D_GLB"],
+      output_name: ["model_file", "model task_id", "GLB"],
+      input: {
+        required: { prompt: ["STRING", { multiline: true }] },
+        optional: {
+          style: ["COMBO", { default: "None", options: ["None", "gold"] }],
+          texture: ["BOOLEAN", { default: true }],
+        },
+        hidden: { auth_token_comfy_org: ["AUTH_TOKEN_COMFY_ORG"] },
+      },
+    }),
+    TripoImageToModelNode: nodeDef({
+      api_node: true,
+      category: "partner/3d/Tripo",
+      display_name: "Tripo: Image to Model",
+      output_node: true,
+      output: ["STRING", "MODEL_TASK_ID", "FILE_3D_GLB"],
+      output_name: ["model_file", "model task_id", "GLB"],
+      input: {
+        required: { image: ["IMAGE", {}] },
+        optional: { texture: ["BOOLEAN", { default: true }] },
+        hidden: { auth_token_comfy_org: ["AUTH_TOKEN_COMFY_ORG"] },
+      },
+    }),
+    // Post-processing 3D node with a non-IMAGE required link — must NOT be picked.
+    TripoTextureNode: nodeDef({
+      api_node: true,
+      category: "partner/3d/Tripo",
+      display_name: "Tripo: Texture model",
+      output_node: true,
+      output: ["STRING", "MODEL_TASK_ID", "FILE_3D_GLB"],
+      input: { required: { model_task_id: ["MODEL_TASK_ID", {}] } },
+    }),
+    // Non-3D API node — excluded.
+    FluxProImageNode: nodeDef({
+      api_node: true,
+      category: "api node/image/BFL",
+      display_name: "Flux Pro",
+      output: ["IMAGE"],
+      input: { required: { prompt: ["STRING", {}] } },
+    }),
+    // Local node — excluded.
+    KSampler: nodeDef({ category: "sampling", output: ["LATENT"] }),
+  };
+}
+
+function objectInfoNo3d(): ObjectInfo {
+  return {
+    FluxProImageNode: nodeDef({
+      api_node: true,
+      category: "api node/image/BFL",
+      output: ["IMAGE"],
+      input: { required: { prompt: ["STRING", {}] } },
+    }),
+    KSampler: nodeDef({ category: "sampling", output: ["LATENT"] }),
+  };
+}
+
+function depsFor(objectInfo: ObjectInfo): {
+  deps: ApiNodesDeps;
+  enqueued: WorkflowJSON[];
+} {
+  const enqueued: WorkflowJSON[] = [];
+  return {
+    enqueued,
+    deps: {
+      getObjectInfo: async () => objectInfo,
+      enqueue: async (workflow) => {
+        enqueued.push(workflow);
+        return { prompt_id: "p-123", queue_remaining: 1 };
+      },
+    },
+  };
+}
+
+describe("3D API-node detection", () => {
+  it("classifies partner 3D nodes and filters by mode capability", () => {
+    const info = objectInfoWith3d();
+    expect(is3dApiNode(info.TripoTextToModelNode)).toBe(true);
+    expect(is3dApiNode(info.FluxProImageNode)).toBe(false);
+    expect(is3dApiNode(info.KSampler)).toBe(false);
+
+    const text = find3dApiNodes(info, "text");
+    expect(text.map((c) => c.class_type)).toEqual(["TripoTextToModelNode"]);
+    expect(text[0].formats).toEqual(["GLB"]);
+
+    const image = find3dApiNodes(info, "image");
+    expect(image.map((c) => c.class_type)).toEqual(["TripoImageToModelNode"]);
+    expect(image[0].image_input).toBe("image");
+  });
+});
+
+describe("generate3d — happy paths", () => {
+  it("text mode enqueues a single partner 3D node with the prompt", async () => {
+    const { deps, enqueued } = depsFor(objectInfoWith3d());
+    const result = await generate3d(
+      { mode: "text", prompt: "a bronze dragon statue" },
+      deps,
+    );
+
+    expect(result.prompt_id).toBe("p-123");
+    expect(result.class_type).toBe("TripoTextToModelNode");
+    expect(result.formats).toEqual(["GLB"]);
+    expect(enqueued).toHaveLength(1);
+    const wf = enqueued[0];
+    expect(wf["1"].class_type).toBe("TripoTextToModelNode");
+    expect(wf["1"].inputs.prompt).toBe("a bronze dragon statue");
+    // Output node — no SaveImage should be auto-added.
+    expect(Object.keys(wf)).toEqual(["1"]);
+  });
+
+  it("image mode wires a LoadImage feeder into the node's IMAGE input", async () => {
+    const { deps, enqueued } = depsFor(objectInfoWith3d());
+    const result = await generate3d(
+      { mode: "image", image: "chair.png", inputs: { texture: false } },
+      deps,
+    );
+
+    expect(result.class_type).toBe("TripoImageToModelNode");
+    const wf = enqueued[0];
+    expect(wf["1"].inputs.image).toEqual(["10", 0]);
+    expect(wf["1"].inputs.texture).toBe(false);
+    expect(wf["10"].class_type).toBe("LoadImage");
+    expect(wf["10"].inputs.image).toBe("chair.png");
+  });
+
+  it("image mode notes an ignored prompt when the node takes none", async () => {
+    const { deps } = depsFor(objectInfoWith3d());
+    const result = await generate3d(
+      { mode: "image", image: "chair.png", prompt: "make it shiny" },
+      deps,
+    );
+    expect(result.notes.some((n) => /prompt was ignored/i.test(n))).toBe(true);
+  });
+
+  it("honors an explicit node override and rejects incapable ones", async () => {
+    const { deps } = depsFor(objectInfoWith3d());
+    const ok = await generate3d(
+      { mode: "text", prompt: "a cube", node: "TripoTextToModelNode" },
+      deps,
+    );
+    expect(ok.class_type).toBe("TripoTextToModelNode");
+
+    await expect(
+      generate3d({ mode: "text", prompt: "a cube", node: "TripoTextureNode" }, deps),
+    ).rejects.toThrow(/not a text-capable 3D API node/);
+  });
+});
+
+describe("generate3d — capability detection / errors", () => {
+  it("errors honestly + actionably when the server has no 3D API nodes", async () => {
+    const { deps, enqueued } = depsFor(objectInfoNo3d());
+    const err = await generate3d({ mode: "text", prompt: "a cube" }, deps).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(String(err.message)).toMatch(/No 3D-capable API\/partner nodes/);
+    expect(String(err.message)).toMatch(/install_custom_node/);
+    expect(String(err.message)).toMatch(/Hunyuan3DWrapper|TripoSR/);
+    // Nothing must be enqueued on the failure path.
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it("validates mode-specific required arguments", async () => {
+    const { deps } = depsFor(objectInfoWith3d());
+    await expect(generate3d({ mode: "text" }, deps)).rejects.toThrow(
+      /requires a non-empty prompt/,
+    );
+    await expect(generate3d({ mode: "image" }, deps)).rejects.toThrow(
+      /requires an input image/,
+    );
+  });
+});

--- a/src/__tests__/tools/generate-3d.test.ts
+++ b/src/__tests__/tools/generate-3d.test.ts
@@ -82,6 +82,15 @@ function objectInfoWith3d(): ObjectInfo {
       output: ["STRING", "MODEL_TASK_ID", "FILE_3D_GLB"],
       input: { required: { model_task_id: ["MODEL_TASK_ID", {}] } },
     }),
+    // DECOY: 3D-category API node with a prompt but NO FILE_3D output (a
+    // utility/plumbing node) — must never be picked as a generation backend.
+    Tripo3dTaskStatusNode: nodeDef({
+      api_node: true,
+      category: "partner/3d/Tripo",
+      display_name: "Tripo: Task status",
+      output: ["STRING"],
+      input: { required: { prompt: ["STRING", {}] } },
+    }),
     // Non-3D API node — excluded.
     FluxProImageNode: nodeDef({
       api_node: true,
@@ -97,6 +106,14 @@ function objectInfoWith3d(): ObjectInfo {
 
 function objectInfoNo3d(): ObjectInfo {
   return {
+    // Category-only 3D decoy (no FILE_3D output) — must NOT count as a backend.
+    Some3dUtilityNode: nodeDef({
+      api_node: true,
+      category: "partner/3d/Acme",
+      display_name: "Acme 3D utility",
+      output: ["STRING"],
+      input: { required: { prompt: ["STRING", {}] } },
+    }),
     FluxProImageNode: nodeDef({
       api_node: true,
       category: "api node/image/BFL",
@@ -129,6 +146,8 @@ describe("3D API-node detection", () => {
     const info = objectInfoWith3d();
     expect(is3dApiNode(info.TripoTextToModelNode)).toBe(true);
     expect(is3dApiNode(info.FluxProImageNode)).toBe(false);
+    // Category alone must not qualify — a real FILE_3D output is required.
+    expect(is3dApiNode(info.Tripo3dTaskStatusNode)).toBe(false);
     expect(is3dApiNode(info.KSampler)).toBe(false);
 
     const text = find3dApiNodes(info, "text");

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -491,6 +491,13 @@ export interface GenerateWithApiNodeArgs {
   class_type: string;
   inputs: Record<string, unknown>;
   disable_random_seed?: boolean;
+  /**
+   * Extra supporting nodes to merge into the enqueued workflow (e.g. a
+   * LoadImage feeding the API node's IMAGE link input). The API node itself is
+   * always node "1", and "2" may be used for an auto-added SaveImage — extra
+   * node ids must avoid both.
+   */
+  extra_nodes?: WorkflowJSON;
 }
 
 export interface GenerateWithApiNodeResult {
@@ -571,6 +578,18 @@ export async function generateWithApiNode(
       _meta: { title: schema.display_name },
     },
   };
+
+  // Merge caller-supplied supporting nodes (e.g. LoadImage → IMAGE link input).
+  if (args.extra_nodes) {
+    for (const [id, node] of Object.entries(args.extra_nodes)) {
+      if (id === "1" || id === "2") {
+        throw new ValidationError(
+          `extra_nodes id "${id}" is reserved (the API node is "1"; "2" may be used for an auto-added output node). Use a different id.`,
+        );
+      }
+      workflow[id] = node;
+    }
+  }
 
   // ComfyUI only executes graphs that reach a terminal OUTPUT_NODE; a bare
   // non-output API node fails validation with "prompt_no_outputs". If the API

--- a/src/services/generate-3d.ts
+++ b/src/services/generate-3d.ts
@@ -54,14 +54,14 @@ function has3dOutput(def: ComfyUINodeDef): boolean {
   );
 }
 
-/** Is the node in a 3D category (e.g. "partner/3d/Tripo", "api node/3d/Rodin")? */
-function has3dCategory(def: ComfyUINodeDef): boolean {
-  return /(^|\/)3d(\/|$)/i.test(def.category ?? "");
-}
-
-/** A hosted partner/API node that produces a 3D model. */
+/**
+ * A hosted partner/API node that produces a 3D model. Requires an actual
+ * FILE_3D* output — a 3D-ish category alone is NOT enough, since 3D categories
+ * also contain post-processing/utility nodes (UV unwrap, retopology, task-id
+ * plumbing) that would be a false "backend" for generation.
+ */
 export function is3dApiNode(def: ComfyUINodeDef): boolean {
-  return isApiNode(def) && (has3dOutput(def) || has3dCategory(def));
+  return isApiNode(def) && has3dOutput(def);
 }
 
 /** Names of required link-type inputs (non-widget — need an upstream node). */

--- a/src/services/generate-3d.ts
+++ b/src/services/generate-3d.ts
@@ -1,0 +1,314 @@
+import type { ComfyUINodeDef, ObjectInfo, WorkflowJSON } from "../comfyui/types.js";
+import { getObjectInfo } from "../comfyui/client.js";
+import { enqueueWorkflow } from "./workflow-executor.js";
+import {
+  isApiNode,
+  generateWithApiNode,
+  type ApiNodesDeps,
+  type GenerateWithApiNodeResult,
+} from "./api-nodes.js";
+import { ValidationError } from "../utils/errors.js";
+
+/**
+ * generate_3d — produce a 3D model (glb/obj/fbx/ply) from a text prompt or an
+ * input image.
+ *
+ * PATH CHOSEN (investigated 2026-07-24): current ComfyUI ships hosted partner
+ * 3D nodes in core (`comfy_api_nodes`) — Tripo, Meshy, Rodin and Hunyuan3D
+ * (Tencent), all under categories like "partner/3d/Tripo" with FILE_3D_*
+ * outputs and OUTPUT_NODE=true. We therefore route through the SAME
+ * generateWithApiNode machinery used by the generate_with_api_node tool: no
+ * local 3D pack install is required, only a comfy.org API key/login on the
+ * server (or COMFY_API_KEY here). Detection is dynamic against /object_info,
+ * so the tool degrades honestly when the server has no 3D-capable API nodes
+ * (old build, --disable-api-nodes) with an actionable error naming local-pack
+ * alternatives.
+ */
+
+const defaultDeps: ApiNodesDeps = {
+  getObjectInfo,
+  enqueue: enqueueWorkflow,
+};
+
+/** Node id used for the LoadImage feeder in image mode ("1"/"2" are reserved). */
+const LOAD_IMAGE_NODE_ID = "10";
+
+/** Widget-ish input types that don't need an upstream link. */
+const WIDGET_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);
+
+function inputType(spec: unknown): string | string[] {
+  if (Array.isArray(spec)) return spec[0] as string | string[];
+  return String(spec);
+}
+
+function isWidgetType(type: string | string[]): boolean {
+  if (Array.isArray(type)) return true; // inline combo options
+  const t = type.toUpperCase();
+  return WIDGET_TYPES.has(t) || t.includes("COMBO") || t.includes("AUTOGROW");
+}
+
+/** Does this node output a 3D model file? */
+function has3dOutput(def: ComfyUINodeDef): boolean {
+  return (Array.isArray(def.output) ? def.output : []).some((o) =>
+    String(o).toUpperCase().startsWith("FILE_3D"),
+  );
+}
+
+/** Is the node in a 3D category (e.g. "partner/3d/Tripo", "api node/3d/Rodin")? */
+function has3dCategory(def: ComfyUINodeDef): boolean {
+  return /(^|\/)3d(\/|$)/i.test(def.category ?? "");
+}
+
+/** A hosted partner/API node that produces a 3D model. */
+export function is3dApiNode(def: ComfyUINodeDef): boolean {
+  return isApiNode(def) && (has3dOutput(def) || has3dCategory(def));
+}
+
+/** Names of required link-type inputs (non-widget — need an upstream node). */
+function requiredLinkInputs(def: ComfyUINodeDef): Array<{ name: string; type: string }> {
+  const out: Array<{ name: string; type: string }> = [];
+  for (const [name, spec] of Object.entries(def.input?.required ?? {})) {
+    const type = inputType(spec);
+    if (!isWidgetType(type)) out.push({ name, type: String(type).toUpperCase() });
+  }
+  return out;
+}
+
+function findStringPromptInput(def: ComfyUINodeDef): string | undefined {
+  for (const section of [def.input?.required, def.input?.optional]) {
+    for (const [name, spec] of Object.entries(section ?? {})) {
+      const type = inputType(spec);
+      if (typeof type === "string" && type.toUpperCase() === "STRING" && /prompt/i.test(name)) {
+        return name;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Can this 3D node run from just a text prompt (no required link inputs)? */
+export function isTextCapable(def: ComfyUINodeDef): boolean {
+  if (requiredLinkInputs(def).length > 0) return false;
+  // Must actually accept a prompt.
+  const req = def.input?.required ?? {};
+  return Object.entries(req).some(([name, spec]) => {
+    const type = inputType(spec);
+    return typeof type === "string" && type.toUpperCase() === "STRING" && /prompt/i.test(name);
+  });
+}
+
+/** Can this 3D node run from a single input image (exactly one required IMAGE link)? */
+export function isImageCapable(def: ComfyUINodeDef): { ok: boolean; imageInput?: string } {
+  const links = requiredLinkInputs(def);
+  const images = links.filter((l) => l.type === "IMAGE");
+  if (images.length !== 1 || links.length !== images.length) return { ok: false };
+  return { ok: true, imageInput: images[0].name };
+}
+
+/** Preferred class_types per mode, best-supported first. */
+const PREFERRED: Record<Generate3dMode, string[]> = {
+  text: [
+    "TripoTextToModelNode",
+    "MeshyTextToModelNode",
+    "TencentTextToModelNode",
+    "Rodin3D_Gen25_Text",
+    "TripoP1TextToModelNode",
+  ],
+  image: [
+    "TripoImageToModelNode",
+    "MeshyImageToModelNode",
+    "TencentImageToModelNode",
+    "Rodin3D_Gen25_Image",
+    "TripoP1ImageToModelNode",
+  ],
+};
+
+export type Generate3dMode = "text" | "image";
+
+export interface ThreeDNodeCandidate {
+  class_type: string;
+  display_name: string;
+  category: string;
+  /** 3D file formats the node outputs (e.g. ["GLB"], ["GLB","OBJ"]). */
+  formats: string[];
+  /** Name of the required IMAGE input (image-capable nodes only). */
+  image_input?: string;
+}
+
+function formatsOf(def: ComfyUINodeDef): string[] {
+  const out: string[] = [];
+  for (const o of Array.isArray(def.output) ? def.output : []) {
+    const s = String(o).toUpperCase();
+    if (s === "FILE_3D") out.push("3D");
+    else if (s.startsWith("FILE_3D_")) out.push(s.slice("FILE_3D_".length));
+  }
+  return [...new Set(out)];
+}
+
+/** Discover 3D-capable API nodes on the connected server, for a given mode. */
+export function find3dApiNodes(
+  objectInfo: ObjectInfo,
+  mode: Generate3dMode,
+): ThreeDNodeCandidate[] {
+  const out: ThreeDNodeCandidate[] = [];
+  for (const [classType, def] of Object.entries(objectInfo)) {
+    if (!def || !is3dApiNode(def)) continue;
+    if (mode === "text") {
+      if (!isTextCapable(def)) continue;
+      out.push({
+        class_type: classType,
+        display_name: def.display_name || classType,
+        category: def.category ?? "",
+        formats: formatsOf(def),
+      });
+    } else {
+      const cap = isImageCapable(def);
+      if (!cap.ok) continue;
+      out.push({
+        class_type: classType,
+        display_name: def.display_name || classType,
+        category: def.category ?? "",
+        formats: formatsOf(def),
+        image_input: cap.imageInput,
+      });
+    }
+  }
+  out.sort((a, b) => a.class_type.localeCompare(b.class_type));
+  return out;
+}
+
+function pickCandidate(
+  candidates: ThreeDNodeCandidate[],
+  mode: Generate3dMode,
+): ThreeDNodeCandidate {
+  for (const preferred of PREFERRED[mode]) {
+    const hit = candidates.find((c) => c.class_type === preferred);
+    if (hit) return hit;
+  }
+  return candidates[0];
+}
+
+function noBackendError(mode: Generate3dMode): ValidationError {
+  return new ValidationError(
+    `No 3D-capable API/partner nodes for ${mode}-to-3D were found on the connected ComfyUI, ` +
+      `so generate_3d has no backend to run on. Recent ComfyUI builds ship hosted 3D partner nodes ` +
+      `in core (Tripo, Meshy, Rodin, Hunyuan3D — categories like "partner/3d/..."); they may be ` +
+      `missing because the ComfyUI build is old or API nodes are disabled (--disable-api-nodes). ` +
+      `Fixes: (1) update ComfyUI (update_comfyui) and remove --disable-api-nodes, then retry; or ` +
+      `(2) install a LOCAL 3D pack and build a workflow with it — e.g. install_custom_node with ` +
+      `"ComfyUI-Hunyuan3DWrapper" (image-to-3D) or "ComfyUI-Flowty-TripoSR" (image-to-3D). ` +
+      `Nothing was installed automatically.`,
+  );
+}
+
+export interface Generate3dArgs {
+  mode: Generate3dMode;
+  /** Text description of the model (required in text mode; optional extra guidance in image mode if the node accepts it). */
+  prompt?: string;
+  /** ComfyUI input-image filename (image mode). Upload first with upload_image. */
+  image?: string;
+  /** Explicit 3D API node class_type to use (overrides auto-selection). */
+  node?: string;
+  /** Provider-specific extra inputs passed through to the node (see get_api_node_schema). */
+  inputs?: Record<string, unknown>;
+  disable_random_seed?: boolean;
+}
+
+export interface Generate3dResult extends GenerateWithApiNodeResult {
+  class_type: string;
+  display_name: string;
+  category: string;
+  /** 3D output formats the chosen node produces. */
+  formats: string[];
+  /** Other 3D nodes that could have been used for this mode. */
+  alternatives: string[];
+}
+
+/**
+ * Generate a 3D model from text or an image by enqueueing a minimal workflow
+ * around a hosted partner 3D node (Tripo/Meshy/Rodin/Hunyuan3D), reusing the
+ * generate_with_api_node machinery. Returns immediately with the prompt_id.
+ */
+export async function generate3d(
+  args: Generate3dArgs,
+  deps: ApiNodesDeps = defaultDeps,
+): Promise<Generate3dResult> {
+  if (args.mode === "text" && !args.prompt?.trim()) {
+    throw new ValidationError('mode "text" requires a non-empty prompt.');
+  }
+  if (args.mode === "image" && !args.image?.trim()) {
+    throw new ValidationError(
+      'mode "image" requires an input image filename (upload one first with upload_image).',
+    );
+  }
+
+  const objectInfo = await deps.getObjectInfo();
+  const candidates = find3dApiNodes(objectInfo, args.mode);
+  if (candidates.length === 0) throw noBackendError(args.mode);
+
+  let chosen: ThreeDNodeCandidate;
+  if (args.node) {
+    const hit = candidates.find((c) => c.class_type === args.node);
+    if (!hit) {
+      throw new ValidationError(
+        `Node "${args.node}" is not a ${args.mode}-capable 3D API node on this server. ` +
+          `Available: ${candidates.map((c) => c.class_type).join(", ")}.`,
+      );
+    }
+    chosen = hit;
+  } else {
+    chosen = pickCandidate(candidates, args.mode);
+  }
+
+  const def = objectInfo[chosen.class_type];
+  const inputs: Record<string, unknown> = { ...(args.inputs ?? {}) };
+  let extra_nodes: WorkflowJSON | undefined;
+  const preNotes: string[] = [];
+
+  if (args.mode === "text") {
+    const promptName = findStringPromptInput(def) ?? "prompt";
+    if (!(promptName in inputs)) inputs[promptName] = args.prompt;
+  } else {
+    const imageInput = chosen.image_input ?? "image";
+    inputs[imageInput] = [LOAD_IMAGE_NODE_ID, 0];
+    extra_nodes = {
+      [LOAD_IMAGE_NODE_ID]: {
+        class_type: "LoadImage",
+        inputs: { image: args.image },
+        _meta: { title: "Load Input Image" },
+      },
+    };
+    if (args.prompt?.trim()) {
+      const promptName = findStringPromptInput(def);
+      if (promptName) {
+        if (!(promptName in inputs)) inputs[promptName] = args.prompt;
+      } else {
+        preNotes.push(
+          `"${chosen.class_type}" takes no text prompt input — the prompt was ignored (image-only node).`,
+        );
+      }
+    }
+  }
+
+  const result = await generateWithApiNode(
+    {
+      class_type: chosen.class_type,
+      inputs,
+      disable_random_seed: args.disable_random_seed,
+      extra_nodes,
+    },
+    deps,
+  );
+
+  return {
+    ...result,
+    notes: [...preNotes, ...result.notes],
+    class_type: chosen.class_type,
+    display_name: chosen.display_name,
+    category: chosen.category,
+    formats: chosen.formats,
+    alternatives: candidates
+      .map((c) => c.class_type)
+      .filter((c) => c !== chosen.class_type),
+  };
+}

--- a/src/tools/generate-3d.ts
+++ b/src/tools/generate-3d.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// SHELL — implement per the PR spec, then (1) wire registerGenerate3dTools into
+// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+export function registerGenerate3dTools(server: McpServer): void {
+  server.tool(
+    "generate_3d",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "generate_3d: not implemented (shell)" }] }),
+  );
+}

--- a/src/tools/generate-3d.ts
+++ b/src/tools/generate-3d.ts
@@ -27,13 +27,13 @@ export function registerGenerate3dTools(server: McpServer): void {
         .string()
         .optional()
         .describe(
-          "Text description of the 3D model (required for mode 'text'; in mode 'image' it is passed along only if the chosen node accepts a prompt).",
+          "REQUIRED when mode is 'text': text description of the 3D model. In mode 'image' it is optional and passed along only if the chosen node accepts a prompt. (Cross-field requirement enforced at runtime — the call fails with a clear error if omitted in text mode.)",
         ),
       image: z
         .string()
         .optional()
         .describe(
-          "ComfyUI input-image filename (required for mode 'image'). Upload local files first with upload_image.",
+          "REQUIRED when mode is 'image': ComfyUI input-image filename. Upload local files first with upload_image. (Cross-field requirement enforced at runtime.)",
         ),
       node: z
         .string()

--- a/src/tools/generate-3d.ts
+++ b/src/tools/generate-3d.ts
@@ -1,13 +1,94 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { generate3d } from "../services/generate-3d.js";
+import { errorToToolResult } from "../utils/errors.js";
 
-// SHELL — implement per the PR spec, then (1) wire registerGenerate3dTools into
-// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+/**
+ * generate_3d — 3D model generation via the connected ComfyUI's hosted partner
+ * 3D nodes (Tripo / Meshy / Rodin / Hunyuan3D), reusing the same machinery as
+ * generate_with_api_node. See ../services/generate-3d.ts for the
+ * path-selection rationale and capability detection.
+ */
 export function registerGenerate3dTools(server: McpServer): void {
   server.tool(
     "generate_3d",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "generate_3d: not implemented (shell)" }] }),
+    "Generate a 3D model (glb/obj/fbx) from a text prompt or an input image, using the connected " +
+      "ComfyUI's hosted partner 3D nodes (Tripo, Meshy, Rodin, Hunyuan3D — auto-detected from the " +
+      "server; these are paid API nodes needing a comfy.org API key/login on the server or COMFY_API_KEY here). " +
+      "Builds and enqueues a minimal workflow and returns immediately with the prompt_id — poll " +
+      "get_job_status / get_history for the resulting model file (saved to ComfyUI's output directory). " +
+      "For image mode, upload the image first with upload_image and pass its filename. " +
+      "If the server has no 3D-capable API nodes, returns an actionable error naming local-pack alternatives.",
+    {
+      mode: z
+        .enum(["text", "image"])
+        .describe('"text" = text-to-3D from prompt; "image" = image-to-3D from an uploaded input image.'),
+      prompt: z
+        .string()
+        .optional()
+        .describe(
+          "Text description of the 3D model (required for mode 'text'; in mode 'image' it is passed along only if the chosen node accepts a prompt).",
+        ),
+      image: z
+        .string()
+        .optional()
+        .describe(
+          "ComfyUI input-image filename (required for mode 'image'). Upload local files first with upload_image.",
+        ),
+      node: z
+        .string()
+        .optional()
+        .describe(
+          'Explicit 3D API node class_type to use (e.g. "MeshyTextToModelNode"); auto-selected if omitted. Use list_api_nodes with filter "3d" to see options.',
+        ),
+      inputs: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          "Provider-specific extra inputs passed through to the node (e.g. style, texture, quality). Use get_api_node_schema on the chosen node for valid keys.",
+        ),
+      disable_random_seed: z
+        .boolean()
+        .optional()
+        .describe("If true, do not randomize seed inputs."),
+    },
+    async (args) => {
+      try {
+        const result = await generate3d({
+          mode: args.mode,
+          prompt: args.prompt,
+          image: args.image,
+          node: args.node,
+          inputs: args.inputs,
+          disable_random_seed: args.disable_random_seed,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  status: "enqueued",
+                  prompt_id: result.prompt_id,
+                  queue_remaining: result.queue_remaining,
+                  node: result.class_type,
+                  display_name: result.display_name,
+                  category: result.category,
+                  formats: result.formats,
+                  alternatives: result.alternatives,
+                  notes: result.notes,
+                  workflow: result.workflow,
+                  next: "Poll get_job_status / get_history with the prompt_id; the 3D model file is written to ComfyUI's output directory when the job completes.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,6 +23,7 @@ import { registerAutoloadedWorkflows } from "./workflow-autoload.js";
 import { registerDefaultsTools } from "./defaults.js";
 import { registerGenerateImageTool } from "./generate-image.js";
 import { registerGenerateAudioTool } from "./generate-audio.js";
+import { registerGenerate3dTools } from "./generate-3d.js";
 import { registerGenerateVideoTool } from "./generate-video.js";
 import { registerRemoveBackgroundTool } from "./remove-background.js";
 import { registerUpscaleImageTool } from "./upscale-image.js";
@@ -91,6 +92,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["skills-config", registerDefaultsTools],
   ["generation", registerGenerateImageTool],
   ["generation", registerGenerateAudioTool],
+  ["generation", registerGenerate3dTools],
   ["generation", registerGenerateVideoTool],
   ["generation", registerRemoveBackgroundTool],
   ["generation", registerUpscaleImageTool],


### PR DESCRIPTION
## Gap: `generate_3d` — Generate a 3D model from text or an image

Parity gap vs ComfyUI Cloud's `generate-3d`. We have image/video/audio generation but **no 3D path**.

**Deliver:** a `generate_3d` MCP tool that produces a 3D model (glb/obj/ply) from a text prompt and/or an input image.

**Approach (investigate first, pick the available path):**
1. **Preferred — a partner/API 3D node** if ComfyUI exposes one: check `list_api_nodes`/`get_api_node_schema` output and `src/tools/api-nodes.ts` for any 3D service (Rodin, Meshy, Tripo, Hunyuan3D-cloud, etc.). If present, route through the existing `generate_with_api_node` machinery — no local install needed.
2. **Fallback — a local 3D pack** (Hunyuan3D-2, TripoSR, StableZero123): detect via installed nodes; if the required pack isn't installed, return a CLEAR, actionable error naming the pack + an `install_custom_node` suggestion (do NOT auto-install).
3. Reuse existing generation plumbing (enqueue + output retrieval); output the model file path/asset.

**Acceptance:** tool registered + wired into `registerAllTools()`; input schema (`prompt?`, `image?`/input ref, `mode: text|image`, optional model/quality); graceful capability detection with an honest "no 3D backend available — install X" error; a unit test (mock the ComfyUI calls) covering the happy path + the no-backend error. `npx tsc --noEmit` clean; `npx vitest run` for the new test passes.

**Wire:** add `import { registerGenerate3dTools } from "./generate-3d.js"` + the call in `registerAllTools()` (src/tools/index.ts).
