### PR TITLE
feat(tools): get_template_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**174 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**175 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-174 tools across workflow execution, generation, iteration, composition, models, and more:
+175 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 174 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 175 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -107,6 +107,7 @@ describe("extractTemplateSlots (API-format template)", () => {
       a: { class_type: "TotallyUnknownNode", inputs: { foo: 3, bar: 1.5, baz: true, qux: "x" } },
       b: { class_type: "Broken", inputs: null },
       c: {},
+      d: { class_type: "ArrayInputs", inputs: [null, { nope: 1 }] }, // malformed: array inputs
     } as unknown as WorkflowJSON;
     const res = extractTemplateSlots(weird, null);
     const foo = res.other_slots.find((s) => s.key === "a.foo");
@@ -115,6 +116,8 @@ describe("extractTemplateSlots (API-format template)", () => {
     expect(res.other_slots.find((s) => s.key === "a.baz")?.type).toBe("BOOLEAN");
     expect(res.other_slots.find((s) => s.key === "a.qux")?.type).toBe("STRING");
     expect(res.slots).toEqual([]);
+    // Array-shaped inputs must NOT produce fake index keys like "d.0".
+    expect(res.other_slots.some((s) => s.node_id === "d")).toBe(false);
   });
 });
 

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -192,6 +192,14 @@ describe("templateGraphToApi (UI-format template, offline fallback schema)", () 
           widgets_values: ["kept anyway"],
         },
         {
+          id: 8,
+          type: "CLIPTextEncode",
+          pos: [0, 0],
+          inputs: [],
+          outputs: [],
+          widgets_values: "bad-scalar", // malformed: must not crash `name in wv`
+        },
+        {
           id: 6,
           type: "CLIPTextEncode",
           pos: [0, 0],

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -192,7 +192,7 @@ describe("templateGraphToApi (UI-format template, offline fallback schema)", () 
           id: 6,
           type: "CLIPTextEncode",
           pos: [0, 0],
-          inputs: [],
+          inputs: [null, { name: "clip", type: "CLIP", link: null }], // null entry must be dropped
           outputs: [],
           widgets_values: ["ok"],
         },

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractTemplateSlots,
+  templateGraphToApi,
+  classifyWidget,
+  FALLBACK_OBJECT_INFO,
+} from "../../tools/template-schema.js";
+import type { ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
+
+// A classic SD txt2img template in API/prompt format — the canonical sample.
+const API_TEMPLATE: WorkflowJSON = {
+  "3": {
+    class_type: "KSampler",
+    inputs: {
+      seed: 123456789,
+      steps: 20,
+      cfg: 7.5,
+      sampler_name: "euler",
+      scheduler: "normal",
+      denoise: 1,
+      model: ["4", 0],
+      positive: ["6", 0],
+      negative: ["7", 0],
+      latent_image: ["5", 0],
+    },
+  },
+  "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd_xl_base_1.0.safetensors" } },
+  "5": { class_type: "EmptyLatentImage", inputs: { width: 1024, height: 1024, batch_size: 1 } },
+  "6": {
+    class_type: "CLIPTextEncode",
+    inputs: { text: "a cat", clip: ["4", 1] },
+    _meta: { title: "Positive Prompt" },
+  },
+  "7": {
+    class_type: "CLIPTextEncode",
+    inputs: { text: "blurry", clip: ["4", 1] },
+    _meta: { title: "Negative Prompt" },
+  },
+  "9": { class_type: "SaveImage", inputs: { filename_prefix: "ComfyUI", images: ["3", 0] } },
+};
+
+const KEY_RE = /^[^.\s]+\.[A-Za-z_][A-Za-z0-9_.]*$/;
+
+describe("extractTemplateSlots (API-format template)", () => {
+  const { slots, other_slots } = extractTemplateSlots(API_TEMPLATE, FALLBACK_OBJECT_INFO);
+  const byKey = new Map(slots.map((s) => [s.key, s]));
+
+  it("emits the expected primary slots with <nodeId>.<widget> keys", () => {
+    expect([...byKey.keys()].sort()).toEqual(
+      [
+        "3.seed", "3.steps", "3.cfg", "3.sampler_name", "3.scheduler", "3.denoise",
+        "4.ckpt_name", "5.width", "5.height", "5.batch_size", "6.text", "7.text",
+      ].sort(),
+    );
+    for (const s of [...slots, ...other_slots]) {
+      expect(s.key).toMatch(KEY_RE);
+      expect(s.key).toBe(`${s.node_id}.${s.widget}`);
+    }
+  });
+
+  it("never emits a slot for a link input", () => {
+    const all = [...slots, ...other_slots].map((s) => s.key);
+    expect(all).not.toContain("3.model");
+    expect(all).not.toContain("3.positive");
+    expect(all).not.toContain("9.images");
+  });
+
+  it("assigns types, roles, values and range metadata from the node schema", () => {
+    expect(byKey.get("3.seed")).toMatchObject({ role: "seed", type: "INT", value: 123456789, min: 0 });
+    expect(byKey.get("3.steps")).toMatchObject({ role: "steps", type: "INT", value: 20, min: 1, max: 10000 });
+    expect(byKey.get("3.cfg")).toMatchObject({ role: "cfg", type: "FLOAT", value: 7.5, min: 0, max: 100 });
+    expect(byKey.get("3.sampler_name")).toMatchObject({ role: "sampler", type: "COMBO" });
+    expect(byKey.get("3.denoise")).toMatchObject({ role: "denoise", type: "FLOAT", min: 0, max: 1 });
+    expect(byKey.get("4.ckpt_name")).toMatchObject({ role: "checkpoint", value: "sd_xl_base_1.0.safetensors" });
+    expect(byKey.get("5.width")).toMatchObject({ role: "width", type: "INT", value: 1024 });
+    expect(byKey.get("6.text")).toMatchObject({ role: "prompt", type: "STRING", value: "a cat", node_title: "Positive Prompt" });
+    expect(byKey.get("7.text")).toMatchObject({ role: "prompt", node_title: "Negative Prompt" });
+  });
+
+  it("routes structural widgets to other_slots, still overridable", () => {
+    expect(byKey.has("9.filename_prefix")).toBe(false);
+    const fp = other_slots.find((s) => s.key === "9.filename_prefix");
+    expect(fp).toMatchObject({ role: "other", value: "ComfyUI", type: "STRING" });
+  });
+
+  it("surfaces combo options (truncated) when the live schema provides them", () => {
+    const live: ObjectInfo = {
+      ...FALLBACK_OBJECT_INFO,
+      KSampler: {
+        ...FALLBACK_OBJECT_INFO.KSampler,
+        input: {
+          required: {
+            ...FALLBACK_OBJECT_INFO.KSampler.input.required!,
+            sampler_name: [["euler", "euler_ancestral", "dpmpp_2m"], {}],
+          },
+        },
+      },
+    };
+    const res = extractTemplateSlots(API_TEMPLATE, live);
+    const sampler = res.slots.find((s) => s.key === "3.sampler_name");
+    expect(sampler?.options).toEqual(["euler", "euler_ancestral", "dpmpp_2m"]);
+    expect(sampler?.options_count).toBe(3);
+  });
+
+  it("does not crash on odd node shapes and infers types without a schema", () => {
+    const weird = {
+      a: { class_type: "TotallyUnknownNode", inputs: { foo: 3, bar: 1.5, baz: true, qux: "x" } },
+      b: { class_type: "Broken", inputs: null },
+      c: {},
+    } as unknown as WorkflowJSON;
+    const res = extractTemplateSlots(weird, null);
+    const foo = res.other_slots.find((s) => s.key === "a.foo");
+    expect(foo).toMatchObject({ type: "INT", value: 3 });
+    expect(res.other_slots.find((s) => s.key === "a.bar")?.type).toBe("FLOAT");
+    expect(res.other_slots.find((s) => s.key === "a.baz")?.type).toBe("BOOLEAN");
+    expect(res.other_slots.find((s) => s.key === "a.qux")?.type).toBe("STRING");
+    expect(res.slots).toEqual([]);
+  });
+});
+
+describe("templateGraphToApi (UI-format template, offline fallback schema)", () => {
+  // Minimal UI-format txt2img: KSampler widgets_values includes the phantom
+  // control_after_generate value ("randomize") that must NOT become a slot.
+  const ui = {
+    last_node_id: 6,
+    last_link_id: 2,
+    nodes: [
+      {
+        id: 3,
+        type: "KSampler",
+        pos: [0, 0],
+        inputs: [{ name: "positive", type: "CONDITIONING", link: 1 }],
+        outputs: [],
+        widgets_values: [42, "randomize", 30, 4.0, "euler", "simple", 0.85],
+      },
+      {
+        id: 6,
+        type: "CLIPTextEncode",
+        pos: [0, 0],
+        inputs: [],
+        outputs: [{ name: "CONDITIONING", type: "CONDITIONING", links: [1] }],
+        widgets_values: ["a scenic mountain"],
+        title: "Positive Prompt",
+      },
+    ],
+    links: [[1, 6, 0, 3, 0, "CONDITIONING"]],
+    version: 0.4,
+  };
+
+  it("maps positional widgets_values to named slots via the fallback schema", () => {
+    const norm = templateGraphToApi(ui, null);
+    expect(norm).not.toBeNull();
+    const { slots } = extractTemplateSlots(norm!.api, norm!.objectInfo);
+    const byKey = new Map(slots.map((s) => [s.key, s]));
+    expect(byKey.get("3.seed")?.value).toBe(42);
+    expect(byKey.get("3.steps")?.value).toBe(30);
+    expect(byKey.get("3.cfg")?.value).toBe(4.0);
+    expect(byKey.get("3.sampler_name")?.value).toBe("euler");
+    expect(byKey.get("3.scheduler")?.value).toBe("simple");
+    expect(byKey.get("3.denoise")?.value).toBe(0.85);
+    expect(byKey.get("6.text")?.value).toBe("a scenic mountain");
+    // The phantom control widget never leaks into any slot.
+    const values = [...slots.map((s) => s.value)];
+    expect(values).not.toContain("randomize");
+  });
+
+  it("returns null for JSON that is neither UI nor API format", () => {
+    expect(templateGraphToApi({ hello: "world" }, null)).toBeNull();
+    expect(templateGraphToApi([1, 2, 3], null)).toBeNull();
+    expect(templateGraphToApi("nope", null)).toBeNull();
+  });
+});
+
+describe("classifyWidget", () => {
+  it("classifies the common runtime widgets", () => {
+    expect(classifyWidget("CLIPTextEncode", "text")).toBe("prompt");
+    expect(classifyWidget("RandomNoise", "noise_seed")).toBe("seed");
+    expect(classifyWidget("LoraLoader", "lora_name")).toBe("lora");
+    expect(classifyWidget("LoraLoader", "strength_model")).toBe("strength");
+    expect(classifyWidget("LoadImage", "image")).toBe("input_image");
+    expect(classifyWidget("UNETLoader", "unet_name")).toBe("model");
+    expect(classifyWidget("FluxGuidance", "guidance")).toBe("guidance");
+    expect(classifyWidget("SaveImage", "filename_prefix")).toBe("other");
+  });
+});

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -181,6 +181,14 @@ describe("templateGraphToApi (UI-format template, offline fallback schema)", () 
         null,
         { pos: [0, 0] }, // missing id/type
         {
+          id: 5,
+          type: "CLIPTextEncode",
+          pos: [0, 0],
+          inputs: {}, // malformed: object where an array belongs
+          outputs: "nope", // malformed
+          widgets_values: ["kept anyway"],
+        },
+        {
           id: 6,
           type: "CLIPTextEncode",
           pos: [0, 0],
@@ -194,7 +202,11 @@ describe("templateGraphToApi (UI-format template, offline fallback schema)", () 
     const norm = templateGraphToApi(broken, null);
     expect(norm).not.toBeNull();
     const { slots } = extractTemplateSlots(norm!.api, norm!.objectInfo);
-    expect(slots.map((s) => s.key)).toContain("6.text");
+    const keys = slots.map((s) => s.key);
+    expect(keys).toContain("6.text");
+    // Node 5 had malformed nested fields but a valid id/type — its widget
+    // survives via the normalized shape instead of crashing the converter.
+    expect(keys).toContain("5.text");
     expect(norm!.warnings.join(" ")).toMatch(/malformed/i);
   });
 

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -164,6 +164,40 @@ describe("templateGraphToApi (UI-format template, offline fallback schema)", () 
     expect(values).not.toContain("randomize");
   });
 
+  it("keeps a two-number literal widget value that is not a node reference", () => {
+    const api = {
+      "1": { class_type: "TotallyUnknownNode", inputs: { size: [512, 512], real_link: ["2", 0] } },
+      "2": { class_type: "AnotherNode", inputs: {} },
+    } as unknown as WorkflowJSON;
+    const res = extractTemplateSlots(api, null);
+    const keys = [...res.slots, ...res.other_slots].map((s) => s.key);
+    expect(keys).toContain("1.size"); // literal, kept
+    expect(keys).not.toContain("1.real_link"); // actual connection, dropped
+  });
+
+  it("survives malformed UI node entries without crashing", () => {
+    const broken = {
+      nodes: [
+        null,
+        { pos: [0, 0] }, // missing id/type
+        {
+          id: 6,
+          type: "CLIPTextEncode",
+          pos: [0, 0],
+          inputs: [],
+          outputs: [],
+          widgets_values: ["ok"],
+        },
+      ],
+      links: [null, [1, 6, 0]],
+    };
+    const norm = templateGraphToApi(broken, null);
+    expect(norm).not.toBeNull();
+    const { slots } = extractTemplateSlots(norm!.api, norm!.objectInfo);
+    expect(slots.map((s) => s.key)).toContain("6.text");
+    expect(norm!.warnings.join(" ")).toMatch(/malformed/i);
+  });
+
   it("returns null for JSON that is neither UI nor API format", () => {
     expect(templateGraphToApi({ hello: "world" }, null)).toBeNull();
     expect(templateGraphToApi([1, 2, 3], null)).toBeNull();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -57,6 +57,7 @@ import { registerNodeDevTools } from "./node-dev.js";
 import { registerComfyCliTools } from "./comfy-cli.js";
 import { registerTrainTools } from "./train.js";
 import { registerAppsTools } from "./apps.js";
+import { registerTemplateSchemaTools } from "./template-schema.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -123,6 +124,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["custom-nodes", registerNodeDevTools],
   ["training", registerTrainTools],
   ["apps", registerAppsTools],
+  ["workflows", registerTemplateSchemaTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -116,7 +116,7 @@ function enumerateSkills(): Array<{ name: string; description: string }> {
 
 /** Enumerate installer packs as { name, family, kind, description, workflow,
  *  has_workflow, has_manifest }. Reads each packs/<name>/pack.yaml. */
-function enumeratePacks(): Array<Record<string, unknown>> {
+export function enumeratePacks(): Array<Record<string, unknown>> {
   const dir = packsDir();
   if (!existsSync(dir)) return [];
   const out: Array<Record<string, unknown>> = [];
@@ -166,7 +166,7 @@ function enumeratePacks(): Array<Record<string, unknown>> {
 /** Locate a pack's workflow.json file path (name-guarded, must exist). Returns
  *  null when the pack or its workflow is missing. Shared by read_pack_workflow
  *  and check_workflow_runtime so they resolve the file identically. */
-function resolvePackWorkflowFile(packName: string): string | null {
+export function resolvePackWorkflowFile(packName: string): string | null {
   const name = packName.trim();
   if (!SAFE_NAME.test(name)) return null;
   const packDir = join(packsDir(), name);

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -282,13 +282,20 @@ export function templateGraphToApi(
             : undefined;
         const inputs = slotArr<NonNullable<UiWorkflow["nodes"][number]["inputs"]>[number]>(n.inputs);
         const outputs = slotArr<NonNullable<UiWorkflow["nodes"][number]["outputs"]>[number]>(n.outputs);
+        // widgets_values may be a positional array OR a name→value record (VHS
+        // nodes) — both are valid. A scalar (string/number/…) would crash the
+        // converter's `name in wv` check, so normalize it away.
+        const wv = n.widgets_values;
+        const widgets_values =
+          Array.isArray(wv) || (wv != null && typeof wv === "object") ? wv : undefined;
         if (
+          widgets_values === wv &&
           inputs?.length === (Array.isArray(n.inputs) ? n.inputs.length : -1) &&
           outputs?.length === (Array.isArray(n.outputs) ? n.outputs.length : -1)
         ) {
           return n; // fully well-shaped, keep as-is
         }
-        return { ...n, inputs, outputs };
+        return { ...n, inputs, outputs, widgets_values };
       });
     if (goodNodes.length !== (ui.nodes ?? []).length) {
       warnings.push(

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -268,19 +268,26 @@ export function templateGraphToApi(
           !!n && typeof n === "object" && typeof (n as { id?: unknown }).id === "number" &&
           typeof (n as { type?: unknown }).type === "string",
       )
-      // The converter iterates node.inputs/outputs as arrays — normalize any
-      // non-array nested field so a malformed node can't crash it. (Non-array
-      // widgets_values is LEGITIMATE — e.g. VHS nodes use a name→value object —
-      // and the converter handles it, so leave that alone.)
-      .map((n) =>
-        Array.isArray(n.inputs ?? []) && Array.isArray(n.outputs ?? [])
-          ? n
-          : {
-              ...n,
-              inputs: Array.isArray(n.inputs) ? n.inputs : undefined,
-              outputs: Array.isArray(n.outputs) ? n.outputs : undefined,
-            },
-      );
+      // The converter iterates node.inputs/outputs as arrays of objects and
+      // dereferences entry fields (input.link, input.name) — normalize any
+      // non-array nested field AND drop non-object entries so a malformed node
+      // can't crash it. (Non-array widgets_values is LEGITIMATE — e.g. VHS
+      // nodes use a name→value object — the converter handles it; leave alone.)
+      .map((n) => {
+        const slotArr = <T>(v: unknown): T[] | undefined =>
+          Array.isArray(v)
+            ? (v.filter((e) => !!e && typeof e === "object") as T[])
+            : undefined;
+        const inputs = slotArr<NonNullable<UiWorkflow["nodes"][number]["inputs"]>[number]>(n.inputs);
+        const outputs = slotArr<NonNullable<UiWorkflow["nodes"][number]["outputs"]>[number]>(n.outputs);
+        if (
+          inputs?.length === (Array.isArray(n.inputs) ? n.inputs.length : -1) &&
+          outputs?.length === (Array.isArray(n.outputs) ? n.outputs.length : -1)
+        ) {
+          return n; // fully well-shaped, keep as-is
+        }
+        return { ...n, inputs, outputs };
+      });
     if (goodNodes.length !== (ui.nodes ?? []).length) {
       warnings.push(
         `Dropped ${(ui.nodes ?? []).length - goodNodes.length} malformed node entr(y/ies) (missing id/type).`,

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -134,7 +134,9 @@ export function extractTemplateSlots(
     const node = api[nodeId];
     if (!node || typeof node !== "object" || typeof node.class_type !== "string") continue;
     const inputs = node.inputs;
-    if (!inputs || typeof inputs !== "object") continue;
+    // An inputs ARRAY is malformed (Object.entries would emit fake "<id>.0"
+    // index keys) — only a name→value record is a valid API-format inputs map.
+    if (!inputs || typeof inputs !== "object" || Array.isArray(inputs)) continue;
     const def = objectInfo?.[node.class_type];
     const title = node._meta?.title;
     for (const [widget, value] of Object.entries(inputs)) {

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -262,11 +262,25 @@ export function templateGraphToApi(
     // odd shapes; report what was dropped.
     const ui = graph as UiWorkflow;
     const warnings: string[] = [];
-    const goodNodes = (ui.nodes ?? []).filter(
-      (n): n is UiWorkflow["nodes"][number] =>
-        !!n && typeof n === "object" && typeof (n as { id?: unknown }).id === "number" &&
-        typeof (n as { type?: unknown }).type === "string",
-    );
+    const goodNodes = (ui.nodes ?? [])
+      .filter(
+        (n): n is UiWorkflow["nodes"][number] =>
+          !!n && typeof n === "object" && typeof (n as { id?: unknown }).id === "number" &&
+          typeof (n as { type?: unknown }).type === "string",
+      )
+      // The converter iterates node.inputs/outputs as arrays — normalize any
+      // non-array nested field so a malformed node can't crash it. (Non-array
+      // widgets_values is LEGITIMATE — e.g. VHS nodes use a name→value object —
+      // and the converter handles it, so leave that alone.)
+      .map((n) =>
+        Array.isArray(n.inputs ?? []) && Array.isArray(n.outputs ?? [])
+          ? n
+          : {
+              ...n,
+              inputs: Array.isArray(n.inputs) ? n.inputs : undefined,
+              outputs: Array.isArray(n.outputs) ? n.outputs : undefined,
+            },
+      );
     if (goodNodes.length !== (ui.nodes ?? []).length) {
       warnings.push(
         `Dropped ${(ui.nodes ?? []).length - goodNodes.length} malformed node entr(y/ies) (missing id/type).`,

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// SHELL — implement per the PR spec, then (1) wire registerTemplateSchemaTools into
+// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+export function registerTemplateSchemaTools(server: McpServer): void {
+  server.tool(
+    "get_template_schema",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "get_template_schema: not implemented (shell)" }] }),
+  );
+}

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -1,13 +1,425 @@
 import { z } from "zod";
+import { readFileSync } from "node:fs";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { errorToToolResult } from "../utils/errors.js";
+import { getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { getObjectInfo } from "../comfyui/client.js";
+import { convertUiToApi, isApiFormat, isUiFormat } from "../services/workflow-converter.js";
+import { enumeratePacks, resolvePackWorkflowFile } from "./skills-access.js";
+import type {
+  ComfyUINodeDef,
+  NodeInputSpec,
+  ObjectInfo,
+  WorkflowJSON,
+  UiWorkflow,
+} from "../comfyui/types.js";
 
-// SHELL — implement per the PR spec, then (1) wire registerTemplateSchemaTools into
-// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+// ── get_template_schema ──────────────────────────────────────────────────────
+// The template-level "what can I override" view: resolve a template (bundled
+// installer pack first, then an official ComfyUI workflow template on the live
+// server — the SAME sources list_packs / list_workflow_templates enumerate and
+// read_pack_workflow loads), normalize it to API/prompt format so every widget
+// has a NAME, then surface the meaningful run-time parameters ("slots").
+//
+// KEY CONVENTION (shared with run_template's `overrides`): every slot key is
+//   "<nodeId>.<widget_name>"        e.g.  "3.seed", "6.text", "5.width"
+// so get_template_schema → run_template round-trips with zero translation.
+
+export interface TemplateSlot {
+  /** Stable override key: "<nodeId>.<widget_name>" — feed straight into run_template overrides. */
+  key: string;
+  node_id: string;
+  class_type: string;
+  /** The node's title when it differs from the class type (helps tell positive vs negative prompt). */
+  node_title?: string;
+  widget: string;
+  /** Semantic role: prompt | seed | steps | cfg | guidance | sampler | scheduler | denoise | width | height | batch_size | checkpoint | lora | model | strength | input_image | input_media | length | frame_rate | shift | other */
+  role: string;
+  /** Value type: INT | FLOAT | STRING | BOOLEAN | COMBO (from node schema when known, else inferred from the value). */
+  type: string;
+  /** The template's current/default value for this widget. */
+  value: unknown;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: unknown[];
+  options_count?: number;
+}
+
+// Roles that make a slot "primary" (surfaced in `slots`); everything else is a
+// still-overridable but structural/secondary widget (surfaced in `other_slots`).
+const PRIMARY_ROLES = new Set([
+  "prompt", "seed", "steps", "cfg", "guidance", "sampler", "scheduler",
+  "denoise", "width", "height", "batch_size", "checkpoint", "lora", "model",
+  "strength", "input_image", "input_media", "length", "frame_rate", "shift",
+]);
+
+/** Classify a widget into a semantic role from its name + owning class type. */
+export function classifyWidget(classType: string, widget: string): string {
+  const w = widget.toLowerCase();
+  const c = classType.toLowerCase();
+  if (w === "text" || w === "prompt" || w === "positive_prompt" || w === "negative_prompt") {
+    if (/textencode|prompt|conditioning/.test(c) || w !== "text") return "prompt";
+  }
+  if (w === "seed" || w === "noise_seed" || w === "rand_seed") return "seed";
+  if (w === "steps") return "steps";
+  if (w === "cfg" || w === "cfg_scale" || w === "guidance_scale") return "cfg";
+  if (w === "guidance") return "guidance";
+  if (w === "sampler_name") return "sampler";
+  if (w === "scheduler") return "scheduler";
+  if (w === "denoise") return "denoise";
+  if (w === "width") return "width";
+  if (w === "height") return "height";
+  if (w === "batch_size") return "batch_size";
+  if (w === "ckpt_name") return "checkpoint";
+  if (w === "lora_name" || /^lora_\d+$/.test(w)) return "lora";
+  if (
+    w === "unet_name" || w === "model_name" || w === "clip_name" ||
+    /^clip_name\d+$/.test(w) || w === "vae_name" || w === "style_model_name" ||
+    w === "control_net_name" || w === "ipadapter_file" || w === "gguf_name"
+  ) {
+    return "model";
+  }
+  if (w === "strength_model" || w === "strength_clip" || (w === "strength" && /lora/.test(c))) {
+    return "strength";
+  }
+  if (w === "image" && /loadimage/.test(c)) return "input_image";
+  if ((w === "video" || w === "audio" || w === "file") && /^load/.test(c)) return "input_media";
+  if (w === "length" || w === "num_frames" || w === "frames" || w === "video_frames") return "length";
+  if (w === "frame_rate" || w === "fps") return "frame_rate";
+  if (w === "shift" || w === "max_shift") return "shift";
+  return "other";
+}
+
+/** A UI-format link value in an API graph: [nodeId, outputSlot]. */
+function isLinkValue(v: unknown): boolean {
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    (typeof v[0] === "string" || typeof v[0] === "number") &&
+    typeof v[1] === "number"
+  );
+}
+
+function specFor(def: ComfyUINodeDef | undefined, widget: string): NodeInputSpec | undefined {
+  if (!def) return undefined;
+  // V3 dynamic-combo nested inputs are keyed "<combo>.<nested>" — no direct
+  // spec lookup; treat as schema-less (value-inferred type).
+  return def.input?.required?.[widget] ?? def.input?.optional?.[widget];
+}
+
+const MAX_OPTIONS = 24;
+
+/**
+ * Extract override slots from an API/prompt-format graph. Pure + offline:
+ * `objectInfo` (live /object_info or the built-in fallback) only ENRICHES
+ * (type/min/max/options) — extraction itself needs nothing but the graph.
+ */
+export function extractTemplateSlots(
+  api: WorkflowJSON,
+  objectInfo?: ObjectInfo | null,
+): { slots: TemplateSlot[]; other_slots: TemplateSlot[] } {
+  const slots: TemplateSlot[] = [];
+  const other: TemplateSlot[] = [];
+  const ids = Object.keys(api).sort((a, b) => {
+    const na = Number(a);
+    const nb = Number(b);
+    if (Number.isFinite(na) && Number.isFinite(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+  for (const nodeId of ids) {
+    const node = api[nodeId];
+    if (!node || typeof node !== "object" || typeof node.class_type !== "string") continue;
+    const inputs = node.inputs;
+    if (!inputs || typeof inputs !== "object") continue;
+    const def = objectInfo?.[node.class_type];
+    const title = node._meta?.title;
+    for (const [widget, value] of Object.entries(inputs)) {
+      if (isLinkValue(value)) continue; // connection, not an overridable widget
+      const slot: TemplateSlot = {
+        key: `${nodeId}.${widget}`,
+        node_id: nodeId,
+        class_type: node.class_type,
+        widget,
+        role: classifyWidget(node.class_type, widget),
+        type: "STRING",
+        value,
+      };
+      if (title && title !== node.class_type) slot.node_title = title;
+      const spec = specFor(def, widget);
+      if (spec) {
+        const [typeSpec, cfg] = spec;
+        if (Array.isArray(typeSpec)) {
+          slot.type = "COMBO";
+          slot.options_count = typeSpec.length;
+          slot.options = typeSpec.slice(0, MAX_OPTIONS);
+        } else {
+          slot.type = String(typeSpec);
+        }
+        if (cfg && typeof cfg === "object") {
+          if (typeof cfg.min === "number") slot.min = cfg.min;
+          if (typeof cfg.max === "number") slot.max = cfg.max;
+          if (typeof cfg.step === "number") slot.step = cfg.step;
+        }
+      } else {
+        // No schema for this node/widget — infer the type from the value.
+        slot.type =
+          typeof value === "number"
+            ? Number.isInteger(value) ? "INT" : "FLOAT"
+            : typeof value === "boolean"
+              ? "BOOLEAN"
+              : "STRING";
+      }
+      (PRIMARY_ROLES.has(slot.role) ? slots : other).push(slot);
+    }
+  }
+  return { slots, other_slots: other };
+}
+
+// ── Fallback node schema ─────────────────────────────────────────────────────
+// A minimal object_info for the common core nodes, used when the live server
+// is unreachable so UI-format templates can still be mapped from positional
+// widgets_values to NAMED widgets (the converter needs a def per class type).
+// Live /object_info always wins when available.
+
+function def(required: Record<string, NodeInputSpec>): ComfyUINodeDef {
+  return {
+    input: { required },
+    input_order: { required: Object.keys(required) },
+    output: [],
+    output_is_list: [],
+    output_name: [],
+    name: "",
+    display_name: "",
+    description: "",
+    category: "",
+    output_node: false,
+  };
+}
+
+const INT: NodeInputSpec = ["INT", {}];
+const FLOAT: NodeInputSpec = ["FLOAT", {}];
+const STR: NodeInputSpec = ["STRING", {}];
+const COMBO: NodeInputSpec = ["COMBO", {}];
+
+export const FALLBACK_OBJECT_INFO: ObjectInfo = {
+  CLIPTextEncode: def({ text: ["STRING", { multiline: true }] }),
+  KSampler: def({
+    seed: ["INT", { min: 0, control_after_generate: true }],
+    steps: ["INT", { min: 1, max: 10000 }],
+    cfg: ["FLOAT", { min: 0, max: 100 }],
+    sampler_name: COMBO,
+    scheduler: COMBO,
+    denoise: ["FLOAT", { min: 0, max: 1 }],
+  }),
+  KSamplerAdvanced: def({
+    add_noise: COMBO,
+    noise_seed: ["INT", { min: 0, control_after_generate: true }],
+    steps: ["INT", { min: 1, max: 10000 }],
+    cfg: ["FLOAT", { min: 0, max: 100 }],
+    sampler_name: COMBO,
+    scheduler: COMBO,
+    start_at_step: INT,
+    end_at_step: INT,
+    return_with_leftover_noise: COMBO,
+  }),
+  EmptyLatentImage: def({ width: INT, height: INT, batch_size: INT }),
+  EmptySD3LatentImage: def({ width: INT, height: INT, batch_size: INT }),
+  CheckpointLoaderSimple: def({ ckpt_name: COMBO }),
+  LoraLoader: def({ lora_name: COMBO, strength_model: FLOAT, strength_clip: FLOAT }),
+  LoraLoaderModelOnly: def({ lora_name: COMBO, strength_model: FLOAT }),
+  LoadImage: def({ image: COMBO }),
+  SaveImage: def({ filename_prefix: STR }),
+  UNETLoader: def({ unet_name: COMBO, weight_dtype: COMBO }),
+  VAELoader: def({ vae_name: COMBO }),
+  CLIPLoader: def({ clip_name: COMBO, type: COMBO }),
+  DualCLIPLoader: def({ clip_name1: COMBO, clip_name2: COMBO, type: COMBO }),
+  RandomNoise: def({ noise_seed: ["INT", { min: 0, control_after_generate: true }] }),
+  KSamplerSelect: def({ sampler_name: COMBO }),
+  BasicScheduler: def({ scheduler: COMBO, steps: INT, denoise: FLOAT }),
+  FluxGuidance: def({ guidance: FLOAT }),
+  CFGGuider: def({ cfg: FLOAT }),
+  ModelSamplingSD3: def({ shift: FLOAT }),
+};
+
+/**
+ * Normalize a loaded template graph (UI or API format) to API/prompt format so
+ * every widget carries a NAME. UI graphs need node defs — live object_info when
+ * reachable, else FALLBACK_OBJECT_INFO (unknown node types are skipped with a
+ * warning rather than crashing). Returns null when the JSON is neither format.
+ */
+export function templateGraphToApi(
+  graph: unknown,
+  objectInfo: ObjectInfo | null,
+): { api: WorkflowJSON; warnings: string[]; objectInfo: ObjectInfo } | null {
+  if (isUiFormat(graph)) {
+    const merged: ObjectInfo = { ...FALLBACK_OBJECT_INFO, ...(objectInfo ?? {}) };
+    const { workflow, warnings } = convertUiToApi(graph as UiWorkflow, merged);
+    return { api: workflow, warnings, objectInfo: merged };
+  }
+  if (isApiFormat(graph)) {
+    return {
+      api: graph,
+      warnings: [],
+      objectInfo: { ...FALLBACK_OBJECT_INFO, ...(objectInfo ?? {}) },
+    };
+  }
+  return null;
+}
+
+/** Fetch an official workflow template's graph from the live ComfyUI. */
+async function loadServerTemplate(
+  name: string,
+): Promise<{ graph: unknown; source: string } | { error: string; available: string[] }> {
+  const base = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  let index: Record<string, unknown> = {};
+  try {
+    const res = await fetch(`${base}/api/workflow_templates`, {
+      signal: AbortSignal.timeout(8000),
+    });
+    if (res.ok) index = (await res.json()) as Record<string, unknown>;
+  } catch {
+    return {
+      error: "Not a bundled pack, and the ComfyUI server is unreachable to look up official workflow templates.",
+      available: [],
+    };
+  }
+  const all: string[] = [];
+  let module: string | null = null;
+  for (const [mod, names] of Object.entries(index)) {
+    if (!Array.isArray(names)) continue;
+    for (const n of names) {
+      const nm = typeof n === "string" ? n : (n as { name?: string })?.name;
+      if (typeof nm !== "string") continue;
+      all.push(nm);
+      if (nm === name && module == null) module = mod;
+    }
+  }
+  if (module == null) {
+    const needle = name.toLowerCase();
+    const near = all.filter((n) => n.toLowerCase().includes(needle)).slice(0, 10);
+    return {
+      error: `No official workflow template named "${name}".`,
+      available: near.length ? near : all.slice(0, 20),
+    };
+  }
+  // Core templates ship in the comfyui-workflow-templates package served under
+  // /templates/; custom-node templates under /api/workflow_templates/<module>/
+  // (older servers: /extensions/<module>/example_workflows/). Try in order.
+  const enc = encodeURIComponent(name);
+  const candidates = [
+    `${base}/templates/${enc}.json`,
+    `${base}/api/workflow_templates/${encodeURIComponent(module)}/${enc}.json`,
+    `${base}/extensions/${encodeURIComponent(module)}/example_workflows/${enc}.json`,
+  ];
+  for (const url of candidates) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      if (!res.ok) continue;
+      return { graph: await res.json(), source: `server-template:${module}` };
+    } catch {
+      // try next candidate
+    }
+  }
+  return {
+    error: `Template "${name}" is indexed (module "${module}") but its workflow JSON could not be fetched from the server.`,
+    available: [],
+  };
+}
+
 export function registerTemplateSchemaTools(server: McpServer): void {
   server.tool(
     "get_template_schema",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "get_template_schema: not implemented (shell)" }] }),
+    "Get a template's OVERRIDABLE run-time parameters (its 'slots') before running it. Pass a bundled pack name (from list_packs) or an official ComfyUI workflow template name (from list_workflow_templates). Returns `slots` — the meaningful knobs: positive/negative prompt, seed, steps, cfg, sampler/scheduler, width/height, checkpoint/LoRA/model files, denoise, batch_size, input image — plus `other_slots` (every remaining overridable widget), each with a stable key `\"<nodeId>.<widget_name>\"`, semantic role, type, current value, and min/max/options where the node schema is known. Feed the keys DIRECTLY into run_template's `overrides` (same convention) for a schema→run round-trip.",
+    {
+      template: z
+        .string()
+        .min(1)
+        .describe("Template name/id: a bundled pack directory name (list_packs) or an official workflow template name (list_workflow_templates)."),
+    },
+    async (args) => {
+      try {
+        const name = args.template.trim();
+        let graph: unknown;
+        let source: string;
+
+        const packFile = resolvePackWorkflowFile(name);
+        if (packFile) {
+          graph = JSON.parse(readFileSync(packFile, "utf8"));
+          source = `pack:${name}`;
+        } else {
+          const res = await loadServerTemplate(name);
+          if ("error" in res) {
+            const packs = enumeratePacks().map((p) => String(p.name));
+            const near = packs.filter((p) => p.toLowerCase().includes(name.toLowerCase()));
+            return {
+              isError: true,
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(
+                    {
+                      error: `Could not resolve template "${name}". ${res.error}`,
+                      near_matches: [...near, ...res.available].slice(0, 20),
+                      hint: "Use list_packs for bundled packs or list_workflow_templates for official templates.",
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          graph = res.graph;
+          source = res.source;
+        }
+
+        // Live node schema enriches types/min/max/options and names UI widgets;
+        // fall back to the built-in core-node table offline.
+        let live: ObjectInfo | null = null;
+        try {
+          live = await getObjectInfo();
+        } catch {
+          live = null;
+        }
+        const normalized = templateGraphToApi(graph, live);
+        if (!normalized) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Template "${name}" resolved (${source}) but its JSON is neither a UI-format nor an API-format ComfyUI workflow.`,
+              },
+            ],
+          };
+        }
+        const { slots, other_slots } = extractTemplateSlots(normalized.api, normalized.objectInfo);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  template: name,
+                  source,
+                  node_schema: live ? "live-object_info" : "builtin-fallback (server unreachable — types/options are best-effort)",
+                  slot_key_format: "<nodeId>.<widget_name> — pass these keys as run_template overrides",
+                  slot_count: slots.length,
+                  slots,
+                  other_slot_count: other_slots.length,
+                  other_slots,
+                  warnings: normalized.warnings.slice(0, 20),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 }

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -91,13 +91,15 @@ export function classifyWidget(classType: string, widget: string): string {
   return "other";
 }
 
-/** A UI-format link value in an API graph: [nodeId, outputSlot]. */
-function isLinkValue(v: unknown): boolean {
+/** An API-format connection reference: [nodeId, outputSlot] — only when the
+ *  referenced node actually exists (a literal like [512, 512] is a widget value). */
+function isLinkValue(v: unknown, nodeKeys: Set<string>): boolean {
   return (
     Array.isArray(v) &&
     v.length === 2 &&
     (typeof v[0] === "string" || typeof v[0] === "number") &&
-    typeof v[1] === "number"
+    typeof v[1] === "number" &&
+    nodeKeys.has(String(v[0]))
   );
 }
 
@@ -121,6 +123,7 @@ export function extractTemplateSlots(
 ): { slots: TemplateSlot[]; other_slots: TemplateSlot[] } {
   const slots: TemplateSlot[] = [];
   const other: TemplateSlot[] = [];
+  const nodeKeys = new Set(Object.keys(api));
   const ids = Object.keys(api).sort((a, b) => {
     const na = Number(a);
     const nb = Number(b);
@@ -135,7 +138,7 @@ export function extractTemplateSlots(
     const def = objectInfo?.[node.class_type];
     const title = node._meta?.title;
     for (const [widget, value] of Object.entries(inputs)) {
-      if (isLinkValue(value)) continue; // connection, not an overridable widget
+      if (isLinkValue(value, nodeKeys)) continue; // connection, not an overridable widget
       const slot: TemplateSlot = {
         key: `${nodeId}.${widget}`,
         node_id: nodeId,
@@ -254,8 +257,25 @@ export function templateGraphToApi(
 ): { api: WorkflowJSON; warnings: string[]; objectInfo: ObjectInfo } | null {
   if (isUiFormat(graph)) {
     const merged: ObjectInfo = { ...FALLBACK_OBJECT_INFO, ...(objectInfo ?? {}) };
-    const { workflow, warnings } = convertUiToApi(graph as UiWorkflow, merged);
-    return { api: workflow, warnings, objectInfo: merged };
+    // isUiFormat only checks that nodes/links are arrays — drop malformed
+    // entries (null nodes, missing id/type) so the converter can't crash on
+    // odd shapes; report what was dropped.
+    const ui = graph as UiWorkflow;
+    const warnings: string[] = [];
+    const goodNodes = (ui.nodes ?? []).filter(
+      (n): n is UiWorkflow["nodes"][number] =>
+        !!n && typeof n === "object" && typeof (n as { id?: unknown }).id === "number" &&
+        typeof (n as { type?: unknown }).type === "string",
+    );
+    if (goodNodes.length !== (ui.nodes ?? []).length) {
+      warnings.push(
+        `Dropped ${(ui.nodes ?? []).length - goodNodes.length} malformed node entr(y/ies) (missing id/type).`,
+      );
+    }
+    const goodLinks = (ui.links ?? []).filter((l) => Array.isArray(l) && l.length >= 6);
+    const sanitized: UiWorkflow = { ...ui, nodes: goodNodes, links: goodLinks as UiWorkflow["links"] };
+    const { workflow, warnings: convWarnings } = convertUiToApi(sanitized, merged);
+    return { api: workflow, warnings: [...warnings, ...convWarnings], objectInfo: merged };
   }
   if (isApiFormat(graph)) {
     return {


### PR DESCRIPTION
## Gap: `get_template_schema` — a template's overridable run-time parameters

Parity gap vs ComfyUI Cloud's `get_template_schema`. We expose per-node specs (`get_node_info`) but not a template-level "what can I override" view.

**Deliver:** `get_template_schema` in `src/tools/template-schema.ts` — `{ template: <name/id> }` → the set of override-able parameters (the meaningful "slots": positive/negative prompt, seed, steps, cfg, sampler, width/height, checkpoint/LoRA, denoise, batch_size, input image, etc.) with, per slot: a stable key (`nodeId.widget` or a friendly alias), type, current/default value, and (where known from node schema) min/max/options.
1. Resolve + load the template workflow (reuse the same resolution as `list_workflow_templates`/`read_pack_workflow`).
2. Walk its nodes; cross-reference `get_node_info`/object_info to classify which widgets are meaningful run-time inputs vs structural. Prefer surfacing primary inputs (prompts, seed, sampler params, dimensions, model loaders, LoadImage).

**Coordinate:** the slot keys MUST be consumable as `run_template`'s `overrides` (PR #<run-template>) — same key convention, so `get_template_schema` → `run_template` round-trips cleanly.

**Acceptance:** wired into `registerAllTools()`; unit test on a sample template asserting the expected slots + types. `tsc --noEmit` clean; new vitest passes.
