### PR TITLE
feat(tools): run_template — one-shot template run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**175 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**176 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-175 tools across workflow execution, generation, iteration, composition, models, and more:
+176 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 175 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 176 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/tools/run-template.test.ts
+++ b/src/__tests__/tools/run-template.test.ts
@@ -62,7 +62,12 @@ const TEMPLATE_GRAPH = {
     class_type: "KSampler",
     inputs: { seed: 1, steps: 20, cfg: 7, model: ["4", 0], positive: ["6", 0] },
   },
-  "6": { class_type: "CLIPTextEncode", inputs: { text: "default prompt", clip: ["4", 1] } },
+  "6": {
+    class_type: "CLIPTextEncode",
+    // `size` is an ARRAY-valued widget whose first element is NOT a node id —
+    // it must be overridable (not misclassified as a graph connection).
+    inputs: { text: "default prompt", size: [1024, 1024], clip: ["4", 1] },
+  },
 };
 
 const dir = mkdtempSync(join(tmpdir(), "run-template-"));
@@ -145,9 +150,21 @@ describe("run_template", () => {
     expect(enqueueWorkflowMock).not.toHaveBeenCalled();
   });
 
+  it("allows overriding an array-valued widget (not a link — first element isn't a node id)", async () => {
+    const handler = getHandler();
+    const res = await handler({
+      template: "anima-txt2img",
+      overrides: { "6.size": [512, 768] },
+    });
+    expect(res.isError).toBeFalsy();
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof TEMPLATE_GRAPH;
+    expect(enqueued["6"].inputs.size).toEqual([512, 768]);
+  });
+
   it("rejects overrides targeting a graph CONNECTION (link) input", async () => {
     const handler = getHandler();
-    const res = await handler({ template: "anima-txt2img", overrides: { "3.model": "x" } });
+    // "3.positive" is ["6", 0] and node "6" exists → a real connection.
+    const res = await handler({ template: "anima-txt2img", overrides: { "3.positive": "x" } });
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toMatch(/CONNECTION/);
     expect(res.content[0].text).toMatch(/seed/); // lists overridable widgets

--- a/src/__tests__/tools/run-template.test.ts
+++ b/src/__tests__/tools/run-template.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, beforeEach, afterAll, vi } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Mock template resolution (skills-access) + enqueue + status/history; keep
+// override parsing + modifyWorkflow (set_input) real so we test the actual
+// "resolve → apply overrides → enqueue" path end to end.
+const resolvePackWorkflowFileMock = vi.fn<(name: string) => string | null>();
+const enumeratePacksMock = vi.fn(() => [
+  { name: "anima-txt2img", has_workflow: true },
+  { name: "anima-img2img", has_workflow: true },
+  { name: "krea2-txt2img", has_workflow: true },
+]);
+vi.mock("../../tools/skills-access.js", () => ({
+  resolvePackWorkflowFile: (...a: [string]) => resolvePackWorkflowFileMock(...a),
+  enumeratePacks: () => enumeratePacksMock(),
+}));
+
+const enqueueWorkflowMock = vi.fn(async () => ({
+  prompt_id: "rt-prompt-1",
+  queue_remaining: 0,
+}));
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: (...a: unknown[]) => enqueueWorkflowMock(...a),
+}));
+
+const getJobStatusMock = vi.fn();
+vi.mock("../../services/queue-manager.js", () => ({
+  getJobStatus: (...a: unknown[]) => getJobStatusMock(...a),
+}));
+
+const getHistoryMock = vi.fn();
+const getObjectInfoMock = vi.fn(async () => ({}));
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+  getObjectInfo: () => getObjectInfoMock(),
+}));
+
+import { registerRunTemplateTools } from "../../tools/run-template.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === "run_template") handler = h;
+    },
+  };
+  registerRunTemplateTools(server as never);
+  if (!handler) throw new Error("run_template not registered");
+  return handler;
+}
+
+// A minimal API-format template graph on disk (what resolvePackWorkflowFile returns).
+const TEMPLATE_GRAPH = {
+  "3": {
+    class_type: "KSampler",
+    inputs: { seed: 1, steps: 20, cfg: 7, model: ["4", 0], positive: ["6", 0] },
+  },
+  "6": { class_type: "CLIPTextEncode", inputs: { text: "default prompt", clip: ["4", 1] } },
+};
+
+const dir = mkdtempSync(join(tmpdir(), "run-template-"));
+const wfFile = join(dir, "workflow.json");
+writeFileSync(wfFile, JSON.stringify(TEMPLATE_GRAPH));
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  resolvePackWorkflowFileMock.mockReset().mockReturnValue(wfFile);
+  enqueueWorkflowMock.mockClear();
+  getJobStatusMock.mockReset();
+  getHistoryMock.mockReset();
+});
+
+describe("run_template", () => {
+  it("applies '<nodeId>.<widget>' overrides so the ENQUEUED workflow reflects them", async () => {
+    const handler = getHandler();
+
+    const res = await handler({
+      template: "anima-txt2img",
+      overrides: { "6.text": "a red fox in snow", "3.steps": 8, "3.cfg": 1.5 },
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(enqueueWorkflowMock).toHaveBeenCalledTimes(1);
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof TEMPLATE_GRAPH;
+    expect(enqueued["6"].inputs.text).toBe("a red fox in snow");
+    expect(enqueued["3"].inputs.steps).toBe(8);
+    expect(enqueued["3"].inputs.cfg).toBe(1.5);
+    // untouched slots + wiring survive
+    expect(enqueued["3"].inputs.model).toEqual(["4", 0]);
+    expect(enqueued["6"].inputs.clip).toEqual(["4", 1]);
+
+    const out = JSON.parse(res.content[0].text);
+    expect(out.prompt_id).toBe("rt-prompt-1");
+    expect(out.status).toBe("enqueued");
+    expect(out.overrides_applied).toEqual(["6.text", "3.steps", "3.cfg"]);
+  });
+
+  it("enqueues the template unmodified when no overrides given", async () => {
+    const handler = getHandler();
+    const res = await handler({ template: "anima-txt2img" });
+    expect(res.isError).toBeFalsy();
+    const enqueued = enqueueWorkflowMock.mock.calls[0][0] as typeof TEMPLATE_GRAPH;
+    expect(enqueued["6"].inputs.text).toBe("default prompt");
+  });
+
+  it("errors with near-matches when the template does not resolve", async () => {
+    resolvePackWorkflowFileMock.mockReturnValue(null);
+    const handler = getHandler();
+
+    const res = await handler({ template: "anima-txt2mg" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/No template named .{0,2}anima-txt2mg/);
+    expect(res.content[0].text).toMatch(/anima-txt2img/);
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects override keys without the nodeId.widget shape", async () => {
+    const handler = getHandler();
+    const res = await handler({ template: "anima-txt2img", overrides: { steps: 8 } });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/<nodeId>\.<widget_name>/);
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects overrides naming a missing node or widget, listing what exists", async () => {
+    const handler = getHandler();
+
+    const badNode = await handler({ template: "anima-txt2img", overrides: { "99.text": "x" } });
+    expect(badNode.isError).toBe(true);
+    expect(badNode.content[0].text).toMatch(/no node .{0,2}99/);
+
+    const badWidget = await handler({ template: "anima-txt2img", overrides: { "6.nope": "x" } });
+    expect(badWidget.isError).toBe(true);
+    expect(badWidget.content[0].text).toMatch(/has no input .{0,2}nope/);
+    expect(badWidget.content[0].text).toMatch(/text/); // lists available inputs
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  it("wait:true polls to completion and returns outputs", async () => {
+    getJobStatusMock
+      .mockResolvedValueOnce({ running: true, pending: false, done: false })
+      .mockResolvedValue({ running: false, pending: false, done: true });
+    getHistoryMock.mockResolvedValue({
+      "rt-prompt-1": {
+        outputs: { "9": { images: [{ filename: "fox.png", type: "output" }] } },
+      },
+    });
+    const handler = getHandler();
+
+    const p = handler({ template: "anima-txt2img", wait: true, timeout_s: 30 });
+    // first poll: not done → 1.5s sleep → second poll: done
+    await vi.waitFor(async () => {
+      const res = await p;
+      const out = JSON.parse(res.content[0].text);
+      expect(out.status).toBe("completed");
+      expect(out.outputs["9"].images[0].filename).toBe("fox.png");
+    }, { timeout: 10000 });
+  }, 15000);
+});

--- a/src/__tests__/tools/run-template.test.ts
+++ b/src/__tests__/tools/run-template.test.ts
@@ -145,6 +145,15 @@ describe("run_template", () => {
     expect(enqueueWorkflowMock).not.toHaveBeenCalled();
   });
 
+  it("rejects overrides targeting a graph CONNECTION (link) input", async () => {
+    const handler = getHandler();
+    const res = await handler({ template: "anima-txt2img", overrides: { "3.model": "x" } });
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/CONNECTION/);
+    expect(res.content[0].text).toMatch(/seed/); // lists overridable widgets
+    expect(enqueueWorkflowMock).not.toHaveBeenCalled();
+  });
+
   it("wait:true polls to completion and returns outputs", async () => {
     getJobStatusMock
       .mockResolvedValueOnce({ running: true, pending: false, done: false })

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -667,8 +667,11 @@ export function isApiFormat(obj: unknown): obj is WorkflowJSON {
   );
 }
 
-/** An API-format connection reference: ["<nodeId>", <outputSlot>]. */
-function isLinkRef(v: unknown, nodeKeys: Set<string>): v is [string | number, number] {
+/** An API-format connection reference: ["<nodeId>", <outputSlot>]. Graph-aware:
+ *  only counts as a link when the first element names an existing node, so
+ *  array-valued widgets like [1024, 1024] are not misclassified. Exported for
+ *  run_template's override validation. */
+export function isLinkRef(v: unknown, nodeKeys: Set<string>): v is [string | number, number] {
   return (
     Array.isArray(v) &&
     v.length === 2 &&

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -58,6 +58,7 @@ import { registerComfyCliTools } from "./comfy-cli.js";
 import { registerTrainTools } from "./train.js";
 import { registerAppsTools } from "./apps.js";
 import { registerTemplateSchemaTools } from "./template-schema.js";
+import { registerRunTemplateTools } from "./run-template.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -125,6 +126,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["training", registerTrainTools],
   ["apps", registerAppsTools],
   ["workflows", registerTemplateSchemaTools],
+  ["workflows", registerRunTemplateTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -38,6 +38,17 @@ function nearMatches(query: string, names: string[]): string[] {
   return scored.slice(0, 8).map((s) => s.name);
 }
 
+/** An API-graph input value of the form [sourceNodeId, outputSlot] is a graph
+ *  connection (link), not a widget value — run_template must not clobber it. */
+function isLinkValue(v: unknown): boolean {
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    (typeof v[0] === "string" || typeof v[0] === "number") &&
+    typeof v[1] === "number"
+  );
+}
+
 /**
  * Parse "<nodeId>.<widget_name>" override keys (the SAME convention
  * get_template_schema emits, so schema→run round-trips) into set_input
@@ -64,10 +75,18 @@ function overridesToOps(
         `Override "${key}": no node "${nodeId}" in the template's graph. Node ids: ${ids}`,
       );
     }
+    const widgetInputs = Object.entries(node.inputs ?? {})
+      .filter(([, v]) => !isLinkValue(v))
+      .map(([k]) => k);
     if (!node.inputs || !(widget in node.inputs)) {
-      const avail = Object.keys(node.inputs ?? {}).join(", ") || "(none)";
+      const avail = widgetInputs.join(", ") || "(none)";
       throw new ValidationError(
-        `Override "${key}": node ${nodeId} (${node.class_type}) has no input "${widget}". Available inputs: ${avail}`,
+        `Override "${key}": node ${nodeId} (${node.class_type}) has no input "${widget}". Overridable widgets: ${avail}`,
+      );
+    }
+    if (isLinkValue(node.inputs[widget])) {
+      throw new ValidationError(
+        `Override "${key}": input "${widget}" on node ${nodeId} (${node.class_type}) is a graph CONNECTION, not a widget — overriding it would break the graph. Overridable widgets: ${widgetInputs.join(", ") || "(none)"}. Use modify_workflow to rewire connections.`,
       );
     }
     ops.push({ op: "set_input", node_id: nodeId, input_name: widget, value });
@@ -102,7 +121,7 @@ async function loadTemplateApiGraph(wfFile: string): Promise<WorkflowJSON> {
 export function registerRunTemplateTools(server: McpServer): void {
   server.tool(
     "run_template",
-    "ONE-SHOT: run a named workflow template (a bundled pack from list_packs) with optional overrides. Resolves the template's expert graph, applies overrides, and enqueues it — replacing the manual read_pack_workflow → modify_workflow → enqueue_workflow chain. Override keys are '<nodeId>.<widget_name>' (e.g. {'6.text': 'a cat', '3.seed': 42}) — the SAME keys get_template_schema reports, so schema→run round-trips. By default returns {prompt_id} immediately; pass wait:true to block until the job completes and return its outputs (images etc.). Unresolvable template names return a clear error with near-matches.",
+    "ONE-SHOT: run a named workflow template (a bundled pack from list_packs) with optional overrides. Resolves the template's expert graph, applies overrides, and enqueues it — replacing the manual read_pack_workflow → modify_workflow → enqueue_workflow chain. Override keys are '<nodeId>.<widget_name>' (e.g. {'6.text': 'a cat', '3.seed': 42}) — the SAME keys the companion get_template_schema tool reports (when available), so schema→run round-trips; only widget values can be overridden, never graph connections. By default returns {prompt_id} immediately; pass wait:true to block until the job completes and return its outputs (images etc.). Unresolvable template names return a clear error with near-matches.",
     {
       template: z
         .string()

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -7,6 +7,7 @@ import { modifyWorkflow, type ModifyOperation } from "../services/workflow-compo
 import {
   isUiFormat,
   isApiFormat,
+  isLinkRef,
   convertUiToApi,
 } from "../services/workflow-converter.js";
 import { getJobStatus } from "../services/queue-manager.js";
@@ -38,17 +39,6 @@ function nearMatches(query: string, names: string[]): string[] {
   return scored.slice(0, 8).map((s) => s.name);
 }
 
-/** An API-graph input value of the form [sourceNodeId, outputSlot] is a graph
- *  connection (link), not a widget value — run_template must not clobber it. */
-function isLinkValue(v: unknown): boolean {
-  return (
-    Array.isArray(v) &&
-    v.length === 2 &&
-    (typeof v[0] === "string" || typeof v[0] === "number") &&
-    typeof v[1] === "number"
-  );
-}
-
 /**
  * Parse "<nodeId>.<widget_name>" override keys (the SAME convention
  * get_template_schema emits, so schema→run round-trips) into set_input
@@ -59,6 +49,7 @@ function overridesToOps(
   overrides: Record<string, unknown>,
 ): ModifyOperation[] {
   const ops: ModifyOperation[] = [];
+  const nodeKeys = new Set(Object.keys(workflow));
   for (const [key, value] of Object.entries(overrides)) {
     const dot = key.indexOf(".");
     if (dot <= 0 || dot === key.length - 1) {
@@ -76,7 +67,7 @@ function overridesToOps(
       );
     }
     const widgetInputs = Object.entries(node.inputs ?? {})
-      .filter(([, v]) => !isLinkValue(v))
+      .filter(([, v]) => !isLinkRef(v, nodeKeys))
       .map(([k]) => k);
     if (!node.inputs || !(widget in node.inputs)) {
       const avail = widgetInputs.join(", ") || "(none)";
@@ -84,7 +75,7 @@ function overridesToOps(
         `Override "${key}": node ${nodeId} (${node.class_type}) has no input "${widget}". Overridable widgets: ${avail}`,
       );
     }
-    if (isLinkValue(node.inputs[widget])) {
+    if (isLinkRef(node.inputs[widget], nodeKeys)) {
       throw new ValidationError(
         `Override "${key}": input "${widget}" on node ${nodeId} (${node.class_type}) is a graph CONNECTION, not a widget — overriding it would break the graph. Overridable widgets: ${widgetInputs.join(", ") || "(none)"}. Use modify_workflow to rewire connections.`,
       );

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -1,13 +1,242 @@
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { resolvePackWorkflowFile, enumeratePacks } from "./skills-access.js";
+import { enqueueWorkflow } from "../services/workflow-executor.js";
+import { modifyWorkflow, type ModifyOperation } from "../services/workflow-composer.js";
+import {
+  isUiFormat,
+  isApiFormat,
+  convertUiToApi,
+} from "../services/workflow-converter.js";
+import { getJobStatus } from "../services/queue-manager.js";
+import { getObjectInfo, getHistory } from "../comfyui/client.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+import { errorToToolResult, ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
 
-// SHELL — implement per the PR spec, then (1) wire registerRunTemplateTools into
-// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Rank pack names by similarity to the query for the not-found error. */
+function nearMatches(query: string, names: string[]): string[] {
+  const q = query.toLowerCase();
+  const scored = names
+    .map((name) => {
+      const n = name.toLowerCase();
+      let score = 0;
+      if (n === q) score = 100;
+      else if (n.includes(q) || q.includes(n)) score = 50;
+      else {
+        // shared token overlap (packs are dash-delimited, e.g. anima-txt2img)
+        const qTokens = new Set(q.split(/[-_ ]+/).filter(Boolean));
+        for (const t of n.split(/[-_ ]+/)) if (qTokens.has(t)) score += 10;
+      }
+      return { name, score };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored.slice(0, 8).map((s) => s.name);
+}
+
+/**
+ * Parse "<nodeId>.<widget_name>" override keys (the SAME convention
+ * get_template_schema emits, so schema→run round-trips) into set_input
+ * operations, validating each against the resolved API graph.
+ */
+function overridesToOps(
+  workflow: WorkflowJSON,
+  overrides: Record<string, unknown>,
+): ModifyOperation[] {
+  const ops: ModifyOperation[] = [];
+  for (const [key, value] of Object.entries(overrides)) {
+    const dot = key.indexOf(".");
+    if (dot <= 0 || dot === key.length - 1) {
+      throw new ValidationError(
+        `Invalid override key "${key}". Use "<nodeId>.<widget_name>", e.g. "3.seed" or "6.text" (the keys get_template_schema reports).`,
+      );
+    }
+    const nodeId = key.slice(0, dot);
+    const widget = key.slice(dot + 1);
+    const node = workflow[nodeId];
+    if (!node) {
+      const ids = Object.keys(workflow).slice(0, 40).join(", ");
+      throw new ValidationError(
+        `Override "${key}": no node "${nodeId}" in the template's graph. Node ids: ${ids}`,
+      );
+    }
+    if (!node.inputs || !(widget in node.inputs)) {
+      const avail = Object.keys(node.inputs ?? {}).join(", ") || "(none)";
+      throw new ValidationError(
+        `Override "${key}": node ${nodeId} (${node.class_type}) has no input "${widget}". Available inputs: ${avail}`,
+      );
+    }
+    ops.push({ op: "set_input", node_id: nodeId, input_name: widget, value });
+  }
+  return ops;
+}
+
+/** Load a template's graph and normalize it to API format for enqueue. */
+async function loadTemplateApiGraph(wfFile: string): Promise<WorkflowJSON> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(wfFile, "utf8"));
+  } catch (err) {
+    throw new ValidationError(
+      `Template workflow file is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (isApiFormat(parsed)) return parsed;
+  if (isUiFormat(parsed)) {
+    const objectInfo = await getObjectInfo();
+    const { workflow, warnings } = convertUiToApi(parsed, objectInfo);
+    if (warnings.length) {
+      logger.warn("run_template: UI→API conversion warnings", { warnings });
+    }
+    return workflow;
+  }
+  throw new ValidationError(
+    "Template workflow is neither UI nor API format — cannot enqueue it.",
+  );
+}
+
 export function registerRunTemplateTools(server: McpServer): void {
   server.tool(
     "run_template",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "run_template: not implemented (shell)" }] }),
+    "ONE-SHOT: run a named workflow template (a bundled pack from list_packs) with optional overrides. Resolves the template's expert graph, applies overrides, and enqueues it — replacing the manual read_pack_workflow → modify_workflow → enqueue_workflow chain. Override keys are '<nodeId>.<widget_name>' (e.g. {'6.text': 'a cat', '3.seed': 42}) — the SAME keys get_template_schema reports, so schema→run round-trips. By default returns {prompt_id} immediately; pass wait:true to block until the job completes and return its outputs (images etc.). Unresolvable template names return a clear error with near-matches.",
+    {
+      template: z
+        .string()
+        .min(1)
+        .describe("Template name — a bundled pack directory (from list_packs), e.g. 'anima-txt2img'."),
+      overrides: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          "Widget overrides keyed '<nodeId>.<widget_name>' (get_template_schema's keys), e.g. {'6.text': 'a red fox', '3.steps': 20}.",
+        ),
+      wait: z
+        .boolean()
+        .optional()
+        .describe("Block until the job completes and return its outputs. Default false: return {prompt_id} immediately."),
+      timeout_s: z
+        .number()
+        .positive()
+        .optional()
+        .describe("Max seconds to wait when wait:true (default 300). On timeout the job keeps running; poll get_job_status."),
+      disable_random_seed: z
+        .boolean()
+        .optional()
+        .describe("If true, do not randomize seed values (combine with a seed override to reproduce exactly)."),
+    },
+    async (args) => {
+      try {
+        // 1. Resolve the template (same resolution as read_pack_workflow).
+        const wfFile = resolvePackWorkflowFile(args.template);
+        if (!wfFile) {
+          const known = enumeratePacks()
+            .filter((p) => p.has_workflow)
+            .map((p) => String(p.name));
+          const near = nearMatches(args.template, known);
+          throw new ValidationError(
+            `No template named "${args.template}".` +
+              (near.length
+                ? ` Did you mean: ${near.join(", ")}?`
+                : ` Available templates: ${known.join(", ") || "(none bundled)"}.`) +
+              " Use list_packs to browse all templates.",
+          );
+        }
+
+        // 2. Load + normalize to API format, then apply overrides via the
+        //    shared modifyWorkflow (set_input) service.
+        let workflow = await loadTemplateApiGraph(wfFile);
+        const overrides = args.overrides ?? {};
+        const ops = overridesToOps(workflow, overrides);
+        if (ops.length) {
+          workflow = modifyWorkflow(workflow, ops).workflow;
+        }
+
+        // 3. Enqueue via the existing enqueue service.
+        const result = await enqueueWorkflow(workflow, {
+          disable_random_seed: args.disable_random_seed,
+        });
+
+        const base = {
+          status: "enqueued",
+          template: args.template,
+          prompt_id: result.prompt_id,
+          queue_remaining: result.queue_remaining,
+          overrides_applied: Object.keys(overrides),
+        };
+
+        if (!args.wait) {
+          return {
+            content: [
+              { type: "text" as const, text: JSON.stringify(base, null, 2) },
+            ],
+          };
+        }
+
+        // 4. Minimal wait: poll get_job_status until done or timeout.
+        //    (A richer wait_for_job tool exists separately; keep this simple.)
+        const timeoutMs = (args.timeout_s ?? 300) * 1000;
+        const start = Date.now();
+        for (;;) {
+          const status = await getJobStatus(result.prompt_id);
+          if (status.done) {
+            let outputs: unknown = null;
+            try {
+              const history = await getHistory(result.prompt_id);
+              outputs = history[result.prompt_id]?.outputs ?? null;
+            } catch (err) {
+              logger.warn("run_template: could not fetch outputs from history", {
+                prompt_id: result.prompt_id,
+                error: err instanceof Error ? err.message : err,
+              });
+            }
+            const failed = Boolean(status.error);
+            return {
+              ...(failed ? { isError: true } : {}),
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(
+                    {
+                      ...base,
+                      status: failed ? "failed" : "completed",
+                      ...(status.error ? { error: status.error } : {}),
+                      ...(status.text_outputs ? { text_outputs: status.text_outputs } : {}),
+                      outputs,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          if (Date.now() - start >= timeoutMs) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(
+                    {
+                      ...base,
+                      status: "timeout",
+                      message: `Job still ${status.running ? "running" : "pending"} after ${args.timeout_s ?? 300}s — it was NOT cancelled. Poll get_job_status("${result.prompt_id}") for completion.`,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
+            };
+          }
+          await sleep(1500);
+        }
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 }

--- a/src/tools/run-template.ts
+++ b/src/tools/run-template.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// SHELL — implement per the PR spec, then (1) wire registerRunTemplateTools into
+// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+export function registerRunTemplateTools(server: McpServer): void {
+  server.tool(
+    "run_template",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "run_template: not implemented (shell)" }] }),
+  );
+}

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -165,7 +165,8 @@ export function enumeratePacks(): Array<Record<string, unknown>> {
 
 /** Locate a pack's workflow.json file path (name-guarded, must exist). Returns
  *  null when the pack or its workflow is missing. Shared by read_pack_workflow
- *  and check_workflow_runtime so they resolve the file identically. */
+ *  and check_workflow_runtime so they resolve the file identically. Also
+ *  exported for run_template, which resolves templates the same way. */
 export function resolvePackWorkflowFile(packName: string): string | null {
   const name = packName.trim();
   if (!SAFE_NAME.test(name)) return null;


### PR DESCRIPTION
## Gap: `run_template` — one-shot run a named template with overrides

Parity gap vs ComfyUI Cloud's `run_template` (the "preferred path when a template matches"). Today an agent must chain `read_pack_workflow` → `modify_workflow` → `enqueue_workflow`.

**Deliver:** `run_template` in `src/tools/run-template.ts` — `{ template: <name/id>, overrides?: {...}, wait?: bool, timeout_s? }`:
1. Resolve the template by name/id (reuse `list_workflow_templates` / `read_pack_workflow` resolution — find where templates are enumerated and loaded; don't reinvent).
2. Apply `overrides` to the template's overridable slots (reuse `modify_workflow`/`apply_node_patch`/`apply_manifest` logic — extract/share, don't duplicate).
3. Enqueue via the existing enqueue service. If `wait`, block on completion (coordinate with the `wait_for_job` shape) and return outputs; else return `{ prompt_id }`.

**Coordinate with siblings:** align the `overrides` slot keys with `get_template_schema`'s output (PR #<template-schema>) so schema→run round-trips. If `wait` overlaps `wait_for_job` (PR #<wait-job>), keep the wait logic minimal/shared rather than gold-plated.

**Acceptance:** wired into `registerAllTools()`; clear error if the template name doesn't resolve (list near-matches); reuses existing template-resolution + override + enqueue code; unit test with a mocked template + overrides asserting the enqueued workflow reflects the overrides. `tsc --noEmit` clean; new vitest passes.
