### PR TITLE
feat(tools): wait_for_job — block until done

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**176 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**177 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-176 tools across workflow execution, generation, iteration, composition, models, and more:
+177 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 176 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 177 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -87,7 +87,10 @@ describe("waitForJob", () => {
     const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
 
     expect(result.timed_out).toBe(false);
-    expect(result.message).toContain('did not complete (status "failed"');
+    expect(result.message).toContain("failed");
+    // Cloud "failed" is definitive — must NOT be hedged as maybe-cancelled.
+    expect(result.message).not.toContain("interrupted");
+    expect(result.message).not.toContain("cancelled");
   });
 
   it("does not call a local interrupted job (done+error status, no error object) a failure", async () => {

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -74,24 +74,32 @@ describe("waitForJob", () => {
     expect(result.message).toContain("RuntimeError");
   });
 
-  it("reports failure for cloud-style done+status_str:'failed' with no error object", async () => {
-    const failed: JobStatus = {
-      running: false,
-      pending: false,
-      done: true,
-      status_str: "failed",
-    };
-    const clock = fakeClock();
-    const statusFn = vi.fn(async () => failed);
+  it.each(["failed", "error"] as const)(
+    "in cloud mode, reports done+status_str:'%s' with no error object as a definitive failure",
+    async (statusStr) => {
+      // Cloud history enrichment can rewrite "failed" to "error", so both
+      // spellings must classify as failure in cloud mode.
+      const failed: JobStatus = {
+        running: false,
+        pending: false,
+        done: true,
+        status_str: statusStr,
+      };
+      const clock = fakeClock();
+      const statusFn = vi.fn(async () => failed);
 
-    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+      const result = await waitForJob(
+        { prompt_id: PROMPT_ID },
+        { statusFn, ...clock, cloudModeFn: () => true },
+      );
 
-    expect(result.timed_out).toBe(false);
-    expect(result.message).toContain("failed");
-    // Cloud "failed" is definitive — must NOT be hedged as maybe-cancelled.
-    expect(result.message).not.toContain("interrupted");
-    expect(result.message).not.toContain("cancelled");
-  });
+      expect(result.timed_out).toBe(false);
+      expect(result.message).toContain("failed");
+      // Cloud failure is definitive — must NOT be hedged as maybe-cancelled.
+      expect(result.message).not.toContain("interrupted");
+      expect(result.message).not.toContain("cancelled");
+    },
+  );
 
   it("does not call a local interrupted job (done+error status, no error object) a failure", async () => {
     // Local ComfyUI reports interruptions exactly like this — done:true,
@@ -105,7 +113,10 @@ describe("waitForJob", () => {
     const clock = fakeClock();
     const statusFn = vi.fn(async () => interrupted);
 
-    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+    const result = await waitForJob(
+      { prompt_id: PROMPT_ID },
+      { statusFn, ...clock, cloudModeFn: () => false },
+    );
 
     expect(result.timed_out).toBe(false);
     expect(result.message).not.toContain("finished with an error");

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -74,6 +74,22 @@ describe("waitForJob", () => {
     expect(result.message).toContain("RuntimeError");
   });
 
+  it("reports failure for cloud-style done+status_str:'failed' with no error object", async () => {
+    const failed: JobStatus = {
+      running: false,
+      pending: false,
+      done: true,
+      status_str: "failed",
+    };
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => failed);
+
+    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+
+    expect(result.timed_out).toBe(false);
+    expect(result.message).toContain("finished with an error (failed)");
+  });
+
   it("returns timed_out (without throwing) when the job never finishes", async () => {
     const clock = fakeClock();
     const statusFn = vi.fn(async () => running);

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -90,6 +90,26 @@ describe("waitForJob", () => {
     expect(result.message).toContain("finished with an error (failed)");
   });
 
+  it("treats cloud-style 'cancelled' (done:false) as terminal instead of spinning", async () => {
+    const cancelled: JobStatus = {
+      running: false,
+      pending: false,
+      done: false,
+      status_str: "cancelled",
+    };
+    const clock = fakeClock();
+    const statusFn = vi
+      .fn<(id: string) => Promise<JobStatus>>()
+      .mockResolvedValueOnce(running)
+      .mockResolvedValueOnce(cancelled);
+
+    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+
+    expect(statusFn).toHaveBeenCalledTimes(2);
+    expect(result.timed_out).toBe(false);
+    expect(result.message).toContain("cancelled");
+  });
+
   it("returns timed_out (without throwing) when the job never finishes", async () => {
     const clock = fakeClock();
     const statusFn = vi.fn(async () => running);

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForJob } from "../../tools/wait-job.js";
+import type { JobStatus } from "../../services/queue-manager.js";
+
+const PROMPT_ID = "prompt-wait-1";
+
+const running: JobStatus = { running: true, pending: false, done: false };
+const pending: JobStatus = { running: false, pending: true, done: false };
+const done: JobStatus = {
+  running: false,
+  pending: false,
+  done: true,
+  status_str: "success",
+};
+
+/** Deterministic clock: sleep advances a fake clock instead of real time. */
+function fakeClock() {
+  let t = 0;
+  return {
+    nowFn: () => t,
+    sleepFn: vi.fn(async (ms: number) => {
+      t += ms;
+    }),
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe("waitForJob", () => {
+  it("polls until the job is done and returns the terminal status", async () => {
+    const clock = fakeClock();
+    const statusFn = vi
+      .fn<(id: string) => Promise<JobStatus>>()
+      .mockResolvedValueOnce(pending)
+      .mockResolvedValueOnce(running)
+      .mockResolvedValueOnce(running)
+      .mockResolvedValueOnce(done);
+
+    const result = await waitForJob(
+      { prompt_id: PROMPT_ID, timeout_s: 300, poll_interval_ms: 1500 },
+      { statusFn, ...clock },
+    );
+
+    expect(statusFn).toHaveBeenCalledTimes(4);
+    expect(statusFn).toHaveBeenCalledWith(PROMPT_ID);
+    expect(result.timed_out).toBe(false);
+    expect(result.polls).toBe(4);
+    expect(result.status).toEqual(done);
+    expect(result.message).toContain("completed");
+    // Slept between polls, never after the terminal poll.
+    expect(clock.sleepFn).toHaveBeenCalledTimes(3);
+    expect(clock.sleepFn).toHaveBeenCalledWith(1500);
+  });
+
+  it("reports an error outcome when the job finishes failed", async () => {
+    const failed: JobStatus = {
+      running: false,
+      pending: false,
+      done: true,
+      status_str: "error",
+      error: {
+        exception_type: "RuntimeError",
+        exception_message: "CUDA out of memory",
+      } as JobStatus["error"],
+    };
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => failed);
+
+    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+
+    expect(result.timed_out).toBe(false);
+    expect(result.status.error).toBeDefined();
+    expect(result.message).toContain("RuntimeError");
+  });
+
+  it("returns timed_out (without throwing) when the job never finishes", async () => {
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => running);
+
+    const result = await waitForJob(
+      { prompt_id: PROMPT_ID, timeout_s: 6, poll_interval_ms: 1500 },
+      { statusFn, ...clock },
+    );
+
+    expect(result.timed_out).toBe(true);
+    // 6s / 1.5s poll -> initial poll + 4 sleeps + final poll at deadline.
+    expect(result.polls).toBe(5);
+    expect(result.status).toEqual(running);
+    expect(result.message).toContain("still running after 6s");
+    expect(result.message).toContain("NOT been cancelled");
+  });
+
+  it("clamps timeout to the hard cap so it can never wait forever", async () => {
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => pending);
+
+    const result = await waitForJob(
+      { prompt_id: PROMPT_ID, timeout_s: 999_999, poll_interval_ms: 30_000 },
+      { statusFn, ...clock },
+    );
+
+    expect(result.timed_out).toBe(true);
+    // Hard cap 1800s at 30s polls -> bounded number of polls, not ~33k.
+    expect(statusFn.mock.calls.length).toBeLessThanOrEqual(62);
+    expect(result.message).toContain("after 1800s");
+  });
+
+  it("clamps poll_interval_ms so tiny values cannot busy-spin", async () => {
+    const clock = fakeClock();
+    const statusFn = vi
+      .fn<(id: string) => Promise<JobStatus>>()
+      .mockResolvedValueOnce(running)
+      .mockResolvedValueOnce(done);
+
+    await waitForJob(
+      { prompt_id: PROMPT_ID, poll_interval_ms: 1 },
+      { statusFn, ...clock },
+    );
+
+    expect(clock.sleepFn).toHaveBeenCalledWith(250);
+  });
+
+  it("propagates status-source errors like get_job_status does", async () => {
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => {
+      throw new Error("ComfyUI unreachable");
+    });
+
+    await expect(
+      waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock }),
+    ).rejects.toThrow("ComfyUI unreachable");
+  });
+});

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -121,6 +121,23 @@ describe("waitForJob", () => {
     expect(clock.sleepFn).toHaveBeenCalledWith(250);
   });
 
+  it("times out even when the status source hangs and never resolves", async () => {
+    const clock = fakeClock();
+    // Never resolves — simulates ComfyUI stalling mid-request. The deadline
+    // race uses REAL time, so use the minimum 1s timeout.
+    const statusFn = vi.fn(() => new Promise<JobStatus>(() => {}));
+
+    const result = await waitForJob(
+      { prompt_id: PROMPT_ID, timeout_s: 1 },
+      { statusFn, ...clock },
+    );
+
+    expect(result.timed_out).toBe(true);
+    expect(result.polls).toBe(1);
+    expect(result.status.done).toBe(false);
+    expect(result.message).toContain("did not respond");
+  }, 10_000);
+
   it("propagates status-source errors like get_job_status does", async () => {
     const clock = fakeClock();
     const statusFn = vi.fn(async () => {

--- a/src/__tests__/tools/wait-job.test.ts
+++ b/src/__tests__/tools/wait-job.test.ts
@@ -87,7 +87,26 @@ describe("waitForJob", () => {
     const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
 
     expect(result.timed_out).toBe(false);
-    expect(result.message).toContain("finished with an error (failed)");
+    expect(result.message).toContain('did not complete (status "failed"');
+  });
+
+  it("does not call a local interrupted job (done+error status, no error object) a failure", async () => {
+    // Local ComfyUI reports interruptions exactly like this — done:true,
+    // status_str "error", and NO structured error.
+    const interrupted: JobStatus = {
+      running: false,
+      pending: false,
+      done: true,
+      status_str: "error",
+    };
+    const clock = fakeClock();
+    const statusFn = vi.fn(async () => interrupted);
+
+    const result = await waitForJob({ prompt_id: PROMPT_ID }, { statusFn, ...clock });
+
+    expect(result.timed_out).toBe(false);
+    expect(result.message).not.toContain("finished with an error");
+    expect(result.message).toContain("interrupted");
   });
 
   it("treats cloud-style 'cancelled' (done:false) as terminal instead of spinning", async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -59,6 +59,7 @@ import { registerTrainTools } from "./train.js";
 import { registerAppsTools } from "./apps.js";
 import { registerTemplateSchemaTools } from "./template-schema.js";
 import { registerRunTemplateTools } from "./run-template.js";
+import { registerWaitJobTools } from "./wait-job.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
 
@@ -127,6 +128,9 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   ["apps", registerAppsTools],
   ["workflows", registerTemplateSchemaTools],
   ["workflows", registerRunTemplateTools],
+  // Appended (not inserted next to queue-management) because tools/list order
+  // is observable and must not shift for existing tools.
+  ["workflows", registerWaitJobTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -129,9 +129,14 @@ export async function waitForJob(
         status.error != null ||
         status.status_str === "failed" ||
         status.status_str === "error";
-      const outcome = failed
-        ? `finished with an error (${status.error?.exception_type ?? status.error?.exception_message ?? status.status_str ?? "execution error"})`
-        : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
+      // Local ComfyUI reports BOTH real failures and user/agent interruptions
+      // as done + status_str "error"; only a structured `error` proves an
+      // actual execution failure. Don't call an interrupted job a failure.
+      const outcome = status.error
+        ? `finished with an error (${status.error.exception_type ?? status.error.exception_message ?? "execution error"})`
+        : failed
+          ? `did not complete (status "${status.status_str}" — failed or was interrupted/cancelled; no execution error was recorded)`
+          : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
       return {
         prompt_id: opts.prompt_id,
         timed_out: false,

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -123,20 +123,20 @@ export async function waitForJob(
     }
 
     if (status.done) {
-      // A failure isn't always a structured `error` — the cloud status source
-      // can report done + status_str "failed"/"error" with no error object.
-      const failed =
-        status.error != null ||
-        status.status_str === "failed" ||
-        status.status_str === "error";
-      // Local ComfyUI reports BOTH real failures and user/agent interruptions
-      // as done + status_str "error"; only a structured `error` proves an
-      // actual execution failure. Don't call an interrupted job a failure.
+      // Classification:
+      //  - structured `error` → definite execution failure;
+      //  - cloud status_str "failed" → definite failure (cloud reports
+      //    cancellation separately as "cancelled");
+      //  - local status_str "error" WITHOUT a structured error is ambiguous —
+      //    local ComfyUI reports both real failures and user/agent
+      //    interruptions this way, so don't call it a failure outright.
       const outcome = status.error
         ? `finished with an error (${status.error.exception_type ?? status.error.exception_message ?? "execution error"})`
-        : failed
-          ? `did not complete (status "${status.status_str}" — failed or was interrupted/cancelled; no execution error was recorded)`
-          : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
+        : status.status_str === "failed"
+          ? `failed (no execution error details were recorded)`
+          : status.status_str === "error"
+            ? `did not complete (status "error" — failed or was interrupted/cancelled; no execution error was recorded)`
+            : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
       return {
         prompt_id: opts.prompt_id,
         timed_out: false,

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -1,13 +1,123 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getJobStatus, type JobStatus } from "../services/queue-manager.js";
+import { errorToToolResult } from "../utils/errors.js";
 
-// SHELL — implement per the PR spec, then (1) wire registerWaitJobTools into
-// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+const DEFAULT_TIMEOUT_S = 300;
+/** Hard cap so wait_for_job can never hang an agent turn indefinitely. */
+const MAX_TIMEOUT_S = 1800;
+const DEFAULT_POLL_INTERVAL_MS = 1500;
+const MIN_POLL_INTERVAL_MS = 250;
+const MAX_POLL_INTERVAL_MS = 30_000;
+
+export interface WaitForJobResult {
+  prompt_id: string;
+  timed_out: boolean;
+  waited_s: number;
+  polls: number;
+  /** Final observed status — the same shape get_job_status returns. */
+  status: JobStatus;
+  message: string;
+}
+
+interface WaitForJobDeps {
+  /** Status source (defaults to the same service get_job_status uses). */
+  statusFn?: (promptId: string) => Promise<JobStatus>;
+  sleepFn?: (ms: number) => Promise<void>;
+  nowFn?: () => number;
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function describeState(status: JobStatus): string {
+  if (status.running) return "running";
+  if (status.pending) return "pending";
+  return "in an unknown (not queued, not finished) state";
+}
+
+/** Poll a job's status until it reaches a terminal state or the timeout elapses.
+ *  Never throws on timeout — the caller gets a clear timed_out result instead.
+ *  Status-source errors DO propagate (same behavior as get_job_status). */
+export async function waitForJob(
+  opts: { prompt_id: string; timeout_s?: number; poll_interval_ms?: number },
+  deps: WaitForJobDeps = {},
+): Promise<WaitForJobResult> {
+  const timeoutS = Math.min(Math.max(opts.timeout_s ?? DEFAULT_TIMEOUT_S, 1), MAX_TIMEOUT_S);
+  const pollMs = Math.min(
+    Math.max(opts.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS, MIN_POLL_INTERVAL_MS),
+    MAX_POLL_INTERVAL_MS,
+  );
+  const statusFn = deps.statusFn ?? getJobStatus;
+  const sleep = deps.sleepFn ?? realSleep;
+  const now = deps.nowFn ?? Date.now;
+
+  const start = now();
+  const deadline = start + timeoutS * 1000;
+  let polls = 0;
+
+  for (;;) {
+    polls++;
+    const status = await statusFn(opts.prompt_id);
+    const waitedS = Math.round((now() - start) / 100) / 10;
+
+    if (status.done) {
+      const outcome = status.error
+        ? `finished with an error (${status.error.exception_type ?? "execution error"})`
+        : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
+      return {
+        prompt_id: opts.prompt_id,
+        timed_out: false,
+        waited_s: waitedS,
+        polls,
+        status,
+        message: `Job ${opts.prompt_id} ${outcome} after ${waitedS}s.`,
+      };
+    }
+
+    const remaining = deadline - now();
+    if (remaining <= 0) {
+      return {
+        prompt_id: opts.prompt_id,
+        timed_out: true,
+        waited_s: waitedS,
+        polls,
+        status,
+        message:
+          `Timed out: job ${opts.prompt_id} is still ${describeState(status)} after ${timeoutS}s ` +
+          `(${polls} polls). It has NOT been cancelled — call wait_for_job again to keep waiting, ` +
+          `get_job_status to check once, or cancel_job to stop it.`,
+      };
+    }
+
+    await sleep(Math.min(pollMs, remaining));
+  }
+}
+
 export function registerWaitJobTools(server: McpServer): void {
   server.tool(
     "wait_for_job",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "wait_for_job: not implemented (shell)" }] }),
+    "Block until ONE ComfyUI job (by prompt_id from enqueue_workflow) reaches a terminal state — done or error — or the timeout elapses. Polls the same status source as get_job_status so the final result has the identical shape (running/pending/done, status_str, error details, execution_stats, text_outputs). Prefer this over calling get_job_status in a loop. On timeout it returns timed_out:true with the last observed status — the job keeps running; call again to keep waiting or cancel_job to stop it.",
+    {
+      prompt_id: z.string().describe("The prompt ID returned by enqueue_workflow"),
+      timeout_s: z
+        .number()
+        .optional()
+        .describe(`Max seconds to wait before returning timed_out:true. Default ${DEFAULT_TIMEOUT_S}, hard cap ${MAX_TIMEOUT_S}.`),
+      poll_interval_ms: z
+        .number()
+        .optional()
+        .describe(`Milliseconds between status polls. Default ${DEFAULT_POLL_INTERVAL_MS} (clamped to ${MIN_POLL_INTERVAL_MS}-${MAX_POLL_INTERVAL_MS}).`),
+    },
+    async (args) => {
+      try {
+        const result = await waitForJob(args);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 }

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -30,6 +30,28 @@ interface WaitForJobDeps {
 const realSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+const POLL_HUNG = Symbol("poll-hung");
+
+/** Race a status poll against the remaining deadline so a stalled/hung status
+ *  request can never suspend the wait past its timeout (the hard cap must hold
+ *  even when ComfyUI stops answering, not just when it answers slowly). */
+async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T | typeof POLL_HUNG> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof POLL_HUNG>((resolve) => {
+        timer = setTimeout(() => resolve(POLL_HUNG), Math.max(ms, 1));
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+    // If the deadline won, a later rejection of the abandoned poll must not
+    // become an unhandled rejection.
+    promise.catch(() => {});
+  }
+}
+
 function describeState(status: JobStatus): string {
   if (status.running) return "running";
   if (status.pending) return "pending";
@@ -56,10 +78,29 @@ export async function waitForJob(
   const deadline = start + timeoutS * 1000;
   let polls = 0;
 
+  let lastStatus: JobStatus | undefined;
+
   for (;;) {
     polls++;
-    const status = await statusFn(opts.prompt_id);
+    const polled = await withDeadline(statusFn(opts.prompt_id), deadline - now());
     const waitedS = Math.round((now() - start) / 100) / 10;
+
+    if (polled === POLL_HUNG) {
+      return {
+        prompt_id: opts.prompt_id,
+        timed_out: true,
+        waited_s: waitedS,
+        polls,
+        status: lastStatus ?? { running: false, pending: false, done: false },
+        message:
+          `Timed out: the status check for job ${opts.prompt_id} did not respond within the ` +
+          `${timeoutS}s timeout (${polls} polls${lastStatus ? `; last observed state: ${describeState(lastStatus)}` : ""}). ` +
+          `ComfyUI may be busy or unreachable — the job has NOT been cancelled. ` +
+          `Try wait_for_job again, get_job_status, or health_check.`,
+      };
+    }
+    const status = polled;
+    lastStatus = status;
 
     if (status.done) {
       const outcome = status.error

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getJobStatus, type JobStatus } from "../services/queue-manager.js";
+import { isCloudMode } from "../config.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 const DEFAULT_TIMEOUT_S = 300;
@@ -25,6 +26,10 @@ interface WaitForJobDeps {
   statusFn?: (promptId: string) => Promise<JobStatus>;
   sleepFn?: (ms: number) => Promise<void>;
   nowFn?: () => number;
+  /** Backend discriminator (defaults to the real config). Cloud never reports
+   *  an interruption as done — cancellation arrives as status "cancelled" —
+   *  so in cloud mode a bare terminal "error"/"failed" IS a failure. */
+  cloudModeFn?: () => boolean;
 }
 
 const realSleep = (ms: number): Promise<void> =>
@@ -125,17 +130,20 @@ export async function waitForJob(
     if (status.done) {
       // Classification:
       //  - structured `error` → definite execution failure;
-      //  - cloud status_str "failed" → definite failure (cloud reports
-      //    cancellation separately as "cancelled");
-      //  - local status_str "error" WITHOUT a structured error is ambiguous —
-      //    local ComfyUI reports both real failures and user/agent
+      //  - status_str "failed"/"error" in CLOUD mode → definite failure
+      //    (cloud reports cancellation separately as "cancelled", never as a
+      //    done job, and history enrichment can rewrite "failed" to "error");
+      //  - LOCAL status_str "error" WITHOUT a structured error is genuinely
+      //    ambiguous — local ComfyUI reports both real failures and user/agent
       //    interruptions this way, so don't call it a failure outright.
+      const errorish = status.status_str === "failed" || status.status_str === "error";
+      const cloud = (deps.cloudModeFn ?? isCloudMode)();
       const outcome = status.error
         ? `finished with an error (${status.error.exception_type ?? status.error.exception_message ?? "execution error"})`
-        : status.status_str === "failed"
-          ? `failed (no execution error details were recorded)`
-          : status.status_str === "error"
-            ? `did not complete (status "error" — failed or was interrupted/cancelled; no execution error was recorded)`
+        : errorish && cloud
+          ? `failed (status "${status.status_str}"; no execution error details were recorded)`
+          : errorish
+            ? `did not complete (status "${status.status_str}" — failed or was interrupted/cancelled; no execution error was recorded)`
             : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
       return {
         prompt_id: opts.prompt_id,

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -102,6 +102,26 @@ export async function waitForJob(
     const status = polled;
     lastStatus = status;
 
+    // Comfy Cloud can report a terminal "cancelled" job that the JobStatus
+    // mapping leaves with done:false (queue-manager maps only completed/failed
+    // to done, but always copies the cloud status into status_str). Waiting on
+    // a cancelled job would otherwise spin until timeout.
+    const cancelled =
+      !status.done &&
+      !status.running &&
+      !status.pending &&
+      (status.status_str === "cancelled" || status.status_str === "canceled");
+    if (cancelled) {
+      return {
+        prompt_id: opts.prompt_id,
+        timed_out: false,
+        waited_s: waitedS,
+        polls,
+        status,
+        message: `Job ${opts.prompt_id} was cancelled (after ${waitedS}s of waiting).`,
+      };
+    }
+
     if (status.done) {
       // A failure isn't always a structured `error` — the cloud status source
       // can report done + status_str "failed"/"error" with no error object.

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// SHELL — implement per the PR spec, then (1) wire registerWaitJobTools into
+// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+export function registerWaitJobTools(server: McpServer): void {
+  server.tool(
+    "wait_for_job",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "wait_for_job: not implemented (shell)" }] }),
+  );
+}

--- a/src/tools/wait-job.ts
+++ b/src/tools/wait-job.ts
@@ -103,8 +103,14 @@ export async function waitForJob(
     lastStatus = status;
 
     if (status.done) {
-      const outcome = status.error
-        ? `finished with an error (${status.error.exception_type ?? "execution error"})`
+      // A failure isn't always a structured `error` — the cloud status source
+      // can report done + status_str "failed"/"error" with no error object.
+      const failed =
+        status.error != null ||
+        status.status_str === "failed" ||
+        status.status_str === "error";
+      const outcome = failed
+        ? `finished with an error (${status.error?.exception_type ?? status.error?.exception_message ?? status.status_str ?? "execution error"})`
         : `completed${status.status_str ? ` (${status.status_str})` : ""}`;
       return {
         prompt_id: opts.prompt_id,


### PR DESCRIPTION
## Gap: `wait_for_job` — block until a job finishes

Parity gap vs ComfyUI Cloud's `wait_for_job`. Today the agent polls `get_job_status` in a loop.

**Deliver:** `wait_for_job` in `src/tools/wait-job.ts` — `{ prompt_id, timeout_s?, poll_interval_ms? }`:
- Poll the job's status (reuse the exact status source `get_job_status` uses — find it in `src/tools/` and share the helper/service, don't duplicate) until it reaches a terminal state (done or error), or the timeout elapses.
- Return the final status + a concise result (mirror `get_job_status`'s terminal shape; include output references if readily available). On timeout, return a clear "still running after Ns" (NOT an error throw unless idiomatic here).
- Sane defaults (e.g. timeout 300s, poll ~1.5s) and a hard cap so it can't hang forever.

**Acceptance:** wired into `registerAllTools()`; reuses the get_job_status status source; unit test with a mocked status sequence (running→done, and a timeout case). `tsc --noEmit` clean; new vitest passes.
