### PR TITLE
feat(tools): batch API (submit/status/output/wait)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**177 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**181 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -244,7 +244,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-177 tools across workflow execution, generation, iteration, composition, models, and more:
+181 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 177 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 181 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/tools/batches.test.ts
+++ b/src/__tests__/tools/batches.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// ── Mock the shared services the batch tools MUST reuse ─────────────────────
+// enqueue path, status source, and history/output retrieval are all mocked at
+// the same module seams the real enqueue_workflow / get_job_status /
+// get_history tools use — proving batches.ts shares those services.
+
+const state = vi.hoisted(() => ({
+  enqueued: [] as Array<Record<string, unknown>>,
+  nextPromptId: 0,
+  statuses: new Map<string, { running: boolean; pending: boolean; done: boolean; status_str?: string; error?: { node_id: string; node_type: string; exception_message: string } }>(),
+  histories: new Map<string, Record<string, unknown>>(),
+}));
+
+vi.mock("../../services/workflow-executor.js", () => ({
+  enqueueWorkflow: vi.fn(async (workflow: Record<string, unknown>) => {
+    state.enqueued.push(workflow);
+    const prompt_id = `prompt-${++state.nextPromptId}`;
+    state.statuses.set(prompt_id, { running: false, pending: true, done: false });
+    return { prompt_id, queue_remaining: state.nextPromptId };
+  }),
+}));
+
+vi.mock("../../services/queue-manager.js", () => ({
+  getJobStatus: vi.fn(async (promptId: string) => {
+    const s = state.statuses.get(promptId);
+    if (!s) return { running: false, pending: false, done: false };
+    return s;
+  }),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getHistory: vi.fn(async (promptId: string) => {
+    const outputs = state.histories.get(promptId);
+    if (!outputs) return {};
+    return {
+      [promptId]: {
+        prompt: {},
+        outputs,
+        status: { status_str: "success", completed: true, messages: [] },
+      },
+    };
+  }),
+}));
+
+// ── Fake McpServer that captures tool handlers ───────────────────────────────
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }>;
+
+function fakeServer(): { server: McpServer; tools: Map<string, ToolHandler> } {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  } as unknown as McpServer;
+  return { server, tools };
+}
+
+function parse(result: { content: Array<{ type: string; text?: string }> }): Record<string, unknown> {
+  return JSON.parse(result.content[0].text ?? "{}") as Record<string, unknown>;
+}
+
+const WF = { "3": { class_type: "KSampler", inputs: { cfg: 7, seed: 1 } } };
+
+describe("batch tools", () => {
+  let dataDir: string;
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "batches-test-"));
+    process.env = { ...OLD_ENV, COMFYUI_MCP_DATA_DIR: dataDir };
+    state.enqueued = [];
+    state.nextPromptId = 0;
+    state.statuses.clear();
+    state.histories.clear();
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  async function registerTools(): Promise<Map<string, ToolHandler>> {
+    const { registerBatchTools } = await import("../../tools/batches.js");
+    const { server, tools } = fakeServer();
+    registerBatchTools(server);
+    return tools;
+  }
+
+  it("submit → status → output round-trip with mocked ComfyUI", async () => {
+    const tools = await registerTools();
+
+    // submit: array-of-workflows form
+    const submitted = parse(await tools.get("submit_batch")!({ workflows: [WF, WF, WF] }));
+    expect(submitted.count).toBe(3);
+    expect((submitted.prompt_ids as string[]).length).toBe(3);
+    const batchId = submitted.batch_id as string;
+    expect(batchId).toMatch(/^batch_/);
+    expect(state.enqueued.length).toBe(3);
+
+    // status: all pending initially
+    let status = parse(await tools.get("get_batch_status")!({ batch_id: batchId }));
+    expect((status.rollup as Record<string, number>).pending).toBe(3);
+    expect(status.all_terminal).toBe(false);
+
+    // advance: 1 done with outputs, 1 error, 1 running
+    const [p1, p2, p3] = submitted.prompt_ids as string[];
+    state.statuses.set(p1, { running: false, pending: false, done: true, status_str: "success" });
+    state.histories.set(p1, { "9": { images: [{ filename: "out_00001.png", subfolder: "", type: "output" }] } });
+    state.statuses.set(p2, {
+      running: false, pending: false, done: true,
+      error: { node_id: "3", node_type: "KSampler", exception_message: "OOM" },
+    });
+    state.statuses.set(p3, { running: true, pending: false, done: false });
+
+    status = parse(await tools.get("get_batch_status")!({ batch_id: batchId }));
+    const rollup = status.rollup as Record<string, number>;
+    expect(rollup.done).toBe(1);
+    expect(rollup.error).toBe(1);
+    expect(rollup.running).toBe(1);
+    expect(status.all_terminal).toBe(false);
+
+    // output: only the done job carries outputs; error job carries the message
+    const output = parse(await tools.get("get_batch_output")!({ batch_id: batchId }));
+    expect(output.completed).toBe(1);
+    const jobs = output.outputs as Array<Record<string, unknown>>;
+    const doneJob = jobs.find((j) => j.prompt_id === p1)!;
+    expect(JSON.stringify(doneJob.outputs)).toContain("out_00001.png");
+    const errJob = jobs.find((j) => j.prompt_id === p2)!;
+    expect(errJob.state).toBe("error");
+    expect(errJob.error_message).toBe("OOM");
+  });
+
+  it("param sweep applies each override set to nodes that have the input", async () => {
+    const tools = await registerTools();
+    const submitted = parse(await tools.get("submit_batch")!({
+      workflow: WF,
+      sweep: [{ cfg: 4 }, { cfg: 9, nonexistent_input: 1 }],
+      disable_random_seed: true,
+    }));
+    expect(submitted.count).toBe(2);
+    expect(state.enqueued.length).toBe(2);
+    const cfg = (i: number) => (state.enqueued[i]["3"] as { inputs: Record<string, unknown> }).inputs.cfg;
+    expect(cfg(0)).toBe(4);
+    expect(cfg(1)).toBe(9);
+    // override for an input no node has must not create it
+    expect("nonexistent_input" in (state.enqueued[1]["3"] as { inputs: Record<string, unknown> }).inputs).toBe(false);
+  });
+
+  it("rejects bad input shapes", async () => {
+    const tools = await registerTools();
+    const r1 = await tools.get("submit_batch")!({});
+    expect(r1.isError).toBe(true);
+    const r2 = await tools.get("submit_batch")!({ workflows: [WF], workflow: WF, sweep: [{}] });
+    expect(r2.isError).toBe(true);
+    const r3 = await tools.get("get_batch_status")!({ batch_id: "batch_nope" });
+    expect(r3.isError).toBe(true);
+  });
+
+  it("DURABILITY: batch_id persisted to disk and valid after a module reload (simulated restart)", async () => {
+    const tools = await registerTools();
+    const submitted = parse(await tools.get("submit_batch")!({ workflows: [WF, WF] }));
+    const batchId = submitted.batch_id as string;
+
+    // Real file on disk, valid JSON (one file per batch, atomic rename)
+    const file = join(dataDir, "batches", `${batchId}.json`);
+    expect(existsSync(file)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(file, "utf8"));
+    expect(onDisk.prompt_ids).toEqual(submitted.prompt_ids);
+
+    // Simulate a server restart: drop all module state, re-register tools
+    vi.resetModules();
+    const tools2 = await registerTools();
+    const status = parse(await tools2.get("get_batch_status")!({ batch_id: batchId }));
+    expect(status.batch_id).toBe(batchId);
+    expect(status.count).toBe(2);
+  });
+
+  it("concurrent submits don't clobber each other's persisted record", async () => {
+    const tools = await registerTools();
+    const [a, b, c] = await Promise.all([
+      tools.get("submit_batch")!({ workflows: [WF] }),
+      tools.get("submit_batch")!({ workflows: [WF] }),
+      tools.get("submit_batch")!({ workflows: [WF] }),
+    ]);
+    for (const r of [a, b, c]) {
+      const id = parse(r).batch_id as string;
+      const onDisk = JSON.parse(readFileSync(join(dataDir, "batches", `${id}.json`), "utf8"));
+      expect(onDisk.prompt_ids).toHaveLength(1);
+    }
+  });
+
+  it("wait_for_batch returns when all terminal, and cannot exceed its timeout (hard cap)", async () => {
+    const { submitBatch, waitForBatch } = await import("../../services/batch-manager.js");
+    const submitted = await submitBatch({ workflows: [WF] });
+    const [p1] = submitted.prompt_ids;
+
+    // Case 1: job never finishes → returns timed_out at the (tiny) timeout
+    const start = Date.now();
+    const timedOut = await waitForBatch(submitted.batch_id, 0.3, 50);
+    expect(timedOut.timed_out).toBe(true);
+    expect(Date.now() - start).toBeLessThan(5000);
+
+    // Case 2: job finishes mid-wait → returns promptly with all_terminal
+    setTimeout(() => {
+      state.statuses.set(p1, { running: false, pending: false, done: true });
+    }, 100);
+    const doneResult = await waitForBatch(submitted.batch_id, 10, 50);
+    expect(doneResult.timed_out).toBe(false);
+    expect(doneResult.all_terminal).toBe(true);
+    expect(doneResult.rollup.done).toBe(1);
+  });
+
+  it("wait_for_batch hard cap holds even when a status fetch stalls forever", async () => {
+    const { submitBatch, waitForBatch } = await import("../../services/batch-manager.js");
+    const { getJobStatus } = await import("../../services/queue-manager.js");
+    const submitted = await submitBatch({ workflows: [WF] });
+
+    // Simulate a wedged ComfyUI: status calls never resolve.
+    vi.mocked(getJobStatus).mockImplementation(() => new Promise(() => undefined));
+
+    const start = Date.now();
+    const result = await waitForBatch(submitted.batch_id, 0.3, 50);
+    expect(Date.now() - start).toBeLessThan(5000);
+    expect(result.timed_out).toBe(true);
+    expect(result.rollup.unknown).toBe(1);
+  });
+});

--- a/src/services/batch-manager.ts
+++ b/src/services/batch-manager.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { enqueueWorkflow } from "./workflow-executor.js";
+import { getJobStatus } from "./queue-manager.js";
+import { getHistory } from "../comfyui/client.js";
+import { applyOverrides } from "./asset-registry.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+import { ValidationError } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface BatchRecord {
+  batch_id: string;
+  created_at: string;
+  prompt_ids: string[];
+}
+
+export type BatchJobState = "pending" | "running" | "done" | "error" | "unknown";
+
+export interface BatchJobStatus {
+  prompt_id: string;
+  state: BatchJobState;
+  status_str?: string;
+  error_message?: string;
+}
+
+export interface BatchStatusResult {
+  batch_id: string;
+  created_at: string;
+  count: number;
+  jobs: BatchJobStatus[];
+  rollup: Record<BatchJobState, number>;
+  all_terminal: boolean;
+}
+
+export interface BatchOutputResult {
+  batch_id: string;
+  count: number;
+  completed: number;
+  outputs: Array<{
+    prompt_id: string;
+    state: BatchJobState;
+    /** Raw ComfyUI history `outputs` for this prompt (node id → outputs, incl.
+     *  images/videos/audio filenames), same shape get_history reports. */
+    outputs?: Record<string, unknown>;
+    error_message?: string;
+  }>;
+}
+
+export interface SubmitBatchResult {
+  batch_id: string;
+  count: number;
+  prompt_ids: string[];
+  /** Present when some (but not all) enqueues failed. */
+  enqueue_errors?: Array<{ index: number; error: string }>;
+}
+
+// ── Durable store (JSON file under the app data dir) ────────────────────────
+
+// One JSON file PER batch under <data dir>/batches/<batch_id>.json.
+// Per-batch files mean concurrent submits — even from SEPARATE server
+// processes sharing the data dir — never read-modify-write a shared file, so
+// no batch can be lost to a racing writer. Each write is tmp+rename (atomic).
+
+function batchesDir(): string {
+  const base =
+    process.env.COMFYUI_MCP_DATA_DIR?.trim() || join(homedir(), ".comfyui-mcp");
+  return join(base, "batches");
+}
+
+/** batch ids are generated as `batch_<uuid>`; reject anything else so a
+ *  caller-supplied id can never traverse outside the batches dir. */
+const BATCH_ID_RE = /^batch_[0-9a-f-]{36}$/;
+
+function batchFilePath(batchId: string): string {
+  return join(batchesDir(), `${batchId}.json`);
+}
+
+async function persistBatch(record: BatchRecord): Promise<void> {
+  const file = batchFilePath(record.batch_id);
+  await mkdir(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`;
+  await writeFile(tmp, JSON.stringify(record, null, 2), "utf8");
+  await rename(tmp, file);
+}
+
+export async function loadBatch(batchId: string): Promise<BatchRecord> {
+  if (!BATCH_ID_RE.test(batchId)) {
+    throw new ValidationError(
+      `Invalid batch_id "${batchId}" — expected the batch_<uuid> id returned by submit_batch.`,
+    );
+  }
+  let record: BatchRecord | undefined;
+  try {
+    const raw = await readFile(batchFilePath(batchId), "utf8");
+    record = JSON.parse(raw) as BatchRecord;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      logger.warn("Batch record unreadable", {
+        batch_id: batchId,
+        error: err instanceof Error ? err.message : err,
+      });
+    }
+  }
+  if (!record || !Array.isArray(record.prompt_ids)) {
+    throw new ValidationError(
+      `Unknown batch_id "${batchId}". Batches persist across restarts in ${batchesDir()}; check the id returned by submit_batch.`,
+    );
+  }
+  return record;
+}
+
+// ── submit ───────────────────────────────────────────────────────────────────
+
+export interface SubmitBatchInput {
+  workflows?: WorkflowJSON[];
+  workflow?: WorkflowJSON;
+  /** Param sweep: one job per override set, applied like modify_workflow's
+   *  flat input overrides (every node that already has the input gets it). */
+  sweep?: Array<Record<string, unknown>>;
+  disable_random_seed?: boolean;
+}
+
+export async function submitBatch(input: SubmitBatchInput): Promise<SubmitBatchResult> {
+  let jobs: WorkflowJSON[];
+  if (input.workflows && input.workflows.length > 0) {
+    if (input.workflow || input.sweep) {
+      throw new ValidationError("Provide EITHER `workflows` OR `workflow`+`sweep`, not both.");
+    }
+    jobs = input.workflows;
+  } else if (input.workflow && input.sweep && input.sweep.length > 0) {
+    jobs = input.sweep.map((overrides) => applyOverrides(input.workflow!, overrides));
+  } else {
+    throw new ValidationError(
+      "submit_batch needs either `workflows` (non-empty array) or `workflow` + `sweep` (non-empty array of override sets).",
+    );
+  }
+
+  const batchId = `batch_${randomUUID()}`;
+  const promptIds: string[] = [];
+  const errors: Array<{ index: number; error: string }> = [];
+
+  for (let i = 0; i < jobs.length; i++) {
+    try {
+      const result = await enqueueWorkflow(jobs[i], {
+        disable_random_seed: input.disable_random_seed,
+      });
+      promptIds.push(result.prompt_id);
+    } catch (err) {
+      errors.push({ index: i, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  if (promptIds.length === 0) {
+    throw new ValidationError(
+      `submit_batch: all ${jobs.length} enqueues failed. First error: ${errors[0]?.error ?? "unknown"}`,
+    );
+  }
+
+  const record: BatchRecord = {
+    batch_id: batchId,
+    created_at: new Date().toISOString(),
+    prompt_ids: promptIds,
+  };
+  await persistBatch(record);
+  logger.info("Batch submitted", { batch_id: batchId, count: promptIds.length, failed: errors.length });
+
+  return {
+    batch_id: batchId,
+    count: promptIds.length,
+    prompt_ids: promptIds,
+    ...(errors.length > 0 ? { enqueue_errors: errors } : {}),
+  };
+}
+
+// ── status ───────────────────────────────────────────────────────────────────
+
+export async function batchStatus(batchId: string): Promise<BatchStatusResult> {
+  const record = await loadBatch(batchId);
+  const jobs: BatchJobStatus[] = [];
+  for (const promptId of record.prompt_ids) {
+    try {
+      const status = await getJobStatus(promptId);
+      const state: BatchJobState = status.error
+        ? "error"
+        : status.done
+          ? "done"
+          : status.running
+            ? "running"
+            : status.pending
+              ? "pending"
+              : "unknown";
+      jobs.push({
+        prompt_id: promptId,
+        state,
+        ...(status.status_str ? { status_str: status.status_str } : {}),
+        ...(status.error ? { error_message: status.error.exception_message } : {}),
+      });
+    } catch (err) {
+      jobs.push({
+        prompt_id: promptId,
+        state: "unknown",
+        error_message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const rollup: Record<BatchJobState, number> = { pending: 0, running: 0, done: 0, error: 0, unknown: 0 };
+  for (const j of jobs) rollup[j.state]++;
+  const all_terminal = jobs.every((j) => j.state === "done" || j.state === "error");
+
+  return {
+    batch_id: record.batch_id,
+    created_at: record.created_at,
+    count: jobs.length,
+    jobs,
+    rollup,
+    all_terminal,
+  };
+}
+
+// ── output ───────────────────────────────────────────────────────────────────
+
+export async function batchOutput(batchId: string): Promise<BatchOutputResult> {
+  const status = await batchStatus(batchId);
+  const outputs: BatchOutputResult["outputs"] = [];
+  let completed = 0;
+
+  for (const job of status.jobs) {
+    if (job.state === "done") {
+      try {
+        const history = await getHistory(job.prompt_id);
+        const entry = history[job.prompt_id];
+        completed++;
+        outputs.push({
+          prompt_id: job.prompt_id,
+          state: job.state,
+          outputs: entry?.outputs ?? {},
+        });
+      } catch (err) {
+        outputs.push({
+          prompt_id: job.prompt_id,
+          state: job.state,
+          error_message: `history fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    } else {
+      outputs.push({
+        prompt_id: job.prompt_id,
+        state: job.state,
+        ...(job.error_message ? { error_message: job.error_message } : {}),
+      });
+    }
+  }
+
+  return { batch_id: batchId, count: status.count, completed, outputs };
+}
+
+// ── wait ─────────────────────────────────────────────────────────────────────
+
+/** Absolute hard cap so wait_for_batch can never hang an agent turn. */
+export const WAIT_HARD_CAP_S = 600;
+const DEFAULT_WAIT_S = 300;
+const POLL_INTERVAL_MS = 2000;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export async function waitForBatch(
+  batchId: string,
+  timeoutS?: number,
+  pollIntervalMs = POLL_INTERVAL_MS,
+): Promise<BatchStatusResult & { timed_out: boolean; waited_s: number }> {
+  const requested = Number.isFinite(timeoutS) && timeoutS! > 0 ? timeoutS! : DEFAULT_WAIT_S;
+  const capped = Math.min(requested, WAIT_HARD_CAP_S);
+  const started = Date.now();
+  const deadline = started + capped * 1000;
+
+  // The HARD cap must hold even when an individual status fetch stalls on a
+  // wedged/unreachable ComfyUI (the underlying fetch has no abort timeout) —
+  // or when the data dir itself sits on a stalled network filesystem. So ALL
+  // awaited work, including the initial record load, runs inside the poll
+  // loop and races an absolute deadline timer: whichever finishes first wins,
+  // and a stalled in-flight await is simply abandoned.
+  let lastStatus: BatchStatusResult | null = null;
+  let record: BatchRecord | null = null;
+
+  const pollLoop = (async (): Promise<BatchStatusResult> => {
+    // Validate the id first so a typo fails fast instead of polling.
+    record = await loadBatch(batchId);
+    let status = await batchStatus(batchId);
+    lastStatus = status;
+    while (!status.all_terminal && Date.now() < deadline) {
+      await sleep(Math.min(pollIntervalMs, Math.max(50, deadline - Date.now())));
+      status = await batchStatus(batchId);
+      lastStatus = status;
+    }
+    return status;
+  })();
+
+  let deadlineTimer: NodeJS.Timeout | undefined;
+  const deadlineHit = new Promise<"deadline">((resolve) => {
+    deadlineTimer = setTimeout(() => resolve("deadline"), Math.max(0, deadline - Date.now()));
+    // Don't let this timer keep the process alive after the loop wins the race.
+    deadlineTimer.unref?.();
+  });
+
+  try {
+    const winner = await Promise.race([pollLoop, deadlineHit]);
+    if (winner !== "deadline") {
+      return {
+        ...winner,
+        timed_out: !winner.all_terminal,
+        waited_s: Math.round((Date.now() - started) / 1000),
+      };
+    }
+  } finally {
+    clearTimeout(deadlineTimer);
+    // Abandoned loop: swallow its eventual settlement so nothing goes unhandled.
+    void pollLoop.catch(() => undefined);
+  }
+
+  // Deadline fired while a poll was still in flight (stalled server or data
+  // dir) — return the last snapshot we managed to get, else an all-unknown
+  // rollup built from the record, else (record load itself stalled) an empty
+  // timed-out shell.
+  // TS can't see the closure assignment above, so re-widen explicitly.
+  const rec = record as BatchRecord | null;
+  const fallback: BatchStatusResult =
+    lastStatus ??
+    (rec
+      ? {
+          batch_id: rec.batch_id,
+          created_at: rec.created_at,
+          count: rec.prompt_ids.length,
+          jobs: rec.prompt_ids.map((prompt_id) => ({
+            prompt_id,
+            state: "unknown" as const,
+            error_message: "status unavailable before wait deadline (ComfyUI unreachable or stalled)",
+          })),
+          rollup: { pending: 0, running: 0, done: 0, error: 0, unknown: rec.prompt_ids.length },
+          all_terminal: false,
+        }
+      : {
+          batch_id: batchId,
+          created_at: "",
+          count: 0,
+          jobs: [],
+          rollup: { pending: 0, running: 0, done: 0, error: 0, unknown: 0 },
+          all_terminal: false,
+        });
+  return {
+    ...fallback,
+    timed_out: true,
+    waited_s: Math.round((Date.now() - started) / 1000),
+  };
+}

--- a/src/tools/batches.ts
+++ b/src/tools/batches.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// SHELL — implement per the PR spec, then (1) wire registerBatchTools into
+// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+export function registerBatchTools(server: McpServer): void {
+  server.tool(
+    "submit_batch",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "submit_batch: not implemented (shell)" }] }),
+  );
+  server.tool(
+    "get_batch_status",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "get_batch_status: not implemented (shell)" }] }),
+  );
+  server.tool(
+    "get_batch_output",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "get_batch_output: not implemented (shell)" }] }),
+  );
+  server.tool(
+    "wait_for_batch",
+    "SHELL — not yet implemented. See PR spec.",
+    { _shell: z.string().optional() },
+    async () => ({ content: [{ type: "text" as const, text: "wait_for_batch: not implemented (shell)" }] }),
+  );
+}

--- a/src/tools/batches.ts
+++ b/src/tools/batches.ts
@@ -1,31 +1,102 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  submitBatch,
+  batchStatus,
+  batchOutput,
+  waitForBatch,
+  WAIT_HARD_CAP_S,
+} from "../services/batch-manager.js";
+import type { WorkflowJSON } from "../comfyui/types.js";
+import { errorToToolResult } from "../utils/errors.js";
 
-// SHELL — implement per the PR spec, then (1) wire registerBatchTools into
-// registerAllTools() in src/tools/index.ts and (2) add a unit test.
+const json = (value: unknown) => ({
+  content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+});
+
 export function registerBatchTools(server: McpServer): void {
   server.tool(
     "submit_batch",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "submit_batch: not implemented (shell)" }] }),
+    "Enqueue MANY ComfyUI workflows under one durable batch_id. Provide EITHER `workflows` (array of API-format workflows) OR one `workflow` plus a `sweep` (array of flat input-override sets — each set produces one job, applied to every node that already has that input, like modify_workflow). Reuses the enqueue_workflow path (seeds re-randomized unless disable_random_seed). Returns { batch_id, count, prompt_ids }; the batch_id → prompt_ids mapping is persisted to disk and stays valid across server restarts. Follow with get_batch_status / wait_for_batch / get_batch_output.",
+    {
+      workflows: z
+        .array(z.record(z.string(), z.any()))
+        .optional()
+        .describe("Array of ComfyUI workflows in API format (node ID -> {class_type, inputs}). Mutually exclusive with workflow+sweep."),
+      workflow: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe("One base workflow in API format, used with `sweep`."),
+      sweep: z
+        .array(z.record(z.string(), z.any()))
+        .optional()
+        .describe('Param sweep: one job per override set, e.g. [{"cfg":6},{"cfg":8,"steps":30}]. Each key is set on every node that already has that input.'),
+      disable_random_seed: z
+        .boolean()
+        .optional()
+        .describe("If true, do not randomize seed values (default randomizes per job)."),
+    },
+    async (args) => {
+      try {
+        const result = await submitBatch({
+          workflows: args.workflows as WorkflowJSON[] | undefined,
+          workflow: args.workflow as WorkflowJSON | undefined,
+          sweep: args.sweep,
+          disable_random_seed: args.disable_random_seed,
+        });
+        return json(result);
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
+
   server.tool(
     "get_batch_status",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "get_batch_status: not implemented (shell)" }] }),
+    "Per-job status for a batch created by submit_batch: each prompt_id's state (pending/running/done/error/unknown) plus rollup counts and all_terminal. Batch ids are durable — they survive server restarts. Uses the same status source as get_job_status.",
+    {
+      batch_id: z.string().describe("The batch_id returned by submit_batch."),
+    },
+    async (args) => {
+      try {
+        return json(await batchStatus(args.batch_id));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
+
   server.tool(
     "get_batch_output",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "get_batch_output: not implemented (shell)" }] }),
+    "Collected outputs for a batch's COMPLETED jobs: for each done prompt_id, the raw ComfyUI history `outputs` (node id → images/videos/audio filenames, same data get_history reports — feed filenames to get_image). Jobs still pending/running are listed with their state; errored jobs carry the error message. Safe to call before the batch finishes.",
+    {
+      batch_id: z.string().describe("The batch_id returned by submit_batch."),
+    },
+    async (args) => {
+      try {
+        return json(await batchOutput(args.batch_id));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
+
   server.tool(
     "wait_for_batch",
-    "SHELL — not yet implemented. See PR spec.",
-    { _shell: z.string().optional() },
-    async () => ({ content: [{ type: "text" as const, text: "wait_for_batch: not implemented (shell)" }] }),
+    `Block until every job in the batch is terminal (done or error) or the timeout elapses, then return the same rollup as get_batch_status plus timed_out/waited_s. Default timeout 300s, hard cap ${WAIT_HARD_CAP_S}s — it can never hang; if timed_out is true, call it again or poll get_batch_status.`,
+    {
+      batch_id: z.string().describe("The batch_id returned by submit_batch."),
+      timeout_s: z
+        .number()
+        .optional()
+        .describe(`Max seconds to wait (default 300, hard cap ${WAIT_HARD_CAP_S}).`),
+    },
+    async (args) => {
+      try {
+        return json(await waitForBatch(args.batch_id, args.timeout_s));
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
   );
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerWorkflowVisualizeTools } from "./workflow-visualize.js";
 import { registerWorkflowComposeTools } from "./workflow-compose.js";
 import { registerWorkflowValidateTools } from "./workflow-validate.js";
 import { registerQueueManagementTools } from "./queue-management.js";
+import { registerBatchTools } from "./batches.js";
 import { registerRegistrySearchTools } from "./registry-search.js";
 import { registerModelManagementTools } from "./model-management.js";
 import { registerModelExtrasTools } from "./model-extras.js";
@@ -131,6 +132,7 @@ const TOOL_GROUPS: ReadonlyArray<readonly [category: string, register: (server: 
   // Appended (not inserted next to queue-management) because tools/list order
   // is observable and must not shift for existing tools.
   ["workflows", registerWaitJobTools],
+  ["workflows", registerBatchTools],
 ];
 
 // ── Blind content mode (panel issue #90) ────────────────────────────────────


### PR DESCRIPTION
## Gap: Batch API — `submit_batch` / `get_batch_status` / `get_batch_output` / `wait_for_batch`

Parity gap vs ComfyUI Cloud. We enqueue one workflow at a time; no way to submit many and collect them under one durable id.

**Deliver 4 tools in `src/tools/batches.ts`:**
- `submit_batch` — accept EITHER an array of API-format workflows, OR one workflow + a param-sweep (list of override sets applied like `modify_workflow`/`apply_node_patch`). Enqueue each (reuse the `enqueue_workflow` code path/service — do NOT duplicate it), record the resulting `prompt_id`s under a generated `batch_id`. Return `{ batch_id, count, prompt_ids }`.
- `get_batch_status` — `{batch_id}` → per-job status (pending/running/done/error) + rollup counts.
- `get_batch_output` — `{batch_id}` → collected outputs (images/videos/audio) for completed jobs, mirroring `get_output`/`get_history` shape.
- `wait_for_batch` — `{batch_id, timeout_s?}` → block until all jobs terminal (or timeout); return the rollup.

**Durability (required):** the `batch_id → prompt_ids` mapping must survive a server restart — persist to a small JSON file under the app/user data dir (see how other tools resolve a data dir). "The batch ID stays valid across sessions."

**Acceptance:** wired into `registerAllTools()`; reuses existing enqueue + output services; unit test covering submit→status→output with mocked ComfyUI + a persisted-then-reloaded batch id. `tsc --noEmit` clean; new vitest passes.
