### PR TITLE
0.48.0 — panel agent defaults to Claude Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.0] - 2026-07-24
+
+### MCP
+
+#### Changed
+- **The panel agent now defaults to Claude Opus 5.** `COMFYUI_MCP_PANEL_MODEL`
+  still pinned `claude-opus-4-8`, so new panel sessions started on the previous
+  Opus unless you overrode it. Set `COMFYUI_MCP_PANEL_MODEL` to pin a different
+  model. No panel-side change was required: the model picker is populated from
+  `query.supportedModels()` rather than a hardcoded catalog, its fallback row
+  uses the `opus` family alias, the advertised Claude effort scale already
+  covers Opus 5's full `low|medium|high|xhigh|max` ladder, and the context
+  window is read from the SDK rather than assumed.
+
+#### Fixed
+- **Double-encoded em dash in published metadata.** The em dash in
+  `package.json`'s `description` and in `docs/docs.json` had been decoded as
+  CP1252 and re-encoded as UTF-8, leaving a literal `â€"`. The description ships
+  to npm and is scraped by third-party directories, so the artifact propagated
+  to every downstream listing.
+
 ## [0.47.0] - 2026-07-23
 
 ### MCP

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -198,7 +198,7 @@ npx -y comfyui-mcp@latest connect
 <ParamField path="COMFYUI_MCP_PANEL_ORCHESTRATOR" type="boolean" default="false">
   Run the panel orchestrator instead of an MCP server (same as `--panel-orchestrator`).
 </ParamField>
-<ParamField path="COMFYUI_MCP_PANEL_MODEL" type="string" default="claude-opus-4-8">
+<ParamField path="COMFYUI_MCP_PANEL_MODEL" type="string" default="claude-opus-5">
   Model for the background panel agents.
 </ParamField>
 <ParamField path="COMFYUI_MCP_BRIDGE_PORT" type="number" default="9180">

--- a/docs/design/panel-orchestrator.md
+++ b/docs/design/panel-orchestrator.md
@@ -59,7 +59,7 @@ comfyui-mcp --panel-orchestrator   (standalone, long-lived background process)
   tab's agent.
 - **`src/orchestrator/panel-agent.ts`** (`PanelAgent` / `PanelAgentManager`):
   one streaming `query()` session per `tab_id`, spawned lazily on the tab's
-  first message. Options: `model: claude-opus-4-8`, `permissionMode:
+  first message. Options: `model: claude-opus-5`, `permissionMode:
   "bypassPermissions"`, `strictMcpConfig: true`, `mcpServers: { comfyui: … }`
   (this build run as a stdio MCP in **non-channels** mode, so it generates
   against the live ComfyUI over `COMFYUI_URL` and never contends for the bridge
@@ -80,7 +80,7 @@ with a clear message instead of running uselessly. Override the port with
   orchestrator instead of an MCP server.
 - `COMFYUI_URL` — live ComfyUI the spawned agents generate against.
 - `COMFYUI_MCP_PANEL_MODEL` — override the panel agent model (default
-  `claude-opus-4-8`).
+  `claude-opus-5`).
 - `COMFYUI_MCP_BRIDGE_PORT` — bridge port (default 9101).
 
 ## Testing

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -166,7 +166,7 @@
     "404": {
       "redirect": false,
       "title": "Lost in the latent space",
-      "description": "That page doesn't exist or moved. Head to the [docs home](/), browse the [blog](/blog), or [get started](/quickstart) â€” install comfyui-mcp and drive ComfyUI from your own Claude session. Still stuck? [Open an issue](https://github.com/artokun/comfyui-mcp/issues)."
+      "description": "That page doesn't exist or moved. Head to the [docs home](/), browse the [blog](/blog), or [get started](/quickstart) — install comfyui-mcp and drive ComfyUI from your own Claude session. Still stuck? [Open an issue](https://github.com/artokun/comfyui-mcp/issues)."
     }
   },
   "seo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "comfyui-mcp",
   "version": "0.40.0",
   "mcpName": "io.github.artokun/comfyui-mcp",
-  "description": "Local-first, agent-native control plane for ComfyUI â€” MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
+  "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",
   "type": "module",
   "main": "dist/index.js",

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -860,7 +860,7 @@ export class AntigravityBackend implements AgentBackend {
   /** Decide whether `model` is usable for THIS provider: non-claude ids pass
    *  (they come from our own picker/config); claude-shaped ids are checked
    *  against the live catalog — Antigravity DOES serve some claude-* models, but
-   *  the panel also leaks its Anthropic-side default (e.g. claude-opus-4-8)
+   *  the panel also leaks its Anthropic-side default (e.g. claude-opus-5)
    *  through opts.model, which must be dropped. Returns the model when
    *  acceptable, undefined when not. Catalog unavailable → drop claude ids
    *  (conservative: a wrong --model makes every turn fail). */

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -881,7 +881,7 @@ export class CodexBackend implements AgentBackend {
     if (!client) throw new Error("codex app-server not initialized");
     const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
     // MODEL PRECEDENCE (P1-1): PanelAgent.start() always passes opts.model = the
-    // CLAUDE panel model (e.g. claude-opus-4-8), which is NOT a valid Codex model.
+    // CLAUDE panel model (e.g. claude-opus-5), which is NOT a valid Codex model.
     // The Codex model configured at construction (deps.model, from
     // COMFYUI_MCP_CODEX_MODEL) must win. Only honor opts.model if it actually looks
     // like a Codex model (so a future Codex-aware picker can still switch live);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1045,7 +1045,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     isForceRemoteFlagSet() || !isLoopbackUrl(comfyuiUrl)
       ? { COMFYUI_MCP_FORCE_REMOTE: "1" }
       : {};
-  const model = process.env.COMFYUI_MCP_PANEL_MODEL ?? "claude-opus-4-8";
+  const model = process.env.COMFYUI_MCP_PANEL_MODEL ?? "claude-opus-5";
   const envEffort = process.env.COMFYUI_MCP_PANEL_EFFORT;
   const effort: Effort | undefined = isEffort(envEffort) ? envEffort : undefined;
   // Single-port multi-provider: ONE orchestrator on ONE bridge port (default
@@ -1147,7 +1147,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   // declared to the app-server alongside the headless comfyui (stdio) MCP. Claude
   // keeps its in-process SDK panel server unchanged.
   const backendId = (process.env.PANEL_AGENT_BACKEND ?? "claude").toLowerCase();
-  // The panel's `model` is a Claude id (e.g. claude-opus-4-8) and is NOT a valid
+  // The panel's `model` is a Claude id (e.g. claude-opus-5) and is NOT a valid
   // Codex model — so for codex we only pass a model when COMFYUI_MCP_CODEX_MODEL
   // is set explicitly; otherwise Codex uses the account's default (e.g. gpt-5.5).
   const codexModel = process.env.COMFYUI_MCP_CODEX_MODEL;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -121,7 +121,7 @@ export interface PanelAgentDeps {
   comfyuiUrl?: string;
   /** Persona appended to the claude_code system-prompt preset. */
   systemAppend: string;
-  /** Pinned model (e.g. claude-opus-4-8). */
+  /** Pinned model (e.g. claude-opus-5). */
   model: string;
   /** Reasoning effort for the session (low..max). Omitted = SDK default. */
   effort?: Effort;


### PR DESCRIPTION
Opus 5 shipped; the panel orchestrator still pinned `claude-opus-4-8`, so every new panel session started on the previous-generation Opus unless the user overrode `COMFYUI_MCP_PANEL_MODEL`.

## What changed

**Panel agent defaults to Claude Opus 5.** Verified against the live Claude Code CLI (2.1.219) that `claude-opus-5` is accepted before switching the pin — a rejected model id would have broken every panel on startup.

**No panel-side change was required**, which is worth recording:
- the model picker is populated from `query.supportedModels()` rather than a hardcoded catalog, so Opus 5 surfaces on its own
- the fallback row uses the `opus` family alias, not a pinned version
- `BACKEND_EFFORTS.claude` already advertises Opus 5's full `low|medium|high|xhigh|max` ladder
- the context window is read from the SDK's `modelUsage`, not assumed

**Also folds in the mojibake fix** (`fix/mojibake-em-dash`): the em dash in `package.json`'s `description` and `docs/docs.json` had been decoded as CP1252 and re-encoded as UTF-8, leaving a literal `â€"`. The description ships to npm and is scraped by third-party directories, so it propagated downstream. It only reaches npm on a version bump — this is that bump.

The blog post keeps `claude-opus-4-8`: it is a dated log transcript, not documentation of the current default.

## Verification

- `npm run lint` (tsc --noEmit) — clean
- `npm run build` — clean
- Full suite: 1939 passed, 4 failed
- **The 4 failures are pre-existing and host-dependent, not regressions.** Confirmed by running them in an isolated worktree at `bf227e7` (the already-published 0.47.0 line): identical 4 failures. They are the `agy`-missing probe, the `node-dev` builtin-`rg` fallback, and two `training-datasets` cases — all environment-sensitive, and none in a path this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)