### PR TITLE
0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.1] - 2026-07-26
+
+### MCP
+
+#### Fixed
+- remove wait_for_job — copy-paste holdover from the official Comfy MCP/CLI (#320)
+
+
 ## [0.48.0] - 2026-07-24
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release 0.48.1 — reconciles `main` with the already-tagged `v0.48.1`.

Contains the version bump + regenerated CHANGELOG for the single change since v0.48.0:
- #320 — remove `wait_for_job` (copy-paste holdover from the official Comfy MCP/CLI); advertised MCP-tool count 182 → 181.

The `v0.48.1` tag is already pushed and the publish workflow is running. **Merge with a merge commit (not squash)** so `main` contains the tagged `0.48.1` commit, matching the 0.48.0 (#319) release flow.