### PR TITLE
fix(glm): default z.ai GLM to glm-5.2

### DIFF
--- a/src/__tests__/services/provider-model-hint.test.ts
+++ b/src/__tests__/services/provider-model-hint.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 describe("providerModelHint", () => {
   it("names the default model AND the env var that overrides it", () => {
     const hint = providerModelHint(GLM);
-    expect(hint).toContain(GLM.defaultModel); // e.g. glm-4.7
+    expect(hint).toContain(GLM.defaultModel); // e.g. glm-5.2
     expect(hint).toContain(GLM.modelEnv); // COMFYUI_MCP_GLM_MODEL
     expect(hint).toMatch(/default/i);
   });

--- a/src/services/openai-provider-registry.ts
+++ b/src/services/openai-provider-registry.ts
@@ -78,7 +78,7 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
     slotHelp: "Z.AI Coding Plan (GLM / Zhipu)",
     envKeys: ["GLM_API_KEY", "ZHIPU_API_KEY", "ZHIPUAI_API_KEY", "ZAI_API_KEY"],
     modelEnv: "COMFYUI_MCP_GLM_MODEL",
-    defaultModel: process.env.COMFYUI_MCP_GLM_MODEL?.trim() || "glm-4.7",
+    defaultModel: process.env.COMFYUI_MCP_GLM_MODEL?.trim() || "glm-5.2",
     ackFallbackLabel: "GLM",
     readyMessage: (agentLabel) =>
       `🟢 comfyui-mcp agent ready — ${agentLabel} on your Z.AI GLM Coding Plan. Ask away.`,
@@ -144,7 +144,7 @@ export function openAiKeyProviderModel(p: OpenAiKeyProvider): string {
  * One-line "which model am I on, and how do I change it?" hint for the panel's
  * API Keys card.
  *
- * These providers ship a pinned default (glm-4.7, kimi-for-coding, kimi-k3) and
+ * These providers ship a pinned default (glm-5.2, kimi-for-coding, kimi-k3) and
  * a `modelEnv` override, but NOTHING in the UI ever said the override existed —
  * so a user on a newer model (e.g. GLM 5.2) had no way to discover they could
  * point at it without reading the source. Generated from the registry rather


### PR DESCRIPTION
Per maintainer request — bump the z.ai GLM provider's pinned default from glm-4.7 to glm-5.2 (newer, available on the coding plan). Still env-overridable (COMFYUI_MCP_GLM_MODEL) and picker-selectable. Build + provider-model-hint tests green.