### PR TITLE
fix(security): prevent path traversal in upload_image/video/audio filename

### DIFF
--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -15,6 +15,30 @@ async function getInputDir(): Promise<string> {
 }
 
 /**
+ * Reject filenames that would escape the ComfyUI input/ directory.
+ * The MCP client is untrusted input, so `filename` must be treated as such.
+ */
+function assertSafeInputFilename(filename: string): string {
+  // Strip any directory components — only allow a bare filename.
+  const safe = basename(filename);
+  if (
+    !safe ||
+    safe === "." ||
+    safe === ".." ||
+    safe !== filename ||
+    safe.includes("/") ||
+    safe.includes("\\") ||
+    safe.includes("\0")
+  ) {
+    throw new ValidationError(
+      `Invalid filename "${filename}": must be a bare filename with no path components.`,
+    );
+  }
+  return safe;
+}
+
+
+/**
  * Copy a local image file into ComfyUI's input/ directory so it can be
  * referenced by LoadImage nodes in workflows.
  */
@@ -23,7 +47,7 @@ export async function uploadImage(
   filename?: string,
 ): Promise<{ filename: string; path: string }> {
   const inputDir = await getInputDir();
-  const resolvedFilename = filename ?? basename(sourcePath);
+  const resolvedFilename = assertSafeInputFilename(filename ?? basename(sourcePath));
 
   // Validate extension
   const ext = extname(resolvedFilename).toLowerCase();
@@ -368,7 +392,7 @@ async function uploadMediaLocal(
   kind: "video" | "audio",
 ): Promise<{ filename: string; path: string }> {
   const inputDir = await getInputDir();
-  const resolvedFilename = filename ?? basename(sourcePath);
+  const resolvedFilename = assertSafeInputFilename(filename ?? basename(sourcePath));
   resolveMediaMime(resolvedFilename, mimeMap, kind);
   const targetPath = join(inputDir, resolvedFilename);
   logger.info(`Uploading ${kind} to ComfyUI input`, { sourcePath, targetPath });


### PR DESCRIPTION
## Summary

The `upload_image` / `upload_video` / `upload_audio` MCP tools accept a caller-supplied `filename` argument and pass it directly into `join(inputDir, filename)` followed by `copyFile(...)`. Because the MCP client is untrusted input under the tool's threat model (the LLM driving the tools, or content it consumes), a filename such as `../../.ssh/authorized_keys` or `../../../tmp/evil.png` escapes ComfyUI's `input/` directory and writes attacker-chosen bytes anywhere the server process can write. This is a classic path-traversal / arbitrary file write (CWE-22).

The upload tools are supposed to be strictly confined to ComfyUI's `input/` directory (that is their entire purpose — placing files where `LoadImage` / `LoadVideo` / `LoadAudio` nodes can pick them up). Escaping that directory is unambiguously outside the tool's contract.

**Affected file / functions:** `src/services/image-management.ts` — `uploadImage(...)` and `uploadMediaLocal(...)` (which backs `uploadVideo` and `uploadAudio`).

**Data flow:**

1. MCP tool call arrives at `src/tools/image-management.ts` with a `filename` string from the client.
2. The tool wrapper forwards it into `uploadImage` / `uploadVideo` / `uploadAudio` in `src/services/image-management.ts`.
3. `resolvedFilename = filename ?? basename(sourcePath)` — the caller's value is used verbatim if provided.
4. `targetPath = join(inputDir, resolvedFilename)` — `join` normalises `..` segments, so the target escapes `inputDir`.
5. `copyFile(sourcePath, targetPath)` writes the file outside `input/`.

## Fix

Add a small `assertSafeInputFilename(filename)` helper that runs before the filename touches `join()`. It:

- Runs `basename(filename)` and requires strict equality with the original (so anything with directory components, including `foo/bar.png`, is rejected — not silently rewritten).
- Rejects empty string, `.`, `..`, and any string containing `/`, `\`, or NUL (`\0`).
- Throws `ValidationError` with a clear message on rejection.

Both call sites (`uploadImage` and `uploadMediaLocal`) route their `resolvedFilename` through this helper. The check is applied to whichever value ends up as `resolvedFilename` — whether it's the caller-supplied `filename` or the fallback `basename(sourcePath)`. Extension validation and MIME resolution then continue as before.

The helper is intentionally strict (reject rather than sanitise) so bugs surface loudly instead of silently placing a file with a stripped path that the caller then can't find.

## Test results

- `npm test` — **827 / 827 pass** (79 test files), including the existing `src/__tests__/services/media-upload.test.ts` which exercises the upload paths. No test changes were required to keep the suite green; the traversal-rejection behaviour is a strict addition on top of the existing contract (legitimate bare filenames like `photo.png` are unaffected).
- Build (`tsc`) passes.

## Proof of concept

With a local dev checkout and any MCP client (or a direct call in the vitest environment), the pre-fix behaviour writes outside `input/`:

```ts
// Before the fix — reproduces the arbitrary-write:
import { uploadImage } from "./src/services/image-management.ts";
await uploadImage("/tmp/harmless.png", "../../../tmp/pwned.png");
// -> writes /tmp/pwned.png (outside ComfyUI's input/ dir)
```

After the fix, the same call throws:

```
ValidationError: Invalid filename "../../../tmp/pwned.png": must be a bare filename with no path components.
```

The same PoC applies to `uploadVideo` / `uploadAudio` via `uploadMediaLocal`. A benign `uploadImage("/tmp/x.png", "photo.png")` continues to work unchanged.

## Security analysis / adversarial review

Before submitting we tried to disprove this:

- **Is there a router-level or framework mitigation?** No — these are MCP tools, not HTTP routes. There is no framework layer normalising or sandboxing filenames between the tool call and the filesystem. The wrapper in `src/tools/image-management.ts` passes `filename` through unchanged.
- **Does `join()` protect us?** No — `path.join` normalises `..` but does not confine the result to the base. `join("/comfy/input", "../../etc/x")` returns `/comfy/etc/x`, which is exactly the vulnerability.
- **Does the extension allow-list save us?** No — an attacker can (and needs to) keep a valid extension like `.png`; `../../.ssh/authorized_keys.png` still passes extension checks and still lands outside `input/`. And even if it didn't, arbitrary-file-write with an attacker-chosen `.png` under a system directory is already a meaningful primitive.
- **Is the caller trusted?** The MCP threat model treats the client (the LLM and any content it processes) as untrusted for the purpose of tool arguments. Prompt injection from external content the model reads is a realistic way to reach this sink with attacker-controlled arguments.
- **Are there parallel unpatched sinks in the same file?** We reviewed `src/services/image-management.ts` for other places that `join(inputDir, x)` with caller-supplied `x`; the two upload paths above are the only ones. Other filesystem operations in the file operate on server-derived paths.

## Notes for the maintainer

- Diff is one file, ~26 net lines added, no behavioural change for legitimate callers.
- `ValidationError` is the same error type already used elsewhere in the service for bad input, so error handling in the tool wrappers is consistent.
- Happy to adjust the error message wording or move the helper into `src/utils/` if you'd prefer it shared.