### PR TITLE
fix(comfyui): restart_comfyui relaunch fails with spawn EFTYPE on Windows (#330)

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 const mockConfig = vi.hoisted(() => ({
@@ -183,6 +184,31 @@ describe("process-control startup readiness", () => {
       }),
     );
     expect(children[0].unref).toHaveBeenCalled();
+  });
+
+  it("anchors a RELATIVE script argv[0] to the ComfyUI root (portable launcher, #330)", async () => {
+    // The standard Windows portable launcher runs `python ComfyUI\main.py` from
+    // the portable ROOT, so sys.argv[0] is relative. Since we force cwd to the
+    // nested ComfyUI dir, passing it verbatim would look for ComfyUI\ComfyUI\
+    // main.py — it must be anchored to config.comfyuiPath.
+    __processControlTestHooks.setLastProcessInfo({
+      pid: 0,
+      port: 8188,
+      argv: ["ComfyUI\\main.py", "--port", "8188"],
+      isDesktopApp: false,
+    });
+    mockSpawnedChildren();
+    mockNoPortProcess();
+    mockFetchOk(true);
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/fake/ComfyUI/python_embeded/python.exe",
+      [join("/fake/ComfyUI", "main.py"), "--port", "8188"],
+      expect.objectContaining({ cwd: "/fake/ComfyUI", shell: false }),
+    );
   });
 
   it("reports timeout instead of ready when bounded probes never succeed", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -33,6 +33,11 @@ vi.mock("../../utils/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
 import {
   __processControlTestHooks,
   startComfyUI,
@@ -97,6 +102,7 @@ beforeEach(() => {
   delete process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES;
   mockConfig.resolvedPort = 8188;
   mockConfig.comfyuiPath = "/fake/ComfyUI";
+  mockFindComfyuiPython.mockReturnValue("/fake/ComfyUI/python_embeded/python.exe");
   __processControlTestHooks.reset();
 });
 
@@ -140,6 +146,43 @@ describe("process-control startup readiness", () => {
     );
     expect(children[0].unref).toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("relaunches via the resolved Python interpreter when argv[0] is a main.py script (#330)", async () => {
+    // Real ComfyUI /system_stats argv is sys.argv: argv[0] is the SCRIPT path
+    // (…/main.py), NOT the interpreter. Spawning that directly on Windows fails
+    // with `spawn EFTYPE`; the relaunch must resolve the Python interpreter and
+    // pass the whole argv as its args.
+    __processControlTestHooks.setLastProcessInfo({
+      pid: 0,
+      port: 8188,
+      argv: ["C:\\ComfyUI\\main.py", "--port", "8188"],
+      isDesktopApp: false,
+    });
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    mockFetchOk(true);
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(mockFindComfyuiPython).toHaveBeenCalledWith("/fake/ComfyUI", [
+      "C:\\ComfyUI\\main.py",
+      "--port",
+      "8188",
+    ]);
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/fake/ComfyUI/python_embeded/python.exe",
+      ["C:\\ComfyUI\\main.py", "--port", "8188"],
+      expect.objectContaining({
+        detached: true,
+        cwd: "/fake/ComfyUI",
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      }),
+    );
+    expect(children[0].unref).toHaveBeenCalled();
   });
 
   it("reports timeout instead of ready when bounded probes never succeed", async () => {

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -5,6 +5,7 @@ import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { findComfyuiPython } from "./env-capabilities.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -481,14 +482,41 @@ function spawnFromProcessInfo(info: ProcessInfo): ChildProcess | null {
     });
   }
 
-  if (info.argv.length === 0) return null;
-  const [pythonExe, ...args] = info.argv;
-  return spawn(pythonExe, args, {
+  const cmd = resolveLaunchCommand(info);
+  if (!cmd) return null;
+  return spawn(cmd.exe, cmd.args, {
     detached: true,
     stdio: "ignore",
     cwd: config.comfyuiPath ?? undefined,
     shell: false,
+    windowsHide: true,
   });
+}
+
+/**
+ * Turn captured process info into a spawnable (executable, args) pair.
+ *
+ * The argv we save comes from ComfyUI's `/system_stats` — i.e. Python's
+ * `sys.argv`, whose argv[0] is the SCRIPT path (`…/main.py`), NOT the Python
+ * interpreter. Spawning that script directly with `shell:false` fails on
+ * Windows with `spawn EFTYPE` (the OS cannot exec a `.py` as a PE binary),
+ * which is exactly the restart_comfyui relaunch failure in #330. When argv[0]
+ * is a script we resolve the real ComfyUI Python interpreter and pass the whole
+ * argv (main.py + flags) as its args. When argv[0] is already an interpreter
+ * (e.g. a supervised child we spawned ourselves), we spawn it verbatim.
+ */
+function resolveLaunchCommand(
+  info: ProcessInfo,
+): { exe: string; args: string[] } | null {
+  if (info.argv.length === 0) return null;
+  const [first, ...rest] = info.argv;
+  const looksLikeScript = /\.pyw?$/i.test(first.trim());
+  if (looksLikeScript) {
+    const python = findComfyuiPython(config.comfyuiPath ?? undefined, info.argv);
+    if (!python) return null;
+    return { exe: python, args: info.argv };
+  }
+  return { exe: first, args: rest };
 }
 
 function handleSupervisedChildStop(

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,6 +1,6 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { platform } from "node:os";
-import { basename, isAbsolute, join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -521,10 +521,19 @@ function resolveLaunchCommand(
     // relative script would resolve against the wrong dir (…/ComfyUI/ComfyUI/
     // main.py). Anchor it: use the absolute path as-is, otherwise main.py under
     // the resolved ComfyUI root.
+    //
+    // The argv mirrors the running ComfyUI's sys.argv, which is Windows-flavored
+    // when ComfyUI runs on Windows — regardless of what OS this process is on.
+    // So detect absoluteness and the script basename in a separator-agnostic way
+    // rather than trusting the host `path` module (which mangles `C:\…` / `\`
+    // paths on POSIX). The final join stays host-native to match comfyuiPath.
+    const isWindowsAbsolute =
+      /^[a-zA-Z]:[\\/]/.test(first) || /^\\\\/.test(first);
+    const scriptBasename = first.split(/[\\/]/).pop() || first;
     const script =
-      isAbsolute(first) || !config.comfyuiPath
+      isAbsolute(first) || isWindowsAbsolute || !config.comfyuiPath
         ? first
-        : join(config.comfyuiPath, basename(first));
+        : join(config.comfyuiPath, scriptBasename);
     return { exe: python, args: [script, ...rest] };
   }
   return { exe: first, args: rest };

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,5 +1,6 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { platform } from "node:os";
+import { basename, isAbsolute, join } from "node:path";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -514,7 +515,17 @@ function resolveLaunchCommand(
   if (looksLikeScript) {
     const python = findComfyuiPython(config.comfyuiPath ?? undefined, info.argv);
     if (!python) return null;
-    return { exe: python, args: info.argv };
+    // sys.argv[0] can be RELATIVE (the standard Windows portable launcher runs
+    // `python ComfyUI\main.py` from the portable root). We force cwd to
+    // config.comfyuiPath — the ComfyUI dir that directly holds main.py — so a
+    // relative script would resolve against the wrong dir (…/ComfyUI/ComfyUI/
+    // main.py). Anchor it: use the absolute path as-is, otherwise main.py under
+    // the resolved ComfyUI root.
+    const script =
+      isAbsolute(first) || !config.comfyuiPath
+        ? first
+        : join(config.comfyuiPath, basename(first));
+    return { exe: python, args: [script, ...rest] };
   }
   return { exe: first, args: rest };
 }


### PR DESCRIPTION
## Root cause

`restart_comfyui` (and `start_comfyui`) relaunch ComfyUI from the argv captured via `/system_stats`. That argv is Python's `sys.argv`, whose **argv[0] is the `main.py` script path, not the Python interpreter**. `spawnFromProcessInfo` did:

```ts
const [pythonExe, ...args] = info.argv;
spawn(pythonExe, args, { shell: false, ... });
```

so it spawned `main.py` as the executable. On Windows, execing a `.py` as a PE binary with `shell:false` fails with **`spawn EFTYPE`** (exec format error). The stop half works because it kills by PID-from-port and never touches argv — so ComfyUI stopped, but the relaunch died, the original PID was gone, and port 8188 stayed down. (On Linux/macOS a `.py` with a shebang + exec bit can accidentally run, which is why this was Windows-only.)

## The fix

`resolveLaunchCommand` now detects when argv[0] is a `.py`/`.pyw` script and resolves the real ComfyUI Python interpreter (reusing the existing `findComfyuiPython` helper — standalone-env / python_embeded / .venv under the install root inferred from `main.py`), then passes the whole argv (`main.py` + flags) as the interpreter's args. When argv[0] is already an interpreter (e.g. a child we spawned ourselves), it is spawned verbatim, so the crash-supervision path is unchanged. Also added `windowsHide:true` to match the other spawn/execFile call sites.

This makes the relaunch use a real, executable interpreter instead of handing a script to `spawn` — the divergence was that the saved argv never contained an interpreter to begin with.

## Tests

- Added a regression test asserting that when `argv[0]` is `…/main.py`, the relaunch resolves the Python interpreter and spawns `python [main.py, ...flags]` with the right options.
- `npx vitest run process-control` → 7/7 pass. `npm run build` (tsc) clean.
- Full `npm test`: 1930 pass, 1 skipped. The single failure (`node-dev.test.ts` expecting search engine `builtin` but ripgrep is installed on this machine) is a pre-existing, environment-dependent assertion unrelated to this change.

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
