### PR TITLE
fix(orchestrator): rebind panel session tabId on explicit signal — self-heal after reconnect/reload/workflow-switch (#322, #331, #332)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -528,6 +528,108 @@ describe("panel-tools: workflow target (per-workflow agent)", () => {
   });
 });
 
+describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-switch / #332 reconnect)", () => {
+  // A minimal fake bridge modelling the ONE fact that matters: which tab ids are
+  // currently live. `send` routes only to a live id (throws `no connected tab`
+  // otherwise, exactly like UiBridge.resolveTarget); canReach/resolveActiveTabId
+  // mirror the real bridge's no-throw / no-tabId helpers.
+  function fakeBridge(live: Set<string>) {
+    const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        const id = opts?.tabId;
+        if (id && !live.has(id)) throw new Error(`no connected tab with id "${id}"`);
+        sent.push({ cmd, tabId: id });
+        return { ok: true, routedTo: id };
+      },
+      push: () => 1,
+      canReach: (tabId: string) => live.has(tabId),
+      resolveActiveTabId: () => {
+        if (live.size === 1) return [...live][0];
+        if (live.size === 0) throw new Error("Panel not reachable: no panel connected");
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    return { bridge, sent };
+  }
+
+  it("panel_set_workflow_target({mode:'current'}) rebinds a DEAD session onto the sole live tab; calls then succeed", async () => {
+    const store = new WorkflowTargetStore();
+    // Only the NEW tab is live; the session was created bound to the old (dead) id.
+    const { bridge, sent } = fakeBridge(new Set(["new-live-tab"]));
+    const ctx = makePanelToolCtx(bridge, "dead-old-tab", store);
+
+    // Before rebind, a graph call to the dead tab fails.
+    const before = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(before.isError).toBe(true);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(ctx.tabId).toBe("new-live-tab");
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toContain("Rebound this session");
+
+    // After rebind, subsequent panel_* calls route to the live tab and succeed.
+    const after = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(after.isError).toBeUndefined();
+    expect(sent.at(-1)?.tabId).toBe("new-live-tab");
+  });
+
+  it("panel_reload rebinds a DEAD session onto the sole live tab, then forwards soft_reload there", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = fakeBridge(new Set(["reconnected-tab"]));
+    const ctx = makePanelToolCtx(bridge, "orphaned-tab", store);
+
+    const res = await defByName("panel_reload").handler({}, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(ctx.tabId).toBe("reconnected-tab");
+    expect(sent.at(-1)).toMatchObject({
+      cmd: { cmd: "soft_reload", scope: "orchestrator" },
+      tabId: "reconnected-tab",
+    });
+  });
+
+  it("does NOT disturb a HEALTHY session: mode:'current' leaves a still-live tabId in place", async () => {
+    const store = new WorkflowTargetStore();
+    // Two live tabs incl. the session's own — a healthy multi-tab deployment.
+    const { bridge } = fakeBridge(new Set(["my-tab", "other-tab"]));
+    const ctx = makePanelToolCtx(bridge, "my-tab", store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(res.isError).toBeUndefined();
+    // Untouched — no rebind (canReach true), so no hijack onto another tab.
+    expect(ctx.tabId).toBe("my-tab");
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).not.toContain("Rebound");
+  });
+
+  it("surfaces a CLEAR error (no guess) when the session is dead AND no single active tab exists", async () => {
+    const store = new WorkflowTargetStore();
+    // Session's tab is dead and 2+ others are live with no last-active → ambiguous.
+    const { bridge } = fakeBridge(new Set(["a", "b"]));
+    const ctx = makePanelToolCtx(bridge, "dead-tab", store);
+
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toMatch(/Multiple panel tabs/);
+    // tabId is NOT silently changed to some arbitrary tab.
+    expect(ctx.tabId).toBe("dead-tab");
+  });
+
+  it("carries a PINNED workflow target across the rebind to the new tab id", async () => {
+    const store = new WorkflowTargetStore();
+    store.set("dead-old-tab", { mode: "pinned", path: "workflows/pinned.json" });
+    const { bridge } = fakeBridge(new Set(["new-live-tab"]));
+    const ctx = makePanelToolCtx(bridge, "dead-old-tab", store);
+
+    // panel_reload triggers the rebind without releasing the pin.
+    await defByName("panel_reload").handler({}, ctx);
+    expect(ctx.tabId).toBe("new-live-tab");
+    expect(store.get("new-live-tab")).toMatchObject({ mode: "pinned", path: "workflows/pinned.json" });
+    expect(store.get("dead-old-tab")).toMatchObject({ mode: "current" });
+  });
+});
+
 describe("panel_connect slot aliases (live panel finding: stripped aliases → auto-match scramble)", () => {
   it("maps from_slot_name/to_slot_name onto from_output/to_input on the wire", async () => {
     const { ctx, calls } = makeFakeCtx();

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -478,6 +478,46 @@ describe("UiBridge (multi-tab)", () => {
     sockB.close();
   });
 
+  it("canReach + resolveActiveTabId back the orchestrator's explicit self-heal (#322/#331/#332)", async () => {
+    // A session was bound to old-tab, which then DIES and a genuinely new socket
+    // reconnects under new-tab — NO migration alias (different socket, first hello).
+    const sockOld = await connectPanel();
+    autoReply(sockOld, "old");
+    sockOld.send(JSON.stringify({ type: "hello", tab_id: "old-tab" }));
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    sockOld.close();
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+
+    const sockNew = await connectPanel();
+    autoReply(sockNew, "new");
+    sockNew.send(JSON.stringify({ type: "hello", tab_id: "new-tab" }));
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+
+    // The old id is orphaned (no migration) — canReach is false, and the no-tabId
+    // resolution the orchestrator invokes at the explicit rebind lands on the sole
+    // live tab. resolveTarget itself is NOT weakened: the old id still throws.
+    expect(bridge.canReach("old-tab")).toBe(false);
+    expect(bridge.canReach("new-tab")).toBe(true);
+    expect(bridge.resolveActiveTabId()).toBe("new-tab");
+    await expect(bridge.send({ cmd: "x" }, { tabId: "old-tab" })).rejects.toThrow(/no connected tab/);
+
+    sockNew.close();
+  });
+
+  it("resolveActiveTabId throws (no guess) when 2+ tabs are connected with no last-active", async () => {
+    const sockA = await connectPanel();
+    autoReply(sockA, "A");
+    sockA.send(JSON.stringify({ type: "hello", tab_id: "tab-a" }));
+    const sockB = await connectPanel();
+    autoReply(sockB, "B");
+    sockB.send(JSON.stringify({ type: "hello", tab_id: "tab-b" }));
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(2));
+
+    expect(() => bridge.resolveActiveTabId()).toThrow(/Multiple panel tabs/);
+    sockA.close();
+    sockB.close();
+  });
+
   it("follows MIGRATION CHAINS: uuid → tmp: → wf: (the exact #210 field sequence)", async () => {
     // The reported failure re-helloed TWICE: legacy random UUID, then the
     // unsaved-tab tmp:<uuid> id, then the saved wf:<hash> id. The ORIGINAL id

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -285,6 +285,21 @@ export interface PanelToolCtx {
   tabId: string;
   /** Per-tab workflow pin store (optional for tests). */
   workflowTarget?: WorkflowTargetStore;
+  /**
+   * EXPLICIT self-heal: re-point THIS session at the currently active/sole
+   * connected tab. The tabId captured at session creation is frozen; a full
+   * ComfyUI reconnect (#332), a frontend reload (#322), or switching to a
+   * different workflow FILE (#331) can surface a brand-NEW browser socket under
+   * a NEW tab id with no migration alias, orphaning the session so every
+   * panel_* call throws `no connected tab`. This rebinds `ctx.tabId` (which
+   * `call`/`confirm` read LIVE) to the active tab — but ONLY when the current
+   * tabId no longer reaches a live tab, so a healthy (possibly multi-tab)
+   * session is never disturbed. It is the deliberate consent signal wired into
+   * panel_set_workflow_target({mode:"current"}) and panel_reload — NOT baked
+   * into resolveTarget. Throws (clear message) when a single active tab can't be
+   * determined. Optional so lightweight test contexts can omit it.
+   */
+  rebindToActiveTab?: () => { previous: string; current: string; rebound: boolean };
 }
 
 /** Build a tab-bound execution context shared by both transports. */
@@ -293,11 +308,20 @@ export function makePanelToolCtx(
   tabId: string,
   workflowTargets?: WorkflowTargetStore,
 ): PanelToolCtx {
+  // The routing tab id is held on the returned ctx object (NOT captured by
+  // value) so an explicit rebind can re-point this session in place: call/
+  // confirm and every handler read `ctx.tabId` LIVE. See rebindToActiveTab.
+  const ctx = {
+    bridge,
+    tabId,
+    workflowTarget: workflowTargets,
+  } as PanelToolCtx;
+
   const call = async (cmd: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> => {
     try {
-      const target = workflowTargets?.get(tabId);
+      const target = workflowTargets?.get(ctx.tabId);
       const routed = target ? withWorkflowTarget(cmd, target) : cmd;
-      return ok(await bridge.send(routed as { cmd: string }, { tabId, timeoutMs }));
+      return ok(await bridge.send(routed as { cmd: string }, { tabId: ctx.tabId, timeoutMs }));
     } catch (err) {
       return fail(err);
     }
@@ -320,14 +344,38 @@ export function makePanelToolCtx(
             { label: "No, cancel", description: "" },
           ],
         } as { cmd: string },
-        { tabId, timeoutMs: 300000 },
+        { tabId: ctx.tabId, timeoutMs: 300000 },
       );
       return isAffirmative(reply);
     } catch {
       return false;
     }
   };
-  return { call, confirm, bridge, tabId, workflowTarget: workflowTargets };
+
+  // EXPLICIT self-heal — see PanelToolCtx.rebindToActiveTab. Only rebinds when
+  // the current tabId is genuinely orphaned (no live tab reachable); a healthy
+  // session is left untouched so this never hijacks routing on a multi-tab
+  // deployment. Throws (clear message, via resolveActiveTabId) when a single
+  // active tab can't be picked.
+  const rebindToActiveTab = (): { previous: string; current: string; rebound: boolean } => {
+    const previous = ctx.tabId;
+    if (bridge.canReach(previous)) return { previous, current: previous, rebound: false };
+    const current = bridge.resolveActiveTabId(); // throws if no single active tab
+    // Carry a pinned workflow target across to the new tab id so a pinned
+    // session keeps its pin after self-healing.
+    const pinned = workflowTargets?.get(previous);
+    if (workflowTargets && pinned && pinned.mode === "pinned") {
+      workflowTargets.clear(previous);
+      workflowTargets.set(current, pinned);
+    }
+    ctx.tabId = current;
+    return { previous, current, rebound: true };
+  };
+
+  ctx.call = call;
+  ctx.confirm = confirm;
+  ctx.rebindToActiveTab = rebindToActiveTab;
+  return ctx;
 }
 
 /**
@@ -962,8 +1010,22 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .optional()
           .describe("'orchestrator' (default): respawn the agent for new backend code. 'frontend': reload the panel UI for new web code."),
       },
-      async (args: A, ctx) =>
-        ctx.call({ cmd: "soft_reload", scope: (args.scope as string) ?? "orchestrator" }, 15000),
+      async (args: A, ctx) => {
+        // panel_reload is an explicit "recover me now" signal — if THIS session's
+        // tab id was orphaned by a reconnect/reload/workflow-switch, self-heal it
+        // onto the active tab first so a stuck session can recover by calling this
+        // (and so the soft_reload frame actually reaches a live tab). A healthy
+        // session is left untouched; an ambiguous multi-tab case surfaces a clear
+        // error rather than guessing.
+        if (ctx.rebindToActiveTab) {
+          try {
+            ctx.rebindToActiveTab();
+          } catch (err) {
+            return fail(err);
+          }
+        }
+        return ctx.call({ cmd: "soft_reload", scope: (args.scope as string) ?? "orchestrator" }, 15000);
+      },
     ),
     def(
       "panel_list_mcp",
@@ -1441,7 +1503,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_workflow_target",
-      "Pin the agent to a specific open workflow tab, or release the pin to follow the user's current tab. Use pinned when the user asks you to work on workflow A while they browse workflow B — set mode:'pinned' and path from panel_list_workflows. Set mode:'current' (or omit path) to follow the active tab again. Does NOT switch what the user sees; it only routes your panel_* graph edits.",
+      "Pin the agent to a specific open workflow tab, or release the pin to follow the user's current tab. Use pinned when the user asks you to work on workflow A while they browse workflow B — set mode:'pinned' and path from panel_list_workflows. Set mode:'current' (or omit path) to follow the active tab again. Does NOT switch what the user sees; it only routes your panel_* graph edits. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab` after ComfyUI reconnected, the panel reloaded, or the user switched to a different workflow FILE, call this with mode:'current' to rebind this session onto the tab that's live now.",
       {
         mode: z
           .enum(["current", "pinned"])
@@ -1462,13 +1524,29 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         if (mode === "pinned" && !(path ?? "").trim()) {
           return fail("Provide path when pinning — use panel_list_workflows to list open workflows.");
         }
+        // mode:'current' is the explicit, user/agent-initiated "rebind me to the
+        // tab that's live now" consent signal. Self-heal a session whose captured
+        // tab id was orphaned (reconnect/reload/workflow-switch) BEFORE writing the
+        // pin store, so subsequent panel_* calls route to the live tab. Surfaces a
+        // clear error if a single active tab can't be determined.
+        let rebindNote = "";
+        if (mode === "current" && ctx.rebindToActiveTab) {
+          try {
+            const { previous, current, rebound } = ctx.rebindToActiveTab();
+            if (rebound) {
+              rebindNote = ` Rebound this session from tab ${previous.slice(0, 8)} onto the active tab ${current.slice(0, 8)}.`;
+            }
+          } catch (err) {
+            return fail(err);
+          }
+        }
         const target = ctx.workflowTarget.set(ctx.tabId, { mode, path, filename });
         ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);
         const hint =
           target.mode === "pinned"
             ? `Pinned to "${target.filename ?? target.path}". Graph tools will target that workflow without switching the user's view.`
             : "Following the user's current workflow tab.";
-        return ok({ ...target, note: hint });
+        return ok({ ...target, note: hint + rebindNote });
       },
     ),
     def(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -714,6 +714,30 @@ export class UiBridge {
     return this.conns.size > 0;
   }
 
+  /** Would a command bound to this EXACT tabId reach a live tab right now?
+   *  (Exact id, an unambiguous prefix, or a live same-socket migration alias —
+   *  the same acceptance `resolveTarget` uses, but as a boolean and never
+   *  throwing.) The orchestrator uses this to tell an orphaned session from a
+   *  healthy one before deciding whether to self-heal via a rebind. */
+  canReach(tabId: string): boolean {
+    try {
+      this.resolveTarget(tabId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** The id of the tab a NO-tabId command would target right now: the sole
+   *  connection, else the last active tab. Throws the SAME clear errors as the
+   *  no-tabId `send` path when it can't pick a single one (none connected, or
+   *  2+ with no last-active). This is the EXPLICIT resolution the orchestrator
+   *  invokes at a user/agent-initiated rebind moment — it deliberately does NOT
+   *  weaken `resolveTarget`, so multi-tab routing stays conservative. */
+  resolveActiveTabId(): string {
+    return this.resolveTarget().tabId;
+  }
+
   /** True when the tab advertised itself as a canvas-less (mobile/remote) client
    *  in its `hello`. Unknown tabs → false. */
   isHeadless(tabId: string): boolean {


### PR DESCRIPTION
## One root cause, three reported issues

An agent's panel MCP tools all route through a `tabId` captured **once** in a closure when the session is created (`makePanelToolCtx`). Every later `call()` sent that frozen id to `UiBridge.send()` / `resolveTarget()`.

When the panel's browser socket comes back as a **genuinely new socket with a new tab id**, no `tabMigrations` alias is recorded (that map only tracks *same-socket* re-hellos), so the session's frozen `ctx.tabId` is permanently orphaned and every `panel_*` call throws `no connected tab with id "<old-id>"` forever. The three duplicate issues are the same bug from three triggers:

- **#332** — a full ComfyUI reconnect
- **#322** — a frontend reload / `panel_reload({scope:"frontend"})`
- **#331** — switching to a different workflow **file**

`panel_set_workflow_target` previously only wrote the `workflowTargets` routing-metadata map — it never changed the tabId used for bridge routing — so it couldn't recover the session either.

## Approach: fix one layer up, NOT in resolveTarget

`UiBridge.resolveTarget()` is deliberately conservative. A naive "if no match and exactly one tab, use it" fallback there would **regress the security test** at `src/__tests__/services/ui-bridge.test.ts:459` ("a DEAD socket's migration alias never routes to an unrelated tab reusing the id") and the multi-tab / multi-viewer / remote-phone routing guarantees. `resolveTarget` is left untouched.

Instead the fix lives in the orchestrator (`src/orchestrator/panel-tools.ts`):

1. **Mutable tabId** — `makePanelToolCtx` holds `tabId` on the returned `ctx` object; `call()`/`confirm()` and every handler read `ctx.tabId` **live** rather than closing over the string.
2. **`rebindToActiveTab()`** — self-heals **only when** the current tabId no longer reaches a live tab (`bridge.canReach`), so a healthy/multi-tab session is never disturbed. It then re-points onto the active/sole tab via `bridge.resolveActiveTabId()` — the same no-tabId resolution a fresh session uses, invoked **explicitly at the consent moment**, not baked into `resolveTarget`. A pinned workflow target carries across to the new id.
3. **Explicit rebind signals** — `panel_set_workflow_target({mode:"current"})` ("follow the tab I'm looking at now") and `panel_reload` ("recover me now") both trigger the rebind. If a single active tab genuinely can't be determined (0 or 2+ ambiguous), they surface a **clear error** rather than guessing.
4. `UiBridge` gains two public helpers — `canReach(tabId)` (non-throwing) and `resolveActiveTabId()` (the no-tabId resolution, throwing the same clear errors) — both delegating to the untouched `resolveTarget`.

## Tests

- `panel-tools.test.ts`: a dead-session `panel_set_workflow_target({mode:"current"})` and `panel_reload` each rebind onto the live tab and subsequent calls succeed; a healthy multi-tab session is left untouched; an ambiguous dead case surfaces a clear error without changing tabId; a pinned target carries across the rebind.
- `ui-bridge.test.ts`: `canReach`/`resolveActiveTabId` back the reconnect (new socket, no migration) scenario, and `resolveActiveTabId` throws (no guess) on 2+ tabs with no last-active. **The security test at line 459 stays green.**

Test summary (`npm test`): **1936 passed | 1 skipped**, plus 1 **pre-existing, unrelated** failure in `node-dev.test.ts` (asserts the `builtin` search fallback but this machine has ripgrep installed, so it reports `ripgrep`; verified it fails identically on the clean base tree, without any of this PR's changes). `npm run build` (tsc) is clean.

Closes #322
Closes #331
Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)