### PR TITLE
0.48.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.4] - 2026-07-28
+
+### MCP
+
+#### Fixed
+- resolve Windows argv paths host-agnostically (#330)
+- anchor a relative main.py argv[0] to the ComfyUI root (#330)
+- rebind panel session tabId on explicit signal — self-heal after reconnect/reload/workflow-switch (#322, #331, #332)
+- relaunch ComfyUI via resolved Python, not sys.argv[0] script (#330)
+- stop truncating the model list at 150 (#326)
+
+
 ## [0.48.3] - 2026-07-28
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.3",
+  "version": "0.48.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.3",
+      "version": "0.48.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.3",
+  "version": "0.48.4",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release reconcile for v0.48.4 (tag pushed; npm publish fires from the tag). Version bump + changelog for the batch merged this session:

- #329 path-traversal fix (CWE-22) in image/media upload
- #333 OpenRouter model-list cap (#326)
- #334 Windows restart_comfyui spawn EFTYPE (#330), host-agnostic path fix
- #335 panel tabId self-heal (#322, #331, #332)
- #327 third-party-host docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)