### PR TITLE
feat(providers): add MiniMax as a first-class API-key provider

### DIFF
--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -73,6 +73,12 @@ placeholder follows the active backend ("Ask Claude…" / "Ask Ollama…").
   `https://api.moonshot.ai/v1`) — distinct from the **Kimi** provider above,
   which is the Kimi Code coding subscription. Override the model with
   `COMFYUI_MCP_MOONSHOT_MODEL` and the base with `COMFYUI_MCP_MOONSHOT_BASE_URL`.
+- **MiniMax** — set `MINIMAX_API_KEY` from
+  [platform.minimax.io](https://platform.minimax.io). No CLI. The default model
+  is `MiniMax-M3` and the default base is the global endpoint
+  `https://api.minimax.io/v1`. For the China region, set
+  `COMFYUI_MCP_MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. Override the model
+  with `COMFYUI_MCP_MINIMAX_MODEL`.
 - **Copilot (experimental)** — sign in from the panel's experimental provider
   row. Off by default; enable experimental backends in Settings first.
 - **Ollama (local)** — no sign-in. Install Ollama and pull a tool-calling

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -130,6 +130,18 @@ describe("backendReadiness", () => {
     else process.env.MOONSHOT_API_KEY = real;
   });
 
+  it("minimax: ready when MINIMAX_API_KEY is set", () => {
+    const real = process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    expect(backendReadiness("minimax", { home: tmp }).ready).toBe(false);
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    const r = backendReadiness("minimax", { home: tmp });
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+    if (real === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = real;
+  });
+
   it("unknown backend is never ready", () => {
     expect(backendReadiness("bogus").ready).toBe(false);
   });

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -6,6 +6,7 @@ import {
   resolveGlmCodeCredentials,
   resolveKimiCodeOAuth,
   resolveMoonshotCredentials,
+  resolveMiniMaxCredentials,
   resolveOpenAICodexOAuth,
   __testing,
 } from "../../services/code-provider-auth.js";
@@ -51,6 +52,30 @@ describe("resolveMoonshotCredentials", () => {
 
   it("throws when MOONSHOT_API_KEY is not set", () => {
     expect(() => resolveMoonshotCredentials()).toThrow(/MOONSHOT_API_KEY/);
+  });
+});
+
+describe("resolveMiniMaxCredentials", () => {
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.COMFYUI_MCP_MINIMAX_BASE_URL;
+  });
+
+  it("reads MINIMAX_API_KEY and default base URL", () => {
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    const creds = resolveMiniMaxCredentials();
+    expect(creds.apiKey).toBe("minimax-test-key");
+    expect(creds.baseUrl).toBe(__testing.MINIMAX_DEFAULT_BASE);
+  });
+
+  it("honors a base URL override (trailing slash stripped)", () => {
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    process.env.COMFYUI_MCP_MINIMAX_BASE_URL = "https://api.minimaxi.com/v1/";
+    expect(resolveMiniMaxCredentials().baseUrl).toBe("https://api.minimaxi.com/v1");
+  });
+
+  it("throws when MINIMAX_API_KEY is not set", () => {
+    expect(() => resolveMiniMaxCredentials()).toThrow(/MINIMAX_API_KEY/);
   });
 });
 

--- a/src/__tests__/services/panel-secrets-slots.test.ts
+++ b/src/__tests__/services/panel-secrets-slots.test.ts
@@ -62,6 +62,12 @@ describe("panel-secrets credential slots (canonical .env)", () => {
     expect(process.env.MOONSHOT_API_KEY).toBe("sk-moonshot-abc123");
   });
 
+  it("the minimax slot writes MINIMAX_API_KEY", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("minimax", "minimax-abc123");
+    expect(process.env.MINIMAX_API_KEY).toBe("minimax-abc123");
+  });
+
   it("rejects an unknown slot", async () => {
     const m = await import("../../services/panel-secrets.js");
     expect(() => m.setPanelSecret("not-a-slot", "x")).toThrow(/unknown credential slot/i);

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -19,6 +19,7 @@ export type BackendId =
   | "glm"
   | "kimi"
   | "moonshot"
+  | "minimax"
   | "ollama"
   | "openrouter"
   | "copilot";

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2025,11 +2025,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the next probe uses the new key, and re-push readiness + models to every
   // live tab so the OpenRouter provider flips to "ready" and lists its models
   // without a reconnect.
-  const KEYED_PROVIDERS = ["openrouter", "custom", "glm", "kimi", "moonshot"];
+  const KEYED_PROVIDERS = ["openrouter", "custom", "glm", "kimi", "moonshot", "minimax"];
   const unsubscribeAgentSecrets = onAgentSecretsChanged(() => {
     hydrateAgentSecretsIntoEnv();
     // A key change can affect ANY keyed provider (OpenRouter/Custom endpoints and
-    // the hosted API-key backends GLM / Kimi / Moonshot) — drop each one's cached
+    // the hosted API-key backends GLM / Kimi / Moonshot / MiniMax) — drop each one's cached
     // probe backend + model list so the next probe carries the fresh credentials
     // (and a revoked key immediately stops reading as "ready" from a stale cache).
     for (const b of KEYED_PROVIDERS) {

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -21,6 +21,7 @@ const KIMI_OAUTH_TOKEN_URL = "https://api.kimi.com/oauth/token";
 export const GLM_CODE_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4";
 export const KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1";
 export const MOONSHOT_DEFAULT_BASE = "https://api.moonshot.ai/v1";
+export const MINIMAX_DEFAULT_BASE = "https://api.minimax.io/v1";
 
 const TOKEN_REFRESH_SKEW_MS = 120_000;
 
@@ -524,6 +525,22 @@ export function resolveMoonshotCredentials(): MoonshotCredentials {
 }
 
 /**
+ * MiniMax platform API key. Env: MINIMAX_API_KEY. OpenAI-compatible
+ * /v1/chat/completions at the global endpoint (https://api.minimax.io/v1);
+ * set COMFYUI_MCP_MINIMAX_BASE_URL to the China-region endpoint
+ * (https://api.minimaxi.com/v1) or any other OpenAI-compatible host.
+ */
+export function resolveMiniMaxCredentials(): MoonshotCredentials {
+  return resolveKeyedCredentials({
+    envKeys: ["MINIMAX_API_KEY"],
+    missingMessage:
+      "MiniMax requires MINIMAX_API_KEY from platform.minimax.io (https://platform.minimax.io/console/api-keys).",
+    baseUrlEnv: "COMFYUI_MCP_MINIMAX_BASE_URL",
+    defaultBaseUrl: MINIMAX_DEFAULT_BASE,
+  });
+}
+
+/**
  * Resolve credentials for a simple OpenAI-compatible api-key provider by its
  * registry id (see services/openai-provider-registry). This is the one place
  * that marries a `simpleKeyAuth` registry id to its resolver, so the generic
@@ -533,6 +550,7 @@ export function resolveMoonshotCredentials(): MoonshotCredentials {
 export function resolveOpenAiKeyCredentials(id: string): { apiKey: string; baseUrl: string } {
   if (id === "glm") return resolveGlmCodeCredentials();
   if (id === "moonshot") return resolveMoonshotCredentials();
+  if (id === "minimax") return resolveMiniMaxCredentials();
   throw new ValidationError(`No OpenAI api-key credential resolver for provider "${id}".`);
 }
 
@@ -763,6 +781,7 @@ export const __testing = {
   GLM_CODE_DEFAULT_BASE,
   KIMI_CODE_DEFAULT_BASE,
   MOONSHOT_DEFAULT_BASE,
+  MINIMAX_DEFAULT_BASE,
   codexAuthPath,
   kimiCodeAuthPath,
   grokAuthPath,

--- a/src/services/openai-provider-registry.ts
+++ b/src/services/openai-provider-registry.ts
@@ -27,7 +27,7 @@
 // the copy/identity that used to be duplicated.
 
 /** The simple OpenAI-compatible API-key providers, by id. */
-export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot";
+export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot" | "minimax";
 
 export interface OpenAiKeyProvider {
   /** Panel backend id (a member of orchestrator BackendId). */
@@ -113,6 +113,20 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
       `🟢 comfyui-mcp agent ready — ${agentLabel} on your Moonshot platform (Kimi K3) API key. Ask away.`,
     degradedMessage:
       "⚠️ The background agent isn't responding — Moonshot (Kimi K3) couldn't start. Set MOONSHOT_API_KEY from platform.kimi.ai, then Disconnect → Connect to retry.",
+    simpleKeyAuth: true,
+  },
+  {
+    id: "minimax",
+    slotLabel: "MiniMax",
+    slotHelp: "MiniMax M3 via the MiniMax platform API key",
+    envKeys: ["MINIMAX_API_KEY"],
+    modelEnv: "COMFYUI_MCP_MINIMAX_MODEL",
+    defaultModel: process.env.COMFYUI_MCP_MINIMAX_MODEL?.trim() || "MiniMax-M3",
+    ackFallbackLabel: "MiniMax",
+    readyMessage: (agentLabel) =>
+      `🟢 comfyui-mcp agent ready — ${agentLabel} on your MiniMax platform API key. Ask away.`,
+    degradedMessage:
+      "⚠️ The background agent isn't responding — MiniMax couldn't start. Set MINIMAX_API_KEY from platform.minimax.io, then Disconnect → Connect to retry.",
     simpleKeyAuth: true,
   },
 ];


### PR DESCRIPTION
Reason: provider-add — add MiniMax as a first-class API-key provider in the OpenAI-compatible provider registry.

## Changes

- `src/services/openai-provider-registry.ts`: add the `minimax` provider to the
  `OpenAiKeyProviderId` union and the `OPENAI_KEY_PROVIDERS` registry
  (`MINIMAX_API_KEY`, `COMFYUI_MCP_MINIMAX_MODEL`, default model `MiniMax-M3`,
  panel slot label/help, connect-ack ready/degraded messages, `simpleKeyAuth`).
- `src/services/code-provider-auth.ts`: add the `MINIMAX_DEFAULT_BASE`
  constant (`https://api.minimax.io/v1`), a `resolveMiniMaxCredentials()`
  resolver, wire it into `resolveOpenAiKeyCredentials("minimax")`, and export
  the constant from `__testing`. The China-region endpoint
  (`https://api.minimaxi.com/v1`) is reachable via the
  `COMFYUI_MCP_MINIMAX_BASE_URL` override.
- `src/orchestrator/agent-backend.ts`: add `| "minimax"` to the `BackendId`
  union.
- `src/orchestrator/index.ts`: add `"minimax"` to the keyed-providers
  cache-drop list so a key change re-probes with fresh credentials.
- `docs/backends.mdx`: document the MiniMax provider, its default model/base,
  and the China-region base URL override.

Because the simple api-key registry is the single source of truth, adding
`minimax` there also derives the credential slot, the agent-secret allowlist
entry, the `KNOWN_BACKENDS` membership, the `makeBackend` factory wiring, the
connect-ack label/ready/degraded text, and the readiness signal — no further
scattered edits are needed.

## Checks

- `npx tsc --noEmit` — passes.
- `npx vitest run` on the touched suites (`code-provider-auth`,
  `panel-secrets-slots`, `backend-readiness`, `provider-model-hint`) — 47 tests
  pass, including the new `resolveMiniMaxCredentials`, minimax credential-slot,
  and minimax readiness cases.
