### PR TITLE
fix(bridge): graceful message for graph_* commands unknown to old panels (WS-0)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
-import { UiBridge } from "../../services/ui-bridge.js";
+import {
+  UiBridge,
+  makeUnknownCommandError,
+  MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
+} from "../../services/ui-bridge.js";
 
 let bridge: UiBridge;
 let port: number;
@@ -870,5 +874,55 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await settle();
     const msg = seen.find((e) => e.type === "user_message" && e.text === "after-close");
     expect(msg?.tab_id).toBe("phone-c"); // reverted to own tab, not routed into the dead id
+  });
+});
+
+describe("makeUnknownCommandError (old-panel version gate)", () => {
+  it("rewrites an Unknown command reply into an actionable update message", () => {
+    const e = makeUnknownCommandError('Unknown command "graph_query"');
+    expect(e).not.toBeNull();
+    expect(e?.message).toContain("graph_query");
+    expect(e?.message).toContain(MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS);
+    expect(e?.message.toLowerCase()).toContain("update");
+    expect(e?.message.toLowerCase()).toContain("reconnect");
+    // The opaque raw internal error must not leak through.
+    expect(e?.message).not.toBe('Unknown command "graph_query"');
+  });
+
+  it("includes the detected panel version when known", () => {
+    const e = makeUnknownCommandError('Unknown command "ui_render"', "0.6.8");
+    expect(e?.message).toContain("0.6.8");
+  });
+
+  it("passes through a genuine command error (returns null)", () => {
+    expect(makeUnknownCommandError("node 5 not found")).toBeNull();
+    expect(makeUnknownCommandError("panel reported an error")).toBeNull();
+  });
+
+  it("tolerates smart quotes and varied casing", () => {
+    expect(makeUnknownCommandError("unknown command “graph_serialize”")?.message).toContain(
+      "graph_serialize",
+    );
+  });
+});
+
+describe("UiBridge.send (graceful gate end-to-end)", () => {
+  it("surfaces an actionable message (with panel version) when an old panel rejects a bridge command", async () => {
+    const sock = await connectPanel(undefined);
+    // Old panel: advertises its version, then rejects unknown bridge commands.
+    sock.send(JSON.stringify({ type: "hello", tab_id: "old-tab", title: "wf", panel_version: "0.6.8" }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        sock.send(
+          JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }),
+        );
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab" })).rejects.toThrow(
+      /too old for "graph_query".*0\.6\.8.*update/is,
+    );
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -899,6 +899,14 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
     expect(makeUnknownCommandError("panel reported an error")).toBeNull();
   });
 
+  it("does NOT rewrite an error that merely quotes the phrase mid-message (anchored)", () => {
+    // A genuine command failure whose text happens to embed the phrase must pass
+    // through untouched — only the panel dispatcher's own leading reply matches.
+    expect(
+      makeUnknownCommandError('graph_run failed: node emitted Unknown command "foo" to stdout'),
+    ).toBeNull();
+  });
+
   it("tolerates smart quotes and varied casing", () => {
     expect(makeUnknownCommandError("unknown command “graph_serialize”")?.message).toContain(
       "graph_serialize",

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -93,8 +93,11 @@ export function makeUnknownCommandError(
   panelVersion?: string,
 ): Error | null {
   // Match the panel's exact shape: `Unknown command "graph_query"` (quotes
-  // optional/variable). Case-insensitive, tolerant of straight or smart quotes.
-  const m = /unknown command\s*["“']?([\w.-]+)["”']?/i.exec(error);
+  // optional/variable). ANCHORED at the start of the (trimmed) message so an
+  // unrelated error that merely QUOTES an unknown-command phrase somewhere in its
+  // text is never rewritten — only the panel dispatcher's own reply, which is
+  // exactly this string. Case-insensitive, tolerant of straight or smart quotes.
+  const m = /^unknown command\s*["“']?([\w.-]+)["”']?/i.exec(error.trim());
   if (!m) return null;
   const cmd = m[1];
   const detected = panelVersion ? ` (detected ${panelVersion})` : "";

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -68,6 +68,40 @@ interface Conn {
   /** Canvas-less client (mobile/remote pseudo-panel) — advertised in `hello`.
    *  Lets tools resolve media to inline bytes instead of a browser /view ref. */
   headless: boolean;
+  /** The sidebar panel's advertised version (`panel_version` in its `hello`), if
+   *  sent. Used to make an "Unknown command" reply from an OLD panel actionable
+   *  (see makeUnknownCommandError) — the panel gained these bridge commands in
+   *  0.11.4, so older builds reject graph_* / ui_* with a raw dispatch error. */
+  panelVersion?: string;
+}
+
+/** Panel build that first implements the full graph_* / ui_* bridge command set.
+ *  Reports of "Unknown command <x>" come from panels older than this. */
+export const MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS = "0.11.4";
+
+/**
+ * A panel replies `{ ok: false, error: 'Unknown command "<cmd>"' }` when the
+ * orchestrator dispatches a bridge command the (older) panel doesn't register —
+ * graph_query, ui_render, graph_serialize, graph_view_nodes_in_viewport, etc. all
+ * shipped in the panel at 0.11.4. Detect that raw dispatch error and rewrite it
+ * into an actionable "update your panel" message instead of surfacing the opaque
+ * internal command name to the agent/user. Returns null when `error` is anything
+ * else (a genuine command failure), so the happy/normal-error path is untouched.
+ */
+export function makeUnknownCommandError(
+  error: string,
+  panelVersion?: string,
+): Error | null {
+  // Match the panel's exact shape: `Unknown command "graph_query"` (quotes
+  // optional/variable). Case-insensitive, tolerant of straight or smart quotes.
+  const m = /unknown command\s*["“']?([\w.-]+)["”']?/i.exec(error);
+  if (!m) return null;
+  const cmd = m[1];
+  const detected = panelVersion ? ` (detected ${panelVersion})` : "";
+  return new Error(
+    `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
+      `to ≥${MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`,
+  );
 }
 
 export interface BridgeCommand {
@@ -539,6 +573,10 @@ export class UiBridge {
           title: typeof msg.title === "string" && msg.title ? msg.title : "untitled",
           connectedAt: existing?.connectedAt ?? new Date().toISOString(),
           headless: incomingHeadless,
+          panelVersion:
+            typeof (msg as { panel_version?: unknown }).panel_version === "string"
+              ? ((msg as { panel_version?: string }).panel_version || undefined)
+              : existing?.panelVersion,
         });
         if (incomingHeadless) this.headlessSeen.add(tabId);
         this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
@@ -883,6 +921,14 @@ export class UiBridge {
     }
     const rid = randomUUID();
     return new Promise((resolve, reject) => {
+      // Rewrite an old-panel "Unknown command" rejection into an actionable
+      // update-your-panel message (see makeUnknownCommandError). Applied to the
+      // reply-error path only; the happy path and genuine command errors are
+      // passed through untouched.
+      const rejectMapped = (err: Error) => {
+        const friendly = makeUnknownCommandError(err.message, conn.panelVersion);
+        reject(friendly ?? err);
+      };
       const timer = setTimeout(() => {
         this.pending.delete(rid);
         reject(
@@ -891,7 +937,12 @@ export class UiBridge {
           ),
         );
       }, timeoutMs);
-      const pending: Pending & { sock?: BridgeSocket } = { resolve, reject, timer, sock: conn.sock };
+      const pending: Pending & { sock?: BridgeSocket } = {
+        resolve,
+        reject: rejectMapped,
+        timer,
+        sock: conn.sock,
+      };
       this.pending.set(rid, pending);
       try {
         conn.sock.send(JSON.stringify({ rid, ...cmd }));


### PR DESCRIPTION
## Summary

When the orchestrator dispatches a `graph_*` / `ui_*` bridge command that an older panel doesn't register, the panel replies `Unknown command "<cmd>"` and the agent surfaced that opaque internal dispatch error. This adds a graceful version-gate: `UiBridge.send` now detects the "Unknown command" reply and rewrites it into an actionable message — the panel is too old for `<cmd>`, update the ComfyUI-MCP panel to ≥0.11.4 (ComfyUI Manager → update comfyui-mcp panel), then reconnect. The detected panel version (learned from the hello's `panel_version`) is included when known.

The happy path and genuine command errors are untouched (`makeUnknownCommandError` returns null for anything that isn't an unknown-command reply).

All these commands (`graph_query`, `ui_render`, `graph_serialize`, `graph_view_nodes_in_viewport`, …) already ship in the current panel (0.11.4). The reports were all from old panels (0.6.8 / ≤0.11.0), so they're already functionally fixed for anyone on a current panel — this change just replaces the confusing raw error with an update prompt for anyone still on an old panel.

## Changes
- `src/services/ui-bridge.ts`: `makeUnknownCommandError` helper + `MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS` const; capture `panel_version` on the connection from hello; remap the reply-error path in `send()`.
- `src/__tests__/services/ui-bridge.test.ts`: unit tests for the helper (rewrite, version inclusion, pass-through, smart-quotes) + an end-to-end `send()` gate test.

## Closed issues (all the unknown-command class)
- mcp: #350, #344
- panel: #161, #162, #167, #172, #191

Not included: mcp #351 is a **different** bug (panel_connect "No compatible output→input pair found" on a union-type resolver in a large graph) — left open.

## CHANGELOG
`fix: graceful version-gate for unknown panel commands (closes #350,#344,#161,#162,#167,#172,#191) [reports from old panels ≤0.11.0; commands shipped in current panel]`

## Testing
- `npm run build` — exit 0
- `npm test` — 1944 passed; the single failure (`node-dev.test.ts` search-node-packs builtin engine) is pre-existing and environmental (verified by stashing this branch's changes — it still fails), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
