### PR TITLE
fix(orchestrator): correct workflow-tab targeting to prevent cross-tab writes (WS-1)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -559,10 +559,7 @@ describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-swit
     const { bridge, sent } = fakeBridge(new Set(["new-live-tab"]));
     const ctx = makePanelToolCtx(bridge, "dead-old-tab", store);
 
-    // Before rebind, a graph call to the dead tab fails.
-    const before = await defByName("panel_graph_outline").handler({}, ctx);
-    expect(before.isError).toBe(true);
-
+    // Explicit rebind (no prior graph call, so auto-heal hasn't fired yet).
     const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
     expect(res.isError).toBeUndefined();
     expect(ctx.tabId).toBe("new-live-tab");
@@ -573,6 +570,66 @@ describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-swit
     const after = await defByName("panel_graph_outline").handler({}, ctx);
     expect(after.isError).toBeUndefined();
     expect(sent.at(-1)?.tabId).toBe("new-live-tab");
+  });
+
+  // ---- Auto-heal: an orphaned current-mode session self-recovers on the next
+  // panel_* call, WITHOUT an explicit panel_set_workflow_target (#372/#178/#170/
+  // #165/#166/#195). Conservative: only when the current tab is unreachable AND a
+  // single active tab is unambiguous; healthy and pinned sessions stay strict.
+  it("auto-heals a DEAD current-mode session onto the sole live tab on the next call", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = fakeBridge(new Set(["reconnected-tab"]));
+    const ctx = makePanelToolCtx(bridge, "stale-tmp-tab", store);
+
+    // No explicit rebind — a plain graph call recovers on its own.
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(ctx.tabId).toBe("reconnected-tab");
+    expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+  });
+
+  it("does NOT auto-heal a HEALTHY session (no hijack of a live multi-tab deployment)", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = fakeBridge(new Set(["my-tab", "other-tab"]));
+    const ctx = makePanelToolCtx(bridge, "my-tab", store);
+
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(ctx.tabId).toBe("my-tab");
+    expect(sent.at(-1)?.tabId).toBe("my-tab");
+  });
+
+  it("does NOT auto-heal a PINNED session — it keeps requiring explicit rebind", async () => {
+    const store = new WorkflowTargetStore();
+    store.set("dead-pinned-tab", { mode: "pinned", path: "workflows/keep.json" });
+    const { bridge } = fakeBridge(new Set(["some-live-tab"]));
+    const ctx = makePanelToolCtx(bridge, "dead-pinned-tab", store);
+
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    // Pinned + dead tab: no silent rebind, so the call surfaces the clear error.
+    expect(res.isError).toBe(true);
+    expect(ctx.tabId).toBe("dead-pinned-tab");
+  });
+
+  it("does NOT auto-heal into an AMBIGUOUS multi-tab set (dead tab, 2+ live, no last-active)", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge } = fakeBridge(new Set(["a", "b"]));
+    const ctx = makePanelToolCtx(bridge, "dead-tab", store);
+
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBe(true); // bridge's own "no connected tab" error
+    expect(ctx.tabId).toBe("dead-tab"); // never silently hijacked
+  });
+
+  it("auto-heals the direct-send adult-consent path (#372)", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = fakeBridge(new Set(["live-again-tab"]));
+    const ctx = makePanelToolCtx(bridge, "orphaned-tab", store);
+
+    await defByName("panel_request_adult_consent").handler({}, ctx);
+    expect(ctx.tabId).toBe("live-again-tab");
+    // The ask_user consent card went to the healed tab, not the dead one.
+    expect(sent.at(-1)?.tabId).toBe("live-again-tab");
   });
 
   it("panel_reload rebinds a DEAD session onto the sole live tab, then forwards soft_reload there", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -300,6 +300,17 @@ export interface PanelToolCtx {
    * determined. Optional so lightweight test contexts can omit it.
    */
   rebindToActiveTab?: () => { previous: string; current: string; rebound: boolean };
+  /**
+   * Best-effort in-place self-heal for the handful of tools that call the bridge
+   * DIRECTLY (not via `ctx.call`) — e.g. panel_request_adult_consent's ask_user
+   * (#372) and the live-canvas graph_serialize. Silently rebinds an orphaned,
+   * current-mode session onto the sole active tab (identical conservative guard
+   * to rebindToActiveTab: only when the current tab is unreachable AND a single
+   * active tab is unambiguous; pinned sessions untouched). Never throws. `call`
+   * and `confirm` already invoke it internally, so most handlers need not. Optional
+   * so lightweight test contexts can omit it.
+   */
+  ensureReachable?: () => void;
 }
 
 /** Build a tab-bound execution context shared by both transports. */
@@ -317,8 +328,44 @@ export function makePanelToolCtx(
     workflowTarget: workflowTargets,
   } as PanelToolCtx;
 
+  // AUTO-HEAL an orphaned session in place. When THIS session's captured tabId no
+  // longer reaches a live tab (a full ComfyUI restart/reconnect #178/#170, a
+  // frontend reload #322, or a switch to a different workflow FILE #331/#372
+  // surfaces a NEW socket under a NEW tab id with no migration alias), silently
+  // rebind onto the sole active tab BEFORE the command is sent — so a session that
+  // was merely orphaned by a reconnect recovers on its own instead of throwing
+  // `no connected tab` on every call and forcing the agent to hand-call
+  // panel_set_workflow_target({mode:"current"}).
+  //
+  // CONSERVATIVE by construction (must not weaken multi-tab routing):
+  //  - fires ONLY when the current tab is genuinely unreachable (canReach false);
+  //    a healthy session — including a healthy MULTI-tab one — is never touched;
+  //  - uses the SAME resolveActiveTabId the explicit rebind uses, which THROWS on
+  //    ambiguity (2+ live tabs, no last-active) and when nothing is connected, so
+  //    an orphaned session is never silently hijacked onto an arbitrary tab —
+  //    the throw is swallowed and the command falls through to the bridge's clear
+  //    `no connected tab` / `Multiple panel tabs` error;
+  //  - PINNED sessions are left strict: a session pinned to a specific workflow
+  //    keeps requiring the explicit rebind consent signal. Only "current"-mode
+  //    (follow-the-active-tab) sessions self-heal, which is faithful to what that
+  //    mode already means.
+  // It routes through makePanelToolCtx only — bridge.resolveTarget itself is
+  // untouched, so the dead-alias security invariant (ui-bridge.test.ts:459) holds.
+  const ensureReachable = (): void => {
+    if (typeof bridge.canReach !== "function") return; // lightweight test ctx
+    if (bridge.canReach(ctx.tabId)) return;
+    if (workflowTargets?.get(ctx.tabId)?.mode === "pinned") return; // stay strict
+    try {
+      rebindToActiveTab();
+    } catch {
+      // Ambiguous (2+ tabs) or nothing connected — leave tabId as-is and let the
+      // command surface the bridge's own clear, tab-listing error.
+    }
+  };
+
   const call = async (cmd: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> => {
     try {
+      ensureReachable();
       const target = workflowTargets?.get(ctx.tabId);
       const routed = target ? withWorkflowTarget(cmd, target) : cmd;
       return ok(await bridge.send(routed as { cmd: string }, { tabId: ctx.tabId, timeoutMs }));
@@ -334,6 +381,7 @@ export function makePanelToolCtx(
   // approvalPolicy "never", so the same in-tool gate is the only safeguard.)
   const confirm = async (question: string, header: string): Promise<boolean> => {
     try {
+      ensureReachable();
       const reply = await bridge.send(
         {
           cmd: "ask_user",
@@ -375,6 +423,7 @@ export function makePanelToolCtx(
   ctx.call = call;
   ctx.confirm = confirm;
   ctx.rebindToActiveTab = rebindToActiveTab;
+  ctx.ensureReachable = ensureReachable;
   return ctx;
 }
 
@@ -398,6 +447,7 @@ async function resolveWorkflowInput(
   }
   let reply: unknown;
   try {
+    ctx.ensureReachable?.();
     reply = await ctx.bridge.send({ cmd: "graph_serialize" } as { cmd: string }, {
       tabId: ctx.tabId,
       timeoutMs: 30000,
@@ -1196,6 +1246,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             "Adult-content gate — to enable NSFW work in this session, please confirm BOTH that you are at least 18 years old AND that creating/viewing adult content is legal in your country/region." +
             (args.reason ? `\n\nContext: ${args.reason}` : "") +
             "\n\nThis is recorded as your consent and can be turned off anytime.";
+          // #372: the consent card goes over the bridge DIRECTLY (not ctx.call), so
+          // self-heal an orphaned current-mode session first — otherwise a session
+          // that lost its live binding (reconnect/reload/workflow-switch) throws a
+          // false `no connected tab` here even though graph tools just worked.
+          ctx.ensureReachable?.();
           const reply = await ctx.bridge.send(
             {
               cmd: "ask_user",


### PR DESCRIPTION
## Root cause

A panel agent session freezes the tab id captured at creation. A full ComfyUI
restart/reconnect, a frontend reload, or a switch to a different workflow **file**
makes the live panel re-hello under a brand-new socket + tab id with **no
migration alias**, orphaning the session. Every `panel_*` call then throws
`no connected tab with id "…". Connected: …`, and the only recovery was for the
agent to hand-call `panel_set_workflow_target({mode:"current"})`.

The explicit self-heal (`rebindToActiveTab`, shipped in #322/#335) already knew how
to recover conservatively — it was just never invoked automatically.

## Fix

`makePanelToolCtx` now auto-heals in place before each command via a new
`ensureReachable()`:

- fires **only** when `bridge.canReach(ctx.tabId)` is false (genuinely orphaned);
- rebinds onto the sole active tab using the same `resolveActiveTabId`, which
  **throws on ambiguity** (2+ live tabs, no last-active) and when nothing is
  connected — so a session is never silently hijacked onto an arbitrary tab;
- leaves **healthy** sessions (incl. multi-tab) and **pinned** sessions untouched
  (pinned keeps the explicit-consent rebind).

Wired into `ctx.call`, `ctx.confirm`, and the two direct-`bridge.send` paths that
bypassed `call` — `panel_request_adult_consent`'s `ask_user` (#372) and the
live-canvas `graph_serialize`.

It routes through the ctx only; **`bridge.resolveTarget` is untouched**, so the
dead-socket alias security invariant (`ui-bridge.test.ts:459`) is preserved and
green.

## Tests

New `panel-tools.test.ts` cases: auto-heal of a dead current-mode session, no
disturbance of a healthy session, no auto-heal of a pinned session, no hijack into
an ambiguous multi-tab set, and the direct-send adult-consent path. Full suite
green except one pre-existing, unrelated `node-dev.test.ts` failure (fails on a
clean tree too).

`npm run build` + `npm test` (incl. ui-bridge.test.ts:459) pass.

fix: auto-heal orphaned workflow-tab binding (closes #372,#178,#170,#165,#166,#195) [reports ≤mcp 0.48.5 / panel 0.11.4]

The panel-side data-corruption cluster (#349,#348,#197,#198) is fixed in the
companion comfyui-mcp-panel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
