### PR TITLE
Correct the Comfy-Org agent-tooling claims (README + 3 docs pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Claude will find (or download) a checkpoint, build a workflow, execute it, and r
 
 **More than a bridge.** Most ComfyUI MCP servers are thin connectors — they forward a prompt and hand back an image. `comfyui-mcp` is a full control plane: it authors and edits the graph node-by-node, runs and iterates on workflows, manages models and custom nodes, and ships model-specific expertise (samplers, CFG, resolutions, curated model URLs) so the agent gets it right without trial and error. If you want a minimal local relay, a lightweight server is fine; if you want an agent that actually *operates* ComfyUI, that's this project.
 
-For **Comfy Cloud** users, [Comfy-Org ships an official Comfy Cloud MCP](https://docs.comfy.org/development/cloud/mcp-server) (currently invite-only beta) which is cloud-exclusive and maintained by the Comfy team. `comfyui-mcp` *also* includes a community cloud-mode (set `COMFYUI_API_KEY` — see [Deployment modes](#deployment-modes)) so a single MCP can target all three deployment shapes from one config; pick whichever fits your workflow.
+For **Comfy Cloud** users, Comfy-Org ships its own [agent tooling](https://docs.comfy.org/agent-tools): **Comfy Cloud MCP** (public beta, hosted on Comfy Cloud GPUs), the **Comfy In-App Agent** (private alpha, inside Comfy Cloud), and a first-party **Comfy Local MCP** (private test, not publicly available yet) — all maintained by the Comfy team. If you don't have a GPU or you want zero setup, that's the better path; go use it.
+
+Where this project differs is that it runs on **your** install and **your** choice of model — including a free local one via Ollama with no account and no network at all. `comfyui-mcp` *also* includes a community cloud-mode (set `COMFYUI_API_KEY` — see [Deployment modes](#deployment-modes)) so a single MCP can target all three deployment shapes from one config.
+
+📊 **[Local vs. Comfy Cloud agent](https://comfyui-mcp.artokun.io/docs/local-vs-comfy-cloud)** — an honest side-by-side, including when Comfy Cloud is the right answer. *(Statuses above are as of July 2026; Comfy-Org ships fast — check their docs for the current state.)*
 
 ### Remote / hosted connector (one command)
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -100,7 +100,7 @@ error. Architecture and `cloud-client` dispatcher originally contributed by
 [@picoSols](https://github.com/picoSols).
 
 <Note>
-  **Comfy-Org ships an [official Comfy Cloud MCP](https://docs.comfy.org/development/cloud/mcp-server)** (currently invite-only beta) which is cloud-exclusive and maintained by the Comfy team. If you only target Comfy Cloud, that's likely the right choice when it goes GA. `comfyui-mcp`'s cloud-mode below is best when you want a single MCP across local / remote / cloud, or you need it today (it's MIT and shipping now).
+  **Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools)** — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha), both maintained by the Comfy team and both running on Comfy Cloud. If you only target Comfy Cloud, that's likely the right choice; see [Local vs. Comfy Cloud](/local-vs-comfy-cloud). `comfyui-mcp`'s cloud-mode below is best when you want a single MCP across local / remote / cloud, or you need it today (it's MIT and shipping now).
 </Note>
 
 <ParamField path="COMFYUI_API_KEY" type="string">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -65,7 +65,7 @@ ComfyUI for you.
 `comfyui-mcp` is the community MCP for **local** and **remote** ComfyUI — that's the primary
 target (Mac/Linux/Windows installs, RunPod, VPS, LAN, etc.).
 
-For **Comfy Cloud** users, Comfy-Org ships an [official Comfy Cloud MCP](https://docs.comfy.org/development/cloud/mcp-server) (currently invite-only beta), cloud-exclusive and maintained by the Comfy team. `comfyui-mcp` also includes a community cloud-mode (`COMFYUI_API_KEY`), so a single MCP can target all three deployment shapes from one config — pick whichever fits your workflow.
+For **Comfy Cloud** users, Comfy-Org ships [official agent tooling](https://docs.comfy.org/agent-tools) — Comfy Cloud MCP (public beta) and the Comfy In-App Agent (private alpha) — maintained by the Comfy team and running on Comfy Cloud. If you have no GPU or want zero setup, use that ([side-by-side](/local-vs-comfy-cloud)). `comfyui-mcp` also includes a community cloud-mode (`COMFYUI_API_KEY`), so a single MCP can target all three deployment shapes from one config — pick whichever fits your workflow.
 
 ---
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -84,7 +84,7 @@ ComfyUI MCP ships on npm as `comfyui-mcp` and runs via `npx` — no global insta
       for the full feature-parity matrix.
     </Note>
     <Note>
-      **Cloud-only?** [Comfy-Org's official Comfy Cloud MCP](https://docs.comfy.org/development/cloud/mcp-server) (invite-only beta) is the canonical choice when it goes GA. Use `comfyui-mcp`'s cloud-mode if you want a single MCP across local / remote / cloud, or you need cloud support today.
+      **Cloud-only?** [Comfy-Org's Comfy Cloud MCP](https://docs.comfy.org/agent-tools) (public beta) is the canonical choice — see [Local vs. Comfy Cloud](/local-vs-comfy-cloud). Use `comfyui-mcp`'s cloud-mode if you want a single MCP across local / remote / cloud, or you need cloud support today.
     </Note>
   </Tab>
 </Tabs>


### PR DESCRIPTION
Follow-up to #387. Four places described Comfy Cloud MCP as **"invite-only beta"** linking `docs.comfy.org/development/cloud/mcp-server`.

Both are wrong now:
- it's in **public beta**, not invite-only
- that URL **308-redirects**; `docs.comfy.org/agent-tools` is canonical (verified 200)
- and it described *one* product where Comfy-Org ships **three**: Cloud MCP (public beta), In-App Agent (private alpha), Local MCP (private test)

Accuracy about a competitor is the entire foundation of the comparison page added in #387 — leaving four other places stale about them undercuts it. Each spot now links that page, which also gives it the internal links it needs to rank.

The README passage additionally does the thing the comparison page does: says plainly that if you have no GPU or want zero setup, **go use Comfy Cloud**.

Files: `README.md`, `docs/configuration.mdx`, `docs/index.mdx`, `docs/installation.mdx`.

Verified: all `/local-vs-comfy-cloud` links resolve, both external URLs 200, no encoding artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)