### PR TITLE
hotfix(orchestrator): stop set_config heartbeat feedback loop (provider snaps back to Claude)

### DIFF
--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2698,26 +2698,38 @@ export async function runPanelOrchestrator(): Promise<void> {
       let ollamaChanged = false;
       if (Array.isArray(cfg.preferred_models)) {
         const ids = cfg.preferred_models.filter((m): m is string => typeof m === "string");
-        setAgentSettings({ preferredModels: ids });
-        ollamaChanged = true;
-        logger.info(`[panel-orchestrator] preferred models → [${ids.join(", ")}]`);
+        // The panel re-sends set_config on EVERY heartbeat. Only apply + re-push on
+        // an ACTUAL change — otherwise re-pushing models makes the panel re-send,
+        // which re-pushes… a tight ~150/s feedback loop that wedges the orchestrator
+        // (a multi-provider user hit exactly this). Mirror the stall_seconds guard.
+        const prevIds = getAgentSettings().preferredModels ?? [];
+        if (ids.length !== prevIds.length || ids.some((v, i) => v !== prevIds[i])) {
+          setAgentSettings({ preferredModels: ids });
+          ollamaChanged = true;
+          logger.info(`[panel-orchestrator] preferred models → [${ids.join(", ")}]`);
+        }
       }
       if (cfg.ollama && typeof cfg.ollama === "object") {
         const o = cfg.ollama as { model?: unknown; api?: unknown; base_url?: unknown };
         const patch: { model?: string; api?: "ollama" | "openai"; baseUrl?: string } = {};
+        // Only count a field as changed when it's env-unset AND the value actually
+        // differs from the current one — so a repeated identical heartbeat config is
+        // a no-op (no re-push, no loop). An env override wins and never "changes".
+        let changed = false;
         if (typeof o.model === "string" && o.model.trim()) {
           patch.model = o.model.trim();
-          if (!process.env.COMFYUI_MCP_OLLAMA_MODEL) ollamaModel = patch.model;
+          if (!process.env.COMFYUI_MCP_OLLAMA_MODEL && patch.model !== ollamaModel) { changed = true; ollamaModel = patch.model; }
         }
         if (o.api === "openai" || o.api === "ollama") {
           patch.api = o.api;
-          if (!process.env.COMFYUI_MCP_OLLAMA_API) ollamaApi = o.api;
+          if (!process.env.COMFYUI_MCP_OLLAMA_API && o.api !== ollamaApi) { changed = true; ollamaApi = o.api; }
         }
         if (typeof o.base_url === "string") {
           patch.baseUrl = o.base_url.trim();
-          if (!process.env.COMFYUI_MCP_OLLAMA_BASE_URL) ollamaBaseUrl = patch.baseUrl || undefined;
+          const nb = patch.baseUrl || undefined;
+          if (!process.env.COMFYUI_MCP_OLLAMA_BASE_URL && nb !== ollamaBaseUrl) { changed = true; ollamaBaseUrl = nb; }
         }
-        if (Object.keys(patch).length) {
+        if (Object.keys(patch).length && changed) {
           setAgentSettings({ ollama: patch });
           ollamaChanged = true;
           // Endpoint may have moved — drop the cached probe backend so the next
@@ -2763,15 +2775,19 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (cucfg && typeof cucfg === "object") {
         const o = cucfg as { model?: unknown; base_url?: unknown };
         const patch: { model?: string; baseUrl?: string } = {};
+        // Change-guard (see preferred_models above): pushReadiness on every heartbeat
+        // config is what drives the panel↔orchestrator feedback loop, so only fire on
+        // an actual change; an env override wins and never counts as changed.
+        let changed = false;
         if (typeof o.model === "string" && o.model.trim()) {
           patch.model = o.model.trim();
-          if (!process.env.COMFYUI_MCP_CUSTOM_MODEL) customModel = patch.model;
+          if (!process.env.COMFYUI_MCP_CUSTOM_MODEL && patch.model !== customModel) { changed = true; customModel = patch.model; }
         }
         if (typeof o.base_url === "string") {
           patch.baseUrl = o.base_url.trim().replace(/[/]$/, "");
-          if (!process.env.COMFYUI_MCP_CUSTOM_BASE_URL) customBaseUrl = patch.baseUrl;
+          if (!process.env.COMFYUI_MCP_CUSTOM_BASE_URL && patch.baseUrl !== customBaseUrl) { changed = true; customBaseUrl = patch.baseUrl; }
         }
-        if (Object.keys(patch).length) {
+        if (Object.keys(patch).length && changed) {
           setAgentSettings({ custom: patch });
           const pb = probeBackends.get("custom");
           if (pb?.close) void pb.close().catch(() => {});


### PR DESCRIPTION
## Live bug (via-panel, user superdrew907)
Selecting any provider snapped back to Claude, ComfyUI read `unknown`, terminal spammed. The attached log showed three config lines repeating every ~7ms — a tight feedback loop.

## Root cause
The panel re-sends `set_config` on every heartbeat. The `stall_seconds` branch guards on actual-change, but the **preferred_models / ollama / custom-endpoint** branches did not — they re-applied and re-pushed (`pushModels` / `pushReadiness`) on **every** `set_config`. A push made the panel re-send its config → re-push → ~150/s loop that wedged the orchestrator so the selected provider couldn't stay active. Triggered by a multi-provider config (Ollama gemma4 + a custom endpoint on :10531).

## Fix
Those three branches now apply + re-push **only on an actual value change** (env overrides win, never count as changed), mirroring the existing `stall_seconds` guard. An identical repeated heartbeat config is now a no-op.

## Verification
Build clean; full suite 1966 pass / 1 skip / 1 pre-existing unrelated `node-dev` env failure. Will live-verify on the rig (restart → confirm the config log no longer loops). No lightweight harness exists for the orchestrator `set_config` path; the change mirrors the tested `stall_seconds` guard.

Note: `llamacpp` / `lmstudio` branches have the same latent no-guard churn (cache-evict + log every heartbeat) but do NOT push, so they don't drive the loop — flagged as a small follow-up.

Closes the superdrew907 via-panel report. [reports ≤mcp 0.48.5 / panel 0.11.4]

🤖 Generated with [Claude Code](https://claude.com/claude-code)