### PR TITLE
0.48.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.6] - 2026-07-29
+
+### MCP
+
+#### Fixed
+- change-guard set_config to stop a heartbeat feedback loop (#393)
+- surface filter/upstream failures instead of empty results (WS-6) (#381)
+- resolve live ComfyUI base dir for relaunch/model-dirs/extra-paths (WS-2) (#383)
+- auto-heal orphaned workflow-tab binding to prevent cross-tab writes (WS-1) (#382)
+- graceful message for graph_* commands unknown to old panels (WS-0) (#380)
+
+
 ## [0.48.5] - 2026-07-28
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.5",
+  "version": "0.48.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.5",
+      "version": "0.48.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.5",
+  "version": "0.48.6",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release reconcile for v0.48.6 (tag pushed; npm publish fires from the tag).

Bundles: Wave-1 via-panel fixes (WS-0 #380, WS-1 #382, WS-2 #383, WS-6 #381), the set_config heartbeat-loop hotfix (#393), and the SEO/docs work (#387, #389).

🤖 Generated with [Claude Code](https://claude.com/claude-code)