### PR TITLE
fix(chat): serialize structured backend/user/canvas payloads instead of [object Object] (WS-9)

### DIFF
--- a/src/__tests__/orchestrator/inject-error-serialization.test.ts
+++ b/src/__tests__/orchestrator/inject-error-serialization.test.ts
@@ -1,0 +1,96 @@
+// Regression for panel #176: a STRUCTURED backend/ComfyUI failure object pushed
+// into a tab's agent must reach the model as readable text, never the literal
+// "[object Object]". Both injection paths are covered: injectRunError (urgent,
+// front-queued) and injectEvent({kind:"run_error"}) (normal enqueue).
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** Records every user-turn text the panel feeds it; ends each turn immediately. */
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  private resolveNext: (() => void) | null = null;
+
+  /** Resolve once at least `n` turns have been read. */
+  waitTurns(n: number, timeoutMs = 2000): Promise<void> {
+    if (this.turns.length >= n) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`only ${this.turns.length} turns read`)), timeoutMs);
+      this.resolveNext = () => {
+        if (this.turns.length >= n) {
+          clearTimeout(timer);
+          resolve();
+        }
+      };
+    });
+  }
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-rec" };
+    for await (const turn of opts.channel) {
+      this.turns.push(turn.text);
+      this.resolveNext?.();
+      yield { type: "assistant", text: "ok" };
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeDeps() {
+  return {
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+  };
+}
+
+describe("[object Object] never appears — structured failures serialize to readable text (#176)", () => {
+  it("injectRunError serializes a structured error object", async () => {
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-inj1", makeDeps() as never, backend);
+    void agent.start();
+
+    // The #176 shape: a structured failure carrying a readable `message` field.
+    await agent.injectRunError({ message: "Individual quota reached.", code: 429 });
+    await backend.waitTurns(1);
+
+    expect(backend.turns[0]).not.toContain("[object Object]");
+    expect(backend.turns[0]).toContain("Individual quota reached.");
+
+    await agent.stop();
+  });
+
+  it("injectEvent run_error serializes an object with no string field via JSON", async () => {
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-inj2", makeDeps() as never, backend);
+    void agent.start();
+
+    agent.injectEvent({ kind: "run_error", error: { node: "KSampler", status: 500 } });
+    await backend.waitTurns(1);
+
+    expect(backend.turns[0]).not.toContain("[object Object]");
+    expect(backend.turns[0]).toContain("KSampler");
+
+    await agent.stop();
+  });
+});

--- a/src/__tests__/utils/to-readable-text.test.ts
+++ b/src/__tests__/utils/to-readable-text.test.ts
@@ -1,0 +1,48 @@
+// Regression: structured payloads (backend failures, ComfyUI execution errors,
+// panel parts) must NEVER render as the literal string "[object Object]" when
+// they land in chat text or a model prompt. See panel issues #176 / #175 / #168.
+
+import { describe, expect, it } from "vitest";
+import { toReadableText } from "../../utils/errors.js";
+
+describe("toReadableText", () => {
+  it("passes a plain string through untouched", () => {
+    expect(toReadableText("hello")).toBe("hello");
+  });
+
+  it("uses the caller fallback for null/undefined", () => {
+    expect(toReadableText(null, "nope")).toBe("nope");
+    expect(toReadableText(undefined, "nope")).toBe("nope");
+  });
+
+  it("prefers a string message/error/text/detail field on an object", () => {
+    expect(toReadableText({ message: "quota reached" })).toBe("quota reached");
+    expect(toReadableText({ error: "boom" })).toBe("boom");
+    expect(toReadableText({ text: "hi" })).toBe("hi");
+    expect(toReadableText({ detail: "d" })).toBe("d");
+  });
+
+  it("uses an Error's message", () => {
+    expect(toReadableText(new Error("kaboom"))).toBe("kaboom");
+  });
+
+  it("JSON-serializes an arbitrary object instead of [object Object]", () => {
+    const out = toReadableText({ code: 429, node: "KSampler" });
+    expect(out).not.toContain("[object Object]");
+    expect(out).toBe('{"code":429,"node":"KSampler"}');
+  });
+
+  it("NEVER returns [object Object] for a structured backend failure", () => {
+    // The exact #176 shape: a quota failure carried as a structured object.
+    const failure = { type: "quota", nested: { limit: 0 } };
+    const out = toReadableText(failure, "unknown error");
+    expect(out).not.toBe("[object Object]");
+    expect(out).not.toContain("[object Object]");
+  });
+
+  it("falls back for a cyclic object rather than throwing or coercing", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(toReadableText(cyclic, "unreadable")).toBe("unreadable");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1338,6 +1338,7 @@ export async function runPanelOrchestrator(): Promise<void> {
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
+  const warnedNoPanelMcp = new Set<string>(); // tabs already told their non-Claude backend lacks panel_* tools (#168)
   const workflowTargets = new WorkflowTargetStore();
   const backendForTab = (panelTabId: string): string =>
     tabBackends.get(panelTabId) ?? defaultBackend;
@@ -3090,12 +3091,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       const ev = event as {
         kind?: string;
         images?: Array<{ filename: string; subfolder?: string; type?: string }>;
-        error?: string;
+        error?: unknown;
         note?: string;
       };
       // A run error is URGENT: interrupt the live turn + front-queue it ("hey,
       // look at me") so the agent stops and fixes it instead of running blind.
       // Everything else (e.g. a finished render's images) is enqueued normally.
+      // `ev.error` may be a STRUCTURED object (ComfyUI's node-level error);
+      // injectRunError normalizes it to readable text, never `[object Object]`.
       if (ev.kind === "run_error") {
         void manager.injectRunError(agentKeyFor(event.tab_id), ev.error ?? "unknown error");
         logger.info(`[panel-orchestrator] tab ${event.tab_id.slice(0, 8)} run_error → agent (interrupt)`);
@@ -3407,6 +3410,24 @@ export async function runPanelOrchestrator(): Promise<void> {
         bridge.push({ type: "turn", state: "done" }, event.tab_id);
       }
       return;
+    }
+    // Live-canvas tool diagnostic (#168): a non-Claude tab drives the canvas
+    // through the loopback HTTP panel-MCP. If that server never started (port
+    // bind failure — the startup error at :panelMcpPort), the backend silently
+    // gets headless-only tools with NO panel_* (panel_graph_outline,
+    // panel_query_graph, …), so the agent can't see or edit the live graph.
+    // Surface it explicitly ONCE per tab instead of failing silently. (Claude
+    // tabs host panel_* in-process and are unaffected.)
+    if (!panelMcpHttp && backendForTab(event.tab_id) !== "claude" && !warnedNoPanelMcp.has(event.tab_id)) {
+      warnedNoPanelMcp.add(event.tab_id);
+      bridge.push(
+        {
+          type: "say",
+          text:
+            "⚠️ Live-canvas tools (panel_graph_outline, panel_query_graph, and the other panel_* tools) are UNAVAILABLE for this provider — the orchestrator's loopback panel-MCP failed to start (usually a port already in use). I can still work headlessly, but I can't see or edit your open graph. Check the orchestrator terminal for the \"could not start the panel HTTP MCP\" error, free the port, and restart. (Claude runs these tools in-process and is unaffected.)",
+        },
+        event.tab_id,
+      );
     }
     manager.send(agentKeyFor(event.tab_id), outText, sendOpts);
   };

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,6 +23,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { toReadableText } from "../utils/errors.js";
 import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
 import {
@@ -357,7 +358,7 @@ export class PanelAgent {
    * reached the agent." Only meaningful when a session is live (the manager only
    * calls this for an existing agent, so we never spawn one just for an event).
    */
-  injectEvent(ev: { kind?: string; images?: ImageRef[]; error?: string; note?: string }): void {
+  injectEvent(ev: { kind?: string; images?: ImageRef[]; error?: unknown; note?: string }): void {
     let text: string | null = null;
     let images: ImageRef[] | undefined;
     if (ev.kind === "executed") {
@@ -387,8 +388,10 @@ export class PanelAgent {
         images = imgs.filter((i) => i.filename).map((i) => ({ ...i, type: i.type ?? "output" }));
       }
     } else if (ev.kind === "run_error") {
+      // ev.error may be a structured ComfyUI error object — normalize to
+      // readable text so it never renders as `[object Object]` (#176).
       text =
-        `[panel event] The user's workflow run just ERRORED: ${ev.error ?? "unknown error"}. ` +
+        `[panel event] The user's workflow run just ERRORED: ${toReadableText(ev.error, "unknown error")}. ` +
         `If it relates to what you were doing, diagnose it (panel_get_errors has the details) and offer a fix.`;
     }
     if (!text) return;
@@ -406,10 +409,14 @@ export class PanelAgent {
    *  run succeeded. INTERRUPT any live turn (re-queued so it resumes AFTER the
    *  error), then put the error at the FRONT of the queue so the agent addresses
    *  it before anything else. */
-  async injectRunError(error: string): Promise<void> {
+  async injectRunError(error: unknown): Promise<void> {
     if (this.closed) return;
+    // The panel forwards ComfyUI's execution error, which may be a STRUCTURED
+    // object ({ node_id, node_type, exception_message, … }), not a string.
+    // Normalize it so the agent reads real text, never `[object Object]` (#176).
+    const readable = toReadableText(error, "unknown error");
     const text =
-      `[panel event] ⚠️ The workflow run you just queued ERRORED on the user's canvas: ${error}. ` +
+      `[panel event] ⚠️ The workflow run you just queued ERRORED on the user's canvas: ${readable}. ` +
       `STOP — do not carry on as if it succeeded. If it relates to what you were doing, diagnose it ` +
       `(panel_get_errors has the full node-level details) and fix it; otherwise tell the user briefly.`;
     if (this.inFlight) {
@@ -979,7 +986,13 @@ export class PanelAgent {
         // exact "three Hellos into the void" failure from the support thread.
         // Surface it as a visible chat line; the follow-up `result` event still
         // advances the turn gate normally.
-        const detail = typeof ev.message === "string" && ev.message.trim() ? ev.message.trim() : "unknown error";
+        // ev.message is typed string, but a backend may surface a structured
+        // failure (quota/rate-limit) object — normalize so a non-string never
+        // renders as `[object Object]` in chat (#176).
+        const detail =
+          typeof ev.message === "string" && ev.message.trim()
+            ? ev.message.trim()
+            : toReadableText(ev.message as unknown, "unknown error");
         this.errorSurfaced = true;
         this.deps.onSay(
           this.tabId,
@@ -1373,7 +1386,7 @@ export class PanelAgentManager {
 
   /** Feed a ComfyUI execution event to an EXISTING agent (no-op if none — we
    *  never spawn an agent just to react to an event). Returns whether delivered. */
-  injectEvent(tabId: string, ev: { kind?: string; images?: ImageRef[]; error?: string; note?: string }): boolean {
+  injectEvent(tabId: string, ev: { kind?: string; images?: ImageRef[]; error?: unknown; note?: string }): boolean {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false; // best-effort; don't enqueue into a closed agent
     agent.injectEvent(ev);
@@ -1382,7 +1395,7 @@ export class PanelAgentManager {
 
   /** Push a ComfyUI execution error to a tab's agent — interrupt the live turn
    *  and front-queue the error so the agent stops and addresses it. */
-  async injectRunError(tabId: string, error: string): Promise<boolean> {
+  async injectRunError(tabId: string, error: unknown): Promise<boolean> {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false;
     await agent.injectRunError(error);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -90,6 +90,39 @@ export class NodeBisectError extends ComfyUIError {
   }
 }
 
+/**
+ * Coerce an arbitrary value into readable chat/prompt text WITHOUT ever falling
+ * back to JavaScript's `Object.prototype.toString` (the source of the infamous
+ * `[object Object]` bubbles — issues #176/#175/#168). A structured backend
+ * failure, ComfyUI execution error, or panel payload must render as something a
+ * human/model can read, never as `[object Object]`.
+ *
+ * Order of preference:
+ *  - a string passes through untouched;
+ *  - a nullish value becomes the caller's fallback;
+ *  - an `Error` uses its `.message`;
+ *  - an object with a string `message` / `error` / `text` / `detail` field uses it;
+ *  - anything else is JSON-serialized (with a guard for cycles / BigInt).
+ */
+export function toReadableText(value: unknown, fallback = "unknown error"): string {
+  if (typeof value === "string") return value;
+  if (value == null) return fallback;
+  if (typeof value !== "object") return String(value);
+  if (value instanceof Error) return value.message || fallback;
+  const rec = value as Record<string, unknown>;
+  for (const key of ["message", "error", "text", "detail"] as const) {
+    const field = rec[key];
+    if (typeof field === "string" && field.trim()) return field;
+  }
+  try {
+    const json = JSON.stringify(value);
+    // `JSON.stringify` returns undefined for a bare function/symbol.
+    return json && json !== "{}" ? json : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 export function errorToToolResult(err: unknown): CallToolResult {
   if (err instanceof ComfyUIError) return err.toToolResult();
   const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Fixes three "[object Object]" serialization reports where structured objects were String()-coerced instead of properly serialized before landing in chat text / the model prompt.

Closes artokun/comfyui-mcp-panel#176
Closes artokun/comfyui-mcp-panel#175
Closes artokun/comfyui-mcp-panel#168

## Root cause per issue

**#176 — structured backend failure renders as `[object Object]`** (FIXED here).
The orchestrator's canvas run-error forwarding (`PanelAgentManager.injectRunError` → `PanelAgent.injectRunError`, and `PanelAgent.injectEvent({kind:"run_error"})`) interpolated the incoming `error` straight into the chat/prompt text via a template literal. The panel forwards ComfyUI's execution error, which can be a **structured object** (`{node_id, node_type, exception_message, …}`), so `${error}` produced `[object Object]`. Fixed with a shared `toReadableText()` helper (prefers a string `message`/`error`/`text`/`detail` field; else JSON-serializes; never `Object.prototype.toString`). The backend `error` event detail also falls back to it for a non-string message.

**#175 — user attachment/multi-part becomes `[object Object]` in the prompt** (LIVES IN PANEL).
The orchestrator only ever receives `event.text` as an already-composed **string** (it guards `typeof event.text !== "string"` and rejects otherwise), so the coercion of a structured user part happens in the panel while it composes the outgoing turn text, not in this repo. No orchestrator code builds the user turn from structured parts. Flagged for the panel-side agent.

**#168 — live-canvas context becomes `[object Object]` + panel_* tools missing** (SPLIT).
- *Serialization half* — LIVES IN PANEL. The live-canvas / "MANUAL CANVAS CHANGES" context block is composed panel-side and arrives inside the string `event.text`; the orchestrator's own context injection (transcript replay) is already string-guarded. Flagged for the panel-side agent.
- *Tool-registration half* — FIXED here, and it is **independent**, not a cascade. Non-Claude backends get their `panel_*` tools from the loopback HTTP panel-MCP (`makeHttpBackendMcpServers` includes the `panel` server only when `panelMcpHttp` started). If that server fails to bind (port in use — plausible on Windows per the existing bind-coexistence note), every non-Claude tab silently degrades to headless-only tools. There is no shared throw/early-return between context composition and tool registration, so the two symptoms are coincidental, not causal. Added an explicit per-tab, first-turn chat diagnostic when `panelMcpHttp` is unavailable for a non-Claude tab, instead of failing silently. (Claude tabs host `panel_*` in-process and are unaffected.)

## Tests
- `src/__tests__/utils/to-readable-text.test.ts` — helper unit coverage incl. "NEVER returns `[object Object]` for a structured backend failure" and a cyclic-object guard.
- `src/__tests__/orchestrator/inject-error-serialization.test.ts` — drives a real `PanelAgent` with a recording backend; asserts both `injectRunError` and `injectEvent(run_error)` deliver readable text (no `[object Object]`) to the model turn.

Typecheck (`npm run lint`) clean; full suite green except one pre-existing, environment-dependent `node-dev` test (ripgrep-vs-builtin engine, untouched by this PR).

[reports ≤panel 0.11.5]