### PR TITLE
fix(orchestrator): normalize preferred_models in set_config guard + civitai ensureReachable (codex follow-ups)

### DIFF
--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   getAgentSettings,
   getNsfwConsent,
+  normalizePreferredModels,
   setAgentSettings,
   setNsfwConsent,
 } from "../../services/panel-settings.js";
@@ -95,5 +96,21 @@ describe("panel-settings agent model preferences", () => {
     setAgentSettings({ preferredModels: ["m:1"] });
     expect(getNsfwConsent().allowed).toBe(true);
     expect(getAgentSettings().preferredModels).toEqual(["m:1"]);
+  });
+});
+
+describe("normalizePreferredModels (#393 loop guard)", () => {
+  it("trims, drops blanks, dedupes, and caps at 50 — the same shape setAgentSettings persists", () => {
+    expect(normalizePreferredModels([" a ", "a", "", "  ", "b"])).toEqual(["a", "b"]);
+    expect(normalizePreferredModels(Array.from({ length: 60 }, (_, i) => `m${i}`)).length).toBe(50);
+  });
+
+  it("is idempotent, so a re-sent normalized list compares EQUAL (no heartbeat re-push)", () => {
+    const once = normalizePreferredModels([" x ", "x", "y"]);
+    expect(normalizePreferredModels(once)).toEqual(once);
+    // What the set_config guard actually compares: raw payload normalized vs the
+    // persisted (already-normalized) list must be equal when nothing changed.
+    setAgentSettings({ preferredModels: [" x ", "x", "y"] });
+    expect(getAgentSettings().preferredModels).toEqual(normalizePreferredModels([" x ", "x", "y"]));
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -100,7 +100,7 @@ import {
   warmLmstudio,
 } from "../services/lmstudio-lifecycle.js";
 import { llamacppProps, llamacppToolsReady } from "../services/llamacpp-probe.js";
-import { getAgentSettings, setAgentSettings } from "../services/panel-settings.js";
+import { getAgentSettings, setAgentSettings, normalizePreferredModels } from "../services/panel-settings.js";
 import {
   gatherEnvCapabilities,
   buildPanelSystemAppend,
@@ -2697,11 +2697,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       const cfg = event as { preferred_models?: unknown; ollama?: unknown };
       let ollamaChanged = false;
       if (Array.isArray(cfg.preferred_models)) {
-        const ids = cfg.preferred_models.filter((m): m is string => typeof m === "string");
         // The panel re-sends set_config on EVERY heartbeat. Only apply + re-push on
         // an ACTUAL change — otherwise re-pushing models makes the panel re-send,
         // which re-pushes… a tight ~150/s feedback loop that wedges the orchestrator
         // (a multi-provider user hit exactly this). Mirror the stall_seconds guard.
+        // NORMALIZE the incoming list the SAME way persistence does before comparing,
+        // else a payload with whitespace/dupes never equals the stored (normalized)
+        // list and re-pushes forever, reviving the loop (#393 follow-up).
+        const ids = normalizePreferredModels(
+          cfg.preferred_models.filter((m): m is string => typeof m === "string"),
+        );
         const prevIds = getAgentSettings().preferredModels ?? [];
         if (ids.length !== prevIds.length || ids.some((v, i) => v !== prevIds[i])) {
           setAgentSettings({ preferredModels: ids });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1453,6 +1453,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // existing parseCreatorQuery path applies it (issue #374 — the tool used
           // to drop `creator` silently, echoing creator:null with zero results).
           const query = creator ? `@${creator}${rawQuery ? " " + rawQuery : " "}` : rawQuery;
+          // Self-heal an orphaned session before a raw bridge.send (matches every
+          // other direct-bridge call site) — without this an orphaned session
+          // wrongly returns "no connected tab" even when a live tab exists (#381).
+          ctx.ensureReachable?.();
           const reply = await ctx.bridge.send(
             { cmd: "civitai_search", query, filters: args.filters, browsingLevels } as { cmd: string },
             { tabId: ctx.tabId, timeoutMs: 10000 },

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -105,14 +105,23 @@ export function getAgentSettings(): AgentSettings {
  * replaces the whole list (the panel sends the full edited list); `ollama`
  * fields merge per-key so e.g. a model change doesn't clobber the base URL.
  */
+/**
+ * Canonical form of a preferred-models list: trim, drop blanks, dedup, cap at 50.
+ * Exported so the set_config handler can compare an INCOMING list against the
+ * persisted one on the SAME footing — comparing a raw payload against this
+ * normalized list would report "changed" on every heartbeat and revive the
+ * config-repush loop (#393 follow-up).
+ */
+export function normalizePreferredModels(list: string[]): string[] {
+  return [...new Set(list.map((m) => m.trim()).filter(Boolean))].slice(0, 50);
+}
+
 export function setAgentSettings(patch: AgentSettings): AgentSettings {
   const settings = read();
   const prev = settings.agent ?? {};
   const next: AgentSettings = { ...prev };
   if (patch.preferredModels !== undefined) {
-    next.preferredModels = [
-      ...new Set(patch.preferredModels.map((m) => m.trim()).filter(Boolean)),
-    ].slice(0, 50);
+    next.preferredModels = normalizePreferredModels(patch.preferredModels);
   }
   if (patch.ollama !== undefined) {
     next.ollama = { ...prev.ollama, ...patch.ollama };


### PR DESCRIPTION
Fix-forwards from the codex retro-review of the storm hotfixes:

- **#393 follow-up (loop):** the `set_config` change-guard compared the RAW `preferred_models` payload against the persisted (normalized) list — a payload with whitespace/dupes never matched → re-pushed every heartbeat, reviving the loop. Extracted `normalizePreferredModels()` and compare on the same footing in guard + persistence.
- **#381 follow-up:** `panel_civitai_search`'s raw `bridge.send` was missing `ctx.ensureReachable?.()` → orphaned session wrongly returned "no connected tab". Added it.

**codex: PASS** (direct-exec, pre-merge) — loop-safe for normalized + whitespace/dup payloads; ensureReachable matches the established pattern; no TDZ. Unit tests added (normalize trim/dedup/cap + idempotency); panel suites green. Will live-test after merge (invariant 2).

[reports ≤mcp 0.48.6]

🤖 Generated with [Claude Code](https://claude.com/claude-code)