### PR TITLE
fix(state): invalidate stale caches/snapshots after restart+edit (WS-3)

### DIFF
--- a/src/__tests__/comfyui/client-ownership-race.test.ts
+++ b/src/__tests__/comfyui/client-ownership-race.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Force local mode. Each `new Client()` is a DISTINCT instance whose getNodeDefs
+// behaviour is settable per instance and whose close() is observable — so we can
+// prove a stale request's catch never closes a NEWER client (codex WS-3 round-2).
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>(
+    "../../config.js",
+  );
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+  };
+});
+
+const instances = vi.hoisted(() => [] as Array<{ closed: boolean }>);
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    closed = false;
+    _impl: () => Promise<unknown> = () => Promise.reject(new Error("unset"));
+    getNodeDefs = () => this._impl();
+    constructor() {
+      instances.push(this);
+    }
+    close() {
+      this.closed = true;
+    }
+  },
+}));
+
+const { getObjectInfo, resetObjectInfoCache, resetClient, resetClientIfCurrent, getClient } =
+  await import("../../comfyui/client.js");
+
+type FakeClient = {
+  closed: boolean;
+  _impl: () => Promise<unknown>;
+};
+
+describe("client ownership race", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    resetClient();
+    resetObjectInfoCache();
+  });
+
+  it("resetClientIfCurrent only resets when the argument is still the current client", () => {
+    const c1 = getClient() as unknown as FakeClient;
+    resetClient(); // c1 closed, singleton cleared
+    const c2 = getClient() as unknown as FakeClient;
+    // c1 is stale — must NOT close the newer c2.
+    expect(resetClientIfCurrent(c1 as never)).toBe(false);
+    expect(c2.closed).toBe(false);
+    // c2 is current — resets.
+    expect(resetClientIfCurrent(c2 as never)).toBe(true);
+    expect(c2.closed).toBe(true);
+    // null never resets.
+    expect(resetClientIfCurrent(null)).toBe(false);
+  });
+
+  it("a stale request's delayed rejection does NOT close the newer client", async () => {
+    // Request A starts on client C1 with a first attempt that rejects LATER.
+    let rejectA!: (e: unknown) => void;
+    const c1 = getClient() as unknown as FakeClient;
+    c1._impl = () => new Promise((_res, rej) => (rejectA = rej));
+    const pA = getObjectInfo(); // inflight on C1, epoch N
+
+    // A restart fires: close C1 and abandon the cache slot (epoch N+1).
+    resetClient();
+    resetObjectInfoCache();
+
+    // Request B creates C2 and succeeds.
+    const c2 = getClient() as unknown as FakeClient;
+    c2._impl = () => Promise.resolve({ NewNode: {} });
+    await expect(getObjectInfo()).resolves.toEqual({ NewNode: {} });
+    expect(c2.closed).toBe(false);
+
+    // NOW A's first attempt rejects. Its catch must reset only if C1 is current —
+    // it isn't (C2 is), so C2 stays open. A retries against the current C2.
+    c2._impl = () => Promise.resolve({ NewNode: {} });
+    rejectA(new Error("fetch failed"));
+    await expect(pA).resolves.toEqual({ NewNode: {} });
+    expect(c2.closed).toBe(false);
+  });
+});

--- a/src/__tests__/comfyui/get-logs-retry.test.ts
+++ b/src/__tests__/comfyui/get-logs-retry.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Force local mode and stub the underlying SDK Client so fetchApi is countable
+// without a network. Mirrors object-info-cache.test.ts.
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>(
+    "../../config.js",
+  );
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+  };
+});
+
+const fetchApi = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    fetchApi = fetchApi;
+    close() {}
+  },
+}));
+
+const { getLogs } = await import("../../comfyui/client.js");
+
+function logsResponse(text: string) {
+  return { text: async () => text };
+}
+
+describe("getLogs reset-and-retry after restart (#399)", () => {
+  beforeEach(() => {
+    fetchApi.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recovers a stale post-restart client by resetting and retrying once", async () => {
+    // First call fails on the stale (torn-down) client — the bare "fetch failed"
+    // #399 saw; the retry against a fresh client succeeds.
+    fetchApi.mockRejectedValueOnce(new Error("fetch failed"));
+    fetchApi.mockResolvedValueOnce(logsResponse("line one\nline two"));
+    await expect(getLogs()).resolves.toEqual(["line one", "line two"]);
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the underlying error (not bare 'fetch failed') when the retry also fails", async () => {
+    fetchApi.mockRejectedValueOnce(new Error("fetch failed"));
+    fetchApi.mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:8188"));
+    await expect(getLogs()).rejects.toThrow("ECONNREFUSED 127.0.0.1:8188");
+    expect(fetchApi).toHaveBeenCalledTimes(2);
+  });
+
+  it("parses a JSON-encoded log string on the happy path without retrying", async () => {
+    fetchApi.mockResolvedValueOnce(logsResponse(JSON.stringify("a\nb\nc")));
+    await expect(getLogs()).resolves.toEqual(["a", "b", "c"]);
+    expect(fetchApi).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/comfyui/object-info-cache.test.ts
+++ b/src/__tests__/comfyui/object-info-cache.test.ts
@@ -82,4 +82,25 @@ describe("getObjectInfo memoization", () => {
     await expect(getObjectInfo()).resolves.toEqual({ KSampler: {} });
     expect(getNodeDefs).toHaveBeenCalledTimes(2);
   });
+
+  it("does NOT commit a fetch that was in flight when a reset invalidated it (racy invalidation)", async () => {
+    // A fetch (returning the PRE-restart schema) is in flight when a restart
+    // fires resetObjectInfoCache(). Its late resolution must NOT repopulate the
+    // cache — a subsequent call must refetch and see the POST-restart schema.
+    let releaseOld!: (v: unknown) => void;
+    getNodeDefs.mockReturnValueOnce(new Promise((r) => (releaseOld = r)));
+    const inflight = getObjectInfo(); // starts under epoch N
+
+    // Restart happens mid-fetch.
+    resetObjectInfoCache(); // epoch N+1, abandons the in-flight slot
+
+    // The old fetch now resolves with the stale schema.
+    releaseOld({ OldNode: {} });
+    await expect(inflight).resolves.toEqual({ OldNode: {} }); // awaiter still served
+
+    // The stale result must NOT have poisoned the cache: the next call refetches.
+    getNodeDefs.mockResolvedValueOnce({ NewNode: {} });
+    await expect(getObjectInfo()).resolves.toEqual({ NewNode: {} });
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
+++ b/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
@@ -1,0 +1,82 @@
+// Coverage for the WS-3 panel_restart_comfyui cache invalidation (codex finding
+// #2): the shared ComfyUI client + object_info cache must be dropped ONLY on a
+// CONFIRMED reboot (`rebooting:true`). A busy-guard / forbidden / no-endpoint
+// refusal comes back as a normal ToolResult with `rebooting:false` — resetting
+// then would close the shared client mid-generation.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resetClient = vi.fn();
+const resetObjectInfoCache = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getObjectInfo: vi.fn(),
+  backfillObjectInfo: vi.fn(),
+  resetClient: () => resetClient(),
+  resetObjectInfoCache: () => resetObjectInfoCache(),
+}));
+
+const { buildPanelToolDefs, rebootConfirmed } = await import(
+  "../../orchestrator/panel-tools.js"
+);
+import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
+import type { ToolResult } from "../../orchestrator/panel-tools.js";
+
+function ctxReplying(reply: unknown): PanelToolCtx {
+  return {
+    call: async () => ({
+      content: [{ type: "text", text: JSON.stringify(reply) }],
+    }),
+    confirm: async () => true,
+    bridge: {} as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  } as PanelToolCtx;
+}
+
+function rebootHandler() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def.handler;
+}
+
+const rr = (obj: unknown): ToolResult =>
+  ({ content: [{ type: "text", text: JSON.stringify(obj) }] }) as ToolResult;
+
+describe("rebootConfirmed", () => {
+  it("is true only for a parsed rebooting:true", () => {
+    expect(rebootConfirmed(rr({ rebooting: true, endpoint: "/v2/manager/reboot" }))).toBe(true);
+  });
+  it("is false for an explicit refusal (busy guard)", () => {
+    expect(rebootConfirmed(rr({ rebooting: false, blocked_busy: true }))).toBe(false);
+  });
+  it("is false when the field is absent, on isError, and on unparseable text", () => {
+    expect(rebootConfirmed(rr({ ok: 1 }))).toBe(false);
+    expect(
+      rebootConfirmed({ content: [{ type: "text", text: "not json" }] } as ToolResult),
+    ).toBe(false);
+    expect(
+      rebootConfirmed({ content: [{ type: "text", text: '{"rebooting":true}' }], isError: true } as ToolResult),
+    ).toBe(false);
+  });
+});
+
+describe("panel_restart_comfyui cache invalidation", () => {
+  beforeEach(() => {
+    resetClient.mockClear();
+    resetObjectInfoCache.mockClear();
+  });
+
+  it("invalidates the client + object_info caches on a CONFIRMED reboot", async () => {
+    await rebootHandler()({ force: false }, ctxReplying({ rebooting: true }));
+    expect(resetClient).toHaveBeenCalledTimes(1);
+    expect(resetObjectInfoCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT touch the caches when the panel REFUSES (busy/forbidden/no-endpoint)", async () => {
+    await rebootHandler()(
+      { force: false },
+      ctxReplying({ rebooting: false, blocked_busy: true, queue_running: 1 }),
+    );
+    expect(resetClient).not.toHaveBeenCalled();
+    expect(resetObjectInfoCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -137,17 +137,30 @@ export async function getSystemStats(): Promise<SystemStats> {
 // Perf gap flagged by josephoibrahim/comfy-cozy (re-validate ~7 s → ~0.5 s).
 let objectInfoCache: ObjectInfo | null = null;
 let objectInfoInflight: Promise<ObjectInfo> | null = null;
+// Invalidation epoch. resetObjectInfoCache() bumps it; a fetch that STARTED under
+// an older epoch must not commit its result to the cache — otherwise a request
+// in flight when a restart invalidates the cache can resolve afterward and
+// repopulate it with the PRE-restart schema, and future callers would await that
+// stale value (codex WS-3 finding #1).
+let objectInfoEpoch = 0;
 
 export async function getObjectInfo(): Promise<ObjectInfo> {
   if (isCloudMode()) return cloudClient.getObjectInfo();
   if (objectInfoCache) return objectInfoCache;
   if (objectInfoInflight) return objectInfoInflight;
 
-  objectInfoInflight = (async () => {
+  const startEpoch = objectInfoEpoch;
+  // Commit to the shared cache ONLY if no invalidation happened while we were
+  // fetching. Awaiters of this promise still get the value (they asked before
+  // the reset), but the cache is not poisoned for callers that arrive after.
+  const commit = (info: ObjectInfo): ObjectInfo => {
+    if (objectInfoEpoch === startEpoch) objectInfoCache = info;
+    return info;
+  };
+
+  const inflight = (async () => {
     try {
-      const info = (await getClient().getNodeDefs()) as unknown as ObjectInfo;
-      objectInfoCache = info;
-      return info;
+      return commit((await getClient().getNodeDefs()) as unknown as ObjectInfo);
     } catch (err) {
       // A managed restart/reboot leaves the cached client bound to a socket that
       // was torn down, so the first call after it surfaces a bare "fetch failed"
@@ -157,27 +170,32 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
         error: err instanceof Error ? err.message : String(err),
       });
       resetClient();
-      const info = (await getClient().getNodeDefs()) as unknown as ObjectInfo;
-      objectInfoCache = info;
-      return info;
+      return commit((await getClient().getNodeDefs()) as unknown as ObjectInfo);
     }
   })();
+  objectInfoInflight = inflight;
 
   try {
-    return await objectInfoInflight;
+    return await inflight;
   } finally {
-    objectInfoInflight = null;
+    // Only clear the shared slot if it's still ours — a concurrent reset may have
+    // already abandoned it and a newer fetch may have taken the slot.
+    if (objectInfoInflight === inflight) objectInfoInflight = null;
   }
 }
 
 /**
  * Drop the memoized /object_info so the next call refetches. Called after
  * ComfyUI restarts (node packs may have changed) and available for tools
- * that mutate the node set mid-session.
+ * that mutate the node set mid-session. Bumps the invalidation epoch and
+ * abandons any in-flight fetch so a fetch started before the reset can never
+ * commit a pre-restart result to the cache.
  */
 export function resetObjectInfoCache(): void {
   objectInfoCache = null;
-  logger.debug("object_info cache reset");
+  objectInfoInflight = null;
+  objectInfoEpoch++;
+  logger.debug("object_info cache reset", { epoch: objectInfoEpoch });
 }
 
 /**

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -159,17 +159,21 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
   };
 
   const inflight = (async () => {
+    // Capture the client this request runs on so the catch only resets THIS one.
+    const startClient = getClient();
     try {
-      return commit((await getClient().getNodeDefs()) as unknown as ObjectInfo);
+      return commit((await startClient.getNodeDefs()) as unknown as ObjectInfo);
     } catch (err) {
       // A managed restart/reboot leaves the cached client bound to a socket that
       // was torn down, so the first call after it surfaces a bare "fetch failed"
       // (issue #376). Drop the stale client and retry once against a fresh one
       // before giving up — this is exactly the reconnect the caller expects.
+      // Only reset if OUR client is still current: a concurrent reset may have
+      // already installed a newer client we must not close.
       logger.warn("getObjectInfo failed; resetting client and retrying once", {
         error: err instanceof Error ? err.message : String(err),
       });
-      resetClient();
+      resetClientIfCurrent(startClient);
       return commit((await getClient().getNodeDefs()) as unknown as ObjectInfo);
     }
   })();
@@ -379,6 +383,20 @@ export function resetClient(): void {
   }
 }
 
+/**
+ * Reset the singleton ONLY if it is still the client the caller was using. A
+ * failing request captures its client at start and passes it here in its catch;
+ * if a concurrent reset (resetObjectInfoCache abandons the in-flight slot) already
+ * spun up a NEW client in the meantime, we must not close that newer client + its
+ * fresh WebSocket out from under whoever created it (codex WS-3 round-2 finding).
+ * Returns true if it actually reset. A null argument never resets.
+ */
+export function resetClientIfCurrent(client: Client | null): boolean {
+  if (!client || clientInstance !== client) return false;
+  resetClient();
+  return true;
+}
+
 export function getComfyUIPath(): string | undefined {
   if (isCloudMode()) return cloudClient.getComfyUIPath();
   return config.comfyuiPath;
@@ -395,13 +413,16 @@ export async function getLogs(): Promise<string[]> {
   // a fresh one before giving up, and surface the underlying error if it still
   // fails so callers see more than "fetch failed".
   let text: string;
+  // Capture the client this request runs on so the catch only resets THIS one
+  // (not a newer client a concurrent reset may have installed).
+  const startClient = getClient();
   try {
-    text = await getClient().fetchApi("/internal/logs").then((r) => r.text());
+    text = await startClient.fetchApi("/internal/logs").then((r) => r.text());
   } catch (err) {
     logger.warn("getLogs failed; resetting client and retrying once", {
       error: err instanceof Error ? err.message : String(err),
     });
-    resetClient();
+    resetClientIfCurrent(startClient);
     try {
       text = await getClient().fetchApi("/internal/logs").then((r) => r.text());
     } catch (err2) {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -368,9 +368,31 @@ export function getComfyUIPath(): string | undefined {
 
 export async function getLogs(): Promise<string[]> {
   if (isCloudMode()) return cloudClient.getLogs();
-  const client = getClient();
-  const res = await client.fetchApi("/internal/logs");
-  const text = await res.text();
+
+  // A managed/panel restart or Manager reboot leaves the cached client bound to
+  // a socket that was torn down, so the first /internal/logs call after it
+  // surfaces a bare "fetch failed" (issue #399) — regardless of any keyword the
+  // caller passed, since filtering happens after this fetch. Mirror the
+  // getObjectInfo reset-and-retry: drop the stale client and retry once against
+  // a fresh one before giving up, and surface the underlying error if it still
+  // fails so callers see more than "fetch failed".
+  let text: string;
+  try {
+    text = await getClient().fetchApi("/internal/logs").then((r) => r.text());
+  } catch (err) {
+    logger.warn("getLogs failed; resetting client and retrying once", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    resetClient();
+    try {
+      text = await getClient().fetchApi("/internal/logs").then((r) => r.text());
+    } catch (err2) {
+      const detail = err2 instanceof Error ? err2.message : String(err2);
+      throw new ConnectionError(
+        `Failed to fetch ComfyUI logs after reconnect retry: ${detail}`,
+      );
+    }
+  }
 
   // ComfyUI returns logs as a JSON-encoded string with \n separators,
   // or as raw text depending on version. Handle both.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -47,7 +47,12 @@ import { setComfyuiSecret, setAgentSecret, isAllowedAgentSecretKey } from "../se
 import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
-import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
+import {
+  getObjectInfo,
+  backfillObjectInfo,
+  resetClient,
+  resetObjectInfoCache,
+} from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import { validateA2UISpecServer } from "../services/a2ui-spec.js";
@@ -2048,7 +2053,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         ) {
           return ok("Cancelled — ComfyUI was not restarted.");
         }
-        return ctx.call({ cmd: "comfy_reboot", force: force === true }, 15000);
+        const res = await ctx.call({ cmd: "comfy_reboot", force: force === true }, 15000);
+        // A panel/Manager reboot restarts ComfyUI out-of-band from the MCP
+        // process-control path, so the orchestrator's WebSocket client and its
+        // memoized /object_info survive the restart and go stale: get_node_info
+        // then returns pre-restart schemas, model dropdowns, and required/optional
+        // placement (#353/#378/#394), and newly installed nodes stay invisible
+        // (#357). The reboot is the triggering event — drop both caches here so
+        // the next call refetches against the fresh server.
+        resetClient();
+        resetObjectInfoCache();
+        return res;
       },
     ),
     def(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -66,7 +66,7 @@ function isAffirmative(reply: unknown): boolean {
   );
 }
 
-type ToolResult = {
+export type ToolResult = {
   content: Array<
     | { type: "text"; text: string }
     | { type: "image"; data: string; mimeType: string }
@@ -85,6 +85,26 @@ function ok(value: unknown): ToolResult {
 function fail(err: unknown): ToolResult {
   const msg = err instanceof Error ? err.message : String(err);
   return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
+}
+
+/**
+ * True only when a comfy_reboot ToolResult carries a CONFIRMED `rebooting:true`
+ * from the panel. `ctx.call` wraps the panel reply via ok() as JSON text and never
+ * throws, so a busy-guard/forbidden/no-endpoint refusal comes back as a normal
+ * ToolResult with `rebooting:false`. Gate cache invalidation on this so a refused
+ * restart never closes the shared client mid-generation. Defensive: any error
+ * flag or unparseable/absent field is treated as NOT confirmed.
+ */
+export function rebootConfirmed(res: ToolResult): boolean {
+  try {
+    if (res?.isError) return false;
+    const text = res?.content?.find((c) => c.type === "text")?.text;
+    if (typeof text !== "string") return false;
+    const parsed = JSON.parse(text) as { rebooting?: unknown };
+    return parsed?.rebooting === true;
+  } catch {
+    return false;
+  }
 }
 
 const slotRef = z.union([z.string(), z.number().int().min(0)]);
@@ -2059,10 +2079,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // memoized /object_info survive the restart and go stale: get_node_info
         // then returns pre-restart schemas, model dropdowns, and required/optional
         // placement (#353/#378/#394), and newly installed nodes stay invisible
-        // (#357). The reboot is the triggering event — drop both caches here so
-        // the next call refetches against the fresh server.
-        resetClient();
-        resetObjectInfoCache();
+        // (#357). The reboot is the triggering event — drop both caches so the
+        // next call refetches against the fresh server.
+        //
+        // BUT `ctx.call` returns a ToolResult (it does NOT throw), and the panel
+        // replies `rebooting:false` when it REFUSES (busy guard, Manager forbids,
+        // no endpoint). Only invalidate on a CONFIRMED `rebooting:true` — resetting
+        // on a refusal would close the shared client mid-generation (codex WS-3
+        // finding #2).
+        if (rebootConfirmed(res)) {
+          resetClient();
+          resetObjectInfoCache();
+        }
         return res;
       },
     ),

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -7,7 +7,7 @@ import {
   TEMPLATE_NAMES,
   type ModifyOperation,
 } from "../services/workflow-composer.js";
-import { getObjectInfo } from "../comfyui/client.js";
+import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -167,12 +167,26 @@ export function registerWorkflowComposeTools(server: McpServer): void {
     async ({ node_type, verbose }) => {
       try {
         logger.info("Getting node info", { filter: node_type, verbose });
-        const info = await getObjectInfo();
+        let info = await getObjectInfo();
 
         let entries = Object.entries(info);
         if (node_type) {
           const lower = node_type.toLowerCase();
           entries = entries.filter(([name]) => name.toLowerCase().includes(lower));
+
+          // Some nodes register individually (`/object_info/<Type>` returns a
+          // schema) but are absent from the bulk `/object_info` payload — seen
+          // with controlnet_aux's DWPreprocessor and with V3-API packs like
+          // comfyui-qwenmultiangle whose nodes the live canvas and panel
+          // recognize but the bulk query omits (#357). When the substring
+          // filter finds nothing, try backfilling the exact type by its own
+          // endpoint before reporting it missing.
+          if (entries.length === 0) {
+            info = await backfillObjectInfo(info, [node_type]);
+            entries = Object.entries(info).filter(([name]) =>
+              name.toLowerCase().includes(lower),
+            );
+          }
         }
 
         if (entries.length === 0) {


### PR DESCRIPTION
Root theme: object-info / model-list / node-schema caches captured once and never invalidated after an out-of-band ComfyUI restart. Invalidate on the triggering event.

## Fixes
- Closes #353 — stale optional-widget schema after restart (object_info cache).
- Closes #357 — get_node_info misses installed V3 nodes: backfill the exact type via `/object_info/<Type>` when the bulk payload omits it, plus cache invalidation on restart.
- Closes #378 — refresh model-dropdown cache after restart.
- Closes #394 — stale model-dropdown values after restart.
- Closes #399 — get_logs "fetch failed" right after restart: extend the getObjectInfo reset/retry pattern to the `/internal/logs` fetch, and surface the underlying error instead of a bare "fetch failed".

## Root cause
`panel_restart_comfyui` reboots ComfyUI via the Manager, out-of-band from the MCP `process-control` restart path (which already resets both caches). So the orchestrator's WebSocket client and its memoized `/object_info` survived the restart and went stale. WS-2 (0.48.6) added reset/retry only on *fetch failure*; after a restart+reconnect the fetch succeeds and returns the stale cache. Fix invalidates `resetClient()` + `resetObjectInfoCache()` at the reboot (the triggering event).

## Tests
`npm run build` + `npm test` pass (only pre-existing `node-dev` ripgrep-env failure). Added `get-logs-retry.test.ts` (reset-and-retry, underlying-error surfacing, happy-path JSON parse).

Panel-side siblings (#196/#199/#221/#223/#171/#185/#181/#203 and get_errors staleness #352/#364) ship in a separate panel PR.

[reports ≤mcp 0.48.6 / panel 0.11.5]