### PR TITLE
fix(chat): serialize structured error/user payloads instead of [object Object] (WS-9)

### DIFF
--- a/src/__tests__/orchestrator/structured-user-text.test.ts
+++ b/src/__tests__/orchestrator/structured-user-text.test.ts
@@ -1,0 +1,110 @@
+// Regression guard for #175: a structured / multi-part user payload must reach
+// the backend as READABLE text, never the literal "[object Object]" and never
+// an empty prompt that silently drops the turn's content.
+//
+// This drives a payload through the SAME chokepoint the production path uses —
+// PanelAgent's batching channel(), which now coerces each queued part with
+// promptText() before joining — and asserts on what the backend actually
+// receives as `turn.text`.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** Minimal backend that records each turn's text and immediately completes it. */
+class RecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  private waiters: Array<{ n: number; resolve: () => void }> = [];
+
+  waitFor(n: number, timeoutMs = 2000): Promise<void> {
+    if (this.turns.length >= n) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`turn ${n} never arrived`)), timeoutMs);
+      this.waiters.push({ n, resolve: () => { clearTimeout(timer); resolve(); } });
+    });
+  }
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-rec" };
+    for await (const turn of opts.channel) {
+      this.turns.push(turn.text);
+      this.waiters = this.waiters.filter((w) => {
+        if (this.turns.length >= w.n) { w.resolve(); return false; }
+        return true;
+      });
+      yield { type: "assistant", text: `ok: ${turn.text}` };
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeDeps() {
+  return {
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+  };
+}
+
+describe("#175 structured user payload reaches the backend as readable text", () => {
+  it("extracts the string `text` field from a multi-part payload", async () => {
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-175a", makeDeps() as never, backend);
+    void agent.start();
+
+    // A structured payload where a plain string is expected (typed via cast, as
+    // it would arrive over the wire).
+    agent.send({ text: "hello from a structured part", parts: [{ kind: "text" }] } as unknown as string);
+    await backend.waitFor(1);
+
+    expect(backend.turns[0]).toBe("hello from a structured part");
+    expect(backend.turns[0]).not.toContain("[object Object]");
+    await agent.stop();
+  });
+
+  it("JSON-serializes a payload with no string text rather than emitting [object Object]", async () => {
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-175b", makeDeps() as never, backend);
+    void agent.start();
+
+    agent.send({ kind: "image", ref: "input/a.png" } as unknown as string);
+    await backend.waitFor(1);
+
+    expect(backend.turns[0]).not.toBe("[object Object]");
+    expect(backend.turns[0]).toContain("input/a.png");
+    await agent.stop();
+  });
+
+  it("does NOT erase a payload whose text is empty but still carries parts", async () => {
+    const backend = new RecordingBackend();
+    const agent = new PanelAgent("tab-175c", makeDeps() as never, backend);
+    void agent.start();
+
+    agent.send({ text: "", parts: [{ kind: "image", ref: "input/b.png" }] } as unknown as string);
+    await backend.waitFor(1);
+
+    expect(backend.turns[0]).not.toBe("");
+    expect(backend.turns[0]).toContain("input/b.png");
+    await agent.stop();
+  });
+});

--- a/src/orchestrator/antigravity-backend.ts
+++ b/src/orchestrator/antigravity-backend.ts
@@ -72,6 +72,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
+import { errorText, promptText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -84,7 +85,7 @@ import {
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /** Kill an entire process tree (identical posture to gemini/codex-backend):
@@ -564,11 +565,11 @@ export class AntigravityBackend implements AgentBackend {
     cwd: string,
     onActivity?: () => void,
   ): AsyncGenerator<AgentEvent> {
-    let text = turn.text;
+    let text = promptText(turn.text);
     if (this.needsSystemPreamble && this.deps.systemAppend) {
       text =
         `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
-        `The user's first message follows.\n\n${turn.text}`;
+        `The user's first message follows.\n\n${text}`;
       this.needsSystemPreamble = false;
     }
     // Image refs: no documented -p image input — the refs are already named in

--- a/src/orchestrator/chatgpt-oauth-backend.ts
+++ b/src/orchestrator/chatgpt-oauth-backend.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger.js";
+import { errorText } from "./error-text.js";
 import type { AgentEvent, BackendStartOptions, ModelChoice, NeutralTurn } from "./agent-backend.js";
 import { CHATGPT_CAPABILITIES } from "./agent-backend.js";
 import { resolveOpenAICodexOAuth } from "../services/code-provider-auth.js";
@@ -46,7 +47,7 @@ type TurnMessage = {
 };
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /** Codex model slugs (gpt-5.x, codex-*) — not Claude panel ids. */

--- a/src/orchestrator/claude-backend.ts
+++ b/src/orchestrator/claude-backend.ts
@@ -20,6 +20,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { errorText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -63,7 +64,7 @@ export async function loadQuery(): Promise<NonNullable<typeof queryFn>> {
 }
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /**

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -42,6 +42,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { errorText, promptText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -54,7 +55,7 @@ import {
 import type { ImageRef } from "./panel-agent.js";
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 const configuredInterruptTimeoutMs = Number(process.env.COMFYUI_MCP_CODEX_INTERRUPT_TIMEOUT_MS);
@@ -1226,11 +1227,11 @@ export class CodexBackend implements AgentBackend {
     // FIRST-TURN PERSONA: the app-server has no thread-level instructions field,
     // so the panel system prompt is prepended to the first turn's input as a
     // clearly-marked system/context preamble (later turns send plain text).
-    let turnText = turn.text;
+    let turnText = promptText(turn.text);
     if (this.needsSystemPreamble && this.deps.systemAppend) {
       turnText =
         `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
-        `The user's first message follows.\n\n${turn.text}`;
+        `The user's first message follows.\n\n${turnText}`;
       this.needsSystemPreamble = false;
     }
 

--- a/src/orchestrator/copilot-backend.ts
+++ b/src/orchestrator/copilot-backend.ts
@@ -46,6 +46,7 @@
 
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { errorText } from "./error-text.js";
 import type { AgentEvent, BackendStartOptions, NeutralTurn } from "./agent-backend.js";
 import { COPILOT_CAPABILITIES } from "./agent-backend.js";
 import { OllamaBackend, type OllamaBackendDeps } from "./ollama-backend.js";
@@ -57,7 +58,7 @@ import {
 import { assertAllowedTokenHost, OAUTH_PROVIDERS, redactTokens } from "../services/oauth-flow.js";
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /** GET endpoint that exchanges the long-lived `ghu_` token for a short-lived

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -105,4 +105,21 @@ describe("promptText (#175)", () => {
     }).not.toThrow();
     expect(out).not.toBe("[object Object]");
   });
+
+  it("never returns '' when text is empty but the parts read throws", () => {
+    const hostile = {
+      get text(): string {
+        return "";
+      },
+      get parts(): unknown {
+        throw new Error("parts exploded");
+      },
+    };
+    let out = "";
+    expect(() => {
+      out = promptText(hostile);
+    }).not.toThrow();
+    expect(out).not.toBe("");
+    expect(out).not.toBe("[object Object]");
+  });
 });

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -1,0 +1,58 @@
+// Coverage for the shared text-coercion helpers that keep structured payloads
+// from surfacing as the literal "[object Object]" in chat / prompts
+// (issues #176, #175).
+
+import { describe, expect, it } from "vitest";
+import { errorText, promptText } from "./error-text.js";
+
+describe("errorText (#176)", () => {
+  it("returns the message of an Error", () => {
+    expect(errorText(new Error("boom"))).toBe("boom");
+  });
+
+  it("never returns [object Object] for a plain object error", () => {
+    const out = errorText({ code: 429, foo: "bar" });
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe('{"code":429,"foo":"bar"}');
+  });
+
+  it("extracts a string message field from a structured error", () => {
+    expect(errorText({ message: "Individual quota reached." })).toBe(
+      "Individual quota reached.",
+    );
+  });
+
+  it("coerces primitives with String()", () => {
+    expect(errorText(42)).toBe("42");
+    expect(errorText(null)).toBe("null");
+  });
+
+  it("degrades a cyclic object to 'unknown error', never [object Object]", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const out = errorText(cyclic);
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe("unknown error");
+  });
+});
+
+describe("promptText (#175)", () => {
+  it("passes strings through unchanged", () => {
+    expect(promptText("hello")).toBe("hello");
+  });
+
+  it("never returns [object Object] for a structured user payload", () => {
+    const out = promptText({ type: "image", ref: "input/a.png" });
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe('{"type":"image","ref":"input/a.png"}');
+  });
+
+  it("extracts a string text field from a multi-part payload", () => {
+    expect(promptText({ text: "typed message", parts: [] })).toBe("typed message");
+  });
+
+  it("maps null/undefined to empty string", () => {
+    expect(promptText(null)).toBe("");
+    expect(promptText(undefined)).toBe("");
+  });
+});

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -34,6 +34,28 @@ describe("errorText (#176)", () => {
     expect(out).not.toBe("[object Object]");
     expect(out).toBe("unknown error");
   });
+
+  it("does not throw and never returns [object Object] for a throwing getter", () => {
+    const hostile = {
+      get message(): string {
+        throw new Error("getter exploded");
+      },
+    };
+    let out = "";
+    expect(() => {
+      out = errorText(hostile);
+    }).not.toThrow();
+    expect(out).not.toBe("[object Object]");
+  });
+
+  it("coerces an Error whose runtime message is a non-string object", () => {
+    const err = new Error("placeholder");
+    // Simulate a subclass / runtime that set a non-string message.
+    (err as { message: unknown }).message = { code: 500 };
+    const out = errorText(err);
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe('{"code":500}');
+  });
 });
 
 describe("promptText (#175)", () => {
@@ -54,5 +76,33 @@ describe("promptText (#175)", () => {
   it("maps null/undefined to empty string", () => {
     expect(promptText(null)).toBe("");
     expect(promptText(undefined)).toBe("");
+  });
+
+  it("does NOT collapse an empty-text payload that still carries parts", () => {
+    const out = promptText({ text: "", parts: [{ kind: "image", ref: "input/b.png" }] });
+    expect(out).not.toBe("");
+    expect(out).toContain("input/b.png");
+  });
+
+  it("gives a non-empty fallback when serialization fails (circular)", () => {
+    const cyclic: Record<string, unknown> = { parts: [1] };
+    cyclic.self = cyclic;
+    const out = promptText(cyclic);
+    expect(out).not.toBe("");
+    expect(out).not.toBe("[object Object]");
+  });
+
+  it("does not throw on a throwing getter and never returns [object Object]", () => {
+    const hostile = {
+      get text(): string {
+        throw new Error("boom");
+      },
+      other: "x",
+    };
+    let out = "";
+    expect(() => {
+      out = promptText(hostile);
+    }).not.toThrow();
+    expect(out).not.toBe("[object Object]");
   });
 });

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -106,6 +106,22 @@ describe("promptText (#175)", () => {
     expect(out).not.toBe("[object Object]");
   });
 
+  it("keeps NON-EMPTY text even when the parts read throws", () => {
+    const hostile = {
+      get text(): string {
+        return "hello";
+      },
+      get parts(): unknown {
+        throw new Error("parts exploded");
+      },
+    };
+    let out = "";
+    expect(() => {
+      out = promptText(hostile);
+    }).not.toThrow();
+    expect(out).toBe("hello");
+  });
+
   it("never returns '' when text is empty but the parts read throws", () => {
     const hostile = {
       get text(): string {

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -6,21 +6,41 @@
  * which then surfaces in the panel chat as an unreadable bubble (#176). Extract
  * a string `message` field when present, otherwise JSON-serialize, and only
  * fall back to `String()` for true primitives.
+ *
+ * Every property read runs inside try/catch: a value may be a Proxy or carry a
+ * throwing getter, and normalization must never itself throw.
  */
 export function errorText(err: unknown): string {
-  if (err instanceof Error) return err.message;
+  if (err instanceof Error) {
+    try {
+      // A subclass can carry a non-string `message` (e.g. an object) — that
+      // would re-introduce "[object Object]", so coerce it.
+      if (typeof err.message === "string" && err.message) return err.message;
+      if (err.message != null) return errorText(err.message);
+    } catch {
+      // fall through to the generic object handling below
+    }
+  }
   if (err && typeof err === "object") {
-    const message = (err as { message?: unknown }).message;
-    if (typeof message === "string" && message.trim()) return message;
+    try {
+      const message = (err as { message?: unknown }).message;
+      if (typeof message === "string" && message.trim()) return message;
+    } catch {
+      // throwing getter/proxy — ignore and try to serialize instead
+    }
     try {
       const json = JSON.stringify(err);
       if (typeof json === "string" && json && json !== "{}") return json;
     } catch {
-      // fall through to the primitive coercion below
+      // circular / bigint / throwing toJSON — fall through
     }
     return "unknown error";
   }
-  return String(err);
+  try {
+    return String(err);
+  } catch {
+    return "unknown error";
+  }
 }
 
 /**
@@ -30,21 +50,39 @@ export function errorText(err: unknown): string {
  * part reaching a prompt template interpolates as "[object Object]", silently
  * losing the message context in the model prompt (#175). Extract a string
  * `text` field when the value is an object, otherwise JSON-serialize — never
- * rely on implicit object coercion.
+ * rely on implicit object coercion, and never collapse a payload that still
+ * carries `parts` to an empty prompt.
  */
 export function promptText(value: unknown): string {
   if (typeof value === "string") return value;
   if (value == null) return "";
   if (typeof value === "object") {
-    const text = (value as { text?: unknown }).text;
-    if (typeof text === "string") return text;
+    let text: unknown;
+    let hasParts = false;
+    try {
+      text = (value as { text?: unknown }).text;
+      const parts = (value as { parts?: unknown }).parts;
+      hasParts = Array.isArray(parts) && parts.length > 0;
+    } catch {
+      // throwing getter/proxy — serialize the whole value below
+    }
+    // A non-empty text field is authoritative. An EMPTY text alongside `parts`
+    // must NOT win — that would drop the parts and yield an empty prompt; fall
+    // through to serialize the whole payload instead.
+    if (typeof text === "string" && (text || !hasParts)) return text;
     try {
       const json = JSON.stringify(value);
       if (typeof json === "string" && json && json !== "{}") return json;
     } catch {
-      // fall through
+      // circular / bigint / throwing toJSON — fall through
     }
+    // Serialization failed but the payload was real content; never hand the
+    // model an empty prompt that silently erases the user's turn.
+    return "[unserializable message payload]";
+  }
+  try {
+    return String(value);
+  } catch {
     return "";
   }
-  return String(value);
 }

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -70,10 +70,11 @@ export function promptText(value: unknown): string {
       // `.parts` would otherwise return ""). Fall through to serialize/fallback.
       readOk = false;
     }
-    // A non-empty text field is authoritative. An EMPTY text alongside `parts`
-    // (or when the `.parts` read threw) must NOT win — that would drop content
-    // and yield an empty prompt; fall through to serialize the whole payload.
-    if (readOk && typeof text === "string" && (text || !hasParts)) return text;
+    // A non-empty text field is ALWAYS authoritative (even if the `.parts` read
+    // threw — the text itself is valid content). An EMPTY text may win only when
+    // the read succeeded AND there are no parts; otherwise fall through to
+    // serialize the whole payload rather than emit an empty prompt.
+    if (typeof text === "string" && (text || (readOk && !hasParts))) return text;
     try {
       const json = JSON.stringify(value);
       if (typeof json === "string" && json && json !== "{}") return json;

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -1,0 +1,50 @@
+/**
+ * Coerce an unknown thrown/rejected value into readable text.
+ *
+ * `String(err)` on a plain object (e.g. a structured JSON-RPC / protocol error
+ * frame that is not an `Error` instance) yields the literal "[object Object]",
+ * which then surfaces in the panel chat as an unreadable bubble (#176). Extract
+ * a string `message` field when present, otherwise JSON-serialize, and only
+ * fall back to `String()` for true primitives.
+ */
+export function errorText(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+    try {
+      const json = JSON.stringify(err);
+      if (typeof json === "string" && json && json !== "{}") return json;
+    } catch {
+      // fall through to the primitive coercion below
+    }
+    return "unknown error";
+  }
+  return String(err);
+}
+
+/**
+ * Coerce a user-turn payload into prompt-safe text.
+ *
+ * A user turn's `text` is normally a string, but a structured/multi-part chat
+ * part reaching a prompt template interpolates as "[object Object]", silently
+ * losing the message context in the model prompt (#175). Extract a string
+ * `text` field when the value is an object, otherwise JSON-serialize — never
+ * rely on implicit object coercion.
+ */
+export function promptText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value === "object") {
+    const text = (value as { text?: unknown }).text;
+    if (typeof text === "string") return text;
+    try {
+      const json = JSON.stringify(value);
+      if (typeof json === "string" && json && json !== "{}") return json;
+    } catch {
+      // fall through
+    }
+    return "";
+  }
+  return String(value);
+}

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -59,17 +59,21 @@ export function promptText(value: unknown): string {
   if (typeof value === "object") {
     let text: unknown;
     let hasParts = false;
+    let readOk = true;
     try {
       text = (value as { text?: unknown }).text;
       const parts = (value as { parts?: unknown }).parts;
       hasParts = Array.isArray(parts) && parts.length > 0;
     } catch {
-      // throwing getter/proxy — serialize the whole value below
+      // throwing getter/proxy — property access is untrustworthy, so DON'T take
+      // the empty-`text` short-circuit below (a `.text` of "" with a throwing
+      // `.parts` would otherwise return ""). Fall through to serialize/fallback.
+      readOk = false;
     }
     // A non-empty text field is authoritative. An EMPTY text alongside `parts`
-    // must NOT win — that would drop the parts and yield an empty prompt; fall
-    // through to serialize the whole payload instead.
-    if (typeof text === "string" && (text || !hasParts)) return text;
+    // (or when the `.parts` read threw) must NOT win — that would drop content
+    // and yield an empty prompt; fall through to serialize the whole payload.
+    if (readOk && typeof text === "string" && (text || !hasParts)) return text;
     try {
       const json = JSON.stringify(value);
       if (typeof json === "string" && json && json !== "{}") return json;

--- a/src/orchestrator/gemini-backend.ts
+++ b/src/orchestrator/gemini-backend.ts
@@ -65,6 +65,7 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:chil
 import { createRequire } from "node:module";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
+import { errorText, promptText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -77,7 +78,7 @@ import {
 import type { ImageRef } from "./panel-agent.js";
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /**
@@ -1033,11 +1034,11 @@ export class GeminiBackend implements AgentBackend {
     // FIRST-TURN PERSONA: ACP session/new has no instructions field, so the panel
     // system prompt is prepended to the first turn's prompt as a clearly-marked
     // system/context preamble (later turns send plain text). Mirrors codex.
-    let turnText = turn.text;
+    let turnText = promptText(turn.text);
     if (this.needsSystemPreamble && this.deps.systemAppend) {
       turnText =
         `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
-        `The user's first message follows.\n\n${turn.text}`;
+        `The user's first message follows.\n\n${turnText}`;
       this.needsSystemPreamble = false;
     }
 

--- a/src/orchestrator/grok-backend.ts
+++ b/src/orchestrator/grok-backend.ts
@@ -63,6 +63,7 @@ import readline from "node:readline";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { logger } from "../utils/logger.js";
+import { errorText, promptText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -83,7 +84,7 @@ import { OAUTH_PROVIDERS, assertAllowedTokenHost, grokTokenFile, redactTokens } 
 import { OllamaBackend } from "./ollama-backend.js";
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /**
@@ -1028,11 +1029,11 @@ export class GrokBackend implements AgentBackend {
     // FIRST-TURN PERSONA: ACP session/new has no instructions field, so the panel
     // system prompt is prepended to the first turn's prompt as a clearly-marked
     // system/context preamble (later turns send plain text). Mirrors codex.
-    let turnText = turn.text;
+    let turnText = promptText(turn.text);
     if (this.needsSystemPreamble && this.deps.systemAppend) {
       turnText =
         `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
-        `The user's first message follows.\n\n${turn.text}`;
+        `The user's first message follows.\n\n${turnText}`;
       this.needsSystemPreamble = false;
     }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -35,6 +35,7 @@ import {
   type SlashCommand,
   type UsageStatus,
 } from "./panel-agent.js";
+import { promptText } from "./error-text.js";
 import { createPanelMcpServer } from "./panel-tools.js";
 import {
   optionsAckFrame,
@@ -3278,13 +3279,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       return;
     }
 
-    if (
-      event.type !== "user_message" ||
-      typeof event.text !== "string" ||
-      !event.tab_id
-    ) {
+    if (event.type !== "user_message" || !event.tab_id) {
       return;
     }
+    // A well-behaved panel sends a string `text`, but a structured / multi-part
+    // payload must be COERCED here rather than silently dropped: dropping loses
+    // the whole turn, and letting a non-string flow downstream interpolates as
+    // "[object Object]" in the model prompt (#175). Coerce at ingress so every
+    // consumer (echo, batching join, backend preamble) sees a real string.
+    if (typeof event.text !== "string") {
+      const rawText = (event as { text?: unknown }).text;
+      if (rawText == null) return; // nothing to say (image-only turns were never accepted here)
+      (event as { text: string }).text = promptText(rawText);
+    }
+    if (typeof event.text !== "string") return; // coerced above — narrows the type for downstream use
     // Echo so the user immediately sees their own message land in the chat.
     bridge.push({ type: "echo", text: event.text }, event.tab_id);
     // Per-message ack: a live server-side signal that the agent received this

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "../utils/logger.js";
+import { errorText } from "./error-text.js";
 import type {
   AgentBackend,
   AgentEvent,
@@ -193,7 +194,7 @@ export const RECOMMENDED_OPENROUTER_MODELS: readonly RecommendedModel[] = [
 ];
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 function textOf(result: McpCallResult): string {

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,6 +23,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
+import { errorText } from "./error-text.js";
 import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
 import {
@@ -37,7 +38,7 @@ export type { ModelInfo, SlashCommand };
 export { fetchSupportedModels, fetchSupportedCommands };
 
 function msgOf(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return errorText(err);
 }
 
 /** Idle window for the per-turn freeze watchdog: if a turn that's in flight

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -23,7 +23,7 @@ import type {
   McpSdkServerConfigWithInstance,
 } from "@anthropic-ai/claude-agent-sdk";
 import { logger } from "../utils/logger.js";
-import { errorText } from "./error-text.js";
+import { errorText, promptText } from "./error-text.js";
 import type { SessionStore } from "./session-store.js";
 import type { AgentBackend, AgentEvent, NeutralTurn } from "./agent-backend.js";
 import {
@@ -640,7 +640,9 @@ export class PanelAgent {
       for (const it of batch) {
         if (it.mid) this.deps.onSeen?.(this.tabId, it.mid);
       }
-      let text = batch.map((it) => it.text).join("\n\n");
+      // Coerce each part before joining: a structured payload that slipped past
+      // ingress would otherwise stringify to "[object Object]" here (#175).
+      let text = batch.map((it) => promptText(it.text)).join("\n\n");
       let images = batch.flatMap((it) => it.images ?? []);
       if (images.length && !this.backend.capabilities.vision) {
         // Text-only backend: every non-vision adapter silently ignores image


### PR DESCRIPTION
## Serialize structured chat payloads instead of "[object Object]"

Companion to comfyui-mcp-panel #228 (WS-9). The panel already string-guards its `say`/`user_message` frames, so these `[object Object]` symptoms originate in the orchestrator's own coercion of structured payloads.

New shared module `src/orchestrator/error-text.ts` with two helpers:

### errorText() — Closes #176
Every backend defined an identical `msgOf(err)` as `err instanceof Error ? err.message : String(err)`. When a backend turn rejects with a **structured** (non-`Error`) failure object — common for JSON/JSON-RPC protocol error frames — `String(obj)` produced the literal `"[object Object]"`, which rendered as an unreadable chat bubble after the real quota/error text.

`errorText()` extracts a string `message` field, else `JSON.stringify`, else `"unknown error"` — never bare `String(obj)`. All nine `msgOf()` helpers (claude/codex/gemini/grok/antigravity/copilot/chatgpt-oauth/ollama backends + panel-agent) delegate to it.

### promptText() — Refs #175
The user-turn text interpolated into each backend's system preamble (`The user's first message follows.\n\n${turn.text}`) is now coerced with `promptText()` in the four backends that build that preamble (antigravity/codex/gemini/grok), so a structured/multi-part user payload can never reach the model prompt as `"[object Object]"`. Extracts a string `text` field or JSON-serializes.

### #168 (partial)
The object-serialization half of #168 is covered by the family-wide hardening above. The other symptom — `panel_*` tools silently missing from a session's tool inventory when the in-process / HTTP panel MCP server is absent — is a handshake/registration robustness issue that needs live verification and is left for a focused follow-up. Not closed here.

### Tests
`src/orchestrator/error-text.test.ts` — both helpers, asserting no `[object Object]` for plain objects, `.message`/`.text` extraction, primitives, and cyclic-object degradation. `npm run lint` (tsc) clean; full `vitest run` green except one pre-existing, unrelated environmental failure (`node-dev.test.ts` ripgrep-vs-builtin search engine).

Refs #175, #168.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
