### PR TITLE
feat(report-bug): fix-then-file default + async Worker submit/poll client

### DIFF
--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -121,9 +121,9 @@ Then file it (no need to ask):
 - **Default path (everyone):** POST the report to our intake Worker — no GitHub
   account needed:
 
-  The Worker is an **async intake**: the POST accepts + queues the report and
-  returns a `job_id`; the issue is filed in the background. Submit, then poll
-  `/status/<job_id>` a few times to get the issue link.
+  The Worker files the issue **synchronously** and returns the link inline
+  (`{ ok, url, number, deduped?, job_id }`); the `job_id` + `/status/<job_id>`
+  poll is only a fallback for the rare case the submit didn't carry a `url`.
 
   ```bash
   # URL is baked in; override with $COMFYUI_MCP_ISSUE_WORKER_URL if set. The
@@ -135,43 +135,55 @@ Then file it (no need to ask):
 
   # 1) Submit. Write the JSON to a temp file first (the body has newlines/quotes).
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
-  RESP=$(curl -fsS -X POST "$WORKER_URL" \
-    -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
-    --data @"$BODY_JSON_FILE")
-  # Fast path may already include the issue: { ok, job_id, status:"done", url, number, deduped? }.
-  # Slow path: { ok, job_id, status:"queued" } — then poll.
-  JOB_ID=$(printf '%s' "$RESP" | sed -n 's/.*"job_id"[: ]*"\([^"]*\)".*/\1/p')
-
-  # 2) Poll a few times for the filed issue link (skip if the submit already had url).
-  if ! printf '%s' "$RESP" | grep -q '"url"'; then
-    for i in 1 2 3 4 5; do
-      sleep 1
-      STAT=$(curl -fsS "$WORKER_URL/status/$JOB_ID")
-      echo "$STAT" | grep -q '"status":"done"'  && { echo "$STAT"; break; }
-      echo "$STAT" | grep -q '"status":"error"' && { echo "$STAT"; break; }
-    done
+  # --max-time bounds the whole request so a hung connection can't wedge us.
+  if ! RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
+      -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
+      --data @"$BODY_JSON_FILE"); then
+    # ANY non-OK / unreachable (401, 5xx, timeout, DNS…): fall back to the
+    # report_issue tool for a prefilled GitHub link. Do NOT poll.
+    echo "worker submit failed — falling back to report_issue"
+  else
+    URL=$(printf '%s' "$RESP" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
+    # 2) Only poll if the submit lacked a url AND we actually got a job_id.
+    if [ -z "$URL" ]; then
+      JOB_ID=$(printf '%s' "$RESP" | sed -n 's/.*"job_id"[: ]*"\([^"]*\)".*/\1/p')
+      if [ -n "$JOB_ID" ]; then
+        for i in 1 2 3 4 5; do
+          sleep 1
+          STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || continue
+          URL=$(printf '%s' "$STAT" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
+          [ -n "$URL" ] && break
+        done
+      fi
+    fi
+    # 3) PRINT the resulting issue link (inline-fast-path OR polled).
+    [ -n "$URL" ] && echo "filed: $URL" || echo "report accepted; link not yet available"
   fi
   ```
-  The final `{ status:"done", url, number, deduped? }` carries the created issue
-  link. A `401 unauthorized` on submit means `$COMFYUI_MCP_ISSUE_CLIENT_KEY` is
-  unset/wrong — fall back to `report_issue`. If polling keeps returning
-  `queued`, the report is still accepted (filing continues server-side); just
-  tell the user it's logged and move on. **Surface the issue link to the user
-  only if they want it** — the filing is autonomous, so a one-line "filed #123"
-  is enough (Step 7).
+  A `401 unauthorized` (or any non-2xx / timeout / unreachable) on submit means
+  fall back to `report_issue` for a prefilled link — don't poll with an empty
+  `JOB_ID`. If polling never yields a `url`, the report is still accepted
+  (filing is synchronous server-side); tell the user it's logged and move on.
+  **Surface the issue link to the user only if they want it** — the filing is
+  autonomous, so a one-line "filed #123" is enough (Step 7).
 - **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool → a prefilled
   GitHub issue link the user can submit in one click.
 
-## Step 6 — Third-party / ComfyUI-core bugs
+## Step 6 — Third-party / ComfyUI-core bugs (offer + ASK first — not autonomous)
 
-Our Worker only files into OUR repos, so these go to **their** GitHub:
+Our Worker only files into OUR repos, so these go to **their** GitHub. Unlike
+our-repo defects (Steps 3–5, which you handle autonomously), third-party bugs
+are **offer-and-ask** at every step — patching someone else's node and posting
+to someone else's tracker are the user's calls, not yours:
 
-- Still attempt a **local workaround** if you safely can (e.g. patch the custom
-  node so the user isn't blocked) — same keep-the-patch logic.
-- To report: identify the node/project's GitHub repo (from its metadata /
-  `list_installed_nodes` / its folder), then use `report_issue` with that
-  `owner/repo` to produce a prefilled issue link, OR `gh issue create -R owner/repo`
-  if `gh` is authed.
+- **Ask before patching.** You may *offer* a local workaround (e.g. patch the
+  custom node so the user isn't blocked) — but apply it only once the user says
+  yes. Same keep-the-patch logic once approved.
+- **Ask before filing.** Identify the node/project's GitHub repo (from its
+  metadata / `list_installed_nodes` / its folder), then — with the user's
+  go-ahead — use `report_issue` with that `owner/repo` (it returns a **prefilled
+  link the user reviews and submits**; it does not auto-file into third-party
+  repos), OR `gh issue create -R owner/repo` if `gh` is authed and they agree.
 - If the user has **no GitHub account**, briefly offer to walk them through
   creating one (github.com/signup) so they can file it — that's how the bug
   reaches the people who can fix it. We can't file it for them.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -158,7 +158,7 @@ Then file it (no need to ask):
   # the exact GitHub issue shape. EXACTLY ONE outcome: real url → filed;
   # anything else (non-2xx/timeout/unreachable, ok!=true, status:"error",
   # missing/invalid url, invalid JSON) → prefilled report_issue fallback.
-  if ! printf '%s' "$RESP" | jq -e . >/dev/null 2>&1; then
+  if ! printf '%s' "$RESP" | jq -e -s 'length == 1' >/dev/null 2>&1; then
     echo "worker did not return valid JSON — fall back to the report_issue tool for a prefilled GitHub link"
   else
     URL=$(printf '%s' "$RESP" | jq -r \

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -161,13 +161,14 @@ Then file it (no need to ask):
           sleep 1
           # Hard transport failure → stop and fall back (do NOT keep polling).
           STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || break
-          # Server-side filing error → stop and fall back.
-          printf '%s' "$STAT" | grep -q '"status":"error"' && break
+          # A real url → done, filed.
           URL=$(printf '%s' "$STAT" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
           [ -n "$URL" ] && break
-          # Otherwise it's a well-formed queued/pending → keep polling until the
-          # ceiling. (A malformed body yields no url and no error marker, so it
-          # simply loops to the ceiling and then falls back — still never "filed".)
+          # No url yet: keep polling ONLY for a well-formed queued/pending.
+          # ANY other body — status:"error", "unknown", "done" without a url, or
+          # malformed JSON — is terminal: BREAK to the fallback, never loop on.
+          STATUS=$(printf '%s' "$STAT" | sed -n 's/.*"status"[: ]*"\([^"]*\)".*/\1/p')
+          [ "$STATUS" = "queued" ] || [ "$STATUS" = "pending" ] || break
         done
       fi
     fi

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -131,6 +131,9 @@ Then file it (no need to ask):
   The Worker files the issue **synchronously** and returns the link inline
   (`{ ok, url, number, deduped?, job_id }`); the `job_id` + `/status/<job_id>`
   poll is only a fallback for the rare case the submit didn't carry a `url`.
+  This shell snippet is the **manual / non-Claude fallback** and **requires
+  `jq`** for safe JSON parsing (Claude agents should use the `report_issue`
+  tool, which already implements this correctly).
 
   ```bash
   # URL is baked in; override with $COMFYUI_MCP_ISSUE_WORKER_URL if set. The
@@ -140,6 +143,9 @@ Then file it (no need to ask):
   # token is server-side in the Worker). Override with $COMFYUI_MCP_ISSUE_CLIENT_KEY.
   CLIENT_KEY="${COMFYUI_MCP_ISSUE_CLIENT_KEY:-9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2}"
 
+  # A url counts as "filed" only if it's a real GitHub issue URL.
+  is_issue_url() { printf '%s' "$1" | grep -Eq '^https://github\.com/[^/]+/[^/]+/issues/[0-9]+$'; }
+
   # 1) Submit. Write the JSON to a temp file first (the body has newlines/quotes).
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
   # --max-time bounds the whole request so a hung connection can't wedge us.
@@ -147,32 +153,36 @@ Then file it (no need to ask):
   if RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
       -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
       --data @"$BODY_JSON_FILE"); then
-    URL=$(printf '%s' "$RESP" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
+    # Parse with jq (NOT sed) — a regex can be fooled by an adversarial substring
+    # like `garbage "url":"..."`. jq failing (non-zero → not valid JSON) is
+    # terminal → fall through to the fallback with URL empty.
+    URL=$(printf '%s' "$RESP" | jq -r '.url // empty' 2>/dev/null || true)
     # 2) Only poll if the submit lacked a url AND we actually got a job_id.
     #    Mirrors the TS: keep polling ONLY while the Worker reports a well-formed
-    #    queued/pending. On the FIRST hard failure — curl transport error /
-    #    timeout / non-2xx, or a status:"error" body — BREAK immediately (do NOT
-    #    continue); the fallback below then prints the prefilled link. Exhausting
-    #    the attempt ceiling with no url is also a fallback, never "filed".
+    #    queued/pending. ANY hard failure (curl transport error/timeout/non-2xx,
+    #    invalid JSON, or a non-queued/pending status) BREAKs to the fallback.
     if [ -z "$URL" ]; then
-      JOB_ID=$(printf '%s' "$RESP" | sed -n 's/.*"job_id"[: ]*"\([^"]*\)".*/\1/p')
+      JOB_ID=$(printf '%s' "$RESP" | jq -r '.job_id // empty' 2>/dev/null || true)
       if [ -n "$JOB_ID" ]; then
         for i in 1 2 3 4 5; do
           sleep 1
           # Hard transport failure → stop and fall back (do NOT keep polling).
           STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || break
+          # Invalid JSON → terminal, break to fallback.
+          echo "$STAT" | jq -e . >/dev/null 2>&1 || break
           # A real url → done, filed.
-          URL=$(printf '%s' "$STAT" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
+          URL=$(printf '%s' "$STAT" | jq -r '.url // empty')
           [ -n "$URL" ] && break
           # No url yet: keep polling ONLY for a well-formed queued/pending.
-          # ANY other body — status:"error", "unknown", "done" without a url, or
-          # malformed JSON — is terminal: BREAK to the fallback, never loop on.
-          STATUS=$(printf '%s' "$STAT" | sed -n 's/.*"status"[: ]*"\([^"]*\)".*/\1/p')
+          # ANY other value — error, unknown, done-without-url — is terminal.
+          STATUS=$(printf '%s' "$STAT" | jq -r '.status // empty')
           [ "$STATUS" = "queued" ] || [ "$STATUS" = "pending" ] || break
         done
       fi
     fi
   fi
+  # Only a real GitHub issue URL counts as filed; anything else → fallback.
+  is_issue_url "$URL" || URL=""
 
   # 3) EXACTLY ONE outcome. A real issue link → print it. ANYTHING else (submit
   # failure, poll failure/timeout, done-with-error, or exhausted with no url) →

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -147,25 +147,27 @@ Then file it (no need to ask):
   # body has newlines/quotes). --max-time bounds the request so a hung
   # connection can't wedge us.
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
-  URL=""
-  if RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
-      -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
-      --data @"$BODY_JSON_FILE"); then
-    # Validate entirely inside jq (no grep — a piped grep can be bypassed by a
-    # multi-line body). Require ok==true AND a url matching the exact GitHub
-    # issue shape. Invalid JSON → jq exits non-zero → URL stays empty → fallback.
-    URL=$(printf '%s' "$RESP" | jq -r \
-      'select(.ok==true) | .url // empty | select(test("^https://github.com/[^/]+/[^/]+/issues/[0-9]+$"))' \
-      2>/dev/null || true)
-  fi
+  RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
+    -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
+    --data @"$BODY_JSON_FILE" || true)
 
-  # 2) EXACTLY ONE outcome. A real issue url → print it. ANYTHING else —
-  # non-2xx / timeout / unreachable, ok!=true, status:"error", missing/invalid
-  # url, or invalid JSON — → prefilled report_issue fallback. Never "accepted".
-  if [ -n "$URL" ]; then
-    echo "filed: $URL"
+  # 2) VALIDATE THE WHOLE BODY FIRST with `jq -e .` — it rejects anything that
+  # isn't a single valid JSON document (trailing garbage → non-zero), so the
+  # extraction below only ever runs on clean JSON (no partial output before a
+  # later parse error). Require ok==true AND status!="error" AND a url matching
+  # the exact GitHub issue shape. EXACTLY ONE outcome: real url → filed;
+  # anything else (non-2xx/timeout/unreachable, ok!=true, status:"error",
+  # missing/invalid url, invalid JSON) → prefilled report_issue fallback.
+  if ! printf '%s' "$RESP" | jq -e . >/dev/null 2>&1; then
+    echo "worker did not return valid JSON — fall back to the report_issue tool for a prefilled GitHub link"
   else
-    echo "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
+    URL=$(printf '%s' "$RESP" | jq -r \
+      'select(.ok==true and (.status!="error")) | .url // empty | select(test("^https://github.com/[^/]+/[^/]+/issues/[0-9]+$"))')
+    if [ -n "$URL" ]; then
+      echo "filed: $URL"
+    else
+      echo "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
+    fi
   fi
   ```
   A real `url` from the POST is the only "filed" outcome. Any submit failure

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -54,17 +54,18 @@ in doubt during beta, file it and move on.
 
 ## Step 2 — Classify whose bug it is
 
-- **OURS** — `comfyui-mcp` (server/tools/orchestrator/agent) or
-  `comfyui-mcp-panel` (the sidebar pack / panel JS / `__init__.py`). → Steps 3–5 (self-heal + Worker/PR).
+- **OURS** — `comfyui-mcp` (server/tools/orchestrator/agent),
+  `comfyui-mcp-panel` (the sidebar pack / panel JS / `__init__.py`), or
+  `comfyui-mcp-issue-worker` (the intake Worker). → Steps 3–5 (self-heal + Worker/PR).
 - **THIRD-PARTY** — a custom node pack, or **ComfyUI core** itself. → Step 6 (their GitHub; our Worker can't file there).
 
 ## Step 3 — Fix it locally FIRST (this is the default, not "when you can")
 
-For any defect in **OUR** repos (`comfyui-mcp` / `comfyui-mcp-panel`), the
-default is to **fix it before/alongside filing** — patch the code **where it
-actually runs** so the user is unblocked immediately and the report arrives as a
-near-PR (code + diff), not just a ticket. Do this every time; don't wait to be
-asked and don't downgrade it to optional.
+For any defect in **OUR** repos (`comfyui-mcp` / `comfyui-mcp-panel` /
+`comfyui-mcp-issue-worker`), the default is to **fix it before/alongside
+filing** — patch the code **where it actually runs** so the user is unblocked
+immediately and the report arrives as a near-PR (code + diff), not just a ticket.
+Do this every time; don't wait to be asked and don't downgrade it to optional.
 
 - `comfyui-mcp`: find the running install from the stack path. If a source
   checkout exists, fix the `.ts` source and `npm run build`; if only the built
@@ -142,13 +143,10 @@ Then file it (no need to ask):
   # 1) Submit. Write the JSON to a temp file first (the body has newlines/quotes).
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
   # --max-time bounds the whole request so a hung connection can't wedge us.
-  if ! RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
+  URL=""
+  if RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
       -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
       --data @"$BODY_JSON_FILE"); then
-    # ANY non-OK / unreachable (401, 5xx, timeout, DNS…): fall back to the
-    # report_issue tool for a prefilled GitHub link. Do NOT poll.
-    echo "worker submit failed — falling back to report_issue"
-  else
     URL=$(printf '%s' "$RESP" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
     # 2) Only poll if the submit lacked a url AND we actually got a job_id.
     if [ -z "$URL" ]; then
@@ -156,22 +154,35 @@ Then file it (no need to ask):
       if [ -n "$JOB_ID" ]; then
         for i in 1 2 3 4 5; do
           sleep 1
+          # A poll curl failure (error/timeout/non-2xx) is NOT success — keep
+          # trying; if we exhaust the loop with no url we fall back below.
           STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || continue
+          # A done-with-error carries no url and must NOT be treated as filed.
+          printf '%s' "$STAT" | grep -q '"status":"error"' && break
           URL=$(printf '%s' "$STAT" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
           [ -n "$URL" ] && break
         done
       fi
     fi
-    # 3) PRINT the resulting issue link (inline-fast-path OR polled).
-    [ -n "$URL" ] && echo "filed: $URL" || echo "report accepted; link not yet available"
+  fi
+
+  # 3) EXACTLY ONE outcome. A real issue link → print it. ANYTHING else (submit
+  # failure, poll failure/timeout, done-with-error, or exhausted with no url) →
+  # fall back to the report_issue prefilled URL. NEVER claim accepted/pending
+  # without a real link.
+  if [ -n "$URL" ]; then
+    echo "filed: $URL"
+  else
+    echo "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
   fi
   ```
-  A `401 unauthorized` (or any non-2xx / timeout / unreachable) on submit means
-  fall back to `report_issue` for a prefilled link — don't poll with an empty
-  `JOB_ID`. If polling never yields a `url`, the report is still accepted
-  (filing is synchronous server-side); tell the user it's logged and move on.
-  **Surface the issue link to the user only if they want it** — the filing is
-  autonomous, so a one-line "filed #123" is enough (Step 7).
+  Mirror this in behavior: a real `url` (inline fast-path OR polled) is the only
+  "filed" outcome. Any submit failure (`401`/non-2xx/timeout/unreachable), any
+  poll failure, a `status:"error"`, or exhausting the poll with no `url` → fall
+  back to `report_issue` for a prefilled link the user submits in one click; do
+  **not** poll with an empty `JOB_ID` and do **not** tell the user it was
+  accepted without a real issue link. **Surface the link only if they want it** —
+  the filing is autonomous, so a one-line "filed #123" is enough (Step 7).
 - **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool → a prefilled
   GitHub issue link the user can submit in one click.
 

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -128,12 +128,12 @@ Then file it (no need to ask):
 - **Default path (everyone):** POST the report to our intake Worker — no GitHub
   account needed:
 
-  The Worker files the issue **synchronously** and returns the link inline
-  (`{ ok, url, number, deduped?, job_id }`); the `job_id` + `/status/<job_id>`
-  poll is only a fallback for the rare case the submit didn't carry a `url`.
-  This shell snippet is the **manual / non-Claude fallback** and **requires
-  `jq`** for safe JSON parsing (Claude agents should use the `report_issue`
-  tool, which already implements this correctly).
+  The Worker files the issue **synchronously**: on success the POST response
+  ALWAYS carries the issue `url` inline (`{ ok:true, url, number, deduped?,
+  job_id }`), so the manual path is **one POST — no polling needed**. This shell
+  snippet is the **manual / non-Claude fallback** and **requires `jq`** for safe
+  JSON parsing (Claude agents should use the `report_issue` tool, which already
+  implements this correctly).
 
   ```bash
   # URL is baked in; override with $COMFYUI_MCP_ISSUE_WORKER_URL if set. The
@@ -143,64 +143,39 @@ Then file it (no need to ask):
   # token is server-side in the Worker). Override with $COMFYUI_MCP_ISSUE_CLIENT_KEY.
   CLIENT_KEY="${COMFYUI_MCP_ISSUE_CLIENT_KEY:-9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2}"
 
-  # A url counts as "filed" only if it's a real GitHub issue URL.
-  is_issue_url() { printf '%s' "$1" | grep -Eq '^https://github\.com/[^/]+/[^/]+/issues/[0-9]+$'; }
-
-  # 1) Submit. Write the JSON to a temp file first (the body has newlines/quotes).
+  # 1) Submit — ONE synchronous POST. Write the JSON to a temp file first (the
+  # body has newlines/quotes). --max-time bounds the request so a hung
+  # connection can't wedge us.
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
-  # --max-time bounds the whole request so a hung connection can't wedge us.
   URL=""
   if RESP=$(curl -fsS --max-time 15 -X POST "$WORKER_URL" \
       -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
       --data @"$BODY_JSON_FILE"); then
-    # Parse with jq (NOT sed) — a regex can be fooled by an adversarial substring
-    # like `garbage "url":"..."`. jq failing (non-zero → not valid JSON) is
-    # terminal → fall through to the fallback with URL empty.
-    URL=$(printf '%s' "$RESP" | jq -r '.url // empty' 2>/dev/null || true)
-    # 2) Only poll if the submit lacked a url AND we actually got a job_id.
-    #    Mirrors the TS: keep polling ONLY while the Worker reports a well-formed
-    #    queued/pending. ANY hard failure (curl transport error/timeout/non-2xx,
-    #    invalid JSON, or a non-queued/pending status) BREAKs to the fallback.
-    if [ -z "$URL" ]; then
-      JOB_ID=$(printf '%s' "$RESP" | jq -r '.job_id // empty' 2>/dev/null || true)
-      if [ -n "$JOB_ID" ]; then
-        for i in 1 2 3 4 5; do
-          sleep 1
-          # Hard transport failure → stop and fall back (do NOT keep polling).
-          STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || break
-          # Invalid JSON → terminal, break to fallback.
-          echo "$STAT" | jq -e . >/dev/null 2>&1 || break
-          # A real url → done, filed.
-          URL=$(printf '%s' "$STAT" | jq -r '.url // empty')
-          [ -n "$URL" ] && break
-          # No url yet: keep polling ONLY for a well-formed queued/pending.
-          # ANY other value — error, unknown, done-without-url — is terminal.
-          STATUS=$(printf '%s' "$STAT" | jq -r '.status // empty')
-          [ "$STATUS" = "queued" ] || [ "$STATUS" = "pending" ] || break
-        done
-      fi
-    fi
+    # Validate entirely inside jq (no grep — a piped grep can be bypassed by a
+    # multi-line body). Require ok==true AND a url matching the exact GitHub
+    # issue shape. Invalid JSON → jq exits non-zero → URL stays empty → fallback.
+    URL=$(printf '%s' "$RESP" | jq -r \
+      'select(.ok==true) | .url // empty | select(test("^https://github.com/[^/]+/[^/]+/issues/[0-9]+$"))' \
+      2>/dev/null || true)
   fi
-  # Only a real GitHub issue URL counts as filed; anything else → fallback.
-  is_issue_url "$URL" || URL=""
 
-  # 3) EXACTLY ONE outcome. A real issue link → print it. ANYTHING else (submit
-  # failure, poll failure/timeout, done-with-error, or exhausted with no url) →
-  # fall back to the report_issue prefilled URL. NEVER claim accepted/pending
-  # without a real link.
+  # 2) EXACTLY ONE outcome. A real issue url → print it. ANYTHING else —
+  # non-2xx / timeout / unreachable, ok!=true, status:"error", missing/invalid
+  # url, or invalid JSON — → prefilled report_issue fallback. Never "accepted".
   if [ -n "$URL" ]; then
     echo "filed: $URL"
   else
     echo "worker did not return an issue link — fall back to the report_issue tool for a prefilled GitHub link"
   fi
   ```
-  Mirror this in behavior: a real `url` (inline fast-path OR polled) is the only
-  "filed" outcome. Any submit failure (`401`/non-2xx/timeout/unreachable), any
-  poll failure, a `status:"error"`, or exhausting the poll with no `url` → fall
-  back to `report_issue` for a prefilled link the user submits in one click; do
-  **not** poll with an empty `JOB_ID` and do **not** tell the user it was
-  accepted without a real issue link. **Surface the link only if they want it** —
-  the filing is autonomous, so a one-line "filed #123" is enough (Step 7).
+  A real `url` from the POST is the only "filed" outcome. Any submit failure
+  (`401`/non-2xx/timeout/unreachable), `ok` not `true`, a `status:"error"` body,
+  a missing/invalid url, or invalid JSON → fall back to `report_issue` for a
+  prefilled link the user submits in one click; never tell the user it was
+  accepted without a real issue link. (A `GET /status/<job_id>` endpoint exists
+  to optionally re-fetch the link later, but it is NOT needed to file — don't
+  poll.) **Surface the link only if they want it** — the filing is autonomous,
+  so a one-line "filed #123" is enough (Step 7).
 - **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool → a prefilled
   GitHub issue link the user can submit in one click.
 

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-bug
-description: Self-heal + report bugs to make the ecosystem better. When you hit ANY defect in comfyui-mcp / the sidebar panel, OR in a third-party custom node / ComfyUI core, use this: diagnose it, attempt a local fix so the user can keep working, and report it the right way (our intake Worker for our repos; the node's own GitHub for third-party). Acts autonomously and just informs the user — it does not ask permission for each step. **BETA — bias HARD toward filing:** trigger on any comfyui-mcp/panel defect you notice — an error, a crash, a tool that returns wrong/misleading/empty output, a silent failure, a confusing result, or a limitation that forced an awkward workaround — EVEN IF you recovered or worked around it. You do NOT need to be blocked. Also on "report this" / "fix this bug". If a future user would hit the same friction, file it — the intake Worker dedupes, so over-reporting is cheap and under-reporting costs us the bug.
+description: Self-heal + report bugs to make the ecosystem better. When you hit ANY defect in comfyui-mcp / the sidebar panel, OR in a third-party custom node / ComfyUI core, use this: diagnose it, and for OUR repos (comfyui-mcp / comfyui-mcp-panel) **fix it locally FIRST** — patch the code where it actually runs so the user is unblocked immediately — then file a report that includes the diff, so reports arrive as near-PRs, not just tickets. (Attempt the fix exactly ONCE; if it's genuinely upstream-only, mark it and include the precise change needed.) Report it the right way: our intake Worker for our repos; the node's own GitHub for third-party. Acts autonomously and just informs the user — it does not ask permission for each step. **BETA — bias HARD toward fix-then-file:** trigger on any comfyui-mcp/panel defect you notice — an error, a crash, a tool that returns wrong/misleading/empty output, a silent failure, a confusing result, or a limitation that forced an awkward workaround — EVEN IF you recovered or worked around it. You do NOT need to be blocked. Also on "report this" / "fix this bug". If a future user would hit the same friction, fix-and-file it — the intake Worker dedupes, so over-reporting is cheap and under-reporting costs us the bug. THIRD-PARTY / ComfyUI-core bugs stay offer-and-ask.
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
@@ -52,9 +52,13 @@ in doubt during beta, file it and move on.
   `comfyui-mcp-panel` (the sidebar pack / panel JS / `__init__.py`). → Steps 3–5 (self-heal + Worker/PR).
 - **THIRD-PARTY** — a custom node pack, or **ComfyUI core** itself. → Step 6 (their GitHub; our Worker can't file there).
 
-## Step 3 — Attempt a local fix (so the user keeps working)
+## Step 3 — Fix it locally FIRST (this is the default, not "when you can")
 
-Patch the code **where it actually runs** so relief is immediate:
+For any defect in **OUR** repos (`comfyui-mcp` / `comfyui-mcp-panel`), the
+default is to **fix it before/alongside filing** — patch the code **where it
+actually runs** so the user is unblocked immediately and the report arrives as a
+near-PR (code + diff), not just a ticket. Do this every time; don't wait to be
+asked and don't downgrade it to optional.
 
 - `comfyui-mcp`: find the running install from the stack path. If a source
   checkout exists, fix the `.ts` source and `npm run build`; if only the built
@@ -63,11 +67,16 @@ Patch the code **where it actually runs** so relief is immediate:
 - `comfyui-mcp-panel`: patch the file under the pack (`web/js/…` for UI,
   `__init__.py` for the pack) — UI changes need a hard-refresh.
 
-Keep the patch **minimal and reversible**. It's fine that a future update will
-overwrite it — that's expected; the user runs the patched version in the
-meantime. If you genuinely **can't** fix it locally (the bug is upstream-only —
-in the SDK, ComfyUI, or needs a release), say so and skip to reporting, marked
-upstream-only.
+**Exactly ONE attempt — don't spiral.** Make one focused, minimal, reversible
+patch. If that single attempt doesn't land — or the bug is genuinely
+**upstream-only** (in the SDK, ComfyUI, or it needs a release you can't make from
+here) — stop patching, mark it `upstream-only`, and include the **precise change
+needed** in the report instead. It's fine that a future update will overwrite a
+local patch — that's expected; the user runs the patched version in the meantime.
+Capture the diff (`git diff`, or diff the file you touched) — Step 5 attaches it.
+
+(THIRD-PARTY / ComfyUI-core defects are the exception: there you still **offer
+and ask first** before patching or filing — see Step 6.)
 
 ## Step 4 — Verify the fix
 
@@ -112,6 +121,10 @@ Then file it (no need to ask):
 - **Default path (everyone):** POST the report to our intake Worker — no GitHub
   account needed:
 
+  The Worker is an **async intake**: the POST accepts + queues the report and
+  returns a `job_id`; the issue is filed in the background. Submit, then poll
+  `/status/<job_id>` a few times to get the issue link.
+
   ```bash
   # URL is baked in; override with $COMFYUI_MCP_ISSUE_WORKER_URL if set. The
   # client key is a soft anti-spam gate — read it from $COMFYUI_MCP_ISSUE_CLIENT_KEY.
@@ -119,14 +132,33 @@ Then file it (no need to ask):
   # Soft anti-spam gate (ships with the panel; not a real secret — the GitHub
   # token is server-side in the Worker). Override with $COMFYUI_MCP_ISSUE_CLIENT_KEY.
   CLIENT_KEY="${COMFYUI_MCP_ISSUE_CLIENT_KEY:-9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2}"
-  curl -fsS -X POST "$WORKER_URL" \
-    -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
-    --data @"$BODY_JSON_FILE"
+
+  # 1) Submit. Write the JSON to a temp file first (the body has newlines/quotes).
   # body: { "repo": "comfyui-mcp" | "comfyui-mcp-panel", "title", "body", "labels": ["via-panel"] }
+  RESP=$(curl -fsS -X POST "$WORKER_URL" \
+    -H "Content-Type: application/json" -H "X-Client-Key: $CLIENT_KEY" \
+    --data @"$BODY_JSON_FILE")
+  # Fast path may already include the issue: { ok, job_id, status:"done", url, number, deduped? }.
+  # Slow path: { ok, job_id, status:"queued" } — then poll.
+  JOB_ID=$(printf '%s' "$RESP" | sed -n 's/.*"job_id"[: ]*"\([^"]*\)".*/\1/p')
+
+  # 2) Poll a few times for the filed issue link (skip if the submit already had url).
+  if ! printf '%s' "$RESP" | grep -q '"url"'; then
+    for i in 1 2 3 4 5; do
+      sleep 1
+      STAT=$(curl -fsS "$WORKER_URL/status/$JOB_ID")
+      echo "$STAT" | grep -q '"status":"done"'  && { echo "$STAT"; break; }
+      echo "$STAT" | grep -q '"status":"error"' && { echo "$STAT"; break; }
+    done
+  fi
   ```
-  Write the JSON to a temp file (the body has newlines/quotes). On success it
-  returns `{ ok, url, number, deduped? }`. A `401 unauthorized` means
-  `$COMFYUI_MCP_ISSUE_CLIENT_KEY` is unset/wrong — fall back to `report_issue`.
+  The final `{ status:"done", url, number, deduped? }` carries the created issue
+  link. A `401 unauthorized` on submit means `$COMFYUI_MCP_ISSUE_CLIENT_KEY` is
+  unset/wrong — fall back to `report_issue`. If polling keeps returning
+  `queued`, the report is still accepted (filing continues server-side); just
+  tell the user it's logged and move on. **Surface the issue link to the user
+  only if they want it** — the filing is autonomous, so a one-line "filed #123"
+  is enough (Step 7).
 - **Fallback** (no `gh`, no Worker URL): use the `report_issue` tool → a prefilled
   GitHub issue link the user can submit in one click.
 

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: report-bug
-description: Self-heal + report bugs to make the ecosystem better. When you hit ANY defect in comfyui-mcp / the sidebar panel, OR in a third-party custom node / ComfyUI core, use this: diagnose it, and for OUR repos (comfyui-mcp / comfyui-mcp-panel) **fix it locally FIRST** — patch the code where it actually runs so the user is unblocked immediately — then file a report that includes the diff, so reports arrive as near-PRs, not just tickets. (Attempt the fix exactly ONCE; if it's genuinely upstream-only, mark it and include the precise change needed.) Report it the right way: our intake Worker for our repos; the node's own GitHub for third-party. Acts autonomously and just informs the user — it does not ask permission for each step. **BETA — bias HARD toward fix-then-file:** trigger on any comfyui-mcp/panel defect you notice — an error, a crash, a tool that returns wrong/misleading/empty output, a silent failure, a confusing result, or a limitation that forced an awkward workaround — EVEN IF you recovered or worked around it. You do NOT need to be blocked. Also on "report this" / "fix this bug". If a future user would hit the same friction, fix-and-file it — the intake Worker dedupes, so over-reporting is cheap and under-reporting costs us the bug. THIRD-PARTY / ComfyUI-core bugs stay offer-and-ask.
+description: Self-heal + report bugs to make the ecosystem better. When you hit ANY defect in comfyui-mcp / the sidebar panel, OR in a third-party custom node / ComfyUI core, use this: diagnose it, and for OUR repos (comfyui-mcp / comfyui-mcp-panel) **fix it locally FIRST** — patch the code where it actually runs so the user is unblocked immediately — then file a report that includes the diff, so reports arrive as near-PRs, not just tickets. (Attempt the fix exactly ONCE; if it's genuinely upstream-only, mark it and include the precise change needed.) Report it the right way: our intake Worker for our repos; the node's own GitHub for third-party. For OUR repos (artokun/comfyui-mcp, comfyui-mcp-panel, comfyui-mcp-issue-worker) act **autonomously** — fix-then-file and just inform the user, no per-step permission. For THIRD-PARTY / ComfyUI-core it is **offer-and-ask**: propose the workaround/report and act only with the user's go-ahead. **BETA — bias HARD toward fix-then-file (our repos):** trigger on any comfyui-mcp/panel defect you notice — an error, a crash, a tool that returns wrong/misleading/empty output, a silent failure, a confusing result, or a limitation that forced an awkward workaround — EVEN IF you recovered or worked around it. You do NOT need to be blocked. Also on "report this" / "fix this bug". If a future user would hit the same friction, fix-and-file it — the intake Worker dedupes, so over-reporting is cheap and under-reporting costs us the bug. THIRD-PARTY / ComfyUI-core bugs stay offer-and-ask.
 ---
 
 # Self-heal & report bugs (make the ecosystem better)
 
 Goal: when something is broken, don't just stop — **diagnose it, try to fix it so
 the user keeps working, and get the fix/report to whoever can fix it upstream.**
-Do this **autonomously**: act, then **inform** the user with a short summary —
-don't pepper them with permission prompts. (Exceptions where you DO pause: a fix
-that touches the user's own workflow/data, anything large/risky, or anything you
-can't make safe — explain and ask.)
+
+**Scope of autonomy — read this first.** For defects in **OUR repos**
+(`artokun/comfyui-mcp`, `comfyui-mcp-panel`, `comfyui-mcp-issue-worker`) act
+**autonomously**: fix-then-file, then **inform** the user with a short summary —
+don't pepper them with permission prompts. For **THIRD-PARTY / ComfyUI-core**
+defects it is **offer-and-ask** (Step 6): you propose the workaround and/or the
+report and act only once the user agrees — it's their call to patch someone
+else's node or post to someone else's tracker. (Even for our repos, DO pause for:
+a fix that touches the user's own workflow/data, anything large/risky, or
+anything you can't make safe — explain and ask.)
 
 This is for **bugs in software**, not ordinary workflow/generation errors (OOM,
 missing model, bad params → use `troubleshooting`). First decide whose bug it is.

--- a/plugin/skills/report-bug/SKILL.md
+++ b/plugin/skills/report-bug/SKILL.md
@@ -149,18 +149,25 @@ Then file it (no need to ask):
       --data @"$BODY_JSON_FILE"); then
     URL=$(printf '%s' "$RESP" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
     # 2) Only poll if the submit lacked a url AND we actually got a job_id.
+    #    Mirrors the TS: keep polling ONLY while the Worker reports a well-formed
+    #    queued/pending. On the FIRST hard failure — curl transport error /
+    #    timeout / non-2xx, or a status:"error" body — BREAK immediately (do NOT
+    #    continue); the fallback below then prints the prefilled link. Exhausting
+    #    the attempt ceiling with no url is also a fallback, never "filed".
     if [ -z "$URL" ]; then
       JOB_ID=$(printf '%s' "$RESP" | sed -n 's/.*"job_id"[: ]*"\([^"]*\)".*/\1/p')
       if [ -n "$JOB_ID" ]; then
         for i in 1 2 3 4 5; do
           sleep 1
-          # A poll curl failure (error/timeout/non-2xx) is NOT success — keep
-          # trying; if we exhaust the loop with no url we fall back below.
-          STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || continue
-          # A done-with-error carries no url and must NOT be treated as filed.
+          # Hard transport failure → stop and fall back (do NOT keep polling).
+          STAT=$(curl -fsS --max-time 10 "$WORKER_URL/status/$JOB_ID") || break
+          # Server-side filing error → stop and fall back.
           printf '%s' "$STAT" | grep -q '"status":"error"' && break
           URL=$(printf '%s' "$STAT" | sed -n 's/.*"url"[: ]*"\([^"]*\)".*/\1/p')
           [ -n "$URL" ] && break
+          # Otherwise it's a well-formed queued/pending → keep polling until the
+          # ceiling. (A malformed body yields no url and no error marker, so it
+          # simply loops to the ceiling and then falls back — still never "filed".)
         done
       fi
     fi

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -41,9 +41,12 @@ describe("normalizeRepo / buildIssueUrl / isOurRepo", () => {
     expect(() => normalizeRepo("nope")).toThrow();
   });
 
-  it("recognizes our repos only", () => {
+  it("recognizes our repos only, case-insensitively", () => {
     expect(isOurRepo("artokun/comfyui-mcp")).toBe(true);
     expect(isOurRepo("artokun/comfyui-mcp-panel")).toBe(true);
+    // git config / this repo use a capital A — must still be ours.
+    expect(isOurRepo("Artokun/comfyui-mcp")).toBe(true);
+    expect(isOurRepo("ARTOKUN/ComfyUI-MCP-Panel")).toBe(true);
     expect(isOurRepo("artokun/other")).toBe(false);
     expect(isOurRepo("someone/comfyui-mcp")).toBe(false);
   });
@@ -97,28 +100,73 @@ describe("submitAndPoll", () => {
     ).rejects.toThrow(/401/);
   });
 
-  it("surfaces a server-side error status from polling", async () => {
+  it("THROWS on a server-side error status from polling (→ caller falls back)", async () => {
     const fetchImpl = (async (url: string) => {
       if (url === "https://w") return res({ ok: true, job_id: "j3", status: "queued" });
       return res({ status: "error", error: "GitHub API error" });
     }) as unknown as typeof fetch;
-    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
-    expect(r).toMatchObject({ status: "error", error: "GitHub API error", job_id: "j3" });
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 }),
+    ).rejects.toThrow(/errored/);
   });
 
-  it("gives up as queued if polling never resolves", async () => {
+  it("THROWS when polling never resolves (exhausts retries) instead of claiming queued success", async () => {
     const fetchImpl = (async (url: string) => {
       if (url === "https://w") return res({ ok: true, job_id: "j4", status: "queued" });
       return res({ status: "queued" });
     }) as unknown as typeof fetch;
-    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 });
-    expect(r.status).toBe("queued");
-    expect(r.job_id).toBe("j4");
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 }),
+    ).rejects.toThrow(/did not complete/);
+  });
+
+  it("THROWS on a poll transport failure (HTTP error) → caller falls back", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://w") return res({ ok: true, job_id: "j5", status: "queued" });
+      return res({ error: "boom" }, 503);
+    }) as unknown as typeof fetch;
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 }),
+    ).rejects.toThrow(/poll failed/);
+  });
+
+  it("timeout: a SUBMIT whose .json() stalls until the AbortController fires → throws", async () => {
+    const fetchImpl = (async (_url: string, init: RequestInit) => ({
+      ok: true,
+      json: () =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    })) as unknown as typeof fetch;
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, timeoutMs: 10 }),
+    ).rejects.toThrow();
+  });
+
+  it("timeout: a POLL whose .json() stalls until the AbortController fires → throws", async () => {
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      if (url === "https://w") return res({ ok: true, job_id: "j6", status: "queued" });
+      return {
+        ok: true,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      };
+    }) as unknown as typeof fetch;
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, timeoutMs: 10 }),
+    ).rejects.toThrow();
   });
 });
 
 describe("report_issue tool (registered handler)", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  const savedTimeout = process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS;
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (savedTimeout === undefined) delete process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS;
+    else process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = savedTimeout;
+  });
 
   it("third-party repo → prefilled URL, filed:false, no network", async () => {
     const spy = vi.fn();
@@ -146,6 +194,54 @@ describe("report_issue tool (registered handler)", () => {
     const { json } = await callTool({ title: "t", body: "b" }); // default our repo
     expect(json).toMatchObject({ filed: true, number: 50 });
     expect(json.url).toBe("https://github.com/artokun/comfyui-mcp/issues/50");
+  });
+
+  it("mixed-case owner (Artokun/comfyui-mcp) is treated as OURS and files via the Worker", async () => {
+    const spy = vi.fn(async () => res({ ok: true, url: "https://github.com/Artokun/comfyui-mcp/issues/60", number: 60, job_id: "jm" }));
+    vi.stubGlobal("fetch", spy);
+    const { json } = await callTool({ title: "t", body: "b", repo: "Artokun/comfyui-mcp" });
+    expect(spy).toHaveBeenCalled(); // hit the Worker, not the prefilled path
+    expect(json).toMatchObject({ filed: true, number: 60 });
+  });
+
+  it("timeout regression (SUBMIT .json() stalls) → prefilled fallback", async () => {
+    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "15";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (_url: string, init: RequestInit) =>
+          ({
+            ok: true,
+            json: () =>
+              new Promise((_resolve, reject) => {
+                init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+              }),
+          }) as unknown as Response,
+      ),
+    );
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("timeout regression (POLL .json() stalls) → prefilled fallback", async () => {
+    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "15";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: RequestInit) => {
+        if (!String(url).includes("/status/")) return res({ ok: true, job_id: "jp2", status: "queued" });
+        return {
+          ok: true,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+            }),
+        } as unknown as Response;
+      }),
+    );
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
   });
 
   it("our repo, Worker returns non-OK (500) → falls back to prefilled URL (generic, not just 401)", async () => {

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -1,10 +1,36 @@
-import { describe, it, expect } from "vitest";
-import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll } from "./report-issue.js";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll, registerReportIssueTools } from "./report-issue.js";
 
 const noSleep = async () => {};
 
 function res(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+// Capture the registered report_issue handler by faking the McpServer.tool API.
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
+function getReportIssueHandler(): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const fakeServer = {
+    tool: (_name: string, _desc: string, _schema: unknown, h: ToolHandler) => {
+      handler = h;
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerReportIssueTools(fakeServer as any);
+  if (!handler) throw new Error("report_issue handler not registered");
+  return handler;
+}
+async function callTool(args: Record<string, unknown>) {
+  const out = await getReportIssueHandler()(args);
+  const text = out.content[0].text;
+  let json: Record<string, unknown> = {};
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // error paths return a plain-text message, not JSON
+  }
+  return { isError: out.isError, text, json };
 }
 
 describe("normalizeRepo / buildIssueUrl / isOurRepo", () => {
@@ -35,6 +61,17 @@ describe("submitAndPoll", () => {
     const fetchImpl = (async () => res({ ok: true, job_id: "j1", status: "done", url: "https://gh/10", number: 10 })) as unknown as typeof fetch;
     const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
     expect(r).toMatchObject({ status: "done", url: "https://gh/10", number: 10 });
+  });
+
+  it("OLD-SYNC fixture: { ok, url, number } with NO job_id/status returns immediately (no poll)", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      return res({ ok: true, url: "https://gh/3", number: 3 });
+    }) as unknown as typeof fetch;
+    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(r).toMatchObject({ status: "done", url: "https://gh/3", number: 3 });
+    expect(calls).toBe(1); // submit only — never polled
   });
 
   it("polls /status until done when the submit is queued", async () => {
@@ -77,5 +114,79 @@ describe("submitAndPoll", () => {
     const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 });
     expect(r.status).toBe("queued");
     expect(r.job_id).toBe("j4");
+  });
+});
+
+describe("report_issue tool (registered handler)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("third-party repo → prefilled URL, filed:false, no network", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { json } = await callTool({ title: "t", body: "b", repo: "someone/their-node" });
+    expect(json).toMatchObject({ filed: false, repo: "someone/their-node" });
+    expect(json.url).toContain("https://github.com/someone/their-node/issues/new");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("no_file:true on our repo → prefilled URL, no network", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { json } = await callTool({ title: "t", body: "b", repo: "artokun/comfyui-mcp", no_file: true });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("https://github.com/artokun/comfyui-mcp/issues/new");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("our repo, Worker files → returns the real issue link, filed:true", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => res({ ok: true, url: "https://github.com/artokun/comfyui-mcp/issues/50", number: 50, job_id: "jx" })),
+    );
+    const { json } = await callTool({ title: "t", body: "b" }); // default our repo
+    expect(json).toMatchObject({ filed: true, number: 50 });
+    expect(json.url).toBe("https://github.com/artokun/comfyui-mcp/issues/50");
+  });
+
+  it("our repo, Worker returns non-OK (500) → falls back to prefilled URL (generic, not just 401)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => res({ error: "boom" }, 500)));
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("https://github.com/artokun/comfyui-mcp/issues/new");
+  });
+
+  it("our repo, Worker returns 401 → falls back to prefilled URL", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => res({ error: "unauthorized" }, 401)));
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("our repo, network failure (fetch rejects) → falls back to prefilled URL", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }));
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("our repo, submit ok but polling errors → surfaces prefilled fallback (filed:false)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).endsWith("/status/" + "jp")) return res({ status: "error", error: "GitHub API error" });
+        // submit: queued with a job_id but no url → forces a poll
+        return res({ ok: true, job_id: "jp", status: "queued" });
+      }),
+    );
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("invalid repo → isError", async () => {
+    const { isError } = await callTool({ title: "t", body: "b", repo: "not-a-repo" });
+    expect(isError).toBe(true);
   });
 });

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { normalizeRepo, buildIssueUrl, isOurRepo, submitAndPoll } from "./report-issue.js";
+
+const noSleep = async () => {};
+
+function res(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+describe("normalizeRepo / buildIssueUrl / isOurRepo", () => {
+  it("normalizes assorted repo inputs", () => {
+    expect(normalizeRepo(undefined)).toBe("artokun/comfyui-mcp");
+    expect(normalizeRepo("https://github.com/foo/bar.git")).toBe("foo/bar");
+    expect(normalizeRepo(" owner/name/ ")).toBe("owner/name");
+    expect(() => normalizeRepo("nope")).toThrow();
+  });
+
+  it("recognizes our repos only", () => {
+    expect(isOurRepo("artokun/comfyui-mcp")).toBe(true);
+    expect(isOurRepo("artokun/comfyui-mcp-panel")).toBe(true);
+    expect(isOurRepo("artokun/other")).toBe(false);
+    expect(isOurRepo("someone/comfyui-mcp")).toBe(false);
+  });
+
+  it("builds a prefilled new-issue URL with labels", () => {
+    const u = new URL(buildIssueUrl("a/b", "T", "B", ["x", "y"]));
+    expect(u.pathname).toBe("/a/b/issues/new");
+    expect(u.searchParams.get("title")).toBe("T");
+    expect(u.searchParams.get("labels")).toBe("x,y");
+  });
+});
+
+describe("submitAndPoll", () => {
+  it("returns the issue link inline when the fast path already filed", async () => {
+    const fetchImpl = (async () => res({ ok: true, job_id: "j1", status: "done", url: "https://gh/10", number: 10 })) as unknown as typeof fetch;
+    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(r).toMatchObject({ status: "done", url: "https://gh/10", number: 10 });
+  });
+
+  it("polls /status until done when the submit is queued", async () => {
+    const calls: string[] = [];
+    let polls = 0;
+    const fetchImpl = (async (url: string) => {
+      calls.push(url);
+      if (url === "https://w") return res({ ok: true, job_id: "j2", status: "queued" });
+      // /status/j2 — queued twice, then done
+      polls++;
+      if (polls < 3) return res({ status: "queued" });
+      return res({ status: "done", url: "https://gh/22", number: 22, deduped: true });
+    }) as unknown as typeof fetch;
+    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
+    expect(r).toMatchObject({ status: "done", url: "https://gh/22", number: 22, deduped: true, job_id: "j2" });
+    expect(calls.filter((c) => c.includes("/status/j2")).length).toBe(3);
+  });
+
+  it("throws on a non-OK submit so the caller can fall back", async () => {
+    const fetchImpl = (async () => res({ error: "unauthorized" }, 401)) as unknown as typeof fetch;
+    await expect(
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep }),
+    ).rejects.toThrow(/401/);
+  });
+
+  it("surfaces a server-side error status from polling", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://w") return res({ ok: true, job_id: "j3", status: "queued" });
+      return res({ status: "error", error: "GitHub API error" });
+    }) as unknown as typeof fetch;
+    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
+    expect(r).toMatchObject({ status: "error", error: "GitHub API error", job_id: "j3" });
+  });
+
+  it("gives up as queued if polling never resolves", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://w") return res({ ok: true, job_id: "j4", status: "queued" });
+      return res({ status: "queued" });
+    }) as unknown as typeof fetch;
+    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 });
+    expect(r.status).toBe("queued");
+    expect(r.job_id).toBe("j4");
+  });
+});

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -39,7 +39,9 @@ export function buildIssueUrl(repo: string, title: string, body: string, labels?
 
 export function isOurRepo(repo: string): boolean {
   const [owner, name] = repo.split("/");
-  return owner === OUR_OWNER && OUR_REPO_NAMES.has(name);
+  // Case-insensitive: git config / this repo use "Artokun" with a capital A,
+  // which must still be recognized as ours (not misrouted as third-party).
+  return owner?.toLowerCase() === OUR_OWNER && OUR_REPO_NAMES.has(name?.toLowerCase());
 }
 
 export interface WorkerFileResult {
@@ -101,30 +103,29 @@ export async function submitAndPoll(opts: {
   if (submit.url) return { ...submit, status: submit.status ?? "done" };
   const jobId = submit.job_id;
   if (!jobId) {
-    // No job to poll and no url — accepted but no link available.
-    return { ...submit, status: submit.status ?? "queued" };
+    // No url AND no job to poll — nothing we can surface. Throw so the caller
+    // falls back to the prefilled link.
+    throw new Error("worker returned neither a url nor a job_id");
   }
 
-  // Fallback poll (only if the submit somehow lacked a url): /status/<job_id>
-  // until done or we run out of tries.
+  // Fallback poll (only if the submit somehow lacked a url): /status/<job_id>.
+  // A 200 "queued" is retried; ANY hard poll failure (transport error, timeout,
+  // non-OK HTTP, body-parse failure) or a "done" without a url, or exhausting
+  // the retries, THROWS — so the caller uses the prefilled-URL fallback rather
+  // than claiming success without a link.
   const base = opts.workerUrl.replace(/\/+$/, "");
-  let last: WorkerFileResult = { status: "queued", job_id: jobId };
   for (let i = 0; i < maxPolls; i++) {
     await sleep(pollDelayMs);
-    try {
-      const parsed = await withTimeout(async (signal): Promise<WorkerFileResult | null> => {
-        const r = await doFetch(`${base}/status/${jobId}`, { signal });
-        if (!r.ok) return null; // e.g. 404 unknown while KV catches up — keep trying
-        return (await r.json()) as WorkerFileResult;
-      });
-      if (!parsed) continue;
-      last = { ...parsed, job_id: jobId };
-      if (last.status === "done" || last.status === "error") break;
-    } catch {
-      continue; // transient — keep trying
-    }
+    const parsed = await withTimeout(async (signal): Promise<WorkerFileResult> => {
+      const r = await doFetch(`${base}/status/${jobId}`, { signal });
+      if (!r.ok) throw new Error(`poll failed: HTTP ${r.status}`);
+      return (await r.json()) as WorkerFileResult;
+    });
+    if (parsed.status === "done" && parsed.url) return { ...parsed, job_id: jobId };
+    if (parsed.status === "error") throw new Error(`worker filing errored: ${parsed.error || "unknown"}`);
+    // else "queued" (or done-without-url) → keep polling
   }
-  return last;
+  throw new Error("worker filing did not complete before polling gave up");
 }
 
 export function registerReportIssueTools(server: McpServer): void {
@@ -164,11 +165,16 @@ export function registerReportIssueTools(server: McpServer): void {
           });
         }
 
-        // Our repo: file via the async intake Worker, poll for the link.
+        // Our repo: file via the intake Worker (submit + poll for the link).
         const workerUrl = process.env.COMFYUI_MCP_ISSUE_WORKER_URL || DEFAULT_WORKER_URL;
         const clientKey = process.env.COMFYUI_MCP_ISSUE_CLIENT_KEY || DEFAULT_CLIENT_KEY;
+        const timeoutEnv = Number(process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS);
+        const timeoutMs = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : undefined;
         const repoName = repo.split("/")[1];
         try {
+          // submitAndPoll ONLY resolves with a done result carrying a real url;
+          // any failure (non-OK submit, transport/timeout, poll error/exhaustion)
+          // throws → we fall back to the prefilled link below.
           const result = await submitAndPoll({
             workerUrl,
             clientKey,
@@ -176,46 +182,28 @@ export function registerReportIssueTools(server: McpServer): void {
             title: args.title,
             body: args.body,
             labels: args.labels,
+            timeoutMs,
           });
-          if (result.status === "done" && result.url) {
-            return jsonResult({
-              url: result.url,
-              number: result.number,
-              deduped: result.deduped,
-              repo,
-              filed: true,
-              job_id: result.job_id,
-              note: result.deduped
-                ? "Filed via intake Worker (matched an existing open issue). Share the link only if the user wants it."
-                : "Filed via intake Worker. Share the link only if the user wants it.",
-            });
-          }
-          if (result.status === "error") {
-            // Server-side filing failed — hand back the prefilled link.
-            return jsonResult({
-              url: prefilledUrl,
-              repo,
-              filed: false,
-              job_id: result.job_id,
-              note: `Intake Worker reported an error (${result.error || "unknown"}). Fallback: prefilled issue link for the user to submit.`,
-            });
-          }
-          // Still queued after polling — accepted, link not yet available.
           return jsonResult({
-            url: prefilledUrl,
+            url: result.url,
+            number: result.number,
+            deduped: result.deduped,
             repo,
             filed: true,
-            pending: true,
             job_id: result.job_id,
-            note: "Report accepted by the intake Worker; filing is still in progress (poll /status/<job_id> later for the link). Prefilled link included as a fallback.",
+            note: result.deduped
+              ? "Filed via intake Worker (matched an existing open issue). Share the link only if the user wants it."
+              : "Filed via intake Worker. Share the link only if the user wants it.",
           });
         } catch (workerErr) {
-          // Worker unreachable / rejected — fall back to the prefilled URL.
+          // ANY submit OR poll failure (non-OK, timeout, unreachable, parse
+          // stall, server error) → prefilled URL fallback. Never claim success
+          // without a real issue link.
           return jsonResult({
             url: prefilledUrl,
             repo,
             filed: false,
-            note: `Intake Worker unreachable (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
+            note: `Could not file via the intake Worker (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
           });
         }
       } catch (err) {

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -1,60 +1,219 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-// Safe-by-default issue reporting: returns a PREFILLED GitHub "new issue" URL
-// rather than auto-filing. No auth, no network, no surprise posts — the user
-// reviews and submits with one click. (A future opt-in could auto-file via gh
-// or a CF Worker; intentionally not the default.)
+// Issue reporting. For OUR repos (comfyui-mcp / comfyui-mcp-panel) this now
+// *files* the issue through the async intake Worker — submit → get a job_id →
+// poll /status/<job_id> for the created issue link. For third-party repos, or
+// when the Worker is unreachable, it falls back to a PREFILLED GitHub "new
+// issue" URL the user can review and submit in one click (no auth, no network).
 
 const DEFAULT_REPO = "artokun/comfyui-mcp";
+
+// Repos the intake Worker is allowed to file into (owner is fixed server-side).
+const OUR_OWNER = "artokun";
+const OUR_REPO_NAMES = new Set(["comfyui-mcp", "comfyui-mcp-panel"]);
+
+// Defaults mirror the report-bug SKILL. Both are overridable via env; the client
+// key is a soft anti-spam gate (not a real secret — the GitHub token is
+// server-side in the Worker).
+const DEFAULT_WORKER_URL = "https://comfyui-mcp-issue-worker.artokun.workers.dev";
+const DEFAULT_CLIENT_KEY = "9b6f2abf09b64006dc6e033f59d2dc8112e34d8347a923c2";
+
+export function normalizeRepo(input: string | undefined): string {
+  const repo = (input || DEFAULT_REPO)
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/\.git$/i, "")
+    .replace(/^\/+|\/+$/g, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    throw new Error(`invalid repo "${repo}" — expected owner/name`);
+  }
+  return repo;
+}
+
+export function buildIssueUrl(repo: string, title: string, body: string, labels?: string[]): string {
+  const params = new URLSearchParams({ title, body });
+  if (labels?.length) params.set("labels", labels.join(","));
+  return `https://github.com/${repo}/issues/new?${params.toString()}`;
+}
+
+export function isOurRepo(repo: string): boolean {
+  const [owner, name] = repo.split("/");
+  return owner === OUR_OWNER && OUR_REPO_NAMES.has(name);
+}
+
+export interface WorkerFileResult {
+  status: "done" | "queued" | "error";
+  url?: string;
+  number?: number;
+  deduped?: boolean;
+  job_id?: string;
+  error?: string;
+}
+
+// Submit to the async intake Worker and poll /status/<job_id> a few times for
+// the created issue link. Injectable fetch/sleep for testing. Throws on network
+// failure or non-OK submit so the caller can fall back to a prefilled URL.
+export async function submitAndPoll(opts: {
+  workerUrl: string;
+  clientKey: string;
+  repoName: string;
+  title: string;
+  body: string;
+  labels?: string[];
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  maxPolls?: number;
+  pollDelayMs?: number;
+  timeoutMs?: number;
+}): Promise<WorkerFileResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const maxPolls = opts.maxPolls ?? 5;
+  const pollDelayMs = opts.pollDelayMs ?? 1000;
+  const timeoutMs = opts.timeoutMs ?? 8000;
+
+  const withTimeout = async (fn: (signal: AbortSignal) => Promise<Response>): Promise<Response> => {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), timeoutMs);
+    try {
+      return await fn(ac.signal);
+    } finally {
+      clearTimeout(t);
+    }
+  };
+
+  const submitRes = await withTimeout((signal) =>
+    doFetch(opts.workerUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Client-Key": opts.clientKey },
+      body: JSON.stringify({ repo: opts.repoName, title: opts.title, body: opts.body, labels: opts.labels }),
+      signal,
+    }),
+  );
+  if (!submitRes.ok) {
+    throw new Error(`worker submit failed: HTTP ${submitRes.status}`);
+  }
+  const submit = (await submitRes.json()) as WorkerFileResult;
+
+  // Fast path: the Worker already filed and returned the link inline.
+  if (submit.url) return { ...submit, status: submit.status ?? "done" };
+  const jobId = submit.job_id;
+  if (!jobId) {
+    // No job to poll and no url — treat as done-without-link (still accepted).
+    return submit;
+  }
+
+  // Poll /status/<job_id> until done/error or we run out of tries.
+  const base = opts.workerUrl.replace(/\/+$/, "");
+  let last: WorkerFileResult = { status: "queued", job_id: jobId };
+  for (let i = 0; i < maxPolls; i++) {
+    await sleep(pollDelayMs);
+    let statusRes: Response;
+    try {
+      statusRes = await withTimeout((signal) => doFetch(`${base}/status/${jobId}`, { signal }));
+    } catch {
+      continue; // transient — keep trying
+    }
+    if (!statusRes.ok) continue;
+    last = (await statusRes.json()) as WorkerFileResult;
+    last.job_id = jobId;
+    if (last.status === "done" || last.status === "error") break;
+  }
+  return last;
+}
 
 export function registerReportIssueTools(server: McpServer): void {
   server.tool(
     "report_issue",
-    "Build a ready-to-open GitHub issue link for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp itself). Returns a URL with the title and body prefilled — SHARE it with the user so they can review and submit it in one click. It does NOT auto-file. Use it when you encounter an error you can't resolve so the user can report it upstream. For panel-specific bugs pass repo='artokun/comfyui-mcp-panel'.",
+    "File or link a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp itself). For OUR repos (artokun/comfyui-mcp, artokun/comfyui-mcp-panel) it FILES the issue via the intake Worker and returns the created issue link (no end-user GitHub auth needed); if the Worker is unreachable it falls back to a prefilled GitHub 'new issue' URL. For third-party repos it returns a prefilled URL to SHARE with the user (it does not auto-file). Pass repo='owner/name' for third-party projects. The filing is autonomous — surface the resulting link to the user only if they want it.",
     {
       title: z.string().min(1).describe("Short, specific issue title."),
       body: z
         .string()
         .min(1)
         .describe(
-          "Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, OS) if known.",
+          "Issue body: what happened, steps to reproduce, the exact error text, and environment (GPU/VRAM, ComfyUI version, OS) if known. Scrub secrets first.",
         ),
       repo: z
         .string()
         .optional()
         .describe("owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel)."),
       labels: z.array(z.string()).optional().describe("Optional GitHub label names to prefill."),
+      no_file: z
+        .boolean()
+        .optional()
+        .describe("Force the prefilled-URL path even for our repos (skip the Worker). Rarely needed."),
     },
     async (args) => {
       try {
-        const repo = (args.repo || DEFAULT_REPO)
-          .trim()
-          .replace(/^https?:\/\/github\.com\//i, "")
-          .replace(/\.git$/i, "")
-          .replace(/^\/+|\/+$/g, "");
-        if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
-          throw new Error(`invalid repo "${repo}" — expected owner/name`);
+        const repo = normalizeRepo(args.repo);
+        const prefilledUrl = buildIssueUrl(repo, args.title, args.body, args.labels);
+
+        // Third-party (or explicitly disabled): prefilled link only, as before.
+        if (!isOurRepo(repo) || args.no_file) {
+          return jsonResult({
+            url: prefilledUrl,
+            repo,
+            filed: false,
+            note: "Prefilled issue link (not auto-filed). Share it with the user to review and submit.",
+          });
         }
-        const params = new URLSearchParams({ title: args.title, body: args.body });
-        if (args.labels?.length) params.set("labels", args.labels.join(","));
-        const url = `https://github.com/${repo}/issues/new?${params.toString()}`;
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  url,
-                  repo,
-                  note: "Prefilled issue link (not auto-filed). Share it with the user to review and submit.",
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+
+        // Our repo: file via the async intake Worker, poll for the link.
+        const workerUrl = process.env.COMFYUI_MCP_ISSUE_WORKER_URL || DEFAULT_WORKER_URL;
+        const clientKey = process.env.COMFYUI_MCP_ISSUE_CLIENT_KEY || DEFAULT_CLIENT_KEY;
+        const repoName = repo.split("/")[1];
+        try {
+          const result = await submitAndPoll({
+            workerUrl,
+            clientKey,
+            repoName,
+            title: args.title,
+            body: args.body,
+            labels: args.labels,
+          });
+          if (result.status === "done" && result.url) {
+            return jsonResult({
+              url: result.url,
+              number: result.number,
+              deduped: result.deduped,
+              repo,
+              filed: true,
+              job_id: result.job_id,
+              note: result.deduped
+                ? "Filed via intake Worker (matched an existing open issue). Share the link only if the user wants it."
+                : "Filed via intake Worker. Share the link only if the user wants it.",
+            });
+          }
+          if (result.status === "error") {
+            // Server-side filing failed — hand back the prefilled link.
+            return jsonResult({
+              url: prefilledUrl,
+              repo,
+              filed: false,
+              job_id: result.job_id,
+              note: `Intake Worker reported an error (${result.error || "unknown"}). Fallback: prefilled issue link for the user to submit.`,
+            });
+          }
+          // Still queued after polling — accepted, link not yet available.
+          return jsonResult({
+            url: prefilledUrl,
+            repo,
+            filed: true,
+            pending: true,
+            job_id: result.job_id,
+            note: "Report accepted by the intake Worker; filing is still in progress (poll /status/<job_id> later for the link). Prefilled link included as a fallback.",
+          });
+        } catch (workerErr) {
+          // Worker unreachable / rejected — fall back to the prefilled URL.
+          return jsonResult({
+            url: prefilledUrl,
+            repo,
+            filed: false,
+            note: `Intake Worker unreachable (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
+          });
+        }
       } catch (err) {
         return {
           content: [
@@ -65,4 +224,10 @@ export function registerReportIssueTools(server: McpServer): void {
       }
     },
   );
+}
+
+function jsonResult(obj: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(obj, null, 2) }],
+  };
 }

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -73,7 +73,10 @@ export async function submitAndPoll(opts: {
   const pollDelayMs = opts.pollDelayMs ?? 1000;
   const timeoutMs = opts.timeoutMs ?? 8000;
 
-  const withTimeout = async (fn: (signal: AbortSignal) => Promise<Response>): Promise<Response> => {
+  // Keep the abort active through BOTH the fetch AND the body parse — otherwise
+  // a hung `.json()` after headers arrive would never time out. The whole
+  // request+parse runs under one AbortController + a hard timeout.
+  const withTimeout = async <T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> => {
     const ac = new AbortController();
     const t = setTimeout(() => ac.abort(), timeoutMs);
     try {
@@ -83,42 +86,43 @@ export async function submitAndPoll(opts: {
     }
   };
 
-  const submitRes = await withTimeout((signal) =>
-    doFetch(opts.workerUrl, {
+  const submit = await withTimeout(async (signal): Promise<WorkerFileResult> => {
+    const r = await doFetch(opts.workerUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Client-Key": opts.clientKey },
       body: JSON.stringify({ repo: opts.repoName, title: opts.title, body: opts.body, labels: opts.labels }),
       signal,
-    }),
-  );
-  if (!submitRes.ok) {
-    throw new Error(`worker submit failed: HTTP ${submitRes.status}`);
-  }
-  const submit = (await submitRes.json()) as WorkerFileResult;
+    });
+    if (!r.ok) throw new Error(`worker submit failed: HTTP ${r.status}`);
+    return (await r.json()) as WorkerFileResult;
+  });
 
-  // Fast path: the Worker already filed and returned the link inline.
+  // Common path: the Worker files synchronously and returns the link inline.
   if (submit.url) return { ...submit, status: submit.status ?? "done" };
   const jobId = submit.job_id;
   if (!jobId) {
-    // No job to poll and no url — treat as done-without-link (still accepted).
-    return submit;
+    // No job to poll and no url — accepted but no link available.
+    return { ...submit, status: submit.status ?? "queued" };
   }
 
-  // Poll /status/<job_id> until done/error or we run out of tries.
+  // Fallback poll (only if the submit somehow lacked a url): /status/<job_id>
+  // until done or we run out of tries.
   const base = opts.workerUrl.replace(/\/+$/, "");
   let last: WorkerFileResult = { status: "queued", job_id: jobId };
   for (let i = 0; i < maxPolls; i++) {
     await sleep(pollDelayMs);
-    let statusRes: Response;
     try {
-      statusRes = await withTimeout((signal) => doFetch(`${base}/status/${jobId}`, { signal }));
+      const parsed = await withTimeout(async (signal): Promise<WorkerFileResult | null> => {
+        const r = await doFetch(`${base}/status/${jobId}`, { signal });
+        if (!r.ok) return null; // e.g. 404 unknown while KV catches up — keep trying
+        return (await r.json()) as WorkerFileResult;
+      });
+      if (!parsed) continue;
+      last = { ...parsed, job_id: jobId };
+      if (last.status === "done" || last.status === "error") break;
     } catch {
       continue; // transient — keep trying
     }
-    if (!statusRes.ok) continue;
-    last = (await statusRes.json()) as WorkerFileResult;
-    last.job_id = jobId;
-    if (last.status === "done" || last.status === "error") break;
   }
   return last;
 }


### PR DESCRIPTION
## What

Two-part reporting enhancement (revised per review).

### Part A — "fix before submit" (SKILL.md)
Local fix is now the firm **DEFAULT** for OUR repos: patch the code where it runs FIRST (exactly **one** attempt — don't spiral), then file with the diff so reports arrive as near-PRs. Updated frontmatter trigger + Step 3. **Step 6 now consistently makes third-party / ComfyUI-core OFFER + ASK** (patch and file only with the user's go-ahead) — resolving the contradiction with the frontmatter; only OUR-repo defects are autonomous. Secret-scrub + engineer-PR/Worker paths intact.

### Part C — wire the client (synchronous Worker contract)
- `report_issue` tool files via the Worker for our repos and returns the real issue link; **prefilled GitHub-URL fallback** on third-party, `no_file`, and **ANY** non-OK / network failure (not just 401).
- `submitAndPoll`: the abort timeout now wraps **both `fetch()` and `.json()`** so a hung body parse can't wedge the call; poll is a fallback only (the Worker returns `url` inline).
- SKILL curl flow: `--max-time` on every curl, **prints** the resulting issue URL, generic fallback to `report_issue` on any failure, never polls with an empty `JOB_ID`.

## Depends on
Worker synchronous contract: artokun/comfyui-mcp-issue-worker#2.

## Tests / gate
- `npm run build` / lint (tsc): green.
- `src/tools/report-issue.test.ts` (17 tests): OLD-SYNC fixture (`{ok,url,number}` no job_id → no poll), fast-inline link, poll-until-done, non-OK throws, poll-error; plus the **registered tool** asserting third-party / `no_file` / non-OK 500 / 401 / network-fail / poll-error all return the prefilled URL, success returns the filed link, invalid repo → isError.
- Full suite: 2017 pass, 1 skipped. The one failing test (`node-dev.test.ts` builtin-vs-ripgrep) is pre-existing and environment-dependent (this machine has ripgrep) — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)