### PR TITLE
fix(resolve): adopt default workspace / Manager route when COMFYUI_PATH unset (#415 #416 #386 #409)

### DIFF
--- a/src/__tests__/services/model-resolver-roots.test.ts
+++ b/src/__tests__/services/model-resolver-roots.test.ts
@@ -2,22 +2,33 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import { resolve } from "node:path";
 
 // Control config (comfyuiPath) per test. isRemoteMode is a controllable mock:
-// resolveComfyUIBase() consults it only when comfyuiPath is unset, to decide
-// whether a local default-workspace fallback is allowed (never in remote mode).
-vi.mock("../../config.js", () => ({
+// resolveEffectiveComfyUIBase() consults it only when comfyuiPath is unset, to
+// decide whether a local default-workspace fallback is allowed (never in remote
+// mode). Shared via vi.hoisted so the config.js and workspace-env.js mocks agree
+// (resolveEffectiveComfyUIBase now backs resolveComfyUIBase and must see the same
+// config + isRemoteMode + saved-workspace state the tests mutate).
+const h = vi.hoisted(() => ({
   config: {
     comfyuiPath: "/comfy" as string | undefined,
     huggingfaceToken: undefined as string | undefined,
     civitaiApiToken: undefined as string | undefined,
   },
-  isRemoteMode: vi.fn(() => false),
+  isRemoteMode: vi.fn<() => boolean>(() => false),
+  getSaved: vi.fn<() => string | undefined>(() => undefined),
+}));
+vi.mock("../../config.js", () => ({
+  config: h.config,
+  isRemoteMode: h.isRemoteMode,
 }));
 
 // Saved default workspace (set via set_default_workspace) — the local fallback
-// resolveComfyUIBase() uses when COMFYUI_PATH is unset and we're not remote.
-const getSavedDefaultWorkspaceSyncMock = vi.fn<() => string | undefined>();
+// resolveEffectiveComfyUIBase() uses when COMFYUI_PATH is unset and we're not
+// remote. The shared helper replicates the real resolution order here.
+const getSavedDefaultWorkspaceSyncMock = h.getSaved;
 vi.mock("../../services/workspace-env.js", () => ({
-  getSavedDefaultWorkspaceSync: () => getSavedDefaultWorkspaceSyncMock(),
+  getSavedDefaultWorkspaceSync: h.getSaved,
+  resolveEffectiveComfyUIBase: () =>
+    h.config.comfyuiPath ?? (h.isRemoteMode() ? undefined : h.getSaved()),
 }));
 
 // node:fs/promises is mocked so stat answers per-path from a fixture map.

--- a/src/__tests__/services/node-verify.test.ts
+++ b/src/__tests__/services/node-verify.test.ts
@@ -8,8 +8,17 @@ vi.mock("../../config.js", () => {
     config,
     getComfyUIApiHost: () => "127.0.0.1:8188",
     getComfyUIProtocol: () => "http",
+    isRemoteMode: () => false,
   };
 });
+
+// node-verify classifies local vs remote via resolveEffectiveComfyUIBase. Back it
+// by the mocked config's comfyuiPath (+ a settable default workspace) so tests can
+// exercise the "COMFYUI_PATH unset but a default workspace exists ⇒ LOCAL" path.
+let savedDefaultWorkspace: string | undefined;
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
+}));
 
 // node-verify imports restartComfyUI at module load; stub it (tests inject deps).
 vi.mock("../../services/process-control.js", () => ({
@@ -65,6 +74,7 @@ NODE_CLASS_MAPPINGS = {
 describe("verifyCustomNode", () => {
   beforeEach(() => {
     config.comfyuiPath = "/fake/comfy";
+    savedDefaultWorkspace = undefined;
   });
 
   it("reports all node types loaded when present in /object_info", async () => {
@@ -118,11 +128,21 @@ describe("verifyCustomNode", () => {
     await expect(verifyCustomNode({}, deps)).rejects.toThrow(ValidationError);
   });
 
-  it("throws ProcessControlError in remote mode (no comfyuiPath)", async () => {
+  it("throws ProcessControlError when there is no local base (remote, no default workspace)", async () => {
     config.comfyuiPath = undefined;
+    savedDefaultWorkspace = undefined;
     await expect(
       verifyCustomNode({ classTypes: ["FooNode"] }, makeDeps()),
     ).rejects.toThrow(ProcessControlError);
+  });
+
+  it("classifies as LOCAL when COMFYUI_PATH is unset but a default workspace is saved (#386/#409)", async () => {
+    config.comfyuiPath = undefined;
+    savedDefaultWorkspace = "/saved/workspace";
+    // Must NOT throw the remote/local-only error; verification proceeds normally.
+    const res = await verifyCustomNode({ classTypes: ["FooNode"] }, makeDeps());
+    expect(res.loaded).toEqual(["FooNode"]);
+    expect(res.missing).toEqual([]);
   });
 
   it("infers from a re-exported literal in a non-__init__ pack source file", async () => {

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -10,6 +10,14 @@ vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: (...a: unknown[]) => getSystemStats(...a),
 }));
 
+// resolveModelsDir's local fallback (COMFYUI_PATH → default workspace) is resolved
+// through the shared helper; back it by the mocked config + a settable default
+// workspace so tests can exercise the "no COMFYUI_PATH but a default workspace" path.
+let savedDefaultWorkspace: string | undefined;
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
+}));
+
 import {
   parseOutputDirFromArgv,
   localOutputDirFallback,
@@ -28,6 +36,7 @@ import { config } from "../../config.js";
 beforeEach(() => {
   getSystemStats.mockReset();
   (config as { comfyuiPath?: string }).comfyuiPath = "/comfy";
+  savedDefaultWorkspace = undefined;
 });
 
 afterEach(() => {
@@ -227,6 +236,20 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
   it("resolveModelsDir falls back to <COMFYUI_PATH>/models when unreachable", async () => {
     getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
     expect(await resolveModelsDir()).toBe(resolve("/comfy", "models"));
+  });
+
+  it("resolveModelsDir falls back to the saved default workspace when COMFYUI_PATH is unset (#415/#416)", async () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    savedDefaultWorkspace = resolve("/saved/workspace");
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveModelsDir()).toBe(join(resolve("/saved/workspace"), "models"));
+  });
+
+  it("resolveModelsDir throws a clear, actionable error when nothing resolves", async () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    savedDefaultWorkspace = undefined;
+    getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(resolveModelsDir()).rejects.toThrow(/set_default_workspace/);
   });
 
   it("resolveServerExtraModelConfig returns the server's config file, undefined when absent", async () => {

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -5,7 +5,7 @@ import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
-import { getSavedDefaultWorkspaceSync } from "./workspace-env.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -134,9 +134,7 @@ export interface LocalModel {
  * target). Returns undefined when no usable local path exists.
  */
 function resolveComfyUIBase(): string | undefined {
-  if (config.comfyuiPath) return config.comfyuiPath;
-  if (isRemoteMode()) return undefined;
-  return getSavedDefaultWorkspaceSync();
+  return resolveEffectiveComfyUIBase();
 }
 
 function getModelsRoot(): string {

--- a/src/services/node-verify.ts
+++ b/src/services/node-verify.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { config, getComfyUIBaseUrl } from "../config.js";
+import { getComfyUIBaseUrl } from "../config.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { restartComfyUI } from "./process-control.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
@@ -84,8 +85,9 @@ const defaultDeps: VerifyDeps = {
     return Object.keys(data as Record<string, unknown>);
   },
   readPackInit: (packName: string) => {
-    if (!config.comfyuiPath) return undefined;
-    const initPath = join(config.comfyuiPath, "custom_nodes", packName, "__init__.py");
+    const base = resolveEffectiveComfyUIBase();
+    if (!base) return undefined;
+    const initPath = join(base, "custom_nodes", packName, "__init__.py");
     if (!existsSync(initPath)) return undefined;
     try {
       return readFileSync(initPath, "utf-8");
@@ -94,8 +96,9 @@ const defaultDeps: VerifyDeps = {
     }
   },
   readPackSources: (packName: string) => {
-    if (!config.comfyuiPath) return [];
-    const packDir = join(config.comfyuiPath, "custom_nodes", packName);
+    const base = resolveEffectiveComfyUIBase();
+    if (!base) return [];
+    const packDir = join(base, "custom_nodes", packName);
     if (!existsSync(packDir)) return [];
     const sources: string[] = [];
     const MAX_FILES = 200;
@@ -204,10 +207,17 @@ export async function verifyCustomNode(
   options: VerifyOptions,
   deps: VerifyDeps = defaultDeps,
 ): Promise<VerifyResult> {
-  if (!config.comfyuiPath) {
+  // Classify LOCAL vs remote by the EFFECTIVE local base (COMFYUI_PATH, else the
+  // saved default workspace when not targeting a remote ComfyUI), not by
+  // COMFYUI_PATH alone — otherwise a local instance backed only by a default
+  // workspace was wrongly rejected as remote when COMFYUI_PATH was unset
+  // (#386/#409). Only a genuinely remote target (or no local base at all) is
+  // unsupported here.
+  if (!resolveEffectiveComfyUIBase()) {
     throw new ProcessControlError(
       "verify_custom_node is local-only: it restarts and inspects a local ComfyUI " +
-        "install and needs COMFYUI_PATH. It cannot verify a remote --comfyui-url target.",
+        "install. It cannot verify a remote --comfyui-url target. Set the COMFYUI_PATH " +
+        "environment variable, or save a default workspace with set_default_workspace.",
     );
   }
 

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, join, resolve } from "node:path";
 import { config } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -150,12 +151,19 @@ export async function resolveModelsDir(): Promise<string> {
       { error: err instanceof Error ? err.message : String(err) },
     );
   }
-  if (!config.comfyuiPath) {
-    throw new ValidationError(
-      "COMFYUI_PATH is not configured. Set the COMFYUI_PATH environment variable.",
-    );
-  }
-  return resolve(config.comfyuiPath, "models");
+  // No live-server base dir available. Fall back to the effective LOCAL base:
+  // COMFYUI_PATH, else the saved default workspace (set_default_workspace) when
+  // NOT in remote mode — so a download resolves to that install rather than
+  // hard-failing just because COMFYUI_PATH is unset (#415/#416). resolveModelsDir
+  // is only reached in local mode (remote downloads short-circuit to the Manager
+  // before any local-dir resolution), so the default workspace is a safe target.
+  const base = resolveEffectiveComfyUIBase();
+  if (base) return resolve(base, "models");
+  throw new ValidationError(
+    "No local ComfyUI models directory could be resolved. Set the COMFYUI_PATH " +
+      "environment variable, save a default workspace with set_default_workspace, " +
+      "or connect to a running ComfyUI so its models directory can be detected.",
+  );
 }
 
 /**

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { config, getComfyUIBaseUrl } from "../config.js";
+import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
 import { ValidationError } from "../utils/errors.js";
@@ -67,6 +67,29 @@ export function getSavedDefaultWorkspaceSync(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * The SINGLE source of truth for the effective LOCAL ComfyUI base directory used
+ * by every filesystem-backed tool (download_model, verify_custom_node, model
+ * lookups, apply_manifest's adoption). Resolution order, applied consistently so
+ * the tools never disagree about where ComfyUI lives when COMFYUI_PATH is unset:
+ *
+ *   1. config.comfyuiPath — COMFYUI_PATH env or auto-detection (wins).
+ *   2. When NOT targeting a remote ComfyUI, the saved DEFAULT WORKSPACE
+ *      (set via set_default_workspace) — this is what get_workspace /
+ *      get_environment already report, so local downloads / model lookups /
+ *      node verification work without COMFYUI_PATH.
+ *
+ * Never returns a local workspace in remote mode (that dir isn't the remote
+ * target; remote-mode callers route through ComfyUI-Manager instead). Returns
+ * undefined when no usable local path exists — callers then either detect a live
+ * server base dir (/system_stats) or emit a clear, actionable error.
+ */
+export function resolveEffectiveComfyUIBase(): string | undefined {
+  if (config.comfyuiPath) return config.comfyuiPath;
+  if (isRemoteMode()) return undefined;
+  return getSavedDefaultWorkspaceSync();
 }
 
 async function readWorkspaceConfig(): Promise<WorkspaceConfig> {


### PR DESCRIPTION
## Problem

A cluster of via-panel reports all trace to tools hard-failing or misresolving the ComfyUI location when `COMFYUI_PATH` is UNSET:

- **#415** `download_model` ignored the persisted default workspace and required `COMFYUI_PATH`.
- **#416** `download_model` hard-failed without `COMFYUI_PATH` instead of using the default-workspace / Manager route.
- **#386 / #409** `verify_custom_node` misclassified a LOCAL instance (backed by a default workspace) as remote.

#408 (WS-4) already fixed the remote-mode `startDownloadJob` branch and made `apply_manifest` adopt a saved default workspace (#390). This PR extends that same resolution to the remaining tools via one shared helper.

## Change

Extracted a single source of truth — `resolveEffectiveComfyUIBase()` in `services/workspace-env.ts`:

1. `config.comfyuiPath` (COMFYUI_PATH / auto-detect) wins;
2. else, when NOT in remote mode, the saved DEFAULT WORKSPACE (`set_default_workspace`);
3. else `undefined`.

Wired into:
- `output-dir.ts` `resolveModelsDir()` — after the live-server `/system_stats` `--base-directory` probe (kept first for #346/#369), falls back to the effective base, then a clear, actionable error naming `COMFYUI_PATH` / `set_default_workspace` / connecting a server. Backs `download_model` end-to-end.
- `model-resolver.ts` `resolveComfyUIBase()` now delegates to the shared helper.
- `node-verify.ts` — the local-vs-remote gate and pack-source reads use the effective base, so a default-workspace-backed instance verifies as LOCAL.

`isRemoteMode()` semantics unchanged; genuinely-remote downloads still route via ComfyUI-Manager and never require a local path.

## Tests

Added: COMFYUI_PATH unset + default workspace ⇒ `resolveModelsDir` resolves to that base; nothing available ⇒ actionable error; `verify_custom_node` = LOCAL with a saved workspace. Updated the `model-resolver-roots` / `output-dir` mocks to back the shared helper.

Full suite green except the pre-existing environment-only `node-dev` ripgrep failure. Build (tsc) clean. No version bump.