### PR TITLE
fix(download): follow HF Xet CAS redirect (#411)

### DIFF
--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -195,6 +195,67 @@ describe("downloadModel cache", () => {
     expect(cached.some((f) => f.endsWith(".safetensors"))).toBe(false);
   });
 
+  it("follows a Hugging Face Xet/CAS cross-origin redirect and drops auth on the hop (#411)", async () => {
+    config.huggingfaceToken = "hf_secrettoken";
+    const hfUrl =
+      "https://huggingface.co/Aitrepreneur/FLX/resolve/main/krea2_turbo_mxfp8.safetensors";
+    // 1st hop: HF resolve URL 302s to the pre-signed Xet/CAS CDN (cross-origin).
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/abc123?sig=xyz" },
+      }),
+    );
+    // 2nd hop: the CDN serves the bytes.
+    fetchMock.mockResolvedValueOnce(okResponse("xet model bytes"));
+
+    const target = await downloadModel(hfUrl, "diffusion_models", "krea.safetensors");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Hop 1 carried the HF bearer token...
+    const [, firstInit] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(firstInit.headers.Authorization).toBe("Bearer hf_secrettoken");
+    // ...but the cross-origin CAS hop must NOT (no token leak to the third-party CDN).
+    const [casUrl, secondInit] = fetchMock.mock.calls[1] as [
+      string,
+      { headers: Record<string, string> },
+    ];
+    expect(casUrl).toContain("cas-bridge.xethub.hf.co");
+    expect(secondInit.headers.Authorization).toBeUndefined();
+    await expect(readFile(target, "utf-8")).resolves.toBe("xet model bytes");
+  });
+
+  it("surfaces the underlying cause when fetch fails at the network layer instead of a bare 'fetch failed' (#411)", async () => {
+    // undici shape: TypeError("fetch failed") whose real reason is on .cause.
+    const netErr = new TypeError("fetch failed");
+    (netErr as { cause?: unknown }).cause = Object.assign(
+      new Error("getaddrinfo ENOTFOUND cas-bridge.xethub.hf.co"),
+      { code: "ENOTFOUND" },
+    );
+    fetchMock.mockRejectedValueOnce(netErr);
+
+    const p = downloadModel(
+      "https://huggingface.co/Aitrepreneur/FLX/resolve/main/krea2_turbo_mxfp8.safetensors",
+      "diffusion_models",
+      "krea.safetensors",
+    );
+    // Clear + actionable: names the real cause (ENOTFOUND) and the Xet/CAS host,
+    // not the generic "fetch failed".
+    await expect(p).rejects.toThrow(/network layer/i);
+    await expect(p).rejects.toThrow(/ENOTFOUND/);
+    await expect(p).rejects.toThrow(/Xet\/CAS/i);
+  });
+
+  it("gives a clear error for an unfollowable redirect (3xx with no Location) (#411)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
+    const p = downloadModel(
+      "https://huggingface.co/some/repo/resolve/main/model.safetensors",
+      "diffusion_models",
+      "m.safetensors",
+    );
+    await expect(p).rejects.toThrow(/no.*Location header/i);
+  });
+
   it("evicts least-recently-used cache files when the optional limit is exceeded", async () => {
     process.env.COMFYUI_LRU_CACHE_SIZE_GB = String(12 / 1024 / 1024 / 1024);
     await fsPromises.mkdir(cacheDir, { recursive: true });

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -29,6 +29,60 @@ const HASH_CHARS = 32;
 const MAX_HTTP_REDIRECTS = 5;
 const inflight = new Map<string, Promise<string>>();
 
+/**
+ * Extract the useful diagnostic bits from an error thrown by `fetch()` itself
+ * (a network-layer failure, not an HTTP status). undici surfaces these as
+ * `TypeError: fetch failed` whose real reason lives on `.cause` (an Error with
+ * a `code`/`errno` such as ENOTFOUND, ECONNRESET, UND_ERR_CONNECT_TIMEOUT, or
+ * a TLS `ERR_TLS_CERT_ALTNAME_INVALID`). The top-level message is the useless
+ * generic "fetch failed" (issue #411) — the actionable detail is one level
+ * down, so unwrap the cause chain into a single readable string.
+ */
+function describeFetchError(err: unknown): { message: string; code?: string } {
+  const parts: string[] = [];
+  let code: string | undefined;
+  let cur: unknown = err;
+  const seen = new Set<unknown>();
+  while (cur instanceof Error && !seen.has(cur)) {
+    seen.add(cur);
+    const c = (cur as { code?: unknown }).code;
+    if (typeof c === "string" && !code) code = c;
+    const label = typeof c === "string" ? `${cur.message} (${c})` : cur.message;
+    if (label && !parts.includes(label)) parts.push(label);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  if (parts.length === 0) parts.push(String(err));
+  return { message: parts.join(": "), code };
+}
+
+/**
+ * Fetch that converts a network-layer failure into a ModelError carrying the
+ * unwrapped `cause` — so a Hugging Face Xet / CAS host that fails DNS, TLS, a
+ * connect timeout, or a proxy reset reports WHY instead of a bare "fetch
+ * failed" (issue #411). HTTP responses (any status) pass straight through; only
+ * a thrown fetch is wrapped. The ModelError is rethrown as-is by downloadWithCache
+ * (it never masks a ModelError), so the actionable cause reaches the tool result.
+ */
+async function fetchOrThrow(
+  url: string,
+  init: RequestInit,
+  logUrl: string,
+): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    const { message, code } = describeFetchError(err);
+    throw new ModelError(
+      `Download request to the model host failed at the network layer: ${message}. ` +
+        `This is a connectivity/TLS/proxy failure reaching the file host (for Hugging Face ` +
+        `this is often the Xet/CAS CDN, e.g. cas-bridge.xethub.hf.co) — not an HTTP error. ` +
+        `Check DNS/connectivity to the host, any corporate proxy or firewall, and system time/TLS certs; ` +
+        `set HF_ENDPOINT to a reachable mirror if huggingface.co is blocked in your region, then retry.`,
+      { url: logUrl, code, cause: message },
+    );
+  }
+}
+
 export const downloadCacheFs = {
   copyFile,
   link,
@@ -116,28 +170,59 @@ async function streamUrlToFile(
   }
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
-    res = await fetch(currentUrl, { headers: currentHeaders, redirect: "manual" });
+    res = await fetchOrThrow(
+      currentUrl,
+      { headers: currentHeaders, redirect: "manual" },
+      currentUrl === url ? logUrl : redactUrlForLogs(currentUrl),
+    );
     if (res.status < 300 || res.status >= 400) break;
 
     if (redirectCount >= MAX_HTTP_REDIRECTS) {
-      throw new ModelError("Download redirect limit exceeded", {
-        url: redactUrlForLogs(currentUrl),
-        status: res.status,
-      });
+      throw new ModelError(
+        `Download redirect limit exceeded (${MAX_HTTP_REDIRECTS}) — the model host kept ` +
+          `redirecting (Hugging Face routes resolve URLs through the Xet/CAS CDN; a loop ` +
+          `here usually means a broken mirror or a proxy rewriting the redirect chain).`,
+        {
+          url: redactUrlForLogs(currentUrl),
+          status: res.status,
+        },
+      );
     }
 
     const location = res.headers.get("location");
-    if (!location) break;
+    if (!location) {
+      // A 3xx with no Location can't be followed. HF's Xet/CAS flow ALWAYS
+      // includes a Location on its resolve redirect, so a missing one means a
+      // proxy stripped it or the host mis-responded — say so instead of the
+      // confusing "Download failed: 302 Found" the !res.ok path would emit.
+      throw new ModelError(
+        `Download failed: the model host returned a ${res.status} redirect with no ` +
+          `Location header, so it can't be followed. For Hugging Face this usually means a ` +
+          `proxy stripped the redirect to the Xet/CAS CDN — check any corporate proxy, or ` +
+          `set HF_ENDPOINT to a reachable mirror and retry.`,
+        { url: redactUrlForLogs(currentUrl), status: res.status },
+      );
+    }
 
     let nextUrl: string;
     try {
       nextUrl = new URL(location, currentUrl).toString();
     } catch {
-      throw new ModelError("Download redirect location is invalid", {
-        url: redactUrlForLogs(currentUrl),
-        status: res.status,
-      });
+      throw new ModelError(
+        `Download failed: the model host returned a ${res.status} redirect to an invalid ` +
+          `Location ("${location}"). The redirect chain can't be followed — retry, or set ` +
+          `HF_ENDPOINT to a reachable mirror if this is a Hugging Face URL.`,
+        {
+          url: redactUrlForLogs(currentUrl),
+          status: res.status,
+        },
+      );
     }
+    // Drop request headers (Authorization etc.) when the redirect crosses
+    // origins. HF's resolve URL 302s to a *pre-signed* Xet/CAS URL on a
+    // different host (e.g. cas-bridge.xethub.hf.co) that needs no auth — and
+    // forwarding our HF Bearer token to a third-party CDN would leak it. This
+    // matches how huggingface_hub follows the CAS redirect.
     const sameOrigin = new URL(nextUrl).origin === new URL(currentUrl).origin;
     currentUrl = nextUrl;
     if (!sameOrigin) currentHeaders = {};


### PR DESCRIPTION
## Problem (#411)
`download_model` and `apply_manifest` fail immediately with a generic `MODEL_ERROR "fetch failed"` for valid, public Hugging Face files stored with **Xet**. The generic message strips the underlying network/redirect cause, so a user can't tell whether it's DNS, TLS, a redirect, Xet/CAS, or a proxy.

## Root cause
The manual redirect-following loop was actually correct (it follows HF's `resolve` → pre-signed Xet/CAS CDN 302 and drops auth cross-origin, matching `huggingface_hub`). The real bug is error handling: a **network-layer** `fetch()` throw (undici `TypeError: fetch failed`) carries its real reason on `.cause` (e.g. `ENOTFOUND cas-bridge.xethub.hf.co`, a TLS altname error, a connect timeout). That `TypeError` is not a `ModelError`, so `downloadWithCache` fell through to a redundant direct download that threw the same bare `fetch failed`, and it propagated with the cause discarded.

## Fix (scope: download-cache / model-resolver only)
- **`fetchOrThrow`** wraps every `fetch()` in the download path and unwraps the undici cause chain into one readable, actionable `ModelError` — naming the Xet/CAS CDN and the concrete things to check (DNS/connectivity, corporate proxy/firewall, system time/TLS certs, `HF_ENDPOINT` mirror). Because it's a `ModelError`, `downloadWithCache` rethrows it as-is (no cause-losing fallback).
- **Unfollowable redirects** now give clear messages: a 3xx with no `Location`, an invalid `Location`, and the redirect-limit case all explain the Xet/CAS flow instead of the confusing `Download failed: 302 Found`.
- Documented the cross-origin auth drop on the CAS hop (pre-signed URL needs no auth; forwarding the HF token to a third-party CDN would leak it).
- **#343 truncated / 0-byte integrity checks left intact.**

## Tests (added to `download-cache.test.ts`)
- Xet cross-origin redirect followed → success, HF bearer sent on hop 1 but **not** forwarded to the CAS CDN on hop 2.
- Network-layer `fetch` failure surfaces the real cause (`ENOTFOUND`, "network layer", "Xet/CAS") instead of a bare "fetch failed".
- Unfollowable redirect (3xx, no `Location`) → clear error.

`tsc` clean; full suite green except the pre-existing/allowed `node-dev` ripgrep-vs-builtin test. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
