### PR TITLE
fix(civitai): surface distinct upstream/auth/timeout failures vs valid-empty (#204)

### DIFF
--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -207,6 +207,49 @@ describe("civitai request error surfacing (distinct failure modes)", () => {
     );
   });
 
+  it("an abort DURING the body read is classified as a timeout, NOT a non-JSON bot-gate", async () => {
+    // Headers arrived (2xx), then the connection aborts while draining the body.
+    const abortErr = Object.assign(new Error("The operation was aborted."), {
+      name: "AbortError",
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw abortErr;
+      },
+      text: async () => "",
+    } as unknown as Response);
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(/timed out/i);
+    // Distinctly NOT the non-JSON category.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw abortErr;
+      },
+      text: async () => "",
+    } as unknown as Response);
+    await expect(resolveCivitaiModelVersion(1)).rejects.not.toThrow(/non-JSON/i);
+  });
+
+  it("a network failure DURING the body read is classified as unreachable, NOT non-JSON", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw new TypeError("terminated");
+      },
+      text: async () => "",
+    } as unknown as Response);
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /unreachable.*network error/i,
+    );
+  });
+
   it("applies a request timeout signal to every civitai fetch", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, files: [] }));
     await resolveCivitaiModelVersion(1);
@@ -665,9 +708,14 @@ describe("fetchCivitaiTopCreators", () => {
     expect(hits[1].thumbs_up).toBeUndefined();
   });
 
-  it("throws ModelError on a bot-gate 401", async () => {
+  it("bot-gate 401 reads as 'auth required', NOT 'your token is invalid' — the leaderboard sends no token even when one is configured", async () => {
+    config.civitaiApiToken = "a-valid-v1-token"; // configured, but NOT sent here
     fetchMock.mockResolvedValueOnce(jsonResponse({}, 401));
-    await expect(fetchCivitaiTopCreators()).rejects.toBeInstanceOf(ModelError);
+    const err = await fetchCivitaiTopCreators().catch((e) => e);
+    expect(err).toBeInstanceOf(ModelError);
+    // Must NOT blame the configured token, since this request never sent it.
+    expect(err.message).toMatch(/requires authentication.*set CIVITAI_API_TOKEN/i);
+    expect(err.message).not.toMatch(/invalid or expired/i);
   });
 
   it("fails FAST when CIVITAI_ENABLED=0 (kill-switch, #127)", async () => {

--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -129,6 +129,92 @@ describe("resolveCivitaiModelVersion", () => {
   });
 });
 
+describe("civitai request error surfacing (distinct failure modes)", () => {
+  // Each failure mode must surface as a DISTINCT, actionable message — never a
+  // swallowed empty and never conflated with a neighbouring status (WS-6 #204).
+  it("401 without a token → 'requires authentication' (set the token)", async () => {
+    config.civitaiApiToken = undefined;
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /requires authentication.*set CIVITAI_API_TOKEN/i,
+    );
+  });
+
+  it("401 WITH a token → 'token invalid or expired' (refresh it)", async () => {
+    config.civitaiApiToken = "stale-token";
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 401));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /invalid or expired.*refresh CIVITAI_API_TOKEN/i,
+    );
+  });
+
+  it("403 → 'forbidden' (permission or region), distinct from 401", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 403));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /403 Forbidden.*permission.*region/i,
+    );
+  });
+
+  it("429 → 'rate-limited' (back off and retry), distinct from an upstream 5xx", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 429));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /rate-limited.*429.*retry/i,
+    );
+  });
+
+  it("5xx → 'upstream error' flagged transient", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /upstream error.*503.*transient/i,
+    );
+  });
+
+  it("our own timeout abort → distinct 'timed out' message (not a hang, not empty)", async () => {
+    const timeoutErr = Object.assign(new Error("The operation timed out."), {
+      name: "TimeoutError",
+    });
+    fetchMock.mockRejectedValueOnce(timeoutErr);
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /timed out.*unreachable/i,
+    );
+    await expect(
+      (async () => {
+        fetchMock.mockRejectedValueOnce(timeoutErr);
+        return resolveCivitaiModelVersion(1);
+      })(),
+    ).rejects.toBeInstanceOf(ModelError);
+  });
+
+  it("network failure (fetch rejects TypeError) → distinct 'unreachable' message", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("fetch failed"));
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /unreachable.*network error/i,
+    );
+  });
+
+  it("2xx that is NOT JSON (bot-gate/interstitial) → distinct non-JSON error, not a garbage empty", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+      text: async () => "<html>Just a moment…</html>",
+    } as unknown as Response);
+    await expect(resolveCivitaiModelVersion(1)).rejects.toThrow(
+      /non-JSON response.*bot-gate|interstitial/i,
+    );
+  });
+
+  it("applies a request timeout signal to every civitai fetch", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1, files: [] }));
+    await resolveCivitaiModelVersion(1);
+    const opts = fetchMock.mock.calls[0][1] as { signal?: AbortSignal };
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
 describe("resolveCivitaiModel", () => {
   it("picks the first (latest) version by default", async () => {
     fetchMock.mockResolvedValueOnce(
@@ -432,6 +518,42 @@ describe("searchCivitaiModels", () => {
   it("rejects an empty query with no creator", async () => {
     await expect(searchCivitaiModels("  ")).rejects.toBeInstanceOf(ValidationError);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("creator + keyword: a FIRST-page failure THROWS (a broken scan must never read as empty)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
+    await expect(
+      searchCivitaiModels("detail", { creator: "jed" }),
+    ).rejects.toThrow(/upstream error.*503/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("creator + keyword: a LATER-page failure surfaces partial hits + scanError (not a silent truncation)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: 1, name: "Detail A", modelVersions: [] }],
+          metadata: { nextCursor: "p2" },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({}, 429)); // page 2 rate-limited
+    const { hits, scanned, scanCapped, scanError } = await searchCivitaiModels(
+      "detail",
+      { creator: "prolific" },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(hits.map((h) => h.model_id)).toEqual([1]); // page-1 match retained
+    expect(scanned).toBe(1);
+    expect(scanCapped).toBe(true); // pages remained → result is not definitive
+    expect(scanError).toMatch(/rate-limited.*429/i); // the miss is attributable
+  });
+
+  it("creator + keyword: no scanError field on a clean full scan", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ items: [{ id: 1, name: "Detail A", modelVersions: [] }] }),
+    );
+    const result = await searchCivitaiModels("detail", { creator: "jed" });
+    expect(result.scanError).toBeUndefined();
   });
 });
 

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -120,6 +120,35 @@ function authHeaders(): Record<string, string> {
 const CIVITAI_TIMEOUT_MS = 15000;
 
 /**
+ * Translate a raw (non-HTTP) transport failure into a DISTINCT, actionable
+ * ModelError, distinguishing our own timeout/abort from a connection-level
+ * network error. Shared by the initial fetch AND the body read, because an
+ * AbortError/connection reset can fire at EITHER point (after headers arrive
+ * but before the body is drained) and must be labelled the same way — never
+ * misread as a bot-gate/non-JSON page.
+ * Returns null when `err` is not a transport failure (e.g. a JSON SyntaxError),
+ * so the caller can fall through to its own classification.
+ */
+function transportError(err: unknown, url: string): ModelError | null {
+  const name = err instanceof Error ? err.name : "";
+  if (name === "TimeoutError" || name === "AbortError") {
+    return new ModelError(
+      `CivitAI request timed out after ${CIVITAI_TIMEOUT_MS / 1000}s ` +
+        `(civitai.com slow or unreachable) — try again shortly.`,
+      { url, timeout: true },
+    );
+  }
+  if (err instanceof TypeError) {
+    return new ModelError(
+      `CivitAI is unreachable (network error: ${err.message}) — ` +
+        `check connectivity and try again.`,
+      { url, network: true },
+    );
+  }
+  return null;
+}
+
+/**
  * Perform the fetch and translate every non-HTTP failure mode (DNS/connection
  * down, TLS, or our own timeout abort) into a DISTINCT, actionable ModelError.
  * A bare `fetch` rejects with an opaque `TypeError: fetch failed` (or a
@@ -136,19 +165,14 @@ async function civitaiFetch(
       signal: AbortSignal.timeout(CIVITAI_TIMEOUT_MS),
     });
   } catch (err) {
-    const name = err instanceof Error ? err.name : "";
-    if (name === "TimeoutError" || name === "AbortError") {
-      throw new ModelError(
-        `CivitAI request timed out after ${CIVITAI_TIMEOUT_MS / 1000}s ` +
-          `(civitai.com slow or unreachable) — try again shortly.`,
-        { url, timeout: true },
-      );
-    }
-    throw new ModelError(
-      `CivitAI is unreachable (network error: ` +
-        `${err instanceof Error ? err.message : String(err)}) — ` +
-        `check connectivity and try again.`,
-      { url, network: true },
+    throw (
+      transportError(err, url) ??
+      new ModelError(
+        `CivitAI is unreachable (network error: ` +
+          `${err instanceof Error ? err.message : String(err)}) — ` +
+          `check connectivity and try again.`,
+        { url, network: true },
+      )
     );
   }
 }
@@ -158,14 +182,22 @@ async function civitaiFetch(
  * auth/rate-limit/upstream failure is never conflated with each other — or,
  * worse, with a genuine empty result. Callers handle 404 themselves (a 404 is
  * "resource absent", a definitive answer, not a fault).
+ *
+ * `tokenSent` reflects whether THIS request actually carried a bearer token —
+ * NOT whether one is configured globally. The tRPC leaderboard deliberately
+ * sends none, so a bot-gate 401 there must read as "auth required", never
+ * "your configured token is invalid".
  */
-async function throwForCivitaiStatus(res: Response, url: string): Promise<never> {
+async function throwForCivitaiStatus(
+  res: Response,
+  url: string,
+  tokenSent: boolean,
+): Promise<never> {
   const body = await res.text().catch(() => "");
   const status = res.status;
-  const hasToken = !!config.civitaiApiToken;
   let message: string;
   if (status === 401) {
-    message = hasToken
+    message = tokenSent
       ? `CivitAI rejected the API token (401 Unauthorized) — it is invalid or ` +
         `expired; refresh CIVITAI_API_TOKEN.`
       : `CivitAI requires authentication for this request (401 Unauthorized) — ` +
@@ -196,7 +228,12 @@ async function throwForCivitaiStatus(res: Response, url: string): Promise<never>
 async function parseCivitaiJson<T>(res: Response, url: string): Promise<T> {
   try {
     return (await res.json()) as T;
-  } catch {
+  } catch (err) {
+    // An abort/timeout or connection reset can surface HERE (headers arrived,
+    // body drain failed). Classify it as the transport failure it is — only a
+    // genuine parse failure (SyntaxError) is the bot-gate/non-JSON case.
+    const transport = transportError(err, url);
+    if (transport) throw transport;
     throw new ModelError(
       `CivitAI returned a non-JSON response (HTTP ${res.status}) — likely a ` +
         `bot-gate or interstitial page rather than the API; try again shortly.`,
@@ -214,7 +251,8 @@ async function civitaiGet<T>(path: string): Promise<T> {
   const url = `${CIVITAI_API_BASE}${path}`;
   logger.debug("CivitAI API request", { url });
 
-  const res = await civitaiFetch(url, authHeaders());
+  const headers = authHeaders();
+  const res = await civitaiFetch(url, headers);
   if (res.status === 404) {
     throw new ModelError(`CivitAI resource not found: ${path}`, {
       url,
@@ -222,7 +260,7 @@ async function civitaiGet<T>(path: string): Promise<T> {
     });
   }
   if (!res.ok) {
-    await throwForCivitaiStatus(res, url);
+    await throwForCivitaiStatus(res, url, "Authorization" in headers);
   }
   return parseCivitaiJson<T>(res, url);
 }
@@ -718,9 +756,11 @@ export async function fetchCivitaiTopCreators(
   // No bearer token here: the leaderboard is public and the API token belongs
   // to the documented v1 surface, not the site's tRPC endpoints. Shares the
   // timeout + distinct network/status/non-JSON error surfacing of civitaiGet.
+  // tokenSent: false — the leaderboard request intentionally carries no bearer
+  // token, so a bot-gate 401 must NOT blame the configured v1 API token.
   const res = await civitaiFetch(url, TRPC_BROWSER_HEADERS);
   if (!res.ok) {
-    await throwForCivitaiStatus(res, url);
+    await throwForCivitaiStatus(res, url, false);
   }
   const data = await parseCivitaiJson<{
     result?: { data?: { json?: CivitaiLeaderboardEntry[] } };

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -111,6 +111,100 @@ function authHeaders(): Record<string, string> {
   return headers;
 }
 
+/**
+ * Ceiling on any single CivitAI request. Without it a hung connection wedges
+ * the tool forever — the worst outcome of all (neither a surfaced error nor an
+ * honest empty). Mirrors the 10s guard the provenance hash-lookup already uses;
+ * a touch longer here because search/model reads can be heavier.
+ */
+const CIVITAI_TIMEOUT_MS = 15000;
+
+/**
+ * Perform the fetch and translate every non-HTTP failure mode (DNS/connection
+ * down, TLS, or our own timeout abort) into a DISTINCT, actionable ModelError.
+ * A bare `fetch` rejects with an opaque `TypeError: fetch failed` (or a
+ * `TimeoutError`) that, once caught upstream, is indistinguishable from any
+ * other crash — exactly the "silently swallowed" failure WS-6 set out to kill.
+ */
+async function civitaiFetch(
+  url: string,
+  headers: Record<string, string>,
+): Promise<Response> {
+  try {
+    return await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(CIVITAI_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    if (name === "TimeoutError" || name === "AbortError") {
+      throw new ModelError(
+        `CivitAI request timed out after ${CIVITAI_TIMEOUT_MS / 1000}s ` +
+          `(civitai.com slow or unreachable) — try again shortly.`,
+        { url, timeout: true },
+      );
+    }
+    throw new ModelError(
+      `CivitAI is unreachable (network error: ` +
+        `${err instanceof Error ? err.message : String(err)}) — ` +
+        `check connectivity and try again.`,
+      { url, network: true },
+    );
+  }
+}
+
+/**
+ * Turn a non-OK HTTP status into a DISTINCT, actionable ModelError so an
+ * auth/rate-limit/upstream failure is never conflated with each other — or,
+ * worse, with a genuine empty result. Callers handle 404 themselves (a 404 is
+ * "resource absent", a definitive answer, not a fault).
+ */
+async function throwForCivitaiStatus(res: Response, url: string): Promise<never> {
+  const body = await res.text().catch(() => "");
+  const status = res.status;
+  const hasToken = !!config.civitaiApiToken;
+  let message: string;
+  if (status === 401) {
+    message = hasToken
+      ? `CivitAI rejected the API token (401 Unauthorized) — it is invalid or ` +
+        `expired; refresh CIVITAI_API_TOKEN.`
+      : `CivitAI requires authentication for this request (401 Unauthorized) — ` +
+        `set CIVITAI_API_TOKEN.`;
+  } else if (status === 403) {
+    message =
+      `CivitAI refused the request (403 Forbidden) — the token lacks ` +
+      `permission, or access is region-blocked.`;
+  } else if (status === 429) {
+    message =
+      `CivitAI rate-limited the request (429 Too Many Requests) — ` +
+      `wait a moment and retry.`;
+  } else if (status >= 500) {
+    message =
+      `CivitAI upstream error (${status} ${res.statusText}) — the site is ` +
+      `having trouble; this is transient, retry shortly.`;
+  } else {
+    message = `CivitAI API ${status}: ${res.statusText}`;
+  }
+  throw new ModelError(message, { url, status, body });
+}
+
+/**
+ * Parse a response body as JSON, converting a non-JSON 2xx (e.g. a Cloudflare
+ * challenge or HTML interstitial served with a 200) into a distinct error
+ * rather than an opaque SyntaxError that reads as an empty/garbage result.
+ */
+async function parseCivitaiJson<T>(res: Response, url: string): Promise<T> {
+  try {
+    return (await res.json()) as T;
+  } catch {
+    throw new ModelError(
+      `CivitAI returned a non-JSON response (HTTP ${res.status}) — likely a ` +
+        `bot-gate or interstitial page rather than the API; try again shortly.`,
+      { url, status: res.status, nonJson: true },
+    );
+  }
+}
+
 async function civitaiGet<T>(path: string): Promise<T> {
   // User-initiated Civitai actions fail FAST with the config explanation when
   // the kill-switch is set (issue #127) — never a hang against a blocked host.
@@ -120,7 +214,7 @@ async function civitaiGet<T>(path: string): Promise<T> {
   const url = `${CIVITAI_API_BASE}${path}`;
   logger.debug("CivitAI API request", { url });
 
-  const res = await fetch(url, { headers: authHeaders() });
+  const res = await civitaiFetch(url, authHeaders());
   if (res.status === 404) {
     throw new ModelError(`CivitAI resource not found: ${path}`, {
       url,
@@ -128,14 +222,9 @@ async function civitaiGet<T>(path: string): Promise<T> {
     });
   }
   if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new ModelError(`CivitAI API ${res.status}: ${res.statusText}`, {
-      url,
-      status: res.status,
-      body,
-    });
+    await throwForCivitaiStatus(res, url);
   }
-  return (await res.json()) as T;
+  return parseCivitaiJson<T>(res, url);
 }
 
 /** Pick the best file from a version's file list: primary first, else the first. */
@@ -393,6 +482,12 @@ export interface CivitaiSearchResult {
    *  page cap with pages left AND fewer than `limit` matches — matching
    *  models past the cap may exist but were not seen. */
   scanCapped?: boolean;
+  /** Creator+keyword mode only: set when a PAGE AFTER THE FIRST failed
+   *  (upstream/timeout/rate-limit) mid-scan. The returned `hits` are a partial
+   *  result from the pages that did load, NOT a definitive answer — the miss of
+   *  any absent match is unattributable. (A first-page failure throws instead,
+   *  so a broken scan is never mistaken for a genuine empty.) */
+  scanError?: string;
 }
 
 function toSearchHit(m: CivitaiSearchItem): CivitaiSearchHit {
@@ -468,9 +563,21 @@ export async function searchCivitaiModels(
   // hit with a next cursor remaining, or the API handed back a degenerate
   // (cycling) cursor we refuse to follow.
   let stoppedEarly = false;
+  // Set when a page AFTER the first fails: we keep the partial matches gathered
+  // so far but flag them as non-definitive. A FIRST-page failure is left to
+  // throw (no partial data exists yet), so a broken scan never looks empty.
+  let scanError: string | undefined;
   for (let page = 0; page < CREATOR_SCAN_MAX_PAGES; page++) {
     if (cursor !== undefined) params.set("cursor", cursor);
-    const data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
+    let data: CivitaiSearchResponse;
+    try {
+      data = await civitaiGet<CivitaiSearchResponse>(`/models?${params.toString()}`);
+    } catch (err) {
+      if (page === 0) throw err; // nothing gathered yet — surface the failure
+      scanError = err instanceof Error ? err.message : String(err);
+      stoppedEarly = true; // pages remained unscanned → the result is partial
+      break;
+    }
     // Dedupe across pages by model id — a misbehaving cursor that replays a
     // page must not double-count `scanned` or fill `limit` with duplicates.
     const items = (data.items ?? []).filter((m) => !seenIds.has(m.id));
@@ -501,6 +608,7 @@ export async function searchCivitaiModels(
     hits: matches.slice(0, limit).map(toSearchHit),
     scanned,
     scanCapped: stoppedEarly && matches.length < limit,
+    ...(scanError ? { scanError } : {}),
   };
 }
 
@@ -608,19 +716,15 @@ export async function fetchCivitaiTopCreators(
   logger.debug("CivitAI leaderboard request", { url });
 
   // No bearer token here: the leaderboard is public and the API token belongs
-  // to the documented v1 surface, not the site's tRPC endpoints.
-  const res = await fetch(url, { headers: TRPC_BROWSER_HEADERS });
+  // to the documented v1 surface, not the site's tRPC endpoints. Shares the
+  // timeout + distinct network/status/non-JSON error surfacing of civitaiGet.
+  const res = await civitaiFetch(url, TRPC_BROWSER_HEADERS);
   if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new ModelError(`CivitAI leaderboard ${res.status}: ${res.statusText}`, {
-      url,
-      status: res.status,
-      body,
-    });
+    await throwForCivitaiStatus(res, url);
   }
-  const data = (await res.json()) as {
+  const data = await parseCivitaiJson<{
     result?: { data?: { json?: CivitaiLeaderboardEntry[] } };
-  };
+  }>(res, url);
   const entries = data.result?.data?.json ?? [];
   const metric = (e: CivitaiLeaderboardEntry, type: string) =>
     e.metrics?.find((m) => m.type === type)?.value;


### PR DESCRIPTION
Fix-forward of the codex-noted residual edges on WS-6 (#381 shipped, #398 follow-up). WS-6 made civitai search surface failures instead of empty results, but codex flagged residual edges where a failure could still hang or be conflated. Scope kept strictly to `src/services/civitai-resolver.ts` (orchestrator/panel untouched, no version bump).

## Root cause / edges
The search path already threw on HTTP errors, but:
1. **No request timeout** on `civitaiGet` or the tRPC leaderboard fetch (only the hash provenance lookup had one) — a hung civitai.com wedged the tool forever: neither a surfaced error nor an honest empty, the single worst outcome.
2. **Raw fetch rejections** (DNS/connection down, TLS, or our own abort) surfaced as an opaque `TypeError: fetch failed` / `TimeoutError`, indistinguishable once caught upstream.
3. **Every non-404 status collapsed** into one generic `CivitAI API {status}` message — 401 vs 403 vs 429 vs 5xx were all the same, none actionable.
4. **A 2xx that isn't JSON** (Cloudflare/bot-gate interstitial served with 200) threw an opaque `SyntaxError` — reads as garbage/empty, not an explained fault.
5. **Pagination partial-failure**: a mid-scan page fault in the creator+keyword scan threw away the page-1 matches, and there was no distinction between a first-page failure (must not look empty) and a later-page one (partial data exists).

## Fix
- 15s `AbortSignal.timeout` on all civitai fetches (mirrors the hash-lookup guard).
- Distinct, actionable `ModelError`s: timeout ("timed out … unreachable"), network ("unreachable (network error)"), **401** (missing token → set it, vs present token → invalid/expired, refresh it), **403** (permission/region), **429** (rate-limited, retry), **5xx** (transient upstream), non-JSON (bot-gate/interstitial). 404 unchanged — a definitive "absent", not a fault.
- Creator+keyword scan: a **first-page** failure **throws** (a broken scan must never read as a genuine empty); a **later-page** failure keeps the partial hits and sets `scanError` + `scanCapped=true` so the miss is attributable, never a silent truncation.
- Shared `civitaiFetch` / `throwForCivitaiStatus` / `parseCivitaiJson` helpers cover both the v1 API and the tRPC leaderboard consistently.

Only a genuinely successful empty query still returns empty.

## Tests
+13 unit tests, one per failure mode, explicitly asserting the error-vs-valid-empty and first-page-vs-later-page distinctions. `civitai-resolver.test.ts` 44/44. Full suite: tsc clean, `npm test` 2060 pass / 1 skipped / 1 pre-existing unrelated `node-dev` ripgrep-vs-builtin engine failure (environment-dependent, the documented allowed failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)