### PR TITLE
fix(crash-log): don't false-positive on swallowed "Exception ignored in: __del__" tracebacks (#341)

### DIFF
--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -93,6 +93,48 @@ ValueError: bad input
     expect(r.fingerprint).toBeUndefined();
   });
 
+  it("does NOT treat a swallowed 'Exception ignored in: __del__' block as a crash", () => {
+    // CPython prints but SWALLOWS exceptions raised in __del__/weakref callbacks
+    // during GC. The process keeps running (subsequent prompts succeed), so the
+    // native signature INSIDE this block must not trip the crash banner.
+    const swallowed = [
+      "2026-07-28 17:11:20 [INFO] got prompt",
+      "Exception ignored in: <function HostBuffer.__del__ at 0x0>",
+      "Traceback (most recent call last):",
+      '  File "~/.venv/Lib/site-packages/comfy_aimdo/host_buffer.py", line 129, in __del__',
+      "    lib.hostbuf_free(ptr)",
+      "OSError: exception: access violation writing 0x0000000000000024",
+      "2026-07-28 17:11:22 [INFO] Prompt executed in 7.18 seconds",
+      "2026-07-28 17:17:22 [INFO] got prompt",
+      "2026-07-28 17:17:30 [INFO] Prompt executed in 8.00 seconds",
+    ].join("\n");
+    const r = parseCrashBlock(swallowed);
+    expect(r.fatal).toBe(false);
+    expect(r.block).toBe("");
+    expect(r.fingerprint).toBeUndefined();
+  });
+
+  it("STILL flags a real native crash that appears after an earlier swallowed __del__ block", () => {
+    // A swallowed destructor block earlier in the tail must not suppress a genuine
+    // process crash that happens later.
+    const mixed = [
+      "Exception ignored in: <function HostBuffer.__del__ at 0x0>",
+      "Traceback (most recent call last):",
+      '  File "~/comfy_aimdo/host_buffer.py", line 129, in __del__',
+      "OSError: exception: access violation writing 0x24",
+      "2026-07-28 17:11:22 [INFO] Prompt executed in 7.18 seconds",
+      "",
+      "Windows fatal exception: access violation",
+      "",
+      "Current thread 0x00004abc (most recent call first):",
+      '  File "C:\\\\ComfyUI\\\\custom_nodes\\\\SomeNode\\\\nodes.py", line 42 in run',
+    ].join("\n");
+    const r = parseCrashBlock(mixed);
+    expect(r.fatal).toBe(true);
+    expect(r.culpritNode).toBe("SomeNode");
+    expect(r.culpritFrame).toBe("nodes.py:42");
+  });
+
   it("fingerprints a crash stably so it can be deduped", () => {
     const a = parseCrashBlock(WAN_CRASH);
     const b = parseCrashBlock(WAN_CRASH + "\n[INFO] more log appended after restart\n");

--- a/src/__tests__/crash-log.test.ts
+++ b/src/__tests__/crash-log.test.ts
@@ -135,6 +135,28 @@ ValueError: bad input
     expect(r.culpritFrame).toBe("nodes.py:42");
   });
 
+  it("flags a real crash after a swallowed block even with CRLF line endings", () => {
+    // Windows logs use CRLF. The blank-line boundary in the swallowed-block
+    // look-back must recognize "\r\n\r\n", or a genuine crash within 1200 chars
+    // of an earlier swallowed block gets wrongly filtered out.
+    const mixed = [
+      "Exception ignored in: <function HostBuffer.__del__ at 0x0>",
+      "Traceback (most recent call last):",
+      '  File "~/comfy_aimdo/host_buffer.py", line 129, in __del__',
+      "OSError: exception: access violation writing 0x24",
+      "[INFO] Prompt executed in 7.18 seconds",
+      "",
+      "Windows fatal exception: access violation",
+      "",
+      "Current thread 0x00004abc (most recent call first):",
+      '  File "C:\\\\ComfyUI\\\\custom_nodes\\\\SomeNode\\\\nodes.py", line 42 in run',
+    ].join("\r\n");
+    const r = parseCrashBlock(mixed);
+    expect(r.fatal).toBe(true);
+    expect(r.culpritNode).toBe("SomeNode");
+    expect(r.culpritFrame).toBe("nodes.py:42");
+  });
+
   it("fingerprints a crash stably so it can be deduped", () => {
     const a = parseCrashBlock(WAN_CRASH);
     const b = parseCrashBlock(WAN_CRASH + "\n[INFO] more log appended after restart\n");

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -76,7 +76,13 @@ const ANY_FRAME =
 function isSwallowedDestructorHit(text: string, index: number): boolean {
   const from = Math.max(0, index - 1200);
   const before = text.slice(from, index);
-  const cut = before.lastIndexOf("\n\n");
+  // Stop at the LAST blank line — handling LF, CRLF, and whitespace-only blank
+  // lines so a Windows (CRLF) log's block boundary isn't missed and the look-back
+  // can't reach into an unrelated earlier block.
+  const blank = /\r?\n[ \t]*\r?\n/g;
+  let cut = -1;
+  let b: RegExpExecArray | null;
+  while ((b = blank.exec(before)) !== null) cut = b.index;
   return /Exception ignored in:/i.test(cut >= 0 ? before.slice(cut) : before);
 }
 

--- a/src/services/crash-log.ts
+++ b/src/services/crash-log.ts
@@ -65,6 +65,21 @@ const CUSTOM_NODE_FRAME =
 const ANY_FRAME =
   /(?:File\s*["']([^"']+?\.py)["']?,?\s*line\s*(\d+))|([^\s"',()]+?\.py):(\d+)/gi;
 
+/**
+ * True when a crash-signature hit sits inside a Python "Exception ignored in:"
+ * block — an exception raised inside a __del__/weakref callback during garbage
+ * collection. CPython PRINTS these but SWALLOWS them: the process keeps running
+ * and subsequent prompts execute normally, so they must NOT be classified as a
+ * process crash. Uses a bounded look-back (1200 chars) that stops at a blank
+ * line, so it cannot reach into an unrelated earlier block.
+ */
+function isSwallowedDestructorHit(text: string, index: number): boolean {
+  const from = Math.max(0, index - 1200);
+  const before = text.slice(from, index);
+  const cut = before.lastIndexOf("\n\n");
+  return /Exception ignored in:/i.test(cut >= 0 ? before.slice(cut) : before);
+}
+
 /** Basename of a path with either separator (no node:path needed for a string). */
 function baseName(p: string): string {
   const parts = p.split(/[\\/]+/);
@@ -89,13 +104,13 @@ export function parseCrashBlock(text: string): CrashParseResult {
   let anchor = -1;
   let sawSignature = false;
   for (const re of CRASH_SIGNATURES) {
-    const idx = text.search(re);
-    // search() finds the first; walk to the LAST via a global clone.
+    // Walk EVERY match via a global clone and take the LAST hit that is NOT
+    // inside a swallowed "Exception ignored in:" destructor block.
     const g = new RegExp(re.source, re.flags.includes("g") ? re.flags : re.flags + "g");
     let m: RegExpExecArray | null;
-    let last = idx;
+    let last = -1;
     while ((m = g.exec(text)) !== null) {
-      last = m.index;
+      if (!isSwallowedDestructorHit(text, m.index)) last = m.index;
       if (m.index === g.lastIndex) g.lastIndex++; // avoid zero-width loop
     }
     if (last >= 0) {


### PR DESCRIPTION
Fixes #341.

## Root cause
`parseCrashBlock()` scans the log tail for native crash signatures (incl. `/access violation/i`) and takes the last hit as the crash anchor. It had no check for whether the hit sits inside a Python **"Exception ignored in:"** destructor block. CPython prints but **swallows** exceptions raised in `__del__`/weakref callbacks during GC — the process is unaffected and subsequent prompts run normally. A `comfy_aimdo HostBuffer.__del__` access violation was therefore mis-reported as a fatal crash, pushing the agent toward destructive recovery (update/git-pull/patch) on a bundled Desktop package that was never broken.

## Fix (minimal)
- Add `isSwallowedDestructorHit(text, index)`: bounded 1200-char look-back that stops at a blank line and matches `Exception ignored in:`.
- In the per-signature anchor scan, skip hits that are swallowed-destructor hits; seed `last = -1` (was the first `search()` index) so a filtered-out position isn't wrongly retained.

If ALL signature hits are swallowed, `sawSignature` stays false → `fatal:false`. A genuine crash after an earlier swallowed block is still flagged.

## Tests
Added two cases to `crash-log.test.ts`:
- swallowed `__del__` block with a native signature → `fatal:false`
- real Windows fatal exception appearing after an earlier swallowed block → `fatal:true`, culprit resolved

`npx tsc --noEmit` clean; full `npm test` passes except the pre-existing environment-only node-dev ripgrep test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)