### PR TITLE
fix(job-status): report present-but-empty ShowText outputs (#373)

### DIFF
--- a/src/__tests__/services/job-history.test.ts
+++ b/src/__tests__/services/job-history.test.ts
@@ -73,9 +73,25 @@ describe("extractTextOutputs", () => {
     ]);
   });
 
-  it("stringifies non-string scalars and drops empty strings", () => {
+  it("stringifies non-string scalars and preserves empty strings", () => {
     const entry = outputsEntry({ "3": { text: ["", 42, true, "keep"] } });
-    expect(extractTextOutputs(entry)).toEqual([{ node_id: "3", text: ["42", "true", "keep"] }]);
+    expect(extractTextOutputs(entry)).toEqual([
+      { node_id: "3", text: ["", "42", "true", "keep"] },
+    ]);
+  });
+
+  it("reports a ShowText node that legitimately emitted an empty string (#373)", () => {
+    // { text: [""] } is a present-but-empty output, not an absent one — it must
+    // be reported so the agent sees the node ran and produced "".
+    expect(extractTextOutputs(outputsEntry({ "5": { text: [""] } }))).toEqual([
+      { node_id: "5", text: [""] },
+    ]);
+    expect(extractTextOutputs(outputsEntry({ "5": { text: "" } }))).toEqual([
+      { node_id: "5", text: [""] },
+    ]);
+    expect(analyzeHistoryEntry(outputsEntry({ "5": { text: [""] } })).text_outputs).toEqual([
+      { node_id: "5", text: [""] },
+    ]);
   });
 
   it("collects text from multiple nodes and ignores image-only nodes", () => {
@@ -93,7 +109,6 @@ describe("extractTextOutputs", () => {
   it("returns nothing for image-only, empty, or malformed outputs", () => {
     expect(extractTextOutputs(outputsEntry({ "5": { images: [] } }))).toEqual([]);
     expect(extractTextOutputs(outputsEntry({ "5": { text: [] } }))).toEqual([]);
-    expect(extractTextOutputs(outputsEntry({ "5": { text: [""] } }))).toEqual([]);
     expect(extractTextOutputs(outputsEntry({ "5": null as unknown as object }))).toEqual([]);
     expect(extractTextOutputs({ prompt: {}, status: {} } as unknown as HistoryEntry)).toEqual([]);
   });

--- a/src/services/job-history.ts
+++ b/src/services/job-history.ts
@@ -187,7 +187,9 @@ export function extractExecutionStats(
  *
  * Shapes in the wild: `{ text: ["hi"] }` (the common one), `{ text: "hi" }`, and
  * packs that use `string` instead of `text`. Non-string scalars are stringified;
- * empty strings are dropped so a node that emitted nothing stays absent.
+ * empty strings are PRESERVED — a ShowText node that legitimately emitted "" is a
+ * real (present-but-empty) output and must be reported, not silently dropped. A
+ * node with no `text`/`string` field at all still stays absent (nothing pushed).
  */
 export function extractTextOutputs(entry: HistoryEntry): TextOutput[] {
   const results: TextOutput[] = [];
@@ -202,11 +204,11 @@ export function extractTextOutputs(entry: HistoryEntry): TextOutput[] {
     for (const key of ["text", "string"] as const) {
       const value = record[key];
       if (typeof value === "string") {
-        if (value.length > 0) text.push(value);
+        text.push(value);
       } else if (Array.isArray(value)) {
         for (const item of value) {
           if (typeof item === "string") {
-            if (item.length > 0) text.push(item);
+            text.push(item);
           } else if (typeof item === "number" || typeof item === "boolean") {
             text.push(String(item));
           }


### PR DESCRIPTION
Fixes #373.

## Root cause
`extractTextOutputs` in `src/services/job-history.ts` filtered out empty strings (`if (value.length > 0)`). A ShowText / PreviewAny node whose upstream returned `""` produces `outputs.<node>.text = [""]` in ComfyUI history. That legitimate present-but-empty output was silently dropped, so `get_job_status` returned `done:true` with no `text_outputs` — making a successful text run look like it produced nothing.

## Fix
Preserve empty strings when collecting text. `{ text: [""] }` / `{ text: "" }` now surface as `{ node_id, text: [""] }`. A node with no `text`/`string` field at all (image-only, `{ text: [] }`) still stays absent — no false positives.

## Tests
Updated `job-history.test.ts`: empty strings are preserved, added an explicit #373 regression case, and kept the image-only / empty-array absence assertions. `tsc --noEmit` clean; full suite passes except the pre-existing environment-only ripgrep test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)