### PR TITLE
fix(env): probe the ComfyUI venv python, not the host (#401)

### DIFF
--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -199,6 +199,8 @@ describe("resolveComfyuiPython (#401)", () => {
     const res = resolveComfyuiPython(dir, undefined);
     expect(res.verified).toBe(true);
     expect(res.python).toBe(exe);
+    // No argv → this is NOT the live interpreter (just the pinned workspace's venv).
+    expect(res.live).toBe(false);
   });
 
   it("finds the embedded python of a portable install as VERIFIED (not just .venv)", async () => {
@@ -217,6 +219,7 @@ describe("resolveComfyuiPython (#401)", () => {
     // A directory with no interpreter under it — the wrong-python scenario.
     const res = resolveComfyuiPython(dir, undefined);
     expect(res.verified).toBe(false);
+    expect(res.live).toBe(false);
     expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
   });
 
@@ -243,25 +246,43 @@ describe("resolveComfyuiPython (#401)", () => {
       join(rootB, "main.py"),
     ]);
     expect(res.verified).toBe(true);
+    expect(res.live).toBe(true);
+    expect(res.liveRoot).toBe(rootB);
     expect(res.python).toBe(exeB); // B, not A
+  });
+
+  it("marks the pinned workspace UNTRUSTED (live:false) when the LIVE root has no on-disk venv", async () => {
+    // Live root B (from argv) has no interpreter on disk; only pinned A does. A must
+    // NOT be reported as the live interpreter — its negative would be a false report.
+    const binA = IS_WIN ? join(dir, "A", ".venv", "Scripts") : join(dir, "A", ".venv", "bin");
+    await mkdir(binA, { recursive: true });
+    const exeA = join(binA, IS_WIN ? "python.exe" : "python3");
+    await writeFile(exeA, "", "utf-8");
+    const rootB = join(dir, "B"); // live root, but no venv created under it
+
+    const res = resolveComfyuiPython(join(dir, "A"), [join(rootB, "main.py")]);
+    expect(res.python).toBe(exeA); // A is the only interpreter we can probe …
+    expect(res.verified).toBe(true);
+    expect(res.live).toBe(false); // … but it is NOT the live interpreter
+    expect(res.liveRoot).toBe(rootB); // live root was resolvable, just not populated
   });
 });
 
 describe("reconcileProbeState (#401 — no false 'not installed')", () => {
-  it("keeps 'not-installed' only when the interpreter is verified AND versions match", () => {
+  it("keeps 'not-installed' only when the interpreter is LIVE and versions match", () => {
     expect(
       reconcileProbeState("not-installed", {
-        verified: true,
+        live: true,
         runningPython: "3.12",
         probePython: "3.12",
       }),
     ).toBe("not-installed");
   });
 
-  it("degrades 'not-installed' to 'unknown' when the interpreter is UNVERIFIED", () => {
+  it("degrades 'not-installed' to 'unknown' when the interpreter is NOT the live one", () => {
     expect(
       reconcileProbeState("not-installed", {
-        verified: false,
+        live: false,
         runningPython: "3.12",
         probePython: "3.12",
       }),
@@ -269,10 +290,10 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
   });
 
   it("degrades 'not-installed' to 'unknown' when probe python DISAGREES with the running instance", () => {
-    // The exact issue: running ComfyUI is 3.12, but we probed a 3.11 PATH python.
+    // The exact issue: running ComfyUI is 3.12, but we probed a 3.11 python.
     expect(
       reconcileProbeState("not-installed", {
-        verified: true,
+        live: true,
         runningPython: "3.12",
         probePython: "3.11",
       }),
@@ -281,12 +302,12 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
 
   it("passes a positive 'installed' through untouched even from an untrusted interpreter", () => {
     expect(
-      reconcileProbeState("installed", { verified: false, runningPython: "3.12", probePython: "3.11" }),
+      reconcileProbeState("installed", { live: false, runningPython: "3.12", probePython: "3.11" }),
     ).toBe("installed");
   });
 
   it("treats undefined as 'unknown'", () => {
-    expect(reconcileProbeState(undefined, { verified: true })).toBe("unknown");
+    expect(reconcileProbeState(undefined, { live: true })).toBe("unknown");
   });
 });
 

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -219,6 +219,32 @@ describe("resolveComfyuiPython (#401)", () => {
     expect(res.verified).toBe(false);
     expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
   });
+
+  it("prefers the LIVE running instance's argv root over a pinned/saved workspace (PR #433 review)", async () => {
+    // Both installs exist with a venv on the same Python major.minor, but only the
+    // LIVE server (root B, from argv main.py) has the package. If we resolved the
+    // pinned/saved root A first, A's negative would survive as a false 'not-installed'
+    // AND process-control could relaunch B's main.py with A's python. The live argv
+    // root must win.
+    const mkVenv = async (root: string): Promise<string> => {
+      const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
+      await mkdir(bin, { recursive: true });
+      const exe = join(bin, IS_WIN ? "python.exe" : "python3");
+      await writeFile(exe, "", "utf-8");
+      return exe;
+    };
+    const rootA = join(dir, "A"); // pinned COMFYUI_PATH / saved default
+    const rootB = join(dir, "B"); // the LIVE running server
+    await mkVenv(rootA);
+    const exeB = await mkVenv(rootB);
+
+    const res = resolveComfyuiPython(rootA, [
+      IS_WIN ? "python.exe" : "python3",
+      join(rootB, "main.py"),
+    ]);
+    expect(res.verified).toBe(true);
+    expect(res.python).toBe(exeB); // B, not A
+  });
 });
 
 describe("reconcileProbeState (#401 — no false 'not installed')", () => {

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir, platform } from "node:os";
+import { join } from "node:path";
 import {
   formatEnvBlock,
   applyStats,
   buildPanelSystemAppend,
+  resolveComfyuiPython,
+  reconcileProbeState,
   type EnvCapabilities,
 } from "../../services/env-capabilities.js";
+
+const IS_WIN = platform() === "win32";
 
 describe("formatEnvBlock", () => {
   it("renders the full compact block from a complete caps object", () => {
@@ -171,6 +178,89 @@ describe("applyStats", () => {
     });
     expect(caps.gpu).toBe("NVIDIA RTX 4090");
     expect(caps.vramTotalGb).toBe(24);
+  });
+});
+
+describe("resolveComfyuiPython (#401)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "comfyui-py-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns the on-disk venv interpreter as VERIFIED", async () => {
+    const venvBin = IS_WIN ? join(dir, ".venv", "Scripts") : join(dir, ".venv", "bin");
+    await mkdir(venvBin, { recursive: true });
+    const exe = join(venvBin, IS_WIN ? "python.exe" : "python3");
+    await writeFile(exe, "", "utf-8");
+
+    const res = resolveComfyuiPython(dir, undefined);
+    expect(res.verified).toBe(true);
+    expect(res.python).toBe(exe);
+  });
+
+  it("finds the embedded python of a portable install as VERIFIED (not just .venv)", async () => {
+    if (!IS_WIN) return; // python_embeded is a Windows-portable layout
+    const embedded = join(dir, "python_embeded");
+    await mkdir(embedded, { recursive: true });
+    const exe = join(embedded, "python.exe");
+    await writeFile(exe, "", "utf-8");
+
+    const res = resolveComfyuiPython(dir, undefined);
+    expect(res.verified).toBe(true);
+    expect(res.python).toBe(exe);
+  });
+
+  it("falls back to a bare PATH name as UNVERIFIED when no venv exists", () => {
+    // A directory with no interpreter under it — the wrong-python scenario.
+    const res = resolveComfyuiPython(dir, undefined);
+    expect(res.verified).toBe(false);
+    expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
+  });
+});
+
+describe("reconcileProbeState (#401 — no false 'not installed')", () => {
+  it("keeps 'not-installed' only when the interpreter is verified AND versions match", () => {
+    expect(
+      reconcileProbeState("not-installed", {
+        verified: true,
+        runningPython: "3.12",
+        probePython: "3.12",
+      }),
+    ).toBe("not-installed");
+  });
+
+  it("degrades 'not-installed' to 'unknown' when the interpreter is UNVERIFIED", () => {
+    expect(
+      reconcileProbeState("not-installed", {
+        verified: false,
+        runningPython: "3.12",
+        probePython: "3.12",
+      }),
+    ).toBe("unknown");
+  });
+
+  it("degrades 'not-installed' to 'unknown' when probe python DISAGREES with the running instance", () => {
+    // The exact issue: running ComfyUI is 3.12, but we probed a 3.11 PATH python.
+    expect(
+      reconcileProbeState("not-installed", {
+        verified: true,
+        runningPython: "3.12",
+        probePython: "3.11",
+      }),
+    ).toBe("unknown");
+  });
+
+  it("passes a positive 'installed' through untouched even from an untrusted interpreter", () => {
+    expect(
+      reconcileProbeState("installed", { verified: false, runningPython: "3.12", probePython: "3.11" }),
+    ).toBe("installed");
+  });
+
+  it("treats undefined as 'unknown'", () => {
+    expect(reconcileProbeState(undefined, { verified: true })).toBe("unknown");
   });
 });
 

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -196,6 +196,32 @@ describe("process-control startup readiness", () => {
     expect(children[0].unref).toHaveBeenCalled();
   });
 
+  it("recognizes a QUOTED main.py script path and relaunches via the interpreter (#401 / #433)", async () => {
+    // A launcher can leave surrounding quotes on argv[0] ("C:\ComfyUI\main.py").
+    // The suffix test must strip them, else the quoted path fails the `.py` check,
+    // bypasses the resolver, and is spawned as the executable.
+    __processControlTestHooks.setLastProcessInfo({
+      pid: 0,
+      port: 8188,
+      argv: ['"C:\\ComfyUI\\main.py"', "--port", "8188"],
+      isDesktopApp: false,
+    });
+    const children = mockSpawnedChildren();
+    mockNoPortProcess();
+    mockFetchOk(true);
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    // Resolved via the Python interpreter, with the UNQUOTED script path.
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/fake/ComfyUI/python_embeded/python.exe",
+      ["C:\\ComfyUI\\main.py", "--port", "8188"],
+      expect.objectContaining({ detached: true, shell: false }),
+    );
+    expect(children[0].unref).toHaveBeenCalled();
+  });
+
   it("anchors a RELATIVE script argv[0] to the ComfyUI root (portable launcher, #330)", async () => {
     // The standard Windows portable launcher runs `python ComfyUI\main.py` from
     // the portable ROOT, so sys.argv[0] is relative. Since we force cwd to the

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -35,6 +35,9 @@ vi.mock("../../comfyui/client.js", () => ({
 vi.mock("node:child_process", () => ({
   execSync: hoisted.execSync,
   spawn: hoisted.spawn,
+  // workspace-env.ts (pulled in transitively via env-capabilities → process-control)
+  // wraps execFile with promisify at load, so the mock must export a function.
+  execFile: vi.fn(),
 }));
 
 import {

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
+
+const IS_WIN = platform() === "win32";
+/** Create a venv interpreter on disk under `root`, returning its absolute path. */
+async function makeVenvPython(root: string): Promise<string> {
+  const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
+  await mkdir(bin, { recursive: true });
+  const exe = join(bin, IS_WIN ? "python.exe" : "python3");
+  await writeFile(exe, "", "utf-8");
+  return exe;
+}
 
 // ---------------------------------------------------------------------------
 // Mocks for modules with side effects / network at load time
@@ -26,6 +36,8 @@ vi.mock("../../config.js", () => ({
   config: h.mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // resolveComfyuiPython → resolveEffectiveComfyUIBase consults isRemoteMode().
+  isRemoteMode: () => false,
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -66,6 +78,8 @@ import {
   setDefaultWorkspace,
   listWorkspaces,
   getEnvironment,
+  liveRootFromArgv,
+  resolveComfyuiPython,
 } from "../../services/workspace-env.js";
 
 async function tmpDir(): Promise<string> {
@@ -465,6 +479,143 @@ describe("getEnvironment", () => {
       const env = await getEnvironment();
       expect(env.local.python_probe_trusted).toBe(true);
       expect(env.local.packages?.torch).toBe("2.5.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves the LIVE server's own interpreter over the pinned COMFYUI_PATH (#401 / #433 getEnvironment)", async () => {
+    const dir = await tmpDir();
+    const rootA = join(dir, "A"); // pinned COMFYUI_PATH
+    const rootB = join(dir, "B"); // the LIVE running server (from argv main.py)
+    await mkdir(rootA, { recursive: true });
+    await mkdir(rootB, { recursive: true });
+    const exeA = await makeVenvPython(rootA);
+    const exeB = await makeVenvPython(rootB);
+    void exeA;
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = rootA;
+      // Live server on 3.12, argv points at B/main.py; A and B share major.minor.
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          argv: [join(rootB, "main.py"), "--port", "8188"],
+        },
+        devices: [],
+      });
+      // Differentiate the two interpreters BY EXECUTABLE PATH: only B has the package.
+      setExecFileResponder((cmd, args) => {
+        const isB = cmd.includes(`${rootB}`);
+        if (args.includes("--version"))
+          return { stdout: isB ? "Python 3.12.9\n" : "Python 3.12.1\n" };
+        if (args.includes("pip"))
+          return { stdout: isB ? "Name: torch\nVersion: 2.6.0\n" : "Name: torch\nVersion: 1.0.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      // Probed B (the live interpreter), not the pinned A.
+      expect(env.local.python?.executable).toBe(exeB);
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("2.6.0"); // B's, not A's 1.0.0
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits packages when the LIVE root has no venv and only the pinned workspace does (#401 / #433)", async () => {
+    const dir = await tmpDir();
+    const rootA = join(dir, "A"); // pinned COMFYUI_PATH — the only venv on disk
+    const rootB = join(dir, "B"); // live root, but NO interpreter under it
+    await mkdir(rootB, { recursive: true });
+    const exeA = await makeVenvPython(rootA);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = rootA;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          argv: [join(rootB, "main.py")],
+        },
+        devices: [],
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.1\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 1.0.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      // We could only probe A, but A is provably NOT the live interpreter → untrusted.
+      expect(env.local.python?.executable).toBe(exeA);
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
+  it("returns the absolute dir of an absolute main.py", () => {
+    const root = IS_WIN ? "C:\\Comfy\\ComfyUI" : "/opt/ComfyUI";
+    const argv = [join(root, "main.py"), "--port", "8188"];
+    expect(liveRootFromArgv(argv)).toBe(root);
+  });
+
+  it("strips surrounding quotes on the main.py path", () => {
+    const root = IS_WIN ? "C:\\Comfy\\ComfyUI" : "/opt/ComfyUI";
+    const argv = [`"${join(root, "main.py")}"`];
+    expect(liveRootFromArgv(argv)).toBe(root);
+  });
+
+  it("resolves a RELATIVE main.py against the server cwd when available, else UNRESOLVED", () => {
+    const cwd = IS_WIN ? "C:\\portable" : "/portable";
+    const rel = IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py";
+    expect(liveRootFromArgv([rel], cwd)).toBe(join(cwd, "ComfyUI"));
+    // No cwd → cannot resolve to an absolute dir → UNRESOLVED (not a bogus rel root).
+    expect(liveRootFromArgv([rel])).toBeUndefined();
+  });
+
+  it("treats a bare 'main.py' as cwd (when absolute) or UNRESOLVED", () => {
+    const cwd = IS_WIN ? "C:\\here" : "/here";
+    expect(liveRootFromArgv(["main.py"], cwd)).toBe(cwd);
+    expect(liveRootFromArgv(["main.py"])).toBeUndefined();
+  });
+
+  it("ignores non-main.py args and returns undefined when there is no main.py", () => {
+    expect(liveRootFromArgv(["python", "--port", "8188"])).toBeUndefined();
+    // A boundary check: 'notmain.py' must NOT be treated as main.py.
+    expect(liveRootFromArgv([IS_WIN ? "C:\\x\\notmain.py" : "/x/notmain.py"])).toBeUndefined();
+  });
+
+  it("returns undefined for missing/empty argv", () => {
+    expect(liveRootFromArgv(undefined)).toBeUndefined();
+    expect(liveRootFromArgv([])).toBeUndefined();
+  });
+});
+
+describe("resolveComfyuiPython live-first (#401 / #433)", () => {
+  it("prefers the live argv root over the pinned COMFYUI_PATH, both with venvs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "comfyui-resolve-"));
+    try {
+      const rootA = join(dir, "A");
+      const rootB = join(dir, "B");
+      await mkdir(rootA, { recursive: true });
+      await mkdir(rootB, { recursive: true });
+      await makeVenvPython(rootA);
+      const exeB = await makeVenvPython(rootB);
+
+      const res = resolveComfyuiPython(rootA, [join(rootB, "main.py")]);
+      expect(res.python).toBe(exeB);
+      expect(res.live).toBe(true);
+      expect(res.liveRoot).toBe(rootB);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -25,6 +25,7 @@ const h = vi.hoisted(() => {
   return {
     mockConfig: { comfyuiPath: undefined as string | undefined, resolvedPort: 8188 },
     mockGetSystemStats: vi.fn(),
+    remoteMode: { value: false },
     execFileResponder: (() => new Error("not configured")) as (
       cmd: string,
       args: string[],
@@ -36,8 +37,8 @@ vi.mock("../../config.js", () => ({
   config: h.mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
-  // resolveComfyuiPython → resolveEffectiveComfyUIBase consults isRemoteMode().
-  isRemoteMode: () => false,
+  // resolveComfyuiPython → resolveEffectiveComfyUIBase + getEnvironment consult this.
+  isRemoteMode: () => h.remoteMode.value,
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -89,6 +90,7 @@ async function tmpDir(): Promise<string> {
 beforeEach(() => {
   mockConfig.comfyuiPath = undefined;
   mockConfig.resolvedPort = 8188;
+  h.remoteMode.value = false;
   mockGetSystemStats.mockReset();
   setExecFileResponder(() => new Error("not configured"));
   resetWorkspaceConfig();
@@ -329,10 +331,14 @@ describe("getEnvironment", () => {
     }
   });
 
-  it("captures the unreachable error and still returns local probes when path set", async () => {
+  it("captures the unreachable error and still returns local probes for a real workspace venv", async () => {
     const dir = await tmpDir();
     const install = join(dir, "ComfyUI");
     await mkdir(install, { recursive: true });
+    // A real workspace venv on disk → resolved.verified, so an unreachable server's
+    // packages are still reported (#401 round 3: only a VERIFIED interpreter is
+    // trusted when unreachable, never a bare PATH fallback).
+    await makeVenvPython(install);
     try {
       configureWorkspace({ configPath: join(dir, "workspace.json") });
       mockConfig.comfyuiPath = install;
@@ -560,6 +566,68 @@ describe("getEnvironment", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("does NOT trust a bare PATH python when the server is unreachable (#401 / #433 round 3)", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI"); // configured, but NO venv on disk
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+      // A bare PATH python answers, but it is NOT provably the workspace's interpreter.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.11.5\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.version).toBe("3.11.5");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined(); // bare PATH packages NOT surfaced
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("never trusts a coincident LOCAL interpreter for a REMOTE server (#401 / #433 round 3)", async () => {
+    const dir = await tmpDir();
+    const rootB = join(dir, "B"); // remote server's argv path — also exists LOCALLY
+    await mkdir(rootB, { recursive: true });
+    await makeVenvPython(rootB); // a coincident local venv on the same path
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      h.remoteMode.value = true; // running ComfyUI is REMOTE
+      mockConfig.comfyuiPath = undefined;
+      // Remote server answers /system_stats; its argv main.py path happens to exist
+      // locally, on the SAME python major.minor.
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          argv: [join(rootB, "main.py")],
+        },
+        devices: [],
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      // The local interpreter is NOT the remote server's — never trusted.
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.note).toMatch(/REMOTE/i);
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
@@ -616,6 +684,23 @@ describe("resolveComfyuiPython live-first (#401 / #433)", () => {
       expect(res.python).toBe(exeB);
       expect(res.live).toBe(true);
       expect(res.liveRoot).toBe(rootB);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("in REMOTE mode, a coincident local live path is NOT marked live and is not probed", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "comfyui-resolve-"));
+    try {
+      const rootB = join(dir, "B");
+      await mkdir(rootB, { recursive: true });
+      const exeB = await makeVenvPython(rootB);
+
+      const res = resolveComfyuiPython(undefined, [join(rootB, "main.py")], { remote: true });
+      // Live root is still reported for provenance, but it is NOT live/probed locally.
+      expect(res.live).toBe(false);
+      expect(res.python).not.toBe(exeB);
+      expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -411,4 +411,62 @@ describe("getEnvironment", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("omits packages (no false report) when the probed python disagrees with the running ComfyUI (#401)", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      // Running ComfyUI is on python 3.12.11 …
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: { os: "nt", python_version: "3.12.11", comfyui_version: "0.27.1" },
+        devices: [],
+      });
+      // … but the interpreter we can probe (bare PATH python) is 3.11.7 — a DIFFERENT
+      // environment. torch etc. from it would be a false report, so degrade.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.11.7\n" };
+        if (args.includes("pip"))
+          return { stdout: "Name: torch\nVersion: 9.9.9\n" }; // must NOT surface
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.version).toBe("3.11.7");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.note).toMatch(/does not match the running ComfyUI python/i);
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports packages when the probed python matches the running ComfyUI major.minor", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: { os: "nt", python_version: "3.12.11", comfyui_version: "0.27.1" },
+        devices: [],
+      });
+      // Same major.minor (3.12) as the running instance → trusted.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("2.5.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -21,6 +21,7 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
 import { join } from "node:path";
 import { isForceRemoteFlagSet } from "../config.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -308,16 +309,27 @@ async function detectAttentionFromComfyLog(
  * Locate the python that ComfyUI actually runs on, the way the
  * triton-sageattention skill describes: prefer the standalone-env / python_embeded
  * / .venv interpreter under COMFYUI_PATH (or the install root inferred from the
- * running server's argv main.py), then fall back to PATH python. Returns the
- * first candidate that exists on disk, or a PATH name as a last resort.
+ * running server's argv main.py), then fall back to PATH python.
+ *
+ * Returns BOTH the interpreter and whether it was VERIFIED — i.e. an actual
+ * on-disk venv/embedded interpreter under a known ComfyUI install root. When no
+ * such interpreter is found we fall back to a bare PATH name (`verified: false`),
+ * which is emphatically NOT guaranteed to be ComfyUI's interpreter: on a portable
+ * install whose venv sits outside the checked locations, PATH python is a DIFFERENT
+ * environment. Probing it for triton/sage there yields a FALSE "not installed"
+ * (issue #401), so callers must treat an unverified interpreter's negative result
+ * as "unknown", not "not-installed".
  */
-export function findComfyuiPython(
+export function resolveComfyuiPython(
   comfyuiPath: string | undefined,
   statsArgv: string[] | undefined,
-): string | undefined {
+): { python: string | undefined; verified: boolean } {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
   const roots: string[] = [];
-  if (comfyuiPath) roots.push(comfyuiPath);
+  // Prefer the explicit COMFYUI_PATH, else the effective local base (saved default
+  // workspace) resolved exactly like every other filesystem-backed tool (#418).
+  const base = comfyuiPath ?? resolveEffectiveComfyUIBase();
+  if (base) roots.push(base);
   // Infer the install root from the running server's argv (…/main.py).
   if (Array.isArray(statsArgv)) {
     const mainPy = statsArgv.find((a) => typeof a === "string" && /main\.py$/i.test(a));
@@ -350,14 +362,25 @@ export function findComfyuiPython(
     // paths are instant. (Linux/Mac UNC isn't a thing; this is the Windows risk.)
     if (/^\\\\/.test(c)) continue;
     try {
-      if (existsSync(c)) return c;
+      if (existsSync(c)) return { python: c, verified: true };
     } catch {
       // ignore and continue
     }
   }
-  // Last resort: a PATH-resolved interpreter (may not be ComfyUI's, but better
-  // than nothing for the import probe).
-  return names[0];
+  // Last resort: a PATH-resolved interpreter. It may NOT be ComfyUI's (see above),
+  // so it is explicitly unverified — a negative probe result off it is untrustworthy.
+  return { python: names[0], verified: false };
+}
+
+/**
+ * Back-compat shim: returns just the interpreter path. Prefer resolveComfyuiPython
+ * when the caller needs to know whether the interpreter was verified as ComfyUI's.
+ */
+export function findComfyuiPython(
+  comfyuiPath: string | undefined,
+  statsArgv: string[] | undefined,
+): string | undefined {
+  return resolveComfyuiPython(comfyuiPath, statsArgv).python;
 }
 
 /**
@@ -370,16 +393,20 @@ export function findComfyuiPython(
 export function probeTritonSage(
   pythonExe: string | undefined,
   timeoutMs = 5000,
-): Promise<{ triton: TriState; sageattention: TriState }> {
+): Promise<{ triton: TriState; sageattention: TriState; pythonVersion?: string }> {
   return new Promise((resolve) => {
     if (!pythonExe) {
       resolve({ triton: "unknown", sageattention: "unknown" });
       return;
     }
     // Print a clear per-package marker so we can tell which imported, even if one
-    // succeeds and the other fails (avoids an all-or-nothing answer).
+    // succeeds and the other fails (avoids an all-or-nothing answer). Also print
+    // the interpreter's own major.minor so the caller can confirm we probed the
+    // SAME python the running ComfyUI reports (#401 — a mismatch means we're
+    // looking at the wrong environment and any negative is untrustworthy).
     const code =
-      "import importlib.util as u;" +
+      "import importlib.util as u,sys;" +
+      "print('python', '%d.%d' % sys.version_info[:2]);" +
       "print('triton', u.find_spec('triton') is not None);" +
       "print('sageattention', u.find_spec('sageattention') is not None)";
     let done = false;
@@ -401,10 +428,15 @@ export function probeTritonSage(
           if (!m) return "unknown";
           return m[1] === "True" ? "installed" : "not-installed";
         };
+        const pyMatch = out.match(/^python\s+(\d+\.\d+)/m);
         // If python ran but errored AFTER printing partial output, still trust
         // whatever lines we got; missing lines stay "unknown".
         void err;
-        resolve({ triton: read("triton"), sageattention: read("sageattention") });
+        resolve({
+          triton: read("triton"),
+          sageattention: read("sageattention"),
+          pythonVersion: pyMatch ? pyMatch[1] : undefined,
+        });
       },
     );
     child.on?.("error", () => {
@@ -413,6 +445,31 @@ export function probeTritonSage(
       resolve({ triton: "unknown", sageattention: "unknown" });
     });
   });
+}
+
+/**
+ * Reconcile a raw import-probe tri-state against how much we trust the interpreter
+ * we probed (#401). A definitive "not-installed" is only believable when we probed
+ * ComfyUI's OWN python — i.e. a verified on-disk venv/embedded interpreter whose
+ * major.minor matches what /system_stats reports for the running instance. When the
+ * interpreter is unverified (bare PATH fallback) or its version disagrees with the
+ * running ComfyUI, we are looking at the wrong environment, so a "not-installed" is
+ * downgraded to "unknown" rather than emitted as a false negative that would make an
+ * agent disable working acceleration. Positives pass through unchanged (a positive
+ * can't be a harmful false negative).
+ */
+export function reconcileProbeState(
+  state: TriState | undefined,
+  opts: { verified: boolean; runningPython?: string; probePython?: string },
+): TriState {
+  const s = state ?? "unknown";
+  const versionMismatch = !!(
+    opts.runningPython &&
+    opts.probePython &&
+    opts.runningPython !== opts.probePython
+  );
+  const trustworthy = opts.verified && !versionMismatch;
+  return s === "not-installed" && !trustworthy ? "unknown" : s;
 }
 
 // ---------------------------------------------------------------------------
@@ -517,11 +574,28 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   }
 
   // --- triton + sageattention (find python, import-probe, ~5s cap) ---
-  const python = findComfyuiPython(opts.comfyuiPath, statsArgv);
+  const { python, verified } = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
   const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
   const ts = await withTimeout(probeTritonSage(python, tritonTimeout), tritonTimeout + 1000);
-  caps.triton = ts?.triton ?? "unknown";
-  caps.sageattention = ts?.sageattention ?? "unknown";
+
+  // Only trust a definitive "not-installed" when we actually probed ComfyUI's own
+  // interpreter (#401). Two ways it can be the WRONG python:
+  //   1. We fell back to a bare PATH name (verified === false) — likely a different
+  //      environment than the running ComfyUI.
+  //   2. The probed interpreter's major.minor disagrees with what /system_stats
+  //      reports for the running instance — provably a different environment.
+  // In either case a "not-installed" is untrustworthy, so we degrade it to
+  // "unknown" rather than emit a false negative that makes an agent disable working
+  // acceleration. A positive ("installed") is still reported — it can't be a false
+  // negative, and the log-marker check below only ever reinforces a positive.
+  const reconcile = (state: TriState | undefined): TriState =>
+    reconcileProbeState(state, {
+      verified,
+      runningPython: caps.python,
+      probePython: ts?.pythonVersion,
+    });
+  caps.triton = reconcile(ts?.triton);
+  caps.sageattention = reconcile(ts?.sageattention);
 
   // A positive signal from the ComfyUI HOST's log wins over the local python probe:
   // in remote mode (pod) the probe can't reach the host, and even locally the log

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -15,13 +15,17 @@
 //     is unit-tested and omits unknown fields cleanly.
 
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
-import { join } from "node:path";
 import { isForceRemoteFlagSet } from "../config.js";
-import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+import { resolveComfyuiPython } from "./workspace-env.js";
+
+// The interpreter resolver lives in workspace-env (which owns ComfyUI-base
+// resolution) so get_environment and this panel probe share ONE live-first
+// implementation and can never disagree (#401 / PR #433). Re-export for
+// back-compat with existing importers/tests.
+export { resolveComfyuiPython };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -306,89 +310,9 @@ async function detectAttentionFromComfyLog(
 // ---------------------------------------------------------------------------
 
 /**
- * Locate the python that ComfyUI actually runs on, the way the
- * triton-sageattention skill describes: prefer the standalone-env / python_embeded
- * / .venv interpreter under COMFYUI_PATH (or the install root inferred from the
- * running server's argv main.py), then fall back to PATH python.
- *
- * Returns BOTH the interpreter and whether it was VERIFIED — i.e. an actual
- * on-disk venv/embedded interpreter under a known ComfyUI install root. When no
- * such interpreter is found we fall back to a bare PATH name (`verified: false`),
- * which is emphatically NOT guaranteed to be ComfyUI's interpreter: on a portable
- * install whose venv sits outside the checked locations, PATH python is a DIFFERENT
- * environment. Probing it for triton/sage there yields a FALSE "not installed"
- * (issue #401), so callers must treat an unverified interpreter's negative result
- * as "unknown", not "not-installed".
- */
-export function resolveComfyuiPython(
-  comfyuiPath: string | undefined,
-  statsArgv: string[] | undefined,
-): { python: string | undefined; verified: boolean } {
-  const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
-  const roots: string[] = [];
-  // The LIVE running instance is the source of truth: resolve the interpreter from
-  // the running server's own argv (…/main.py) FIRST, so we verify the python that
-  // is ACTUALLY running ComfyUI — not merely the first venv found under a persisted
-  // default workspace, which may be a different install (a false negative there
-  // survives reconciliation, and process-control could relaunch the live server
-  // with the wrong python). See #401 / PR #433 review.
-  let hasLiveArgvRoot = false;
-  if (Array.isArray(statsArgv)) {
-    const mainPy = statsArgv.find((a) => typeof a === "string" && /main\.py$/i.test(a));
-    if (mainPy) {
-      const root = mainPy.replace(/[\\/]+main\.py$/i, "");
-      if (root) {
-        roots.push(root);
-        hasLiveArgvRoot = true;
-      }
-    }
-  }
-  // Explicit COMFYUI_PATH (user-pinned install) next.
-  if (comfyuiPath && !roots.includes(comfyuiPath)) roots.push(comfyuiPath);
-  // The saved DEFAULT workspace (#418) is only a last-resort guess — consult it
-  // ONLY when we have neither a live argv NOR an explicit COMFYUI_PATH to trust.
-  // Otherwise a stale default could shadow the running server's interpreter.
-  if (!hasLiveArgvRoot && !comfyuiPath) {
-    const saved = resolveEffectiveComfyUIBase();
-    if (saved && !roots.includes(saved)) roots.push(saved);
-  }
-
-  const candidates: string[] = [];
-  for (const root of roots) {
-    if (IS_WIN) {
-      candidates.push(join(root, "standalone-env", "python.exe"));
-      candidates.push(join(root, "python_embeded", "python.exe"));
-      candidates.push(join(root, ".venv", "Scripts", "python.exe"));
-      candidates.push(join(root, "venv", "Scripts", "python.exe"));
-      // Desktop app keeps the embedded python a level up beside the install.
-      candidates.push(join(root, "..", "python_embeded", "python.exe"));
-    } else {
-      candidates.push(join(root, ".venv", "bin", "python3"));
-      candidates.push(join(root, ".venv", "bin", "python"));
-      candidates.push(join(root, "venv", "bin", "python3"));
-      candidates.push(join(root, "venv", "bin", "python"));
-    }
-  }
-
-  for (const c of candidates) {
-    // Skip UNC / network roots (\\server\share) — a dead/slow network path makes
-    // existsSync() block for seconds and we gather env at startup. Local drive
-    // paths are instant. (Linux/Mac UNC isn't a thing; this is the Windows risk.)
-    if (/^\\\\/.test(c)) continue;
-    try {
-      if (existsSync(c)) return { python: c, verified: true };
-    } catch {
-      // ignore and continue
-    }
-  }
-  // Last resort: a PATH-resolved interpreter. It may NOT be ComfyUI's (see above),
-  // so it is explicitly unverified — a negative probe result off it is untrustworthy.
-  return { python: names[0], verified: false };
-}
-
-/**
- * Back-compat shim: returns just the interpreter path. Prefer resolveComfyuiPython
- * when the caller needs to know whether the interpreter was verified as ComfyUI's.
+ * Back-compat shim: returns just the interpreter path (LIVE-first resolution lives
+ * in workspace-env.resolveComfyuiPython). Prefer resolveComfyuiPython when the caller
+ * needs to know whether the interpreter is the LIVE server's own (issue #401).
  */
 export function findComfyuiPython(
   comfyuiPath: string | undefined,
@@ -464,17 +388,17 @@ export function probeTritonSage(
 /**
  * Reconcile a raw import-probe tri-state against how much we trust the interpreter
  * we probed (#401). A definitive "not-installed" is only believable when we probed
- * ComfyUI's OWN python — i.e. a verified on-disk venv/embedded interpreter whose
- * major.minor matches what /system_stats reports for the running instance. When the
- * interpreter is unverified (bare PATH fallback) or its version disagrees with the
- * running ComfyUI, we are looking at the wrong environment, so a "not-installed" is
- * downgraded to "unknown" rather than emitted as a false negative that would make an
- * agent disable working acceleration. Positives pass through unchanged (a positive
- * can't be a harmful false negative).
+ * ComfyUI's OWN python — i.e. the LIVE interpreter resolved from the running server's
+ * argv root, whose major.minor also matches what /system_stats reports. When the
+ * interpreter is NOT the live one (a bare PATH fallback, or a different/persisted
+ * workspace) or its version disagrees with the running ComfyUI, we are looking at the
+ * wrong environment, so a "not-installed" is downgraded to "unknown" rather than
+ * emitted as a false negative that would make an agent disable working acceleration.
+ * Positives pass through unchanged (a positive can't be a harmful false negative).
  */
 export function reconcileProbeState(
   state: TriState | undefined,
-  opts: { verified: boolean; runningPython?: string; probePython?: string },
+  opts: { live: boolean; runningPython?: string; probePython?: string },
 ): TriState {
   const s = state ?? "unknown";
   const versionMismatch = !!(
@@ -482,7 +406,7 @@ export function reconcileProbeState(
     opts.probePython &&
     opts.runningPython !== opts.probePython
   );
-  const trustworthy = opts.verified && !versionMismatch;
+  const trustworthy = opts.live && !versionMismatch;
   return s === "not-installed" && !trustworthy ? "unknown" : s;
 }
 
@@ -587,24 +511,24 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
     ).then((m) => m ?? "unknown");
   }
 
-  // --- triton + sageattention (find python, import-probe, ~5s cap) ---
-  const { python, verified } = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
+  // --- triton + sageattention (resolve the LIVE python, import-probe, ~5s cap) ---
+  const { python, live } = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
   const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
   const ts = await withTimeout(probeTritonSage(python, tritonTimeout), tritonTimeout + 1000);
 
-  // Only trust a definitive "not-installed" when we actually probed ComfyUI's own
-  // interpreter (#401). Two ways it can be the WRONG python:
-  //   1. We fell back to a bare PATH name (verified === false) — likely a different
-  //      environment than the running ComfyUI.
-  //   2. The probed interpreter's major.minor disagrees with what /system_stats
-  //      reports for the running instance — provably a different environment.
-  // In either case a "not-installed" is untrustworthy, so we degrade it to
-  // "unknown" rather than emit a false negative that makes an agent disable working
+  // Only trust a definitive "not-installed" when we probed the LIVE running server's
+  // OWN interpreter (#401). Otherwise it can be the WRONG python:
+  //   1. A bare PATH fallback (no on-disk venv/embedded interpreter found).
+  //   2. A different/persisted workspace that merely happens to have a venv — its
+  //      negative would still be a false report about the running instance.
+  //   3. Its major.minor disagrees with what /system_stats reports.
+  // In each case a "not-installed" is untrustworthy, so we degrade it to "unknown"
+  // rather than emit a false negative that makes an agent disable working
   // acceleration. A positive ("installed") is still reported — it can't be a false
   // negative, and the log-marker check below only ever reinforces a positive.
   const reconcile = (state: TriState | undefined): TriState =>
     reconcileProbeState(state, {
-      verified,
+      live,
       runningPython: caps.python,
       probePython: ts?.pythonVersion,
     });

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -326,17 +326,31 @@ export function resolveComfyuiPython(
 ): { python: string | undefined; verified: boolean } {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
   const roots: string[] = [];
-  // Prefer the explicit COMFYUI_PATH, else the effective local base (saved default
-  // workspace) resolved exactly like every other filesystem-backed tool (#418).
-  const base = comfyuiPath ?? resolveEffectiveComfyUIBase();
-  if (base) roots.push(base);
-  // Infer the install root from the running server's argv (…/main.py).
+  // The LIVE running instance is the source of truth: resolve the interpreter from
+  // the running server's own argv (…/main.py) FIRST, so we verify the python that
+  // is ACTUALLY running ComfyUI — not merely the first venv found under a persisted
+  // default workspace, which may be a different install (a false negative there
+  // survives reconciliation, and process-control could relaunch the live server
+  // with the wrong python). See #401 / PR #433 review.
+  let hasLiveArgvRoot = false;
   if (Array.isArray(statsArgv)) {
     const mainPy = statsArgv.find((a) => typeof a === "string" && /main\.py$/i.test(a));
     if (mainPy) {
       const root = mainPy.replace(/[\\/]+main\.py$/i, "");
-      if (root && !roots.includes(root)) roots.push(root);
+      if (root) {
+        roots.push(root);
+        hasLiveArgvRoot = true;
+      }
     }
+  }
+  // Explicit COMFYUI_PATH (user-pinned install) next.
+  if (comfyuiPath && !roots.includes(comfyuiPath)) roots.push(comfyuiPath);
+  // The saved DEFAULT workspace (#418) is only a last-resort guess — consult it
+  // ONLY when we have neither a live argv NOR an explicit COMFYUI_PATH to trust.
+  // Otherwise a stale default could shadow the running server's interpreter.
+  if (!hasLiveArgvRoot && !comfyuiPath) {
+    const saved = resolveEffectiveComfyUIBase();
+    if (saved && !roots.includes(saved)) roots.push(saved);
   }
 
   const candidates: string[] = [];

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -512,9 +512,19 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   }
 
   // --- triton + sageattention (resolve the LIVE python, import-probe, ~5s cap) ---
-  const { python, live } = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
-  const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
-  const ts = await withTimeout(probeTritonSage(python, tritonTimeout), tritonTimeout + 1000);
+  // In REMOTE mode the local python-import probe can't reach the server's host, and a
+  // coincident LOCAL path is NOT the remote interpreter — probing it risks BOTH a
+  // false negative and a false positive for the remote server. So skip the probe
+  // entirely and rely solely on the ComfyUI-log positive markers below (#401 round 3).
+  const remote = caps.location === "REMOTE";
+  let live = false;
+  let ts: { triton: TriState; sageattention: TriState; pythonVersion?: string } | undefined;
+  if (!remote) {
+    const resolved = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
+    live = resolved.live;
+    const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
+    ts = await withTimeout(probeTritonSage(resolved.python, tritonTimeout), tritonTimeout + 1000);
+  }
 
   // Only trust a definitive "not-installed" when we probed the LIVE running server's
   // OWN interpreter (#401). Otherwise it can be the WRONG python:
@@ -522,6 +532,7 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   //   2. A different/persisted workspace that merely happens to have a venv — its
   //      negative would still be a false report about the running instance.
   //   3. Its major.minor disagrees with what /system_stats reports.
+  //   4. REMOTE mode — no local interpreter is the server's (probe skipped above).
   // In each case a "not-installed" is untrustworthy, so we degrade it to "unknown"
   // rather than emit a false negative that makes an agent disable working
   // acceleration. A positive ("installed") is still reported — it can't be a false

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -516,7 +516,12 @@ function resolveLaunchCommand(
 ): { exe: string; args: string[] } | null {
   if (info.argv.length === 0) return null;
   const [first, ...rest] = info.argv;
-  const looksLikeScript = /\.pyw?$/i.test(first.trim());
+  // Strip surrounding quotes a launcher may leave on the script path BEFORE the
+  // suffix test — otherwise `"C:\…\main.py"` fails the `.py` check, bypasses the
+  // unified live-first resolver, and gets treated as the executable (#401 / PR #433
+  // round 3). Kept in sync with liveRootFromArgv's quote handling.
+  const firstUnquoted = first.trim().replace(/^["']+/, "").replace(/["']+$/, "");
+  const looksLikeScript = /\.pyw?$/i.test(firstUnquoted);
   if (looksLikeScript) {
     const python = findComfyuiPython(config.comfyuiPath ?? undefined, info.argv);
     if (!python) return null;
@@ -533,11 +538,11 @@ function resolveLaunchCommand(
     // rather than trusting the host `path` module (which mangles `C:\…` / `\`
     // paths on POSIX). The final join stays host-native to match comfyuiPath.
     const isWindowsAbsolute =
-      /^[a-zA-Z]:[\\/]/.test(first) || /^\\\\/.test(first);
-    const scriptBasename = first.split(/[\\/]/).pop() || first;
+      /^[a-zA-Z]:[\\/]/.test(firstUnquoted) || /^\\\\/.test(firstUnquoted);
+    const scriptBasename = firstUnquoted.split(/[\\/]/).pop() || firstUnquoted;
     const script =
-      isAbsolute(first) || isWindowsAbsolute || !config.comfyuiPath
-        ? first
+      isAbsolute(firstUnquoted) || isWindowsAbsolute || !config.comfyuiPath
+        ? firstUnquoted
         : join(config.comfyuiPath, scriptBasename);
     return { exe: python, args: [script, ...rest] };
   }

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -319,32 +319,65 @@ async function probe(
   }
 }
 
-/** Resolve the python executable to probe, preferring a venv inside the workspace. */
-function pythonCandidates(workspacePath: string | undefined): string[] {
+/**
+ * Resolve python interpreters to probe, most-preferred first, each tagged with
+ * whether it is VERIFIED to be ComfyUI's own interpreter (an on-disk venv/embedded
+ * python under the workspace) vs a bare PATH fallback. Portable/standalone installs
+ * keep python under python_embeded / standalone-env — not just .venv — so we check
+ * all of them (#401: only checking .venv made a portable install fall through to a
+ * DIFFERENT PATH python, producing a false package report).
+ */
+function pythonCandidates(
+  workspacePath: string | undefined,
+): Array<{ exe: string; verified: boolean }> {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
-  const candidates: string[] = [];
+  const candidates: Array<{ exe: string; verified: boolean }> = [];
   if (workspacePath) {
-    const venvBin = IS_WIN
-      ? join(workspacePath, ".venv", "Scripts")
-      : join(workspacePath, ".venv", "bin");
-    for (const n of names) {
-      const p = join(venvBin, n);
-      if (existsSync(p)) candidates.push(p);
+    const embedded = IS_WIN
+      ? [
+          join(workspacePath, "standalone-env", "python.exe"),
+          join(workspacePath, "python_embeded", "python.exe"),
+          join(workspacePath, "..", "python_embeded", "python.exe"),
+        ]
+      : [];
+    const venvBins = IS_WIN
+      ? [join(workspacePath, ".venv", "Scripts"), join(workspacePath, "venv", "Scripts")]
+      : [join(workspacePath, ".venv", "bin"), join(workspacePath, "venv", "bin")];
+    const onDisk: string[] = [...embedded];
+    for (const bin of venvBins) for (const n of names) onDisk.push(join(bin, n));
+    for (const p of onDisk) {
+      // Skip UNC paths — existsSync on a dead network share can block for seconds.
+      if (/^\\\\/.test(p)) continue;
+      try {
+        if (existsSync(p)) candidates.push({ exe: p, verified: true });
+      } catch {
+        // ignore and continue
+      }
     }
   }
-  // Fall back to PATH-resolved interpreters
-  candidates.push(...names);
+  // Fall back to PATH-resolved interpreters — NOT guaranteed to be ComfyUI's.
+  for (const n of names) candidates.push({ exe: n, verified: false });
   return candidates;
 }
 
 async function probePython(
   workspacePath: string | undefined,
-): Promise<{ executable: string; version: string } | undefined> {
-  for (const exe of pythonCandidates(workspacePath)) {
+): Promise<{ executable: string; version: string; verified: boolean } | undefined> {
+  for (const { exe, verified } of pythonCandidates(workspacePath)) {
     const version = await probe(exe, ["--version"]);
-    if (version) return { executable: exe, version: version.replace(/^Python\s+/i, "") };
+    if (version)
+      return { executable: exe, version: version.replace(/^Python\s+/i, ""), verified };
   }
   return undefined;
+}
+
+/** True when two python version strings share the same major.minor (3.12.11 ~ 3.12.0). */
+function pythonVersionsAgree(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  const mm = (v: string): string | undefined => v.replace(/^Python\s+/i, "").match(/^(\d+\.\d+)/)?.[1];
+  const ma = mm(a);
+  const mb = mm(b);
+  return !!ma && ma === mb;
 }
 
 async function probePipPackages(
@@ -434,6 +467,11 @@ export interface EnvironmentInfo {
   local: {
     workspace_path?: string;
     python?: { executable: string; version: string };
+    /** Whether the probed python is trusted to be the running ComfyUI's own
+     *  interpreter. False when a bare PATH python was used or its version
+     *  disagrees with the running instance — in that case `packages` is omitted
+     *  rather than reporting versions from the wrong environment (#401). */
+    python_probe_trusted?: boolean;
     git?: { rev?: string; branch?: string };
     comfyui_manager_version?: string;
     packages?: Record<string, string>;
@@ -504,9 +542,31 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
 
   const py = await probePython(workspacePath);
   if (py) {
-    local.python = py;
-    const pkgs = await probePipPackages(py.executable, KEY_PACKAGES);
-    if (Object.keys(pkgs).length > 0) local.packages = pkgs;
+    local.python = { executable: py.executable, version: py.version };
+    // Decide whether to trust this interpreter as the running ComfyUI's own.
+    // The provable failure mode (#401): the running instance is reachable and its
+    // python major.minor disagrees with the interpreter we probed — then we are
+    // demonstrably looking at the WRONG environment, so reporting its package
+    // versions would be a false capability report. Degrade honestly instead.
+    const runningPy = running.python_version;
+    const provableMismatch =
+      running.reachable && !!runningPy && !pythonVersionsAgree(py.version, runningPy);
+    const trusted = !provableMismatch;
+    local.python_probe_trusted = trusted;
+    if (trusted) {
+      const pkgs = await probePipPackages(py.executable, KEY_PACKAGES);
+      if (Object.keys(pkgs).length > 0) local.packages = pkgs;
+    } else {
+      local.note = [
+        local.note,
+        `Probed python ${py.version} does not match the running ComfyUI python ` +
+          `${runningPy} — the probe interpreter is a different environment, so ` +
+          `package versions are omitted rather than reported from the wrong python (#401). ` +
+          `Point COMFYUI_PATH at the install whose venv runs ComfyUI for an accurate report.`,
+      ]
+        .filter(Boolean)
+        .join(" ");
+    }
   } else {
     local.note = [
       local.note,

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -391,22 +391,31 @@ export interface ComfyuiPythonResolution {
  * installs keep python under python_embeded / standalone-env (not just .venv), so all
  * are checked. Falls back to a bare PATH name (`verified:false, live:false`) when no
  * on-disk interpreter is found — a negative off THAT is untrustworthy (#401 / PR #433).
+ *
+ * REMOTE mode (`opts.remote`): the live interpreter is on the REMOTE host and cannot be
+ * probed locally, so a locally-existing argv path is NOT treated as `live` — otherwise a
+ * coincident local install would have its (version-matching) negatives mis-reported as
+ * authoritative for a server running elsewhere. In remote mode we do not probe the live
+ * root at all; callers degrade to honest-unknown / untrusted (#401 / PR #433 round 3).
  */
 export function resolveComfyuiPython(
   comfyuiPath: string | undefined,
   statsArgv: string[] | undefined,
-  cwd?: string,
+  opts?: { cwd?: string; remote?: boolean },
 ): ComfyuiPythonResolution {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
-  const liveRoot = liveRootFromArgv(statsArgv, cwd);
+  const remote = opts?.remote ?? false;
+  const liveRoot = liveRootFromArgv(statsArgv, opts?.cwd);
 
   const rootsWithFlag: Array<{ root: string; live: boolean }> = [];
-  if (liveRoot) rootsWithFlag.push({ root: liveRoot, live: true });
+  // Only a LOCAL live root is a probeable live interpreter. Skip it entirely in remote
+  // mode so we never probe a coincident local path as if it were the remote server's.
+  if (liveRoot && !remote) rootsWithFlag.push({ root: liveRoot, live: true });
   if (comfyuiPath && comfyuiPath !== liveRoot) {
     rootsWithFlag.push({ root: comfyuiPath, live: false });
   }
-  // Saved default only when we have nothing more trustworthy to go on.
-  if (!liveRoot && !comfyuiPath) {
+  // Saved default only when we have nothing more trustworthy to go on (never remote).
+  if (!liveRoot && !comfyuiPath && !remote) {
     const saved = resolveEffectiveComfyUIBase();
     if (saved) rootsWithFlag.push({ root: saved, live: false });
   }
@@ -593,7 +602,8 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   // the panel env block, so the two paths can never disagree (#401 / PR #433). The
   // running server's argv root wins over an explicit COMFYUI_PATH, which wins over
   // the saved default.
-  const resolved = resolveComfyuiPython(workspacePath, statsArgv, statsCwd);
+  const remote = isRemoteMode();
+  const resolved = resolveComfyuiPython(workspacePath, statsArgv, { cwd: statsCwd, remote });
 
   // The install root we can actually inspect on disk: an explicit/saved workspace,
   // else the live server's own root (so we still report git/manager for a live
@@ -619,20 +629,25 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
 
     // "Trusted" means the probed interpreter IS the one running ComfyUI, so its
     // package list truly describes the live environment (#401). Order of certainty:
+    //   - REMOTE: the running server is elsewhere; NO local interpreter is its own,
+    //     so never trust a local probe (a coincident local path is not the server's).
     //   - resolved.live: we resolved the interpreter from the live server's own
     //     argv root — provably correct.
-    //   - server unreachable: nothing live to contradict; report the configured
-    //     workspace's packages (clearly labelled as the configured workspace).
+    //   - server unreachable: nothing live to contradict, but only trust a REAL
+    //     workspace venv/embedded python — NOT a bare PATH fallback (which is not
+    //     provably the configured workspace's interpreter).
     //   - live root unknown (reachable but argv gave no resolvable root): best we
     //     can do is a version cross-check against the running instance.
     //   - live root KNOWN but we're not on it (a different/saved workspace): the
     //     probe is a DIFFERENT environment — untrusted, omit packages.
     const runningPy = running.python_version;
     let trusted: boolean;
-    if (resolved.live) {
+    if (remote) {
+      trusted = false;
+    } else if (resolved.live) {
       trusted = true;
     } else if (!running.reachable) {
-      trusted = true;
+      trusted = resolved.verified;
     } else if (!resolved.liveRoot) {
       trusted = pythonVersionsAgree(ver, runningPy);
     } else {
@@ -644,9 +659,13 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
       const pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
       if (Object.keys(pkgs).length > 0) local.packages = pkgs;
     } else {
-      const detail = resolved.liveRoot
-        ? `the probe interpreter is a different workspace than the running ComfyUI (it does not match the running ComfyUI python ${runningPy})`
-        : `probed python ${ver} does not match the running ComfyUI python ${runningPy}`;
+      const detail = remote
+        ? "the running ComfyUI is REMOTE — a locally-probed interpreter is not the remote server's environment"
+        : resolved.liveRoot
+          ? `the probe interpreter is a different workspace than the running ComfyUI (it does not match the running ComfyUI python ${runningPy})`
+          : !running.reachable
+            ? "the server is unreachable and no workspace venv/embedded python was found (a bare PATH python is not authoritative)"
+            : `probed python ${ver} does not match the running ComfyUI python ${runningPy}`;
       local.note = [
         local.note,
         `Package versions omitted: ${detail}, so reporting them would be a false ` +

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve as pathResolve } from "node:path";
 import { promisify } from "node:util";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
@@ -320,55 +320,109 @@ async function probe(
 }
 
 /**
- * Resolve python interpreters to probe, most-preferred first, each tagged with
- * whether it is VERIFIED to be ComfyUI's own interpreter (an on-disk venv/embedded
- * python under the workspace) vs a bare PATH fallback. Portable/standalone installs
- * keep python under python_embeded / standalone-env — not just .venv — so we check
- * all of them (#401: only checking .venv made a portable install fall through to a
- * DIFFERENT PATH python, producing a false package report).
+ * Derive the ABSOLUTE directory that holds the running server's `main.py` from its
+ * `/system_stats` argv (Python's `sys.argv`, whose argv[0] is the script path). This
+ * is the LIVE running instance's install root — the source of truth for which python
+ * is actually running ComfyUI (#401 / PR #433 review). Robust against the argv shapes
+ * codex flagged: surrounding quotes are stripped; a RELATIVE `ComfyUI/main.py` or a
+ * bare `main.py` is resolved against the server's reported cwd WHEN AVAILABLE; and if
+ * the main.py path cannot be resolved to an absolute directory we return `undefined`
+ * (UNRESOLVED) rather than a bogus/relative root — callers must NOT then silently
+ * fall back to a persisted default and mark it "live".
  */
-function pythonCandidates(
-  workspacePath: string | undefined,
-): Array<{ exe: string; verified: boolean }> {
+export function liveRootFromArgv(
+  argv: string[] | undefined,
+  cwd?: string,
+): string | undefined {
+  if (!Array.isArray(argv)) return undefined;
+  for (const rawArg of argv) {
+    if (typeof rawArg !== "string") continue;
+    // Strip surrounding quotes a launcher may leave on the path.
+    const a = rawArg.trim().replace(/^["']+/, "").replace(/["']+$/, "");
+    // Must actually END in main.py / main.pyw (boundary guards against notmain.py).
+    if (!/(^|[\\/])main\.pyw?$/i.test(a)) continue;
+    const dir = dirname(a);
+    if (dir === "." || dir === "") {
+      // Bare "main.py" — only resolvable via an absolute cwd.
+      return cwd && isAbsolute(cwd) ? cwd : undefined;
+    }
+    if (isAbsolute(dir)) return dir;
+    // Relative dir (e.g. "ComfyUI/main.py") — resolve against the server's cwd.
+    if (cwd && isAbsolute(cwd)) return pathResolve(cwd, dir);
+    return undefined; // cannot resolve to an absolute dir → UNRESOLVED
+  }
+  return undefined;
+}
+
+/** Platform interpreter candidates under a ComfyUI install root, most-preferred first. */
+function interpreterCandidates(root: string): string[] {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
-  const candidates: Array<{ exe: string; verified: boolean }> = [];
-  if (workspacePath) {
-    const embedded = IS_WIN
-      ? [
-          join(workspacePath, "standalone-env", "python.exe"),
-          join(workspacePath, "python_embeded", "python.exe"),
-          join(workspacePath, "..", "python_embeded", "python.exe"),
-        ]
-      : [];
-    const venvBins = IS_WIN
-      ? [join(workspacePath, ".venv", "Scripts"), join(workspacePath, "venv", "Scripts")]
-      : [join(workspacePath, ".venv", "bin"), join(workspacePath, "venv", "bin")];
-    const onDisk: string[] = [...embedded];
-    for (const bin of venvBins) for (const n of names) onDisk.push(join(bin, n));
-    for (const p of onDisk) {
+  const candidates: string[] = [];
+  if (IS_WIN) {
+    candidates.push(join(root, "standalone-env", "python.exe"));
+    candidates.push(join(root, "python_embeded", "python.exe"));
+    candidates.push(join(root, "..", "python_embeded", "python.exe"));
+  }
+  const venvBins = IS_WIN
+    ? [join(root, ".venv", "Scripts"), join(root, "venv", "Scripts")]
+    : [join(root, ".venv", "bin"), join(root, "venv", "bin")];
+  for (const bin of venvBins) for (const n of names) candidates.push(join(bin, n));
+  return candidates;
+}
+
+export interface ComfyuiPythonResolution {
+  /** The interpreter to probe. Absolute when verified; a bare PATH name as last resort. */
+  python: string | undefined;
+  /** The interpreter exists on disk under a known ComfyUI root (venv/embedded). */
+  verified: boolean;
+  /** That root is the LIVE running server's own install root — i.e. this is provably
+   *  the interpreter running ComfyUI. Only a `live` interpreter's negatives are
+   *  authoritative; anything else must be treated as unknown/untrusted (#401). */
+  live: boolean;
+  /** The resolved absolute live root, when one could be determined from argv. */
+  liveRoot?: string;
+}
+
+/**
+ * Resolve the python that ComfyUI actually runs on, LIVE-FIRST. The running server's
+ * argv-derived install root is tried BEFORE an explicit COMFYUI_PATH, which is tried
+ * before the saved default workspace (#418) — and the saved default is consulted ONLY
+ * when there is neither a live argv nor an explicit path to trust. Portable/standalone
+ * installs keep python under python_embeded / standalone-env (not just .venv), so all
+ * are checked. Falls back to a bare PATH name (`verified:false, live:false`) when no
+ * on-disk interpreter is found — a negative off THAT is untrustworthy (#401 / PR #433).
+ */
+export function resolveComfyuiPython(
+  comfyuiPath: string | undefined,
+  statsArgv: string[] | undefined,
+  cwd?: string,
+): ComfyuiPythonResolution {
+  const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
+  const liveRoot = liveRootFromArgv(statsArgv, cwd);
+
+  const rootsWithFlag: Array<{ root: string; live: boolean }> = [];
+  if (liveRoot) rootsWithFlag.push({ root: liveRoot, live: true });
+  if (comfyuiPath && comfyuiPath !== liveRoot) {
+    rootsWithFlag.push({ root: comfyuiPath, live: false });
+  }
+  // Saved default only when we have nothing more trustworthy to go on.
+  if (!liveRoot && !comfyuiPath) {
+    const saved = resolveEffectiveComfyUIBase();
+    if (saved) rootsWithFlag.push({ root: saved, live: false });
+  }
+
+  for (const { root, live } of rootsWithFlag) {
+    for (const c of interpreterCandidates(root)) {
       // Skip UNC paths — existsSync on a dead network share can block for seconds.
-      if (/^\\\\/.test(p)) continue;
+      if (/^\\\\/.test(c)) continue;
       try {
-        if (existsSync(p)) candidates.push({ exe: p, verified: true });
+        if (existsSync(c)) return { python: c, verified: true, live, liveRoot };
       } catch {
         // ignore and continue
       }
     }
   }
-  // Fall back to PATH-resolved interpreters — NOT guaranteed to be ComfyUI's.
-  for (const n of names) candidates.push({ exe: n, verified: false });
-  return candidates;
-}
-
-async function probePython(
-  workspacePath: string | undefined,
-): Promise<{ executable: string; version: string; verified: boolean } | undefined> {
-  for (const { exe, verified } of pythonCandidates(workspacePath)) {
-    const version = await probe(exe, ["--version"]);
-    if (version)
-      return { executable: exe, version: version.replace(/^Python\s+/i, ""), verified };
-  }
-  return undefined;
+  return { python: names[0], verified: false, live: false, liveRoot };
 }
 
 /** True when two python version strings share the same major.minor (3.12.11 ~ 3.12.0). */
@@ -498,6 +552,10 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     reachable: false,
     api_target: apiTarget,
   };
+  // argv/cwd of the LIVE server (from /system_stats) drive live-first interpreter
+  // resolution below — captured here so a probe never targets the wrong python.
+  let statsArgv: string[] | undefined;
+  let statsCwd: string | undefined;
   try {
     const stats = await getSystemStats();
     running.reachable = true;
@@ -505,6 +563,9 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     running.python_version = stats.system.python_version;
     running.embedded_python = stats.system.embedded_python;
     running.comfyui_version = stats.system.comfyui_version;
+    statsArgv = stats.system.argv;
+    // ComfyUI does not currently report cwd, but tolerate it if a future/build does.
+    statsCwd = (stats.system as { cwd?: string }).cwd;
     running.devices = (stats.devices ?? []).map((d) => ({
       name: d.name,
       type: d.type,
@@ -527,42 +588,70 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   const local: EnvironmentInfo["local"] = {};
   const cfg = await readWorkspaceConfig();
   const workspacePath = config.comfyuiPath ?? cfg.defaultWorkspace;
-  if (!workspacePath) {
+
+  // LIVE-FIRST interpreter resolution — identical to resolveComfyuiPython used by
+  // the panel env block, so the two paths can never disagree (#401 / PR #433). The
+  // running server's argv root wins over an explicit COMFYUI_PATH, which wins over
+  // the saved default.
+  const resolved = resolveComfyuiPython(workspacePath, statsArgv, statsCwd);
+
+  // The install root we can actually inspect on disk: an explicit/saved workspace,
+  // else the live server's own root (so we still report git/manager for a live
+  // server even when no workspace path is configured).
+  const localRoot = workspacePath ?? resolved.liveRoot;
+  if (!localRoot) {
     local.note =
       "No local ComfyUI path configured (COMFYUI_PATH unset, none auto-detected, " +
-      "and no saved default workspace). Local environment probes skipped; remote " +
-      "/system_stats used instead.";
+      "and no saved default workspace) and no live server main.py to locate one. " +
+      "Local environment probes skipped; remote /system_stats used instead.";
     return { running_instance: running, local };
   }
 
-  local.workspace_path = workspacePath;
+  local.workspace_path = localRoot;
   if (!config.comfyuiPath && cfg.defaultWorkspace) {
     local.note = `Using saved default workspace "${cfg.defaultWorkspace}" (COMFYUI_PATH not set).`;
   }
 
-  const py = await probePython(workspacePath);
-  if (py) {
-    local.python = { executable: py.executable, version: py.version };
-    // Decide whether to trust this interpreter as the running ComfyUI's own.
-    // The provable failure mode (#401): the running instance is reachable and its
-    // python major.minor disagrees with the interpreter we probed — then we are
-    // demonstrably looking at the WRONG environment, so reporting its package
-    // versions would be a false capability report. Degrade honestly instead.
+  const version = resolved.python ? await probe(resolved.python, ["--version"]) : undefined;
+  if (resolved.python && version) {
+    const ver = version.replace(/^Python\s+/i, "");
+    local.python = { executable: resolved.python, version: ver };
+
+    // "Trusted" means the probed interpreter IS the one running ComfyUI, so its
+    // package list truly describes the live environment (#401). Order of certainty:
+    //   - resolved.live: we resolved the interpreter from the live server's own
+    //     argv root — provably correct.
+    //   - server unreachable: nothing live to contradict; report the configured
+    //     workspace's packages (clearly labelled as the configured workspace).
+    //   - live root unknown (reachable but argv gave no resolvable root): best we
+    //     can do is a version cross-check against the running instance.
+    //   - live root KNOWN but we're not on it (a different/saved workspace): the
+    //     probe is a DIFFERENT environment — untrusted, omit packages.
     const runningPy = running.python_version;
-    const provableMismatch =
-      running.reachable && !!runningPy && !pythonVersionsAgree(py.version, runningPy);
-    const trusted = !provableMismatch;
+    let trusted: boolean;
+    if (resolved.live) {
+      trusted = true;
+    } else if (!running.reachable) {
+      trusted = true;
+    } else if (!resolved.liveRoot) {
+      trusted = pythonVersionsAgree(ver, runningPy);
+    } else {
+      trusted = false;
+    }
     local.python_probe_trusted = trusted;
+
     if (trusted) {
-      const pkgs = await probePipPackages(py.executable, KEY_PACKAGES);
+      const pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
       if (Object.keys(pkgs).length > 0) local.packages = pkgs;
     } else {
+      const detail = resolved.liveRoot
+        ? `the probe interpreter is a different workspace than the running ComfyUI (it does not match the running ComfyUI python ${runningPy})`
+        : `probed python ${ver} does not match the running ComfyUI python ${runningPy}`;
       local.note = [
         local.note,
-        `Probed python ${py.version} does not match the running ComfyUI python ` +
-          `${runningPy} — the probe interpreter is a different environment, so ` +
-          `package versions are omitted rather than reported from the wrong python (#401). ` +
-          `Point COMFYUI_PATH at the install whose venv runs ComfyUI for an accurate report.`,
+        `Package versions omitted: ${detail}, so reporting them would be a false ` +
+          `capability report (#401). Point COMFYUI_PATH at the install actually ` +
+          `running ComfyUI for an accurate report.`,
       ]
         .filter(Boolean)
         .join(" ");
@@ -570,16 +659,16 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   } else {
     local.note = [
       local.note,
-      "Python interpreter not found on PATH or in workspace .venv.",
+      "Python interpreter not found on PATH or in the workspace venv/embedded python.",
     ]
       .filter(Boolean)
       .join(" ");
   }
 
-  const git = await probeGitRev(workspacePath);
+  const git = await probeGitRev(localRoot);
   if (git) local.git = git;
 
-  const managerVersion = await readManagerVersion(workspacePath);
+  const managerVersion = await readManagerVersion(localRoot);
   if (managerVersion) local.comfyui_manager_version = managerVersion;
 
   return { running_instance: running, local };


### PR DESCRIPTION
## Problem (#401)

`get_environment` and the panel's live ENVIRONMENT line probed the **wrong Python interpreter**, producing false capability reports. Most damagingly, a machine with Triton installed and working reported `Triton: not installed`, which led an agent to edit a 231-node workflow and disable `triton_kernels=true` — silently removing a real speedup the user had deliberately enabled.

## Root cause

Both python-probe helpers fell back to a bare PATH `python.exe` whenever the venv wasn't at one narrowly-checked location:
- `env-capabilities.findComfyuiPython` checked `python_embeded`/`standalone-env`/`.venv` then a PATH name — but returned the PATH name as a plain string with no signal that it was an *unverified* fallback, and `probeTritonSage` reported its `find_spec` negatives as authoritative `not-installed`.
- `workspace-env.pythonCandidates` only checked `.venv/Scripts`, so a portable install (embedded python, or a non-default venv) fell straight through to a different PATH python — the reporter's `local.python.version` (3.11.7) disagreed with `running_instance.python_version` (3.12.11).

## Fix

**`src/services/env-capabilities.ts`**
- `resolveComfyuiPython()` now returns `{ python, verified }` — `verified` is true only for an on-disk venv/embedded interpreter under the resolved ComfyUI base (reuses `resolveEffectiveComfyUIBase` from #418, with the `argv main.py` inference retained). `findComfyuiPython` kept as a back-compat string shim (still used by process-control).
- `probeTritonSage()` also prints the interpreter's own `major.minor`.
- New pure `reconcileProbeState()` downgrades a `not-installed` to `unknown` when the interpreter is **unverified** OR its version **disagrees** with the running instance. Positives (`installed`) always pass through; the log-marker check still reinforces positives.

**`src/services/workspace-env.ts`**
- `get_environment` broadens candidate interpreters to the portable layouts (`python_embeded`, `standalone-env`, `venv`) and, when the probed python **provably** disagrees with the running ComfyUI python (running reachable + different major.minor), omits the package list, sets `local.python_probe_trusted:false`, and adds an honest note — rather than reporting torch/etc. from the wrong environment.

Honest degradation to `unknown` beats a false `not installed`: the asymmetry matters because a false negative makes an agent break a working setup.

## Tests
- `env-capabilities.test.ts`: `resolveComfyuiPython` verified/unverified cases (venv, portable embedded, PATH fallback); `reconcileProbeState` matrix (verified+match keeps negative; unverified or version-mismatch → unknown; positives untouched).
- `workspace-env.test.ts`: version-mismatch omits packages with the honest note + `python_probe_trusted:false`; matching major.minor reports packages.
- `remote-restart.test.ts`: added `execFile` to the `node:child_process` mock (new transitive import edge `env-capabilities → workspace-env`).
- Full suite green except the pre-existing node-dev ripgrep-vs-builtin failure (environment-dependent, unrelated). tsc clean.

Scope: environment-probe services + their tests only. No orchestrator edits, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)