### PR TITLE
fix(templates): align get_template_schema with list_workflow_templates (#391)

### DIFF
--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -277,6 +277,15 @@ describe("resolveTemplateFromIndex (id/key alignment with list_workflow_template
     expect(r).toEqual({ match: { module: "ComfyUI-MVAdapter", name: "i2mv_sdxl_ldm_lora" } });
   });
 
+  it("does NOT flag a name duplicated WITHIN one module as ambiguous", () => {
+    // ComfyUI's index builder can list the same basename twice in one module.
+    const dupIndex: Record<string, unknown> = {
+      "ComfyUI-MVAdapter": ["i2mv_sdxl_ldm_lora", "i2mv_sdxl_ldm_lora"],
+    };
+    const r = resolveTemplateFromIndex(dupIndex, "i2mv_sdxl_ldm_lora");
+    expect(r).toEqual({ match: { module: "ComfyUI-MVAdapter", name: "i2mv_sdxl_ldm_lora" } });
+  });
+
   it("returns not-found (with the full module/name catalog) for an unknown template", () => {
     const r = resolveTemplateFromIndex(INDEX, "does_not_exist");
     expect("error" in r && r.error).toBe("not-found");

--- a/src/__tests__/tools/template-schema.test.ts
+++ b/src/__tests__/tools/template-schema.test.ts
@@ -3,6 +3,7 @@ import {
   extractTemplateSlots,
   templateGraphToApi,
   classifyWidget,
+  resolveTemplateFromIndex,
   FALLBACK_OBJECT_INFO,
 } from "../../tools/template-schema.js";
 import type { ObjectInfo, WorkflowJSON } from "../../comfyui/types.js";
@@ -238,5 +239,49 @@ describe("classifyWidget", () => {
     expect(classifyWidget("UNETLoader", "unet_name")).toBe("model");
     expect(classifyWidget("FluxGuidance", "guidance")).toBe("guidance");
     expect(classifyWidget("SaveImage", "filename_prefix")).toBe("other");
+  });
+});
+
+describe("resolveTemplateFromIndex (id/key alignment with list_workflow_templates)", () => {
+  // Mirrors what /api/workflow_templates returns: modules → arrays of names.
+  // Custom-node modules (ComfyUI-MVAdapter) list plain string names; the core
+  // comfyui-workflow-templates package lists objects with a `name` field.
+  const INDEX: Record<string, unknown> = {
+    "ComfyUI-MVAdapter": ["i2mv_sdxl_ldm_view_selector", "i2mv_sdxl_ldm_lora"],
+    "comfyui-workflow-templates": [{ name: "default", title: "Default" }, { name: "flux_dev" }],
+    "OtherPack": ["i2mv_sdxl_ldm_lora"], // same name, different module → ambiguous
+  };
+
+  it("resolves a bare custom-node template name that list_workflow_templates returned", () => {
+    const r = resolveTemplateFromIndex(INDEX, "i2mv_sdxl_ldm_view_selector");
+    expect(r).toEqual({ match: { module: "ComfyUI-MVAdapter", name: "i2mv_sdxl_ldm_view_selector" } });
+  });
+
+  it("resolves a core template whose index entry is an object with a name field", () => {
+    const r = resolveTemplateFromIndex(INDEX, "flux_dev");
+    expect(r).toEqual({ match: { module: "comfyui-workflow-templates", name: "flux_dev" } });
+  });
+
+  it("reports ambiguity when the same name exists in multiple modules", () => {
+    const r = resolveTemplateFromIndex(INDEX, "i2mv_sdxl_ldm_lora");
+    expect("error" in r && r.error).toBe("ambiguous");
+    if ("error" in r && r.error === "ambiguous") {
+      expect(r.candidates.map((c) => `${c.module}/${c.name}`).sort()).toEqual(
+        ["ComfyUI-MVAdapter/i2mv_sdxl_ldm_lora", "OtherPack/i2mv_sdxl_ldm_lora"],
+      );
+    }
+  });
+
+  it("accepts a source-qualified <module>/<name> id to disambiguate", () => {
+    const r = resolveTemplateFromIndex(INDEX, "ComfyUI-MVAdapter/i2mv_sdxl_ldm_lora");
+    expect(r).toEqual({ match: { module: "ComfyUI-MVAdapter", name: "i2mv_sdxl_ldm_lora" } });
+  });
+
+  it("returns not-found (with the full module/name catalog) for an unknown template", () => {
+    const r = resolveTemplateFromIndex(INDEX, "does_not_exist");
+    expect("error" in r && r.error).toBe("not-found");
+    if ("error" in r && r.error === "not-found") {
+      expect(r.all).toContain("ComfyUI-MVAdapter/i2mv_sdxl_ldm_view_selector");
+    }
   });
 });

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse as parseYaml } from "yaml";
 import { errorToToolResult } from "../utils/errors.js";
-import { getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { getComfyUIBaseUrl, getComfyUIAuthHeaders } from "../config.js";
 import { checkWorkflowRuntime, extractWorkflowClassTypes } from "../services/api-nodes.js";
 
 // Optional, opt-in observability hook for the knowledge-parity smoke test: when
@@ -307,8 +307,12 @@ export function registerSkillsAccessTools(server: McpServer): void {
     async () => {
       try {
         traceToolCall("list_workflow_templates", {});
-        const base = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+        // Canonical base URL + auth headers — same connected-ComfyUI path
+        // get_template_schema uses, so a proxied/authed remote resolves
+        // consistently between listing and schema lookup.
+        const base = getComfyUIBaseUrl();
         const res = await fetch(`${base}/api/workflow_templates`, {
+          headers: getComfyUIAuthHeaders(),
           signal: AbortSignal.timeout(8000),
         });
         if (!res.ok) {

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { readFileSync } from "node:fs";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { errorToToolResult } from "../utils/errors.js";
-import { getComfyUIApiHost, getComfyUIProtocol } from "../config.js";
+import { getComfyUIBaseUrl, getComfyUIAuthHeaders } from "../config.js";
 import { getObjectInfo } from "../comfyui/client.js";
 import { convertUiToApi, isApiFormat, isUiFormat } from "../services/workflow-converter.js";
 import { enumeratePacks, resolvePackWorkflowFile } from "./skills-access.js";
@@ -317,14 +317,69 @@ export function templateGraphToApi(
   return null;
 }
 
+/** A single template entry located in the /api/workflow_templates index. */
+export interface TemplateIndexMatch {
+  module: string;
+  name: string;
+}
+
+/**
+ * Resolve a template query against the /api/workflow_templates index — the SAME
+ * index list_workflow_templates returns. Pure + offline so it is unit-testable
+ * independent of the live server.
+ *
+ * The query may be a bare template name ("i2mv_sdxl_ldm_view_selector") OR a
+ * source-qualified id ("ComfyUI-MVAdapter/i2mv_sdxl_ldm_view_selector") — the
+ * qualified form (module/name, matching how list_workflow_templates groups
+ * entries) disambiguates when the same name is provided by multiple modules.
+ */
+export function resolveTemplateFromIndex(
+  index: Record<string, unknown>,
+  query: string,
+):
+  | { match: TemplateIndexMatch }
+  | { error: "not-found"; all: string[] }
+  | { error: "ambiguous"; candidates: TemplateIndexMatch[] } {
+  // A source-qualified id splits on the FIRST slash into module + name. Module
+  // names don't contain slashes; template names in practice don't either, but
+  // splitting on the first slash keeps the (module) prefix authoritative.
+  const slash = query.indexOf("/");
+  const qModule = slash > 0 ? query.slice(0, slash) : null;
+  const qName = slash > 0 ? query.slice(slash + 1) : query;
+
+  const all: string[] = [];
+  const matches: TemplateIndexMatch[] = [];
+  for (const [mod, names] of Object.entries(index)) {
+    if (!Array.isArray(names)) continue;
+    for (const n of names) {
+      const nm = typeof n === "string" ? n : (n as { name?: string })?.name;
+      if (typeof nm !== "string") continue;
+      all.push(`${mod}/${nm}`);
+      if (nm === qName && (qModule == null || mod === qModule)) {
+        matches.push({ module: mod, name: nm });
+      }
+    }
+  }
+  if (matches.length === 0) return { error: "not-found", all };
+  if (matches.length > 1) return { error: "ambiguous", candidates: matches };
+  return { match: matches[0] };
+}
+
 /** Fetch an official workflow template's graph from the live ComfyUI. */
 async function loadServerTemplate(
   name: string,
 ): Promise<{ graph: unknown; source: string } | { error: string; available: string[] }> {
-  const base = `${getComfyUIProtocol()}://${getComfyUIApiHost()}`;
+  // Use the SAME canonical base URL + auth headers as the connected ComfyUI
+  // client (getObjectInfo/getClient). A bare protocol://host:port fetch drops
+  // the reverse-proxy base path and any gateway auth headers, so a proxied or
+  // authed remote that list_workflow_templates (now) reaches would otherwise
+  // look "unreachable" here — the inconsistency this issue reported.
+  const base = getComfyUIBaseUrl();
+  const authHeaders = getComfyUIAuthHeaders();
   let index: Record<string, unknown> = {};
   try {
     const res = await fetch(`${base}/api/workflow_templates`, {
+      headers: authHeaders,
       signal: AbortSignal.timeout(8000),
     });
     if (res.ok) index = (await res.json()) as Record<string, unknown>;
@@ -334,29 +389,27 @@ async function loadServerTemplate(
       available: [],
     };
   }
-  const all: string[] = [];
-  let module: string | null = null;
-  for (const [mod, names] of Object.entries(index)) {
-    if (!Array.isArray(names)) continue;
-    for (const n of names) {
-      const nm = typeof n === "string" ? n : (n as { name?: string })?.name;
-      if (typeof nm !== "string") continue;
-      all.push(nm);
-      if (nm === name && module == null) module = mod;
+
+  const resolved = resolveTemplateFromIndex(index, name);
+  if ("error" in resolved) {
+    if (resolved.error === "ambiguous") {
+      return {
+        error: `Template name "${name}" is provided by multiple sources — qualify it as "<module>/${name}".`,
+        available: resolved.candidates.map((c) => `${c.module}/${c.name}`),
+      };
     }
-  }
-  if (module == null) {
     const needle = name.toLowerCase();
-    const near = all.filter((n) => n.toLowerCase().includes(needle)).slice(0, 10);
+    const near = resolved.all.filter((n) => n.toLowerCase().includes(needle)).slice(0, 10);
     return {
       error: `No official workflow template named "${name}".`,
-      available: near.length ? near : all.slice(0, 20),
+      available: near.length ? near : resolved.all.slice(0, 20),
     };
   }
+  const { module, name: tmpl } = resolved.match;
   // Core templates ship in the comfyui-workflow-templates package served under
   // /templates/; custom-node templates under /api/workflow_templates/<module>/
   // (older servers: /extensions/<module>/example_workflows/). Try in order.
-  const enc = encodeURIComponent(name);
+  const enc = encodeURIComponent(tmpl);
   const candidates = [
     `${base}/templates/${enc}.json`,
     `${base}/api/workflow_templates/${encodeURIComponent(module)}/${enc}.json`,
@@ -364,7 +417,7 @@ async function loadServerTemplate(
   ];
   for (const url of candidates) {
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+      const res = await fetch(url, { headers: authHeaders, signal: AbortSignal.timeout(8000) });
       if (!res.ok) continue;
       return { graph: await res.json(), source: `server-template:${module}` };
     } catch {
@@ -372,7 +425,7 @@ async function loadServerTemplate(
     }
   }
   return {
-    error: `Template "${name}" is indexed (module "${module}") but its workflow JSON could not be fetched from the server.`,
+    error: `Template "${tmpl}" is indexed (module "${module}") but its workflow JSON could not be fetched from the server.`,
     available: [],
   };
 }

--- a/src/tools/template-schema.ts
+++ b/src/tools/template-schema.ts
@@ -349,6 +349,10 @@ export function resolveTemplateFromIndex(
 
   const all: string[] = [];
   const matches: TemplateIndexMatch[] = [];
+  // Dedupe by module/name: ComfyUI's index builder can list the same basename
+  // twice within one module (multiple recognized workflow dirs). That is NOT
+  // cross-source ambiguity, so collapse duplicates before the ambiguity check.
+  const seen = new Set<string>();
   for (const [mod, names] of Object.entries(index)) {
     if (!Array.isArray(names)) continue;
     for (const n of names) {
@@ -356,6 +360,9 @@ export function resolveTemplateFromIndex(
       if (typeof nm !== "string") continue;
       all.push(`${mod}/${nm}`);
       if (nm === qName && (qModule == null || mod === qModule)) {
+        const dedupeKey = `${mod}/${nm}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
         matches.push({ module: mod, name: nm });
       }
     }


### PR DESCRIPTION
Fixes #391.

`get_template_schema` failed to resolve templates that `list_workflow_templates` had just returned (e.g. `i2mv_sdxl_ldm_view_selector`), reporting the ComfyUI server "unreachable" even though listing worked.

## Root causes
1. **Reachability inconsistency.** `loadServerTemplate` (and `list_workflow_templates`) fetched a raw `protocol://host:port` URL, dropping the reverse-proxy base path and gateway auth headers that the connected ComfyUI client (`getObjectInfo`/`getClient`) uses. A proxied/authed remote looked "unreachable" to schema lookup while the rest of the client worked. Both paths now use `getComfyUIBaseUrl()` + `getComfyUIAuthHeaders()`.
2. **id/key mismatch.** Resolution silently took the *first* module for a bare name and couldn't accept a source-qualified id. Extracted a pure, unit-tested `resolveTemplateFromIndex()` that matches against the same `/api/workflow_templates` index `list_workflow_templates` returns, handles object-shaped core entries, reports ambiguity, and accepts a `"<module>/<name>"` qualified id.

## Tests
Added `resolveTemplateFromIndex` unit tests (bare name, object-entry core template, ambiguous same-name-across-modules, source-qualified disambiguation, not-found catalog). `npx tsc --noEmit` clean; full `npm test` passes except the pre-existing environment-only node-dev ripgrep test.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)