### PR TITLE
fix(get_image): structured not-found for non-image /view payloads (#385)

### DIFF
--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -28,7 +28,7 @@ vi.mock("../../comfyui/client.js", () => ({
 }));
 
 import { getOutputImage, listOutputImages } from "../../services/image-management.js";
-import { ValidationError } from "../../utils/errors.js";
+import { ValidationError, ComfyUIError } from "../../utils/errors.js";
 
 beforeEach(() => {
   mockConfig.comfyuiPath = "/comfy";
@@ -151,6 +151,39 @@ describe("getOutputImage — path-traversal sanitisation (CWE-22)", () => {
       getOutputImage("hero.png", "output", "video/../.."),
     ).rejects.toBeInstanceOf(ValidationError);
     expect(fetchImageMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOutputImage — non-image /view payloads (issue #385)", () => {
+  // ComfyUI (or a proxy) can answer /view with a 200 whose body is a JSON/HTML
+  // error page or is empty — most often for a `type=input` ref that doesn't
+  // resolve to a real input file. The old code saved those bytes as a `.png`
+  // and returned a corrupt inline image, so the MCP client choked decoding it
+  // ("Unexpected end of JSON input"). It must now throw a structured not-found.
+
+  it("throws IMAGE_NOT_FOUND when /view returns a JSON error body for an input ref", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"error":"not found"}').toString("base64"),
+      mimeType: "application/json",
+    });
+    const err = await getOutputImage("06.png", "input", "qwen").catch((e) => e);
+    expect(err).toBeInstanceOf(ComfyUIError);
+    expect(err.code).toBe("IMAGE_NOT_FOUND");
+  });
+
+  it("throws IMAGE_NOT_FOUND when /view returns an empty body", async () => {
+    fetchImageMock.mockResolvedValue({ base64: "", mimeType: "image/png" });
+    await expect(
+      getOutputImage("06.png", "input", "qwen"),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("still resolves for a genuine image payload", async () => {
+    // (mock default is image/png with real bytes)
+    await expect(getOutputImage("06.png", "input", "qwen")).resolves.toMatchObject({
+      mimeType: "image/png",
+      filename: "06.png",
+    });
   });
 });
 

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -570,7 +570,17 @@ export async function fetchImage(
   const params = new URLSearchParams({ filename, type, subfolder });
   const res = await client.fetchApi(`/view?${params.toString()}`);
   if (!res.ok) {
-    throw new Error(`ComfyUI /view returned ${res.status} for "${filename}"`);
+    const where = subfolder ? `${type}/${subfolder}` : type;
+    throw new ComfyUIError(
+      `ComfyUI /view returned ${res.status} for "${filename}" (${where}). ` +
+        (res.status === 404
+          ? `No such file in the ComfyUI ${type} directory` +
+            (subfolder ? ` under subfolder "${subfolder}"` : "") +
+            `. Check the filename/subfolder (e.g. via list_output_images or get_history).`
+          : `The ComfyUI server rejected the request.`),
+      res.status === 404 ? "IMAGE_NOT_FOUND" : "VIEW_ERROR",
+      { status: res.status, filename, type, subfolder },
+    );
   }
   const contentType = res.headers.get("content-type") ?? "image/png";
   const mimeType = contentType.split(";")[0].trim();

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -2,7 +2,7 @@ import { readFile, copyFile, readdir, stat } from "node:fs/promises";
 import { join, basename, extname, relative, sep } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getHistory } from "../comfyui/client.js";
-import { ValidationError, ModelError } from "../utils/errors.js";
+import { ValidationError, ModelError, ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { resolveOutputDir, resolveInputDir } from "./output-dir.js";
 
@@ -455,6 +455,29 @@ export async function getOutputImage(
 ): Promise<{ base64: string; mimeType: string; filename: string }> {
   assertSafeViewRef(filename, subfolder);
   const result = await fetchImage(filename, type, subfolder);
+
+  // Guard against non-image /view payloads. ComfyUI (or a reverse proxy in
+  // front of it) can answer /view with a 200 whose body is actually a JSON or
+  // HTML error page, or an empty body — this happens most often for `type=input`
+  // refs, where the caller picked a filename/subfolder that doesn't resolve to a
+  // real input file. The old code saved those bytes verbatim as a `.png` and
+  // returned them as an inline image block, so the MCP client then choked trying
+  // to decode them ("Unexpected end of JSON input"). Fail loudly and structured
+  // instead, so get_image surfaces a clean not-found rather than a corrupt image.
+  const mime = result.mimeType.toLowerCase();
+  const isImage = mime.startsWith("image/");
+  if (!isImage || result.base64.length === 0) {
+    const where = subfolder ? `${type}/${subfolder}` : type;
+    throw new ComfyUIError(
+      `ComfyUI /view did not return an image for "${filename}" (${where}); ` +
+        `got ${result.base64.length === 0 ? "an empty response" : `content-type "${result.mimeType}"`}. ` +
+        `The file may not exist in the ComfyUI ${type} directory — ` +
+        `check the filename/subfolder (e.g. via list_output_images or get_history).`,
+      "IMAGE_NOT_FOUND",
+      { filename, type, subfolder, mimeType: result.mimeType },
+    );
+  }
+
   return { ...result, filename };
 }
 


### PR DESCRIPTION
Fixes #385.

### Root cause
`get_image` (`getOutputImage`) forwarded the `/view` response bytes straight to disk as a `.png` and returned them as an inline image block, without checking that ComfyUI actually returned an image. When `/view` answers with a `200` whose body is a JSON/HTML error page or is empty — which happens most often for a `type=input` reference whose filename/subfolder does not resolve to a real input file — the MCP client then failed decoding the corrupt image, surfacing as `Unexpected end of JSON input`.

### Fix (minimal)
- `getOutputImage`: after fetching, reject non-image payloads (content-type not `image/*`, or empty body) with a structured `IMAGE_NOT_FOUND` `ComfyUIError` that points the caller at `list_output_images` / `get_history`. No more saving a JSON/HTML error page as a `.png`.
- `fetchImage` (local client): the non-ok `/view` path now throws a structured `IMAGE_NOT_FOUND` (404) / `VIEW_ERROR` naming the `type`/`subfolder`, instead of a bare `Error`.

Video/audio staging (`stage_output_as_input`) is untouched — the image-only guard lives in `getOutputImage`, not in `fetchImage`.

### Tests
Added regression tests in `image-management-traversal.test.ts`: JSON-body and empty-body `/view` responses for a `type=input` ref now throw `IMAGE_NOT_FOUND`; a genuine image still resolves. `npx tsc --noEmit` clean; full `npm test` passes except the pre-existing environment-only node-dev ripgrep test.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)