### PR TITLE
release: 0.48.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.8] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- download_model follows the HF Xet CAS redirect and surfaces the real network cause (DNS/proxy/TLS/HF_ENDPOINT) instead of a generic "fetch failed" (#411) (#427)
+- civitai search surfaces distinct upstream/auth(token-aware 401)/403/429/5xx/timeout/non-JSON failures instead of a misleading empty or generic error (WS-6) (#428)
+- crash detector no longer false-positives on a swallowed "Exception ignored in: __del__" finalizer traceback (#341) (#429)
+- get_job_status reports a present-but-empty ShowText/PreviewAny output instead of dropping it (#373) (#430)
+- model_metadata_read gives an actionable message when the optional model-explorer node is absent, instead of leaking a raw 404 (#363) (#431)
+- get_node_info honors the live /object_info registration key when backfilling, so a registered node (e.g. DetectorForNSFW) resolves (#404) (#432)
+- get_template_schema routes through the connected client's base URL + auth and resolves template ids consistently with list_workflow_templates (proxy/auth-safe) (#391) (#434)
+- get_image returns a structured not-found for non-image /view payloads (type=input refs) instead of a corrupt inline image / JSON parse error (#385) (#435)
+
+
 ## [0.48.7] - 2026-07-29
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.7",
+  "version": "0.48.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.7",
+      "version": "0.48.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.7",
+  "version": "0.48.8",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.8 (tag pushed → npm publish). 8 fixes: HF Xet download (#411), civitai error-hardening (#204/WS-6), crash-detector __del__ false-positive (#341), job-status empty ShowText (#373), model-explorer 404 message (#363), get_node_info live-key (#404), get_template_schema proxy/auth+id (#391), get_image non-image payload (#385). All codex-gated + CI-green; six came through the parallel Workflow batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)