### PR TITLE
release: 0.48.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.9] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- get_environment probes the ComfyUI venv/embedded python (resolved live-first from the running server's argv → COMFYUI_PATH → saved default workspace) instead of a bare PATH python, fixing false capability reports like "Triton: not installed"; remote/unreachable/ambiguous cases report an honest untrusted result rather than a confident wrong one (#401) (#433)
+
+
 ## [0.48.8] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.8",
+  "version": "0.48.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.8",
+      "version": "0.48.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.8",
+  "version": "0.48.9",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.9 (tag pushed → npm publish). One fix: get_environment probes the ComfyUI venv/embedded python live-first (#401/#433) instead of a bare PATH python — fixes false 'Triton: not installed' etc.; remote/unreachable ⇒ honest untrusted. codex PASS (4 rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)