### PR TITLE
fix(train): fail fast on persistent Claude auth failure in caption_dataset (#438)

### DIFF
--- a/src/__tests__/services/train-caption.test.ts
+++ b/src/__tests__/services/train-caption.test.ts
@@ -14,12 +14,14 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
     const mode = queryMode;
     return (async function* () {
       if (mode === "auth") {
-        // How the SDK reports a not-logged-in run: an error `result`, not a throw.
-        yield { type: "result", subtype: "error_during_execution", is_error: true, result: "Not logged in · Please run /login" };
+        // REAL Agent SDK 0.3.x error-result shape: SDKResultError carries text
+        // in `errors: string[]` and has NO `result` field. If the service reads
+        // `result` instead of `errors`, this test must fail.
+        yield { type: "result", subtype: "error_during_execution", is_error: true, errors: ["Not logged in · Please run /login"] };
         return;
       }
       if (mode === "transient" || mode === "counting-transient") {
-        yield { type: "result", subtype: "error_during_execution", is_error: true, result: "transient hiccup — try again" };
+        yield { type: "result", subtype: "error_during_execution", is_error: true, errors: ["transient hiccup — try again"] };
         return;
       }
       yield {

--- a/src/__tests__/services/train-caption.test.ts
+++ b/src/__tests__/services/train-caption.test.ts
@@ -1,19 +1,34 @@
-import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
+import { describe, expect, it, beforeAll, afterAll, afterEach, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // Mock the Agent SDK before anything imports the caption service — no real
-// subscription calls in tests.
+// subscription calls in tests. `queryMode` lets individual tests swap in a
+// failure stream (auth error / transient error) without re-mocking the module.
+let queryMode: "ok" | "auth" | "transient" | "counting-transient" = "ok";
+let queryCalls = 0;
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () =>
-    (async function* () {
+  query: () => {
+    queryCalls++;
+    const mode = queryMode;
+    return (async function* () {
+      if (mode === "auth") {
+        // How the SDK reports a not-logged-in run: an error `result`, not a throw.
+        yield { type: "result", subtype: "error_during_execution", is_error: true, result: "Not logged in · Please run /login" };
+        return;
+      }
+      if (mode === "transient" || mode === "counting-transient") {
+        yield { type: "result", subtype: "error_during_execution", is_error: true, result: "transient hiccup — try again" };
+        return;
+      }
       yield {
         type: "assistant",
         message: { content: [{ type: "text", text: "e2echar, waiting at a rainy bus stop, city lights" }] },
       };
       yield { type: "result", subtype: "success" };
-    })(),
+    })();
+  },
 }));
 
 let root: string;
@@ -26,6 +41,15 @@ beforeAll(() => {
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, "img_00001.png"), "fakepng");
   writeFileSync(join(dir, "img_00002.png"), "fakepng");
+  // A larger set so "stops after the first failure" is distinguishable from
+  // "iterated every file".
+  const bdir = join(root, "datasets", "beta");
+  mkdirSync(bdir, { recursive: true });
+  for (let i = 1; i <= 5; i++) writeFileSync(join(bdir, `img_0000${i}.png`), "fakepng");
+});
+afterEach(() => {
+  queryMode = "ok";
+  queryCalls = 0;
 });
 afterAll(() => {
   if (saved === undefined) delete process.env.COMFYUI_MCP_TRAINING_DIR;
@@ -33,7 +57,7 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-import { captionDataset, captionImage } from "../../services/train-caption.js";
+import { captionDataset, captionImage, CaptionAuthError } from "../../services/train-caption.js";
 
 describe("captionImage", () => {
   it("returns the model's bare caption (quotes stripped)", async () => {
@@ -59,5 +83,25 @@ describe("captionDataset", () => {
     const r = await captionDataset("alpha", { only: ["img_00002.png"] });
     expect(r).toEqual({ captioned: 1, failed: [] });
     expect(readFileSync(join(root, "datasets", "alpha", "img_00002.txt"), "utf-8")).toContain("e2echar");
+  });
+
+  it("fails fast on a persistent auth failure — stops after the FIRST file, does not iterate all (#438)", async () => {
+    queryMode = "auth";
+    await expect(captionDataset("beta", { trigger: "e2echar" })).rejects.toBeInstanceOf(CaptionAuthError);
+    // The whole batch shares one Claude session — one auth probe, not 5.
+    expect(queryCalls).toBe(1);
+  });
+
+  it("auth error carries an actionable /login message", async () => {
+    queryMode = "auth";
+    await expect(captionDataset("beta", {})).rejects.toThrow(/login/i);
+  });
+
+  it("a transient per-file error still continues through the whole batch", async () => {
+    queryMode = "transient";
+    const r = await captionDataset("beta", {});
+    expect(r.captioned).toBe(0);
+    expect(r.failed).toHaveLength(5); // every file attempted, none aborted the batch
+    expect(queryCalls).toBe(5);
   });
 });

--- a/src/services/train-caption.ts
+++ b/src/services/train-caption.ts
@@ -60,6 +60,37 @@ async function getQuery() {
  *  utility call on the user's subscription). Override via COMFYUI_MCP_CAPTION_MODEL. */
 const CAPTION_MODEL = process.env.COMFYUI_MCP_CAPTION_MODEL?.trim() || "claude-haiku-4-5";
 
+/** A PERSISTENT failure that dooms every remaining image — a missing/invalid
+ *  Claude Code login, or a backend that can't run vision captioning at all.
+ *  captionDataset bails the batch on the first one instead of re-hitting the
+ *  same auth wall 32 times (issue #438: the panel backend was Codex, so every
+ *  image returned "Not logged in — Please run /login"). */
+export class CaptionAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CaptionAuthError";
+  }
+}
+
+/** Does this SDK error text mean "no usable Claude Code credentials", i.e. a
+ *  failure that will repeat identically for every image? Matches the Agent
+ *  SDK's not-logged-in / invalid-key / auth phrasings. */
+function isAuthFailureText(text: string): boolean {
+  const t = text.toLowerCase();
+  return (
+    t.includes("not logged in") ||
+    t.includes("/login") ||
+    t.includes("please run /login") ||
+    t.includes("invalid api key") ||
+    t.includes("invalid x-api-key") ||
+    t.includes("authentication_error") ||
+    t.includes("authentication error") ||
+    t.includes("oauth token has expired") ||
+    t.includes("unauthorized") ||
+    (t.includes("credit balance") && t.includes("too low"))
+  );
+}
+
 function captionPrompt(opts: { guide?: string; trigger?: string }): string {
   const lines = [
     "Write ONE caption for this image for LoRA training. Rules:",
@@ -108,12 +139,32 @@ export async function captionImage(opts: {
   });
   let text = "";
   for await (const msg of q) {
-    const m = msg as { type: string; message?: { content?: Array<{ type: string; text?: string }> } };
+    const m = msg as {
+      type: string;
+      subtype?: string;
+      is_error?: boolean;
+      result?: string;
+      message?: { content?: Array<{ type: string; text?: string }> };
+    };
     if (m.type === "assistant" && m.message?.content) {
       text += m.message.content
         .filter((c) => c.type === "text")
         .map((c) => c.text ?? "")
         .join("");
+    } else if (m.type === "result" && (m.is_error || (m.subtype && m.subtype !== "success"))) {
+      // The SDK reports a failed run (e.g. "Not logged in — Please run /login")
+      // as an error `result`, NOT a thrown exception — previously this was
+      // silently dropped and every image failed with the generic "empty
+      // caption" message. Surface it, and flag auth failures so the batch bails.
+      const detail = (m.result ?? "").trim() || `caption run failed (${m.subtype ?? "error"})`;
+      if (isAuthFailureText(detail)) {
+        throw new CaptionAuthError(
+          `Claude captioning is unavailable — the Claude Code session is not authenticated ` +
+            `(SDK said: ${detail}). Run \`claude /login\`, or set ANTHROPIC_API_KEY, then retry. ` +
+            `Captioning always runs through Claude regardless of the panel's active backend.`,
+        );
+      }
+      throw new Error(detail);
     }
   }
   const caption = text.trim().replace(/^["']|["']$/g, "");
@@ -152,6 +203,18 @@ export async function captionDataset(
       await updateDataset(name, { setCaptions: { [it.file]: caption } });
       captioned++;
     } catch (err) {
+      // A PERSISTENT auth/credential failure dooms every remaining image — the
+      // whole batch runs on one Claude session (issue #438). Fail fast with an
+      // actionable error instead of iterating N files re-hitting the same wall.
+      // Per-file transient errors (bad image, empty caption, write conflict)
+      // still just get recorded and the loop continues.
+      if (
+        err instanceof CaptionAuthError ||
+        (err instanceof Error && isAuthFailureText(err.message))
+      ) {
+        const message = err instanceof CaptionAuthError ? err.message : (err as Error).message;
+        throw new CaptionAuthError(message);
+      }
       failed.push({ file: it.file, error: err instanceof Error ? err.message : String(err) });
     }
   }

--- a/src/services/train-caption.ts
+++ b/src/services/train-caption.ts
@@ -143,6 +143,12 @@ export async function captionImage(opts: {
       type: string;
       subtype?: string;
       is_error?: boolean;
+      // Agent SDK 0.3.x contract: an ERROR result (SDKResultError, subtype
+      // `error_during_execution` etc.) carries its text in `errors: string[]`
+      // and has NO `result` field. Only a SUCCESS result (SDKResultSuccess)
+      // has `result: string`. Reading the wrong field is how the auth message
+      // was being lost (issue #438 codex round 1).
+      errors?: string[];
       result?: string;
       message?: { content?: Array<{ type: string; text?: string }> };
     };
@@ -153,10 +159,14 @@ export async function captionImage(opts: {
         .join("");
     } else if (m.type === "result" && (m.is_error || (m.subtype && m.subtype !== "success"))) {
       // The SDK reports a failed run (e.g. "Not logged in — Please run /login")
-      // as an error `result`, NOT a thrown exception — previously this was
-      // silently dropped and every image failed with the generic "empty
-      // caption" message. Surface it, and flag auth failures so the batch bails.
-      const detail = (m.result ?? "").trim() || `caption run failed (${m.subtype ?? "error"})`;
+      // as an error `result` message, NOT a thrown exception — previously this
+      // was silently dropped and every image failed with the generic "empty
+      // caption" message. Pull the text from `errors[]` (the error variant's
+      // field), and flag auth failures so the batch bails.
+      const detail =
+        (Array.isArray(m.errors) ? m.errors.join("; ") : "").trim() ||
+        (m.result ?? "").trim() ||
+        `caption run failed (${m.subtype ?? "error"})`;
       if (isAuthFailureText(detail)) {
         throw new CaptionAuthError(
           `Claude captioning is unavailable — the Claude Code session is not authenticated ` +

--- a/src/tools/train.ts
+++ b/src/tools/train.ts
@@ -468,7 +468,7 @@ export function registerTrainTools(server: McpServer): void {
 
   server.tool(
     "train_caption_dataset",
-    "Caption a whole staged dataset (or a subset) with the user's own Claude subscription and WRITE the captions into its .txt files (one vision turn per image, sequential). Use after gathering images, before train_start. Per-file failures are reported without stopping the batch. Optional guide text steers all captions; optional trigger is prepended to each.",
+    "Caption a whole staged dataset (or a subset) with the user's own Claude subscription and WRITE the captions into its .txt files (one vision turn per image, sequential). Captioning ALWAYS runs through Claude (Agent SDK) regardless of the panel's active backend, so it needs a logged-in Claude Code session (or ANTHROPIC_API_KEY). Use after gathering images, before train_start. Per-file transient failures are reported without stopping the batch, but a persistent auth/credential failure stops immediately with an actionable error rather than failing every image. Optional guide text steers all captions; optional trigger is prepended to each.",
     {
       name: z.string().min(1).describe("Dataset name (from train_list_datasets)."),
       guide: z.string().optional().describe("Extra style guidance applied to every caption."),


### PR DESCRIPTION
Fixes #438.

## Root cause
`train_caption_dataset` always captions through the Claude Agent SDK (`query()`), regardless of the panel's active backend. When the Claude Code session is not authenticated (issue reporter's panel backend was Codex), the SDK reports `Not logged in — Please run /login` as an **error `result` message**, not a thrown exception. `captionImage` only read `assistant` text and silently dropped the error result, so every image fell through to the generic `"the model returned an empty caption"` error. Result: 32 sequential wasted vision turns, all failing identically, with a confusing message.

## Fix
- `captionImage` now inspects the SDK `result` message. On an error result it surfaces the real SDK text, and for **persistent** auth/credential failures (not logged in, `/login`, invalid key, expired OAuth token, credit balance too low) it throws a typed `CaptionAuthError`.
- `captionDataset` bails the entire batch on the first `CaptionAuthError` (or an equivalently-phrased thrown error) with an actionable message — `Run \`claude /login\`, or set ANTHROPIC_API_KEY, then retry` — instead of re-hitting the same auth wall for every file.
- Transient per-file errors still get recorded in `failed[]` and the loop continues, unchanged.
- Tool description updated to state captioning always runs through Claude and needs a logged-in session.

## Tests (src/__tests__/services/train-caption.test.ts)
- persistent auth failure ⇒ rejects with `CaptionAuthError` after the **first** file (asserts only 1 SDK call across a 5-image set, not 5)
- auth error carries an actionable `/login` message
- a transient per-file error still continues through the whole batch (5 attempts, 5 recorded failures, batch not aborted)
- existing success/subset tests still pass

tsc clean; full `npm test` green except the two known-environmental failures (`node-dev` ripgrep; `ui-bridge` EACCES port-bind in sandbox) — neither touches this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)