### PR TITLE
fix(reconnect): preserve/re-resolve ComfyUI base so download resume survives reconnect (#420)

### DIFF
--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -240,6 +240,31 @@ describe("download job registry", () => {
     expect(hoisted.lastDispatchArg).toBe(false);
   });
 
+  it("#420 cross-call dedup: a Manager→local flip BETWEEN two calls still finds the one in-flight job", async () => {
+    // The registry index must be ROUTE-INDEPENDENT (#420 codex round 2). Two
+    // SEPARATE calls for the SAME request, with a reachability flip between them
+    // (call 1 → Manager, call 2 → local), used to compute DIFFERENT keys (remote
+    // tuple vs resolved local path) — so call 2 missed the in-flight entry and
+    // started a SECOND writer onto one file. With a stable request key, call 2
+    // adopts call 1.
+    hoisted.dispatchQueue.push(true, false);
+    const first = await startDownloadJob(URL_A, "loras");
+    const second = await startDownloadJob(URL_A, "loras");
+    expect(second.job).toBe(first.job); // same in-flight job, no duplicate
+    expect(hoisted.calls).toBe(1); // exactly ONE writer for the request
+    expect(listDownloadJobs()).toHaveLength(1); // one registry entry, not two
+  });
+
+  it("#420 cross-call dedup: a local→Manager flip BETWEEN two calls also finds the one job", async () => {
+    // The reverse flip direction must dedup too.
+    hoisted.dispatchQueue.push(false, true);
+    const first = await startDownloadJob(URL_A, "loras");
+    const second = await startDownloadJob(URL_A, "loras");
+    expect(second.job).toBe(first.job);
+    expect(hoisted.calls).toBe(1);
+    expect(listDownloadJobs()).toHaveLength(1);
+  });
+
   it("lists newest first", async () => {
     await startDownloadJob(URL_A, "checkpoints");
     await new Promise((r) => setTimeout(r, 2));

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -265,6 +265,60 @@ describe("download job registry", () => {
     expect(listDownloadJobs()).toHaveLength(1);
   });
 
+  it("#420 rule 1: B adopts A's destination, then a B-repeat after a local→Manager flip still finds the ONE writer", async () => {
+    // A and B are DIFFERENT urls resolving to the SAME local destination. B adopts
+    // A by destination; the adoption must re-index B's request key onto A. Otherwise
+    // a later B-repeat whose route FLIPS to Manager (dropping the destination key)
+    // has only its request key, misses A, and starts a SECOND writer onto one file.
+    hoisted.dispatchQueue.push(false, false, true); // A local, B local (adopts A), B-repeat Manager
+    const a = await startDownloadJob(URL_A, "checkpoints", "m.safetensors");
+    const b = await startDownloadJob(URL_B, "checkpoints", "m.safetensors");
+    expect(b.job).toBe(a.job); // B adopts A by destination
+    const bAgain = await startDownloadJob(URL_B, "checkpoints", "m.safetensors");
+    expect(bAgain.job).toBe(a.job); // still the SAME writer, via B's re-indexed request key
+    expect(hoisted.calls).toBe(1); // ONE writer for one file — no double-write
+    expect(listDownloadJobs()).toHaveLength(1);
+  });
+
+  it("#420 rule 3: a FINISHED entry is not adopted and never shadows a live writer on the same destination", async () => {
+    // X finishes; a different-url request to the SAME destination starts a fresh
+    // writer Y; then repeating X's request must adopt the LIVE Y — not the dead X,
+    // and not a third writer.
+    const x = await startDownloadJob(URL_A, "checkpoints", "m.safetensors");
+    hoisted.resolvers[0].resolve("C:/models/checkpoints/m.safetensors");
+    await x.settled;
+    expect(x.job.status).toBe("done");
+
+    const y = await startDownloadJob(URL_B, "checkpoints", "m.safetensors"); // same dest, X done → new writer
+    expect(y.job).not.toBe(x.job);
+    expect(hoisted.calls).toBe(2);
+
+    const xAgain = await startDownloadJob(URL_A, "checkpoints", "m.safetensors"); // X's request repeats
+    expect(xAgain.job).toBe(y.job); // adopts the LIVE writer, not the finished X
+    expect(hoisted.calls).toBe(2); // no duplicate started
+    expect(listDownloadJobs()).toHaveLength(1); // finished X retired; only Y remains
+  });
+
+  it("#420 rule 2: retiring a superseded entry never deletes a live writer's index row", async () => {
+    // X (finished) is superseded by Y (live) on the same destination; subsequent
+    // same-destination requests must keep adopting the single live Y — its index
+    // rows are never deleted out from under it by a stale retire.
+    const x = await startDownloadJob(URL_A, "checkpoints", "m.safetensors");
+    hoisted.resolvers[0].resolve("C:/models/checkpoints/m.safetensors");
+    await x.settled;
+
+    const y = await startDownloadJob(URL_A, "checkpoints", "m.safetensors"); // retires X, starts Y
+    expect(y.job).not.toBe(x.job);
+    expect(y.job.status).toBe("downloading");
+
+    const viaB = await startDownloadJob(URL_B, "checkpoints", "m.safetensors");
+    const viaBAgain = await startDownloadJob(URL_B, "checkpoints", "m.safetensors");
+    expect(viaB.job).toBe(y.job);
+    expect(viaBAgain.job).toBe(y.job);
+    expect(hoisted.calls).toBe(2); // only X then Y ever wrote
+    expect(listDownloadJobs()).toHaveLength(1);
+  });
+
   it("lists newest first", async () => {
     await startDownloadJob(URL_A, "checkpoints");
     await new Promise((r) => setTimeout(r, 2));

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -24,6 +24,11 @@ vi.mock("../../config.js", async () => {
 // blank/path-ful rejection) are covered against the real code in
 // model-resolver.test.ts.
 vi.mock("../../services/model-resolver.js", () => ({
+  // The single routing decision startDownloadJob now consults to choose the job
+  // identity: manager-dispatch (remote OR #420 reconnect-fallback) skips local
+  // target resolution; local streams key by the resolved targetPath. Driven by the
+  // same `hoisted.remote` flag so the existing remote-mode assertions hold.
+  shouldDispatchDownloadToManager: vi.fn(async () => hoisted.remote),
   downloadModel: vi.fn((url: string) => {
     hoisted.calls += 1;
     return new Promise<string>((resolve, reject) => {
@@ -166,6 +171,22 @@ describe("download job registry", () => {
     expect(hoisted.calls).toBe(1); // downloadModel invoked (takes the Manager path)
     // A repeated identical remote request still adopts the in-flight job.
     const again = await startDownloadJob(URL_A, "checkpoints");
+    expect(again.job).toBe(job);
+    expect(hoisted.calls).toBe(1);
+  });
+
+  it("#420: a reconnect-fallback Manager route keys WITHOUT resolving a local target", async () => {
+    // After a reconnect drops the effective base, shouldDispatchDownloadToManager
+    // returns true for a nominally-local session (driven here by hoisted.remote).
+    // startDownloadJob must then take the Manager path and NOT resolve a local
+    // targetPath (which would throw "no local ComfyUI path configured") — the exact
+    // #420 immediate failure. Adoption of a repeated request must still hold.
+    hoisted.remote = true;
+    const { job } = await startDownloadJob(URL_A, "loras");
+    expect(job.status).toBe("downloading");
+    expect(hoisted.resolveTargetCalls).toBe(0);
+    expect(hoisted.calls).toBe(1);
+    const again = await startDownloadJob(URL_A, "loras");
     expect(again.job).toBe(job);
     expect(hoisted.calls).toBe(1);
   });

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -5,6 +5,14 @@ const hoisted = vi.hoisted(() => ({
   calls: 0,
   remote: false,
   resolveTargetCalls: 0,
+  // Routing-predicate instrumentation. `dispatchQueue` lets a test make the
+  // predicate FLIP between evaluations; `dispatchEvals` counts how many times it
+  // was actually evaluated; `lastDispatchArg` records the decision threaded into
+  // downloadModel — together they prove the route is decided ONCE and the writer
+  // follows it (#420 codex round 1 split-brain guard).
+  dispatchQueue: [] as boolean[],
+  dispatchEvals: 0,
+  lastDispatchArg: undefined as boolean | undefined,
 }));
 
 // isRemoteMode gates the identity branch in startDownloadJob. Keep every other
@@ -26,15 +34,24 @@ vi.mock("../../config.js", async () => {
 vi.mock("../../services/model-resolver.js", () => ({
   // The single routing decision startDownloadJob now consults to choose the job
   // identity: manager-dispatch (remote OR #420 reconnect-fallback) skips local
-  // target resolution; local streams key by the resolved targetPath. Driven by the
-  // same `hoisted.remote` flag so the existing remote-mode assertions hold.
-  shouldDispatchDownloadToManager: vi.fn(async () => hoisted.remote),
-  downloadModel: vi.fn((url: string) => {
-    hoisted.calls += 1;
-    return new Promise<string>((resolve, reject) => {
-      hoisted.resolvers.push({ resolve, reject, url });
-    });
+  // target resolution; local streams key by the resolved targetPath. `dispatchQueue`
+  // (when non-empty) supplies successive return values so a test can FLIP the
+  // predicate between evaluations; otherwise it mirrors `hoisted.remote`.
+  shouldDispatchDownloadToManager: vi.fn(async () => {
+    hoisted.dispatchEvals += 1;
+    return hoisted.dispatchQueue.length ? hoisted.dispatchQueue.shift()! : hoisted.remote;
   }),
+  // Capture the routing decision THREADED IN by startDownloadJob (5th arg) so a
+  // test can assert the writer used the job's decision, not a fresh evaluation.
+  downloadModel: vi.fn(
+    (url: string, _sub?: string, _fn?: string, _auth?: unknown, dispatchToManager?: boolean) => {
+      hoisted.calls += 1;
+      hoisted.lastDispatchArg = dispatchToManager;
+      return new Promise<string>((resolve, reject) => {
+        hoisted.resolvers.push({ resolve, reject, url });
+      });
+    },
+  ),
   resolveDownloadTarget: vi.fn(async (url: string, sub: string, filename?: string) => {
     hoisted.resolveTargetCalls += 1;
     const s = String(sub ?? "").trim();
@@ -66,6 +83,9 @@ describe("download job registry", () => {
     hoisted.calls = 0;
     hoisted.remote = false;
     hoisted.resolveTargetCalls = 0;
+    hoisted.dispatchQueue.length = 0;
+    hoisted.dispatchEvals = 0;
+    hoisted.lastDispatchArg = undefined;
     resetDownloadJobs();
   });
 
@@ -189,6 +209,35 @@ describe("download job registry", () => {
     const again = await startDownloadJob(URL_A, "loras");
     expect(again.job).toBe(job);
     expect(hoisted.calls).toBe(1);
+  });
+
+  it("#420 split-brain guard: the writer follows the job's ONE routing decision even if reachability would flip", async () => {
+    // The predicate awaits live /system_stats + mutable base config, so it could
+    // return DIFFERENT answers at the two points it used to be evaluated (job-id
+    // keying, then the writer). Model that flip: first eval → Manager, a hypothetical
+    // second eval → local. The fix evaluates ONCE and threads the result through, so:
+    hoisted.dispatchQueue.push(true, false); // [job-eval → true, would-be writer-eval → false]
+    const { job } = await startDownloadJob(URL_A, "loras");
+    // Keyed as a Manager job off the FIRST (only) evaluation — no local target resolved.
+    expect(hoisted.resolveTargetCalls).toBe(0);
+    // The predicate was evaluated EXACTLY ONCE (the "false" in the queue is untouched)…
+    expect(hoisted.dispatchEvals).toBe(1);
+    expect(hoisted.dispatchQueue).toEqual([false]);
+    // …and the writer received that SAME decision (true), NOT a fresh re-evaluation.
+    expect(hoisted.lastDispatchArg).toBe(true);
+    // One request → one writer, one job. No split, no duplicate.
+    expect(hoisted.calls).toBe(1);
+    expect(listDownloadJobs()).toHaveLength(1);
+  });
+
+  it("threads the LOCAL decision into the writer too (not just the Manager case)", async () => {
+    // Symmetric guard: a local job must hand downloadModel dispatchToManager=false
+    // so the writer streams to the same targetPath the id was keyed on.
+    hoisted.remote = false;
+    await startDownloadJob(URL_A, "checkpoints");
+    expect(hoisted.resolveTargetCalls).toBe(1); // local id keyed by resolved target
+    expect(hoisted.dispatchEvals).toBe(1);
+    expect(hoisted.lastDispatchArg).toBe(false);
   });
 
   it("lists newest first", async () => {

--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for shouldDispatchDownloadToManager — the single routing decision
+ * that keeps model downloads working after a panel/orchestrator RECONNECT drops
+ * the effective ComfyUI base (#420). Distinct from #418 (base resolution at
+ * START): here the base is LOST later, and a nominally-local (loopback) session
+ * must fall back to the connected ComfyUI-Manager route — the same live server
+ * list_local_models still reaches over HTTP — instead of throwing
+ * "no local ComfyUI path configured".
+ */
+
+const hoisted = vi.hoisted(() => ({
+  remote: false,
+  base: undefined as string | undefined,
+  stats: undefined as unknown,
+  statsThrows: false,
+}));
+
+// isRemoteMode is the first gate; keep every other real config export.
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return { ...actual, isRemoteMode: () => hoisted.remote };
+});
+
+// resolveEffectiveComfyUIBase is the "do we have a local base?" gate. Control it
+// directly so the test doesn't depend on the host's real workspace config / FS.
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/workspace-env.js")>(
+    "../../services/workspace-env.js",
+  );
+  return { ...actual, resolveEffectiveComfyUIBase: () => hoisted.base };
+});
+
+// getSystemStats stands in for the connected server's /system_stats. getClient is
+// pulled in transitively by model-resolver; stub it so the import doesn't fail.
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: () => ({ fetchApi: vi.fn() }),
+  getSystemStats: vi.fn(async () => {
+    if (hoisted.statsThrows) throw new Error("ECONNREFUSED");
+    return hoisted.stats;
+  }),
+}));
+
+import { shouldDispatchDownloadToManager } from "../../services/model-resolver.js";
+
+beforeEach(() => {
+  hoisted.remote = false;
+  hoisted.base = undefined;
+  hoisted.stats = undefined;
+  hoisted.statsThrows = false;
+});
+
+describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
+  it("REMOTE mode always dispatches to the Manager", async () => {
+    hoisted.remote = true;
+    // Even if a local base somehow resolves, remote wins (no local FS).
+    hoisted.base = "/some/local/comfy";
+    expect(await shouldDispatchDownloadToManager()).toBe(true);
+  });
+
+  it("streams LOCAL when a local base is resolvable (COMFYUI_PATH / default workspace)", async () => {
+    hoisted.base = "/home/me/ComfyUI";
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+
+  it("#420: no local base + reachable server WITHOUT --base-directory → Manager route", async () => {
+    // The reconnect case: base lost, but the live server is still connected. It
+    // was NOT launched with --base-directory, so there's no local dir to stream
+    // to — hand the fetch to its Manager rather than failing.
+    hoisted.base = undefined;
+    hoisted.stats = { system: { argv: ["main.py", "--listen"] } };
+    expect(await shouldDispatchDownloadToManager()).toBe(true);
+  });
+
+  it("no local base + reachable server WITH --base-directory → still streams local", async () => {
+    // Desktop install advertises its real base dir via argv; that dir is on this
+    // same (loopback) filesystem, so keep the local streaming path.
+    hoisted.base = undefined;
+    hoisted.stats = {
+      system: { argv: ["main.py", "--base-directory", "/data/ComfyUI"] },
+    };
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+
+  it("no local base + UNREACHABLE server → stays local so the resolver throws a clear error", async () => {
+    hoisted.base = undefined;
+    hoisted.statsThrows = true;
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+});

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -249,6 +249,7 @@ describe("applyManifest", () => {
       "loras",
       "model.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
   });
 
@@ -410,6 +411,7 @@ describe("applyManifest", () => {
       expect.stringMatching(/checkpoints[\\/]foo/),
       "model.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
   });
 
@@ -434,6 +436,7 @@ describe("applyManifest", () => {
       "loras",
       "new.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
   });
 

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -80,6 +80,10 @@ vi.mock("../../services/model-resolver.js", () => ({
     "unet",
   ],
   downloadModel: (...a: unknown[]) => downloadModelMock(...a),
+  // startDownloadJob consults this to choose local-vs-Manager routing (#420).
+  // Mirror the same mode gate the config mock uses so manifest downloads key the
+  // same way they always did (local unless remote).
+  shouldDispatchDownloadToManager: async () => mockConfig.remote ?? !mockConfig.comfyuiPath,
   // startDownloadJob resolves the destination via this before streaming; stub it
   // so a distinct targetPath is derived per (subfolder, filename) without a server.
   resolveDownloadTarget: async (url: string, sub: string, filename?: string) => {

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -443,6 +443,44 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
   });
 });
 
+describe("downloadModel — threaded routing decision (#420 split-brain guard)", () => {
+  it("forces the Manager dispatch when dispatchToManager=true, even with a LOCAL config", async () => {
+    // config.comfyuiPath is set (local mode), so self-evaluation would stream to
+    // disk. Passing the job's already-decided route must WIN — the writer follows
+    // the decision the job id was keyed on, never a fresh evaluation.
+    config.comfyuiPath = "/comfy";
+    const out = await downloadModel(
+      "https://example.com/model.safetensors",
+      "checkpoints",
+      "model.safetensors",
+      undefined,
+      true, // dispatchToManager — decided upstream by startDownloadJob
+    );
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled(); // no local streaming
+    expect(out).toContain("ComfyUI-Manager");
+  });
+
+  it("forces local streaming when dispatchToManager=false, even in remote-like config", async () => {
+    // Even with comfyuiPath unset (self-eval would pick Manager), an explicit
+    // false route makes the writer take the local path (and here fail at fetch),
+    // proving the passed decision overrides self-evaluation both ways.
+    config.comfyuiPath = undefined;
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, statusText: "err" });
+    await expect(
+      downloadModel(
+        "https://example.com/model.safetensors",
+        "checkpoints",
+        "model.safetensors",
+        undefined,
+        false, // dispatchToManager=false → local writer
+      ),
+    ).rejects.toBeInstanceOf(ModelError);
+    expect(installModelViaManagerMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("resolveDownloadTarget (shared destination resolver)", () => {
   const URL = "https://example.com/path/big.safetensors";
 

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -233,6 +233,7 @@ describe("download_civitai_model", () => {
       "checkpoints",
       "cool.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("Cool Model");
@@ -256,6 +257,7 @@ describe("download_civitai_model", () => {
       "loras",
       "v.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
     expect(res.isError).toBeFalsy();
   });
@@ -293,6 +295,7 @@ describe("download_civitai_model", () => {
       "loras",
       "custom.safetensors",
       undefined,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
   });
 

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -10,6 +10,9 @@ vi.mock("../../services/model-resolver.js", async () => {
     ...actual,
     downloadModel: (...a: unknown[]) => downloadModelMock(...a),
     listLocalModels: (...a: unknown[]) => listLocalModelsMock(...a),
+    // Deterministic local routing (no live server probe) so startDownloadJob keys
+    // the job locally and threads dispatchToManager=false into downloadModel.
+    shouldDispatchDownloadToManager: async () => false,
     // startDownloadJob resolves the destination via this before streaming; stub
     // it so the tool tests don't need a live server to compute a targetPath.
     resolveDownloadTarget: async (url: string, sub: string, filename?: string) => {
@@ -67,6 +70,7 @@ describe("download_model tool", () => {
       "checkpoints",
       "x.safetensors",
       auth,
+      false, // routing decision threaded through (local, #420 codex round 1)
     );
     expect(res.isError).toBeFalsy();
   });

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -52,8 +52,16 @@ export interface DownloadJob {
 interface Entry {
   job: DownloadJob;
   settled: Promise<void>;
+  /** Every registry key this entry is indexed under (request key, and the
+   *  destination key when locally resolvable). Kept so a superseding job can
+   *  unregister ALL of a stale entry's keys — no orphaned index rows. */
+  keys: string[];
 }
 
+// The in-flight registry is indexed under MULTIPLE keys per job so dedup is
+// ROUTE-INDEPENDENT: a repeated request finds the in-flight job whether or not the
+// Manager↔local route flipped between calls (#420 codex round 2). One Entry object
+// is shared by all its keys.
 const jobs = new Map<string, Entry>();
 
 /** The tray keys rows on a hash of the SOURCE URL; match it so both agree. */
@@ -73,14 +81,15 @@ export function downloadJobIdFor(targetPath: string): string {
 }
 
 /**
- * REMOTE-mode id: there is NO local filesystem to resolve a targetPath from —
- * downloadModel dispatches to the ComfyUI host's Manager, which decides the
- * server-side destination. Key by a canonical, collision-safe JSON-encoded tuple
- * of {url, trimmed subfolder, filename} so field boundaries are unambiguous and a
- * repeated identical request still adopts the in-flight job. (We can't dedupe two
- * DIFFERENT urls aimed at one server-side dest here — the server owns that.)
+ * ROUTE-INDEPENDENT request key: a canonical, collision-safe JSON-encoded tuple of
+ * {url, trimmed subfolder, filename}. Derived ONLY from the request inputs — never
+ * from the resolved destination or the chosen route — so a repeated call for the
+ * SAME request adopts the in-flight job regardless of a Manager↔local reachability
+ * flip between calls (#420 codex round 2). Every job is indexed under this key; a
+ * locally-resolvable job is ALSO indexed under its destination key (below) so the
+ * "two different URLs → one local destination → one writer" dedup still holds.
  */
-function remoteDownloadJobIdFor(
+function requestDownloadKey(
   url: string,
   targetSubfolder: string,
   filename?: string,
@@ -137,18 +146,43 @@ export async function startDownloadJob(
   // Manager-key + local-writer (or a duplicate job) for one request (#420 codex
   // round 1). One decision keys the identity AND drives the writer.
   const dispatchToManager = await shouldDispatchDownloadToManager();
-  const id = dispatchToManager
-    ? remoteDownloadJobIdFor(url, targetSubfolder, filename)
-    : downloadJobIdFor((await resolveDownloadTarget(url, targetSubfolder, filename)).targetPath);
+
+  // DEDUP INDEX (route-independent) vs WRITER ROUTE (the single decision above) are
+  // deliberately separated (#420 codex round 2). The in-flight lookup/registration
+  // is keyed by the REQUEST (url+subfolder+filename), which NEVER changes with the
+  // route — so two separate calls for one request with a Manager↔local flip between
+  // them still resolve to ONE job (no same-file double-write). When the request is
+  // locally resolvable we ALSO index the destination-path key, preserving the
+  // "two different URLs → same local destination → one writer" dedup (WS-4). An
+  // invalid filename/subfolder is REJECTED here (by resolveDownloadTarget), up
+  // front, exactly as the write would reject it.
+  const reqKey = requestDownloadKey(url, targetSubfolder, filename);
+  let destKey: string | undefined;
+  if (!dispatchToManager) {
+    const target = await resolveDownloadTarget(url, targetSubfolder, filename);
+    destKey = downloadJobIdFor(target.targetPath);
+  }
+  // The PUBLIC id (download_status handle): the destination key when we have one
+  // (so distinct destinations are separately pollable), else the request key.
+  const id = destKey ?? reqKey;
+  // Lookup order: request key first (catches a route flip), then destination key
+  // (catches two-URLs-one-dest). Either hit adopts the same in-flight writer.
+  const lookupKeys = destKey ? [reqKey, destKey] : [reqKey];
   const trayId = downloadIdFor(url);
-  const existing = jobs.get(id);
+
+  const existing = lookupKeys.map((k) => jobs.get(k)).find((e) => e !== undefined);
   if (existing && existing.job.status === "downloading") {
-    logger.info(`Download already in flight, adopting it: ${id}`, {
+    logger.info(`Download already in flight, adopting it: ${existing.job.id}`, {
       url,
       target_subfolder: targetSubfolder,
       filename,
     });
     return existing;
+  }
+  // A superseded (done/error) entry under any of our keys is retired first, so its
+  // stale index rows can't shadow the new writer (retry-after-failure).
+  if (existing) {
+    for (const k of existing.keys) jobs.delete(k);
   }
 
   const job: DownloadJob = {
@@ -187,21 +221,30 @@ export async function startDownloadJob(
       job.finished_at = Date.now();
     });
 
-  const entry: Entry = { job, settled };
-  jobs.set(id, entry);
+  // Index under EVERY key (deduped) so any of them adopts this one writer.
+  const keys = [...new Set(lookupKeys)];
+  const entry: Entry = { job, settled, keys };
+  for (const k of keys) jobs.set(k, entry);
   return entry;
 }
 
 export function getDownloadJob(id: string): DownloadJob | undefined {
-  // The registry is keyed by the distinct public id (URL+destination), so each
-  // destination resolves to its own job.
+  // The registry indexes each job under its request key and (when local) its
+  // destination key; the public id is one of those, so a direct get resolves it.
   return jobs.get(id)?.job;
 }
 
 export function listDownloadJobs(): DownloadJob[] {
-  return [...jobs.values()]
-    .map((e) => e.job)
-    .sort((a, b) => b.started_at - a.started_at);
+  // One Entry is indexed under multiple keys — dedup by identity so a job appears
+  // once regardless of how many keys point at it.
+  const seen = new Set<Entry>();
+  const out: DownloadJob[] = [];
+  for (const e of jobs.values()) {
+    if (seen.has(e)) continue;
+    seen.add(e);
+    out.push(e.job);
+  }
+  return out.sort((a, b) => b.started_at - a.started_at);
 }
 
 /** Test seam — the registry is process-global otherwise. */

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -64,6 +64,29 @@ interface Entry {
 // is shared by all its keys.
 const jobs = new Map<string, Entry>();
 
+/**
+ * Point `key` at `entry`, ENTRY-SCOPED (#420 codex round 3, rule 2/3): never clobber
+ * a row currently owned by a DIFFERENT, still-in-flight writer — that would orphan a
+ * live download's index. Records the key on the entry so it can be retired later.
+ */
+function registerKey(entry: Entry, key: string): void {
+  const cur = jobs.get(key);
+  if (cur && cur !== entry && cur.job.status === "downloading") return;
+  if (!entry.keys.includes(key)) entry.keys.push(key);
+  jobs.set(key, entry);
+}
+
+/**
+ * Retire a superseded (done/error) entry, ENTRY-SCOPED (#420 codex round 3, rule 2):
+ * only delete an index row that STILL points at THIS entry, so retiring an older job
+ * can never delete a key that has since been reassigned to a newer/live entry.
+ */
+function retireEntry(entry: Entry): void {
+  for (const key of entry.keys) {
+    if (jobs.get(key) === entry) jobs.delete(key);
+  }
+}
+
 /** The tray keys rows on a hash of the SOURCE URL; match it so both agree. */
 export function downloadIdFor(url: string): string {
   return createHash("sha256").update(url).digest("hex").slice(0, 16);
@@ -165,24 +188,47 @@ export async function startDownloadJob(
   // The PUBLIC id (download_status handle): the destination key when we have one
   // (so distinct destinations are separately pollable), else the request key.
   const id = destKey ?? reqKey;
-  // Lookup order: request key first (catches a route flip), then destination key
-  // (catches two-URLs-one-dest). Either hit adopts the same in-flight writer.
+  // This call's keys: the route-independent request key, plus the destination key
+  // when locally resolvable (two-URLs-one-dest dedup).
   const lookupKeys = destKey ? [reqKey, destKey] : [reqKey];
   const trayId = downloadIdFor(url);
 
-  const existing = lookupKeys.map((k) => jobs.get(k)).find((e) => e !== undefined);
-  if (existing && existing.job.status === "downloading") {
-    logger.info(`Download already in flight, adopting it: ${existing.job.id}`, {
+  // ADOPT ONLY AN IN-FLIGHT ENTRY (#420 codex round 3, rule 3): a FINISHED entry
+  // under any key is treated as absent — it must never shadow a currently-downloading
+  // writer reachable under another key, nor cause a retire that overwrites a live row.
+  // Scan every key and prefer an in-flight match.
+  let adopted: Entry | undefined;
+  for (const k of lookupKeys) {
+    const e = jobs.get(k);
+    if (e && e.job.status === "downloading") {
+      adopted = e;
+      break;
+    }
+  }
+  if (adopted) {
+    // Re-index THIS call's keys onto the adopted entry (#420 codex round 3, rule 1):
+    // when URL B adopts URL A's in-flight job by destination, B's request key must
+    // now point at the same entry too — otherwise a later repeat of B (especially
+    // after a local→Manager flip that drops the destination key) would miss it and
+    // start a second writer onto one file. Entry-scoped, so it can't steal a live row.
+    for (const k of lookupKeys) registerKey(adopted, k);
+    logger.info(`Download already in flight, adopting it: ${adopted.job.id}`, {
       url,
       target_subfolder: targetSubfolder,
       filename,
     });
-    return existing;
+    return adopted;
   }
-  // A superseded (done/error) entry under any of our keys is retired first, so its
-  // stale index rows can't shadow the new writer (retry-after-failure).
-  if (existing) {
-    for (const k of existing.keys) jobs.delete(k);
+  // No in-flight match. Retire any superseded (done/error) entries shadowing our keys
+  // — entry-scoped, so we only clear rows still pointing at that finished entry and
+  // never delete a row now owned by a different, live writer (rule 2).
+  const retired = new Set<Entry>();
+  for (const k of lookupKeys) {
+    const e = jobs.get(k);
+    if (e && !retired.has(e)) {
+      retireEntry(e);
+      retired.add(e);
+    }
   }
 
   const job: DownloadJob = {
@@ -221,10 +267,11 @@ export async function startDownloadJob(
       job.finished_at = Date.now();
     });
 
-  // Index under EVERY key (deduped) so any of them adopts this one writer.
-  const keys = [...new Set(lookupKeys)];
-  const entry: Entry = { job, settled, keys };
-  for (const k of keys) jobs.set(k, entry);
+  // Index under EVERY key (deduped) so any of them adopts this one writer. Uses the
+  // entry-scoped registerKey guard so a fresh registration can never overwrite a row
+  // still owned by a different, live writer (rule 3).
+  const entry: Entry = { job, settled, keys: [] };
+  for (const k of new Set(lookupKeys)) registerKey(entry, k);
   return entry;
 }
 

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -130,7 +130,14 @@ export async function startDownloadJob(
   // reconnect case: a nominally-local session whose effective base was lost still
   // routes through the connected Manager (and must NOT try to resolve a local
   // targetPath, which would throw), keying by the same canonical remote identity.
-  const id = (await shouldDispatchDownloadToManager())
+  //
+  // CRITICAL: evaluate the route EXACTLY ONCE and thread it into downloadModel
+  // below. The predicate awaits live /system_stats and reads mutable base config,
+  // so a reconnect/reachability flip between two evaluations would split the job —
+  // Manager-key + local-writer (or a duplicate job) for one request (#420 codex
+  // round 1). One decision keys the identity AND drives the writer.
+  const dispatchToManager = await shouldDispatchDownloadToManager();
+  const id = dispatchToManager
     ? remoteDownloadJobIdFor(url, targetSubfolder, filename)
     : downloadJobIdFor((await resolveDownloadTarget(url, targetSubfolder, filename)).targetPath);
   const trayId = downloadIdFor(url);
@@ -156,7 +163,7 @@ export async function startDownloadJob(
 
   // The promise is stored, never left dangling — an unhandled rejection here
   // would take down the process on a simple 404.
-  const settled = downloadModel(url, targetSubfolder, filename, auth)
+  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager)
     .then(async (path) => {
       job.path = path;
       if (onComplete) {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -15,8 +15,11 @@
  */
 
 import { createHash } from "node:crypto";
-import { isRemoteMode } from "../config.js";
-import { downloadModel, resolveDownloadTarget } from "./model-resolver.js";
+import {
+  downloadModel,
+  resolveDownloadTarget,
+  shouldDispatchDownloadToManager,
+} from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
 import { logger } from "../utils/logger.js";
 
@@ -123,8 +126,11 @@ export async function startDownloadJob(
   // there is NO local filesystem — downloadModel short-circuits to the Manager
   // dispatch, so resolving a local models dir would wrongly THROW (COMFYUI_PATH
   // unset). Key by a canonical remote identity instead and let downloadModel take
-  // the Manager path.
-  const id = isRemoteMode()
+  // the Manager path. shouldDispatchDownloadToManager() also covers the #420
+  // reconnect case: a nominally-local session whose effective base was lost still
+  // routes through the connected Manager (and must NOT try to resolve a local
+  // targetPath, which would throw), keying by the same canonical remote identity.
+  const id = (await shouldDispatchDownloadToManager())
     ? remoteDownloadJobIdFor(url, targetSubfolder, filename)
     : downloadJobIdFor((await resolveDownloadTarget(url, targetSubfolder, filename)).targetPath);
   const trayId = downloadIdFor(url);

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -3,7 +3,7 @@ import type { Stats } from "node:fs";
 import { readdir, stat, mkdir, readFile } from "node:fs/promises";
 import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
-import { getClient } from "../comfyui/client.js";
+import { getClient, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
 import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
@@ -11,7 +11,7 @@ import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { downloadWithCache } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
-import { resolveModelsDir } from "./output-dir.js";
+import { resolveModelsDir, parseModelsDirFromArgv } from "./output-dir.js";
 import {
   applyDownloadAuth,
   redactUrlForLogs,
@@ -695,6 +695,43 @@ async function downloadModelViaManagerRemote(
   return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authWarning}`;
 }
 
+/**
+ * Decide whether a model download must be handed to the CONNECTED ComfyUI's
+ * ComfyUI-Manager (a server-side fetch) instead of being streamed to local disk.
+ *
+ * Returns true when:
+ *   - REMOTE mode — there is no local filesystem at all (the original behavior); OR
+ *   - we are NOMINALLY LOCAL (loopback target) but have NO resolvable local base:
+ *     COMFYUI_PATH is unset — or was LOST across a panel/orchestrator reconnect
+ *     (#420) — and no default workspace is saved, AND the connected server did not
+ *     advertise a discoverable `--base-directory` to stream into, YET a live server
+ *     IS reachable to accept a Manager dispatch. This is exactly the reconnect
+ *     failure in #420: the previous session downloaded fine, the reconnect dropped
+ *     the effective base, and the local path then threw "no local ComfyUI path
+ *     configured" instead of routing through the still-connected Manager (the same
+ *     route list_local_models keeps using over HTTP). #418 fixed base resolution
+ *     at START; this keeps downloads working when the base goes missing LATER.
+ *
+ * Stays LOCAL (false) whenever a local base is resolvable (resolveEffectiveComfyUIBase)
+ * OR the server reports a base/models dir we can write to directly; also false when
+ * no server is reachable, so the local resolver surfaces its clear, actionable error
+ * rather than silently succeeding.
+ */
+export async function shouldDispatchDownloadToManager(): Promise<boolean> {
+  if (isRemoteMode()) return true;
+  // A configured/auto-detected COMFYUI_PATH or saved default workspace → stream local.
+  if (resolveEffectiveComfyUIBase()) return false;
+  try {
+    const stats = await getSystemStats();
+    // Reachable server: stream locally only if it exposes a base/models dir we can
+    // write to; otherwise hand the fetch to its ComfyUI-Manager (reconnect-safe).
+    return !parseModelsDirFromArgv(stats.system?.argv);
+  } catch {
+    // No reachable server → nothing to dispatch to. Let the local resolver throw.
+    return false;
+  }
+}
+
 export async function downloadModel(
   url: string,
   targetSubfolder: string,
@@ -717,7 +754,7 @@ export async function downloadModel(
   // can carry query params); header/basic/bearer auth can't be forwarded to
   // Manager, so those are surfaced as a clear warning rather than reported as a
   // clean success.
-  if (isRemoteMode()) {
+  if (await shouldDispatchDownloadToManager()) {
     return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth);
   }
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -737,6 +737,16 @@ export async function downloadModel(
   targetSubfolder: string,
   filename?: string,
   auth?: DownloadAuth,
+  /**
+   * The ALREADY-DECIDED route (Manager vs local disk). startDownloadJob computes
+   * shouldDispatchDownloadToManager() ONCE to key the job identity, then threads
+   * that same decision here so the writer can never diverge from the key — a
+   * reconnect/reachability flip BETWEEN two evaluations would otherwise split the
+   * job (Manager-key + local-writer, or a duplicate job) (#420 codex round 1).
+   * Omitted by direct callers (the download_model tool path without a job), which
+   * evaluate the predicate themselves.
+   */
+  dispatchToManager?: boolean,
 ): Promise<string> {
   // Region flags (issue #127) applied at THE choke point every download path
   // funnels through (local disk AND the remote Manager dispatch below).
@@ -754,7 +764,13 @@ export async function downloadModel(
   // can carry query params); header/basic/bearer auth can't be forwarded to
   // Manager, so those are surfaced as a clear warning rather than reported as a
   // clean success.
-  if (await shouldDispatchDownloadToManager()) {
+  // Use the route the caller already decided (job path), else evaluate it now
+  // (direct callers). Never re-evaluate when a decision was threaded in — that is
+  // the split-brain guard: the writer must follow the SAME route the job id was
+  // keyed on, even if reachability/base config flipped since (#420 codex round 1).
+  const routeToManager =
+    dispatchToManager ?? (await shouldDispatchDownloadToManager());
+  if (routeToManager) {
     return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth);
   }
 

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { unlink, writeFile } from "node:fs/promises";
+import { isAbsolute } from "node:path";
 import { isLocalMode, config } from "../config.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -436,8 +437,14 @@ export function registerModelExtrasTools(server: McpServer): void {
 
           // Write usage-docs sidecars beside the file so the panel agent has the
           // description, trigger words, and example generation params on hand.
-          // Local-only: remote mode has no local FS (savedPath is a status string).
-          if (isLocalMode() && resolved.metadata) {
+          // Only when the file actually landed on the LOCAL filesystem: a real
+          // streamed download returns an ABSOLUTE path, whereas a remote OR
+          // reconnect-fallback Manager dispatch (#420) returns a human-readable
+          // status descriptor — writing a sidecar beside that string would create a
+          // stray file. isAbsolute(savedPath) distinguishes the two precisely
+          // (a Manager dispatch is loopback-"local" mode too, so isLocalMode() alone
+          // would misfire on the #420 fallback).
+          if (isAbsolute(savedPath) && resolved.metadata) {
             const sidecar = await writeCivitaiSidecar(savedPath, resolved.metadata);
             if (sidecar) {
               const tw = resolved.metadata.trainedWords;


### PR DESCRIPTION
## Problem (#420)

After a panel/orchestrator **reconnect**, the effective local ComfyUI base is lost, so an in-progress or retried `download_civitai_model` / `download_model` fails immediately with *"COMFYUI_PATH is not configured / no local ComfyUI path configured"* — even though the same connected local ComfyUI is still reachable (`list_local_models` keeps working over HTTP). Distinct from #418, which fixed base resolution **at START**; this is the base going missing **later**, across a reconnect.

Root cause: the local download path only fell back to the connected **ComfyUI-Manager** route when `isRemoteMode()` was true. A nominally-local (loopback) session whose effective base was dropped (COMFYUI_PATH lost/never set, no saved default workspace, server not launched with `--base-directory`) took the local branch and threw at destination resolution instead of routing through the still-connected Manager.

## Fix

Add one shared routing predicate `shouldDispatchDownloadToManager()` in `model-resolver.ts` (reuses `resolveEffectiveComfyUIBase` from #418, no divergent path), consulted by **both** `downloadModel` (the writer) and `startDownloadJob` (the job-registry identity), so they can't disagree:

- **remote** → Manager (unchanged).
- **local, base resolvable** (COMFYUI_PATH / saved default workspace) → stream local (unchanged).
- **local, no base, server reachable *without* `--base-directory`** → **dispatch to the connected Manager** (the #420 fix — the route `list_local_models` already uses).
- **local, no base, server reachable *with* `--base-directory`** (Desktop) → stream to that local dir (unchanged).
- **local, no base, server unreachable** → stay local so the resolver surfaces its clear, actionable error.

Also guard the CivitAI sidecar write on `isAbsolute(savedPath)` so a Manager-fallback (which returns a status *descriptor*, not a path) doesn't write a stray sidecar file — `isLocalMode()` alone misfires because the fallback is loopback-"local" too.

## Scope

No `orchestrator/index.ts` changes. Edits confined to the download-resume/routing service layer + tests.

## Tests

- New `download-manager-routing.test.ts` — unit tests for `shouldDispatchDownloadToManager` across all five cases (incl. the #420 reconnect fallback).
- `download-jobs.test.ts` — new regression: a reconnect-fallback Manager route keys the job **without** resolving a local target (the exact immediate-failure path), and a repeated request still adopts the in-flight job.
- Updated `download-jobs` + `manifest` test mocks to export the new predicate.
- `tsc --noEmit` clean; full `npm test` green except the pre-existing `node-dev` ripgrep-vs-builtin environmental failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
