### PR TITLE
release: 0.48.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.10] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- download resume survives an orchestrator/panel reconnect: a nominally-local session that loses its resolvable ComfyUI base after reconnect now routes the download through the still-connected ComfyUI-Manager instead of failing with "COMFYUI_PATH is not configured"; the in-flight job registry is dual-keyed (route-independent request key + destination) so a Manager<->local route flip can't spawn a duplicate same-file writer (#420) (#440)
+- train_caption_dataset fails fast on a persistent Claude auth failure (not-logged-in / invalid key / expired token) with an actionable message, instead of looping every image re-hitting the same error; transient per-file errors still continue (#438) (#439)
+
+
 ## [0.48.9] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.9",
+  "version": "0.48.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.9",
+      "version": "0.48.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.9",
+  "version": "0.48.10",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.10 (tag pushed → npm publish). Two fixes: reconnect download-resume routes to the connected Manager when the local base is lost + dual-keyed job registry preventing duplicate same-file writers (#420/#440, 4 codex rounds); train_caption_dataset fails fast on persistent Claude auth failure (#438/#439). 🤖 Generated with Claude Code