### PR TITLE
fix(codex): serialize run-finished callback payload, don't clobber streamed reply (#421 #422)

### DIFF
--- a/src/__tests__/orchestrator/codex-callback-serialize.test.ts
+++ b/src/__tests__/orchestrator/codex-callback-serialize.test.ts
@@ -1,0 +1,137 @@
+// The Codex app-server `item/completed` commit for an `agentMessage` normally
+// carries a string `text`, but newer builds can send structured content that
+// String()-coerces to "[object Object]" and OVERWRITES the streamed reply the
+// user already saw (#421, #422). These tests drive the notification handler and
+// assert the committed `assistant` event is readable text — falling back to the
+// streamed buffer when the final commit is malformed.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type BackendModule = typeof import("../../orchestrator/codex-backend.js");
+let CodexBackend: BackendModule["CodexBackend"];
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ CodexBackend } = await import("../../orchestrator/codex-backend.js"));
+});
+
+function makeClient() {
+  return {
+    notificationHandler: null as ((message: unknown) => void) | null,
+    exitError: null,
+    exitPromise: new Promise(() => {}),
+    request: vi.fn(async (method: string) => {
+      if (method === "thread/start") return { thread: { id: "thread-1" }, model: "gpt-5.6-sol" };
+      if (method === "turn/start") return { turn: { id: "turn-1" } };
+      throw new Error(`unexpected request: ${method}`);
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Drain the async iterator until the turn's terminal `result`, collecting events. */
+async function driveTurn(
+  notify: (client: ReturnType<typeof makeClient>) => void,
+): Promise<Array<Record<string, unknown>>> {
+  const client = makeClient();
+  const backend = new CodexBackend({ model: "gpt-5.6-sol" });
+  Object.assign(backend, { client });
+
+  async function* channel() {
+    yield { text: "go" };
+  }
+
+  const iterator = backend.run({ channel: channel() });
+  const events: Array<Record<string, unknown>> = [];
+
+  // Drain concurrently — pulling keeps the async generator advancing (past the
+  // session yield) so it can register the notification handler and start the turn.
+  const drain = (async () => {
+    for (let i = 0; i < 100; i += 1) {
+      const { value, done } = await iterator.next();
+      if (done) break;
+      events.push(value as Record<string, unknown>);
+      if ((value as { type?: string }).type === "result") break;
+    }
+  })();
+
+  // Wait for the turn to be registered before pushing notifications.
+  for (let attempt = 0; attempt < 50 && !(backend as any).turnId; attempt += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  notify(client);
+  await drain;
+  return events;
+}
+
+const completedTurn = (client: ReturnType<typeof makeClient>) =>
+  client.notificationHandler?.({
+    method: "turn/completed",
+    params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+  });
+
+describe("CodexBackend run-finished commit serialization (#421, #422)", () => {
+  it("commits a STRUCTURED agentMessage payload as readable text, not [object Object]", async () => {
+    const events = await driveTurn((client) => {
+      client.notificationHandler?.({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: "m1", text: [{ type: "text", text: "run finished ok" }] },
+        },
+      });
+      completedTurn(client);
+    });
+    const assistant = events.find((e) => e.type === "assistant");
+    expect(assistant?.text).toBe("run finished ok");
+    expect(assistant?.text).not.toBe("[object Object]");
+  });
+
+  it("does NOT clobber the streamed reply when the final commit coerces to empty", async () => {
+    const events = await driveTurn((client) => {
+      // Stream the real reply the user sees.
+      client.notificationHandler?.({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "m1", delta: "Hello, streamed " },
+      });
+      client.notificationHandler?.({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "m1", delta: "world." },
+      });
+      // Malformed final commit — an object with no readable text.
+      client.notificationHandler?.({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: "m1", text: { unexpected: "shape" } },
+        },
+      });
+      completedTurn(client);
+    });
+    const assistant = events.find((e) => e.type === "assistant");
+    expect(assistant?.text).toBe("Hello, streamed world.");
+    expect(assistant?.text).not.toBe("[object Object]");
+  });
+
+  it("still commits a plain-string final commit unchanged", async () => {
+    const events = await driveTurn((client) => {
+      client.notificationHandler?.({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: "m1", text: "just a string" },
+        },
+      });
+      completedTurn(client);
+    });
+    const assistant = events.find((e) => e.type === "assistant");
+    expect(assistant?.text).toBe("just a string");
+  });
+});

--- a/src/__tests__/orchestrator/codex-callback-serialize.test.ts
+++ b/src/__tests__/orchestrator/codex-callback-serialize.test.ts
@@ -119,6 +119,40 @@ describe("CodexBackend run-finished commit serialization (#421, #422)", () => {
     expect(assistant?.text).not.toBe("[object Object]");
   });
 
+  it("resets the streamed-text buffer between commits in a multi-message turn", async () => {
+    const events = await driveTurn((client) => {
+      // First message: streamed, then a malformed commit → falls back to stream.
+      client.notificationHandler?.({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "m1", delta: "first reply" },
+      });
+      client.notificationHandler?.({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: "m1", text: { bad: "shape" } },
+        },
+      });
+      // Second message: a DIFFERENT malformed commit with NO deltas. Its fallback
+      // must be "" (buffer reset), NOT the stale "first reply".
+      client.notificationHandler?.({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "agentMessage", id: "m2", text: { also: "bad" } },
+        },
+      });
+      completedTurn(client);
+    });
+    const assistants = events.filter((e) => e.type === "assistant");
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0]?.text).toBe("first reply");
+    // No stale carryover from the first message's stream buffer.
+    expect(assistants[1]?.text).toBe("");
+  });
+
   it("still commits a plain-string final commit unchanged", async () => {
     const events = await driveTurn((client) => {
       client.notificationHandler?.({

--- a/src/orchestrator/codex-backend.ts
+++ b/src/orchestrator/codex-backend.ts
@@ -42,7 +42,7 @@ import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
 import { logger } from "../utils/logger.js";
-import { errorText, promptText } from "./error-text.js";
+import { errorText, messageText, promptText } from "./error-text.js";
 import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
 import {
   type AgentBackend,
@@ -1057,6 +1057,10 @@ export class CodexBackend implements AgentBackend {
     let streamOpen = false;
     let streamKind: "text" | "thinking" | null = null;
     let interrupted = false;
+    // Accumulate the streamed reply text so a malformed final commit (structured
+    // `agentMessage.text` coercing to empty/"[object Object]") can fall back to the
+    // text the user already saw stream in, instead of clobbering it (#421, #422).
+    let assistantTextBuffer = "";
 
     const openStream = (id: string | null, kind: "text" | "thinking") => {
       if (streamOpen && streamKind === kind) return;
@@ -1110,6 +1114,7 @@ export class CodexBackend implements AgentBackend {
           const itemId = params.itemId as string | undefined;
           if (typeof delta === "string" && delta) {
             openStream(itemId ?? null, "text");
+            assistantTextBuffer += delta;
             push({ type: "assistant_delta", text: delta });
           }
           break;
@@ -1147,7 +1152,14 @@ export class CodexBackend implements AgentBackend {
           const itemType = item?.type as string | undefined;
           closeStream();
           if (itemType === "agentMessage") {
-            const text = ((item?.text as string | undefined) ?? "").trim();
+            // `item.text` is normally a string, but newer app-server builds can
+            // send structured content (arrays/objects) that String()-coerces to
+            // "[object Object]". Route it through the shared serializer, and if it
+            // still yields nothing readable, fall back to the streamed text the
+            // user already saw rather than committing an empty/garbage bubble that
+            // overwrites the good reply (#421, #422).
+            const committed = messageText(item?.text).trim();
+            const text = committed || assistantTextBuffer.trim();
             const id = item?.id as string | undefined;
             push({
               type: "assistant",
@@ -1155,6 +1167,9 @@ export class CodexBackend implements AgentBackend {
               ...(id ? { id } : {}),
               // No per-turn rewind anchor for Codex (forkAtAnchor=false) — omit uuid.
             });
+            // Reset for a possible next agentMessage in the same turn so its
+            // fallback can't inherit this one's streamed text.
+            assistantTextBuffer = "";
           } else {
             const name = toolNameOf(item);
             if (name) push({ type: "tool_call", name, phase: "end", detail: item });

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -169,6 +169,29 @@ describe("messageText (#421, #422)", () => {
     expect(messageText("[object Object]")).toBe("");
   });
 
+  it("treats a PADDED sentinel as empty (trims before judging)", () => {
+    expect(messageText(" [object Object] ")).toBe("");
+    expect(messageText({ text: "  [object Object]  " })).toBe("");
+  });
+
+  it("falls through a whitespace-only text to a real sibling key", () => {
+    expect(messageText({ text: " ", content: "real final" })).toBe("real final");
+  });
+
+  it("preserves internal/edge spacing of a genuine message", () => {
+    expect(messageText("  hello world  ")).toBe("  hello world  ");
+  });
+
+  it("returns '' (no throw) for a revoked Proxy payload", () => {
+    const revocable = Proxy.revocable({ text: "x" }, {});
+    revocable.revoke();
+    let out = "unset";
+    expect(() => {
+      out = messageText(revocable.proxy);
+    }).not.toThrow();
+    expect(out).toBe("");
+  });
+
   it("returns '' (never [object Object]) for an unreadable object so callers can fall back", () => {
     const out = messageText({ foo: 1, bar: 2 });
     expect(out).not.toBe("[object Object]");

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -3,7 +3,7 @@
 // (issues #176, #175).
 
 import { describe, expect, it } from "vitest";
-import { errorText, promptText } from "./error-text.js";
+import { errorText, messageText, promptText } from "./error-text.js";
 
 describe("errorText (#176)", () => {
   it("returns the message of an Error", () => {
@@ -137,5 +137,64 @@ describe("promptText (#175)", () => {
     }).not.toThrow();
     expect(out).not.toBe("");
     expect(out).not.toBe("[object Object]");
+  });
+});
+
+describe("messageText (#421, #422)", () => {
+  it("passes a plain string reply through unchanged", () => {
+    expect(messageText("Done — 4 images rendered.")).toBe("Done — 4 images rendered.");
+  });
+
+  it("extracts readable text from a structured object payload", () => {
+    const out = messageText({ text: "the run finished" });
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe("the run finished");
+  });
+
+  it("joins array-of-parts structured content", () => {
+    const out = messageText([
+      { type: "text", text: "hello " },
+      { type: "text", text: "world" },
+    ]);
+    expect(out).toBe("hello world");
+  });
+
+  it("reaches into content/value/output_text/message keys", () => {
+    expect(messageText({ content: "via content" })).toBe("via content");
+    expect(messageText({ output_text: "via output_text" })).toBe("via output_text");
+    expect(messageText({ message: { text: "nested" } })).toBe("nested");
+  });
+
+  it("treats the literal [object Object] sentinel as empty (not real content)", () => {
+    expect(messageText("[object Object]")).toBe("");
+  });
+
+  it("returns '' (never [object Object]) for an unreadable object so callers can fall back", () => {
+    const out = messageText({ foo: 1, bar: 2 });
+    expect(out).not.toBe("[object Object]");
+    expect(out).toBe("");
+  });
+
+  it("does not throw and returns '' for a throwing getter", () => {
+    const hostile = {
+      get text(): string {
+        throw new Error("boom");
+      },
+    };
+    let out = "";
+    expect(() => {
+      out = messageText(hostile);
+    }).not.toThrow();
+    expect(out).not.toBe("[object Object]");
+  });
+
+  it("does not recurse forever on a cyclic payload", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.text = cyclic;
+    let out = "";
+    expect(() => {
+      out = messageText(cyclic);
+    }).not.toThrow();
+    expect(out).toBe("");
   });
 });

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -91,3 +91,60 @@ export function promptText(value: unknown): string {
     return "";
   }
 }
+
+/**
+ * Coerce an assistant/agent-message payload into readable display text.
+ *
+ * A provider's run-finished commit (e.g. Codex app-server `item/completed` for an
+ * `agentMessage`) is normally `{ text: "…" }` with a string `text`, but newer
+ * structured content can nest the reply as an array of parts or an object under
+ * `text` / `content` / `value` / `output_text` / `message`. Blindly coercing that
+ * with `String()` yields the literal "[object Object]", which then OVERWRITES the
+ * already-streamed reply in the sidebar (#421, #422 — the orchestrator-side
+ * sibling of the WS-9 panel cluster).
+ *
+ * Recursively extract the first readable string, joining array parts. Return ""
+ * (never "[object Object]") when nothing readable is found, so callers can detect
+ * the empty/malformed case and fall back to their buffered stream text instead of
+ * clobbering it. Every property read runs inside try/catch — a value may be a
+ * Proxy or carry a throwing getter, and normalization must never itself throw.
+ */
+export function messageText(value: unknown): string {
+  return coerceMessageText(value, 0);
+}
+
+const MESSAGE_TEXT_KEYS = ["text", "content", "value", "output_text", "message"] as const;
+
+function coerceMessageText(value: unknown, depth: number): string {
+  if (typeof value === "string") {
+    // The literal sentinel is never real content — treat it as empty so the
+    // caller falls back to the streamed text rather than displaying it.
+    return value === "[object Object]" ? "" : value;
+  }
+  if (value == null) return "";
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (depth > 6) return ""; // defend against adversarial / cyclic nesting
+  if (Array.isArray(value)) {
+    const parts: string[] = [];
+    for (const part of value) {
+      const t = coerceMessageText(part, depth + 1);
+      if (t) parts.push(t);
+    }
+    return parts.join("");
+  }
+  if (typeof value === "object") {
+    for (const key of MESSAGE_TEXT_KEYS) {
+      let inner: unknown;
+      try {
+        inner = (value as Record<string, unknown>)[key];
+      } catch {
+        continue; // throwing getter/proxy — try the next candidate key
+      }
+      if (inner == null) continue;
+      const t = coerceMessageText(inner, depth + 1);
+      if (t) return t;
+    }
+    return "";
+  }
+  return "";
+}

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -117,34 +117,45 @@ const MESSAGE_TEXT_KEYS = ["text", "content", "value", "output_text", "message"]
 
 function coerceMessageText(value: unknown, depth: number): string {
   if (typeof value === "string") {
-    // The literal sentinel is never real content — treat it as empty so the
-    // caller falls back to the streamed text rather than displaying it.
-    return value === "[object Object]" ? "" : value;
+    // Judge EMPTINESS on the trimmed form: whitespace-only text and a padded
+    // sentinel (e.g. " [object Object] ") are both non-content and must fall
+    // through so a real sibling key (content/value/…) or the streamed fallback
+    // wins — but return the ORIGINAL string (preserving spacing) for genuine text.
+    const trimmed = value.trim();
+    if (trimmed === "" || trimmed === "[object Object]") return "";
+    return value;
   }
   if (value == null) return "";
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   if (depth > 6) return ""; // defend against adversarial / cyclic nesting
-  if (Array.isArray(value)) {
-    const parts: string[] = [];
-    for (const part of value) {
-      const t = coerceMessageText(part, depth + 1);
-      if (t) parts.push(t);
-    }
-    return parts.join("");
-  }
-  if (typeof value === "object") {
-    for (const key of MESSAGE_TEXT_KEYS) {
-      let inner: unknown;
-      try {
-        inner = (value as Record<string, unknown>)[key];
-      } catch {
-        continue; // throwing getter/proxy — try the next candidate key
+  // Wrap ALL structural inspection (Array.isArray + every property read) in one
+  // try/catch: a revoked/hostile Proxy can throw on the type check itself, and
+  // normalization must degrade to "" rather than propagate the throw.
+  try {
+    if (Array.isArray(value)) {
+      const parts: string[] = [];
+      for (const part of value) {
+        const t = coerceMessageText(part, depth + 1);
+        if (t) parts.push(t);
       }
-      if (inner == null) continue;
-      const t = coerceMessageText(inner, depth + 1);
-      if (t) return t;
+      return parts.join("");
     }
-    return "";
+    if (typeof value === "object") {
+      for (const key of MESSAGE_TEXT_KEYS) {
+        let inner: unknown;
+        try {
+          inner = (value as Record<string, unknown>)[key];
+        } catch {
+          continue; // throwing getter/proxy on this key — try the next candidate
+        }
+        if (inner == null) continue;
+        const t = coerceMessageText(inner, depth + 1);
+        if (t) return t;
+      }
+      return "";
+    }
+  } catch {
+    return ""; // revoked Proxy / hostile trap — never propagate
   }
   return "";
 }


### PR DESCRIPTION
## Root cause
The Codex app-server `item/completed` commit for a finished `agentMessage` assumed a string `text` and used `((item.text) ?? "").trim()`. Newer app-server builds send structured content (arrays/objects). `String()`-coercing that yields the literal `[object Object]`, and because the commit is authoritative it OVERWROTE the already-streamed reply the user saw. This is the orchestrator-side sibling of the WS-9 `[object Object]` cluster (panel side fixed in 0.11.7 via `coerceMessageText`).

## Fix
- **`src/orchestrator/error-text.ts`** — new shared `messageText()` serializer alongside `errorText`/`promptText`. Recursively extracts readable text from string / array-of-parts / object payloads (keys `text`, `content`, `value`, `output_text`, `message`), rejects the literal `[object Object]` sentinel, and returns `""` for unreadable payloads so callers can detect the empty case. Depth-guarded and try/catch around every property read (Proxy / throwing getter safe).
- **`src/orchestrator/codex-backend.ts`** — route the `item/completed` agentMessage text through `messageText()`; accumulate streamed `assistant_delta` text into a buffer and fall back to it when the final commit coerces to empty, so a malformed commit no longer clobbers the good streamed reply. Buffer resets after each commit.

`src/orchestrator/index.ts` was **not** modified — the fix lives entirely in the backend + shared helper.

## Tests
- `error-text.test.ts`: `messageText` unit coverage (structured → readable text, array join, alt keys, `[object Object]` → `""`, unreadable → `""`, throwing getter, cyclic).
- `codex-callback-serialize.test.ts` (new): drives the notification handler — structured payload commits as readable text; an empty/malformed final commit does NOT overwrite the streamed reply; plain-string commit unchanged.

`tsc --noEmit` clean. Full `npm test` green except the known-flaky `node-dev` ripgrep-vs-builtin engine test (pre-existing, allowed). No version bump.

Closes #421, #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
