### PR TITLE
fix(packs): Krea 2 manifest — drop ComfyUI-Manager dep + correct UNET mapping (#441 #407)

### DIFF
--- a/packs/krea2-combo/install-runpod.sh
+++ b/packs/krea2-combo/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/krea2-combo/install-windows.bat
+++ b/packs/krea2-combo/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/krea2-combo/manifest.yaml
+++ b/packs/krea2-combo/manifest.yaml
@@ -9,7 +9,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy            # Power Lora Loader / Any Switch
   - https://github.com/kijai/ComfyUI-KJNodes            # Set/Get bus, Ideogram4PromptBuilderKJ, ImageSharpenKJ, INTConstant
   - https://github.com/cubiq/ComfyUI_essentials         # ImageResize+ (two-pass roundtrip resize)

--- a/packs/krea2-txt2img-json/install-runpod.sh
+++ b/packs/krea2-txt2img-json/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI-Krea2T-Enhancer" "https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"

--- a/packs/krea2-txt2img-json/install-windows.bat
+++ b/packs/krea2-txt2img-json/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI-Krea2T-Enhancer" "https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"

--- a/packs/krea2-txt2img-json/manifest.yaml
+++ b/packs/krea2-txt2img-json/manifest.yaml
@@ -9,7 +9,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy            # Power Lora Loader / Any Switch
   - https://github.com/kijai/ComfyUI-KJNodes            # Set/Get bus, Ideogram4PromptBuilderKJ, ImageSharpenKJ
   - https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer            # Krea2T-Enhancer — V2 model detail-boost patch (ships ACTIVE)

--- a/packs/krea2-txt2img-manual/install-runpod.sh
+++ b/packs/krea2-txt2img-manual/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI-Krea2T-Enhancer" "https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"

--- a/packs/krea2-txt2img-manual/install-windows.bat
+++ b/packs/krea2-txt2img-manual/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI-Krea2T-Enhancer" "https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer"

--- a/packs/krea2-txt2img-manual/manifest.yaml
+++ b/packs/krea2-txt2img-manual/manifest.yaml
@@ -8,7 +8,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy            # Power Lora Loader / Any Switch
   - https://github.com/kijai/ComfyUI-KJNodes            # Set/Get bus, ImageSharpenKJ
   - https://github.com/capitan01R/ComfyUI-Krea2T-Enhancer            # Krea2T-Enhancer — V2 model detail-boost patch (ships ACTIVE)


### PR DESCRIPTION
## Summary
Fixes two Krea 2 pack-manifest issues.

### #441 — Remove ComfyUI-Manager from Krea 2 pack dependencies
`ComfyUI-Manager` was listed under `custom_nodes:` in the Krea 2 manifests. `apply_manifest` then cloned a duplicate `custom_nodes/ComfyUI-Manager` on Desktop installs where Manager is already infrastructure, causing install churn / restart conflicts. Removed the dep from all three Krea 2 packs and regenerated their installers:
- `krea2-txt2img-manual`
- `krea2-combo`
- `krea2-txt2img-json`

### #407 — UNET resolves to Flux 2 Klein
Root cause is **not** in pack data. The manifest, `workflow.json` (node 54 `UNETLoader`), and `pack.yaml` all already correctly reference `krea2_turbo_fp8.safetensors`. `flux-2-klein-9b.safetensors` appears nowhere in the repo.

The substitution happens at runtime in the orchestrator: `convertUiToApi` (`src/services/workflow-converter.ts`) applies a "classic combo widget" stale-value fallback — when a `unet_name` isn't present in the connected server's live `/object_info` model list, it is overwritten with `comboOpts[0]` (the first installed UNET, which on the reporter's box is `flux-2-klein-9b.safetensors`). That is orchestrator behavior, out of scope for a pack-manifest fix.

**Correct-UNET target: determinable and already correct** — `krea2_turbo_fp8.safetensors`. No pack-data change was needed for #407; a proper fix belongs in `convertUiToApi` (a separate orchestrator PR).

## Note / follow-up
`ComfyUI-Manager` is declared the same way in ~50 other bundled pack manifests. This PR only touches the Krea 2 family (issue scope). A follow-up sweep (or having `apply_manifest` recognize an already-functional Manager) is recommended.

## Validation
- `npm run build` (tsc) — clean
- `npm run packs:validate` — all OK (krea2 packs: OK)
- `npm run packs:check-models` — krea2 packs "no live gaps"; the 7 FAILs are pre-existing in `z-image-xy-plot`, untouched here
- `npm test` — 2131 passed; only failure is the known-allowed `node-dev` ripgrep test (`builtin` vs `ripgrep`)

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)