### PR TITLE
release: 0.48.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.11] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- the codex run-finished callback serializes a structured final-commit payload to readable text instead of `[object Object]`, and no longer overwrites the already-streamed reply when the final commit is empty/malformed (falls back to the streamed text) (#421 #422) (#443)
+- Krea 2 packs no longer declare ComfyUI-Manager as a custom-node dependency, so apply_manifest stops cloning a duplicate ComfyUI-Manager on Desktop installs where it's already present (#441) (#445)
+
+
 ## [0.48.10] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.10",
+  "version": "0.48.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.10",
+      "version": "0.48.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.10",
+  "version": "0.48.11",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.11 (tag pushed → npm publish). Two fixes: codex run-finished callback serializes structured payloads + won't clobber the streamed reply (#421/#422/#443); Krea 2 packs drop the ComfyUI-Manager dep (#441/#445). 🤖 Generated with Claude Code