### PR TITLE
fix(comfy-cli): idle-timeout downloads so live progress isn't killed at 60s (#417)

### DIFF
--- a/src/__tests__/services/comfy-cli.test.ts
+++ b/src/__tests__/services/comfy-cli.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   assertComfyCliOk,
+  awaitProcessWithIdleTimeout,
   isSupportedComfyCliVersion,
   normalizeComfyCliResult,
   parseComfyCliEnvelope,
@@ -103,6 +105,98 @@ describe("comfy-cli adapter", () => {
     expect(shouldUseComfyCli(undefined, false, "/bin/comfy", "1.11.1")).toBe(false);
     expect(shouldUseComfyCli(true, false, null, null)).toBe(true);
     expect(shouldUseComfyCli(false, true, "/bin/comfy", "1.11.1")).toBe(false);
+  });
+
+  it("treats download progress output as liveness and does NOT kill a long-but-live download", async () => {
+    vi.useFakeTimers();
+    try {
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      let killed = false;
+      const child = {
+        stdout,
+        stderr,
+        on(event: string, listener: (arg: unknown) => void) {
+          proc.on(event, listener);
+          return this;
+        },
+        kill() {
+          killed = true;
+          // A real SIGTERM ends the process; emit close so the promise settles.
+          proc.emit("close", null);
+          return true;
+        },
+      };
+      const proc = new EventEmitter();
+
+      const IDLE = 120_000;
+      const promise = awaitProcessWithIdleTimeout(child, IDLE);
+
+      // comfy-cli emits ONLY the "Start downloading" progress line, then keeps
+      // emitting progress every 90s (< idle window) across a 450s download —
+      // far longer than the old 60s hard wall-clock timeout.
+      stderr.emit("data", "Start downloading URL ... into E:\\ComfyUI\\models\\text_encoders\\model.safetensors\n");
+      for (let elapsed = 90_000; elapsed <= 450_000; elapsed += 90_000) {
+        await vi.advanceTimersByTimeAsync(90_000);
+        expect(killed).toBe(false); // never killed while progressing
+        stderr.emit("data", `progress ${elapsed / 1000}s\n`);
+      }
+      // Download finishes: emit the final JSON envelope on stdout, then close.
+      stdout.emit(
+        "data",
+        '{"schema":"envelope/1","type":"envelope","ok":true,"command":"model download","version":"1.12.0","where":"local","data":{"path":"model.safetensors"},"error":null}\n',
+      );
+      proc.emit("close", 0);
+
+      const result = await promise;
+      expect(killed).toBe(false);
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+
+      const envelope = parseComfyCliEnvelope(result.stdout);
+      expect(envelope.ok).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still terminates a TRULY idle/stalled download after the idle window elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const stdout = new EventEmitter();
+      const stderr = new EventEmitter();
+      const proc = new EventEmitter();
+      let killed = false;
+      const child = {
+        stdout,
+        stderr,
+        on(event: string, listener: (arg: unknown) => void) {
+          proc.on(event, listener);
+          return this;
+        },
+        kill() {
+          killed = true;
+          proc.emit("close", null);
+          return true;
+        },
+      };
+
+      const IDLE = 120_000;
+      const promise = awaitProcessWithIdleTimeout(child, IDLE);
+
+      // Same progress-only stderr as the real bug report, then goes silent.
+      stderr.emit("data", "Start downloading URL ... into E:\\ComfyUI\\models\\text_encoders\\model.safetensors\n");
+      await vi.advanceTimersByTimeAsync(IDLE - 1);
+      expect(killed).toBe(false); // not yet
+      await vi.advanceTimersByTimeAsync(2);
+
+      const result = await promise;
+      expect(killed).toBe(true);
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects Windows command shims that execFile cannot launch directly", () => {

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -25,8 +25,88 @@ export interface ComfyCliRunOptions {
   workspace?: string | null;
   where?: "local" | "cloud";
   timeoutMs?: number;
+  /**
+   * Idle (liveness) timeout in milliseconds. When set, the process is only
+   * killed if it produces NO stdout/stderr output for this long — each chunk
+   * of output (e.g. a downloader progress line) resets the clock. This lets a
+   * long-but-live download run to completion while still terminating a truly
+   * stalled one. Takes precedence over `timeoutMs` when both are provided.
+   */
+  idleTimeoutMs?: number;
   env?: NodeJS.ProcessEnv;
   cwd?: string;
+}
+
+/** Minimal shape of the child process we consume; keeps this testable. */
+export interface IdleTimeoutChild {
+  stdout: NodeJS.EventEmitter | null;
+  stderr: NodeJS.EventEmitter | null;
+  on(event: "error", listener: (error: Error) => void): unknown;
+  on(event: "close", listener: (code: number | null) => void): unknown;
+  kill(signal?: NodeJS.Signals): unknown;
+}
+
+export interface IdleTimeoutResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+/**
+ * Await a spawned child process, killing it only after `idleTimeoutMs` elapses
+ * with no output on either stream. Any stdout/stderr chunk is treated as
+ * liveness and resets the idle timer. Exported for direct testing.
+ */
+export function awaitProcessWithIdleTimeout(
+  child: IdleTimeoutChild,
+  idleTimeoutMs: number,
+  timers: { setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout } = { setTimeout, clearTimeout },
+): Promise<IdleTimeoutResult> {
+  return new Promise<IdleTimeoutResult>((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearIdle = () => {
+      if (idleTimer) {
+        timers.clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+    };
+    const armIdle = () => {
+      clearIdle();
+      idleTimer = timers.setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, idleTimeoutMs);
+    };
+
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+      armIdle();
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+      armIdle();
+    });
+    child.on("error", (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearIdle();
+      reject(error);
+    });
+    child.on("close", (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearIdle();
+      resolve({ stdout, stderr, exitCode: timedOut ? 1 : code ?? 0, timedOut });
+    });
+
+    armIdle();
+  });
 }
 
 const MIN_COMFY_CLI_VERSION = [1, 11, 1] as const;
@@ -219,6 +299,41 @@ export async function runComfyCli<T = unknown>(args: readonly string[], options:
     return unsupportedVersionEnvelope<T>(args, options, detectedVersion);
   }
   const version = detectedVersion!;
+  if (options.idleTimeoutMs != null) {
+    try {
+      const child = childProcess.spawn(executable, buildArgs(args, options), {
+        windowsHide: true,
+        env: { ...process.env, PYTHONUTF8: "1", ...options.env },
+        cwd: options.cwd,
+      });
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      const result = await awaitProcessWithIdleTimeout(child, options.idleTimeoutMs);
+      if (result.timedOut) {
+        return {
+          schema: "envelope/1",
+          type: "envelope",
+          ok: false,
+          command: args.join(" "),
+          version,
+          where: options.where ?? null,
+          data: null,
+          error: {
+            code: "idle_timeout",
+            message:
+              `comfy-cli produced no output for ${Math.round(options.idleTimeoutMs / 1000)}s and was terminated as stalled.`,
+            hint: "The download appears stuck. Check network connectivity and the source URL, then retry.",
+            details: { stdout: result.stdout.trim(), stderr: result.stderr.trim() },
+          },
+        };
+      }
+      return normalizeComfyCliResult<T>(args, options, result, version);
+    } catch (error) {
+      const spawnError = error as Error & { code?: string };
+      if (spawnError.code === "ENOENT") throw error;
+      return normalizeComfyCliResult<T>(args, options, { stdout: "", stderr: spawnError.message, exitCode: 1 }, version);
+    }
+  }
   try {
     const result = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
       childProcess.execFile(

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -19,7 +19,7 @@ function textEnvelope(envelope: unknown) {
   };
 }
 
-async function call(args: string[], options: { workspace?: string; where?: "local" | "cloud"; timeoutMs?: number; cwd?: string }) {
+async function call(args: string[], options: { workspace?: string; where?: "local" | "cloud"; timeoutMs?: number; idleTimeoutMs?: number; cwd?: string }) {
   return textEnvelope(await runComfyCli(args, options));
 }
 
@@ -252,6 +252,13 @@ export function registerComfyCliTools(server: McpServer): void {
           command.push("--model-names", args.modelNames.join(" "));
         }
         if (args.limit && args.action !== "show" && args.action !== "list-folders") command.push("--limit", String(args.limit));
+        // A download can legitimately run for many minutes. Gate it on an IDLE
+        // (liveness) timeout so a still-progressing download is not killed —
+        // downloader progress output resets the clock — while a truly stalled
+        // one is still terminated. Other actions keep the fast hard timeout.
+        if (args.action === "download") {
+          return await call(command, { workspace: args.workspace, where: args.where, idleTimeoutMs: 120_000 });
+        }
         return await call(command, { workspace: args.workspace, where: args.where, timeoutMs: 60_000 });
       } catch (error) {
         return errorToToolResult(error);


### PR DESCRIPTION
Fixes #417.

## Problem
`comfy_cli_models(action=download)` ran under a fixed **60s wall-clock** timeout. A legitimately-progressing download whose only stderr was the normal `Start downloading URL ... into ...` progress line was killed at 60s and mapped to `legacy_command_failed` with no actionable reason.

## Fix
Downloads now use an **idle (liveness) timeout** instead of a hard wall-clock one:
- `runComfyCli` gains an `idleTimeoutMs` option. When set, it `spawn`s the process and resets the idle timer on every stdout/stderr chunk — progress output counts as liveness.
- A long-but-live download runs to completion; a truly idle/stalled one is still terminated after the idle window (120s), surfaced as a distinct `idle_timeout` error rather than a bogus `legacy_command_failed`.
- Non-download actions keep the fast 60s hard timeout.

The core wiring is extracted into `awaitProcessWithIdleTimeout` (injectable timers) so it can be unit-tested deterministically.

## Test
Two fake-timer tests model the real runtime shape (progress-only stderr, exactly the bug's stream):
- a 450s download emitting periodic progress is **never killed** and finishes ok;
- a progress-then-silent download **is** killed right after the 120s idle window (`timedOut`, exit 1).

Build green; full suite green except the pre-existing node-dev ripgrep failure.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)