### PR TITLE
fix(converter): don't silently swap an unavailable model for the first installed one (#407)

### DIFF
--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -316,3 +316,89 @@ describe("convertUiToApi — serialized-widget nodes (has_serialized_properties)
     expect(inputs.frame_rate).not.toBe(24);
   });
 });
+
+describe("convertUiToApi — asset-combo fallback (issue #407)", () => {
+  // Real Krea 2 manual-pack shape: node 54 is a UNETLoader whose saved
+  // unet_name is the advertised Krea Turbo model, but the CONNECTED server only
+  // has flux-2-klein installed. object_info's combo therefore lists the wrong
+  // files. Previously comboOpts[0] silently rewrote unet_name to the first
+  // installed model, producing a misleading "success".
+  const KREA_INFO = {
+    UNETLoader: {
+      input: {
+        required: {
+          unet_name: [
+            ["flux-2-klein-9b.safetensors", "some-other-unet.safetensors"],
+          ],
+          weight_dtype: [["default", "fp8_e4m3fn"]],
+        },
+      },
+    },
+    KSampler: {
+      input: {
+        required: {
+          model: ["MODEL"],
+          sampler_name: [["euler", "dpmpp_2m", "heun"]],
+          steps: ["INT"],
+        },
+      },
+    },
+  } as never;
+
+  function kreaGraph(unetName: string) {
+    return {
+      nodes: [
+        {
+          id: 54,
+          type: "UNETLoader",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [10] }],
+          widgets_values: [unetName, "fp8_e4m3fn"],
+        },
+        {
+          id: 60,
+          type: "KSampler",
+          mode: 0,
+          inputs: [{ name: "model", type: "MODEL", link: 10 }],
+          outputs: [],
+          // sampler_name "euler" is valid; a stale value must still fall back.
+          widgets_values: ["euler", 20],
+        },
+      ],
+      links: [[10, 54, 0, 60, 0, "MODEL"]],
+    } as never;
+  }
+
+  it("keeps the declared model name when it is not installed, instead of substituting the first installed model", () => {
+    const declared = "krea2_turbo_fp8.safetensors";
+    const { workflow, warnings } = convertUiToApi(kreaGraph(declared), KREA_INFO);
+    // The declared model survives — NOT rewritten to flux-2-klein-9b.
+    expect(workflow["54"].inputs.unet_name).toBe(declared);
+    expect(workflow["54"].inputs.unet_name).not.toBe("flux-2-klein-9b.safetensors");
+    // …and the substitution is flagged so it surfaces as a real missing-asset error.
+    expect(
+      warnings.some(
+        (w) => w.includes("54") && w.includes(declared) && /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("still falls back for a non-asset enum combo (stale UI-helper value)", () => {
+    // A KSampler.sampler_name of a value not in the list is a plain enum, not a
+    // file — the harmless first-option fallback must still apply.
+    const graph = kreaGraph("flux-2-klein-9b.safetensors");
+    graph.nodes[1].widgets_values = ["totally_not_a_sampler", 20];
+    const { workflow } = convertUiToApi(graph, KREA_INFO);
+    expect(workflow["60"].inputs.sampler_name).toBe("euler"); // first option
+  });
+
+  it("does not warn or alter a valid installed model", () => {
+    const { workflow, warnings } = convertUiToApi(
+      kreaGraph("flux-2-klein-9b.safetensors"),
+      KREA_INFO,
+    );
+    expect(workflow["54"].inputs.unet_name).toBe("flux-2-klein-9b.safetensors");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -401,4 +401,58 @@ describe("convertUiToApi — asset-combo fallback (issue #407)", () => {
     expect(workflow["54"].inputs.unet_name).toBe("flux-2-klein-9b.safetensors");
     expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
   });
+
+  it("keeps the declared value for an EXTENSIONLESS asset combo (DiffusersLoader.model_path)", () => {
+    // DiffusersLoader lists extensionless directory names — no file extension to
+    // key off, so detection must fall back to the asset-widget-name allowlist.
+    const info = {
+      DiffusersLoader: {
+        input: {
+          required: {
+            model_path: [["installed-diffusers-dir", "another-dir"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "DiffusersLoader",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["krea-turbo-diffusers"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.model_path).toBe("krea-turbo-diffusers");
+    expect(workflow["1"].inputs.model_path).not.toBe("installed-diffusers-dir");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("keeps the declared value for a .pt2 checkpoint (extension coverage)", () => {
+    const info = {
+      CheckpointLoaderSimple: {
+        input: { required: { ckpt_name: [["installed.pt2", "other.pt2"]] } },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "CheckpointLoaderSimple",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["not-installed.pt2"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.ckpt_name).toBe("not-installed.pt2");
+  });
 });

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -91,11 +91,39 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
  * to the first option is harmless.
  */
 const ASSET_FILE_RE =
-  /\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx|vae|pkl|npz|safetensor)$/i;
+  /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml)$/i;
 
 function looksLikeAssetFilename(value: unknown): boolean {
   return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
 }
+
+/**
+ * Widget names that are ALWAYS server-side asset selectors, even when their
+ * options carry no file extension (e.g. DiffusersLoader.model_path lists
+ * extensionless directory names). Substituting a different entry here silently
+ * swaps the user's model, so these must never take the comboOpts[0] fallback.
+ * Deliberately excludes enum-shaped "_name" widgets (sampler_name, scheduler)
+ * whose first-option fallback is legitimate.
+ */
+const ASSET_WIDGET_NAMES = new Set([
+  "ckpt_name",
+  "unet_name",
+  "vae_name",
+  "lora_name",
+  "clip_name",
+  "clip_name1",
+  "clip_name2",
+  "clip_name3",
+  "clip_name4",
+  "control_net_name",
+  "controlnet_name",
+  "style_model_name",
+  "gligen_name",
+  "hypernetwork_name",
+  "clip_vision_name",
+  "model_path",
+  "diffusion_model",
+]);
 
 /**
  * Check if an input has control_after_generate in its spec config.
@@ -1247,6 +1275,7 @@ export function convertUiToApi(
         !comboOpts.includes(value as never)
       ) {
         const isAssetCombo =
+          ASSET_WIDGET_NAMES.has(name) ||
           looksLikeAssetFilename(value) ||
           comboOpts.some((opt) => looksLikeAssetFilename(opt));
         if (isAssetCombo) {

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -83,6 +83,21 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
 }
 
 /**
+ * Model/asset file extensions that appear in ComfyUI loader combos
+ * (unet_name, ckpt_name, vae_name, lora_name, control_net_name, clip_name, …).
+ * Used to distinguish an asset-selection combo — where substituting a different
+ * installed file silently swaps the user's model — from a plain enum combo
+ * (sampler_name, a stale "Select to add Wildcard" UI helper) where falling back
+ * to the first option is harmless.
+ */
+const ASSET_FILE_RE =
+  /\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx|vae|pkl|npz|safetensor)$/i;
+
+function looksLikeAssetFilename(value: unknown): boolean {
+  return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
+}
+
+/**
  * Check if an input has control_after_generate in its spec config.
  * These inputs (like seed, noise_seed) have a phantom "fixed"/"randomize" widget
  * in the UI's widgets_values array that doesn't correspond to any named input.
@@ -1215,13 +1230,37 @@ export function convertUiToApi(
       // value from a node version with different options), fall back to the
       // default first option. ComfyUI hard-rejects "Value not in list" otherwise,
       // so defaulting is strictly safer than passing the stale value through.
+      //
+      // EXCEPTION (issue #407): an ASSET-selection combo (unet_name, ckpt_name,
+      // vae_name, lora_name, …) lists the files installed on the *connected*
+      // server. When the declared model isn't installed there, comboOpts[0] is a
+      // completely unrelated model — e.g. Krea 2's "krea2_turbo_fp8.safetensors"
+      // silently became "flux-2-klein-9b.safetensors" (the first installed unet).
+      // Silently swapping one model for another produces a misleading graph that
+      // can't render the advertised workflow. For asset combos we KEEP the
+      // declared value and warn, so it surfaces as an honest missing-asset error
+      // instead of a wrong-model success.
       const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
       if (
         Array.isArray(comboOpts) &&
         comboOpts.length > 0 &&
         !comboOpts.includes(value as never)
       ) {
-        inputs[name] = comboOpts[0];
+        const isAssetCombo =
+          looksLikeAssetFilename(value) ||
+          comboOpts.some((opt) => looksLikeAssetFilename(opt));
+        if (isAssetCombo) {
+          warnings.push(
+            `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+              value,
+            )}" is not installed on the connected server — keeping the declared value so it surfaces as a missing-asset error rather than silently substituting "${String(
+              comboOpts[0],
+            )}".`,
+          );
+          // inputs[name] already holds the declared value; leave it untouched.
+        } else {
+          inputs[name] = comboOpts[0];
+        }
       }
 
       const opts = (


### PR DESCRIPTION
## Problem (#407)

`convertUiToApi` falls back to `comboOpts[0]` when a combo widget's saved value isn't present in the connected server's `/object_info`. That fallback is correct for stale UI-helper enums (Impact's "Select to add Wildcard"), but for **asset combos** (`unet_name`, `ckpt_name`, `vae_name`, `lora_name`, …) it silently rewrites the declared model to an unrelated installed file.

Concretely: Krea 2's `krea2_turbo_fp8.safetensors` became `flux-2-klein-9b.safetensors` (the first installed unet), so `panel_strip_workflow(pack:"krea2-txt2img-manual")` returned a misleading graph that can't produce the advertised workflow. Same silent-combo-change class as #240.

## Fix

Distinguish asset combos (value or options look like model filenames — `.safetensors/.ckpt/.gguf/…`) from plain enum combos. For asset combos, **keep the declared value** and push a warning so an uninstalled model surfaces as an honest missing-asset error instead of a wrong-model "success". Enum combos still fall back to the first option unchanged.

## Test

`workflow-converter.test.ts` gains a suite modeling the real Krea 2 UNETLoader runtime shape (node 54, connected server only has flux-2-klein):
- uninstalled model name is preserved + warned (fails before, passes after)
- non-asset enum (sampler_name) still falls back
- valid installed model is untouched and unwarned

Build green; full suite green except the pre-existing node-dev ripgrep-vs-builtin failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)