### PR TITLE
fix(audio): update ace_step_15 template to current nodes_ace schema (#448)

### DIFF
--- a/src/__tests__/services/generate-audio.test.ts
+++ b/src/__tests__/services/generate-audio.test.ts
@@ -78,25 +78,35 @@ describe("generateAudio", () => {
           prompt: "ambient pads",
           duration: 60,
           unet: "acestep_v1.5_xl_sft_bf16.safetensors",
+          musical_key: "E minor",
+          guidance_scale: 3.5,
         },
         deps,
       );
-      const wf = enqueued[0];
+      // Round-trip through JSON: ComfyUI receives the serialized graph, and any
+      // `undefined` input silently disappears on serialization — which is
+      // exactly the "Required input is missing" failure mode of #448. Asserting
+      // on the post-serialization object catches present-but-undefined fields.
+      const wf = JSON.parse(JSON.stringify(enqueued[0])) as WorkflowJSON;
 
       // 1. UNETLoader takes `unet_name`, never `ckpt_name`.
       const unetLoader = byClass(wf, "UNETLoader");
       expect(unetLoader?.inputs.unet_name).toBe("acestep_v1.5_xl_sft_bf16.safetensors");
       expect(unetLoader?.inputs).not.toHaveProperty("ckpt_name");
 
-      // 2. TextEncodeAceStepAudio1.5 must supply all required inputs and must
-      //    not carry the retired `text`/`cfg`/`key` names.
+      // 2. TextEncodeAceStepAudio1.5 must supply all required inputs (each with
+      //    a defined, serializable value) and must not carry the retired
+      //    `text`/`cfg`/`key` names.
       const enc = byClass(wf, "TextEncodeAceStepAudio1.5");
       expect(enc).toBeDefined();
       for (const req of [
         "tags",
         "lyrics",
+        "seed",
         "bpm",
+        "duration",
         "timesignature",
+        "language",
         "keyscale",
         "generate_audio_codes",
         "cfg_scale",
@@ -105,12 +115,23 @@ describe("generateAudio", () => {
         "top_k",
         "min_p",
       ]) {
-        expect(enc?.inputs, `encoder missing required input: ${req}`).toHaveProperty(req);
+        // After the JSON round-trip an `undefined` value would have been
+        // dropped, so hasOwnProperty here proves the field is really present.
+        expect(
+          Object.prototype.hasOwnProperty.call(enc?.inputs ?? {}, req),
+          `encoder missing required input: ${req}`,
+        ).toBe(true);
+        expect(enc?.inputs[req], `encoder input ${req} is undefined`).not.toBeUndefined();
       }
       expect(enc?.inputs).not.toHaveProperty("text");
       expect(enc?.inputs).not.toHaveProperty("cfg");
       expect(enc?.inputs).not.toHaveProperty("key");
       expect(typeof enc?.inputs.generate_audio_codes).toBe("boolean");
+      // Concrete values / arg mappings.
+      expect(enc?.inputs.tags).toBe("ambient pads"); // prompt -> tags
+      expect(enc?.inputs.duration).toBe(60);
+      expect(enc?.inputs.keyscale).toBe("E minor"); // musical_key -> keyscale
+      expect(enc?.inputs.cfg_scale).toBe(3.5); // guidance_scale -> cfg_scale
 
       // 3. SaveAudioMP3 requires `quality`.
       const save = byClass(wf, "SaveAudioMP3");

--- a/src/__tests__/services/generate-audio.test.ts
+++ b/src/__tests__/services/generate-audio.test.ts
@@ -57,11 +57,65 @@ describe("generateAudio", () => {
       expect(enqueued).toHaveLength(1);
 
       const wf = enqueued[0];
-      expect(byClass(wf, "TextEncodeAceStepAudio1.5")?.inputs.text).toBe("lofi piano loop");
+      // The prompt is the ACE "tags" (style/description) input, not `text`.
+      expect(byClass(wf, "TextEncodeAceStepAudio1.5")?.inputs.tags).toBe("lofi piano loop");
       expect(byClass(wf, "EmptyAceStep1.5LatentAudio")?.inputs.seconds).toBe(30);
       // The decode/save tail must exist so the run produces a file.
       expect(byClass(wf, "VAEDecodeAudio")).toBeDefined();
       expect(byClass(wf, "SaveAudioMP3")).toBeDefined();
+    });
+
+    // Regression for #448: the built-in ace_step_15 template used stale node
+    // schemas (ckpt_name instead of unet_name, `text`/`cfg` on the encoder,
+    // no `quality` on SaveAudioMP3) and omitted 9 required encoder inputs, so
+    // ComfyUI rejected every generated graph with "Required input is missing".
+    // This asserts the exact runtime contract of comfy_extras.nodes_ace.
+    it("emits every required input for the current comfy_extras.nodes_ace schema (#448)", async () => {
+      const { deps, enqueued } = makeDeps();
+      await generateAudio(
+        {
+          model_family: "ace_step_1.5",
+          prompt: "ambient pads",
+          duration: 60,
+          unet: "acestep_v1.5_xl_sft_bf16.safetensors",
+        },
+        deps,
+      );
+      const wf = enqueued[0];
+
+      // 1. UNETLoader takes `unet_name`, never `ckpt_name`.
+      const unetLoader = byClass(wf, "UNETLoader");
+      expect(unetLoader?.inputs.unet_name).toBe("acestep_v1.5_xl_sft_bf16.safetensors");
+      expect(unetLoader?.inputs).not.toHaveProperty("ckpt_name");
+
+      // 2. TextEncodeAceStepAudio1.5 must supply all required inputs and must
+      //    not carry the retired `text`/`cfg`/`key` names.
+      const enc = byClass(wf, "TextEncodeAceStepAudio1.5");
+      expect(enc).toBeDefined();
+      for (const req of [
+        "tags",
+        "lyrics",
+        "bpm",
+        "timesignature",
+        "keyscale",
+        "generate_audio_codes",
+        "cfg_scale",
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+      ]) {
+        expect(enc?.inputs, `encoder missing required input: ${req}`).toHaveProperty(req);
+      }
+      expect(enc?.inputs).not.toHaveProperty("text");
+      expect(enc?.inputs).not.toHaveProperty("cfg");
+      expect(enc?.inputs).not.toHaveProperty("key");
+      expect(typeof enc?.inputs.generate_audio_codes).toBe("boolean");
+
+      // 3. SaveAudioMP3 requires `quality`.
+      const save = byClass(wf, "SaveAudioMP3");
+      expect(save?.inputs.quality).toBeDefined();
+      expect(["V0", "128k", "320k"]).toContain(save?.inputs.quality);
     });
 
     it("auto-resolves UNet/VAE/CLIP from local models when not specified", async () => {

--- a/src/services/workflow-composer.ts
+++ b/src/services/workflow-composer.ts
@@ -621,6 +621,14 @@ interface AceStep15Txt2AudioParams {
   language?: string;
   musical_key?: string;
   guidance_scale?: number;
+  bpm?: number;
+  timesignature?: string;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  generate_audio_codes?: boolean;
+  audio_quality?: string;
   filename_prefix?: string;
 }
 
@@ -654,13 +662,23 @@ function buildAceStep15Txt2Audio(p: AceStep15Txt2AudioParams): WorkflowJSON {
   const shift = p.shift ?? 3;
   const language = p.language ?? "en";
   const key = p.musical_key ?? "C major";
-  const posCfg = p.guidance_scale ?? 0.85;
+  // `cfg_scale` on TextEncodeAceStepAudio1.5 defaults to 2 in the node schema;
+  // it is distinct from the sampler's `cfg` and from `temperature` (0.85).
+  const cfgScale = p.guidance_scale ?? 2;
+  const bpm = p.bpm ?? 120;
+  const timesignature = p.timesignature ?? "4";
+  const temperature = p.temperature ?? 0.85;
+  const topP = p.top_p ?? 0.9;
+  const topK = p.top_k ?? 0;
+  const minP = p.min_p ?? 0;
+  const generateAudioCodes = p.generate_audio_codes ?? true;
+  const audioQuality = p.audio_quality ?? "320k";
   const prefix = p.filename_prefix ?? "audio/ace_step";
 
   return {
     "1": {
       class_type: "UNETLoader",
-      inputs: { ckpt_name: unet, weight_dtype: "default" },
+      inputs: { unet_name: unet, weight_dtype: "default" },
     },
     "2": {
       class_type: "DualCLIPLoader",
@@ -686,13 +704,20 @@ function buildAceStep15Txt2Audio(p: AceStep15Txt2AudioParams): WorkflowJSON {
       class_type: "TextEncodeAceStepAudio1.5",
       inputs: {
         clip: conn("2", 0),
-        seed,
-        duration,
-        text: prompt,
+        tags: prompt,
         lyrics,
+        seed,
+        bpm,
+        duration,
+        timesignature,
         language,
-        key,
-        cfg: posCfg,
+        keyscale: key,
+        generate_audio_codes: generateAudioCodes,
+        cfg_scale: cfgScale,
+        temperature,
+        top_p: topP,
+        top_k: topK,
+        min_p: minP,
       },
     },
     "7": {
@@ -720,7 +745,7 @@ function buildAceStep15Txt2Audio(p: AceStep15Txt2AudioParams): WorkflowJSON {
     },
     "10": {
       class_type: "SaveAudioMP3",
-      inputs: { audio: conn("9", 0), filename_prefix: prefix },
+      inputs: { audio: conn("9", 0), filename_prefix: prefix, quality: audioQuality },
     },
   };
 }

--- a/src/tools/generate-audio.ts
+++ b/src/tools/generate-audio.ts
@@ -81,7 +81,9 @@ export function registerGenerateAudioTool(server: McpServer): void {
       guidance_scale: z
         .number()
         .optional()
-        .describe("Text encoder guidance scale (ACE only, default: 0.85)"),
+        .describe(
+          "TextEncodeAceStepAudio1.5 cfg_scale — text encoder guidance scale (ACE only, default: 2)",
+        ),
 
       // Stable Audio 3 specific
       checkpoint: z


### PR DESCRIPTION
Fixes #448.

## Problem
The built-in `ace_step_15` template (used by `create_workflow(template:"ace_step_15")` and `generate_audio(model_family:"ace_step_1.5")`) emitted stale node schemas that current ComfyUI rejects with `Required input is missing`.

## Fix
In `buildAceStep15Txt2Audio` (`src/services/workflow-composer.ts`):
- `UNETLoader`: `ckpt_name` -> `unet_name`
- `TextEncodeAceStepAudio1.5`: drop retired `text`/`cfg`/`key`; map prompt->`tags`, musical_key->`keyscale`, guidance_scale->`cfg_scale` (default 2); add `bpm`, `timesignature`, `temperature`, `top_p`, `top_k`, `min_p`, `generate_audio_codes`
- `SaveAudioMP3`: add required `quality` (default `320k`)

New params are optional with schema-matching defaults, so callers/DefaultsManager are unaffected.

## Test
Adds a regression test in `generate-audio.test.ts` that asserts the exact `comfy_extras.nodes_ace` contract (unet_name, all 11 encoder inputs present, retired names absent, SaveAudioMP3 quality). Confirmed it fails on old code and passes after. No version bump.

Full suite green except the pre-existing node-dev ripgrep-engine assertion.