### PR TITLE
fix(download): harden #343 resume + cloud/cache-hit integrity edges

### DIFF
--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -355,6 +355,26 @@ describe("downloadModel cache", () => {
     ).rejects.toThrow(/resume rejected/i);
   });
 
+  it("accepts a 206 whose Content-Range uses a mixed-case range unit (RFC 9110 §14.1) (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/mixedcase.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"mc-etag"');
+
+    // "Bytes" (capital B) is a legitimate, case-insensitive range unit.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "Bytes 4-7/8" },
+      }),
+    );
+
+    const target = await downloadModel(url, "checkpoints", "mixedcase-out.safetensors");
+    await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBB");
+  });
+
   it("refuses a SHORT 206 that does not run to the end of the file (RFC 9110 partial range) (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/short206.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -355,6 +355,30 @@ describe("downloadModel cache", () => {
     ).rejects.toThrow(/resume rejected/i);
   });
 
+  it("refuses a SHORT 206 that does not run to the end of the file (RFC 9110 partial range) (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/short206.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // resume offset = 4
+    await writeFile(sidecar, '"s2-etag"');
+
+    // 206 whose Content-Range says the file is 1000 bytes but only serves
+    // bytes 4-7 — appending 4 bytes and using content-length (4) as the target
+    // would finalize an 8-byte file as "complete" for a 1000-byte model.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/1000" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "short206-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
+    await expect(stat(partial)).rejects.toThrow();
+  });
+
   it("does NOT resume a validator-less partial — restarts cleanly instead of appending (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/novalidator.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -127,6 +127,9 @@ describe("downloadModel cache", () => {
     const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
     const partialPath = join(cacheDir, `.${hash}.safetensors.partial`);
     await writeFile(partialPath, "AAAA"); // 4 bytes of prior progress
+    // A resume is only attempted when we hold the validator captured on the
+    // first attempt (replayed as If-Range); seed it so the resume proceeds.
+    await writeFile(`${partialPath}.etag`, '"resume-etag"');
 
     // Server returns 206 with the remaining bytes.
     fetchMock.mockResolvedValueOnce(
@@ -157,6 +160,9 @@ describe("downloadModel cache", () => {
     const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
     const partialPath = join(cacheDir, `.${hash}.safetensors.partial`);
     await writeFile(partialPath, "STALE_PARTIAL_CONTENT");
+    // With a validator present we send Range+If-Range; the server ignoring the
+    // range (or the file having changed) replies 200 and we overwrite cleanly.
+    await writeFile(`${partialPath}.etag`, '"stale-etag"');
 
     fetchMock.mockResolvedValueOnce(okResponse("full body from server"));
 
@@ -311,8 +317,9 @@ describe("downloadModel cache", () => {
   it("refuses to append a 206 whose Content-Range starts at the WRONG offset (would corrupt) (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/badrange.safetensors";
-    const { partial } = await cachePaths(url);
+    const { partial, sidecar } = await cachePaths(url);
     await writeFile(partial, "AAAA"); // resume offset = 4
+    await writeFile(sidecar, '"br-etag"');
 
     // Misbehaving server/proxy: says it's resuming from byte 0, not 4.
     fetchMock.mockResolvedValueOnce(
@@ -325,9 +332,74 @@ describe("downloadModel cache", () => {
 
     await expect(
       downloadModel(url, "checkpoints", "badrange-out.safetensors"),
-    ).rejects.toThrow(/resume mismatch/i);
+    ).rejects.toThrow(/resume rejected/i);
     // The corrupt partial (and its sidecar) are removed so a retry starts clean.
     await expect(stat(partial)).rejects.toThrow();
+    await expect(stat(sidecar)).rejects.toThrow();
+  });
+
+  it("refuses a 206 that omits Content-Range entirely (can't prove the offset) (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/nocr.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"nocr-etag"');
+
+    // 206 but NO Content-Range — we cannot verify where it resumes from.
+    fetchMock.mockResolvedValueOnce(
+      new Response("ZZZZ", { status: 206, statusText: "Partial Content" }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "nocr-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
+  });
+
+  it("does NOT resume a validator-less partial — restarts cleanly instead of appending (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/novalidator.safetensors";
+    const { partial } = await cachePaths(url);
+    // A stale partial with NO sidecar (e.g. left by a pre-fix build). We cannot
+    // prove the upstream file is unchanged, so a Range resume is unsafe.
+    await writeFile(partial, "AAAA");
+
+    fetchMock.mockResolvedValueOnce(okResponse("FRESHFULLBODY"));
+
+    const target = await downloadModel(url, "checkpoints", "novalidator-out.safetensors");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    // No Range / If-Range without a trustworthy validator.
+    expect(init.headers.Range).toBeUndefined();
+    expect(init.headers["If-Range"]).toBeUndefined();
+    // The stale prefix is discarded — final file is the fresh body, not "AAAA...".
+    await expect(readFile(target, "utf-8")).resolves.toBe("FRESHFULLBODY");
+  });
+
+  it("persists the validator sidecar on a fresh write so a later resume can guard with If-Range (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/sidecar.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+
+    // Fresh download (no partial) whose stream ends early → truncated, so the
+    // partial + its newly-written validator are left on disk for a resume.
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode("half")); c.close(); },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "1000", etag: '"captured-v9"' },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "sidecar-out.safetensors"),
+    ).rejects.toThrow(/truncat/i);
+
+    // The validator was captured and PAIRS with the truncated partial bytes.
+    await expect(stat(partial)).resolves.toBeTruthy();
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"captured-v9"');
   });
 
   it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -256,6 +256,96 @@ describe("downloadModel cache", () => {
     await expect(p).rejects.toThrow(/no.*Location header/i);
   });
 
+  // Deterministic cache paths for a URL (mirrors cachePathForUrl in the impl).
+  async function cachePaths(url: string) {
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    const target = join(cacheDir, `${hash}.safetensors`);
+    const partial = join(cacheDir, `.${hash}.safetensors.partial`);
+    return { hash, target, partial, sidecar: `${partial}.etag` };
+  }
+
+  it("sends If-Range from the persisted validator and RESTARTS (not appends) when the upstream file changed (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/changed.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    // A leftover partial from a prior attempt, plus the validator we captured then.
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"etag-v1"');
+
+    // The file changed upstream → server ignores the Range and returns 200 with
+    // the full (new) body. Appending would corrupt; we must overwrite.
+    fetchMock.mockResolvedValueOnce(okResponse("FULLNEWBODY"));
+
+    const target = await downloadModel(url, "checkpoints", "changed-out.safetensors");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(init.headers.Range).toBe("bytes=4-");
+    expect(init.headers["If-Range"]).toBe('"etag-v1"');
+    // Overwritten with the fresh body — NOT "AAAAFULLNEWBODY".
+    await expect(readFile(target, "utf-8")).resolves.toBe("FULLNEWBODY");
+  });
+
+  it("sends If-Range and appends a matching 206 whose Content-Range starts at the resume offset (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/match.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"etag-stable"');
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    const target = await downloadModel(url, "checkpoints", "match-out.safetensors");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(init.headers["If-Range"]).toBe('"etag-stable"');
+    await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBB");
+  });
+
+  it("refuses to append a 206 whose Content-Range starts at the WRONG offset (would corrupt) (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/badrange.safetensors";
+    const { partial } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // resume offset = 4
+
+    // Misbehaving server/proxy: says it's resuming from byte 0, not 4.
+    fetchMock.mockResolvedValueOnce(
+      new Response("ZZZZZZZZ", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 0-7/8" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "badrange-out.safetensors"),
+    ).rejects.toThrow(/resume mismatch/i);
+    // The corrupt partial (and its sidecar) are removed so a retry starts clean.
+    await expect(stat(partial)).rejects.toThrow();
+  });
+
+  it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/zerohit.safetensors";
+    const { target } = await cachePaths(url);
+    // A pre-existing empty cache file (interrupted rename / older build / tamper).
+    await writeFile(target, "");
+
+    fetchMock.mockResolvedValueOnce(okResponse("real bytes this time"));
+
+    const out = await downloadModel(url, "checkpoints", "zerohit-out.safetensors");
+
+    // The empty hit must NOT have short-circuited the download.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(readFile(out, "utf-8")).resolves.toBe("real bytes this time");
+  });
+
   it("evicts least-recently-used cache files when the optional limit is exceeded", async () => {
     process.env.COMFYUI_LRU_CACHE_SIZE_GB = String(12 / 1024 / 1024 / 1024);
     await fsPromises.mkdir(cacheDir, { recursive: true });

--- a/src/__tests__/services/storage-download-integrity.test.ts
+++ b/src/__tests__/services/storage-download-integrity.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #343 edge: S3/Azure downloads must enforce the same truncation guard as the
+// HTTP path — a cloud stream that ends early can otherwise be reported as a
+// complete download. These tests mock the cloud SDKs to a Body that yields
+// fewer bytes than the authoritative Content-Length and assert we reject.
+
+const s3Send = vi.fn();
+vi.mock("@aws-sdk/client-s3", () => {
+  class S3Client {
+    send = s3Send;
+    destroy() {}
+  }
+  class GetObjectCommand {
+    constructor(public input: unknown) {}
+  }
+  return { S3Client, GetObjectCommand };
+});
+
+const azureDownload = vi.fn();
+vi.mock("@azure/storage-blob", () => {
+  class BlobServiceClient {
+    static fromConnectionString() {
+      return new BlobServiceClient();
+    }
+    getContainerClient() {
+      return { getBlobClient: () => ({ download: azureDownload }) };
+    }
+  }
+  return { BlobServiceClient };
+});
+
+import { downloadS3ToFile } from "../../services/storage/s3.js";
+
+let tempDir: string;
+let target: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "comfyui-mcp-cloud-integrity-"));
+  target = join(tempDir, "out.safetensors");
+  s3Send.mockReset();
+  azureDownload.mockReset();
+  process.env.AWS_ACCESS_KEY_ID = "test";
+  process.env.AWS_SECRET_ACCESS_KEY = "test";
+  process.env.AWS_REGION = "us-east-1";
+});
+
+afterEach(async () => {
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.AWS_REGION;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("S3 download integrity (#343)", () => {
+  it("rejects a truncated S3 object (bytes written < ContentLength)", async () => {
+    // Body yields only 5 bytes but S3 declares the object is 1000.
+    s3Send.mockResolvedValueOnce({
+      Body: Readable.from(Buffer.from("short")),
+      ContentLength: 1000,
+    });
+
+    await expect(downloadS3ToFile("s3://bucket/key.safetensors", target)).rejects.toThrow(
+      /truncat/i,
+    );
+  });
+
+  it("accepts a complete S3 object whose written bytes match ContentLength", async () => {
+    const body = Buffer.from("exactly-right-bytes");
+    s3Send.mockResolvedValueOnce({
+      Body: Readable.from(body),
+      ContentLength: body.length,
+    });
+
+    await downloadS3ToFile("s3://bucket/ok.safetensors", target);
+    await expect(readFile(target, "utf-8")).resolves.toBe("exactly-right-bytes");
+    expect((await stat(target)).size).toBe(body.length);
+  });
+
+  it("does not falsely reject when ContentLength is absent (size unknown)", async () => {
+    const body = Buffer.from("no-length-header-body");
+    s3Send.mockResolvedValueOnce({ Body: Readable.from(body) });
+
+    await downloadS3ToFile("s3://bucket/nolen.safetensors", target);
+    await expect(readFile(target, "utf-8")).resolves.toBe("no-length-header-body");
+  });
+});

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -342,25 +342,43 @@ async function streamUrlToFile(
   // upstream file changed — so we overwrite and restart, which is correct.
   const appendMode = effectiveResume > 0 && res.status === 206;
 
+  // The authoritative full-file size, taken from a 206's Content-Range total.
+  // Used as the truncation target so a SHORT 206 (a server that satisfies only
+  // part of the requested range — RFC 9110 §15.3.7) can't slip through.
+  let rangeTotal: number | undefined;
   if (appendMode) {
-    // #343 edge: a 206 MUST prove it resumes from exactly the byte we asked for.
-    // Reject it unless the Content-Range parses AND its start equals our resume
-    // offset — a missing/malformed header, or a different start (misconfigured
-    // proxy/mirror), would otherwise make us append at the wrong offset and
-    // silently corrupt the file. Drop the partial + validator so the next
-    // attempt starts clean rather than compounding the corruption.
+    // #343 edge: a 206 MUST fully prove where it resumes AND how big the whole
+    // file is. Parse Content-Range strictly as `bytes <start>-<end>/<total>` and
+    // reject unless: start === our resume offset, end >= start, total is known
+    // and consistent (end === total-1, i.e. the range runs to the end of the
+    // representation). A missing/malformed/partial range (e.g. `bytes 4-7/1000`
+    // returning only 4 of the remaining bytes, or `bytes 4-3/3`, or unanchored
+    // garbage) would otherwise let a truncated file be finalized as complete or
+    // be appended at the wrong offset. Drop the partial + validator so a retry
+    // starts clean rather than compounding the corruption.
     const contentRange = res.headers.get("content-range");
-    const m = contentRange ? /bytes\s+(\d+)-\d+\/(?:\d+|\*)/i.exec(contentRange) : null;
-    if (!m || Number(m[1]) !== effectiveResume) {
+    const m = contentRange ? /^bytes (\d+)-(\d+)\/(\d+)$/.exec(contentRange.trim()) : null;
+    const start = m ? Number(m[1]) : NaN;
+    const end = m ? Number(m[2]) : NaN;
+    const total = m ? Number(m[3]) : NaN;
+    const valid =
+      m !== null &&
+      start === effectiveResume &&
+      end >= start &&
+      total > end &&
+      end === total - 1;
+    if (!valid) {
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
       throw new ModelError(
-        `Download resume rejected: expected a 206 resuming at byte ${effectiveResume} but the ` +
-          `server's Content-Range was ${contentRange ? `"${contentRange}"` : "absent"}. Refusing ` +
-          `to append (would corrupt the file). Removed the partial; retry for a clean download.`,
+        `Download resume rejected: a 206 for byte ${effectiveResume}+ must carry a complete, ` +
+          `consistent Content-Range "bytes ${effectiveResume}-<end>/<total>" reaching the end of ` +
+          `the file, but the server sent ${contentRange ? `"${contentRange}"` : "no Content-Range"}. ` +
+          `Refusing to append (would corrupt or truncate the file). Removed the partial; retry.`,
         { url: logUrl, status: res.status },
       );
     }
+    rangeTotal = total;
   }
 
   const flags = appendMode ? "a" : "w";
@@ -381,10 +399,15 @@ async function streamUrlToFile(
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
   const fileStream = createWriteStream(targetPath, { flags });
 
-  // Content-Length is the REMAINING bytes for a 206 resume, so add the bytes
-  // already on disk to get the true expected total.
+  // Truncation target = the true full-file size. For a validated 206 that is the
+  // Content-Range total (NOT content-length, which is only the remaining slice
+  // and would mask a short 206). For a 200 it is the Content-Length.
   const lengthHeader = Number(res.headers.get("content-length") || 0);
-  const expectedTotal = lengthHeader > 0 ? lengthHeader + (appendMode ? effectiveResume : 0) : 0;
+  const expectedTotal = appendMode
+    ? (rangeTotal ?? 0)
+    : lengthHeader > 0
+      ? lengthHeader
+      : 0;
 
   // A pipeline() can resolve on a stream that ended EARLY (server dropped the
   // connection, proxy cut it, disk edge case) — leaving a 0-byte or truncated

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -4,11 +4,13 @@ import {
   copyFile,
   link,
   mkdir,
+  readFile,
   readdir,
   rename,
   rm,
   stat,
   utimes,
+  writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
@@ -28,6 +30,28 @@ const DEFAULT_CACHE_DIR = join(homedir(), ".comfyui-mcp", "cache");
 const HASH_CHARS = 32;
 const MAX_HTTP_REDIRECTS = 5;
 const inflight = new Map<string, Promise<string>>();
+
+/** Best-effort remove — never throws (rm may be stubbed in tests, or the file
+ *  may already be gone). Used on the integrity-failure cleanup paths. */
+async function safeRm(path: string): Promise<void> {
+  try {
+    await rm(path, { force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+/** On-disk size, or undefined when it can't be determined (fs layer stubbed in
+ *  tests, or a stat hiccup) — callers must not block a download over a missing
+ *  number, only over a number that proves corruption. */
+async function fileSizeOrUndefined(path: string): Promise<number | undefined> {
+  try {
+    const st = await stat(path);
+    return typeof st?.size === "number" ? st.size : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Extract the useful diagnostic bits from an error thrown by `fetch()` itself
@@ -144,6 +168,28 @@ async function touch(path: string): Promise<void> {
   await downloadCacheFs.utimes(path, now, now);
 }
 
+/** Read a persisted resume validator (ETag / Last-Modified) or null if absent.
+ *  Best-effort: a missing/unreadable sidecar just means "resume without an
+ *  If-Range guard" — never fatal. */
+async function readValidatorSidecar(path: string): Promise<string | null> {
+  try {
+    const raw = (await readFile(path, "utf-8")).trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the resume validator next to a .partial. Best-effort — a failure
+ *  here only costs us the change-detection guard on a later resume. */
+async function writeValidatorSidecar(path: string, value: string): Promise<void> {
+  try {
+    await writeFile(path, value, "utf-8");
+  } catch {
+    /* best effort */
+  }
+}
+
 async function streamUrlToFile(
   url: string,
   targetPath: string,
@@ -152,9 +198,22 @@ async function streamUrlToFile(
   storageAuth: CloudStorageAuth = {},
   resumeFromBytes = 0,
   progress?: ProgressMeta,
+  resumable = false,
 ): Promise<void> {
   if (supportsCloudDownload(url)) {
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
+    // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
+    // downloaders verify their own Content-Length (truncation), but a stream
+    // that yielded ZERO bytes can still resolve cleanly — backstop it here so a
+    // 0-byte cloud object can never be reported as a successful download.
+    const actual = await fileSizeOrUndefined(targetPath);
+    if (actual === 0) {
+      await safeRm(targetPath);
+      throw new ModelError(
+        "Download produced a 0-byte file — the cloud source (S3/Azure) sent no data. Removed it; retry.",
+        { url: logUrl },
+      );
+    }
     return;
   }
 
@@ -163,10 +222,25 @@ async function streamUrlToFile(
   // matching Content-Range we append; if it returns 200 (range unsupported,
   // or the file changed upstream) we truncate and restart. Idea from
   // josephoibrahim/comfy-cozy.
+  //
+  // #343 edge: a plain Range resume is unsafe if the upstream file CHANGED
+  // between the two calls — we would append fresh bytes onto a stale prefix and
+  // the size check could still pass, producing a corrupt file. Guard it with a
+  // conditional resume: we persist the first response's validator (ETag, else
+  // Last-Modified) in a sidecar next to the .partial and replay it as `If-Range`
+  // on resume. Per RFC 9110 the server then returns 206 (append) ONLY if the
+  // resource is byte-for-byte unchanged, otherwise 200 with the full body (which
+  // our append-vs-truncate logic below restarts cleanly). Belt-and-braces, we
+  // also validate the 206 Content-Range starts exactly at our resume offset.
+  const validatorSidecar = `${targetPath}.etag`;
   let currentUrl = url;
   let currentHeaders = headers;
   if (resumeFromBytes > 0) {
     currentHeaders = { ...currentHeaders, Range: `bytes=${resumeFromBytes}-` };
+    if (resumable) {
+      const priorValidator = await readValidatorSidecar(validatorSidecar);
+      if (priorValidator) currentHeaders["If-Range"] = priorValidator;
+    }
   }
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
@@ -248,9 +322,43 @@ async function streamUrlToFile(
 
   // Decide append vs truncate based on the response. If we asked for a range
   // and got 206, append; any other 2xx (typically 200) means the server is
-  // sending the full file so we must overwrite.
+  // sending the full file so we must overwrite. A 200 to a range request is
+  // exactly what If-Range yields when the upstream file changed — the truncate
+  // path below discards the stale prefix and restarts, which is correct.
   const appendMode = resumeFromBytes > 0 && res.status === 206;
+
+  if (appendMode) {
+    // #343 edge: a 206 MUST resume from exactly the byte we asked for. A server
+    // that echoes a different Content-Range start (misconfigured proxy/mirror)
+    // would make us append at the wrong offset and silently corrupt the file.
+    // Refuse to append in that case — drop the partial + validator so the next
+    // attempt starts clean rather than compounding the corruption.
+    const contentRange = res.headers.get("content-range");
+    const m = contentRange ? /bytes\s+(\d+)-\d+\/(?:\d+|\*)/i.exec(contentRange) : null;
+    if (m && Number(m[1]) !== resumeFromBytes) {
+      await safeRm(targetPath);
+      await safeRm(validatorSidecar);
+      throw new ModelError(
+        `Download resume mismatch: server sent a 206 starting at byte ${m[1]} but we resumed ` +
+          `from ${resumeFromBytes}. Refusing to append (would corrupt the file). Removed the ` +
+          `partial; retry for a clean download.`,
+        { url: logUrl, status: res.status },
+      );
+    }
+  }
+
   const flags = appendMode ? "a" : "w";
+
+  // Persist the upstream validator so a FUTURE resume of this partial can send
+  // If-Range and detect a changed file. Only meaningful for a full/fresh write
+  // (flags "w") of a resumable (.partial) target — write it before streaming so
+  // that if THIS stream truncates, the sidecar already matches the bytes on
+  // disk. On a 206 append the sidecar already exists and still matches.
+  if (resumable && !appendMode) {
+    const validator = res.headers.get("etag") || res.headers.get("last-modified");
+    if (validator) await writeValidatorSidecar(validatorSidecar, validator);
+    else await safeRm(validatorSidecar);
+  }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
   const fileStream = createWriteStream(targetPath, { flags });
@@ -302,6 +410,8 @@ async function streamUrlToFile(
   if (!progress) {
     await pipeline(nodeStream, fileStream);
     await assertComplete();
+    // Complete: the validator sidecar is only needed to guard a resume, so drop it.
+    if (resumable) await safeRm(validatorSidecar);
     return;
   }
 
@@ -334,6 +444,7 @@ async function streamUrlToFile(
   try {
     await pipeline(nodeStream, counter, fileStream);
     await assertComplete();
+    if (resumable) await safeRm(validatorSidecar);
     bytesPerSec = 0;
     emit("done", true);
   } catch (err) {
@@ -361,8 +472,16 @@ async function downloadIntoCache(
     try {
       const info = await downloadCacheFs.stat(target);
       if (info.isFile()) {
-        await touch(target);
-        return target;
+        // #343 edge: never serve a 0-byte cache entry as a hit. One could exist
+        // from an interrupted rename, an older build without the size gate, or
+        // external tampering — treat it as a miss and re-download rather than
+        // materializing an empty file that reports success.
+        if (info.size === 0) {
+          await downloadCacheFs.rm(target, { force: true }).catch(() => undefined);
+        } else {
+          await touch(target);
+          return target;
+        }
       }
     } catch {
       // Cache miss.
@@ -396,6 +515,7 @@ async function downloadIntoCache(
         storageAuth,
         resumeFromBytes,
         progress,
+        true, // resumable: cache partials use the .partial + If-Range resume handshake
       );
       await downloadCacheFs.rename(partial, target);
       await touch(target);
@@ -408,6 +528,10 @@ async function downloadIntoCache(
         const remaining = await downloadCacheFs.stat(partial);
         if (remaining.size === 0) {
           await downloadCacheFs.rm(partial, { force: true }).catch(() => undefined);
+          // The validator sidecar is only meaningful alongside a resumable
+          // partial — drop it too so a later attempt doesn't If-Range against a
+          // file that no longer exists.
+          await downloadCacheFs.rm(`${partial}.etag`, { force: true }).catch(() => undefined);
         }
       } catch {
         // Partial gone — nothing to clean.

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -357,7 +357,8 @@ async function streamUrlToFile(
     // be appended at the wrong offset. Drop the partial + validator so a retry
     // starts clean rather than compounding the corruption.
     const contentRange = res.headers.get("content-range");
-    const m = contentRange ? /^bytes (\d+)-(\d+)\/(\d+)$/.exec(contentRange.trim()) : null;
+    // Range-unit name is case-insensitive (RFC 9110 §14.1) — accept "Bytes"/"BYTES".
+    const m = contentRange ? /^bytes (\d+)-(\d+)\/(\d+)$/i.exec(contentRange.trim()) : null;
     const start = m ? Number(m[1]) : NaN;
     const end = m ? Number(m[2]) : NaN;
     const total = m ? Number(m[3]) : NaN;

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -235,11 +235,26 @@ async function streamUrlToFile(
   const validatorSidecar = `${targetPath}.etag`;
   let currentUrl = url;
   let currentHeaders = headers;
+  // How many bytes we will actually attempt to resume from. A resume is only
+  // SAFE when we can prove the upstream file is unchanged, which requires the
+  // validator (ETag/Last-Modified) we persisted on the first attempt. Without a
+  // sidecar — a stale partial from a pre-fix build, or a server that sent no
+  // validator — we cannot detect a changed file, so we must NOT append: fall
+  // back to a clean restart (Range omitted, the "w" flag truncates the partial).
+  let effectiveResume = resumeFromBytes;
   if (resumeFromBytes > 0) {
-    currentHeaders = { ...currentHeaders, Range: `bytes=${resumeFromBytes}-` };
-    if (resumable) {
-      const priorValidator = await readValidatorSidecar(validatorSidecar);
-      if (priorValidator) currentHeaders["If-Range"] = priorValidator;
+    const priorValidator = resumable
+      ? await readValidatorSidecar(validatorSidecar)
+      : null;
+    if (priorValidator) {
+      currentHeaders = {
+        ...currentHeaders,
+        Range: `bytes=${resumeFromBytes}-`,
+        "If-Range": priorValidator,
+      };
+    } else {
+      // No trustworthy validator → discard the un-verifiable partial state.
+      effectiveResume = 0;
     }
   }
   let res: Response;
@@ -320,28 +335,29 @@ async function streamUrlToFile(
     throw new ModelError("Download response has no body", { url: logUrl });
   }
 
-  // Decide append vs truncate based on the response. If we asked for a range
-  // and got 206, append; any other 2xx (typically 200) means the server is
-  // sending the full file so we must overwrite. A 200 to a range request is
-  // exactly what If-Range yields when the upstream file changed — the truncate
-  // path below discards the stale prefix and restarts, which is correct.
-  const appendMode = resumeFromBytes > 0 && res.status === 206;
+  // Decide append vs truncate based on the response. We only append when we
+  // actually asked for a range (effectiveResume > 0, i.e. we had a validator)
+  // AND the server honoured it with a 206. Any other 2xx (typically 200) means
+  // the server is sending the full file — exactly what If-Range yields when the
+  // upstream file changed — so we overwrite and restart, which is correct.
+  const appendMode = effectiveResume > 0 && res.status === 206;
 
   if (appendMode) {
-    // #343 edge: a 206 MUST resume from exactly the byte we asked for. A server
-    // that echoes a different Content-Range start (misconfigured proxy/mirror)
-    // would make us append at the wrong offset and silently corrupt the file.
-    // Refuse to append in that case — drop the partial + validator so the next
+    // #343 edge: a 206 MUST prove it resumes from exactly the byte we asked for.
+    // Reject it unless the Content-Range parses AND its start equals our resume
+    // offset — a missing/malformed header, or a different start (misconfigured
+    // proxy/mirror), would otherwise make us append at the wrong offset and
+    // silently corrupt the file. Drop the partial + validator so the next
     // attempt starts clean rather than compounding the corruption.
     const contentRange = res.headers.get("content-range");
     const m = contentRange ? /bytes\s+(\d+)-\d+\/(?:\d+|\*)/i.exec(contentRange) : null;
-    if (m && Number(m[1]) !== resumeFromBytes) {
+    if (!m || Number(m[1]) !== effectiveResume) {
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
       throw new ModelError(
-        `Download resume mismatch: server sent a 206 starting at byte ${m[1]} but we resumed ` +
-          `from ${resumeFromBytes}. Refusing to append (would corrupt the file). Removed the ` +
-          `partial; retry for a clean download.`,
+        `Download resume rejected: expected a 206 resuming at byte ${effectiveResume} but the ` +
+          `server's Content-Range was ${contentRange ? `"${contentRange}"` : "absent"}. Refusing ` +
+          `to append (would corrupt the file). Removed the partial; retry for a clean download.`,
         { url: logUrl, status: res.status },
       );
     }
@@ -349,15 +365,17 @@ async function streamUrlToFile(
 
   const flags = appendMode ? "a" : "w";
 
-  // Persist the upstream validator so a FUTURE resume of this partial can send
-  // If-Range and detect a changed file. Only meaningful for a full/fresh write
-  // (flags "w") of a resumable (.partial) target — write it before streaming so
-  // that if THIS stream truncates, the sidecar already matches the bytes on
-  // disk. On a 206 append the sidecar already exists and still matches.
+  // On a fresh/full write (restart) of a resumable target, make the validator
+  // and the on-disk bytes failure-atomic: first drop any stale sidecar AND the
+  // stale partial (so a crash here leaves NO validator → the next attempt has no
+  // sidecar and safely restarts), THEN persist the new validator so that once we
+  // begin writing, a truncated partial is already paired with a MATCHING
+  // validator. On a 206 append the existing sidecar already matches — leave it.
   if (resumable && !appendMode) {
+    await safeRm(validatorSidecar);
+    await safeRm(targetPath);
     const validator = res.headers.get("etag") || res.headers.get("last-modified");
     if (validator) await writeValidatorSidecar(validatorSidecar, validator);
-    else await safeRm(validatorSidecar);
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
@@ -366,7 +384,7 @@ async function streamUrlToFile(
   // Content-Length is the REMAINING bytes for a 206 resume, so add the bytes
   // already on disk to get the true expected total.
   const lengthHeader = Number(res.headers.get("content-length") || 0);
-  const expectedTotal = lengthHeader > 0 ? lengthHeader + (appendMode ? resumeFromBytes : 0) : 0;
+  const expectedTotal = lengthHeader > 0 ? lengthHeader + (appendMode ? effectiveResume : 0) : 0;
 
   // A pipeline() can resolve on a stream that ended EARLY (server dropped the
   // connection, proxy cut it, disk edge case) — leaving a 0-byte or truncated
@@ -384,13 +402,11 @@ async function streamUrlToFile(
     // hiccuped) → can't verify, so don't block a download over a missing number.
     if (actual === undefined) return;
     if (actual === 0) {
-      // Nothing landed — remove it so it can't masquerade as a real file / poison
-      // resume. Best-effort: rm may be stubbed, so never let it throw here.
-      try {
-        await rm(targetPath, { force: true });
-      } catch {
-        /* best effort */
-      }
+      // Nothing landed — remove it (and its validator sidecar) so it can't
+      // masquerade as a real file / poison a resume with a validator that has
+      // no matching bytes. Best-effort: never let cleanup throw here.
+      await safeRm(targetPath);
+      if (resumable) await safeRm(validatorSidecar);
       throw new ModelError(
         "Download produced a 0-byte file — the source sent no data. Removed it; retry.",
         { url: logUrl },
@@ -417,7 +433,7 @@ async function streamUrlToFile(
 
   // Tally bytes as they flow and report throughput to the panel tray.
   const total = expectedTotal;
-  let downloaded = appendMode ? resumeFromBytes : 0;
+  let downloaded = appendMode ? effectiveResume : 0;
   let windowStart = Date.now();
   let windowBytes = downloaded;
   let bytesPerSec = 0;

--- a/src/services/storage/azure-blob.ts
+++ b/src/services/storage/azure-blob.ts
@@ -1,4 +1,5 @@
 import { createReadStream, createWriteStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import type {
   BlobClient,
@@ -145,6 +146,19 @@ export async function downloadAzureBlobToFile(url: string, targetPath: string): 
       });
     }
     await pipeline(response.readableStreamBody, createWriteStream(targetPath));
+    // #343 edge: verify the written size against the blob's authoritative
+    // contentLength so an early-ending stream can't be reported as a complete
+    // download (silent truncation).
+    const expected = typeof response.contentLength === "number" ? response.contentLength : 0;
+    if (expected > 0) {
+      const actual = (await stat(targetPath)).size;
+      if (actual < expected) {
+        throw new ModelError(
+          `Azure Blob download truncated: wrote ${actual} of ${expected} bytes — the stream ended early. Not complete; retry.`,
+          { url: redactUrlForLogs(url) },
+        );
+      }
+    }
   } catch (err) {
     if (err instanceof ModelError || err instanceof ValidationError) throw err;
     throw new ModelError("Azure Blob download failed", {

--- a/src/services/storage/s3.ts
+++ b/src/services/storage/s3.ts
@@ -1,5 +1,6 @@
 import { createReadStream } from "node:fs";
 import { createWriteStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import type {
   S3Client,
@@ -71,6 +72,20 @@ export async function downloadS3ToFile(
       throw new ModelError("S3 download response has no body", { url: redactUrlForLogs(url) });
     }
     await pipeline(bodyToReadable(response.Body), createWriteStream(targetPath));
+    // #343 edge: the S3 stream can end early (dropped connection) and pipeline()
+    // still resolves, leaving a truncated file. S3 tells us the authoritative
+    // object size in ContentLength — verify the bytes on disk match before this
+    // download can ever be reported as successful.
+    const expected = typeof response.ContentLength === "number" ? response.ContentLength : 0;
+    if (expected > 0) {
+      const actual = (await stat(targetPath)).size;
+      if (actual < expected) {
+        throw new ModelError(
+          `S3 download truncated: wrote ${actual} of ${expected} bytes — the stream ended early. Not complete; retry.`,
+          { url: redactUrlForLogs(url) },
+        );
+      }
+    }
   } catch (err) {
     if (err instanceof ModelError || err instanceof ValidationError) throw err;
     throw new ModelError("S3 download failed", {


### PR DESCRIPTION
## Summary
Fix-forward the codex #343 download-resume **edges**. The base #343 size gate (0-byte / truncated on the HTTP pipeline) already shipped; this closes the remaining silent-corruption paths.

### HTTP resume validation (ETag / Content-Range)
- Persist the first response's validator (`ETag`, else `Last-Modified`) in a sidecar next to the `.partial`, and replay it as `If-Range` on resume. Per RFC 9110 the server returns `206` (safe append) only if the resource is byte-for-byte unchanged; otherwise `200` full body, which the existing append-vs-truncate logic restarts cleanly. This prevents appending fresh bytes onto a stale prefix when the upstream file changed.
- A `206` whose `Content-Range` does not start at the requested resume offset is now refused (drops the partial + sidecar) — a misbehaving proxy/mirror would otherwise corrupt the file.

### Cloud (S3 / Azure) + cache-hit integrity
- `s3.ts` / `azure-blob.ts` verify the written byte count against the authoritative `ContentLength` (truncation), and the cache layer backstops a 0-byte cloud object.
- A 0-byte cache entry is never served as a hit — treated as a miss and re-downloaded.

## Tests
`src/__tests__/services/download-cache.test.ts` gains 4 edge tests modeling real runtime shapes: If-Range restart on change, matching-206 append, wrong-offset 206 refusal, and 0-byte cache-hit re-download. Full suite green (only the pre-existing node-dev ripgrep-vs-builtin failure remains). No version bump.

Refs #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)