### PR TITLE
release: 0.48.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.12] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- comfy_cli_models download uses a 120s IDLE/liveness timeout (progress resets the clock) instead of a fixed 60s wall-clock, so a long-but-live download isn't killed while a truly stalled one still times out (as a distinct idle_timeout error) (#417)
+- convertUiToApi keeps a declared asset value (unet/ckpt/vae/lora/model_path) and warns instead of silently swapping it for the first installed model when it's not present on the server — so e.g. Krea 2's krea2_turbo_fp8 no longer becomes flux-2-klein-9b; plain enum combos still fall back (#407)
+- download resume hardened (#343 edges): ETag/If-Range-gated resume, strict full Content-Range validation, failure-atomic sidecar handling, plus S3/Azure Content-Length truncation checks and 0-byte cache-hit recovery (#343)
+- built-in ace_step_15 audio template updated to the current comfy_extras nodes_ace schema (unet_name, full TextEncodeAceStepAudio required inputs, SaveAudioMP3 quality) (#448)
+- restart_comfyui/port detection: detect ComfyUI liveness via the reachable server (answered /system_stats) and parse netstat locale-independently, instead of falsely reporting "no process on port" (#449)
+
+
 ## [0.48.11] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.11",
+  "version": "0.48.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.11",
+      "version": "0.48.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.11",
+  "version": "0.48.12",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.12 (tag pushed → npm publish). 5 fixes from the workflow blast: comfy_cli idle-timeout (#417), converter no-silent-model-swap (#407), #343 download-resume edges, ace_step template (#448), restart port-detect (#449). All self-gated codex-pass + CI-green. 🤖 Generated with Claude Code