### PR TITLE
fix(gemini): recognize API-key auth in backend readiness (#456)

### DIFF
--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -93,6 +93,53 @@ describe("backendReadiness", () => {
     expect(r.ready).toBe(true);
   });
 
+  it("gemini: CLI on PATH but no auth of any kind → not ready (#456)", () => {
+    const real = { g: process.env.GEMINI_API_KEY, gg: process.env.GOOGLE_API_KEY };
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    putOnPath(process.platform === "win32" ? "gemini.cmd" : "gemini");
+    const r = backendReadiness("gemini", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(false);
+    expect(r.ready).toBe(false);
+    if (real.g === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = real.g;
+    if (real.gg === undefined) delete process.env.GOOGLE_API_KEY;
+    else process.env.GOOGLE_API_KEY = real.gg;
+  });
+
+  it("gemini: ready via GEMINI_API_KEY with no oauth_creds.json (#456)", () => {
+    const real = process.env.GEMINI_API_KEY;
+    putOnPath(process.platform === "win32" ? "gemini.cmd" : "gemini");
+    process.env.GEMINI_API_KEY = "AIza-test-key";
+    const r = backendReadiness("gemini", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+    if (real === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = real;
+  });
+
+  it("gemini: ready via settings.json gemini-api-key with no key in env (#456)", () => {
+    const real = { g: process.env.GEMINI_API_KEY, gg: process.env.GOOGLE_API_KEY };
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    putOnPath(process.platform === "win32" ? "gemini.cmd" : "gemini");
+    mkdirSync(join(tmp, ".gemini"), { recursive: true });
+    writeFileSync(
+      join(tmp, ".gemini", "settings.json"),
+      JSON.stringify({ security: { auth: { selectedType: "gemini-api-key" } } }),
+    );
+    const r = backendReadiness("gemini", { home: tmp });
+    expect(r.cli).toBe(true);
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+    if (real.g === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = real.g;
+    if (real.gg === undefined) delete process.env.GOOGLE_API_KEY;
+    else process.env.GOOGLE_API_KEY = real.gg;
+  });
+
   it("chatgpt: ready when ~/.codex/auth.json exists (no CLI)", () => {
     mkdirSync(join(tmp, ".codex"), { recursive: true });
     writeFileSync(join(tmp, ".codex", "auth.json"), "{}");

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -9,7 +9,7 @@
 // which the panel then prefers (see comfyui-mcp-panel: applyReadiness on a
 // {type:"backends"} bridge frame).
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readOAuthStatus } from "../services/code-provider-auth.js";
@@ -93,6 +93,24 @@ function onPath(names: string[]): boolean {
     }
   }
   return false;
+}
+
+/** True if <geminiHome>/.gemini/settings.json selects API-key auth
+ *  (security.auth.selectedType === "gemini-api-key"). This is an
+ *  env-independent "configured for API key" signal (issue #456): the gemini CLI
+ *  writes it on `/auth` → "Gemini API key" and it persists across processes,
+ *  unlike GEMINI_API_KEY which the orchestrator only inherits if set before
+ *  launch. Never throws — a missing/corrupt file just means "no signal". */
+function geminiSettingsUsesApiKey(geminiHome: string): boolean {
+  try {
+    const raw = readFileSync(join(geminiHome, ".gemini", "settings.json"), "utf8");
+    const parsed = JSON.parse(raw) as {
+      security?: { auth?: { selectedType?: unknown } };
+    };
+    return parsed?.security?.auth?.selectedType === "gemini-api-key";
+  } catch {
+    return false;
+  }
 }
 
 function fileExists(...parts: string[]): boolean {
@@ -192,10 +210,24 @@ export function backendReadiness(
   }
   if (b === "gemini") {
     const cli = onPath(CLI_NAMES.gemini);
-    // The gemini CLI caches its Google OAuth at <home>/.gemini/oauth_creds.json
-    // (or GEMINI_CLI_HOME when set).
+    // API-key auth is a first-class gemini CLI mode and writes NO
+    // oauth_creds.json (issue #456). Mirror the kimi branch and accept ANY of:
+    //   1. GEMINI_API_KEY / GOOGLE_API_KEY in the orchestrator's env, or
+    //   2. Google OAuth cached at <home>/.gemini/oauth_creds.json (or
+    //      GEMINI_CLI_HOME when set), or
+    //   3. an env-independent "configured for API key" signal —
+    //      <home>/.gemini/settings.json with
+    //      security.auth.selectedType === "gemini-api-key". This lets a user
+    //      who authed with a key before ComfyUI launched (so the key isn't in
+    //      this process's env yet) still read as ready rather than "not signed
+    //      in"; a genuinely-bad/absent key surfaces via the connect ack's model
+    //      probe (degraded), same as every other key provider.
     const geminiHome = process.env.GEMINI_CLI_HOME || home;
-    const auth = fileExists(geminiHome, ".gemini", "oauth_creds.json");
+    const apiKey =
+      !!(process.env.GEMINI_API_KEY?.trim() || process.env.GOOGLE_API_KEY?.trim());
+    const oauth = fileExists(geminiHome, ".gemini", "oauth_creds.json");
+    const apiKeyConfigured = geminiSettingsUsesApiKey(geminiHome);
+    const auth = apiKey || oauth || apiKeyConfigured;
     return { backend: "gemini", cli, auth, ready: cli && auth };
   }
   if (b === "antigravity") {


### PR DESCRIPTION
@
## Root cause

`src/orchestrator/backend-readiness.ts`, the `gemini` branch derived `auth` **solely** from the presence of `~/.gemini/oauth_creds.json` (Google OAuth). API-key auth is a first-class gemini CLI mode (`/auth` → "Gemini API key", `GEMINI_API_KEY` in env) that writes **no** `oauth_creds.json`, so every API-key user was reported `auth:false, ready:false` — the panel showed "Tap to set up — Not signed in" and clicking it looped the setup prompt. The `kimi` branch right above already accepts `apiKey || oauth`; gemini was simply missing the API-key path.

## Fix

Mirror the hosted-key providers. Gemini `auth` is now true if **any** of:
1. `GEMINI_API_KEY` / `GOOGLE_API_KEY` set in the orchestrator env, or
2. `~/.gemini/oauth_creds.json` present (existing behavior), or
3. `~/.gemini/settings.json` has `security.auth.selectedType === "gemini-api-key"` — an **env-independent** signal (per the issue), so a user who set the key before ComfyUI launched (key not yet in this process env) still reads ready instead of "not signed in". A bad/absent key still surfaces via the connect ack model probe (degraded), same as every other key provider.

`GEMINI_CLI_HOME` is still honored for all disk paths.

## Tests

Added 3 cases: CLI-only ⇒ not ready; `GEMINI_API_KEY` (no oauth file) ⇒ ready; `settings.json` gemini-api-key with no env key ⇒ ready. `tsc --noEmit` clean; full `npm test` green except the pre-existing node-dev ripgrep-vs-builtin failure (unrelated to this change).

## Scope notes

Change is confined to the provider-readiness module — no orchestrator/index.ts change needed. No version bump. The issue also flags a **panel-side** secondary bug (re-firing the setup prompt / not re-probing readiness after a setup turn) which lives in the separate `comfyui-mcp-panel` repo and is out of scope here.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@