### PR TITLE
fix(comfy-cli): fall back to the live server to list local models when comfy-cli is absent (#460)

### DIFF
--- a/src/__tests__/services/local-models-fallback.test.ts
+++ b/src/__tests__/services/local-models-fallback.test.ts
@@ -63,6 +63,31 @@ describe("comfy_cli_models local fallback (#460)", () => {
     expect(data).toEqual({ folder: "loras", count: 2, files: ["a.safetensors", "b.safetensors"] });
   });
 
+  it("caps list-folder output at the limit (mirrors --limit)", async () => {
+    mocks.listLocalModels.mockResolvedValue([
+      model("a.safetensors", "loras"),
+      model("b.safetensors", "loras"),
+      model("c.safetensors", "loras"),
+    ]);
+    const { data } = await listLocalModelsFallback({ action: "list-folder", folder: "loras", limit: 2 });
+    expect(data).toEqual({ folder: "loras", count: 2, files: ["a.safetensors", "b.safetensors"] });
+  });
+
+  it("maps singular --type aliases to real folders for list-folder and search", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockResolvedValue({});
+    await listLocalModelsFallback({ action: "search", type: "checkpoint" });
+    await listLocalModelsFallback({ action: "search", type: "lora" });
+    await listLocalModelsFallback({ action: "search", type: "unet" });
+    await listLocalModelsFallback({ action: "list-folder", folder: "checkpoint" });
+    expect(mocks.listLocalModels.mock.calls.map((c) => c[0])).toEqual([
+      "checkpoints",
+      "loras",
+      "diffusion_models",
+      "checkpoints",
+    ]);
+  });
+
   it("searches by text and honors the limit", async () => {
     mocks.listLocalModels.mockResolvedValue([
       model("flux_dev.safetensors", "checkpoints"),
@@ -71,6 +96,23 @@ describe("comfy_cli_models local fallback (#460)", () => {
     ]);
     const { data } = await listLocalModelsFallback({ action: "search", text: "flux", limit: 1 });
     expect(data).toMatchObject({ count: 1, results: [{ name: "flux_dev.safetensors", type: "checkpoints" }] });
+  });
+
+  it("show returns the exact (case-insensitive) name match", async () => {
+    mocks.listLocalModels.mockResolvedValue([
+      model("flux_dev.safetensors", "checkpoints"),
+      model("flux_schnell.safetensors", "checkpoints"),
+    ]);
+    const { data } = await listLocalModelsFallback({ action: "show", name: "FLUX_DEV.safetensors" });
+    expect(data).toMatchObject({ name: "flux_dev.safetensors", type: "checkpoints" });
+  });
+
+  it("show does NOT substring-guess — a partial name with multiple matches is not-found", async () => {
+    mocks.listLocalModels.mockResolvedValue([
+      model("flux_dev.safetensors", "checkpoints"),
+      model("flux_schnell.safetensors", "checkpoints"),
+    ]);
+    await expect(listLocalModelsFallback({ action: "show", name: "flux" })).rejects.toThrow(/was not found/i);
   });
 
   it("throws a clear error when neither comfy-cli nor a reachable server is available", async () => {

--- a/src/__tests__/services/local-models-fallback.test.ts
+++ b/src/__tests__/services/local-models-fallback.test.ts
@@ -73,16 +73,49 @@ describe("comfy_cli_models local fallback (#460)", () => {
     expect(data).toEqual({ folder: "loras", count: 2, files: ["a.safetensors", "b.safetensors"] });
   });
 
-  it("maps singular --type aliases to real folders for list-folder and search", async () => {
+  // Mirrors comfy-cli's _TYPE_TO_FOLDER (comfy_cli/command/models/search.py)
+  // EXACTLY — every alias must resolve to the same folder as the CLI.
+  const CLI_TYPE_TO_FOLDER: Record<string, string> = {
+    checkpoint: "checkpoints",
+    checkpoints: "checkpoints",
+    lora: "loras",
+    loras: "loras",
+    vae: "vae",
+    controlnet: "controlnet",
+    upscale: "upscale_models",
+    upscale_models: "upscale_models",
+    clip: "clip",
+    clip_vision: "clip_vision",
+    unet: "diffusion_models",
+    diffusion: "diffusion_models",
+    diffusion_models: "diffusion_models",
+    style: "style_models",
+    style_models: "style_models",
+    embeddings: "embeddings",
+    hypernetworks: "hypernetworks",
+    gligen: "gligen",
+  };
+
+  it("resolves every comfy-cli --type alias to the same folder for search", async () => {
     mocks.listLocalModels.mockResolvedValue([]);
     mocks.getSystemStats.mockResolvedValue({});
-    await listLocalModelsFallback({ action: "search", type: "checkpoint" });
-    await listLocalModelsFallback({ action: "search", type: "lora" });
-    await listLocalModelsFallback({ action: "search", type: "unet" });
+    const aliases = Object.keys(CLI_TYPE_TO_FOLDER);
+    for (const type of aliases) {
+      await listLocalModelsFallback({ action: "search", type });
+    }
+    expect(mocks.listLocalModels.mock.calls.map((c) => c[0])).toEqual(
+      aliases.map((a) => CLI_TYPE_TO_FOLDER[a]),
+    );
+  });
+
+  it("maps aliases for list-folder too (e.g. upscale→upscale_models, diffusion→diffusion_models)", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockResolvedValue({});
+    await listLocalModelsFallback({ action: "list-folder", folder: "upscale" });
+    await listLocalModelsFallback({ action: "list-folder", folder: "diffusion" });
     await listLocalModelsFallback({ action: "list-folder", folder: "checkpoint" });
     expect(mocks.listLocalModels.mock.calls.map((c) => c[0])).toEqual([
-      "checkpoints",
-      "loras",
+      "upscale_models",
       "diffusion_models",
       "checkpoints",
     ]);

--- a/src/__tests__/services/local-models-fallback.test.ts
+++ b/src/__tests__/services/local-models-fallback.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listLocalModels: vi.fn(),
+  getSystemStats: vi.fn(),
+  comfyuiPath: undefined as string | undefined,
+}));
+
+vi.mock("../../services/model-resolver.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/model-resolver.js")>(
+    "../../services/model-resolver.js",
+  );
+  return { ...actual, listLocalModels: mocks.listLocalModels };
+});
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mocks.getSystemStats,
+}));
+
+vi.mock("../../config.js", () => ({
+  get config() {
+    return { comfyuiPath: mocks.comfyuiPath };
+  },
+}));
+
+import {
+  isLocalModelsListAction,
+  listLocalModelsFallback,
+} from "../../services/local-models-fallback.js";
+
+const model = (name: string, type: string) => ({ name, path: `${type}/${name}`, size: 0, modified: "", type });
+
+describe("comfy_cli_models local fallback (#460)", () => {
+  beforeEach(() => {
+    mocks.listLocalModels.mockReset();
+    mocks.getSystemStats.mockReset();
+    mocks.comfyuiPath = undefined;
+  });
+
+  it("recognizes the read-only listing actions", () => {
+    for (const a of ["list-folders", "list-folder", "search", "show"]) {
+      expect(isLocalModelsListAction(a)).toBe(true);
+    }
+    for (const a of ["download", "remove"]) {
+      expect(isLocalModelsListAction(a)).toBe(false);
+    }
+  });
+
+  it("lists local model folders via the connected server when comfy-cli is absent", async () => {
+    mocks.listLocalModels.mockResolvedValue([
+      model("sd_xl.safetensors", "checkpoints"),
+      model("lcm.safetensors", "loras"),
+    ]);
+    const { command, data } = await listLocalModelsFallback({ action: "list-folders" });
+    expect(command).toBe("models list-folders");
+    expect(data).toEqual({ folders: ["checkpoints", "loras"] });
+    expect(mocks.getSystemStats).not.toHaveBeenCalled();
+  });
+
+  it("lists files in a folder", async () => {
+    mocks.listLocalModels.mockResolvedValue([model("a.safetensors", "loras"), model("b.safetensors", "loras")]);
+    const { data } = await listLocalModelsFallback({ action: "list-folder", folder: "loras" });
+    expect(data).toEqual({ folder: "loras", count: 2, files: ["a.safetensors", "b.safetensors"] });
+  });
+
+  it("searches by text and honors the limit", async () => {
+    mocks.listLocalModels.mockResolvedValue([
+      model("flux_dev.safetensors", "checkpoints"),
+      model("flux_schnell.safetensors", "checkpoints"),
+      model("sd15.safetensors", "checkpoints"),
+    ]);
+    const { data } = await listLocalModelsFallback({ action: "search", text: "flux", limit: 1 });
+    expect(data).toMatchObject({ count: 1, results: [{ name: "flux_dev.safetensors", type: "checkpoints" }] });
+  });
+
+  it("throws a clear error when neither comfy-cli nor a reachable server is available", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(listLocalModelsFallback({ action: "list-folders" })).rejects.toThrow(
+      /no local model source is available/i,
+    );
+  });
+
+  it("returns an empty list (not an error) when the server is reachable but empty", async () => {
+    mocks.listLocalModels.mockResolvedValue([]);
+    mocks.getSystemStats.mockResolvedValue({});
+    const { data } = await listLocalModelsFallback({ action: "list-folders" });
+    expect(data).toEqual({ folders: [] });
+  });
+});

--- a/src/__tests__/tools/comfy-cli.test.ts
+++ b/src/__tests__/tools/comfy-cli.test.ts
@@ -17,6 +17,14 @@ vi.mock("../../services/comfy-cli.js", () => ({
   },
 }));
 
+const fallbackMocks = vi.hoisted(() => ({ fallback: vi.fn() }));
+vi.mock("../../services/local-models-fallback.js", async () => {
+  const actual = await vi.importActual<typeof import("../../services/local-models-fallback.js")>(
+    "../../services/local-models-fallback.js",
+  );
+  return { ...actual, listLocalModelsFallback: fallbackMocks.fallback };
+});
+
 import { registerComfyCliTools } from "../../tools/comfy-cli.js";
 
 type Handler = (args: Record<string, any>) => Promise<CallToolResult>;
@@ -47,8 +55,10 @@ describe("comfy-cli MCP command construction", () => {
   beforeEach(() => {
     mocks.run.mockReset();
     mocks.run.mockResolvedValue(envelope());
-    mocks.resolve.mockClear();
+    mocks.resolve.mockReset();
+    mocks.resolve.mockReturnValue("/bin/comfy");
     mocks.version.mockClear();
+    fallbackMocks.fallback.mockReset();
   });
 
   it("uses the same workspace for status path and version", async () => {
@@ -112,6 +122,33 @@ describe("comfy-cli MCP command construction", () => {
       ["model", "download", "--url", "https://example.com/m.safetensors", "--relative-path", "models/loras"],
       ["model", "remove", "--relative-path", "models/loras", "--model-names", "a.safetensors b.safetensors"],
     ]);
+  });
+
+  it("falls back to the live server for local listing when comfy-cli is absent (#460)", async () => {
+    mocks.resolve.mockReturnValue(undefined); // comfy-cli not on PATH
+    fallbackMocks.fallback.mockResolvedValue({
+      command: "models list-folders",
+      data: { folders: ["checkpoints", "loras"] },
+    });
+    const result = await handlers().get("comfy_cli_models")!({ action: "list-folders", where: "local" });
+    expect(mocks.run).not.toHaveBeenCalled();
+    expect(fallbackMocks.fallback).toHaveBeenCalledWith(expect.objectContaining({ action: "list-folders" }));
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed).toMatchObject({ ok: true, source: "local_models", data: { folders: ["checkpoints", "loras"] } });
+  });
+
+  it("does NOT fall back when a workspace is pinned — comfy-cli surfaces its own error", async () => {
+    mocks.resolve.mockReturnValue(undefined);
+    await handlers().get("comfy_cli_models")!({ action: "list-folders", where: "local", workspace: "/ws" });
+    expect(fallbackMocks.fallback).not.toHaveBeenCalled();
+    expect(mocks.run).toHaveBeenCalled();
+  });
+
+  it("does NOT fall back for mutation actions like download", async () => {
+    mocks.resolve.mockReturnValue(undefined);
+    await handlers().get("comfy_cli_models")!({ action: "download", url: "https://example.com/m.safetensors" });
+    expect(fallbackMocks.fallback).not.toHaveBeenCalled();
+    expect(mocks.run).toHaveBeenCalled();
   });
 
   it("keeps skill installation dry-run unless apply is explicit", async () => {

--- a/src/services/local-models-fallback.ts
+++ b/src/services/local-models-fallback.ts
@@ -13,6 +13,36 @@ import { config } from "../config.js";
 // the live /object_info fallback for comfy_cli_search_nodes (#354).
 // ---------------------------------------------------------------------------
 
+/**
+ * comfy-cli's `models search --type` accepts singular type aliases and maps them
+ * to the real ComfyUI model folder before scanning (e.g. `checkpoint` →
+ * `checkpoints`, `lora` → `loras`, `unet` → `diffusion_models`). The fallback
+ * must apply the SAME mapping or a valid search returns a wrong empty result.
+ * Unknown / already-canonical values pass through unchanged.
+ */
+const TYPE_ALIASES: Record<string, string> = {
+  checkpoint: "checkpoints",
+  lora: "loras",
+  vae: "vae",
+  unet: "diffusion_models",
+  diffusion_model: "diffusion_models",
+  controlnet: "controlnet",
+  embedding: "embeddings",
+  clip: "clip",
+  clip_vision: "clip_vision",
+  text_encoder: "text_encoders",
+  upscale_model: "upscale_models",
+  hypernetwork: "hypernetworks",
+  style_model: "style_models",
+  diffuser: "diffusers",
+  gligen: "gligen",
+  photomaker: "photomaker",
+};
+
+function resolveModelFolder(type: string): string {
+  return TYPE_ALIASES[type.toLowerCase()] ?? type;
+}
+
 /** Read-only comfy_cli_models actions that can be served without comfy-cli. */
 export type LocalModelsListAction = "list-folders" | "list-folder" | "search" | "show";
 
@@ -71,13 +101,17 @@ export async function listLocalModelsFallback(args: {
     }
     case "list-folder": {
       if (!args.folder) throw new Error("folder is required for list-folder");
-      const models = await listLocalModels(args.folder);
+      const folder = resolveModelFolder(args.folder);
+      const models = await listLocalModels(folder);
       if (models.length === 0) await assertLocalSourceAvailable();
-      const files = models.map((m) => m.name);
-      return { command: `models list-folder ${args.folder}`, data: { folder: args.folder, count: files.length, files } };
+      let files = models.map((m) => m.name);
+      // comfy-cli forwards `--limit` for list-folder; cap the same way.
+      if (args.limit && args.limit > 0) files = files.slice(0, args.limit);
+      return { command: `models list-folder ${folder}`, data: { folder, count: files.length, files } };
     }
     case "search": {
-      const models = await listLocalModels(args.type);
+      // Map the CLI's singular `--type` alias to the real folder before scanning.
+      const models = await listLocalModels(args.type ? resolveModelFolder(args.type) : undefined);
       if (models.length === 0) await assertLocalSourceAvailable();
       const needle = (args.text ?? "").trim().toLowerCase();
       let hits = needle ? models.filter((m) => m.name.toLowerCase().includes(needle)) : models;
@@ -90,9 +124,11 @@ export async function listLocalModelsFallback(args: {
       const models = await listLocalModels();
       if (models.length === 0) await assertLocalSourceAvailable();
       const needle = args.name.toLowerCase();
-      const match =
-        models.find((m) => m.name.toLowerCase() === needle) ??
-        models.find((m) => m.name.toLowerCase().includes(needle));
+      // comfy `models show <name>` addresses a specific model by name — return
+      // the EXACT (case-insensitive) match only. A substring guess would report
+      // an arbitrary model (e.g. show "flux" picking one of several), so no
+      // exact match is a clear not-found.
+      const match = models.find((m) => m.name.toLowerCase() === needle);
       if (!match) throw new Error(`Model '${args.name}' was not found among the connected ComfyUI's local models.`);
       return {
         command: `models show ${args.name}`,

--- a/src/services/local-models-fallback.ts
+++ b/src/services/local-models-fallback.ts
@@ -1,0 +1,112 @@
+import { listLocalModels, MODEL_SUBDIRS } from "./model-resolver.js";
+import { getSystemStats } from "../comfyui/client.js";
+import { config } from "../config.js";
+
+// ---------------------------------------------------------------------------
+// Local-model discovery fallback for comfy_cli_models (issue #460). The
+// read-only listing actions (list-folders, list-folder, search, show) don't
+// actually need the separate comfy-cli executable: the connected ComfyUI
+// already exposes what's installed via its /models REST endpoint (with a
+// COMFYUI_PATH filesystem scan behind it). This reproduces those actions
+// directly through the existing listLocalModels() path so model discovery
+// keeps working on a plain local install with no comfy-cli on PATH — mirroring
+// the live /object_info fallback for comfy_cli_search_nodes (#354).
+// ---------------------------------------------------------------------------
+
+/** Read-only comfy_cli_models actions that can be served without comfy-cli. */
+export type LocalModelsListAction = "list-folders" | "list-folder" | "search" | "show";
+
+export function isLocalModelsListAction(action: string): action is LocalModelsListAction {
+  return action === "list-folders" || action === "list-folder" || action === "search" || action === "show";
+}
+
+export interface LocalModelsFallbackResult {
+  command: string;
+  data: unknown;
+}
+
+/**
+ * When listLocalModels() yields nothing it may be an empty (but reachable)
+ * server, OR it may mean we have no usable local source at all. The latter must
+ * be a clear error rather than a silent empty list, so callers know to install
+ * comfy-cli or point at a reachable ComfyUI. A local COMFYUI_PATH always counts
+ * as a source; otherwise we probe the connected server cheaply via system_stats.
+ */
+async function assertLocalSourceAvailable(): Promise<void> {
+  if (config.comfyuiPath) return;
+  try {
+    await getSystemStats();
+    return; // server reachable — an empty result is a legitimate answer
+  } catch {
+    throw new Error(
+      "comfy-cli was not found and no local model source is available: COMFYUI_PATH is unset and the connected ComfyUI server is unreachable. " +
+        "Install comfy-cli>=1.11.1 (or set COMFY_CLI_PATH), set COMFYUI_PATH, or connect to a running ComfyUI server.",
+    );
+  }
+}
+
+/**
+ * Serve a read-only comfy_cli_models listing action from the connected
+ * ComfyUI's local models (via listLocalModels), for use when comfy-cli is
+ * absent. Throws when a required argument is missing (mirrors the CLI path).
+ */
+export async function listLocalModelsFallback(args: {
+  action: LocalModelsListAction;
+  folder?: string;
+  text?: string;
+  type?: string;
+  name?: string;
+  limit?: number;
+}): Promise<LocalModelsFallbackResult> {
+  switch (args.action) {
+    case "list-folders": {
+      // comfy `models list-folders` reports the model folder names. We list
+      // the folders that actually contain at least one model, keeping the
+      // canonical ordering of MODEL_SUBDIRS.
+      const models = await listLocalModels();
+      if (models.length === 0) await assertLocalSourceAvailable();
+      const present = new Set(models.map((m) => m.type));
+      const folders = MODEL_SUBDIRS.filter((f) => present.has(f));
+      return { command: "models list-folders", data: { folders } };
+    }
+    case "list-folder": {
+      if (!args.folder) throw new Error("folder is required for list-folder");
+      const models = await listLocalModels(args.folder);
+      if (models.length === 0) await assertLocalSourceAvailable();
+      const files = models.map((m) => m.name);
+      return { command: `models list-folder ${args.folder}`, data: { folder: args.folder, count: files.length, files } };
+    }
+    case "search": {
+      const models = await listLocalModels(args.type);
+      if (models.length === 0) await assertLocalSourceAvailable();
+      const needle = (args.text ?? "").trim().toLowerCase();
+      let hits = needle ? models.filter((m) => m.name.toLowerCase().includes(needle)) : models;
+      if (args.limit && args.limit > 0) hits = hits.slice(0, args.limit);
+      const results = hits.map((m) => ({ name: m.name, type: m.type, path: m.path }));
+      return { command: "models search", data: { count: results.length, results } };
+    }
+    case "show": {
+      if (!args.name) throw new Error("name is required for show");
+      const models = await listLocalModels();
+      if (models.length === 0) await assertLocalSourceAvailable();
+      const needle = args.name.toLowerCase();
+      const match =
+        models.find((m) => m.name.toLowerCase() === needle) ??
+        models.find((m) => m.name.toLowerCase().includes(needle));
+      if (!match) throw new Error(`Model '${args.name}' was not found among the connected ComfyUI's local models.`);
+      return {
+        command: `models show ${args.name}`,
+        data: {
+          name: match.name,
+          type: match.type,
+          path: match.path,
+          size: match.size,
+          modified: match.modified,
+          ...(match.baseModel ? { baseModel: match.baseModel } : {}),
+          ...(match.triggerWords?.length ? { triggerWords: match.triggerWords } : {}),
+          ...(match.civitaiUrl ? { civitaiUrl: match.civitaiUrl } : {}),
+        },
+      };
+    }
+  }
+}

--- a/src/services/local-models-fallback.ts
+++ b/src/services/local-models-fallback.ts
@@ -14,29 +14,31 @@ import { config } from "../config.js";
 // ---------------------------------------------------------------------------
 
 /**
- * comfy-cli's `models search --type` accepts singular type aliases and maps them
- * to the real ComfyUI model folder before scanning (e.g. `checkpoint` →
- * `checkpoints`, `lora` → `loras`, `unet` → `diffusion_models`). The fallback
- * must apply the SAME mapping or a valid search returns a wrong empty result.
- * Unknown / already-canonical values pass through unchanged.
+ * comfy-cli's `models search --type` maps its `--type` value to the real ComfyUI
+ * model folder before scanning. This mirrors comfy-cli's `_TYPE_TO_FOLDER`
+ * (comfy_cli/command/models/search.py) EXACTLY so a `--type` that comfy-cli
+ * would resolve is resolved identically here — otherwise a valid fallback search
+ * returns a wrong empty result. Values not in the map pass through unchanged.
  */
 const TYPE_ALIASES: Record<string, string> = {
   checkpoint: "checkpoints",
+  checkpoints: "checkpoints",
   lora: "loras",
+  loras: "loras",
   vae: "vae",
-  unet: "diffusion_models",
-  diffusion_model: "diffusion_models",
   controlnet: "controlnet",
-  embedding: "embeddings",
+  upscale: "upscale_models",
+  upscale_models: "upscale_models",
   clip: "clip",
   clip_vision: "clip_vision",
-  text_encoder: "text_encoders",
-  upscale_model: "upscale_models",
-  hypernetwork: "hypernetworks",
-  style_model: "style_models",
-  diffuser: "diffusers",
+  unet: "diffusion_models",
+  diffusion: "diffusion_models",
+  diffusion_models: "diffusion_models",
+  style: "style_models",
+  style_models: "style_models",
+  embeddings: "embeddings",
+  hypernetworks: "hypernetworks",
   gligen: "gligen",
-  photomaker: "photomaker",
 };
 
 function resolveModelFolder(type: string): string {

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -6,6 +6,10 @@ import {
   runComfyCli,
 } from "../services/comfy-cli.js";
 import { searchLiveObjectInfo } from "../services/object-info-search.js";
+import {
+  isLocalModelsListAction,
+  listLocalModelsFallback,
+} from "../services/local-models-fallback.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 const whereSchema = z.enum(["local", "cloud"]).optional();
@@ -212,7 +216,7 @@ export function registerComfyCliTools(server: McpServer): void {
 
   server.tool(
     "comfy_cli_models",
-    "Discover model folders/files locally or in Comfy Cloud, download model URLs into a workspace, or remove workspace model files through official comfy-cli.",
+    "Discover model folders/files locally or in Comfy Cloud, download model URLs into a workspace, or remove workspace model files through official comfy-cli. When comfy-cli is not installed/on PATH and the target is the connected (local) server, the read-only listing actions (list-folders, list-folder, search, show) fall back to that server's own local models (via /models) — so model discovery works without the CLI.",
     {
       action: z.enum(["list-folders", "list-folder", "search", "show", "download", "remove"]),
       folder: z.string().optional(),
@@ -228,6 +232,36 @@ export function registerComfyCliTools(server: McpServer): void {
     },
     async (args) => {
       try {
+        // Local models fallback (#460): the read-only listing actions don't
+        // need comfy-cli — the connected local ComfyUI already reports its
+        // installed models. When comfy-cli is absent and we're targeting the
+        // connected server (not Comfy Cloud, no pinned workspace), serve the
+        // listing from listLocalModels() instead of failing on the missing CLI.
+        // A pinned `workspace` may be a DIFFERENT install than the connected
+        // server, so we don't substitute silently — we fall through and let
+        // comfy-cli surface its clear not-found error for that workspace.
+        // Mirrors the live /object_info fallback for comfy_cli_search_nodes.
+        const listAction = isLocalModelsListAction(args.action) ? args.action : undefined;
+        if (
+          listAction &&
+          args.where !== "cloud" &&
+          !args.workspace &&
+          !resolveComfyCliExecutable({ workspace: args.workspace })
+        ) {
+          const { command, data } = await listLocalModelsFallback({ ...args, action: listAction });
+          return textEnvelope({
+            schema: "envelope/1",
+            type: "envelope",
+            ok: true,
+            command,
+            version: "local-models-fallback",
+            where: "local",
+            source: "local_models",
+            note: "comfy-cli was not found; listed the connected ComfyUI's local models instead.",
+            data,
+            error: null,
+          });
+        }
         const command = [args.action === "download" || args.action === "remove" ? "model" : "models", args.action];
         if (args.action === "list-folder") {
           if (!args.folder) throw new Error("folder is required for list-folder");


### PR DESCRIPTION
## Root cause
`comfy_cli_models`' read-only listing actions (`list-folders`, `list-folder`, `search`, `show`) shell out to the separate `comfy-cli` executable and error with `comfy-cli was not found...` when it is not on PATH — even on a normal local install where the connected ComfyUI already exposes its installed models via `/models`. Callers were forced to fall back to raw filesystem inspection.

This is the same fallback class as #354/#408 (`comfy_cli_search_nodes` falling back to the connected server's live `/object_info`), but for **listing local models**.

## Fix
When comfy-cli is absent/unavailable **and** the target is the connected local server (not Comfy Cloud, and no pinned `workspace`), the read-only listing actions are served from the existing `listLocalModels()` path (ComfyUI `/models` REST endpoint + `COMFYUI_PATH` filesystem scan) instead of failing. Response carries `source: "local_models"` and a note explaining the substitution — mirroring the search-nodes fallback envelope.

A pinned `workspace` may be a *different* install than the connected server, so we do **not** substitute silently there — we fall through and let comfy-cli surface its clear not-found error for that workspace. Mutation actions (`download`, `remove`) still require comfy-cli.

When neither comfy-cli, a reachable server, nor `COMFYUI_PATH` is available, a clear actionable error is raised instead of a silent empty list.

## Tests
- New `src/__tests__/services/local-models-fallback.test.ts`: folder/file/search mapping, limit handling, clear error when neither source is available, and empty-but-reachable server returns an empty list (not an error).
- New tool-level cases in `comfy-cli.test.ts`: fallback fires when comfy-cli is absent; does NOT fire when a workspace is pinned or for mutation actions.
- `tsc --noEmit` clean; full `npm test` green except the pre-existing `node-dev` ripgrep-vs-builtin environment test (unrelated).

No version bump.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)