### PR TITLE
release: 0.48.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.13] - 2026-07-30
+
+### MCP
+
+#### Fixed
+- Gemini backend readiness recognizes API-key auth (GEMINI_API_KEY/GOOGLE_API_KEY, or ~/.gemini/settings.json security.auth.selectedType=gemini-api-key), not just OAuth — so an API-key-authed Gemini no longer shows as "Not signed in" (#456)
+- comfy_cli_models list actions (list-folders/list-folder/search/show) fall back to the connected local server's /models when comfy-cli is absent (mirrors #354), with faithful comfy-cli semantics — type-alias→folder mapping, exact-match show, list-folder limit; mutations still require comfy-cli; pinned workspace / cloud never substituted (#460)
+
+
 ## [0.48.12] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.12",
+  "version": "0.48.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.12",
+      "version": "0.48.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.12",
+  "version": "0.48.13",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile 0.48.13 (tag pushed → npm publish). 2 fixes: Gemini readiness recognizes API-key auth (#456); comfy_cli_models list falls back to the live server when comfy-cli is absent (#460). Both codex PASS. 🤖 Generated with Claude Code