### PR TITLE
fix(download): surface declined-resume + enable safe HF Xet resume instead of silent full re-download (#467)

### DIFF
--- a/src/__tests__/services/download-cache-failclosed.test.ts
+++ b/src/__tests__/services/download-cache-failclosed.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #467 P1-B: assertComplete() must FAIL CLOSED when an authoritative expected size
+// is known but the written file's size can't be read (a transient stat failure) —
+// it must NOT finalize (rename .partial into cache) an unverifiable download.
+//
+// Force that by wrapping node:fs/promises' stat so it throws while a flag is set;
+// everything else passes through to the real implementation.
+const statCtl = { fail: false };
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    default: actual,
+    stat: async (p: Parameters<typeof actual.stat>[0], ...rest: unknown[]) => {
+      if (statCtl.fail) throw Object.assign(new Error("EIO: simulated stat failure"), { code: "EIO" });
+      // @ts-expect-error passthrough
+      return actual.stat(p, ...rest);
+    },
+  };
+});
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    huggingfaceToken: undefined as string | undefined,
+    civitaiApiToken: undefined as string | undefined,
+  };
+  return { config, isRemoteMode: () => !config.comfyuiPath };
+});
+
+import { config } from "../../config.js";
+import { downloadWithCache } from "../../services/download-cache.js";
+
+const fetchMock = vi.fn();
+let tempDir: string;
+let cacheDir: string;
+let comfyDir: string;
+
+beforeEach(async () => {
+  statCtl.fail = false;
+  tempDir = await mkdtemp(join(tmpdir(), "comfyui-mcp-failclosed-"));
+  cacheDir = join(tempDir, "cache");
+  comfyDir = join(tempDir, "comfy");
+  process.env.COMFYUI_DOWNLOAD_CACHE_DIR = cacheDir;
+  delete process.env.COMFYUI_LRU_CACHE_SIZE_GB;
+  config.comfyuiPath = comfyDir;
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(async () => {
+  statCtl.fail = false;
+  vi.unstubAllGlobals();
+  delete process.env.COMFYUI_DOWNLOAD_CACHE_DIR;
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("assertComplete fail-closed (#467 P1-B)", () => {
+  it("does NOT finalize (rename into cache) when the size can't be verified against a known Content-Length", async () => {
+    // A full body WITH an authoritative Content-Length. Normally this verifies and
+    // finalizes; with stat failing at completion it must fail closed instead.
+    fetchMock.mockResolvedValueOnce(
+      new Response("the-model-bytes", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "15" },
+      }),
+    );
+
+    statCtl.fail = true;
+    await expect(
+      downloadWithCache({
+        url: "https://example.com/models/failclosed.safetensors",
+        headers: {},
+        targetPath: join(comfyDir, "out.safetensors"),
+      }),
+    ).rejects.toThrow(/could not be verified|not finalizing/i);
+
+    // Crucially: nothing was renamed into the cache as a "successful" download.
+    statCtl.fail = false;
+    const cached = await readdir(cacheDir).catch(() => [] as string[]);
+    expect(cached.some((f) => f.endsWith(".safetensors"))).toBe(false);
+  });
+});

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -1124,6 +1124,44 @@ describe("downloadModel cache", () => {
     renameSpy.mockRestore();
   });
 
+  it("PRESERVES the original at a named backup when even the Windows restore fails (never lost) (#467)", async () => {
+    if (process.platform !== "win32") return;
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const dest = join(comfyDir, "precious2.safetensors");
+    await writeFile(dest, "ORIGINAL-PRECIOUS-BYTES");
+
+    const linkSpy = vi.spyOn(downloadCacheFs, "link").mockRejectedValue(Object.assign(new Error("EXDEV"), { code: "EXDEV" }));
+    const copySpy = vi.spyOn(downloadCacheFs, "copyFile").mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" }));
+    let dlToDest = 0;
+    const renameSpy = vi.spyOn(downloadCacheFs, "rename").mockImplementation(async (from: string, to: string) => {
+      if (String(from).includes(".dl-") && to === dest) {
+        dlToDest += 1;
+        throw Object.assign(new Error(dlToDest === 1 ? "EPERM" : "EIO"), { code: dlToDest === 1 ? "EPERM" : "EIO" });
+      }
+      if (String(from).includes(".bak-") && to === dest) {
+        throw Object.assign(new Error("EIO: restore failed too"), { code: "EIO" }); // restore ALSO fails
+      }
+      return fsPromises.rename(from, to); // dest → .bak backup succeeds
+    });
+
+    const url = "https://example.com/models/winrestorefail.safetensors";
+    fetchMock.mockImplementation(() => Promise.resolve(okResponse("NEW-BYTES")));
+
+    // The error must NAME the backup so the file is recoverable (not silently lost).
+    await expect(downloadWithCache({ url, headers: {}, targetPath: dest })).rejects.toThrow(/PRESERVED at ".*\.bak-.*"/i);
+    // The original bytes still exist on disk under the backup name.
+    const baks = (await readdir(comfyDir)).filter((f) => f.includes(".bak-"));
+    expect(baks).toHaveLength(1);
+    await expect(readFile(join(comfyDir, baks[0]), "utf-8")).resolves.toBe("ORIGINAL-PRECIOUS-BYTES");
+    // No leftover .dl temp.
+    expect((await readdir(comfyDir)).some((f) => f.includes(".dl-"))).toBe(false);
+    linkSpy.mockRestore();
+    copySpy.mockRestore();
+    renameSpy.mockRestore();
+  });
+
   it("does NOT serve a LEGACY bare-URL cache entry to an unauthenticated caller — no cross-auth leak (#467 P1-C)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -19,8 +19,19 @@ vi.mock("../../config.js", () => {
 });
 
 import { config } from "../../config.js";
-import { downloadCacheFs } from "../../services/download-cache.js";
+import {
+  downloadCacheFs,
+  getResumeDiagnostic,
+  resetResumeDiagnostics,
+} from "../../services/download-cache.js";
 import { downloadModel } from "../../services/model-resolver.js";
+
+/** Tray id for a URL — mirrors download-jobs' downloadIdFor / the cache's
+ *  trayIdForUrl, so a test can look up the resume diagnostic (#467). */
+async function trayIdFor(url: string): Promise<string> {
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(url).digest("hex").slice(0, 16);
+}
 
 const fetchMock = vi.fn();
 let tempDir: string;
@@ -42,6 +53,7 @@ beforeEach(async () => {
   config.civitaiApiToken = undefined;
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
+  resetResumeDiagnostics();
 });
 
 afterEach(async () => {
@@ -417,6 +429,122 @@ describe("downloadModel cache", () => {
     expect(init.headers["If-Range"]).toBeUndefined();
     // The stale prefix is discarded — final file is the fresh body, not "AAAA...".
     await expect(readFile(target, "utf-8")).resolves.toBe("FRESHFULLBODY");
+  });
+
+  it("SURFACES a validator-less declined resume instead of silently discarding the partial (#467)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/silentdiscard.safetensors";
+    const { partial } = await cachePaths(url);
+    // A 21-byte partial with NO sidecar (the HF Xet case: the CAS CDN sent no
+    // ETag/Last-Modified on the original body, so none was ever written).
+    await writeFile(partial, "STALE_PARTIAL_CONTENT"); // 21 bytes
+
+    fetchMock.mockResolvedValueOnce(okResponse("FRESHFULLBODY"));
+
+    const target = await downloadModel(url, "checkpoints", "silentdiscard-out.safetensors");
+    await expect(readFile(target, "utf-8")).resolves.toBe("FRESHFULLBODY");
+
+    // The discard is no longer silent: a diagnostic records WHY and HOW MUCH.
+    const diag = getResumeDiagnostic(await trayIdFor(url));
+    expect(diag?.outcome).toBe("declined:no-validator");
+    expect(diag?.discardedBytes).toBe(21);
+  });
+
+  it("persists a validator from the HF resolve REDIRECT (X-Linked-Etag) so a Xet partial becomes resumable (#467)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/big.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+
+    // Hop 1: resolve URL 302s cross-origin to the CAS CDN, carrying the
+    // content-addressed X-Linked-Etag (but no plain ETag).
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=abc",
+          "x-linked-etag": '"xet-content-hash-v1"',
+        },
+      }),
+    );
+    // Hop 2: the CAS CDN serves the body with NEITHER ETag NOR Last-Modified,
+    // and the stream ends early (truncated) so the partial + sidecar survive.
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode("half")); c.close(); },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "1000" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "diffusion_models", "big-out.safetensors"),
+    ).rejects.toThrow(/truncat/i);
+
+    // Previously NO sidecar was written (final CAS 200 has no validator) so the
+    // partial could never resume. Now the redirect's X-Linked-Etag is captured.
+    await expect(stat(partial)).resolves.toBeTruthy();
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"xet-content-hash-v1"');
+  });
+
+  it("forwards Range across a cross-origin CAS redirect and APPENDS a 206 (HF Xet resume) (#467)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/resume-xet.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // 4 bytes already downloaded
+    await writeFile(sidecar, '"xet-content-hash-v1"');
+
+    // Hop 1: resolve URL 302s cross-origin (If-Range unchanged → range honored).
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=abc" },
+      }),
+    );
+    // Hop 2: the CAS CDN honors the byte range and returns a 206.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    const target = await downloadModel(url, "diffusion_models", "resume-xet-out.safetensors");
+
+    // Hop 1 (resolve) carried Range + If-Range...
+    const [, firstInit] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(firstInit.headers.Range).toBe("bytes=4-");
+    expect(firstInit.headers["If-Range"]).toBe('"xet-content-hash-v1"');
+    // ...and CRUCIALLY the cross-origin CAS hop STILL carried Range (previously
+    // dropped with all headers → resume was impossible on Xet).
+    const [casUrl, secondInit] = fetchMock.mock.calls[1] as [string, { headers: Record<string, string> }];
+    expect(casUrl).toContain("cas-bridge.xethub.hf.co");
+    expect(secondInit.headers.Range).toBe("bytes=4-");
+    // The bytes were appended, not re-downloaded from 0.
+    await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBB");
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("resumed");
+  });
+
+  it("declines + SURFACES a changed-upstream resume (If-Range miss, 200) — safety preserved (#467/#343)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/changed-surfaced.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // 4 bytes
+    await writeFile(sidecar, '"etag-old"');
+
+    // Upstream changed → If-Range miss → server sends full 200, not a 206.
+    fetchMock.mockResolvedValueOnce(okResponse("BRANDNEWBODY"));
+
+    const target = await downloadModel(url, "checkpoints", "changed-surfaced-out.safetensors");
+    // Overwritten with the fresh body — safety preserved, no corrupt append.
+    await expect(readFile(target, "utf-8")).resolves.toBe("BRANDNEWBODY");
+
+    const diag = getResumeDiagnostic(await trayIdFor(url));
+    expect(diag?.outcome).toBe("declined:etag-changed");
+    expect(diag?.discardedBytes).toBe(4);
   });
 
   it("persists the validator sidecar on a fresh write so a later resume can guard with If-Range (#343 edge)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -967,6 +967,17 @@ describe("downloadModel cache", () => {
     expect(cloudPrincipalKey(s3url, {})).toBe(cloudPrincipalKey(s3url, {}));
     expect(alice).toBe(cloudPrincipalKey(s3url, { s3: { access_key_id: "AK-ALICE", secret_access_key: "x" } }));
 
+    // SDK-level endpoint env vars change the EFFECTIVE endpoint even with explicit
+    // creds → must change the identity (#467 P1-B).
+    const explicit = { s3: { access_key_id: "AK", secret_access_key: "x" } };
+    const baseline = cloudPrincipalKey(s3url, explicit);
+    const prevEp = process.env.AWS_ENDPOINT_URL_S3;
+    process.env.AWS_ENDPOINT_URL_S3 = "https://minio.internal:9000";
+    const withEp = cloudPrincipalKey(s3url, explicit);
+    if (prevEp !== undefined) process.env.AWS_ENDPOINT_URL_S3 = prevEp;
+    else delete process.env.AWS_ENDPOINT_URL_S3;
+    expect(withEp).not.toBe(baseline);
+
     // A non-cloud URL contributes no cloud discriminator.
     expect(cloudPrincipalKey("https://example.com/x.safetensors", {})).toBe("");
   });
@@ -1074,6 +1085,42 @@ describe("downloadModel cache", () => {
     await expect(readFile(dest, "utf-8")).resolves.toBe("ORIGINAL-PRECIOUS-BYTES");
     const leftovers = (await readdir(comfyDir)).filter((f) => f.includes(".mat-") || f.includes(".dl-"));
     expect(leftovers).toHaveLength(0);
+    renameSpy.mockRestore();
+  });
+
+  it("preserves the existing destination when the Windows overwrite retry itself fails (#467)", async () => {
+    if (process.platform !== "win32") return; // the backup/restore path is Windows-only
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const dest = join(comfyDir, "precious.safetensors");
+    await writeFile(dest, "ORIGINAL-PRECIOUS-BYTES");
+
+    // Force materialize to fail (link/copy) so the DIRECT fallback runs, then make
+    // the fallback's temp→dest swap EPERM (triggers the Windows backup dance) and
+    // its RETRY EIO (the retry itself fails) — the original dest must be restored.
+    const linkSpy = vi.spyOn(downloadCacheFs, "link").mockRejectedValue(Object.assign(new Error("EXDEV"), { code: "EXDEV" }));
+    const copySpy = vi.spyOn(downloadCacheFs, "copyFile").mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" }));
+    let dlToDestAttempts = 0;
+    const renameSpy = vi.spyOn(downloadCacheFs, "rename").mockImplementation(async (from: string, to: string) => {
+      if (String(from).includes(".dl-") && to === dest) {
+        dlToDestAttempts += 1;
+        // First: EPERM (can't overwrite) → backup dance. Retry: EIO (retry fails).
+        throw Object.assign(new Error(dlToDestAttempts === 1 ? "EPERM" : "EIO"), { code: dlToDestAttempts === 1 ? "EPERM" : "EIO" });
+      }
+      return fsPromises.rename(from, to); // dest→backup and backup→dest restore run for real
+    });
+
+    const url = "https://example.com/models/winretry.safetensors";
+    fetchMock.mockImplementation(() => Promise.resolve(okResponse("NEW-BYTES")));
+
+    await expect(downloadWithCache({ url, headers: {}, targetPath: dest })).rejects.toThrow(/EIO/i);
+    // The original destination was RESTORED (never lost), despite the failed retry.
+    await expect(readFile(dest, "utf-8")).resolves.toBe("ORIGINAL-PRECIOUS-BYTES");
+    const leftovers = (await readdir(comfyDir)).filter((f) => /\.(dl|bak)-/.test(f));
+    expect(leftovers).toHaveLength(0);
+    linkSpy.mockRestore();
+    copySpy.mockRestore();
     renameSpy.mockRestore();
   });
 

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -785,6 +785,24 @@ describe("downloadModel cache", () => {
     await expect(readFile(bob, "utf-8")).resolves.toBe("BOB-ONLY-BYTES");
   });
 
+  it("separates same-URL downloads by ANY custom auth header, not just known names (#467 P1-2)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/customhdr.safetensors";
+    // A NON-allowlisted custom auth header still selects a distinct representation.
+    fetchMock.mockResolvedValueOnce(okResponse("ALICE-CUSTOM"));
+    fetchMock.mockResolvedValueOnce(okResponse("BOB-CUSTOM"));
+
+    const alice = join(comfyDir, "ca.safetensors");
+    const bob = join(comfyDir, "cb.safetensors");
+    await downloadWithCache({ url, headers: { "X-Custom-Auth": "alice" }, targetPath: alice });
+    await downloadWithCache({ url, headers: { "X-Custom-Auth": "bob" }, targetPath: bob });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2); // NOT coalesced despite same URL
+    await expect(readFile(alice, "utf-8")).resolves.toBe("ALICE-CUSTOM");
+    await expect(readFile(bob, "utf-8")).resolves.toBe("BOB-CUSTOM");
+  });
+
   it("DOES cache/coalesce same-URL downloads with the SAME auth header (public dedup preserved) (#467 P1-2)", async () => {
     const { downloadWithCache } = await import("../../services/download-cache.js");
     await fsPromises.mkdir(comfyDir, { recursive: true });

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -447,6 +447,32 @@ describe("downloadModel cache", () => {
     await expect(stat(partial)).rejects.toThrow();
   });
 
+  it("REFUSES a resume 206 whose total UNDERSTATES the size the original download recorded (#467)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/shrink.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // 4 bytes already downloaded
+    // Sidecar records the validator AND the authoritative total the ORIGINAL 200
+    // declared (4096). A resume 206 that claims a SMALLER total is a server
+    // understating the size — must be refused (would finalize a short prefix).
+    await writeFile(sidecar, '"etag-v1"\n4096');
+
+    // Internally-consistent but understated 206: bytes 4-7/8 (total 8 ≠ 4096).
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "shrink-out.safetensors"),
+    ).rejects.toThrow(/total size|reports a total|resume rejected/i);
+    // The stale partial + sidecar are removed so a retry restarts clean.
+    await expect(stat(partial)).rejects.toThrow();
+  });
+
   it("does NOT resume a validator-less partial — restarts cleanly instead of appending (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/novalidator.safetensors";
@@ -538,9 +564,10 @@ describe("downloadModel cache", () => {
     ).rejects.toThrow(/truncat/i);
 
     // Previously NO sidecar was written (final CAS 200 has no validator) so the
-    // partial could never resume. Now the redirect's X-Linked-Etag is captured.
+    // partial could never resume. Now the redirect's X-Linked-Etag is captured,
+    // plus the authoritative total on line 2 (#467).
     await expect(stat(partial)).resolves.toBeTruthy();
-    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"xet-content-hash-v1"');
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"xet-content-hash-v1"\n1000');
   });
 
   it("forwards Range across a cross-origin CAS redirect and APPENDS a 206 (HF Xet resume) (#467)", async () => {
@@ -750,9 +777,10 @@ describe("downloadModel cache", () => {
       downloadModel(url, "checkpoints", "sidecar-out.safetensors"),
     ).rejects.toThrow(/truncat/i);
 
-    // The validator was captured and PAIRS with the truncated partial bytes.
+    // The validator was captured and PAIRS with the truncated partial bytes, with
+    // the authoritative total (Content-Length 1000) on line 2 (#467).
     await expect(stat(partial)).resolves.toBeTruthy();
-    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"captured-v9"');
+    await expect(readFile(sidecar, "utf-8")).resolves.toBe('"captured-v9"\n1000');
   });
 
   it("REJECTS + removes an OVERSIZED 206 that streams MORE than its Content-Range total (#467 P0-1)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -201,6 +201,30 @@ describe("downloadModel cache", () => {
     await expect(readFile(target, "utf-8")).resolves.toBe("full body from server");
   });
 
+  it("REFUSES an UNSOLICITED partial 206 on a FRESH request — never finalizes a short prefix (#467 P0)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/unsolicited206.safetensors";
+    // Fresh request (no seeded partial → no Range sent). A misbehaving server/proxy
+    // answers with 206 bytes 0-1023/4096 and Content-Length 1024. Deriving the size
+    // from Content-Length (1024) instead of the Content-Range total (4096) would let
+    // a 1 KiB prefix be finalized into cache as the whole 4096-byte model.
+    fetchMock.mockResolvedValueOnce(
+      new Response("A".repeat(1024), {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 0-1023/4096", "content-length": "1024" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "unsolicited206-out.safetensors"),
+    ).rejects.toThrow(/no Range|unsolicited|206/i);
+
+    // The short prefix must NOT have been renamed into the cache as a complete file.
+    const cached = await readdir(cacheDir).catch(() => [] as string[]);
+    expect(cached.some((f) => f.endsWith(".safetensors"))).toBe(false);
+  });
+
   it("rejects a truncated download (Content-Length exceeds bytes received) instead of reporting success (#343)", async () => {
     // Stream body yields only "short" (5 bytes) but the server claims 1000 —
     // pipeline() resolves on the early end, so without the size check this would

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -802,6 +802,24 @@ describe("downloadModel cache", () => {
     await expect(readFile(two, "utf-8")).resolves.toBe("SHARED-BYTES");
   });
 
+  it("gives same-URL DIFFERENT-auth downloads DISTINCT resume-diagnostic slots (#467 P2)", async () => {
+    const { resumeKeyFor, recordResumeDiagnostic, getResumeDiagnostic, trayIdForUrl } =
+      await import("../../services/download-resume-diag.js");
+    const url = "https://example.com/models/p2.safetensors";
+    const kAlice = resumeKeyFor(url, JSON.stringify({ type: "bearer", token: "alice" }));
+    const kBob = resumeKeyFor(url, JSON.stringify({ type: "bearer", token: "bob" }));
+    // Different auth → different slots; no auth → the bare tray id (compat).
+    expect(kAlice).not.toBe(kBob);
+    expect(resumeKeyFor(url)).toBe(trayIdForUrl(url));
+
+    // A concurrent resume for Bob must NOT clobber Alice's declined-discard record.
+    recordResumeDiagnostic(kAlice, "declined:no-validator", 12345);
+    recordResumeDiagnostic(kBob, "resumed", 0);
+    expect(getResumeDiagnostic(kAlice)?.outcome).toBe("declined:no-validator");
+    expect(getResumeDiagnostic(kAlice)?.discardedBytes).toBe(12345);
+    expect(getResumeDiagnostic(kBob)?.outcome).toBe("resumed");
+  });
+
   it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/zerohit.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -601,6 +601,50 @@ describe("downloadModel cache", () => {
     expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
   });
 
+  it("REFUSES a resume 206 when a LATER redirect hop reports a changed X-Linked-Etag (multi-hop) (#467/#343)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/multihop.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"xet-hash-v1"');
+
+    // Hop 1: same-origin 302 whose X-Linked-Etag MATCHES the partial...
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://huggingface.co/org/repo/resolve/main/multihop2",
+          "x-linked-etag": '"xet-hash-v1"',
+        },
+      }),
+    );
+    // Hop 2: a LATER cross-origin 302 that reports a DIFFERENT object — the file
+    // changed; an earlier match must not let this slip through.
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=z",
+          "x-linked-etag": '"xet-hash-v2-CHANGED"',
+        },
+      }),
+    );
+    // Hop 3: CAS 206 for the changed object.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "diffusion_models", "multihop-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
+    await expect(stat(partial)).rejects.toThrow();
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+  });
+
   it("declines + SURFACES a changed-upstream resume (If-Range miss, 200) — safety preserved (#467/#343)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/changed-surfaced.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -933,6 +933,39 @@ describe("downloadModel cache", () => {
     expect(capB.box.d?.outcome).toBe("declined:no-validator");
   });
 
+  it("cloudPrincipalKey separates S3/Azure principals by EXPLICIT auth AND env creds (#467 P1-B)", async () => {
+    const { cloudPrincipalKey } = await import("../../services/storage/index.js");
+    const s3url = "s3://bucket/key.safetensors";
+    // Explicit different access keys → different principals.
+    const alice = cloudPrincipalKey(s3url, { s3: { access_key_id: "AK-ALICE", secret_access_key: "x" } });
+    const bob = cloudPrincipalKey(s3url, { s3: { access_key_id: "AK-BOB", secret_access_key: "x" } });
+    expect(alice).not.toBe(bob);
+    expect(alice).toBeTruthy();
+
+    // ENV-derived creds also participate (the cross-principal-leak fix): an
+    // env-authenticated principal must differ from anonymous.
+    const prev = process.env.AWS_ACCESS_KEY_ID;
+    process.env.AWS_ACCESS_KEY_ID = "AK-FROM-ENV";
+    const envKey = cloudPrincipalKey(s3url, {});
+    delete process.env.AWS_ACCESS_KEY_ID;
+    const anonKey = cloudPrincipalKey(s3url, {});
+    if (prev !== undefined) process.env.AWS_ACCESS_KEY_ID = prev;
+    expect(envKey).not.toBe(anonKey);
+
+    // Azure env connection-string participates too.
+    const azUrl = "https://acct.blob.core.windows.net/c/blob.bin";
+    const prevAz = process.env.AZURE_STORAGE_CONNECTION_STRING;
+    process.env.AZURE_STORAGE_CONNECTION_STRING = "AccountName=acct;AccountKey=KKK==";
+    const azEnv = cloudPrincipalKey(azUrl, {});
+    delete process.env.AZURE_STORAGE_CONNECTION_STRING;
+    const azAnon = cloudPrincipalKey(azUrl, {});
+    if (prevAz !== undefined) process.env.AZURE_STORAGE_CONNECTION_STRING = prevAz;
+    expect(azEnv).not.toBe(azAnon);
+
+    // A non-cloud URL contributes no cloud discriminator.
+    expect(cloudPrincipalKey("https://example.com/x.safetensors", {})).toBe("");
+  });
+
   it("materializes concurrent same-destination DIFFERENT-representation downloads without poisoning either cache entry (#467)", async () => {
     const { downloadWithCache } = await import("../../services/download-cache.js");
     await fsPromises.mkdir(cacheDir, { recursive: true });

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -528,6 +528,42 @@ describe("downloadModel cache", () => {
     expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("resumed");
   });
 
+  it("REFUSES to append a CAS 206 when the redirect's content-addressed X-Linked-Etag changed, even if the CDN honors the Range (#467/#343)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/xet-changed.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"xet-hash-OLD"'); // partial written against OLD content
+
+    // Hop 1: resolve 302 now advertises a DIFFERENT content hash (file changed).
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=new",
+          "x-linked-etag": '"xet-hash-NEW"',
+        },
+      }),
+    );
+    // Hop 2: a misbehaving CAS that honors the stale Range and 206s the NEW object.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    // We must NOT splice new-object bytes onto the stale prefix — reject instead.
+    await expect(
+      downloadModel(url, "diffusion_models", "xet-changed-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
+    // Stale partial + sidecar removed so a retry restarts clean.
+    await expect(stat(partial)).rejects.toThrow();
+    await expect(stat(sidecar)).rejects.toThrow();
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+  });
+
   it("declines + SURFACES a changed-upstream resume (If-Range miss, 200) — safety preserved (#467/#343)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/changed-surfaced.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -598,7 +598,8 @@ describe("downloadModel cache", () => {
     ).rejects.toThrow(/resume rejected/i);
     await expect(stat(partial)).rejects.toThrow();
     await expect(stat(sidecar)).rejects.toThrow();
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+    // Unverifiable, not proven-changed: no validator was available to compare.
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:unverifiable");
   });
 
   it("REFUSES a resume 206 when a LATER redirect hop reports a changed X-Linked-Etag (multi-hop) (#467/#343)", async () => {
@@ -645,14 +646,14 @@ describe("downloadModel cache", () => {
     expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
   });
 
-  it("declines + SURFACES a changed-upstream resume (If-Range miss, 200) — safety preserved (#467/#343)", async () => {
+  it("declines + SURFACES a full-response resume (If-Range miss / no range support, 200) — safety preserved (#467/#343)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/changed-surfaced.safetensors";
     const { partial, sidecar } = await cachePaths(url);
     await writeFile(partial, "AAAA"); // 4 bytes
     await writeFile(sidecar, '"etag-old"');
 
-    // Upstream changed → If-Range miss → server sends full 200, not a 206.
+    // Upstream changed (or no range support) → server sends full 200, not a 206.
     fetchMock.mockResolvedValueOnce(okResponse("BRANDNEWBODY"));
 
     const target = await downloadModel(url, "checkpoints", "changed-surfaced-out.safetensors");
@@ -660,7 +661,7 @@ describe("downloadModel cache", () => {
     await expect(readFile(target, "utf-8")).resolves.toBe("BRANDNEWBODY");
 
     const diag = getResumeDiagnostic(await trayIdFor(url));
-    expect(diag?.outcome).toBe("declined:etag-changed");
+    expect(diag?.outcome).toBe("declined:full-response");
     expect(diag?.discardedBytes).toBe(4);
   });
 

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -802,6 +802,38 @@ describe("downloadModel cache", () => {
     await expect(readFile(two, "utf-8")).resolves.toBe("SHARED-BYTES");
   });
 
+  it("preserves the physical download's resume diagnostic for a COALESCED same-key consumer (#467 P1-b)", async () => {
+    const { downloadWithCache, getResumeDiagnostic } = await import(
+      "../../services/download-cache.js"
+    );
+    const { trayIdForUrl } = await import("../../services/download-resume-diag.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/coalesce-diag.safetensors";
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    // Validator-less partial → the ONE physical download declines + records.
+    await writeFile(join(cacheDir, `.${hash}.safetensors.partial`), "OLDPARTIALBYTES");
+
+    // A single, initially-pending fetch — both callers coalesce onto it.
+    let release!: (r: Response) => void;
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((res) => {
+        release = res;
+      }),
+    );
+
+    const a = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "a.safetensors") });
+    const b = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "b.safetensors") });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1)); // coalesced to ONE fetch
+    release(okResponse("FRESHFULLBODY"));
+    await Promise.all([a, b]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The coalesced second consumer must NOT have wiped the recorded decision.
+    expect(getResumeDiagnostic(trayIdForUrl(url))?.outcome).toBe("declined:no-validator");
+  });
+
   it("gives same-URL DIFFERENT-auth downloads DISTINCT resume-diagnostic slots (#467 P2)", async () => {
     const { resumeKeyFor, recordResumeDiagnostic, getResumeDiagnostic, trayIdForUrl } =
       await import("../../services/download-resume-diag.js");

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -967,6 +967,47 @@ describe("downloadModel cache", () => {
     expect(leftovers).toHaveLength(0);
   });
 
+  it("direct-fallback (materialize failed) does NOT write through a destination hardlink into a cache inode (#467)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+
+    // A pre-existing WINNER cache entry, with the destination HARDLINKED to it (as a
+    // concurrent successful materialize would leave it).
+    const winnerCache = join(cacheDir, "winner.safetensors");
+    await writeFile(winnerCache, "WINNER-BYTES");
+    const dest = join(comfyDir, "same.safetensors");
+    await fsPromises.link(winnerCache, dest); // dest shares WINNER's inode
+
+    // Force materialize to fail at its link/copy stage — BEFORE it touches dest — so
+    // downloadWithCache takes the DIRECT fallback while dest is STILL hardlinked to
+    // the winner's cache inode (the poison window). link/copyFile are used ONLY by
+    // materializeCacheFile, so this doesn't disturb the cache write.
+    const linkSpy = vi
+      .spyOn(downloadCacheFs, "link")
+      .mockRejectedValue(Object.assign(new Error("EXDEV"), { code: "EXDEV" }));
+    const copySpy = vi
+      .spyOn(downloadCacheFs, "copyFile")
+      .mockRejectedValue(Object.assign(new Error("EIO"), { code: "EIO" }));
+
+    const url = "https://example.com/models/fallback-poison.safetensors";
+    // Fresh Response per call (cache-write fetch + fallback fetch) — a body streams once.
+    fetchMock.mockImplementation(() => Promise.resolve(okResponse("LOSER-FRESH-BYTES")));
+
+    await downloadWithCache({ url, headers: {}, targetPath: dest });
+
+    // The WINNER cache inode must be UNTOUCHED — the fallback wrote a fresh temp and
+    // renamed over dest, never streaming "w" THROUGH dest's hardlink into the inode.
+    await expect(readFile(winnerCache, "utf-8")).resolves.toBe("WINNER-BYTES");
+    // The destination now holds the fallback's freshly-downloaded bytes.
+    await expect(readFile(dest, "utf-8")).resolves.toBe("LOSER-FRESH-BYTES");
+    // No leftover fallback/materialize temp files.
+    const leftovers = (await readdir(comfyDir)).filter((f) => f.includes(".dl-") || f.includes(".mat-"));
+    expect(leftovers).toHaveLength(0);
+    linkSpy.mockRestore();
+    copySpy.mockRestore();
+  });
+
   it("does NOT serve a LEGACY bare-URL cache entry to an unauthenticated caller — no cross-auth leak (#467 P1-C)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import * as fsPromises from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -29,6 +30,24 @@ import type { ResumeDiagnostic } from "../../services/download-resume-diag.js";
 function resumeCapture() {
   const box: { d?: ResumeDiagnostic } = {};
   return { box, onResume: (d: ResumeDiagnostic) => { box.d = d; } };
+}
+
+/** Mirror of the impl's cache identity (download-cache.ts): the 32-hex cache-file
+ *  hash for a URL + optional request headers. Kept in lockstep with cacheIdentity
+ *  — namespaced (#467 P1-C) and header-aware (#467 P1-2). */
+function reprFor(headers: Record<string, string> = {}): string {
+  const keys = Object.keys(headers);
+  if (keys.length === 0) return "";
+  const joined = keys
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .map((k) => `${k.toLowerCase()}=${headers[k]}`)
+    .join("\n");
+  return createHash("sha256").update(joined).digest("hex").slice(0, 12);
+}
+function cacheHashFor(url: string, headers: Record<string, string> = {}): string {
+  const repr = reprFor(headers);
+  const identity = repr ? `v2\n${url}\n${repr}` : `v2\n${url}`;
+  return createHash("sha256").update(identity).digest("hex").slice(0, 32);
 }
 
 const fetchMock = vi.fn();
@@ -130,10 +149,8 @@ describe("downloadModel cache", () => {
   it("resumes from a leftover partial file using HTTP Range and appends a 206 response", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     // Pre-seed the .partial that the cache deterministic-names.
-    // The cache key derives from sha256(url).slice(0,32) + the URL's pathname extension.
     const url = "https://example.com/models/resume.safetensors";
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    const hash = cacheHashFor(url);
     const partialPath = join(cacheDir, `.${hash}.safetensors.partial`);
     await writeFile(partialPath, "AAAA"); // 4 bytes of prior progress
     // A resume is only attempted when we hold the validator captured on the
@@ -165,8 +182,7 @@ describe("downloadModel cache", () => {
   it("overwrites the partial when the server replies 200 (Range unsupported)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/norange.safetensors";
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    const hash = cacheHashFor(url);
     const partialPath = join(cacheDir, `.${hash}.safetensors.partial`);
     await writeFile(partialPath, "STALE_PARTIAL_CONTENT");
     // With a validator present we send Range+If-Range; the server ignoring the
@@ -272,9 +288,8 @@ describe("downloadModel cache", () => {
   });
 
   // Deterministic cache paths for a URL (mirrors cachePathForUrl in the impl).
-  async function cachePaths(url: string) {
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+  function cachePaths(url: string, headers: Record<string, string> = {}) {
+    const hash = cacheHashFor(url, headers);
     const target = join(cacheDir, `${hash}.safetensors`);
     const partial = join(cacheDir, `.${hash}.safetensors.partial`);
     return { hash, target, partial, sidecar: `${partial}.etag` };
@@ -850,8 +865,7 @@ describe("downloadModel cache", () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/coalesce-diag.safetensors";
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    const hash = cacheHashFor(url);
     // Validator-less partial → the ONE physical download declines + reports.
     await writeFile(join(cacheDir, `.${hash}.safetensors.partial`), "OLDPARTIALBYTES");
 
@@ -883,8 +897,7 @@ describe("downloadModel cache", () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/cachehit-clear.safetensors";
-    const { createHash } = await import("node:crypto");
-    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    const hash = cacheHashFor(url);
     // A COMPLETE cache entry → this download is a hit (no fetch, no streamUrlToFile).
     await writeFile(join(cacheDir, `${hash}.safetensors`), "CACHED-BYTES");
 
@@ -901,12 +914,10 @@ describe("downloadModel cache", () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/p2.safetensors";
-    const { createHash } = await import("node:crypto");
     // Alice and Bob use different auth → different physical cache identities, so
     // each seeds its OWN validator-less partial and gets its OWN decision.
     for (const who of ["alice", "bob"]) {
-      const repr = createHash("sha256").update(`authorization=Bearer ${who}`).digest("hex").slice(0, 12);
-      const id = createHash("sha256").update(`${url}\n${repr}`).digest("hex").slice(0, 32);
+      const id = cacheHashFor(url, { Authorization: `Bearer ${who}` });
       await writeFile(join(cacheDir, `.${id}.safetensors.partial`), `OLD-${who}`);
     }
     fetchMock.mockResolvedValueOnce(okResponse("ALICE-FRESH"));
@@ -920,6 +931,26 @@ describe("downloadModel cache", () => {
     // Each caller received its own decline — no shared key, no cross-talk.
     expect(capA.box.d?.outcome).toBe("declined:no-validator");
     expect(capB.box.d?.outcome).toBe("declined:no-validator");
+  });
+
+  it("does NOT serve a LEGACY bare-URL cache entry to an unauthenticated caller — no cross-auth leak (#467 P1-C)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/legacy.safetensors";
+    // Simulate a PRE-upgrade entry cached under the bare-URL namespace (sha256(url),
+    // no "v2" prefix) — which the OLD code ALSO used for AUTHENTICATED downloads,
+    // so serving it to a new unauthenticated caller would leak auth-scoped bytes.
+    const legacyHash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    await writeFile(join(cacheDir, `${legacyHash}.safetensors`), "LEAKED-AUTHED-BYTES");
+
+    fetchMock.mockResolvedValueOnce(okResponse("FRESH-PUBLIC-BYTES"));
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    const out = join(comfyDir, "legacy-out.safetensors");
+    await downloadWithCache({ url, headers: {}, targetPath: out });
+
+    // The legacy entry is namespaced away → a fresh download happened, no leak.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(readFile(out, "utf-8")).resolves.toBe("FRESH-PUBLIC-BYTES");
   });
 
   it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -834,6 +834,31 @@ describe("downloadModel cache", () => {
     expect(getResumeDiagnostic(trayIdForUrl(url))?.outcome).toBe("declined:no-validator");
   });
 
+  it("clears a stale resume diagnostic on a cache HIT so it isn't misattributed (#467)", async () => {
+    const { downloadWithCache, getResumeDiagnostic } = await import(
+      "../../services/download-cache.js"
+    );
+    const { recordResumeDiagnostic, trayIdForUrl } = await import(
+      "../../services/download-resume-diag.js"
+    );
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/cachehit-clear.safetensors";
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
+    // A COMPLETE cache entry → this download is a hit (no fetch, no streamUrlToFile).
+    await writeFile(join(cacheDir, `${hash}.safetensors`), "CACHED-BYTES");
+    // A stale decline left over from an EARLIER attempt for the same slot.
+    recordResumeDiagnostic(trayIdForUrl(url), "declined:no-validator", 999);
+    expect(getResumeDiagnostic(trayIdForUrl(url))?.outcome).toBe("declined:no-validator");
+
+    await downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "ch.safetensors") });
+
+    expect(fetchMock).not.toHaveBeenCalled(); // served from cache
+    // The cache hit performed no resume/discard, so the stale decision is cleared.
+    expect(getResumeDiagnostic(trayIdForUrl(url))).toBeUndefined();
+  });
+
   it("gives same-URL DIFFERENT-auth downloads DISTINCT resume-diagnostic slots (#467 P2)", async () => {
     const { resumeKeyFor, recordResumeDiagnostic, getResumeDiagnostic, trayIdForUrl } =
       await import("../../services/download-resume-diag.js");

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -496,11 +496,16 @@ describe("downloadModel cache", () => {
     await writeFile(partial, "AAAA"); // 4 bytes already downloaded
     await writeFile(sidecar, '"xet-content-hash-v1"');
 
-    // Hop 1: resolve URL 302s cross-origin (If-Range unchanged → range honored).
+    // Hop 1: resolve URL 302s cross-origin, advertising the SAME content-addressed
+    // X-Linked-Etag as the partial — proving the object is unchanged, so the
+    // cross-origin 206 append is allowed (a cross-origin resume REQUIRES this).
     fetchMock.mockResolvedValueOnce(
       new Response(null, {
         status: 302,
-        headers: { location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=abc" },
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=abc",
+          "x-linked-etag": '"xet-content-hash-v1"',
+        },
       }),
     );
     // Hop 2: the CAS CDN honors the byte range and returns a 206.
@@ -559,6 +564,38 @@ describe("downloadModel cache", () => {
       downloadModel(url, "diffusion_models", "xet-changed-out.safetensors"),
     ).rejects.toThrow(/resume rejected/i);
     // Stale partial + sidecar removed so a retry restarts clean.
+    await expect(stat(partial)).rejects.toThrow();
+    await expect(stat(sidecar)).rejects.toThrow();
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+  });
+
+  it("REFUSES a cross-origin CAS 206 whose redirect gives NO content-addressed validator (can't prove unchanged) (#467/#343)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/xet-unproven.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"xet-hash-v1"');
+
+    // Hop 1: resolve 302s cross-origin WITHOUT an X-Linked-Etag — we cannot prove
+    // the CAS object still matches the partial.
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=x" },
+      }),
+    );
+    // Hop 2: CAS honors the stale Range and 206s — but we must NOT trust it.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "diffusion_models", "xet-unproven-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
     await expect(stat(partial)).rejects.toThrow();
     await expect(stat(sidecar)).rejects.toThrow();
     expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -19,18 +19,16 @@ vi.mock("../../config.js", () => {
 });
 
 import { config } from "../../config.js";
-import {
-  downloadCacheFs,
-  getResumeDiagnostic,
-  resetResumeDiagnostics,
-} from "../../services/download-cache.js";
+import { downloadCacheFs } from "../../services/download-cache.js";
 import { downloadModel } from "../../services/model-resolver.js";
+import type { ResumeDiagnostic } from "../../services/download-resume-diag.js";
 
-/** Tray id for a URL — mirrors download-jobs' downloadIdFor / the cache's
- *  trayIdForUrl, so a test can look up the resume diagnostic (#467). */
-async function trayIdFor(url: string): Promise<string> {
-  const { createHash } = await import("node:crypto");
-  return createHash("sha256").update(url).digest("hex").slice(0, 16);
+/** Capture the resume decision a physical download reports (#467). The decision
+ *  is delivered to the CALLER via an onResume callback (no shared map), so a test
+ *  passes this box's `onResume` to downloadModel and reads `box.d` afterward. */
+function resumeCapture() {
+  const box: { d?: ResumeDiagnostic } = {};
+  return { box, onResume: (d: ResumeDiagnostic) => { box.d = d; } };
 }
 
 const fetchMock = vi.fn();
@@ -53,7 +51,6 @@ beforeEach(async () => {
   config.civitaiApiToken = undefined;
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
-  resetResumeDiagnostics();
 });
 
 afterEach(async () => {
@@ -441,13 +438,16 @@ describe("downloadModel cache", () => {
 
     fetchMock.mockResolvedValueOnce(okResponse("FRESHFULLBODY"));
 
-    const target = await downloadModel(url, "checkpoints", "silentdiscard-out.safetensors");
+    const cap = resumeCapture();
+    const target = await downloadModel(
+      url, "checkpoints", "silentdiscard-out.safetensors", undefined, undefined, cap.onResume,
+    );
     await expect(readFile(target, "utf-8")).resolves.toBe("FRESHFULLBODY");
 
-    // The discard is no longer silent: a diagnostic records WHY and HOW MUCH.
-    const diag = getResumeDiagnostic(await trayIdFor(url));
-    expect(diag?.outcome).toBe("declined:no-validator");
-    expect(diag?.discardedBytes).toBe(21);
+    // The discard is no longer silent: the decision records WHY and HOW MUCH.
+    expect(cap.box.d?.outcome).toBe("declined:no-validator");
+    expect(cap.box.d?.discardedBytes).toBe(21);
+    expect(cap.box.d?.discarded).toBe(true);
   });
 
   it("persists a validator from the HF resolve REDIRECT (X-Linked-Etag) so a Xet partial becomes resumable (#467)", async () => {
@@ -517,7 +517,10 @@ describe("downloadModel cache", () => {
       }),
     );
 
-    const target = await downloadModel(url, "diffusion_models", "resume-xet-out.safetensors");
+    const cap = resumeCapture();
+    const target = await downloadModel(
+      url, "diffusion_models", "resume-xet-out.safetensors", undefined, undefined, cap.onResume,
+    );
 
     // Hop 1 (resolve) carried Range + If-Range...
     const [, firstInit] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
@@ -530,7 +533,7 @@ describe("downloadModel cache", () => {
     expect(secondInit.headers.Range).toBe("bytes=4-");
     // The bytes were appended, not re-downloaded from 0.
     await expect(readFile(target, "utf-8")).resolves.toBe("AAAABBBB");
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("resumed");
+    expect(cap.box.d?.outcome).toBe("resumed");
   });
 
   it("REFUSES to append a CAS 206 when the redirect's content-addressed X-Linked-Etag changed, even if the CDN honors the Range (#467/#343)", async () => {
@@ -560,13 +563,15 @@ describe("downloadModel cache", () => {
     );
 
     // We must NOT splice new-object bytes onto the stale prefix — reject instead.
+    const cap = resumeCapture();
     await expect(
-      downloadModel(url, "diffusion_models", "xet-changed-out.safetensors"),
+      downloadModel(url, "diffusion_models", "xet-changed-out.safetensors", undefined, undefined, cap.onResume),
     ).rejects.toThrow(/resume rejected/i);
     // Stale partial + sidecar removed so a retry restarts clean.
     await expect(stat(partial)).rejects.toThrow();
     await expect(stat(sidecar)).rejects.toThrow();
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+    expect(cap.box.d?.outcome).toBe("declined:etag-changed");
+    expect(cap.box.d?.discarded).toBe(true);
   });
 
   it("REFUSES a cross-origin CAS 206 whose redirect gives NO content-addressed validator (can't prove unchanged) (#467/#343)", async () => {
@@ -593,13 +598,14 @@ describe("downloadModel cache", () => {
       }),
     );
 
+    const cap = resumeCapture();
     await expect(
-      downloadModel(url, "diffusion_models", "xet-unproven-out.safetensors"),
+      downloadModel(url, "diffusion_models", "xet-unproven-out.safetensors", undefined, undefined, cap.onResume),
     ).rejects.toThrow(/resume rejected/i);
     await expect(stat(partial)).rejects.toThrow();
     await expect(stat(sidecar)).rejects.toThrow();
     // Unverifiable, not proven-changed: no validator was available to compare.
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:unverifiable");
+    expect(cap.box.d?.outcome).toBe("declined:unverifiable");
   });
 
   it("REFUSES a resume 206 when a LATER redirect hop reports a changed X-Linked-Etag (multi-hop) (#467/#343)", async () => {
@@ -639,11 +645,12 @@ describe("downloadModel cache", () => {
       }),
     );
 
+    const cap = resumeCapture();
     await expect(
-      downloadModel(url, "diffusion_models", "multihop-out.safetensors"),
+      downloadModel(url, "diffusion_models", "multihop-out.safetensors", undefined, undefined, cap.onResume),
     ).rejects.toThrow(/resume rejected/i);
     await expect(stat(partial)).rejects.toThrow();
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+    expect(cap.box.d?.outcome).toBe("declined:etag-changed");
   });
 
   it("declines + SURFACES a full-response resume (If-Range miss / no range support, 200) — safety preserved (#467/#343)", async () => {
@@ -656,13 +663,15 @@ describe("downloadModel cache", () => {
     // Upstream changed (or no range support) → server sends full 200, not a 206.
     fetchMock.mockResolvedValueOnce(okResponse("BRANDNEWBODY"));
 
-    const target = await downloadModel(url, "checkpoints", "changed-surfaced-out.safetensors");
+    const cap = resumeCapture();
+    const target = await downloadModel(
+      url, "checkpoints", "changed-surfaced-out.safetensors", undefined, undefined, cap.onResume,
+    );
     // Overwritten with the fresh body — safety preserved, no corrupt append.
     await expect(readFile(target, "utf-8")).resolves.toBe("BRANDNEWBODY");
 
-    const diag = getResumeDiagnostic(await trayIdFor(url));
-    expect(diag?.outcome).toBe("declined:full-response");
-    expect(diag?.discardedBytes).toBe(4);
+    expect(cap.box.d?.outcome).toBe("declined:full-response");
+    expect(cap.box.d?.discardedBytes).toBe(4);
   });
 
   it("persists the validator sidecar on a fresh write so a later resume can guard with If-Range (#343 edge)", async () => {
@@ -758,12 +767,13 @@ describe("downloadModel cache", () => {
       }),
     );
 
+    const cap = resumeCapture();
     await expect(
-      downloadModel(url, "diffusion_models", "finalconflict-out.safetensors"),
+      downloadModel(url, "diffusion_models", "finalconflict-out.safetensors", undefined, undefined, cap.onResume),
     ).rejects.toThrow(/resume rejected/i);
     await expect(stat(partial)).rejects.toThrow();
     await expect(stat(sidecar)).rejects.toThrow();
-    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+    expect(cap.box.d?.outcome).toBe("declined:etag-changed");
   });
 
   it("does NOT coalesce same-URL downloads carrying DIFFERENT auth headers — each gets its own bytes (#467 P1-2)", async () => {
@@ -820,17 +830,14 @@ describe("downloadModel cache", () => {
     await expect(readFile(two, "utf-8")).resolves.toBe("SHARED-BYTES");
   });
 
-  it("preserves the physical download's resume diagnostic for a COALESCED same-key consumer (#467 P1-b)", async () => {
-    const { downloadWithCache, getResumeDiagnostic } = await import(
-      "../../services/download-cache.js"
-    );
-    const { trayIdForUrl } = await import("../../services/download-resume-diag.js");
+  it("reports the resume decision ONLY to the physical stream's caller; a COALESCED consumer gets none (#467 P1-b)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/coalesce-diag.safetensors";
     const { createHash } = await import("node:crypto");
     const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
-    // Validator-less partial → the ONE physical download declines + records.
+    // Validator-less partial → the ONE physical download declines + reports.
     await writeFile(join(cacheDir, `.${hash}.safetensors.partial`), "OLDPARTIALBYTES");
 
     // A single, initially-pending fetch — both callers coalesce onto it.
@@ -841,24 +848,23 @@ describe("downloadModel cache", () => {
       }),
     );
 
-    const a = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "a.safetensors") });
-    const b = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "b.safetensors") });
+    const capA = resumeCapture();
+    const capB = resumeCapture();
+    const a = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "a.safetensors"), onResume: capA.onResume });
+    const b = downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "b.safetensors"), onResume: capB.onResume });
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1)); // coalesced to ONE fetch
     release(okResponse("FRESHFULLBODY"));
     await Promise.all([a, b]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    // The coalesced second consumer must NOT have wiped the recorded decision.
-    expect(getResumeDiagnostic(trayIdForUrl(url))?.outcome).toBe("declined:no-validator");
+    // The stream's owner (A) got the decision; the coalesced consumer (B) got NONE
+    // — no shared map to clobber, and B is never misattributed A's decision.
+    expect(capA.box.d?.outcome).toBe("declined:no-validator");
+    expect(capB.box.d).toBeUndefined();
   });
 
-  it("clears a stale resume diagnostic on a cache HIT so it isn't misattributed (#467)", async () => {
-    const { downloadWithCache, getResumeDiagnostic } = await import(
-      "../../services/download-cache.js"
-    );
-    const { recordResumeDiagnostic, trayIdForUrl } = await import(
-      "../../services/download-resume-diag.js"
-    );
+  it("does NOT report a resume decision on a cache HIT (#467)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/cachehit-clear.safetensors";
@@ -866,33 +872,39 @@ describe("downloadModel cache", () => {
     const hash = createHash("sha256").update(url).digest("hex").slice(0, 32);
     // A COMPLETE cache entry → this download is a hit (no fetch, no streamUrlToFile).
     await writeFile(join(cacheDir, `${hash}.safetensors`), "CACHED-BYTES");
-    // A stale decline left over from an EARLIER attempt for the same slot.
-    recordResumeDiagnostic(trayIdForUrl(url), "declined:no-validator", 999);
-    expect(getResumeDiagnostic(trayIdForUrl(url))?.outcome).toBe("declined:no-validator");
 
-    await downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "ch.safetensors") });
+    const cap = resumeCapture();
+    await downloadWithCache({ url, headers: {}, targetPath: join(comfyDir, "ch.safetensors"), onResume: cap.onResume });
 
     expect(fetchMock).not.toHaveBeenCalled(); // served from cache
-    // The cache hit performed no resume/discard, so the stale decision is cleared.
-    expect(getResumeDiagnostic(trayIdForUrl(url))).toBeUndefined();
+    // No resume/discard happened, so nothing is reported (can't be misattributed).
+    expect(cap.box.d).toBeUndefined();
   });
 
-  it("gives same-URL DIFFERENT-auth downloads DISTINCT resume-diagnostic slots (#467 P2)", async () => {
-    const { resumeKeyFor, recordResumeDiagnostic, getResumeDiagnostic, trayIdForUrl } =
-      await import("../../services/download-resume-diag.js");
+  it("reports same-URL DIFFERENT-auth downloads to their OWN callers (no cross-talk) (#467 P2)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
     const url = "https://example.com/models/p2.safetensors";
-    const kAlice = resumeKeyFor(url, JSON.stringify({ type: "bearer", token: "alice" }));
-    const kBob = resumeKeyFor(url, JSON.stringify({ type: "bearer", token: "bob" }));
-    // Different auth → different slots; no auth → the bare tray id (compat).
-    expect(kAlice).not.toBe(kBob);
-    expect(resumeKeyFor(url)).toBe(trayIdForUrl(url));
+    const { createHash } = await import("node:crypto");
+    // Alice and Bob use different auth → different physical cache identities, so
+    // each seeds its OWN validator-less partial and gets its OWN decision.
+    for (const who of ["alice", "bob"]) {
+      const repr = createHash("sha256").update(`authorization=Bearer ${who}`).digest("hex").slice(0, 12);
+      const id = createHash("sha256").update(`${url}\n${repr}`).digest("hex").slice(0, 32);
+      await writeFile(join(cacheDir, `.${id}.safetensors.partial`), `OLD-${who}`);
+    }
+    fetchMock.mockResolvedValueOnce(okResponse("ALICE-FRESH"));
+    fetchMock.mockResolvedValueOnce(okResponse("BOB-FRESH"));
 
-    // A concurrent resume for Bob must NOT clobber Alice's declined-discard record.
-    recordResumeDiagnostic(kAlice, "declined:no-validator", 12345);
-    recordResumeDiagnostic(kBob, "resumed", 0);
-    expect(getResumeDiagnostic(kAlice)?.outcome).toBe("declined:no-validator");
-    expect(getResumeDiagnostic(kAlice)?.discardedBytes).toBe(12345);
-    expect(getResumeDiagnostic(kBob)?.outcome).toBe("resumed");
+    const capA = resumeCapture();
+    const capB = resumeCapture();
+    await downloadWithCache({ url, headers: { Authorization: "Bearer alice" }, targetPath: join(comfyDir, "pa.safetensors"), onResume: capA.onResume });
+    await downloadWithCache({ url, headers: { Authorization: "Bearer bob" }, targetPath: join(comfyDir, "pb.safetensors"), onResume: capB.onResume });
+
+    // Each caller received its own decline — no shared key, no cross-talk.
+    expect(capA.box.d?.outcome).toBe("declined:no-validator");
+    expect(capB.box.d?.outcome).toBe("declined:no-validator");
   });
 
   it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -933,6 +933,40 @@ describe("downloadModel cache", () => {
     expect(capB.box.d?.outcome).toBe("declined:no-validator");
   });
 
+  it("materializes concurrent same-destination DIFFERENT-representation downloads without poisoning either cache entry (#467)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/samedest.safetensors";
+    // Two representations (different auth) → two distinct cache entries. Return the
+    // body by Authorization header (NOT call order — the two downloads race under
+    // Promise.all), so each representation deterministically gets its own bytes and
+    // any cross-contamination would be a genuine cache poison, not a mock artifact.
+    fetchMock.mockImplementation((_u: string, init: { headers?: Record<string, string> }) =>
+      Promise.resolve(
+        okResponse(init?.headers?.Authorization === "Bearer alice" ? "ALICE-CACHE-BYTES" : "BOB-CACHE-BYTES"),
+      ),
+    );
+    // ...materialized to the SAME on-disk destination (concurrent writers).
+    const dest = join(comfyDir, "same.safetensors");
+    await Promise.all([
+      downloadWithCache({ url, headers: { Authorization: "Bearer alice" }, targetPath: dest }),
+      downloadWithCache({ url, headers: { Authorization: "Bearer bob" }, targetPath: dest }),
+    ]);
+
+    // Each cache entry must retain ITS OWN bytes — the atomic temp+rename
+    // materialize must never write through a hardlink into the other's inode.
+    const aHash = cacheHashFor(url, { Authorization: "Bearer alice" });
+    const bHash = cacheHashFor(url, { Authorization: "Bearer bob" });
+    await expect(readFile(join(cacheDir, `${aHash}.safetensors`), "utf-8")).resolves.toBe("ALICE-CACHE-BYTES");
+    await expect(readFile(join(cacheDir, `${bHash}.safetensors`), "utf-8")).resolves.toBe("BOB-CACHE-BYTES");
+    // The destination holds one of the two (last writer wins) — but a VALID one.
+    expect(["ALICE-CACHE-BYTES", "BOB-CACHE-BYTES"]).toContain(await readFile(dest, "utf-8"));
+    // No leftover temp materialization files.
+    const leftovers = (await readdir(comfyDir)).filter((f) => f.includes(".mat-"));
+    expect(leftovers).toHaveLength(0);
+  });
+
   it("does NOT serve a LEGACY bare-URL cache entry to an unauthenticated caller — no cross-auth leak (#467 P1-C)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     await fsPromises.mkdir(comfyDir, { recursive: true });

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -692,6 +692,116 @@ describe("downloadModel cache", () => {
     await expect(readFile(sidecar, "utf-8")).resolves.toBe('"captured-v9"');
   });
 
+  it("REJECTS + removes an OVERSIZED 206 that streams MORE than its Content-Range total (#467 P0-1)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/oversized206.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA"); // resume offset 4
+    await writeFile(sidecar, '"ov-etag"');
+
+    // 206 claims bytes 4-7/8 (total 8) but the body is 6 bytes → 4+6 = 10 > 8.
+    // Without the exact-size check this corrupt 10-byte file would be finalized.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "checkpoints", "oversized206-out.safetensors"),
+    ).rejects.toThrow(/oversized/i);
+    // The corrupt bytes are removed (NOT left to masquerade as resumable).
+    await expect(stat(partial)).rejects.toThrow();
+    await expect(stat(sidecar)).rejects.toThrow();
+  });
+
+  it("REJECTS + removes an OVERSIZED 200 that streams MORE than its Content-Length (#467 P0-1)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/oversized200.safetensors";
+    // 200 claims 4 bytes but streams 9.
+    fetchMock.mockResolvedValueOnce(
+      new Response("TOOMANYBS", { status: 200, statusText: "OK", headers: { "content-length": "4" } }),
+    );
+    await expect(
+      downloadModel(url, "checkpoints", "oversized200-out.safetensors"),
+    ).rejects.toThrow(/oversized/i);
+    const cached = await readdir(cacheDir).catch(() => [] as string[]);
+    expect(cached.some((f) => f.endsWith(".safetensors"))).toBe(false);
+  });
+
+  it("REFUSES a cross-origin 206 whose FINAL response carries a DIFFERENT X-Linked-Etag than the matching redirect (#467 P0-2)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/finalconflict.safetensors";
+    const { partial, sidecar } = await cachePaths(url);
+    await writeFile(partial, "AAAA");
+    await writeFile(sidecar, '"xet-v1"');
+
+    // Hop 1: resolve 302 cross-origin whose X-Linked-Etag MATCHES the partial...
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=a",
+          "x-linked-etag": '"xet-v1"',
+        },
+      }),
+    );
+    // Hop 2: the FINAL CAS 206 advertises a DIFFERENT content hash — the object
+    // changed at the CDN. A matching redirect must NOT let this slip through.
+    fetchMock.mockResolvedValueOnce(
+      new Response("BBBB", {
+        status: 206,
+        statusText: "Partial Content",
+        headers: { "content-range": "bytes 4-7/8", "x-linked-etag": '"xet-v2-CHANGED"' },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "diffusion_models", "finalconflict-out.safetensors"),
+    ).rejects.toThrow(/resume rejected/i);
+    await expect(stat(partial)).rejects.toThrow();
+    await expect(stat(sidecar)).rejects.toThrow();
+    expect(getResumeDiagnostic(await trayIdFor(url))?.outcome).toBe("declined:etag-changed");
+  });
+
+  it("does NOT coalesce same-URL downloads carrying DIFFERENT auth headers — each gets its own bytes (#467 P1-2)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/gated.safetensors";
+    // Two users, two tokens → two representations. They must NOT share a stream.
+    fetchMock.mockResolvedValueOnce(okResponse("ALICE-ONLY-BYTES"));
+    fetchMock.mockResolvedValueOnce(okResponse("BOB-ONLY-BYTES"));
+
+    const alice = join(comfyDir, "alice.safetensors");
+    const bob = join(comfyDir, "bob.safetensors");
+    await downloadWithCache({ url, headers: { Authorization: "Bearer alice" }, targetPath: alice });
+    await downloadWithCache({ url, headers: { Authorization: "Bearer bob" }, targetPath: bob });
+
+    // Separate representations → separate fetches, no cache coalescing.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(readFile(alice, "utf-8")).resolves.toBe("ALICE-ONLY-BYTES");
+    await expect(readFile(bob, "utf-8")).resolves.toBe("BOB-ONLY-BYTES");
+  });
+
+  it("DOES cache/coalesce same-URL downloads with the SAME auth header (public dedup preserved) (#467 P1-2)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const url = "https://example.com/models/sameauth.safetensors";
+    fetchMock.mockResolvedValueOnce(okResponse("SHARED-BYTES"));
+
+    const one = join(comfyDir, "one.safetensors");
+    const two = join(comfyDir, "two.safetensors");
+    await downloadWithCache({ url, headers: { Authorization: "Bearer same" }, targetPath: one });
+    await downloadWithCache({ url, headers: { Authorization: "Bearer same" }, targetPath: two });
+
+    // Identical representation → second call is a cache hit, only one fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(readFile(one, "utf-8")).resolves.toBe("SHARED-BYTES");
+    await expect(readFile(two, "utf-8")).resolves.toBe("SHARED-BYTES");
+  });
+
   it("never serves a 0-byte cache entry as a hit — re-downloads instead (#343 edge)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/zerohit.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -962,6 +962,11 @@ describe("downloadModel cache", () => {
     if (prevAz !== undefined) process.env.AZURE_STORAGE_CONNECTION_STRING = prevAz;
     expect(azEnv).not.toBe(azAnon);
 
+    // Ambient (no explicit key) is STABLE within a process (same nonce) so in-process
+    // cache hits stay safe; explicit auth is stable too.
+    expect(cloudPrincipalKey(s3url, {})).toBe(cloudPrincipalKey(s3url, {}));
+    expect(alice).toBe(cloudPrincipalKey(s3url, { s3: { access_key_id: "AK-ALICE", secret_access_key: "x" } }));
+
     // A non-cloud URL contributes no cloud discriminator.
     expect(cloudPrincipalKey("https://example.com/x.safetensors", {})).toBe("");
   });
@@ -1039,6 +1044,37 @@ describe("downloadModel cache", () => {
     expect(leftovers).toHaveLength(0);
     linkSpy.mockRestore();
     copySpy.mockRestore();
+  });
+
+  it("a non-Windows rename failure during materialize/fallback does NOT destroy the existing destination (#467 P1-A)", async () => {
+    const { downloadWithCache } = await import("../../services/download-cache.js");
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    await fsPromises.mkdir(comfyDir, { recursive: true });
+    const dest = join(comfyDir, "keepme.safetensors");
+    await writeFile(dest, "ORIGINAL-PRECIOUS-BYTES");
+
+    // Fail ONLY the materialize/fallback swap renames (.mat-/.dl-) with a non-Windows
+    // error — the cache-write rename (.partial → cache file) must still pass through.
+    const renameSpy = vi
+      .spyOn(downloadCacheFs, "rename")
+      .mockImplementation(async (from: string, to: string) => {
+        if (String(from).includes(".mat-") || String(from).includes(".dl-")) {
+          throw Object.assign(new Error("EIO: simulated non-overwrite rename failure"), { code: "EIO" });
+        }
+        return fsPromises.rename(from, to);
+      });
+
+    const url = "https://example.com/models/rename-eio.safetensors";
+    fetchMock.mockImplementation(() => Promise.resolve(okResponse("NEW-BYTES")));
+
+    await expect(downloadWithCache({ url, headers: {}, targetPath: dest })).rejects.toThrow(/EIO/i);
+
+    // The EIO path must NOT have removed the destination (that rm only guards the
+    // Windows overwrite errors) — the original file is intact.
+    await expect(readFile(dest, "utf-8")).resolves.toBe("ORIGINAL-PRECIOUS-BYTES");
+    const leftovers = (await readdir(comfyDir)).filter((f) => f.includes(".mat-") || f.includes(".dl-"));
+    expect(leftovers).toHaveLength(0);
+    renameSpy.mockRestore();
   });
 
   it("does NOT serve a LEGACY bare-URL cache entry to an unauthenticated caller — no cross-auth leak (#467 P1-C)", async () => {

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -201,6 +201,39 @@ describe("downloadModel cache", () => {
     await expect(readFile(target, "utf-8")).resolves.toBe("full body from server");
   });
 
+  it("uses HF X-Linked-Size (not an understated CAS Content-Length) to reject a short fresh download (#467)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://huggingface.co/org/repo/resolve/main/xlsize.safetensors";
+    // Hop 1: resolve 302 declares the AUTHORITATIVE object size via X-Linked-Size.
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: {
+          location: "https://cas-bridge.xethub.hf.co/xet-bridge-us/obj?sig=z",
+          "x-linked-etag": '"xet-v1"',
+          "x-linked-size": "4096",
+        },
+      }),
+    );
+    // Hop 2: the CAS 200 UNDERSTATES Content-Length (1024) and streams only 1024 of
+    // the real 4096 bytes — a truncating CDN. Trusting Content-Length would finalize
+    // a 1 KiB file as the whole 4096-byte model.
+    fetchMock.mockResolvedValueOnce(
+      new Response("A".repeat(1024), {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "1024" },
+      }),
+    );
+
+    await expect(
+      downloadModel(url, "diffusion_models", "xlsize-out.safetensors"),
+    ).rejects.toThrow(/truncat/i);
+    // The short body was NOT renamed into cache as complete.
+    const cached = await readdir(cacheDir).catch(() => [] as string[]);
+    expect(cached.some((f) => f.endsWith(".safetensors"))).toBe(false);
+  });
+
   it("REFUSES an UNSOLICITED partial 206 on a FRESH request — never finalizes a short prefix (#467 P0)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/unsolicited206.safetensors";

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -428,6 +428,21 @@ describe("downloadModel cache", () => {
     await expect(readFile(target, "utf-8")).resolves.toBe("FRESHFULLBODY");
   });
 
+  it("FAILS the download (never silently discards) when the stale partial can't be truncated on restart (#467/#343)", async () => {
+    await fsPromises.mkdir(cacheDir, { recursive: true });
+    const url = "https://example.com/models/untruncatable.safetensors";
+    const { partial } = await cachePaths(url);
+    // Make the partial path a DIRECTORY so writeFile(targetPath, "") (the explicit
+    // restart truncation) fails — we must throw, not fall through to a silent "w".
+    await fsPromises.mkdir(partial, { recursive: true });
+
+    fetchMock.mockResolvedValueOnce(okResponse("FRESHFULLBODY"));
+
+    await expect(
+      downloadModel(url, "checkpoints", "untruncatable-out.safetensors"),
+    ).rejects.toThrow(/restart failed|could not truncate/i);
+  });
+
   it("SURFACES a validator-less declined resume instead of silently discarding the partial (#467)", async () => {
     await fsPromises.mkdir(cacheDir, { recursive: true });
     const url = "https://example.com/models/silentdiscard.safetensors";

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -73,7 +73,10 @@ import {
   resetDownloadJobs,
   downloadIdFor,
 } from "../../services/download-jobs.js";
-import { downloadModel } from "../../services/model-resolver.js";
+import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
+import { mkdtemp, mkdir, symlink, rm as fsRm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 
 const URL_A = "https://huggingface.co/org/repo/resolve/main/big.safetensors";
 const URL_B = "https://huggingface.co/org/repo/resolve/main/other.safetensors";
@@ -398,6 +401,54 @@ describe("download job registry", () => {
       expect(hoisted.calls).toBe(2);
     } else {
       expect(hoisted.calls).toBe(2); // case-sensitive FS → genuinely different files
+    }
+  });
+
+  it("serializes REMOTE different-auth jobs whose subfolders canonicalize to one destination (#467 P1-C)", async () => {
+    hoisted.remote = true; // Manager dispatch — no local target resolution
+    // Same file+URL, subfolders that trim/normalize to the SAME remote destination,
+    // but DIFFERENT auth → distinct jobs that must be serialized (one server file).
+    const a = await startDownloadJob(URL_A, " loras/sub ", "m.safetensors", { type: "bearer", token: "alice" });
+    const b = await startDownloadJob(URL_A, "loras//sub", "m.safetensors", { type: "bearer", token: "bob" });
+    expect(b.job).not.toBe(a.job); // distinct (different auth)
+    expect(hoisted.calls).toBe(1); // serialized on the canonical remote destination
+    hoisted.resolvers[0].resolve("ok");
+    await a.settled;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(hoisted.calls).toBe(2);
+  });
+
+  it("serializes different-auth jobs whose SYMLINKED subfolders resolve to one physical file (#467 P1-C)", async () => {
+    // Build base/real and base/alias -> base/real; the destination tail (sub/m)
+    // doesn't exist yet (the writer would mkdir it), exercising the deepest-existing
+    // -ancestor realpath collapse.
+    const base = await mkdtemp(pathJoin(tmpdir(), "djobs-symlink-"));
+    const realDir = pathJoin(base, "real");
+    const aliasDir = pathJoin(base, "alias");
+    await mkdir(realDir, { recursive: true });
+    try {
+      await symlink(realDir, aliasDir, "junction");
+    } catch {
+      await fsRm(base, { recursive: true, force: true });
+      return; // symlinks/junctions unsupported here — skip
+    }
+    try {
+      // Two distinct-auth jobs whose resolved targetPaths differ only by alias vs real.
+      vi.mocked(resolveDownloadTarget)
+        .mockResolvedValueOnce({ targetDir: pathJoin(aliasDir, "sub"), filename: "m.safetensors", targetPath: pathJoin(aliasDir, "sub", "m.safetensors") })
+        .mockResolvedValueOnce({ targetDir: pathJoin(realDir, "sub"), filename: "m.safetensors", targetPath: pathJoin(realDir, "sub", "m.safetensors") });
+
+      const a = await startDownloadJob(URL_A, "checkpoints", "m.safetensors", { type: "bearer", token: "alice" });
+      const b = await startDownloadJob(URL_A, "checkpoints", "m.safetensors", { type: "bearer", token: "bob" });
+      expect(b.job).not.toBe(a.job); // distinct (different auth + different lexical path)
+      // realpath collapses alias→real for the EXISTING prefix, so both share a chain.
+      expect(hoisted.calls).toBe(1);
+      hoisted.resolvers[0].resolve("ok");
+      await a.settled;
+      await new Promise((r) => setTimeout(r, 0));
+      expect(hoisted.calls).toBe(2);
+    } finally {
+      await fsRm(base, { recursive: true, force: true });
     }
   });
 

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -325,4 +325,33 @@ describe("download job registry", () => {
     await startDownloadJob(URL_B, "loras");
     expect(listDownloadJobs()[0].url).toBe(URL_B);
   });
+
+  // #467 P1-A: the job layer dedups BEFORE the header-aware cache layer, so it must
+  // fold auth into its keys — otherwise two concurrent same-URL+same-dest calls with
+  // DIFFERENT auth adopt the first job and the second caller gets the first's bytes
+  // AND resume callback.
+  it("does NOT coalesce concurrent same-URL+same-dest jobs with DIFFERENT auth", async () => {
+    const a = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "alice" });
+    const b = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "bob" });
+    // Two separate in-flight writers/jobs — the second was NOT adopted.
+    expect(b.job).not.toBe(a.job);
+    expect(b.job.id).not.toBe(a.job.id);
+    expect(hoisted.calls).toBe(2);
+    expect(listDownloadJobs()).toHaveLength(2);
+  });
+
+  it("STILL coalesces concurrent same-URL+same-dest jobs with the SAME auth", async () => {
+    const a = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "same" });
+    const b = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "same" });
+    expect(b.job).toBe(a.job); // adopted the in-flight job (one writer)
+    expect(hoisted.calls).toBe(1);
+    expect(listDownloadJobs()).toHaveLength(1);
+  });
+
+  it("does NOT let an authenticated job adopt a concurrent UNauthenticated one (same dest)", async () => {
+    const pub = await startDownloadJob(URL_A, "checkpoints"); // no auth
+    const authed = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "x" });
+    expect(authed.job).not.toBe(pub.job);
+    expect(hoisted.calls).toBe(2);
+  });
 });

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -73,6 +73,7 @@ import {
   resetDownloadJobs,
   downloadIdFor,
 } from "../../services/download-jobs.js";
+import { downloadModel } from "../../services/model-resolver.js";
 
 const URL_A = "https://huggingface.co/org/repo/resolve/main/big.safetensors";
 const URL_B = "https://huggingface.co/org/repo/resolve/main/other.safetensors";
@@ -329,15 +330,57 @@ describe("download job registry", () => {
   // #467 P1-A: the job layer dedups BEFORE the header-aware cache layer, so it must
   // fold auth into its keys — otherwise two concurrent same-URL+same-dest calls with
   // DIFFERENT auth adopt the first job and the second caller gets the first's bytes
-  // AND resume callback.
-  it("does NOT coalesce concurrent same-URL+same-dest jobs with DIFFERENT auth", async () => {
+  // AND resume callback. #467 P1-C: two such distinct jobs to ONE destination are
+  // SERIALIZED (not run concurrently) so each callback sees its own bytes.
+  it("does NOT coalesce concurrent same-URL+same-dest jobs with DIFFERENT auth (distinct + serialized)", async () => {
     const a = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "alice" });
     const b = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "bob" });
-    // Two separate in-flight writers/jobs — the second was NOT adopted.
+    // Two DISTINCT jobs — the second was NOT adopted.
     expect(b.job).not.toBe(a.job);
     expect(b.job.id).not.toBe(a.job.id);
-    expect(hoisted.calls).toBe(2);
     expect(listDownloadJobs()).toHaveLength(2);
+    // Serialized on the shared destination: only A's writer has started; B waits.
+    expect(hoisted.calls).toBe(1);
+
+    // Completing A releases B's OWN writer (its own bytes/callback, not A's).
+    hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+    await a.settled;
+    // Let B's chained continuation run.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(hoisted.calls).toBe(2);
+  });
+
+  it("serializes same-dest different-auth so each onComplete sees ITS OWN bytes (#467 P1-C)", async () => {
+    // Simulate the shared destination: each writer overwrites it with its own token,
+    // and each job's onComplete records what it observed there.
+    let destContent = "";
+    const seen: Record<string, string> = {};
+    const orig = vi.mocked(downloadModel).getMockImplementation();
+    vi.mocked(downloadModel).mockImplementation(
+      async (_url: string, sub: string, fn?: string, auth?: unknown) => {
+        hoisted.calls += 1;
+        destContent = (auth as { token?: string })?.token ?? "none"; // "materialize"
+        return `/M/${sub}/${fn ?? "big.safetensors"}`;
+      },
+    );
+    try {
+      const a = await startDownloadJob(URL_A, "checkpoints", "m.safetensors", { type: "bearer", token: "alice" }, async () => {
+        seen.alice = destContent; // read the destination during Alice's own callback
+        return [];
+      });
+      const b = await startDownloadJob(URL_A, "checkpoints", "m.safetensors", { type: "bearer", token: "bob" }, async () => {
+        seen.bob = destContent;
+        return [];
+      });
+      await Promise.all([a.settled, b.settled]);
+
+      // Each callback saw ITS OWN representation's bytes — Bob's writer did not swap
+      // the destination out from under Alice's callback (would fail without #467 P1-C).
+      expect(seen.alice).toBe("alice");
+      expect(seen.bob).toBe("bob");
+    } finally {
+      if (orig) vi.mocked(downloadModel).mockImplementation(orig);
+    }
   });
 
   it("STILL coalesces concurrent same-URL+same-dest jobs with the SAME auth", async () => {
@@ -351,7 +394,12 @@ describe("download job registry", () => {
   it("does NOT let an authenticated job adopt a concurrent UNauthenticated one (same dest)", async () => {
     const pub = await startDownloadJob(URL_A, "checkpoints"); // no auth
     const authed = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "x" });
+    // Distinct jobs (not adopted); serialized behind the unauthenticated one.
     expect(authed.job).not.toBe(pub.job);
+    expect(hoisted.calls).toBe(1);
+    hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+    await pub.settled;
+    await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.calls).toBe(2);
   });
 });

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -383,6 +383,24 @@ describe("download job registry", () => {
     }
   });
 
+  it("serializes case-variant same-file destinations on case-insensitive filesystems (#467 P1-C)", async () => {
+    // Same (no) auth but case-variant subfolders resolve to distinct path STRINGS,
+    // so they are distinct jobs — but on a case-insensitive FS they are ONE physical
+    // file and must be serialized.
+    const a = await startDownloadJob(URL_A, "checkpoints", "m.safetensors");
+    const b = await startDownloadJob(URL_A, "Checkpoints", "m.safetensors");
+    expect(b.job).not.toBe(a.job);
+    if (process.platform === "win32" || process.platform === "darwin") {
+      expect(hoisted.calls).toBe(1); // serialized — same physical file
+      hoisted.resolvers[0].resolve("/M/checkpoints/m.safetensors");
+      await a.settled;
+      await new Promise((r) => setTimeout(r, 0));
+      expect(hoisted.calls).toBe(2);
+    } else {
+      expect(hoisted.calls).toBe(2); // case-sensitive FS → genuinely different files
+    }
+  });
+
   it("STILL coalesces concurrent same-URL+same-dest jobs with the SAME auth", async () => {
     const a = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "same" });
     const b = await startDownloadJob(URL_A, "checkpoints", undefined, { type: "bearer", token: "same" });

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -250,6 +250,7 @@ describe("applyManifest", () => {
       "model.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
   });
 
@@ -412,6 +413,7 @@ describe("applyManifest", () => {
       "model.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
   });
 
@@ -437,6 +439,7 @@ describe("applyManifest", () => {
       "new.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
   });
 

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -250,7 +250,7 @@ describe("applyManifest", () => {
       "model.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
   });
 
@@ -413,7 +413,7 @@ describe("applyManifest", () => {
       "model.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
   });
 
@@ -439,7 +439,7 @@ describe("applyManifest", () => {
       "new.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
   });
 

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -29,10 +29,12 @@ vi.mock("node:fs/promises", () => ({
   link: vi.fn(),
   mkdir: (...a: unknown[]) => mkdirMock(...a),
   readdir: vi.fn(),
+  readFile: vi.fn(),
   rename: vi.fn(),
   rm: (...a: unknown[]) => rmMock(...a),
   stat: (...a: unknown[]) => statMock(...a),
   utimes: vi.fn(),
+  writeFile: vi.fn(),
 }));
 
 // downloadModel now roots the destination at the LIVE server's models dir

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -234,6 +234,7 @@ describe("download_civitai_model", () => {
       "cool.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("Cool Model");
@@ -258,6 +259,7 @@ describe("download_civitai_model", () => {
       "v.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
     expect(res.isError).toBeFalsy();
   });
@@ -296,6 +298,7 @@ describe("download_civitai_model", () => {
       "custom.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
   });
 

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -234,7 +234,7 @@ describe("download_civitai_model", () => {
       "cool.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("Cool Model");
@@ -259,7 +259,7 @@ describe("download_civitai_model", () => {
       "v.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
     expect(res.isError).toBeFalsy();
   });
@@ -298,7 +298,7 @@ describe("download_civitai_model", () => {
       "custom.safetensors",
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
   });
 

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -23,6 +23,7 @@ vi.mock("node:fs/promises", () => ({
   link: vi.fn(),
   mkdir: vi.fn(),
   readdir: vi.fn(),
+  realpath: (p: string) => Promise.resolve(p), // identity — no symlinks in these tests
   rename: vi.fn(),
   rm: vi.fn(),
   stat: (...a: unknown[]) => statMock(...a),

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -71,6 +71,7 @@ describe("download_model tool", () => {
       "x.safetensors",
       auth,
       false, // routing decision threaded through (local, #420 codex round 1)
+      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
     );
     expect(res.isError).toBeFalsy();
   });

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -71,7 +71,7 @@ describe("download_model tool", () => {
       "x.safetensors",
       auth,
       false, // routing decision threaded through (local, #420 codex round 1)
-      expect.any(String), // resumeKey — representation-aware diagnostic slot (#467 P2)
+      expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
     );
     expect(res.isError).toBeFalsy();
   });

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -267,18 +267,29 @@ async function streamUrlToFile(
   onResume?: ResumeReporter,
 ): Promise<void> {
   if (supportsCloudDownload(url)) {
-    // Cloud downloaders (S3/Azure) don't range-resume — they open a "w" stream
-    // and overwrite the target. If a partial exists, it's being discarded; surface
-    // that (#467) instead of silently restarting, mirroring the HTTP no-validator
-    // case (the cloud object carries no ETag/Last-Modified resume validator here).
+    // Cloud downloaders (S3/Azure) don't range-resume — they overwrite the target.
+    // If a partial exists it's being discarded; surface that (#467) instead of a
+    // silent restart. Truncate it OURSELVES first and CONFIRM (throw on failure)
+    // BEFORE reporting discarded:true — the cloud SDKs validate the request/body
+    // before opening their write stream, so reporting pre-download could otherwise
+    // claim a discard that a later auth/network failure never performed (P1-1).
     if (resumable && resumeFromBytes > 0) {
+      try {
+        await writeFile(targetPath, "");
+      } catch (err) {
+        throw new ModelError(
+          `Download restart failed: could not truncate the stale ${resumeFromBytes}-byte partial ` +
+            `before a cloud re-download. Retry (a fresh attempt restarts from 0).`,
+          { url: logUrl, cause: err instanceof Error ? err.message : String(err) },
+        );
+      }
       logger.warn(
-        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: cloud ` +
-          `downloads (S3/Azure) don't support byte-range resume, so the partial is overwritten — ` +
+        `Discarded a ${resumeFromBytes}-byte partial download and restarting from 0: cloud ` +
+          `downloads (S3/Azure) don't support byte-range resume, so the partial was overwritten — ` +
           `re-downloading in full.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      onResume?.({ outcome: "declined:no-validator", discardedBytes: resumeFromBytes, discarded: true });
+      onResume?.({ outcome: "declined:full-response", discardedBytes: resumeFromBytes, discarded: true });
     }
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -585,6 +585,23 @@ async function streamUrlToFile(
     }
   }
 
+  // A 206 to a request we did NOT range (a FRESH download, or a no-validator
+  // decline — effectiveResume === 0, no Range sent) is UNSOLICITED and unsafe: its
+  // body is only a partial slice, but the "w"/Content-Length path below would
+  // finalize that short prefix as a complete file (e.g. `bytes 0-1023/4096` with
+  // Content-Length 1024 → a 1 KiB file renamed into cache as the whole 4096-byte
+  // model). Refuse it — a no-Range request must be answered with 200 (#467 P0).
+  if (res.status === 206 && effectiveResume === 0) {
+    await safeRm(targetPath);
+    if (resumable) await safeRm(validatorSidecar);
+    throw new ModelError(
+      `Download failed: the server returned "206 Partial Content" to a request that sent NO Range ` +
+        `header. An unsolicited partial response can't be finalized as a complete file (it would ` +
+        `silently truncate the model). Removed any partial; retry.`,
+      { url: logUrl, status: res.status },
+    );
+  }
+
   // Decide append vs truncate based on the response. We only append when we
   // actually asked for a range (effectiveResume > 0, i.e. we had a validator)
   // AND the server honoured it with a 206. Any other 2xx (typically 200) means
@@ -972,7 +989,11 @@ async function reserveExclusiveTemp(base: string, tag: string): Promise<string> 
  *  new name; copy-falling-back there is what truncates a stale hardlinked temp and
  *  poisons a cache inode, #467 P1-A) and NOT other errors (propagate). */
 function isHardlinkUnsupported(code: unknown): boolean {
-  return code === "EXDEV" || code === "EPERM" || code === "ENOSYS" || code === "EACCES";
+  // ONLY genuine "hardlinks aren't usable here" codes: cross-device (EXDEV), the FS
+  // doesn't support links (ENOSYS/EPERM — some Windows/network FS). NOT EACCES — an
+  // ACL denial is a real permission error that must propagate, not silently copy
+  // (#467 P2).
+  return code === "EXDEV" || code === "EPERM" || code === "ENOSYS";
 }
 
 /** Rename `tmp` over `targetPath`. On POSIX, rename atomically replaces an existing

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -184,17 +184,18 @@ function cacheSizeLimitBytes(): number {
 }
 
 /** Representation-affecting request headers, folded into the cache identity so a
- *  same-URL fetch carrying DIFFERENT auth (e.g. two users' Bearer tokens, or a
- *  Cookie/API-key that selects a user-scoped or gated representation) can NEVER
- *  share a cache entry / in-flight stream and install the wrong bytes (#467
- *  P1-2). Query-param auth already varies the URL itself (applyDownloadAuth folds
- *  it in), so this covers the header-auth case the URL can't. Volatile hop
- *  headers (Range/If-Range) are added later inside streamUrlToFile and are
- *  deliberately excluded — they must not fragment the cache. Empty ⇒ the key is
- *  the bare URL, so unauthenticated public downloads keep their existing paths. */
+ *  same-URL fetch carrying DIFFERENT auth/headers (two users' Bearer tokens, a
+ *  Cookie/API-key, or ANY custom header like `X-Custom-Auth` that selects a
+ *  user-scoped or gated representation) can NEVER share a cache entry / in-flight
+ *  stream and install the wrong bytes (#467 P1-2). Query-param auth already
+ *  varies the URL itself (applyDownloadAuth folds it in), so this covers the
+ *  header case the URL can't. Hashes EVERY caller-supplied header (an allowlist
+ *  would silently miss custom auth headers) — these are the request headers built
+ *  from the caller's auth/config, NOT the volatile hop headers (Range/If-Range),
+ *  which are added later inside streamUrlToFile and never reach here. Empty ⇒ the
+ *  key is the bare URL, so unauthenticated public downloads keep existing paths. */
 function representationKey(headers: Record<string, string>): string {
   const relevant = Object.keys(headers)
-    .filter((k) => /^(authorization|cookie|x-api-key|x-auth-token)$/i.test(k))
     .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
     .map((k) => `${k.toLowerCase()}=${headers[k]}`)
     .join("\n");
@@ -278,15 +279,11 @@ async function streamUrlToFile(
    *  Defaults to the URL tray id for internal/direct callers. */
   resumeKey?: string,
 ): Promise<void> {
-  // The slot this download's resume decision is recorded under.
+  // The slot this download's resume decision is recorded under. The per-attempt
+  // RESET of this slot happens in downloadIntoCache (the single new-physical-
+  // download gate that also covers cache hits and the mkdir/fallback path),
+  // NOT here — see #467 P1-b/P2.
   const diagKey = resumeKey ?? trayIdForUrl(url);
-  // Per-attempt reset (#467 P2): a GENUINELY-NEW physical download clears any
-  // decision left by an EARLIER attempt for this slot, then records its own
-  // below. This lives HERE — the single physical-download entry point — not in
-  // startDownloadJob, so a job that merely COALESCES onto an in-flight download
-  // (downloadIntoCache's inflight map) never runs it and therefore can't wipe the
-  // active stream's recorded decision (#467 P1-b).
-  if (resumable) clearResumeDiagnostic(diagKey);
   if (supportsCloudDownload(url)) {
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
@@ -786,6 +783,14 @@ async function downloadIntoCache(
   if (existing) return existing;
 
   const promise = (async () => {
+    // Per-attempt reset (#467 P1-b/P2): a GENUINELY-NEW physical download for this
+    // slot clears any decision left by an EARLIER attempt, up front — BEFORE the
+    // mkdir/cache-hit/miss branches — so it also covers a cache hit (which never
+    // reaches streamUrlToFile) AND a cache-dir mkdir failure (which falls back to
+    // a direct download that records nothing). A job that merely COALESCES onto an
+    // in-flight download returned at `if (existing)` above, so it never runs this
+    // and can't wipe the active stream's recorded decision.
+    clearResumeDiagnostic(resumeKey ?? trayIdForUrl(url));
     await downloadCacheFs.mkdir(cacheDir(), { recursive: true });
 
     try {
@@ -799,11 +804,8 @@ async function downloadIntoCache(
           await downloadCacheFs.rm(target, { force: true }).catch(() => undefined);
         } else {
           await touch(target);
-          // Cache hit ⇒ no resume/discard happened this attempt. Clear any prior
-          // decision for this slot so download_status can't attribute an EARLIER
-          // attempt's decline to this fresh cache-hit job — the per-attempt reset
-          // that streamUrlToFile would do, but a hit never reaches it (#467).
-          clearResumeDiagnostic(resumeKey ?? trayIdForUrl(url));
+          // Cache hit ⇒ no resume/discard this attempt; the slot was already
+          // cleared at the top of this promise body (#467).
           return target;
         }
       }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -947,6 +947,26 @@ function randomTempPath(base: string, tag: string): string {
   return `${base}.${tag}-${randomBytes(12).toString("hex")}.tmp`;
 }
 
+/** Reserve an unguessable temp path by creating it EXCLUSIVELY (O_EXCL via the "wx"
+ *  flag), retrying on the astronomically-unlikely EEXIST. Guarantees the returned
+ *  path is a FRESH standalone inode — so a subsequent "w" open (streamUrlToFile /
+ *  the S3/Azure downloaders truncate) writes to our own new file and can NEVER
+ *  follow a pre-existing hardlink into a cache inode (#467 P1-A). */
+async function reserveExclusiveTemp(base: string, tag: string): Promise<string> {
+  for (let attempt = 1; ; attempt++) {
+    const p = randomTempPath(base, tag);
+    try {
+      await writeFile(p, "", { flag: "wx" });
+      return p;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === "EEXIST" && attempt < MATERIALIZE_TEMP_ATTEMPTS) {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 /** True for a hardlink error that means "hardlinks aren't usable here" — the ONLY
  *  case where copy-fallback is legitimate. NOT EEXIST (a name collision — retry a
  *  new name; copy-falling-back there is what truncates a stale hardlinked temp and
@@ -955,22 +975,28 @@ function isHardlinkUnsupported(code: unknown): boolean {
   return code === "EXDEV" || code === "EPERM" || code === "ENOSYS" || code === "EACCES";
 }
 
-/** Rename `tmp` over `targetPath`, with a Windows EPERM-over-existing rm+retry.
- *  The temp already holds the fully-materialized bytes, so the brief gap where the
- *  DESTINATION is absent is safe (it's the destination, not a cache inode, and
- *  last-writer-wins on it is the intended concurrent semantics). Cleans `tmp` if
- *  the swap ultimately fails. */
+/** Rename `tmp` over `targetPath`. On POSIX, rename atomically replaces an existing
+ *  destination. Windows can't rename OVER an existing file and returns EPERM/EACCES/
+ *  EEXIST — ONLY then do we remove the destination and retry (the temp already holds
+ *  the fully-materialized bytes, so the brief gap where the destination is absent is
+ *  safe). Any OTHER rename error (ENOENT, EIO, EXDEV, …) must NOT destroy a valid
+ *  existing destination (#467): clean our temp and propagate. */
 async function renameTempOverDestination(tmp: string, targetPath: string): Promise<void> {
   try {
     await downloadCacheFs.rename(tmp, targetPath);
     return;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "EPERM" && code !== "EACCES" && code !== "EEXIST") {
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      throw err;
+    }
     await downloadCacheFs.rm(targetPath, { force: true }).catch(() => undefined);
     try {
       await downloadCacheFs.rename(tmp, targetPath);
-    } catch (err) {
+    } catch (e) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
-      throw err;
+      throw e;
     }
   }
 }
@@ -1091,15 +1117,15 @@ export async function downloadWithCache(
       url: logUrl,
       error: err instanceof Error ? err.message : String(err),
     });
-    // Write to an UNGUESSABLE temp then rename over the destination — NEVER stream
-    // "w" directly at targetPath (#467). If a concurrent materialize already
-    // hardlinked targetPath to a cache inode, a direct "w" open would follow that
-    // hardlink and overwrite the OTHER representation's cache entry with these bytes
-    // (poison). A random fresh temp is its own inode, and rename only swaps the
-    // directory entry — so cache inodes stay intact and a failed stream leaves the
-    // destination untouched. Random (not pid+counter) so a stale/reused-PID temp
-    // can't be silently truncated (#467 P1-A).
-    const tmp = randomTempPath(options.targetPath, "dl");
+    // Download to an EXCLUSIVELY-created, unguessable temp then rename over the
+    // destination — NEVER stream "w" directly at targetPath (#467). If a concurrent
+    // materialize already hardlinked targetPath to a cache inode, a direct "w" open
+    // would follow that hardlink and overwrite the OTHER representation's cache
+    // entry with these bytes (poison). Reserving the temp with O_EXCL guarantees a
+    // fresh standalone inode, so the downloader's "w"/truncate can never follow a
+    // pre-existing hardlink; rename only swaps the directory entry. A failed stream
+    // leaves the destination untouched.
+    const tmp = await reserveExclusiveTemp(options.targetPath, "dl");
     try {
       await downloadUrlToFile(
         options.url,

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -353,6 +353,11 @@ async function streamUrlToFile(
   // both as the sidecar fallback (so Xet downloads become resumable) AND as the
   // resume-time change check below (#467).
   let redirectValidator: string | null = null;
+  // Set if ANY hop in the redirect chain reports a content-addressed X-Linked-Etag
+  // that DIFFERS from the validator the partial was written against — proof the
+  // upstream object changed, even if a later/earlier hop happens to match. Closes
+  // the multi-hop hole where only the first (or last) value is inspected (#467).
+  let sawChangedRedirectValidator = false;
   // Did the bytes ultimately come from a DIFFERENT origin than we requested (HF
   // resolve → CAS CDN)? A cross-origin 206 can't lean on the requesting origin's
   // If-Range — the CDN may honor a stale Range and 206 a CHANGED object — so a
@@ -373,7 +378,15 @@ async function streamUrlToFile(
     // object hash) on the 302; the final CAS 200 carries NO validator. Without
     // this, Xet downloads never persisted a sidecar and could never resume (#467).
     // ONLY X-Linked-Etag — a generic ETag on a 3xx is the pointer's, not the file's.
-    if (!redirectValidator) redirectValidator = res.headers.get("x-linked-etag");
+    // Keep the LAST value seen (nearest the final object) for the sidecar/match,
+    // AND flag if ANY hop's value contradicts the persisted validator on a resume.
+    const hopValidator = res.headers.get("x-linked-etag");
+    if (hopValidator) {
+      redirectValidator = hopValidator;
+      if (requestedResume && priorValidator && hopValidator !== priorValidator) {
+        sawChangedRedirectValidator = true;
+      }
+    }
 
     if (redirectCount >= MAX_HTTP_REDIRECTS) {
       throw new ModelError(
@@ -465,7 +478,9 @@ async function streamUrlToFile(
   // gated — a 200 is a full body and restarts cleanly through the branch below.
   // On refusal, drop the partial + sidecar so a retry is a clean full download.
   if (requestedResume && res.status === 206) {
-    const provenChange = redirectValidator !== null && redirectValidator !== priorValidator;
+    const provenChange =
+      sawChangedRedirectValidator ||
+      (redirectValidator !== null && redirectValidator !== priorValidator);
     const unprovenCrossOrigin = crossOriginRedirect && redirectValidator !== priorValidator; // includes missing
     if (provenChange || unprovenCrossOrigin) {
       const why = provenChange

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -215,8 +215,19 @@ function extractValidator(res: Response): string | null {
  */
 export type ResumeOutcome =
   | "resumed"
+  /** No validator sidecar existed, so a safe resume couldn't even be attempted;
+   *  the partial was discarded and re-downloaded in full (in-stream restart). */
   | "declined:no-validator"
-  | "declined:etag-changed";
+  /** We attempted a conditional resume but the server answered with a full 200
+   *  instead of a 206 — the upstream changed OR the host doesn't support range
+   *  resume; either way the partial was discarded (in-stream restart). */
+  | "declined:full-response"
+  /** A 206 whose content-addressed validator PROVED the upstream object changed
+   *  — refused to avoid a corrupt append; the job errors and a retry restarts. */
+  | "declined:etag-changed"
+  /** A cross-origin (CDN) 206 that carried NO content-addressed validator, so an
+   *  unchanged upstream couldn't be proven — refused for safety; retry restarts. */
+  | "declined:unverifiable";
 
 export interface ResumeDiagnostic {
   outcome: ResumeOutcome;
@@ -309,6 +320,11 @@ async function streamUrlToFile(
   // response to distinguish a taken resume (206) from an If-Range MISS (200 =
   // upstream changed) so we can surface WHY the partial was discarded (#467).
   let requestedResume = false;
+  // Set when a partial existed but no sidecar validator did, so we declined to
+  // resume. The discard is only REPORTED once we actually truncate it (after a
+  // successful response), so a fetch/redirect/status failure before then can't
+  // falsely claim the partial was discarded (#467 codex round 4).
+  let resumeDeclinedNoValidator = false;
   // The persisted content-addressed validator we are resuming AGAINST — kept so
   // we can re-compare it to the value the resolve redirect reports NOW, and
   // refuse the append ourselves if they differ (belt-and-braces on top of the
@@ -326,23 +342,14 @@ async function streamUrlToFile(
       };
       requestedResume = true;
     } else {
-      // No trustworthy validator → discard the un-verifiable partial state. This
-      // is the deliberate #343 safety fallback, but it used to be SILENT: a
+      // No trustworthy validator → we will discard the un-verifiable partial and
+      // restart (the deliberate #343 safety fallback). This USED to be silent: a
       // multi-GB HF Xet partial (whose CAS CDN sent no ETag/Last-Modified, so no
       // sidecar was ever written) got thrown away and re-downloaded from 0 with
-      // no log and no signal to the agent (#467). Log it AND record a diagnostic
-      // download_status can surface.
+      // no log and no signal (#467). Defer the log/diagnostic until we actually
+      // truncate (below), so a pre-write failure can't falsely report a discard.
       effectiveResume = 0;
-      logger.warn(
-        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
-          `ETag/Last-Modified validator was ever persisted for it, so a safe resume can't be ` +
-          `verified (common on Hugging Face's Xet/CAS CDN, which omits both headers on the file ` +
-          `body). This is the safety-first behavior — an unverifiable resume risks a corrupt ` +
-          `file (#343). Future downloads capture the validator from the resolve redirect so they ` +
-          `CAN resume.`,
-        { url: logUrl, discardedBytes: resumeFromBytes },
-      );
-      if (resumable) recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
+      if (resumable) resumeDeclinedNoValidator = true;
     }
   }
   // The content-addressed validator captured from the resolve REDIRECT (HF's
@@ -483,12 +490,19 @@ async function streamUrlToFile(
       (redirectValidator !== null && redirectValidator !== priorValidator);
     const unprovenCrossOrigin = crossOriginRedirect && redirectValidator !== priorValidator; // includes missing
     if (provenChange || unprovenCrossOrigin) {
+      // provenChange (a validator we saw DIFFERS from the partial's) is a proven
+      // change; unprovenCrossOrigin alone (no validator to compare) is merely
+      // UNVERIFIABLE — report each honestly rather than always "changed".
       const why = provenChange
         ? "the resolve redirect now points at a DIFFERENT content-addressed object (X-Linked-Etag changed)"
         : "the resume crossed origins to a CDN that returned no content-addressed validator, so an unchanged upstream can't be proven";
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
-      recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
+      recordResumeDiagnostic(
+        url,
+        provenChange ? "declined:etag-changed" : "declined:unverifiable",
+        resumeFromBytes,
+      );
       logger.warn(
         `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: ${why}. ` +
           `Refusing to append the 206 (would risk corrupting the file, #343). Removed the partial; retry.`,
@@ -557,19 +571,33 @@ async function streamUrlToFile(
   // begin writing, a truncated partial is already paired with a MATCHING
   // validator. On a 206 append the existing sidecar already matches — leave it.
   if (resumable && !appendMode) {
-    // If we ASKED to resume (had a validator, sent Range+If-Range) but the
-    // server didn't honor it (200, not 206), the upstream file changed — the
-    // If-Range miss — so the partial is being discarded. Surface WHY (#467)
-    // rather than silently restarting.
+    // We are about to TRUNCATE the partial (flags "w") — this is the point the
+    // discard actually happens, so report it here (not before the response, which
+    // could have failed and left the partial intact — #467 codex round 4).
     if (requestedResume) {
+      // Asked to resume (had a validator, sent Range+If-Range) but got a full 200
+      // — the upstream changed OR the host doesn't support range resume. Either
+      // way the partial is discarded and the file re-downloaded in full.
       logger.warn(
         `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: the server ` +
-          `answered the If-Range resume request with a full ${res.status} instead of a 206, which ` +
-          `means the upstream file CHANGED since the partial was written. Appending would corrupt ` +
-          `it (#343), so re-downloading in full.`,
+          `answered the If-Range resume request with a full ${res.status} instead of a 206 — the ` +
+          `upstream file changed, or the host doesn't support resuming — so re-downloading in full.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
+      recordResumeDiagnostic(url, "declined:full-response", resumeFromBytes);
+    } else if (resumeDeclinedNoValidator) {
+      // A partial existed but no sidecar validator did, so we never even sent a
+      // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
+      // which omits ETag/Last-Modified on the body). Discard + re-download in full.
+      logger.warn(
+        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
+          `ETag/Last-Modified validator was ever persisted for it, so a safe resume can't be ` +
+          `verified (common on Hugging Face's Xet/CAS CDN, which omits both headers on the file ` +
+          `body). This is the safety-first behavior — an unverifiable resume risks a corrupt file ` +
+          `(#343). Future downloads capture the validator from the resolve redirect so they CAN resume.`,
+        { url: logUrl, discardedBytes: resumeFromBytes },
+      );
+      recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
     }
     await safeRm(validatorSidecar);
     await safeRm(targetPath);

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -988,9 +988,9 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     // ONLY on Windows does rename fail because it can't replace an existing file
-    // (EPERM/EACCES/EEXIST) — only there do we remove-and-retry. On POSIX rename
-    // atomically replaces, so ANY error there is a real failure that must NOT
-    // destroy a valid existing destination: clean the temp and propagate.
+    // (EPERM/EACCES/EEXIST). On POSIX rename atomically replaces, so ANY error
+    // there is a real failure that must NOT destroy a valid destination: clean the
+    // temp and propagate.
     const windowsOverwrite =
       process.platform === "win32" &&
       (code === "EPERM" || code === "EACCES" || code === "EEXIST");
@@ -998,10 +998,23 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw err;
     }
-    await downloadCacheFs.rm(targetPath, { force: true }).catch(() => undefined);
+    // Windows: move the existing destination ASIDE first, then swap the temp in.
+    // If the swap fails, RESTORE the backup — a valid destination must never be
+    // lost even when the retry itself errors (#467).
+    const backup = `${targetPath}.bak-${randomBytes(9).toString("hex")}.tmp`;
+    let backedUp = false;
+    try {
+      await downloadCacheFs.rename(targetPath, backup);
+      backedUp = true;
+    } catch {
+      /* destination may not exist — nothing to move aside */
+    }
     try {
       await downloadCacheFs.rename(tmp, targetPath);
+      if (backedUp) await downloadCacheFs.rm(backup, { force: true }).catch(() => undefined);
     } catch (e) {
+      // Swap failed — put the original destination back, drop our temp.
+      if (backedUp) await downloadCacheFs.rename(backup, targetPath).catch(() => undefined);
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw e;
     }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -967,7 +967,13 @@ async function materializeCacheFile(
     await downloadCacheFs.link(cachePath, tmp);
     mode = "hardlink";
   } catch {
-    await downloadCacheFs.copyFile(cachePath, tmp);
+    try {
+      await downloadCacheFs.copyFile(cachePath, tmp);
+    } catch (e) {
+      // A partial copy could linger — clean the temp before propagating.
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      throw e;
+    }
     mode = "copy";
   }
   try {
@@ -1057,14 +1063,34 @@ export async function downloadWithCache(
       url: logUrl,
       error: err instanceof Error ? err.message : String(err),
     });
-    await downloadUrlToFile(
-      options.url,
-      options.targetPath,
-      options.headers,
-      logUrl,
-      options.storageAuth,
-      options.progress,
-    );
+    // Write to a UNIQUE temp then rename over the destination — NEVER stream "w"
+    // directly at targetPath (#467). If a concurrent materialize already hardlinked
+    // targetPath to a cache inode, a direct "w" open would follow that hardlink and
+    // overwrite the OTHER representation's cache entry with these bytes (poison).
+    // A fresh temp is its own inode, and rename only swaps the directory entry — so
+    // cache inodes stay intact and a failed stream leaves the destination untouched.
+    const tmp = `${options.targetPath}.dl-${process.pid}-${materializeSeq++}.tmp`;
+    try {
+      await downloadUrlToFile(
+        options.url,
+        tmp,
+        options.headers,
+        logUrl,
+        options.storageAuth,
+        options.progress,
+      );
+      try {
+        await downloadCacheFs.rename(tmp, options.targetPath);
+      } catch {
+        // Windows can EPERM renaming over an existing/hardlinked target — remove it
+        // (breaking any cache hardlink WITHOUT writing through it) and retry.
+        await downloadCacheFs.rm(options.targetPath, { force: true }).catch(() => undefined);
+        await downloadCacheFs.rename(tmp, options.targetPath);
+      }
+    } catch (e) {
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      throw e;
+    }
     return { targetPath: options.targetPath, usedCache: false };
   }
 }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -190,6 +190,69 @@ async function writeValidatorSidecar(path: string, value: string): Promise<void>
   }
 }
 
+/** The strongest resume validator a response can offer, preferring Hugging
+ *  Face's content-addressed `X-Linked-Etag` (the LFS/Xet object hash — carried
+ *  on the huggingface.co/resolve 302, NOT on the CAS CDN's final 200) over a
+ *  plain ETag, falling back to Last-Modified. Capturing X-Linked-Etag from the
+ *  redirect is what lets HF Xet downloads persist a sidecar at all (#467): the
+ *  final CAS response returns neither ETag nor Last-Modified, so without this a
+ *  Xet partial could NEVER be safely resumed. */
+function extractValidator(res: Response): string | null {
+  return (
+    res.headers.get("x-linked-etag") ||
+    res.headers.get("etag") ||
+    res.headers.get("last-modified")
+  );
+}
+
+/**
+ * Why a resume was (or wasn't) taken on the most recent attempt for a given
+ * source URL. Recorded in-process so `download_status` — which runs in the SAME
+ * MCP server process as the streaming download — can tell the agent/user that a
+ * multi-GB `.partial` was discarded and WHY, instead of a silent full
+ * re-download (#467). Keyed by the tray id (a 16-hex hash of the source URL),
+ * matching DownloadJob.trayId so the status tool can look it up directly.
+ */
+export type ResumeOutcome =
+  | "resumed"
+  | "declined:no-validator"
+  | "declined:etag-changed";
+
+export interface ResumeDiagnostic {
+  outcome: ResumeOutcome;
+  /** Bytes of pre-existing `.partial` discarded on a declined resume (0 when the
+   *  resume was taken). */
+  discardedBytes: number;
+  /** Epoch ms this decision was made. */
+  at: number;
+}
+
+const resumeDiagnostics = new Map<string, ResumeDiagnostic>();
+
+/** Tray id for a source URL — MUST match download-jobs' downloadIdFor so
+ *  download_status can key a diagnostic off the job it already holds. */
+function trayIdForUrl(url: string): string {
+  return createHash("sha256").update(url).digest("hex").slice(0, 16);
+}
+
+function recordResumeDiagnostic(
+  url: string,
+  outcome: ResumeOutcome,
+  discardedBytes: number,
+): void {
+  resumeDiagnostics.set(trayIdForUrl(url), { outcome, discardedBytes, at: Date.now() });
+}
+
+/** Read the last resume decision for a download's tray id (or undefined). */
+export function getResumeDiagnostic(trayId: string): ResumeDiagnostic | undefined {
+  return resumeDiagnostics.get(trayId);
+}
+
+/** Test seam — the diagnostics map is process-global otherwise. */
+export function resetResumeDiagnostics(): void {
+  resumeDiagnostics.clear();
+}
+
 async function streamUrlToFile(
   url: string,
   targetPath: string,
@@ -242,6 +305,10 @@ async function streamUrlToFile(
   // validator — we cannot detect a changed file, so we must NOT append: fall
   // back to a clean restart (Range omitted, the "w" flag truncates the partial).
   let effectiveResume = resumeFromBytes;
+  // Did we actually ask the server to resume (Range + If-Range)? Used after the
+  // response to distinguish a taken resume (206) from an If-Range MISS (200 =
+  // upstream changed) so we can surface WHY the partial was discarded (#467).
+  let requestedResume = false;
   if (resumeFromBytes > 0) {
     const priorValidator = resumable
       ? await readValidatorSidecar(validatorSidecar)
@@ -252,11 +319,31 @@ async function streamUrlToFile(
         Range: `bytes=${resumeFromBytes}-`,
         "If-Range": priorValidator,
       };
+      requestedResume = true;
     } else {
-      // No trustworthy validator → discard the un-verifiable partial state.
+      // No trustworthy validator → discard the un-verifiable partial state. This
+      // is the deliberate #343 safety fallback, but it used to be SILENT: a
+      // multi-GB HF Xet partial (whose CAS CDN sent no ETag/Last-Modified, so no
+      // sidecar was ever written) got thrown away and re-downloaded from 0 with
+      // no log and no signal to the agent (#467). Log it AND record a diagnostic
+      // download_status can surface.
       effectiveResume = 0;
+      logger.warn(
+        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
+          `ETag/Last-Modified validator was ever persisted for it, so a safe resume can't be ` +
+          `verified (common on Hugging Face's Xet/CAS CDN, which omits both headers on the file ` +
+          `body). This is the safety-first behavior — an unverifiable resume risks a corrupt ` +
+          `file (#343). Future downloads capture the validator from the resolve redirect so they ` +
+          `CAN resume.`,
+        { url: logUrl, discardedBytes: resumeFromBytes },
+      );
+      if (resumable) recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
     }
   }
+  // Captured from the FIRST redirect hop that carries one (HF's resolve 302
+  // carries X-Linked-Etag even though the final CAS 200 carries no validator) —
+  // used as the sidecar fallback so Xet downloads become resumable (#467).
+  let redirectValidator: string | null = null;
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
     res = await fetchOrThrow(
@@ -265,6 +352,12 @@ async function streamUrlToFile(
       currentUrl === url ? logUrl : redactUrlForLogs(currentUrl),
     );
     if (res.status < 300 || res.status >= 400) break;
+
+    // Capture a resume validator off the redirect itself. HF's resolve URL 302s
+    // to the CAS CDN and carries X-Linked-Etag (the content-addressed object
+    // hash) on the 302; the final CAS 200 carries NO validator. Without this,
+    // Xet downloads never persisted a sidecar and could never resume (#467).
+    if (!redirectValidator) redirectValidator = extractValidator(res);
 
     if (redirectCount >= MAX_HTTP_REDIRECTS) {
       throw new ModelError(
@@ -307,14 +400,22 @@ async function streamUrlToFile(
         },
       );
     }
-    // Drop request headers (Authorization etc.) when the redirect crosses
-    // origins. HF's resolve URL 302s to a *pre-signed* Xet/CAS URL on a
+    // Drop credential-bearing headers (Authorization etc.) when the redirect
+    // crosses origins. HF's resolve URL 302s to a *pre-signed* Xet/CAS URL on a
     // different host (e.g. cas-bridge.xethub.hf.co) that needs no auth — and
     // forwarding our HF Bearer token to a third-party CDN would leak it. This
-    // matches how huggingface_hub follows the CAS redirect.
+    // matches how huggingface_hub follows the CAS redirect. BUT keep Range /
+    // If-Range: they are not credentials, and the pre-signed CAS URL supports
+    // byte-range requests — dropping them meant a resume's Range never reached
+    // the CDN, so HF Xet resumes always fell back to a full re-download (#467).
     const sameOrigin = new URL(nextUrl).origin === new URL(currentUrl).origin;
     currentUrl = nextUrl;
-    if (!sameOrigin) currentHeaders = {};
+    if (!sameOrigin) {
+      const preserved: Record<string, string> = {};
+      if (currentHeaders.Range) preserved.Range = currentHeaders.Range;
+      if (currentHeaders["If-Range"]) preserved["If-Range"] = currentHeaders["If-Range"];
+      currentHeaders = preserved;
+    }
   }
 
   if (!res.ok) {
@@ -391,10 +492,31 @@ async function streamUrlToFile(
   // begin writing, a truncated partial is already paired with a MATCHING
   // validator. On a 206 append the existing sidecar already matches — leave it.
   if (resumable && !appendMode) {
+    // If we ASKED to resume (had a validator, sent Range+If-Range) but the
+    // server didn't honor it (200, not 206), the upstream file changed — the
+    // If-Range miss — so the partial is being discarded. Surface WHY (#467)
+    // rather than silently restarting.
+    if (requestedResume) {
+      logger.warn(
+        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: the server ` +
+          `answered the If-Range resume request with a full ${res.status} instead of a 206, which ` +
+          `means the upstream file CHANGED since the partial was written. Appending would corrupt ` +
+          `it (#343), so re-downloading in full.`,
+        { url: logUrl, discardedBytes: resumeFromBytes },
+      );
+      recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
+    }
     await safeRm(validatorSidecar);
     await safeRm(targetPath);
-    const validator = res.headers.get("etag") || res.headers.get("last-modified");
+    // Prefer the final response's validator; fall back to one captured off the
+    // redirect chain (HF Xet: the CAS 200 has none, but the resolve 302 carried
+    // X-Linked-Etag) so the partial written now becomes resumable later (#467).
+    const validator = extractValidator(res) || redirectValidator;
     if (validator) await writeValidatorSidecar(validatorSidecar, validator);
+  } else if (appendMode) {
+    // A resume was actually taken (validated 206 append). Record it so
+    // download_status can report the partial was reused, not discarded (#467).
+    recordResumeDiagnostic(url, "resumed", 0);
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -987,7 +987,14 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
     return;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
-    if (code !== "EPERM" && code !== "EACCES" && code !== "EEXIST") {
+    // ONLY on Windows does rename fail because it can't replace an existing file
+    // (EPERM/EACCES/EEXIST) — only there do we remove-and-retry. On POSIX rename
+    // atomically replaces, so ANY error there is a real failure that must NOT
+    // destroy a valid existing destination: clean the temp and propagate.
+    const windowsOverwrite =
+      process.platform === "win32" &&
+      (code === "EPERM" || code === "EACCES" || code === "EEXIST");
+    if (!windowsOverwrite) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw err;
     }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -586,22 +586,27 @@ async function streamUrlToFile(
   // begin writing, a truncated partial is already paired with a MATCHING
   // validator. On a 206 append the existing sidecar already matches — leave it.
   if (resumable && !appendMode) {
-    // Drop the stale sidecar + partial FIRST, then only AFTER confirming the
-    // partial is actually gone do we announce the discard (#467 P1-1). safeRm
-    // swallows failures, so a diagnostic recorded before removal could otherwise
-    // claim "discarded" while the bytes are still on disk — and a later
-    // stream-open failure would leave them permanently. Confirm, then report.
+    // Drop any stale sidecar, then EXPLICITLY truncate the stale partial to zero
+    // and verify that truncation SUCCEEDED before we either (a) pair a new
+    // validator with the file or (b) report the discard. Doing the truncation
+    // ourselves (create-or-truncate to 0) — rather than relying on the lazy "w"
+    // stream open below — lets us confirm the old prefix is gone up front. The
+    // ordering is the #343 safety invariant: a new validator must NEVER be paired
+    // with un-truncated stale bytes (a later If-Range 206 would then append fresh
+    // bytes onto a stale prefix and silently corrupt the file). If truncation
+    // fails, we write NO validator (a retry sees no sidecar → safe restart) and
+    // report nothing (the discard didn't actually happen).
     await safeRm(validatorSidecar);
-    await safeRm(targetPath);
-    // POSITIVELY confirm the partial is gone (ENOENT) or truncated to empty —
-    // NOT merely "stat returned no number", which fileSizeOrUndefined also emits
-    // on a stat hiccup. A swallowed rm failure + a stat hiccup must NOT read as a
-    // confirmed discard (#467 P1-1): only a real ENOENT or size 0 counts.
-    const discardConfirmed = resumeFromBytes > 0 && (await partialConfirmedDiscarded(targetPath));
-    if (discardConfirmed && requestedResume) {
+    let truncated = true;
+    try {
+      await writeFile(targetPath, "");
+    } catch {
+      truncated = false;
+    }
+    if (truncated && resumeFromBytes > 0 && requestedResume) {
       // Asked to resume (had a validator, sent Range+If-Range) but got a full 200
-      // — the upstream changed OR the host doesn't support range resume. Either
-      // way the partial has now been discarded and the file re-downloaded in full.
+      // — the upstream changed OR the host doesn't support range resume. The
+      // partial is now truncated and the file is being re-downloaded in full.
       logger.warn(
         `Discarded a ${resumeFromBytes}-byte partial download and restarting from 0: the server ` +
           `answered the If-Range resume request with a full ${res.status} instead of a 206 — the ` +
@@ -609,10 +614,10 @@ async function streamUrlToFile(
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
       onResume?.({ outcome: "declined:full-response", discardedBytes: resumeFromBytes, discarded: true });
-    } else if (discardConfirmed && resumeDeclinedNoValidator) {
+    } else if (truncated && resumeFromBytes > 0 && resumeDeclinedNoValidator) {
       // A partial existed but no sidecar validator did, so we never even sent a
       // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
-      // which omits ETag/Last-Modified on the body). Discarded + re-download full.
+      // which omits ETag/Last-Modified on the body). Truncated + re-download full.
       logger.warn(
         `Discarded a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
           `ETag/Last-Modified validator was ever persisted for it, so a safe resume can't be ` +
@@ -623,11 +628,14 @@ async function streamUrlToFile(
       );
       onResume?.({ outcome: "declined:no-validator", discardedBytes: resumeFromBytes, discarded: true });
     }
-    // Prefer the final response's validator; fall back to one captured off the
-    // redirect chain (HF Xet: the CAS 200 has none, but the resolve 302 carried
-    // X-Linked-Etag) so the partial written now becomes resumable later (#467).
-    const validator = extractValidator(res) || redirectValidator;
-    if (validator) await writeValidatorSidecar(validatorSidecar, validator);
+    // Persist the new validator ONLY once the file is confirmed truncated, so it
+    // can never pair with a stale prefix (#343). Prefer the final response's
+    // validator; fall back to one captured off the redirect chain (HF Xet: the CAS
+    // 200 has none, but the resolve 302 carried X-Linked-Etag).
+    if (truncated) {
+      const validator = extractValidator(res) || redirectValidator;
+      if (validator) await writeValidatorSidecar(validatorSidecar, validator);
+    }
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -20,7 +20,11 @@ import { ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
-import { recordResumeDiagnostic, trayIdForUrl } from "./download-resume-diag.js";
+import {
+  clearResumeDiagnostic,
+  recordResumeDiagnostic,
+  trayIdForUrl,
+} from "./download-resume-diag.js";
 // Re-export the resume-diagnostic read/reset API so existing importers of
 // download-cache keep working; the registry itself now lives in a dep-light
 // module (download-resume-diag) to avoid pulling storage/* into consumers' mocks.
@@ -276,6 +280,13 @@ async function streamUrlToFile(
 ): Promise<void> {
   // The slot this download's resume decision is recorded under.
   const diagKey = resumeKey ?? trayIdForUrl(url);
+  // Per-attempt reset (#467 P2): a GENUINELY-NEW physical download clears any
+  // decision left by an EARLIER attempt for this slot, then records its own
+  // below. This lives HERE — the single physical-download entry point — not in
+  // startDownloadJob, so a job that merely COALESCES onto an in-flight download
+  // (downloadIntoCache's inflight map) never runs it and therefore can't wipe the
+  // active stream's recorded decision (#467 P1-b).
+  if (resumable) clearResumeDiagnostic(diagKey);
   if (supportsCloudDownload(url)) {
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
@@ -512,20 +523,29 @@ async function streamUrlToFile(
             : " on a redirect hop") +
           ")"
         : "the resume crossed origins to a CDN that returned no content-addressed validator, so an unchanged upstream can't be proven";
+      // Remove the stale partial + sidecar, then CONFIRM the partial is actually
+      // gone (safeRm swallows failures) before claiming it — a swallowed rm
+      // failure must not be reported as "removed", and would otherwise leave a
+      // partial a retry re-hits (#467 P1-a). The declined outcome is accurate
+      // regardless (we refused to append); only the removal wording is conditional.
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
+      const removed = await partialConfirmedDiscarded(targetPath);
       recordResumeDiagnostic(
         diagKey,
         provenChange ? "declined:etag-changed" : "declined:unverifiable",
         resumeFromBytes,
       );
+      const tail = removed
+        ? "Removed the stale partial so a retry restarts cleanly."
+        : "Could not remove the stale partial — a retry may repeat this rejection; delete the .partial manually if so.";
       logger.warn(
-        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: ${why}. ` +
-          `Refusing to append the 206 (would risk corrupting the file, #343). Removed the partial; retry.`,
-        { url: logUrl, discardedBytes: resumeFromBytes },
+        `Refusing to append a 206 and ${removed ? "discarded" : "abandoning"} a ${resumeFromBytes}-byte ` +
+          `partial: ${why} — appending would risk corrupting the file (#343). ${tail}`,
+        { url: logUrl, discardedBytes: resumeFromBytes, partialRemoved: removed },
       );
       throw new ModelError(
-        `Download resume rejected: ${why}. Removed the stale partial so a retry restarts cleanly.`,
+        `Download resume rejected: ${why}. ${tail}`,
         { url: logUrl },
       );
     }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -189,10 +189,22 @@ function representationKey(headers: Record<string, string>): string {
   return relevant ? createHash("sha256").update(relevant).digest("hex").slice(0, 12) : "";
 }
 
+/** Cache-identity namespace. Bumped when the identity SCHEME changes so entries
+ *  from an older scheme can never be served under the new one. Critically this
+ *  fixes a cross-auth leak (#467 P1-C): the PRE-header-aware code cached
+ *  header-authenticated downloads under the BARE URL, so without a namespace a
+ *  post-upgrade UNAUTHENTICATED caller (also bare-URL) could be served bytes that
+ *  were cached earlier under someone's auth. We can't tell a legacy entry's
+ *  provenance, so ALL new identities — authed AND unauthed — are prefixed, which
+ *  orphans every legacy `sha256(url)` entry (a one-time re-download; orphans age
+ *  out via LRU when COMFYUI_LRU_CACHE_SIZE_GB is set, else are inert on disk). */
+const CACHE_NS = "v2";
+
 function cacheIdentity(url: string, headers: Record<string, string>): string {
   const repr = representationKey(headers);
-  // Backward compatible: no auth headers ⇒ hash the bare URL exactly as before.
-  return repr ? `${url}\n${repr}` : url;
+  // Namespaced for BOTH authed and unauthed so neither can collide with a legacy
+  // bare-URL entry of unknown auth provenance (#467 P1-C).
+  return repr ? `${CACHE_NS}\n${url}\n${repr}` : `${CACHE_NS}\n${url}`;
 }
 
 function cachePathForUrl(url: string, headers: Record<string, string> = {}): string {
@@ -698,9 +710,24 @@ async function streamUrlToFile(
     } catch {
       actual = undefined;
     }
-    // Couldn't read a real size (e.g. the fs layer is stubbed in tests, or stat
-    // hiccuped) → can't verify, so don't block a download over a missing number.
-    if (actual === undefined) return;
+    // Couldn't read the written size. FAIL CLOSED when we have an authoritative
+    // expected total to check against (#467 P1-B): a transient stat failure must
+    // NOT let an early/oversized body be finalized (renamed into cache) as a
+    // success — that is exactly the silent-corruption class #343 guards. Keep the
+    // partial on disk (it may still be range-resumable) and error instead. Only
+    // when NO expected total is known (server sent no Content-Length/Content-Range)
+    // do we return — there is nothing to verify against, so a missing size can't
+    // prove corruption and mustn't block the download.
+    if (actual === undefined) {
+      if (expectedTotal > 0) {
+        throw new ModelError(
+          `Download could not be verified: expected ${expectedTotal} bytes but the written file size ` +
+            `couldn't be read — not finalizing (the file may be incomplete). Retry.`,
+          { url: logUrl },
+        );
+      }
+      return;
+    }
     if (actual === 0) {
       // Nothing landed — remove it (and its validator sidecar) so it can't
       // masquerade as a real file / poison a resume with a validator that has

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -20,21 +20,7 @@ import { ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
-import {
-  clearResumeDiagnostic,
-  recordResumeDiagnostic,
-  trayIdForUrl,
-} from "./download-resume-diag.js";
-// Re-export the resume-diagnostic read/reset API so existing importers of
-// download-cache keep working; the registry itself now lives in a dep-light
-// module (download-resume-diag) to avoid pulling storage/* into consumers' mocks.
-export {
-  getResumeDiagnostic,
-  clearResumeDiagnostic,
-  resetResumeDiagnostics,
-  type ResumeOutcome,
-  type ResumeDiagnostic,
-} from "./download-resume-diag.js";
+import type { ResumeReporter } from "./download-resume-diag.js";
 import {
   downloadCloudUrlToFile,
   supportsCloudDownload,
@@ -160,10 +146,11 @@ export interface DownloadCacheOptions {
   logUrl?: string;
   storageAuth?: CloudStorageAuth;
   progress?: ProgressMeta;
-  /** Representation-aware slot the resume diagnostic is recorded under, so
-   *  download_status reads THIS download's decision even when a concurrent
-   *  same-URL/different-auth download exists (#467 P2). Defaults to the URL tray id. */
-  resumeKey?: string;
+  /** Sink for this download's resume decision, reported to the CALLER (the job)
+   *  so it stores the outcome on itself — never in a shared keyed map that could
+   *  misattribute it to another job (#467). Not called on a coalesced/cache-hit
+   *  path (no physical resume happened). */
+  onResume?: ResumeReporter;
 }
 
 export interface DownloadCacheResult {
@@ -274,16 +261,11 @@ async function streamUrlToFile(
   resumeFromBytes = 0,
   progress?: ProgressMeta,
   resumable = false,
-  /** Stable key the resume diagnostic is recorded under — threaded from the job
-   *  so download_status reads the SAME slot (representation-aware, #467 P2).
-   *  Defaults to the URL tray id for internal/direct callers. */
-  resumeKey?: string,
+  /** Sink for THIS physical download's resume decision, threaded from the job so
+   *  the outcome is stored on that job — never in a shared keyed map that could
+   *  misattribute it to another job (#467). Absent for internal/direct callers. */
+  onResume?: ResumeReporter,
 ): Promise<void> {
-  // The slot this download's resume decision is recorded under. The per-attempt
-  // RESET of this slot happens in downloadIntoCache (the single new-physical-
-  // download gate that also covers cache hits and the mkdir/fallback path),
-  // NOT here — see #467 P1-b/P2.
-  const diagKey = resumeKey ?? trayIdForUrl(url);
   if (supportsCloudDownload(url)) {
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
@@ -528,12 +510,11 @@ async function streamUrlToFile(
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
       const removed = await partialConfirmedDiscarded(targetPath);
-      recordResumeDiagnostic(
-        diagKey,
-        provenChange ? "declined:etag-changed" : "declined:unverifiable",
-        resumeFromBytes,
-        removed,
-      );
+      onResume?.({
+        outcome: provenChange ? "declined:etag-changed" : "declined:unverifiable",
+        discardedBytes: resumeFromBytes,
+        discarded: removed,
+      });
       const tail = removed
         ? "Removed the stale partial so a retry restarts cleanly."
         : "Could not remove the stale partial — a retry may repeat this rejection; delete the .partial manually if so.";
@@ -627,7 +608,7 @@ async function streamUrlToFile(
           `upstream file changed, or the host doesn't support resuming — so re-downloading in full.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      recordResumeDiagnostic(diagKey, "declined:full-response", resumeFromBytes);
+      onResume?.({ outcome: "declined:full-response", discardedBytes: resumeFromBytes, discarded: true });
     } else if (discardConfirmed && resumeDeclinedNoValidator) {
       // A partial existed but no sidecar validator did, so we never even sent a
       // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
@@ -640,7 +621,7 @@ async function streamUrlToFile(
           `(#343). Future downloads capture the validator from the resolve redirect so they CAN resume.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      recordResumeDiagnostic(diagKey, "declined:no-validator", resumeFromBytes);
+      onResume?.({ outcome: "declined:no-validator", discardedBytes: resumeFromBytes, discarded: true });
     }
     // Prefer the final response's validator; fall back to one captured off the
     // redirect chain (HF Xet: the CAS 200 has none, but the resolve 302 carried
@@ -650,7 +631,7 @@ async function streamUrlToFile(
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).
-    recordResumeDiagnostic(diagKey, "resumed", 0, false);
+    onResume?.({ outcome: "resumed", discardedBytes: 0, discarded: false });
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
@@ -771,7 +752,7 @@ async function downloadIntoCache(
   logUrl?: string,
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
-  resumeKey?: string,
+  onResume?: ResumeReporter,
 ): Promise<string> {
   // Header-aware identity (#467 P1-2): a same-URL download with a different
   // Authorization/Cookie/API-key gets its OWN cache file, partial and in-flight
@@ -780,17 +761,13 @@ async function downloadIntoCache(
   const key = target;
 
   const existing = inflight.get(key);
+  // A job COALESCING onto an in-flight physical download gets no resume decision
+  // of its own — the decision is reported to the job that actually runs the
+  // stream (#467). This is inherent to the callback model: onResume is not passed
+  // to the shared promise, so a coalesced caller simply awaits the same result.
   if (existing) return existing;
 
   const promise = (async () => {
-    // Per-attempt reset (#467 P1-b/P2): a GENUINELY-NEW physical download for this
-    // slot clears any decision left by an EARLIER attempt, up front — BEFORE the
-    // mkdir/cache-hit/miss branches — so it also covers a cache hit (which never
-    // reaches streamUrlToFile) AND a cache-dir mkdir failure (which falls back to
-    // a direct download that records nothing). A job that merely COALESCES onto an
-    // in-flight download returned at `if (existing)` above, so it never runs this
-    // and can't wipe the active stream's recorded decision.
-    clearResumeDiagnostic(resumeKey ?? trayIdForUrl(url));
     await downloadCacheFs.mkdir(cacheDir(), { recursive: true });
 
     try {
@@ -804,8 +781,8 @@ async function downloadIntoCache(
           await downloadCacheFs.rm(target, { force: true }).catch(() => undefined);
         } else {
           await touch(target);
-          // Cache hit ⇒ no resume/discard this attempt; the slot was already
-          // cleared at the top of this promise body (#467).
+          // Cache hit ⇒ no resume/discard this attempt; onResume is never called,
+          // so the job's resume field stays empty (nothing to surface).
           return target;
         }
       }
@@ -842,7 +819,7 @@ async function downloadIntoCache(
         resumeFromBytes,
         progress,
         true, // resumable: cache partials use the .partial + If-Range resume handshake
-        resumeKey,
+        onResume,
       );
       await downloadCacheFs.rename(partial, target);
       await touch(target);
@@ -944,7 +921,7 @@ export async function downloadWithCache(
       logUrl,
       options.storageAuth,
       options.progress,
-      options.resumeKey,
+      options.onResume,
     );
     const materializedBy = await materializeCacheFile(cachePath, options.targetPath);
     await evictLruIfNeeded();

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -353,6 +353,12 @@ async function streamUrlToFile(
   // both as the sidecar fallback (so Xet downloads become resumable) AND as the
   // resume-time change check below (#467).
   let redirectValidator: string | null = null;
+  // Did the bytes ultimately come from a DIFFERENT origin than we requested (HF
+  // resolve → CAS CDN)? A cross-origin 206 can't lean on the requesting origin's
+  // If-Range — the CDN may honor a stale Range and 206 a CHANGED object — so a
+  // cross-origin resume append MUST independently prove the content is unchanged
+  // via the content-addressed X-Linked-Etag (#467/#343).
+  let crossOriginRedirect = false;
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
     res = await fetchOrThrow(
@@ -421,6 +427,7 @@ async function streamUrlToFile(
     const sameOrigin = new URL(nextUrl).origin === new URL(currentUrl).origin;
     currentUrl = nextUrl;
     if (!sameOrigin) {
+      crossOriginRedirect = true;
       const preserved: Record<string, string> = {};
       if (currentHeaders.Range) preserved.Range = currentHeaders.Range;
       if (currentHeaders["If-Range"]) preserved["If-Range"] = currentHeaders["If-Range"];
@@ -446,34 +453,37 @@ async function streamUrlToFile(
     throw new ModelError("Download response has no body", { url: logUrl });
   }
 
-  // #467/#343 belt-and-braces: if the resolve redirect now reports a DIFFERENT
-  // content-addressed object (X-Linked-Etag) than the partial was written
-  // against, the upstream file changed — and because the cross-origin CAS URL
-  // may honor our Range and return a 206 REGARDLESS of the origin's If-Range, we
-  // must refuse the append OURSELVES rather than trust the CDN. Content-addressed
-  // ⇒ an equal validator proves identical bytes; an unequal one proves change.
-  // Drop the partial + sidecar so a retry is a clean full download.
-  if (
-    requestedResume &&
-    priorValidator &&
-    redirectValidator &&
-    redirectValidator !== priorValidator
-  ) {
-    await safeRm(targetPath);
-    await safeRm(validatorSidecar);
-    recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
-    logger.warn(
-      `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: the resolve ` +
-        `redirect now points at a DIFFERENT content-addressed object (X-Linked-Etag changed), so ` +
-        `the upstream file changed since the partial was written. Refusing to append even if the ` +
-        `CDN returns a 206 (would corrupt the file, #343). Removed the partial; retry.`,
-      { url: logUrl, discardedBytes: resumeFromBytes },
-    );
-    throw new ModelError(
-      "Download resume rejected: the upstream file changed (content-addressed validator no longer " +
-        "matches the partial). Removed the stale partial so a retry restarts cleanly.",
-      { url: logUrl },
-    );
+  // #467/#343 belt-and-braces on a 206 RESUME APPEND. A same-origin 206 is safe:
+  // the very server that evaluated our If-Range is the one serving the bytes, so
+  // a 206 already proves the resource is unchanged. A CROSS-ORIGIN 206 (HF resolve
+  // → CAS CDN) cannot lean on that — the CDN may honor a stale Range and 206 a
+  // CHANGED object regardless of the origin's If-Range — so we must independently
+  // prove the object is unchanged via the content-addressed X-Linked-Etag captured
+  // off the redirect: it MUST be present AND equal the validator the partial was
+  // written against. We also refuse any 206 whose redirect PROVES a change
+  // (X-Linked-Etag present but different), cross-origin or not. Only 206s are
+  // gated — a 200 is a full body and restarts cleanly through the branch below.
+  // On refusal, drop the partial + sidecar so a retry is a clean full download.
+  if (requestedResume && res.status === 206) {
+    const provenChange = redirectValidator !== null && redirectValidator !== priorValidator;
+    const unprovenCrossOrigin = crossOriginRedirect && redirectValidator !== priorValidator; // includes missing
+    if (provenChange || unprovenCrossOrigin) {
+      const why = provenChange
+        ? "the resolve redirect now points at a DIFFERENT content-addressed object (X-Linked-Etag changed)"
+        : "the resume crossed origins to a CDN that returned no content-addressed validator, so an unchanged upstream can't be proven";
+      await safeRm(targetPath);
+      await safeRm(validatorSidecar);
+      recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
+      logger.warn(
+        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: ${why}. ` +
+          `Refusing to append the 206 (would risk corrupting the file, #343). Removed the partial; retry.`,
+        { url: logUrl, discardedBytes: resumeFromBytes },
+      );
+      throw new ModelError(
+        `Download resume rejected: ${why}. Removed the stale partial so a retry restarts cleanly.`,
+        { url: logUrl },
+      );
+    }
   }
 
   // Decide append vs truncate based on the response. We only append when we

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -267,6 +267,19 @@ async function streamUrlToFile(
   onResume?: ResumeReporter,
 ): Promise<void> {
   if (supportsCloudDownload(url)) {
+    // Cloud downloaders (S3/Azure) don't range-resume — they open a "w" stream
+    // and overwrite the target. If a partial exists, it's being discarded; surface
+    // that (#467) instead of silently restarting, mirroring the HTTP no-validator
+    // case (the cloud object carries no ETag/Last-Modified resume validator here).
+    if (resumable && resumeFromBytes > 0) {
+      logger.warn(
+        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: cloud ` +
+          `downloads (S3/Azure) don't support byte-range resume, so the partial is overwritten — ` +
+          `re-downloading in full.`,
+        { url: logUrl, discardedBytes: resumeFromBytes },
+      );
+      onResume?.({ outcome: "declined:no-validator", discardedBytes: resumeFromBytes, discarded: true });
+    }
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
     // downloaders verify their own Content-Length (truncation), but a stream
@@ -597,13 +610,22 @@ async function streamUrlToFile(
     // fails, we write NO validator (a retry sees no sidecar → safe restart) and
     // report nothing (the discard didn't actually happen).
     await safeRm(validatorSidecar);
-    let truncated = true;
+    // If we can't truncate the stale partial, FAIL rather than fall through to the
+    // "w" open below: a partial-truncate failure that the later "w" open then
+    // silently fixed would perform the discard WITHOUT reporting it (#467). By
+    // throwing here we guarantee the discard is either reported (truncation
+    // succeeded) or the download errors (never a silent discard). The sidecar was
+    // already removed, so a retry sees no validator → safe restart (#343).
     try {
       await writeFile(targetPath, "");
-    } catch {
-      truncated = false;
+    } catch (err) {
+      throw new ModelError(
+        `Download restart failed: could not truncate the stale ${resumeFromBytes}-byte partial to ` +
+          `re-download it. Removed its validator; retry (a fresh attempt restarts from 0).`,
+        { url: logUrl, cause: err instanceof Error ? err.message : String(err) },
+      );
     }
-    if (truncated && resumeFromBytes > 0 && requestedResume) {
+    if (resumeFromBytes > 0 && requestedResume) {
       // Asked to resume (had a validator, sent Range+If-Range) but got a full 200
       // — the upstream changed OR the host doesn't support range resume. The
       // partial is now truncated and the file is being re-downloaded in full.
@@ -614,7 +636,7 @@ async function streamUrlToFile(
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
       onResume?.({ outcome: "declined:full-response", discardedBytes: resumeFromBytes, discarded: true });
-    } else if (truncated && resumeFromBytes > 0 && resumeDeclinedNoValidator) {
+    } else if (resumeFromBytes > 0 && resumeDeclinedNoValidator) {
       // A partial existed but no sidecar validator did, so we never even sent a
       // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
       // which omits ETag/Last-Modified on the body). Truncated + re-download full.
@@ -628,14 +650,12 @@ async function streamUrlToFile(
       );
       onResume?.({ outcome: "declined:no-validator", discardedBytes: resumeFromBytes, discarded: true });
     }
-    // Persist the new validator ONLY once the file is confirmed truncated, so it
+    // The file is now confirmed truncated (we threw otherwise), so a new validator
     // can never pair with a stale prefix (#343). Prefer the final response's
     // validator; fall back to one captured off the redirect chain (HF Xet: the CAS
     // 200 has none, but the resolve 302 carried X-Linked-Etag).
-    if (truncated) {
-      const validator = extractValidator(res) || redirectValidator;
-      if (validator) await writeValidatorSidecar(validatorSidecar, validator);
-    }
+    const validator = extractValidator(res) || redirectValidator;
+    if (validator) await writeValidatorSidecar(validatorSidecar, validator);
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -440,6 +440,12 @@ async function streamUrlToFile(
   // cross-origin resume append MUST independently prove the content is unchanged
   // via the content-addressed X-Linked-Etag (#467/#343).
   let crossOriginRedirect = false;
+  // The AUTHORITATIVE full-file size Hugging Face declares on the resolve redirect
+  // (X-Linked-Size — the true LFS/Xet object size), captured because the final CAS
+  // 200's Content-Length can UNDERSTATE it (a truncating proxy/CDN). Used as the
+  // expected total so a short body fails verification instead of finalizing as
+  // complete — the fresh-download analogue of the resume total cross-check (#467).
+  let redirectSize: number | undefined;
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
     res = await fetchOrThrow(
@@ -463,6 +469,9 @@ async function streamUrlToFile(
         sawChangedRedirectValidator = true;
       }
     }
+    // Capture the authoritative object size the redirect declares (last non-empty).
+    const hopSize = Number(res.headers.get("x-linked-size"));
+    if (Number.isFinite(hopSize) && hopSize > 0) redirectSize = hopSize;
 
     if (redirectCount >= MAX_HTTP_REDIRECTS) {
       throw new ModelError(
@@ -680,7 +689,7 @@ async function streamUrlToFile(
       throw new ModelError(
         `Download resume rejected: the server now reports a total size of ${total} bytes, but the ` +
           `original download recorded ${priorTotal}. The upstream size changed — appending would ` +
-          `corrupt or truncate the file. Removed the partial; retry.`,
+          `corrupt or truncate the file. Refusing to append; retry from a clean restart.`,
         { url: logUrl, status: res.status },
       );
     }
@@ -755,7 +764,10 @@ async function streamUrlToFile(
     // Content-Length IS the total) so a later resume can reject a 206 that
     // understates it (#467).
     const validator = extractValidator(res) || redirectValidator;
-    const fullTotal = Number(res.headers.get("content-length")) || undefined;
+    // Authoritative total: the GREATER of Content-Length and HF's X-Linked-Size, so
+    // a later resume cross-checks against the TRUE size, not an understated one (#467).
+    const fullTotal =
+      Math.max(Number(res.headers.get("content-length")) || 0, redirectSize ?? 0) || undefined;
     if (validator) await writeValidatorSidecar(validatorSidecar, validator, fullTotal);
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
@@ -766,15 +778,15 @@ async function streamUrlToFile(
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
   const fileStream = createWriteStream(targetPath, { flags });
 
-  // Truncation target = the true full-file size. For a validated 206 that is the
-  // Content-Range total (NOT content-length, which is only the remaining slice
-  // and would mask a short 206). For a 200 it is the Content-Length.
+  // Truncation/verification target = the true full-file size. For a validated 206
+  // that is the Content-Range total (NOT content-length, which is only the
+  // remaining slice and would mask a short 206). For a fresh/restart 200 it is the
+  // GREATER of the response's Content-Length and Hugging Face's authoritative
+  // X-Linked-Size — so a CDN that UNDERSTATES Content-Length can't finalize a short
+  // body as complete (assertComplete then requires the full X-Linked-Size) (#467).
   const lengthHeader = Number(res.headers.get("content-length") || 0);
-  const expectedTotal = appendMode
-    ? (rangeTotal ?? 0)
-    : lengthHeader > 0
-      ? lengthHeader
-      : 0;
+  const fresh200Total = Math.max(lengthHeader > 0 ? lengthHeader : 0, redirectSize ?? 0);
+  const expectedTotal = appendMode ? (rangeTotal ?? 0) : fresh200Total;
 
   // A pipeline() can resolve on a stream that ended EARLY (server dropped the
   // connection, proxy cut it, disk edge case) — leaving a 0-byte or truncated

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -535,6 +535,7 @@ async function streamUrlToFile(
         diagKey,
         provenChange ? "declined:etag-changed" : "declined:unverifiable",
         resumeFromBytes,
+        removed,
       );
       const tail = removed
         ? "Removed the stale partial so a retry restarts cleanly."
@@ -652,7 +653,7 @@ async function streamUrlToFile(
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).
-    recordResumeDiagnostic(diagKey, "resumed", 0);
+    recordResumeDiagnostic(diagKey, "resumed", 0, false);
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
@@ -798,6 +799,11 @@ async function downloadIntoCache(
           await downloadCacheFs.rm(target, { force: true }).catch(() => undefined);
         } else {
           await touch(target);
+          // Cache hit ⇒ no resume/discard happened this attempt. Clear any prior
+          // decision for this slot so download_status can't attribute an EARLIER
+          // attempt's decline to this fresh cache-hit job — the per-attempt reset
+          // that streamUrlToFile would do, but a hit never reaches it (#467).
+          clearResumeDiagnostic(resumeKey ?? trayIdForUrl(url));
           return target;
         }
       }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -246,23 +246,41 @@ async function touch(path: string): Promise<void> {
   await downloadCacheFs.utimes(path, now, now);
 }
 
-/** Read a persisted resume validator (ETag / Last-Modified) or null if absent.
- *  Best-effort: a missing/unreadable sidecar just means "resume without an
- *  If-Range guard" — never fatal. */
-async function readValidatorSidecar(path: string): Promise<string | null> {
+/** A parsed resume sidecar: the change-detection validator (ETag / X-Linked-Etag /
+ *  Last-Modified) and, when the first attempt knew it, the AUTHORITATIVE full-file
+ *  size. The size lets a later resume reject a 206 whose Content-Range total
+ *  DISAGREES with what the original response declared — a server that understates
+ *  the total on resume (e.g. `bytes 4-7/8` for a file first seen as 4096) can no
+ *  longer finalize a short prefix as complete (#467). */
+interface ResumeSidecar {
+  validator: string;
+  total?: number;
+}
+
+/** Read the resume sidecar (line 1 = validator, optional line 2 = total) or null.
+ *  Best-effort: a missing/unreadable sidecar just means "resume without an If-Range
+ *  guard" — never fatal. Backward compatible with pre-total single-line sidecars. */
+async function readValidatorSidecar(path: string): Promise<ResumeSidecar | null> {
   try {
-    const raw = (await readFile(path, "utf-8")).trim();
-    return raw.length > 0 ? raw : null;
+    const raw = await readFile(path, "utf-8");
+    const lines = raw.split("\n");
+    const validator = (lines[0] ?? "").trim();
+    if (validator.length === 0) return null;
+    const total = lines.length > 1 ? Number(lines[1].trim()) : NaN;
+    return Number.isFinite(total) && total > 0 ? { validator, total } : { validator };
   } catch {
     return null;
   }
 }
 
-/** Persist the resume validator next to a .partial. Best-effort — a failure
- *  here only costs us the change-detection guard on a later resume. */
-async function writeValidatorSidecar(path: string, value: string): Promise<void> {
+/** Persist the resume validator (+ authoritative total when known) next to a
+ *  .partial. Best-effort — a failure here only costs the change-detection guard on
+ *  a later resume. The validator is a single-line header value; the optional total
+ *  goes on line 2. */
+async function writeValidatorSidecar(path: string, value: string, total?: number): Promise<void> {
   try {
-    await writeFile(path, value, "utf-8");
+    const body = typeof total === "number" && total > 0 ? `${value}\n${total}` : value;
+    await writeFile(path, body, "utf-8");
   } catch {
     /* best effort */
   }
@@ -377,10 +395,14 @@ async function streamUrlToFile(
   // refuse the append ourselves if they differ (belt-and-braces on top of the
   // origin's If-Range: we never trust a CAS 206 whose upstream object changed).
   let priorValidator: string | null = null;
+  // The authoritative full-file size the ORIGINAL response declared (persisted in
+  // the sidecar), if known — a resume 206 whose Content-Range total DISAGREES with
+  // this is a server understating the size, and must be refused (#467).
+  let priorTotal: number | undefined;
   if (resumeFromBytes > 0) {
-    priorValidator = resumable
-      ? await readValidatorSidecar(validatorSidecar)
-      : null;
+    const sidecar = resumable ? await readValidatorSidecar(validatorSidecar) : null;
+    priorValidator = sidecar?.validator ?? null;
+    priorTotal = sidecar?.total;
     if (priorValidator) {
       currentHeaders = {
         ...currentHeaders,
@@ -594,10 +616,11 @@ async function streamUrlToFile(
   if (res.status === 206 && effectiveResume === 0) {
     await safeRm(targetPath);
     if (resumable) await safeRm(validatorSidecar);
+    const cleared = await partialConfirmedDiscarded(targetPath);
     throw new ModelError(
       `Download failed: the server returned "206 Partial Content" to a request that sent NO Range ` +
         `header. An unsolicited partial response can't be finalized as a complete file (it would ` +
-        `silently truncate the model). Removed any partial; retry.`,
+        `silently truncate the model). ${cleared ? "Removed any partial; retry." : "Could not remove the partial — delete it manually and retry."}`,
       { url: logUrl, status: res.status },
     );
   }
@@ -643,6 +666,21 @@ async function streamUrlToFile(
           `consistent Content-Range "bytes ${effectiveResume}-<end>/<total>" reaching the end of ` +
           `the file, but the server sent ${contentRange ? `"${contentRange}"` : "no Content-Range"}. ` +
           `Refusing to append (would corrupt or truncate the file). Removed the partial; retry.`,
+        { url: logUrl, status: res.status },
+      );
+    }
+    // Cross-check the 206's total against the AUTHORITATIVE size the ORIGINAL
+    // response declared (persisted in the sidecar). A server that understates the
+    // total on resume — e.g. `bytes 4-7/8` for a file first seen as 4096 — would
+    // otherwise let a short prefix finalize as "complete" (#467). Refuse the
+    // mismatch (also catches a partial we already have that exceeds the new total).
+    if (priorTotal !== undefined && total !== priorTotal) {
+      await safeRm(targetPath);
+      await safeRm(validatorSidecar);
+      throw new ModelError(
+        `Download resume rejected: the server now reports a total size of ${total} bytes, but the ` +
+          `original download recorded ${priorTotal}. The upstream size changed — appending would ` +
+          `corrupt or truncate the file. Removed the partial; retry.`,
         { url: logUrl, status: res.status },
       );
     }
@@ -712,9 +750,13 @@ async function streamUrlToFile(
     // The file is now confirmed truncated (we threw otherwise), so a new validator
     // can never pair with a stale prefix (#343). Prefer the final response's
     // validator; fall back to one captured off the redirect chain (HF Xet: the CAS
-    // 200 has none, but the resolve 302 carried X-Linked-Etag).
+    // 200 has none, but the resolve 302 carried X-Linked-Etag). Persist the
+    // AUTHORITATIVE full-file size (this restart response is a full 200, so its
+    // Content-Length IS the total) so a later resume can reject a 206 that
+    // understates it (#467).
     const validator = extractValidator(res) || redirectValidator;
-    if (validator) await writeValidatorSidecar(validatorSidecar, validator);
+    const fullTotal = Number(res.headers.get("content-length")) || undefined;
+    if (validator) await writeValidatorSidecar(validatorSidecar, validator, fullTotal);
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -254,7 +254,16 @@ function recordResumeDiagnostic(
   resumeDiagnostics.set(trayIdForUrl(url), { outcome, discardedBytes, at: Date.now() });
 }
 
-/** Read the last resume decision for a download's tray id (or undefined). */
+/** Read the last resume decision for a download's tray id (or undefined).
+ *
+ *  Keyed by tray id (URL hash) BY DESIGN, not per job/destination: the cache
+ *  coalesces every same-URL fetch into ONE `.partial` and ONE streamUrlToFile
+ *  call (downloadIntoCache's inflight map is keyed by the URL-derived cache
+ *  path), then hardlinks/copies that single file to each destination. So two
+ *  concurrent jobs for one URL with different destinations are two VIEWS of the
+ *  same physical download and share the same resume decision — reporting it on
+ *  both is accurate. Callers still gate on `at >= job.started_at` so a decision
+ *  from a PRIOR attempt for the same URL isn't attributed to a later job. */
 export function getResumeDiagnostic(trayId: string): ResumeDiagnostic | undefined {
   return resumeDiagnostics.get(trayId);
 }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { createWriteStream } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import { createWriteStream, constants as fsConstants } from "node:fs";
 import {
   copyFile,
   link,
@@ -22,6 +22,7 @@ import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import {
+  cloudPrincipalKey,
   downloadCloudUrlToFile,
   supportsCloudDownload,
   type CloudStorageAuth,
@@ -200,24 +201,16 @@ function representationKey(headers: Record<string, string>): string {
  *  out via LRU when COMFYUI_LRU_CACHE_SIZE_GB is set, else are inert on disk). */
 const CACHE_NS = "v2";
 
-/** Discriminator for cloud (S3/Azure) credentials/endpoint. `storageAuth` selects
- *  a different client/credentials (and can select a different endpoint/bucket) for
- *  a `s3://`/azure URL, but it travels SEPARATELY from the HTTP headers — so
- *  without folding it in, an authenticated cloud download could populate a cache
- *  entry later served to an unauthenticated caller, or two distinct-auth cloud
- *  jobs could coalesce onto one transfer (#467). */
-function cloudAuthKey(storageAuth?: CloudStorageAuth): string {
-  if (!storageAuth || Object.keys(storageAuth).length === 0) return "";
-  return createHash("sha256").update(JSON.stringify(storageAuth)).digest("hex").slice(0, 12);
-}
-
 function cacheIdentity(
   url: string,
   headers: Record<string, string>,
   storageAuth?: CloudStorageAuth,
 ): string {
   const repr = representationKey(headers);
-  const cloud = cloudAuthKey(storageAuth);
+  // The EFFECTIVE cloud principal (explicit storageAuth MERGED with env creds/
+  // endpoint/region), not just explicit storageAuth — so an env-authenticated cloud
+  // entry can't be served later under different/absent creds (#467 P1-B).
+  const cloud = supportsCloudDownload(url) ? cloudPrincipalKey(url, storageAuth) : "";
   // Namespaced for BOTH authed and unauthed so neither can collide with a legacy
   // bare-URL entry of unknown auth provenance (#467 P1-C). Representation-affecting
   // HTTP headers AND cloud credentials each add a line so different auth can never
@@ -944,45 +937,34 @@ async function downloadIntoCache(
   }
 }
 
-let materializeSeq = 0;
+/** A cryptographically-random, unguessable temp path next to `base`. NOT a
+ *  predictable pid+counter name (#467 P1-A): a predictable name can collide with a
+ *  temp left by a crashed attempt or a reused PID, and — if that leftover is still
+ *  hardlinked to a cache inode — a non-exclusive create would truncate it and
+ *  corrupt that cache entry. Random + exclusive-create makes a collision effectively
+ *  impossible AND detectable (EEXIST), so we never write over a pre-existing file. */
+function randomTempPath(base: string, tag: string): string {
+  return `${base}.${tag}-${randomBytes(12).toString("hex")}.tmp`;
+}
 
-async function materializeCacheFile(
-  cachePath: string,
-  targetPath: string,
-): Promise<"hardlink" | "copy"> {
-  if (resolve(cachePath) === resolve(targetPath)) return "hardlink";
+/** True for a hardlink error that means "hardlinks aren't usable here" — the ONLY
+ *  case where copy-fallback is legitimate. NOT EEXIST (a name collision — retry a
+ *  new name; copy-falling-back there is what truncates a stale hardlinked temp and
+ *  poisons a cache inode, #467 P1-A) and NOT other errors (propagate). */
+function isHardlinkUnsupported(code: unknown): boolean {
+  return code === "EXDEV" || code === "EPERM" || code === "ENOSYS" || code === "EACCES";
+}
 
-  // Materialize ATOMICALLY via a unique temp entry + rename, never by writing
-  // directly at targetPath (#467). Two jobs materializing DIFFERENT representations
-  // to the SAME on-disk path can race: if one linked targetPath to its cache inode
-  // and the other then copyFile()'d over that path, the copy would write THROUGH
-  // the hardlink INTO the first job's cache inode — poisoning that cache entry with
-  // the other representation's bytes. Building in a fresh temp (a hardlink to, or a
-  // copy of, our OWN cache inode) and renaming over targetPath keeps every cache
-  // inode read-only from here and makes the final swap atomic (last-writer-wins on
-  // the destination only, never on a cache entry).
-  const tmp = `${targetPath}.mat-${process.pid}-${materializeSeq++}.tmp`;
-  let mode: "hardlink" | "copy";
-  try {
-    await downloadCacheFs.link(cachePath, tmp);
-    mode = "hardlink";
-  } catch {
-    try {
-      await downloadCacheFs.copyFile(cachePath, tmp);
-    } catch (e) {
-      // A partial copy could linger — clean the temp before propagating.
-      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
-      throw e;
-    }
-    mode = "copy";
-  }
+/** Rename `tmp` over `targetPath`, with a Windows EPERM-over-existing rm+retry.
+ *  The temp already holds the fully-materialized bytes, so the brief gap where the
+ *  DESTINATION is absent is safe (it's the destination, not a cache inode, and
+ *  last-writer-wins on it is the intended concurrent semantics). Cleans `tmp` if
+ *  the swap ultimately fails. */
+async function renameTempOverDestination(tmp: string, targetPath: string): Promise<void> {
   try {
     await downloadCacheFs.rename(tmp, targetPath);
+    return;
   } catch {
-    // Windows can EPERM when renaming OVER an existing (or hardlinked) target —
-    // remove it and retry. The temp already holds the fully-materialized bytes, so
-    // the brief gap where targetPath is absent is safe: it's the DESTINATION, not a
-    // cache inode, and last-writer-wins on it is the intended concurrent semantics.
     await downloadCacheFs.rm(targetPath, { force: true }).catch(() => undefined);
     try {
       await downloadCacheFs.rename(tmp, targetPath);
@@ -991,7 +973,53 @@ async function materializeCacheFile(
       throw err;
     }
   }
-  return mode;
+}
+
+const MATERIALIZE_TEMP_ATTEMPTS = 5;
+
+async function materializeCacheFile(
+  cachePath: string,
+  targetPath: string,
+): Promise<"hardlink" | "copy"> {
+  if (resolve(cachePath) === resolve(targetPath)) return "hardlink";
+
+  // Materialize ATOMICALLY into an UNGUESSABLE, EXCLUSIVELY-created temp, then
+  // rename over targetPath — never write directly at targetPath, and never reuse a
+  // possibly-stale temp name (#467 P1-A). Two jobs materializing DIFFERENT
+  // representations to the SAME path can race; building each in its own random temp
+  // (a hardlink to, or an EXCLUSIVE copy of, our OWN cache inode) keeps every cache
+  // inode read-only here and makes the final swap atomic (last-writer-wins on the
+  // destination only, never a cache entry).
+  for (let attempt = 1; ; attempt++) {
+    const tmp = randomTempPath(targetPath, "mat");
+    let mode: "hardlink" | "copy";
+    try {
+      await downloadCacheFs.link(cachePath, tmp);
+      mode = "hardlink";
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      // Name collision → pick a fresh random name (never copy-fall-back onto a
+      // possibly-stale, possibly-cache-hardlinked temp).
+      if (code === "EEXIST") {
+        if (attempt >= MATERIALIZE_TEMP_ATTEMPTS) throw err;
+        continue;
+      }
+      // Only fall back to copy when hardlinks genuinely aren't usable here.
+      if (!isHardlinkUnsupported(code)) throw err;
+      try {
+        // EXCLUSIVE copy: fail (EEXIST) rather than truncate a pre-existing file.
+        await downloadCacheFs.copyFile(cachePath, tmp, fsConstants.COPYFILE_EXCL);
+      } catch (e) {
+        const ecode = (e as NodeJS.ErrnoException)?.code;
+        await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+        if (ecode === "EEXIST" && attempt < MATERIALIZE_TEMP_ATTEMPTS) continue;
+        throw e;
+      }
+      mode = "copy";
+    }
+    await renameTempOverDestination(tmp, targetPath);
+    return mode;
+  }
 }
 
 async function evictLruIfNeeded(): Promise<void> {
@@ -1063,13 +1091,15 @@ export async function downloadWithCache(
       url: logUrl,
       error: err instanceof Error ? err.message : String(err),
     });
-    // Write to a UNIQUE temp then rename over the destination — NEVER stream "w"
-    // directly at targetPath (#467). If a concurrent materialize already hardlinked
-    // targetPath to a cache inode, a direct "w" open would follow that hardlink and
-    // overwrite the OTHER representation's cache entry with these bytes (poison).
-    // A fresh temp is its own inode, and rename only swaps the directory entry — so
-    // cache inodes stay intact and a failed stream leaves the destination untouched.
-    const tmp = `${options.targetPath}.dl-${process.pid}-${materializeSeq++}.tmp`;
+    // Write to an UNGUESSABLE temp then rename over the destination — NEVER stream
+    // "w" directly at targetPath (#467). If a concurrent materialize already
+    // hardlinked targetPath to a cache inode, a direct "w" open would follow that
+    // hardlink and overwrite the OTHER representation's cache entry with these bytes
+    // (poison). A random fresh temp is its own inode, and rename only swaps the
+    // directory entry — so cache inodes stay intact and a failed stream leaves the
+    // destination untouched. Random (not pid+counter) so a stale/reused-PID temp
+    // can't be silently truncated (#467 P1-A).
+    const tmp = randomTempPath(options.targetPath, "dl");
     try {
       await downloadUrlToFile(
         options.url,
@@ -1079,14 +1109,7 @@ export async function downloadWithCache(
         options.storageAuth,
         options.progress,
       );
-      try {
-        await downloadCacheFs.rename(tmp, options.targetPath);
-      } catch {
-        // Windows can EPERM renaming over an existing/hardlinked target — remove it
-        // (breaking any cache hardlink WITHOUT writing through it) and retry.
-        await downloadCacheFs.rm(options.targetPath, { force: true }).catch(() => undefined);
-        await downloadCacheFs.rename(tmp, options.targetPath);
-      }
+      await renameTempOverDestination(tmp, options.targetPath);
     } catch (e) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw e;

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -977,20 +977,15 @@ function isHardlinkUnsupported(code: unknown): boolean {
 
 /** Rename `tmp` over `targetPath`. On POSIX, rename atomically replaces an existing
  *  destination. Windows can't rename OVER an existing file and returns EPERM/EACCES/
- *  EEXIST — ONLY then do we remove the destination and retry (the temp already holds
- *  the fully-materialized bytes, so the brief gap where the destination is absent is
- *  safe). Any OTHER rename error (ENOENT, EIO, EXDEV, …) must NOT destroy a valid
- *  existing destination (#467): clean our temp and propagate. */
+ *  EEXIST — ONLY then do we move the destination ASIDE and swap. Any OTHER rename
+ *  error (ENOENT, EIO, EXDEV, …) must NOT touch a valid existing destination (#467):
+ *  clean our temp and propagate. */
 async function renameTempOverDestination(tmp: string, targetPath: string): Promise<void> {
   try {
     await downloadCacheFs.rename(tmp, targetPath);
     return;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
-    // ONLY on Windows does rename fail because it can't replace an existing file
-    // (EPERM/EACCES/EEXIST). On POSIX rename atomically replaces, so ANY error
-    // there is a real failure that must NOT destroy a valid destination: clean the
-    // temp and propagate.
     const windowsOverwrite =
       process.platform === "win32" &&
       (code === "EPERM" || code === "EACCES" || code === "EEXIST");
@@ -998,9 +993,10 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw err;
     }
-    // Windows: move the existing destination ASIDE first, then swap the temp in.
-    // If the swap fails, RESTORE the backup — a valid destination must never be
-    // lost even when the retry itself errors (#467).
+    // Windows: move the existing destination ASIDE to a backup, then swap the temp
+    // in. On ANY swap failure, RESTORE the backup so a valid destination is never
+    // lost. If even the restore fails, the original is INTACT at `backup` — surface
+    // that path in the error so it's recoverable, never silently stranded (#467).
     const backup = `${targetPath}.bak-${randomBytes(9).toString("hex")}.tmp`;
     let backedUp = false;
     try {
@@ -1013,9 +1009,21 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
       await downloadCacheFs.rename(tmp, targetPath);
       if (backedUp) await downloadCacheFs.rm(backup, { force: true }).catch(() => undefined);
     } catch (e) {
-      // Swap failed — put the original destination back, drop our temp.
-      if (backedUp) await downloadCacheFs.rename(backup, targetPath).catch(() => undefined);
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      if (backedUp) {
+        const restored = await downloadCacheFs
+          .rename(backup, targetPath)
+          .then(() => true)
+          .catch(() => false);
+        if (!restored) {
+          throw new ModelError(
+            `Download could not be finalized and the destination could not be restored — your ` +
+              `previous file is PRESERVED at "${backup}"; move it back to "${targetPath}" manually. ` +
+              `Cause: ${e instanceof Error ? e.message : String(e)}`,
+            { url: targetPath },
+          );
+        }
+      }
       throw e;
     }
   }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -20,6 +20,17 @@ import { ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
+import { recordResumeDiagnostic } from "./download-resume-diag.js";
+// Re-export the resume-diagnostic read/reset API so existing importers of
+// download-cache keep working; the registry itself now lives in a dep-light
+// module (download-resume-diag) to avoid pulling storage/* into consumers' mocks.
+export {
+  getResumeDiagnostic,
+  clearResumeDiagnostic,
+  resetResumeDiagnostics,
+  type ResumeOutcome,
+  type ResumeDiagnostic,
+} from "./download-resume-diag.js";
 import {
   downloadCloudUrlToFile,
   supportsCloudDownload,
@@ -151,8 +162,35 @@ function cacheSizeLimitBytes(): number {
   return raw * 1024 * 1024 * 1024;
 }
 
-function cachePathForUrl(url: string): string {
-  const hash = createHash("sha256").update(url).digest("hex").slice(0, HASH_CHARS);
+/** Representation-affecting request headers, folded into the cache identity so a
+ *  same-URL fetch carrying DIFFERENT auth (e.g. two users' Bearer tokens, or a
+ *  Cookie/API-key that selects a user-scoped or gated representation) can NEVER
+ *  share a cache entry / in-flight stream and install the wrong bytes (#467
+ *  P1-2). Query-param auth already varies the URL itself (applyDownloadAuth folds
+ *  it in), so this covers the header-auth case the URL can't. Volatile hop
+ *  headers (Range/If-Range) are added later inside streamUrlToFile and are
+ *  deliberately excluded — they must not fragment the cache. Empty ⇒ the key is
+ *  the bare URL, so unauthenticated public downloads keep their existing paths. */
+function representationKey(headers: Record<string, string>): string {
+  const relevant = Object.keys(headers)
+    .filter((k) => /^(authorization|cookie|x-api-key|x-auth-token)$/i.test(k))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+    .map((k) => `${k.toLowerCase()}=${headers[k]}`)
+    .join("\n");
+  return relevant ? createHash("sha256").update(relevant).digest("hex").slice(0, 12) : "";
+}
+
+function cacheIdentity(url: string, headers: Record<string, string>): string {
+  const repr = representationKey(headers);
+  // Backward compatible: no auth headers ⇒ hash the bare URL exactly as before.
+  return repr ? `${url}\n${repr}` : url;
+}
+
+function cachePathForUrl(url: string, headers: Record<string, string> = {}): string {
+  const hash = createHash("sha256")
+    .update(cacheIdentity(url, headers))
+    .digest("hex")
+    .slice(0, HASH_CHARS);
   let extension = "";
   try {
     extension = extname(basename(new URL(url).pathname));
@@ -203,74 +241,6 @@ function extractValidator(res: Response): string | null {
     res.headers.get("etag") ||
     res.headers.get("last-modified")
   );
-}
-
-/**
- * Why a resume was (or wasn't) taken on the most recent attempt for a given
- * source URL. Recorded in-process so `download_status` — which runs in the SAME
- * MCP server process as the streaming download — can tell the agent/user that a
- * multi-GB `.partial` was discarded and WHY, instead of a silent full
- * re-download (#467). Keyed by the tray id (a 16-hex hash of the source URL),
- * matching DownloadJob.trayId so the status tool can look it up directly.
- */
-export type ResumeOutcome =
-  | "resumed"
-  /** No validator sidecar existed, so a safe resume couldn't even be attempted;
-   *  the partial was discarded and re-downloaded in full (in-stream restart). */
-  | "declined:no-validator"
-  /** We attempted a conditional resume but the server answered with a full 200
-   *  instead of a 206 — the upstream changed OR the host doesn't support range
-   *  resume; either way the partial was discarded (in-stream restart). */
-  | "declined:full-response"
-  /** A 206 whose content-addressed validator PROVED the upstream object changed
-   *  — refused to avoid a corrupt append; the job errors and a retry restarts. */
-  | "declined:etag-changed"
-  /** A cross-origin (CDN) 206 that carried NO content-addressed validator, so an
-   *  unchanged upstream couldn't be proven — refused for safety; retry restarts. */
-  | "declined:unverifiable";
-
-export interface ResumeDiagnostic {
-  outcome: ResumeOutcome;
-  /** Bytes of pre-existing `.partial` discarded on a declined resume (0 when the
-   *  resume was taken). */
-  discardedBytes: number;
-  /** Epoch ms this decision was made. */
-  at: number;
-}
-
-const resumeDiagnostics = new Map<string, ResumeDiagnostic>();
-
-/** Tray id for a source URL — MUST match download-jobs' downloadIdFor so
- *  download_status can key a diagnostic off the job it already holds. */
-function trayIdForUrl(url: string): string {
-  return createHash("sha256").update(url).digest("hex").slice(0, 16);
-}
-
-function recordResumeDiagnostic(
-  url: string,
-  outcome: ResumeOutcome,
-  discardedBytes: number,
-): void {
-  resumeDiagnostics.set(trayIdForUrl(url), { outcome, discardedBytes, at: Date.now() });
-}
-
-/** Read the last resume decision for a download's tray id (or undefined).
- *
- *  Keyed by tray id (URL hash) BY DESIGN, not per job/destination: the cache
- *  coalesces every same-URL fetch into ONE `.partial` and ONE streamUrlToFile
- *  call (downloadIntoCache's inflight map is keyed by the URL-derived cache
- *  path), then hardlinks/copies that single file to each destination. So two
- *  concurrent jobs for one URL with different destinations are two VIEWS of the
- *  same physical download and share the same resume decision — reporting it on
- *  both is accurate. Callers still gate on `at >= job.started_at` so a decision
- *  from a PRIOR attempt for the same URL isn't attributed to a later job. */
-export function getResumeDiagnostic(trayId: string): ResumeDiagnostic | undefined {
-  return resumeDiagnostics.get(trayId);
-}
-
-/** Test seam — the diagnostics map is process-global otherwise. */
-export function resetResumeDiagnostics(): void {
-  resumeDiagnostics.clear();
 }
 
 async function streamUrlToFile(
@@ -487,17 +457,27 @@ async function streamUrlToFile(
   // a 206 already proves the resource is unchanged. A CROSS-ORIGIN 206 (HF resolve
   // → CAS CDN) cannot lean on that — the CDN may honor a stale Range and 206 a
   // CHANGED object regardless of the origin's If-Range — so we must independently
-  // prove the object is unchanged via the content-addressed X-Linked-Etag captured
-  // off the redirect: it MUST be present AND equal the validator the partial was
-  // written against. We also refuse any 206 whose redirect PROVES a change
-  // (X-Linked-Etag present but different), cross-origin or not. Only 206s are
-  // gated — a 200 is a full body and restarts cleanly through the branch below.
+  // prove the object is unchanged via the content-addressed X-Linked-Etag: it MUST
+  // be present AND equal the validator the partial was written against. We check
+  // BOTH the values captured off the 3xx redirects AND the FINAL response's own
+  // X-Linked-Etag — a matching redirect followed by a final CDN 206 carrying a
+  // DIFFERENT content hash must NOT slip through (#467 P0-2). We refuse any 206
+  // whose observed validators PROVE a change (present but different), cross-origin
+  // or not. Only 206s are gated — a 200 is a full body and restarts cleanly below.
   // On refusal, drop the partial + sidecar so a retry is a clean full download.
   if (requestedResume && res.status === 206) {
+    // The final response's OWN content-addressed validator (the CAS 206 usually
+    // omits it, but when present it describes exactly THESE bytes — authoritative).
+    const finalValidator = res.headers.get("x-linked-etag");
+    // Any content-addressed validator we observed that CONTRADICTS the partial's.
     const provenChange =
       sawChangedRedirectValidator ||
-      (redirectValidator !== null && redirectValidator !== priorValidator);
-    const unprovenCrossOrigin = crossOriginRedirect && redirectValidator !== priorValidator; // includes missing
+      (redirectValidator !== null && redirectValidator !== priorValidator) ||
+      (finalValidator !== null && finalValidator !== priorValidator);
+    // The validator that best binds THESE bytes: the final response's own, else
+    // the nearest redirect's. Used for the cross-origin "must be proven" check.
+    const boundValidator = finalValidator ?? redirectValidator;
+    const unprovenCrossOrigin = crossOriginRedirect && boundValidator !== priorValidator; // includes missing
     if (provenChange || unprovenCrossOrigin) {
       // provenChange (a validator we saw DIFFERS from the partial's) is a proven
       // change; unprovenCrossOrigin alone (no validator to compare) is merely
@@ -580,26 +560,33 @@ async function streamUrlToFile(
   // begin writing, a truncated partial is already paired with a MATCHING
   // validator. On a 206 append the existing sidecar already matches — leave it.
   if (resumable && !appendMode) {
-    // We are about to TRUNCATE the partial (flags "w") — this is the point the
-    // discard actually happens, so report it here (not before the response, which
-    // could have failed and left the partial intact — #467 codex round 4).
-    if (requestedResume) {
+    // Drop the stale sidecar + partial FIRST, then only AFTER confirming the
+    // partial is actually gone do we announce the discard (#467 P1-1). safeRm
+    // swallows failures, so a diagnostic recorded before removal could otherwise
+    // claim "discarded" while the bytes are still on disk — and a later
+    // stream-open failure would leave them permanently. Confirm, then report.
+    await safeRm(validatorSidecar);
+    await safeRm(targetPath);
+    const stillOnDisk = await fileSizeOrUndefined(targetPath);
+    const discardConfirmed =
+      resumeFromBytes > 0 && (stillOnDisk === undefined || stillOnDisk === 0);
+    if (discardConfirmed && requestedResume) {
       // Asked to resume (had a validator, sent Range+If-Range) but got a full 200
       // — the upstream changed OR the host doesn't support range resume. Either
-      // way the partial is discarded and the file re-downloaded in full.
+      // way the partial has now been discarded and the file re-downloaded in full.
       logger.warn(
-        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: the server ` +
+        `Discarded a ${resumeFromBytes}-byte partial download and restarting from 0: the server ` +
           `answered the If-Range resume request with a full ${res.status} instead of a 206 — the ` +
           `upstream file changed, or the host doesn't support resuming — so re-downloading in full.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
       recordResumeDiagnostic(url, "declined:full-response", resumeFromBytes);
-    } else if (resumeDeclinedNoValidator) {
+    } else if (discardConfirmed && resumeDeclinedNoValidator) {
       // A partial existed but no sidecar validator did, so we never even sent a
       // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
-      // which omits ETag/Last-Modified on the body). Discard + re-download in full.
+      // which omits ETag/Last-Modified on the body). Discarded + re-download full.
       logger.warn(
-        `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
+        `Discarded a ${resumeFromBytes}-byte partial download and restarting from 0: no ` +
           `ETag/Last-Modified validator was ever persisted for it, so a safe resume can't be ` +
           `verified (common on Hugging Face's Xet/CAS CDN, which omits both headers on the file ` +
           `body). This is the safety-first behavior — an unverifiable resume risks a corrupt file ` +
@@ -608,8 +595,6 @@ async function streamUrlToFile(
       );
       recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
     }
-    await safeRm(validatorSidecar);
-    await safeRm(targetPath);
     // Prefer the final response's validator; fall back to one captured off the
     // redirect chain (HF Xet: the CAS 200 has none, but the resolve 302 carried
     // X-Linked-Etag) so the partial written now becomes resumable later (#467).
@@ -665,6 +650,22 @@ async function streamUrlToFile(
       // but do NOT report this as a completed download.
       throw new ModelError(
         `Download truncated: wrote ${actual} of ${expectedTotal} bytes — the stream ended early. Not complete; retry to resume.`,
+        { url: logUrl },
+      );
+    }
+    if (expectedTotal > 0 && actual > expectedTotal) {
+      // OVERSIZED — the server streamed MORE than the authoritative size (a 206
+      // Content-Range total, or a 200 Content-Length). A validated resume that
+      // claims `bytes 4-7/8` but streams extra bytes would otherwise finalize a
+      // corrupt file with no error (#467 P0-1). This is NOT resumable — the bytes
+      // on disk are wrong — so remove the partial + validator and fail; a retry
+      // starts clean rather than range-resuming a corrupt prefix.
+      await safeRm(targetPath);
+      if (resumable) await safeRm(validatorSidecar);
+      throw new ModelError(
+        `Download oversized: wrote ${actual} bytes but the file is only ${expectedTotal} — the ` +
+          `response sent more data than its declared size (corrupt or misbehaving server). Removed ` +
+          `the bad file; retry.`,
         { url: logUrl },
       );
     }
@@ -724,7 +725,10 @@ async function downloadIntoCache(
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
 ): Promise<string> {
-  const target = cachePathForUrl(url);
+  // Header-aware identity (#467 P1-2): a same-URL download with a different
+  // Authorization/Cookie/API-key gets its OWN cache file, partial and in-flight
+  // slot — never coalesced onto another caller's stream/representation.
+  const target = cachePathForUrl(url, headers);
   const key = target;
 
   const existing = inflight.get(key);

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -309,8 +309,13 @@ async function streamUrlToFile(
   // response to distinguish a taken resume (206) from an If-Range MISS (200 =
   // upstream changed) so we can surface WHY the partial was discarded (#467).
   let requestedResume = false;
+  // The persisted content-addressed validator we are resuming AGAINST — kept so
+  // we can re-compare it to the value the resolve redirect reports NOW, and
+  // refuse the append ourselves if they differ (belt-and-braces on top of the
+  // origin's If-Range: we never trust a CAS 206 whose upstream object changed).
+  let priorValidator: string | null = null;
   if (resumeFromBytes > 0) {
-    const priorValidator = resumable
+    priorValidator = resumable
       ? await readValidatorSidecar(validatorSidecar)
       : null;
     if (priorValidator) {
@@ -340,9 +345,13 @@ async function streamUrlToFile(
       if (resumable) recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
     }
   }
-  // Captured from the FIRST redirect hop that carries one (HF's resolve 302
-  // carries X-Linked-Etag even though the final CAS 200 carries no validator) —
-  // used as the sidecar fallback so Xet downloads become resumable (#467).
+  // The content-addressed validator captured from the resolve REDIRECT (HF's
+  // 302 carries X-Linked-Etag — the file's LFS/Xet content hash — even though
+  // the final CAS 200 carries no validator). Strictly X-Linked-Etag: a generic
+  // ETag/Last-Modified on a 3xx describes the redirect/pointer resource, NOT the
+  // target file, so it must never be promoted to the file's validator. Used
+  // both as the sidecar fallback (so Xet downloads become resumable) AND as the
+  // resume-time change check below (#467).
   let redirectValidator: string | null = null;
   let res: Response;
   for (let redirectCount = 0; ; redirectCount += 1) {
@@ -353,11 +362,12 @@ async function streamUrlToFile(
     );
     if (res.status < 300 || res.status >= 400) break;
 
-    // Capture a resume validator off the redirect itself. HF's resolve URL 302s
-    // to the CAS CDN and carries X-Linked-Etag (the content-addressed object
-    // hash) on the 302; the final CAS 200 carries NO validator. Without this,
-    // Xet downloads never persisted a sidecar and could never resume (#467).
-    if (!redirectValidator) redirectValidator = extractValidator(res);
+    // Capture the content-addressed resume validator off the redirect itself.
+    // HF's resolve URL 302s to the CAS CDN and carries X-Linked-Etag (the LFS/Xet
+    // object hash) on the 302; the final CAS 200 carries NO validator. Without
+    // this, Xet downloads never persisted a sidecar and could never resume (#467).
+    // ONLY X-Linked-Etag — a generic ETag on a 3xx is the pointer's, not the file's.
+    if (!redirectValidator) redirectValidator = res.headers.get("x-linked-etag");
 
     if (redirectCount >= MAX_HTTP_REDIRECTS) {
       throw new ModelError(
@@ -434,6 +444,36 @@ async function streamUrlToFile(
 
   if (!res.body) {
     throw new ModelError("Download response has no body", { url: logUrl });
+  }
+
+  // #467/#343 belt-and-braces: if the resolve redirect now reports a DIFFERENT
+  // content-addressed object (X-Linked-Etag) than the partial was written
+  // against, the upstream file changed — and because the cross-origin CAS URL
+  // may honor our Range and return a 206 REGARDLESS of the origin's If-Range, we
+  // must refuse the append OURSELVES rather than trust the CDN. Content-addressed
+  // ⇒ an equal validator proves identical bytes; an unequal one proves change.
+  // Drop the partial + sidecar so a retry is a clean full download.
+  if (
+    requestedResume &&
+    priorValidator &&
+    redirectValidator &&
+    redirectValidator !== priorValidator
+  ) {
+    await safeRm(targetPath);
+    await safeRm(validatorSidecar);
+    recordResumeDiagnostic(url, "declined:etag-changed", resumeFromBytes);
+    logger.warn(
+      `Discarding a ${resumeFromBytes}-byte partial download and restarting from 0: the resolve ` +
+        `redirect now points at a DIFFERENT content-addressed object (X-Linked-Etag changed), so ` +
+        `the upstream file changed since the partial was written. Refusing to append even if the ` +
+        `CDN returns a 206 (would corrupt the file, #343). Removed the partial; retry.`,
+      { url: logUrl, discardedBytes: resumeFromBytes },
+    );
+    throw new ModelError(
+      "Download resume rejected: the upstream file changed (content-addressed validator no longer " +
+        "matches the partial). Removed the stale partial so a retry restarts cleanly.",
+      { url: logUrl },
+    );
   }
 
   // Decide append vs truncate based on the response. We only append when we

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -179,8 +179,8 @@ function cacheSizeLimitBytes(): number {
  *  header case the URL can't. Hashes EVERY caller-supplied header (an allowlist
  *  would silently miss custom auth headers) — these are the request headers built
  *  from the caller's auth/config, NOT the volatile hop headers (Range/If-Range),
- *  which are added later inside streamUrlToFile and never reach here. Empty ⇒ the
- *  key is the bare URL, so unauthenticated public downloads keep existing paths. */
+ *  which are added later inside streamUrlToFile and never reach here. Empty ⇒ no
+ *  header line is added to the identity (the URL still carries the v2 namespace). */
 function representationKey(headers: Record<string, string>): string {
   const relevant = Object.keys(headers)
     .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
@@ -200,16 +200,42 @@ function representationKey(headers: Record<string, string>): string {
  *  out via LRU when COMFYUI_LRU_CACHE_SIZE_GB is set, else are inert on disk). */
 const CACHE_NS = "v2";
 
-function cacheIdentity(url: string, headers: Record<string, string>): string {
-  const repr = representationKey(headers);
-  // Namespaced for BOTH authed and unauthed so neither can collide with a legacy
-  // bare-URL entry of unknown auth provenance (#467 P1-C).
-  return repr ? `${CACHE_NS}\n${url}\n${repr}` : `${CACHE_NS}\n${url}`;
+/** Discriminator for cloud (S3/Azure) credentials/endpoint. `storageAuth` selects
+ *  a different client/credentials (and can select a different endpoint/bucket) for
+ *  a `s3://`/azure URL, but it travels SEPARATELY from the HTTP headers — so
+ *  without folding it in, an authenticated cloud download could populate a cache
+ *  entry later served to an unauthenticated caller, or two distinct-auth cloud
+ *  jobs could coalesce onto one transfer (#467). */
+function cloudAuthKey(storageAuth?: CloudStorageAuth): string {
+  if (!storageAuth || Object.keys(storageAuth).length === 0) return "";
+  return createHash("sha256").update(JSON.stringify(storageAuth)).digest("hex").slice(0, 12);
 }
 
-function cachePathForUrl(url: string, headers: Record<string, string> = {}): string {
+function cacheIdentity(
+  url: string,
+  headers: Record<string, string>,
+  storageAuth?: CloudStorageAuth,
+): string {
+  const repr = representationKey(headers);
+  const cloud = cloudAuthKey(storageAuth);
+  // Namespaced for BOTH authed and unauthed so neither can collide with a legacy
+  // bare-URL entry of unknown auth provenance (#467 P1-C). Representation-affecting
+  // HTTP headers AND cloud credentials each add a line so different auth can never
+  // share bytes (#467 P1-2). Empty discriminators are omitted, so unauthenticated
+  // public downloads stay stable under the v2 namespace.
+  let id = `${CACHE_NS}\n${url}`;
+  if (repr) id += `\n${repr}`;
+  if (cloud) id += `\ncloud:${cloud}`;
+  return id;
+}
+
+function cachePathForUrl(
+  url: string,
+  headers: Record<string, string> = {},
+  storageAuth?: CloudStorageAuth,
+): string {
   const hash = createHash("sha256")
-    .update(cacheIdentity(url, headers))
+    .update(cacheIdentity(url, headers, storageAuth))
     .digest("hex")
     .slice(0, HASH_CHARS);
   let extension = "";
@@ -820,10 +846,10 @@ async function downloadIntoCache(
   progress?: ProgressMeta,
   onResume?: ResumeReporter,
 ): Promise<string> {
-  // Header-aware identity (#467 P1-2): a same-URL download with a different
-  // Authorization/Cookie/API-key gets its OWN cache file, partial and in-flight
-  // slot — never coalesced onto another caller's stream/representation.
-  const target = cachePathForUrl(url, headers);
+  // Representation-aware identity (#467): a same-URL download with different HTTP
+  // auth headers OR different cloud (S3/Azure) credentials gets its OWN cache file,
+  // partial and in-flight slot — never coalesced onto another caller's stream.
+  const target = cachePathForUrl(url, headers, storageAuth);
   const key = target;
 
   const existing = inflight.get(key);
@@ -918,20 +944,48 @@ async function downloadIntoCache(
   }
 }
 
+let materializeSeq = 0;
+
 async function materializeCacheFile(
   cachePath: string,
   targetPath: string,
 ): Promise<"hardlink" | "copy"> {
   if (resolve(cachePath) === resolve(targetPath)) return "hardlink";
 
-  await downloadCacheFs.rm(targetPath, { force: true });
+  // Materialize ATOMICALLY via a unique temp entry + rename, never by writing
+  // directly at targetPath (#467). Two jobs materializing DIFFERENT representations
+  // to the SAME on-disk path can race: if one linked targetPath to its cache inode
+  // and the other then copyFile()'d over that path, the copy would write THROUGH
+  // the hardlink INTO the first job's cache inode — poisoning that cache entry with
+  // the other representation's bytes. Building in a fresh temp (a hardlink to, or a
+  // copy of, our OWN cache inode) and renaming over targetPath keeps every cache
+  // inode read-only from here and makes the final swap atomic (last-writer-wins on
+  // the destination only, never on a cache entry).
+  const tmp = `${targetPath}.mat-${process.pid}-${materializeSeq++}.tmp`;
+  let mode: "hardlink" | "copy";
   try {
-    await downloadCacheFs.link(cachePath, targetPath);
-    return "hardlink";
+    await downloadCacheFs.link(cachePath, tmp);
+    mode = "hardlink";
   } catch {
-    await downloadCacheFs.copyFile(cachePath, targetPath);
-    return "copy";
+    await downloadCacheFs.copyFile(cachePath, tmp);
+    mode = "copy";
   }
+  try {
+    await downloadCacheFs.rename(tmp, targetPath);
+  } catch {
+    // Windows can EPERM when renaming OVER an existing (or hardlinked) target —
+    // remove it and retry. The temp already holds the fully-materialized bytes, so
+    // the brief gap where targetPath is absent is safe: it's the DESTINATION, not a
+    // cache inode, and last-writer-wins on it is the intended concurrent semantics.
+    await downloadCacheFs.rm(targetPath, { force: true }).catch(() => undefined);
+    try {
+      await downloadCacheFs.rename(tmp, targetPath);
+    } catch (err) {
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      throw err;
+    }
+  }
+  return mode;
 }
 
 async function evictLruIfNeeded(): Promise<void> {

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -20,7 +20,7 @@ import { ModelError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { redactUrlForLogs } from "./download-auth.js";
 import { reportDownloadProgress, type DownloadProgress } from "./download-progress.js";
-import { recordResumeDiagnostic } from "./download-resume-diag.js";
+import { recordResumeDiagnostic, trayIdForUrl } from "./download-resume-diag.js";
 // Re-export the resume-diagnostic read/reset API so existing importers of
 // download-cache keep working; the registry itself now lives in a dep-light
 // module (download-resume-diag) to avoid pulling storage/* into consumers' mocks.
@@ -61,6 +61,19 @@ async function fileSizeOrUndefined(path: string): Promise<number | undefined> {
     return typeof st?.size === "number" ? st.size : undefined;
   } catch {
     return undefined;
+  }
+}
+
+/** POSITIVELY true only when `path` is confirmed discarded — it no longer exists
+ *  (stat throws ENOENT) or exists but is empty (size 0). A non-ENOENT stat error
+ *  (a transient fs hiccup) or a still-present non-empty file returns false, so a
+ *  swallowed removal failure is never mistaken for a completed discard (#467). */
+async function partialConfirmedDiscarded(path: string): Promise<boolean> {
+  try {
+    const st = await stat(path);
+    return typeof st?.size === "number" && st.size === 0;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === "ENOENT";
   }
 }
 
@@ -143,6 +156,10 @@ export interface DownloadCacheOptions {
   logUrl?: string;
   storageAuth?: CloudStorageAuth;
   progress?: ProgressMeta;
+  /** Representation-aware slot the resume diagnostic is recorded under, so
+   *  download_status reads THIS download's decision even when a concurrent
+   *  same-URL/different-auth download exists (#467 P2). Defaults to the URL tray id. */
+  resumeKey?: string;
 }
 
 export interface DownloadCacheResult {
@@ -252,7 +269,13 @@ async function streamUrlToFile(
   resumeFromBytes = 0,
   progress?: ProgressMeta,
   resumable = false,
+  /** Stable key the resume diagnostic is recorded under — threaded from the job
+   *  so download_status reads the SAME slot (representation-aware, #467 P2).
+   *  Defaults to the URL tray id for internal/direct callers. */
+  resumeKey?: string,
 ): Promise<void> {
+  // The slot this download's resume decision is recorded under.
+  const diagKey = resumeKey ?? trayIdForUrl(url);
   if (supportsCloudDownload(url)) {
     await downloadCloudUrlToFile(url, targetPath, storageAuth);
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
@@ -483,12 +506,16 @@ async function streamUrlToFile(
       // change; unprovenCrossOrigin alone (no validator to compare) is merely
       // UNVERIFIABLE — report each honestly rather than always "changed".
       const why = provenChange
-        ? "the resolve redirect now points at a DIFFERENT content-addressed object (X-Linked-Etag changed)"
+        ? "the upstream now reports a DIFFERENT content-addressed object (X-Linked-Etag changed" +
+          (finalValidator !== null && finalValidator !== priorValidator
+            ? " on the final response"
+            : " on a redirect hop") +
+          ")"
         : "the resume crossed origins to a CDN that returned no content-addressed validator, so an unchanged upstream can't be proven";
       await safeRm(targetPath);
       await safeRm(validatorSidecar);
       recordResumeDiagnostic(
-        url,
+        diagKey,
         provenChange ? "declined:etag-changed" : "declined:unverifiable",
         resumeFromBytes,
       );
@@ -567,9 +594,11 @@ async function streamUrlToFile(
     // stream-open failure would leave them permanently. Confirm, then report.
     await safeRm(validatorSidecar);
     await safeRm(targetPath);
-    const stillOnDisk = await fileSizeOrUndefined(targetPath);
-    const discardConfirmed =
-      resumeFromBytes > 0 && (stillOnDisk === undefined || stillOnDisk === 0);
+    // POSITIVELY confirm the partial is gone (ENOENT) or truncated to empty —
+    // NOT merely "stat returned no number", which fileSizeOrUndefined also emits
+    // on a stat hiccup. A swallowed rm failure + a stat hiccup must NOT read as a
+    // confirmed discard (#467 P1-1): only a real ENOENT or size 0 counts.
+    const discardConfirmed = resumeFromBytes > 0 && (await partialConfirmedDiscarded(targetPath));
     if (discardConfirmed && requestedResume) {
       // Asked to resume (had a validator, sent Range+If-Range) but got a full 200
       // — the upstream changed OR the host doesn't support range resume. Either
@@ -580,7 +609,7 @@ async function streamUrlToFile(
           `upstream file changed, or the host doesn't support resuming — so re-downloading in full.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      recordResumeDiagnostic(url, "declined:full-response", resumeFromBytes);
+      recordResumeDiagnostic(diagKey, "declined:full-response", resumeFromBytes);
     } else if (discardConfirmed && resumeDeclinedNoValidator) {
       // A partial existed but no sidecar validator did, so we never even sent a
       // Range — a safe resume couldn't be verified (common on HF's Xet/CAS CDN,
@@ -593,7 +622,7 @@ async function streamUrlToFile(
           `(#343). Future downloads capture the validator from the resolve redirect so they CAN resume.`,
         { url: logUrl, discardedBytes: resumeFromBytes },
       );
-      recordResumeDiagnostic(url, "declined:no-validator", resumeFromBytes);
+      recordResumeDiagnostic(diagKey, "declined:no-validator", resumeFromBytes);
     }
     // Prefer the final response's validator; fall back to one captured off the
     // redirect chain (HF Xet: the CAS 200 has none, but the resolve 302 carried
@@ -603,7 +632,7 @@ async function streamUrlToFile(
   } else if (appendMode) {
     // A resume was actually taken (validated 206 append). Record it so
     // download_status can report the partial was reused, not discarded (#467).
-    recordResumeDiagnostic(url, "resumed", 0);
+    recordResumeDiagnostic(diagKey, "resumed", 0);
   }
 
   const nodeStream = Readable.fromWeb(res.body as import("node:stream/web").ReadableStream);
@@ -724,6 +753,7 @@ async function downloadIntoCache(
   logUrl?: string,
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
+  resumeKey?: string,
 ): Promise<string> {
   // Header-aware identity (#467 P1-2): a same-URL download with a different
   // Authorization/Cookie/API-key gets its OWN cache file, partial and in-flight
@@ -784,6 +814,7 @@ async function downloadIntoCache(
         resumeFromBytes,
         progress,
         true, // resumable: cache partials use the .partial + If-Range resume handshake
+        resumeKey,
       );
       await downloadCacheFs.rename(partial, target);
       await touch(target);
@@ -885,6 +916,7 @@ export async function downloadWithCache(
       logUrl,
       options.storageAuth,
       options.progress,
+      options.resumeKey,
     );
     const materializedBy = await materializeCacheFile(cachePath, options.targetPath);
     await evictLruIfNeeded();

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -21,6 +21,7 @@ import {
   shouldDispatchDownloadToManager,
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
+import { clearResumeDiagnostic } from "./download-resume-diag.js";
 import { logger } from "../utils/logger.js";
 
 export interface DownloadJob {
@@ -230,6 +231,11 @@ export async function startDownloadJob(
       retired.add(e);
     }
   }
+
+  // A fresh attempt: clear any resume decision left by an EARLIER attempt for the
+  // same URL so download_status can only ever surface THIS attempt's outcome (a
+  // per-attempt reset — robust where a timestamp compare isn't; #467 P2).
+  clearResumeDiagnostic(trayId);
 
   const job: DownloadJob = {
     id,

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -83,6 +83,16 @@ const jobs = new Map<string, Entry>();
 // downloads only — the Manager writes server-side and has no local race).
 const destChains = new Map<string, Promise<void>>();
 
+/** Canonicalize a destination key for the serialization chain. Case-insensitive
+ *  filesystems (Windows always; macOS by default) alias `Checkpoints/m` and
+ *  `checkpoints/m` to ONE physical file, so lower-case the key there to serialize
+ *  those too (#467 P1-C). POSIX (Linux) is case-sensitive — leave it exact. */
+function normalizeDestKey(key: string): string {
+  return process.platform === "win32" || process.platform === "darwin"
+    ? key.toLowerCase()
+    : key;
+}
+
 /**
  * Point `key` at `entry`, ENTRY-SCOPED (#420 codex round 3, rule 2/3): never clobber
  * a row currently owned by a DIFFERENT, still-in-flight writer — that would orphan a
@@ -217,14 +227,26 @@ export async function startDownloadJob(
   // front, exactly as the write would reject it.
   const reqKey = requestDownloadKey(url, targetSubfolder, filename, auth);
   let destKey: string | undefined;
-  let destPath: string | undefined;
+  // The key jobs SERIALIZE on (#467 P1-C) — the physical destination, AUTH-FREE and
+  // normalized for case-insensitive filesystems, so two different-auth (or
+  // different-cased) requests to the same file run one-at-a-time and each callback
+  // sees its own bytes. LOCAL: the resolved on-disk targetPath. REMOTE: a canonical
+  // "remote:<subfolder>/<name>" — the Manager writes ONE server-side file per
+  // (subfolder, name), so overlapping different-auth dispatches to it are serialized
+  // too (the local callback race is inherently local, but this keeps the server
+  // write single-writer and the last-started result deterministic).
+  let serializeKey: string;
   if (!dispatchToManager) {
     const target = await resolveDownloadTarget(url, targetSubfolder, filename);
-    destPath = target.targetPath;
     // Fold auth into the destination key too (#467 P1-A): two concurrent calls to
     // the SAME on-disk destination with DIFFERENT auth are DIFFERENT downloads
     // (different representations) and must NOT dedup to one writer/one job.
     destKey = downloadJobIdFor(`${target.targetPath}\n${authIdentity(auth)}`);
+    serializeKey = normalizeDestKey(target.targetPath);
+  } else {
+    const remoteName =
+      filename ?? (url.split(/[/?#]/).filter(Boolean).pop() ?? "model");
+    serializeKey = normalizeDestKey(`remote:${String(targetSubfolder ?? "").trim()}/${remoteName}`);
   }
   // The PUBLIC id (download_status handle): the destination key when we have one
   // (so distinct destinations are separately pollable), else the request key.
@@ -282,10 +304,10 @@ export async function startDownloadJob(
     started_at: Date.now(),
   };
 
-  // Serialize behind any in-flight job writing the SAME destination path (#467
-  // P1-C) so this job's download+materialize+onComplete run without a concurrent
-  // different-auth writer swapping the destination out from under its callback.
-  const priorSameDest = destPath ? destChains.get(destPath) : undefined;
+  // Serialize behind any in-flight job writing the SAME destination (#467 P1-C) so
+  // this job's download+materialize+onComplete run without a concurrent different-
+  // auth writer swapping the destination out from under its callback.
+  const priorSameDest = destChains.get(serializeKey);
 
   // The promise is stored, never left dangling — an unhandled rejection here
   // would take down the process on a simple 404.
@@ -323,13 +345,10 @@ export async function startDownloadJob(
 
   // Make THIS job the tail of its destination's serialization chain, and prune the
   // chain entry once it's the last one to settle (bounded map).
-  if (destPath) {
-    const key = destPath;
-    destChains.set(key, settled);
-    void settled.finally(() => {
-      if (destChains.get(key) === settled) destChains.delete(key);
-    });
-  }
+  destChains.set(serializeKey, settled);
+  void settled.finally(() => {
+    if (destChains.get(serializeKey) === settled) destChains.delete(serializeKey);
+  });
 
   // Index under EVERY key (deduped) so any of them adopts this one writer. Uses the
   // entry-scoped registerKey guard so a fresh registration can never overwrite a row

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -21,7 +21,7 @@ import {
   shouldDispatchDownloadToManager,
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
-import { clearResumeDiagnostic, resumeKeyFor } from "./download-resume-diag.js";
+import { resumeKeyFor } from "./download-resume-diag.js";
 import { logger } from "../utils/logger.js";
 
 export interface DownloadJob {
@@ -240,13 +240,11 @@ export async function startDownloadJob(
   // Representation-aware diagnostic slot: same URL + different auth ⇒ different
   // physical cache download ⇒ different resume decision (#467 P2). The auth param
   // is the per-caller differentiator (config-global tokens are identical across
-  // concurrent calls, so they need not enter the key).
+  // concurrent calls, so they need not enter the key). The per-attempt RESET of
+  // this slot happens where a genuinely-new physical download begins (inside
+  // streamUrlToFile), NOT here — clearing here would wipe an in-flight download's
+  // recorded decision when THIS job merely coalesces onto it (#467 P1-b).
   const resumeKey = resumeKeyFor(url, auth ? JSON.stringify(auth) : undefined);
-
-  // A fresh attempt: clear any resume decision left by an EARLIER attempt for the
-  // same slot so download_status can only ever surface THIS attempt's outcome (a
-  // per-attempt reset — robust where a timestamp compare isn't; #467 P2).
-  clearResumeDiagnostic(resumeKey);
 
   const job: DownloadJob = {
     id,

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -71,6 +71,18 @@ interface Entry {
 // is shared by all its keys.
 const jobs = new Map<string, Entry>();
 
+// Per-DESTINATION-PATH serialization chain (#467 P1-C). Two concurrent jobs for
+// the SAME on-disk destination with DIFFERENT auth are (correctly) distinct jobs
+// with distinct representations — but they both materialize to that ONE path, and
+// each runs post-download work (onComplete) against it. Running them concurrently
+// lets one job's writer replace the destination WHILE the other's onComplete reads
+// it — so Alice's callback could process Bob's bytes. We serialize by the auth-free
+// destination path so each job's download+materialize+onComplete sees ITS OWN bytes
+// uninterrupted; the final on-disk file is deterministically the last-started job's
+// (inherent: one path can hold one file). Keyed by the resolved targetPath (LOCAL
+// downloads only — the Manager writes server-side and has no local race).
+const destChains = new Map<string, Promise<void>>();
+
 /**
  * Point `key` at `entry`, ENTRY-SCOPED (#420 codex round 3, rule 2/3): never clobber
  * a row currently owned by a DIFFERENT, still-in-flight writer — that would orphan a
@@ -205,8 +217,10 @@ export async function startDownloadJob(
   // front, exactly as the write would reject it.
   const reqKey = requestDownloadKey(url, targetSubfolder, filename, auth);
   let destKey: string | undefined;
+  let destPath: string | undefined;
   if (!dispatchToManager) {
     const target = await resolveDownloadTarget(url, targetSubfolder, filename);
+    destPath = target.targetPath;
     // Fold auth into the destination key too (#467 P1-A): two concurrent calls to
     // the SAME on-disk destination with DIFFERENT auth are DIFFERENT downloads
     // (different representations) and must NOT dedup to one writer/one job.
@@ -268,14 +282,23 @@ export async function startDownloadJob(
     started_at: Date.now(),
   };
 
+  // Serialize behind any in-flight job writing the SAME destination path (#467
+  // P1-C) so this job's download+materialize+onComplete run without a concurrent
+  // different-auth writer swapping the destination out from under its callback.
+  const priorSameDest = destPath ? destChains.get(destPath) : undefined;
+
   // The promise is stored, never left dangling — an unhandled rejection here
   // would take down the process on a simple 404.
   // The physical download reports its resume decision straight onto THIS job — no
   // shared keyed map, so it can never be misattributed to another job (#467).
-  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, (d) => {
-    job.resume = d;
-  })
-    .then(async (path) => {
+  const settled = (async () => {
+    // Wait for the prior same-destination job to fully finish (never fail THIS job
+    // because that one errored — swallow its result).
+    if (priorSameDest) await priorSameDest.catch(() => undefined);
+    try {
+      const path = await downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, (d) => {
+        job.resume = d;
+      });
       job.path = path;
       if (onComplete) {
         // Post-processing must not turn a landed file into a failed download —
@@ -291,12 +314,22 @@ export async function startDownloadJob(
       }
       job.status = "done";
       job.finished_at = Date.now();
-    })
-    .catch((err: unknown) => {
+    } catch (err: unknown) {
       job.status = "error";
       job.error = err instanceof Error ? err.message : String(err);
       job.finished_at = Date.now();
+    }
+  })();
+
+  // Make THIS job the tail of its destination's serialization chain, and prune the
+  // chain entry once it's the last one to settle (bounded map).
+  if (destPath) {
+    const key = destPath;
+    destChains.set(key, settled);
+    void settled.finally(() => {
+      if (destChains.get(key) === settled) destChains.delete(key);
     });
+  }
 
   // Index under EVERY key (deduped) so any of them adopts this one writer. Uses the
   // entry-scoped registerKey guard so a fresh registration can never overwrite a row
@@ -328,4 +361,5 @@ export function listDownloadJobs(): DownloadJob[] {
 /** Test seam — the registry is process-global otherwise. */
 export function resetDownloadJobs(): void {
   jobs.clear();
+  destChains.clear();
 }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -21,7 +21,7 @@ import {
   shouldDispatchDownloadToManager,
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
-import { clearResumeDiagnostic } from "./download-resume-diag.js";
+import { clearResumeDiagnostic, resumeKeyFor } from "./download-resume-diag.js";
 import { logger } from "../utils/logger.js";
 
 export interface DownloadJob {
@@ -34,6 +34,11 @@ export interface DownloadJob {
    *  Kept separate from `id` so distinct-destination jobs still read their live
    *  byte progress from the tray. */
   trayId: string;
+  /** Slot the resume diagnostic is recorded/read under (#467 P2). Tray id when
+   *  unauthenticated, else tray id + an auth discriminator — so a concurrent
+   *  same-URL download with DIFFERENT auth (a separate physical cache download)
+   *  gets its OWN resume decision instead of clobbering this one. */
+  resumeKey: string;
   url: string;
   target_subfolder: string;
   filename?: string;
@@ -232,14 +237,21 @@ export async function startDownloadJob(
     }
   }
 
+  // Representation-aware diagnostic slot: same URL + different auth ⇒ different
+  // physical cache download ⇒ different resume decision (#467 P2). The auth param
+  // is the per-caller differentiator (config-global tokens are identical across
+  // concurrent calls, so they need not enter the key).
+  const resumeKey = resumeKeyFor(url, auth ? JSON.stringify(auth) : undefined);
+
   // A fresh attempt: clear any resume decision left by an EARLIER attempt for the
-  // same URL so download_status can only ever surface THIS attempt's outcome (a
+  // same slot so download_status can only ever surface THIS attempt's outcome (a
   // per-attempt reset — robust where a timestamp compare isn't; #467 P2).
-  clearResumeDiagnostic(trayId);
+  clearResumeDiagnostic(resumeKey);
 
   const job: DownloadJob = {
     id,
     trayId,
+    resumeKey,
     url,
     target_subfolder: targetSubfolder,
     filename,
@@ -249,7 +261,7 @@ export async function startDownloadJob(
 
   // The promise is stored, never left dangling — an unhandled rejection here
   // would take down the process on a simple 404.
-  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager)
+  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, resumeKey)
     .then(async (path) => {
       job.path = path;
       if (onComplete) {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -15,6 +15,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import {
   downloadModel,
   resolveDownloadTarget,
@@ -77,20 +79,57 @@ const jobs = new Map<string, Entry>();
 // each runs post-download work (onComplete) against it. Running them concurrently
 // lets one job's writer replace the destination WHILE the other's onComplete reads
 // it — so Alice's callback could process Bob's bytes. We serialize by the auth-free
-// destination path so each job's download+materialize+onComplete sees ITS OWN bytes
+// destination so each job's download+materialize+onComplete sees ITS OWN bytes
 // uninterrupted; the final on-disk file is deterministically the last-started job's
-// (inherent: one path can hold one file). Keyed by the resolved targetPath (LOCAL
-// downloads only — the Manager writes server-side and has no local race).
+// (inherent: one path can hold one file). Keyed by the realpath-collapsed,
+// case-normalized LOCAL targetPath, OR a canonical remote:<subfolder>/<name> for
+// Manager-dispatched jobs (which write ONE server-side file per subfolder+name).
 const destChains = new Map<string, Promise<void>>();
 
-/** Canonicalize a destination key for the serialization chain. Case-insensitive
- *  filesystems (Windows always; macOS by default) alias `Checkpoints/m` and
- *  `checkpoints/m` to ONE physical file, so lower-case the key there to serialize
- *  those too (#467 P1-C). POSIX (Linux) is case-sensitive — leave it exact. */
-function normalizeDestKey(key: string): string {
+/** Canonicalize a LOCAL destination key for the serialization chain. Case-
+ *  insensitive filesystems (Windows always; macOS by default) alias `Checkpoints/m`
+ *  and `checkpoints/m` to ONE physical file, so lower-case the key there to
+ *  serialize those too (#467 P1-C). POSIX (Linux) is case-sensitive — leave exact. */
+function normalizeLocalDestKey(key: string): string {
   return process.platform === "win32" || process.platform === "darwin"
     ? key.toLowerCase()
     : key;
+}
+
+/** The LOCAL serialization key: collapse symlinks/junctions via realpath on the
+ *  parent dir (best-effort — the dir may not exist yet, so fall back to the lexical
+ *  path), then case-normalize. Two aliased subfolders resolving to ONE physical file
+ *  then share a chain (#467 P1-C). */
+async function localSerializeKey(targetPath: string): Promise<string> {
+  let realParent: string;
+  try {
+    realParent = await realpath(dirname(targetPath));
+  } catch {
+    realParent = dirname(targetPath);
+  }
+  return normalizeLocalDestKey(join(realParent, basename(targetPath)));
+}
+
+/** The REMOTE serialization key. The Manager writes ONE server-side file per
+ *  (subfolder, name); derive the name the way the resolve/Manager path does
+ *  (URL pathname basename when no explicit filename) and normalize separators so
+ *  `a//b` == `a/b` and query variants collapse. The remote host's case-sensitivity
+ *  is UNKNOWN here, so lower-case unconditionally — over-serializing is safe, under-
+ *  serializing (concurrent same-file writes) is not (#467 P1-C). */
+function remoteSerializeKey(url: string, targetSubfolder: string, filename?: string): string {
+  let name = filename;
+  if (!name) {
+    try {
+      name = basename(new URL(url).pathname);
+    } catch {
+      name = url.split(/[/?#]/).filter(Boolean).pop();
+    }
+  }
+  const sub = String(targetSubfolder ?? "")
+    .split(/[/\\]+/)
+    .filter(Boolean)
+    .join("/");
+  return `remote:${sub}/${name || "model"}`.toLowerCase();
 }
 
 /**
@@ -242,11 +281,9 @@ export async function startDownloadJob(
     // the SAME on-disk destination with DIFFERENT auth are DIFFERENT downloads
     // (different representations) and must NOT dedup to one writer/one job.
     destKey = downloadJobIdFor(`${target.targetPath}\n${authIdentity(auth)}`);
-    serializeKey = normalizeDestKey(target.targetPath);
+    serializeKey = await localSerializeKey(target.targetPath);
   } else {
-    const remoteName =
-      filename ?? (url.split(/[/?#]/).filter(Boolean).pop() ?? "model");
-    serializeKey = normalizeDestKey(`remote:${String(targetSubfolder ?? "").trim()}/${remoteName}`);
+    serializeKey = remoteSerializeKey(url, targetSubfolder, filename);
   }
   // The PUBLIC id (download_status handle): the destination key when we have one
   // (so distinct destinations are separately pollable), else the request key.

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -100,14 +100,16 @@ export function downloadIdFor(url: string): string {
 }
 
 /**
- * The download's DISTINCT public id — a hash of the canonical resolved on-disk
- * `targetPath` (from the shared resolveDownloadTarget), used as BOTH the registry
- * key and `job.id`. Identity is the DESTINATION, not the URL: two requests that
- * resolve to the SAME file are one job/one writer (even from different URLs);
- * requests to different destinations are separately pollable via download_status.
+ * The download's DISTINCT public id — a hash of the given identity string. Callers
+ * pass the canonical resolved on-disk `targetPath` PLUS an auth discriminator
+ * (#467 P1-A), so identity is the DESTINATION *and representation*: two requests
+ * that resolve to the SAME file with the SAME auth are one job/one writer (even
+ * from different URLs), but the SAME file with DIFFERENT auth are DIFFERENT
+ * downloads (a different representation) and must not dedup. Requests to different
+ * destinations are separately pollable via download_status.
  */
-export function downloadJobIdFor(targetPath: string): string {
-  return createHash("sha256").update(targetPath).digest("hex").slice(0, 16);
+export function downloadJobIdFor(identity: string): string {
+  return createHash("sha256").update(identity).digest("hex").slice(0, 16);
 }
 
 /**

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -119,15 +119,30 @@ export function downloadJobIdFor(targetPath: string): string {
  * locally-resolvable job is ALSO indexed under its destination key (below) so the
  * "two different URLs → one local destination → one writer" dedup still holds.
  */
+/** A stable per-request discriminator for the caller's auth/representation. The
+ *  JOB layer dedups BEFORE the header-aware cache layer is reached, and it is
+ *  otherwise auth-blind — so without this, two concurrent same-URL+same-dest
+ *  calls with DIFFERENT bearer/custom headers would adopt the FIRST job and the
+ *  second caller would get the first's bytes AND resume callback (#467 P1-A). The
+ *  `auth` param is the per-caller differentiator (config-global tokens are
+ *  identical across concurrent calls, so they need not enter the key). Two auth
+ *  encodings that transmit the SAME headers may still be split here — harmless:
+ *  they then coalesce correctly at the cache layer (same representation). */
+function authIdentity(auth?: DownloadAuth): string {
+  return auth ? createHash("sha256").update(JSON.stringify(auth)).digest("hex").slice(0, 12) : "";
+}
+
 function requestDownloadKey(
   url: string,
   targetSubfolder: string,
   filename?: string,
+  auth?: DownloadAuth,
 ): string {
   const canonical = JSON.stringify([
     url,
     String(targetSubfolder ?? "").trim(),
     filename ?? null,
+    authIdentity(auth),
   ]);
   return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
 }
@@ -186,11 +201,14 @@ export async function startDownloadJob(
   // "two different URLs → same local destination → one writer" dedup (WS-4). An
   // invalid filename/subfolder is REJECTED here (by resolveDownloadTarget), up
   // front, exactly as the write would reject it.
-  const reqKey = requestDownloadKey(url, targetSubfolder, filename);
+  const reqKey = requestDownloadKey(url, targetSubfolder, filename, auth);
   let destKey: string | undefined;
   if (!dispatchToManager) {
     const target = await resolveDownloadTarget(url, targetSubfolder, filename);
-    destKey = downloadJobIdFor(target.targetPath);
+    // Fold auth into the destination key too (#467 P1-A): two concurrent calls to
+    // the SAME on-disk destination with DIFFERENT auth are DIFFERENT downloads
+    // (different representations) and must NOT dedup to one writer/one job.
+    destKey = downloadJobIdFor(`${target.targetPath}\n${authIdentity(auth)}`);
   }
   // The PUBLIC id (download_status handle): the destination key when we have one
   // (so distinct destinations are separately pollable), else the request key.

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -108,7 +108,14 @@ async function realpathDeepestExisting(p: string): Promise<string> {
     try {
       const real = await realpath(current);
       return tail.length ? join(real, ...tail.reverse()) : real;
-    } catch {
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      // Only ABSENCE walks upward. An existing-but-unresolvable ancestor (EIO,
+      // EACCES, ELOOP, …) must NOT be treated as absent — walking past it would
+      // reconstruct the un-collapsed lexical ALIAS and defeat serialization (wrong-
+      // bytes race). Fail CLOSED: propagate so the job errors rather than risk it
+      // (#467). A transient error here is far rarer than the corruption it guards.
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
       const parent = dirname(current);
       if (parent === current) return p; // reached the root without resolving — give up
       tail.push(basename(current));

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -21,7 +21,7 @@ import {
   shouldDispatchDownloadToManager,
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
-import { resumeKeyFor } from "./download-resume-diag.js";
+import type { ResumeDiagnostic } from "./download-resume-diag.js";
 import { logger } from "../utils/logger.js";
 
 export interface DownloadJob {
@@ -34,11 +34,12 @@ export interface DownloadJob {
    *  Kept separate from `id` so distinct-destination jobs still read their live
    *  byte progress from the tray. */
   trayId: string;
-  /** Slot the resume diagnostic is recorded/read under (#467 P2). Tray id when
-   *  unauthenticated, else tray id + an auth discriminator — so a concurrent
-   *  same-URL download with DIFFERENT auth (a separate physical cache download)
-   *  gets its OWN resume decision instead of clobbering this one. */
-  resumeKey: string;
+  /** This job's OWN resume decision (#467), reported by its physical download via
+   *  a callback and stored here — so download_status surfaces exactly this job's
+   *  outcome and never a stale/other job's. Absent when no resumable download ran
+   *  (Manager dispatch, cache hit, a job that coalesced onto another's stream, or
+   *  a failure before streaming). */
+  resume?: ResumeDiagnostic;
   url: string;
   target_subfolder: string;
   filename?: string;
@@ -237,19 +238,9 @@ export async function startDownloadJob(
     }
   }
 
-  // Representation-aware diagnostic slot: same URL + different auth ⇒ different
-  // physical cache download ⇒ different resume decision (#467 P2). The auth param
-  // is the per-caller differentiator (config-global tokens are identical across
-  // concurrent calls, so they need not enter the key). The per-attempt RESET of
-  // this slot happens where a genuinely-new physical download begins (inside
-  // streamUrlToFile), NOT here — clearing here would wipe an in-flight download's
-  // recorded decision when THIS job merely coalesces onto it (#467 P1-b).
-  const resumeKey = resumeKeyFor(url, auth ? JSON.stringify(auth) : undefined);
-
   const job: DownloadJob = {
     id,
     trayId,
-    resumeKey,
     url,
     target_subfolder: targetSubfolder,
     filename,
@@ -259,7 +250,11 @@ export async function startDownloadJob(
 
   // The promise is stored, never left dangling — an unhandled rejection here
   // would take down the process on a simple 404.
-  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, resumeKey)
+  // The physical download reports its resume decision straight onto THIS job — no
+  // shared keyed map, so it can never be misattributed to another job (#467).
+  const settled = downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, (d) => {
+    job.resume = d;
+  })
     .then(async (path) => {
       job.path = path;
       if (onComplete) {

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -96,18 +96,33 @@ function normalizeLocalDestKey(key: string): string {
     : key;
 }
 
-/** The LOCAL serialization key: collapse symlinks/junctions via realpath on the
- *  parent dir (best-effort — the dir may not exist yet, so fall back to the lexical
- *  path), then case-normalize. Two aliased subfolders resolving to ONE physical file
- *  then share a chain (#467 P1-C). */
-async function localSerializeKey(targetPath: string): Promise<string> {
-  let realParent: string;
-  try {
-    realParent = await realpath(dirname(targetPath));
-  } catch {
-    realParent = dirname(targetPath);
+/** realpath the DEEPEST EXISTING ANCESTOR of `p` and re-append the not-yet-created
+ *  tail. `realpath(p)` alone fails (and falls back to the lexical path) whenever any
+ *  descendant is absent — but the writer mkdir's the tree later, so a symlink/
+ *  junction in the EXISTING prefix must still be collapsed (#467 P1-C). Walking up
+ *  to the deepest existing dir collapses that prefix regardless of the missing tail. */
+async function realpathDeepestExisting(p: string): Promise<string> {
+  const tail: string[] = [];
+  let current = p;
+  for (;;) {
+    try {
+      const real = await realpath(current);
+      return tail.length ? join(real, ...tail.reverse()) : real;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return p; // reached the root without resolving — give up
+      tail.push(basename(current));
+      current = parent;
+    }
   }
-  return normalizeLocalDestKey(join(realParent, basename(targetPath)));
+}
+
+/** The LOCAL serialization key: collapse symlinks/junctions in the destination path
+ *  (via the deepest existing ancestor), then case-normalize — so two aliased
+ *  subfolders resolving to ONE physical file share a chain (#467 P1-C). */
+async function localSerializeKey(targetPath: string): Promise<string> {
+  const real = await realpathDeepestExisting(targetPath);
+  return normalizeLocalDestKey(real);
 }
 
 /** The REMOTE serialization key. The Manager writes ONE server-side file per
@@ -125,11 +140,15 @@ function remoteSerializeKey(url: string, targetSubfolder: string, filename?: str
       name = url.split(/[/?#]/).filter(Boolean).pop();
     }
   }
+  // Mirror the Manager writer's trim() then separator-normalize so ` loras/sub `,
+  // `loras/sub`, and `loras//sub` all canonicalize to one key (#467 P1-C).
   const sub = String(targetSubfolder ?? "")
+    .trim()
     .split(/[/\\]+/)
+    .map((s) => s.trim())
     .filter(Boolean)
     .join("/");
-  return `remote:${sub}/${name || "model"}`.toLowerCase();
+  return `remote:${sub}/${(name || "model").trim()}`.toLowerCase();
 }
 
 /**

--- a/src/services/download-resume-diag.ts
+++ b/src/services/download-resume-diag.ts
@@ -30,9 +30,15 @@ export type ResumeOutcome =
 
 export interface ResumeDiagnostic {
   outcome: ResumeOutcome;
-  /** Bytes of pre-existing `.partial` discarded on a declined resume (0 when the
+  /** Bytes of pre-existing `.partial` involved in a declined resume (0 when the
    *  resume was taken). */
   discardedBytes: number;
+  /** Whether the stale partial was CONFIRMED removed/truncated. True for the
+   *  in-stream restart declines (recorded only after a confirmed discard) and for
+   *  a 206 refusal whose removal was verified; false when a 206 refusal could NOT
+   *  remove the partial (a swallowed rm failure) — so download_status never claims
+   *  "discarded" when the bytes may still be on disk (#467). */
+  discarded: boolean;
   /** Epoch ms this decision was made. */
   at: number;
 }
@@ -65,15 +71,17 @@ export function recordResumeDiagnostic(
   key: string,
   outcome: ResumeOutcome,
   discardedBytes: number,
+  discarded = true,
 ): void {
-  resumeDiagnostics.set(key, { outcome, discardedBytes, at: Date.now() });
+  resumeDiagnostics.set(key, { outcome, discardedBytes, discarded, at: Date.now() });
 }
 
 /** Read the last resume decision for a download's resume key (or undefined).
  *
  *  Keyed by the resume key (see resumeKeyFor), matching DownloadJob.resumeKey.
- *  Only THIS attempt's decision is ever present: startDownloadJob clears the key
- *  when a fresh job starts (#467 P2), so a stale discard can't be misattributed.
+ *  Only THIS attempt's decision is ever present: the per-attempt reset runs where
+ *  a genuinely-new physical download begins (streamUrlToFile) and on a cache hit
+ *  (#467 P1-b/P2), so a stale decision can't be misattributed to a later attempt.
  *  Two concurrent same-URL jobs with DIFFERENT auth get DISTINCT keys (they are
  *  separate physical cache downloads); same-URL same-auth jobs to different
  *  destinations share ONE physical download and one key — accurately. */
@@ -81,13 +89,14 @@ export function getResumeDiagnostic(key: string): ResumeDiagnostic | undefined {
   return resumeDiagnostics.get(key);
 }
 
-/** Clear any prior resume decision for a tray id. Called when a NEW download job
- *  starts so a decision from an EARLIER attempt for the same URL can never be
- *  attributed to this one — a per-attempt reset that closes the timestamp-compare
- *  equality/rollback hole (#467 P2), robust to same-ms Date.now() and wall-clock
- *  rollback that a `diag.at >= started_at` check misses. */
-export function clearResumeDiagnostic(trayId: string): void {
-  resumeDiagnostics.delete(trayId);
+/** Clear any prior resume decision for a slot. Called where a genuinely-new
+ *  physical download begins (streamUrlToFile) and on a cache hit — NOT per job —
+ *  so a decision from an EARLIER attempt can never be attributed to a later one,
+ *  while a job that merely coalesces onto an in-flight download does not wipe the
+ *  active stream's decision (#467 P1-b/P2). Closes the timestamp-compare
+ *  equality/rollback hole a `diag.at >= started_at` check would miss. */
+export function clearResumeDiagnostic(key: string): void {
+  resumeDiagnostics.delete(key);
 }
 
 /** Test seam — the diagnostics map is process-global otherwise. */

--- a/src/services/download-resume-diag.ts
+++ b/src/services/download-resume-diag.ts
@@ -1,16 +1,14 @@
-// In-process resume-decision registry (#467).
+// Resume-decision types + reporting callback (#467).
 //
-// When a resumable download declines to reuse (or refuses) a `.partial`, this
-// records WHY so `download_status` — which runs in the SAME MCP server process
-// as the streaming download — can tell the agent/user that a multi-GB partial
-// was discarded and for what reason, instead of a silent full re-download.
-//
-// Kept in its OWN module (only node:crypto) rather than in download-cache so
-// that download-jobs can clear a stale decision on a new attempt WITHOUT pulling
-// download-cache's heavy transitive deps (storage/*, which needs child_process)
-// into every consumer's test mocks.
-
-import { createHash } from "node:crypto";
+// When a resumable download declines to reuse (or refuses) a `.partial`, the
+// streaming layer reports WHY through a callback threaded from the caller (the
+// download job), which stores it ON the job. Reporting to the specific job —
+// rather than into a shared, string-keyed global map — means a decision can
+// NEVER be misattributed to a different job (a stale prior attempt, a Manager
+// dispatch, a cache hit, or a same-URL job whose identity is computed
+// differently): a job only ever sees the decision its OWN physical download
+// produced. A job that coalesces onto another's in-flight physical download
+// simply gets none (the decision is surfaced on the job that ran the stream).
 
 export type ResumeOutcome =
   | "resumed"
@@ -34,72 +32,13 @@ export interface ResumeDiagnostic {
    *  resume was taken). */
   discardedBytes: number;
   /** Whether the stale partial was CONFIRMED removed/truncated. True for the
-   *  in-stream restart declines (recorded only after a confirmed discard) and for
+   *  in-stream restart declines (reported only after a confirmed discard) and for
    *  a 206 refusal whose removal was verified; false when a 206 refusal could NOT
-   *  remove the partial (a swallowed rm failure) — so download_status never claims
+   *  remove the partial (a swallowed rm failure) — so status never claims
    *  "discarded" when the bytes may still be on disk (#467). */
   discarded: boolean;
-  /** Epoch ms this decision was made. */
-  at: number;
 }
 
-const resumeDiagnostics = new Map<string, ResumeDiagnostic>();
-
-/** Tray id for a source URL — MUST match download-jobs' downloadIdFor so
- *  download_status can key a diagnostic off the job it already holds. */
-export function trayIdForUrl(url: string): string {
-  return createHash("sha256").update(url).digest("hex").slice(0, 16);
-}
-
-/** The key a resume diagnostic is stored under. It is the tray id (URL hash)
- *  PLUS a per-representation discriminator when the caller supplied auth — so two
- *  CONCURRENT same-URL downloads carrying DIFFERENT auth (now separate physical
- *  cache downloads, #467 P1-2) record and read DISTINCT diagnostics instead of
- *  clobbering each other. No auth ⇒ bare tray id, so the common case (and the
- *  panel tray key) is unchanged. `authIdentity` is any stable per-caller string
- *  (e.g. JSON of the DownloadAuth); the exact value only needs to be identical
- *  between the recorder (streamUrlToFile) and the reader (download_status), which
- *  is guaranteed by computing it ONCE per job and threading it to both. */
-export function resumeKeyFor(url: string, authIdentity?: string): string {
-  const tray = trayIdForUrl(url);
-  if (!authIdentity) return tray;
-  const disc = createHash("sha256").update(authIdentity).digest("hex").slice(0, 8);
-  return `${tray}:${disc}`;
-}
-
-export function recordResumeDiagnostic(
-  key: string,
-  outcome: ResumeOutcome,
-  discardedBytes: number,
-  discarded = true,
-): void {
-  resumeDiagnostics.set(key, { outcome, discardedBytes, discarded, at: Date.now() });
-}
-
-/** Read the last resume decision for a download's resume key (or undefined).
- *
- *  Keyed by the resume key (see resumeKeyFor), matching DownloadJob.resumeKey.
- *  Only THIS attempt's decision is ever present: the per-attempt reset runs where
- *  a genuinely-new physical download begins (streamUrlToFile) and on a cache hit
- *  (#467 P1-b/P2), so a stale decision can't be misattributed to a later attempt.
- *  Two concurrent same-URL jobs with DIFFERENT auth get DISTINCT keys (they are
- *  separate physical cache downloads); same-URL same-auth jobs to different
- *  destinations share ONE physical download and one key — accurately. */
-export function getResumeDiagnostic(key: string): ResumeDiagnostic | undefined {
-  return resumeDiagnostics.get(key);
-}
-
-/** Clear any prior resume decision for a slot. Called where a genuinely-new
- *  physical download begins (streamUrlToFile) and on a cache hit — NOT per job —
- *  so a decision from an EARLIER attempt can never be attributed to a later one,
- *  while a job that merely coalesces onto an in-flight download does not wipe the
- *  active stream's decision (#467 P1-b/P2). Closes the timestamp-compare
- *  equality/rollback hole a `diag.at >= started_at` check would miss. */
-export function clearResumeDiagnostic(key: string): void {
-  resumeDiagnostics.delete(key);
-}
-
-/** Test seam — the diagnostics map is process-global otherwise. */
-export function resetResumeDiagnostics(): void {
-  resumeDiagnostics.clear();
-}
+/** Sink the streaming layer calls (at most once, on the terminal decision) to
+ *  report a resume outcome to the caller. Absent for internal/direct callers. */
+export type ResumeReporter = (diagnostic: ResumeDiagnostic) => void;

--- a/src/services/download-resume-diag.ts
+++ b/src/services/download-resume-diag.ts
@@ -1,0 +1,80 @@
+// In-process resume-decision registry (#467).
+//
+// When a resumable download declines to reuse (or refuses) a `.partial`, this
+// records WHY so `download_status` — which runs in the SAME MCP server process
+// as the streaming download — can tell the agent/user that a multi-GB partial
+// was discarded and for what reason, instead of a silent full re-download.
+//
+// Kept in its OWN module (only node:crypto) rather than in download-cache so
+// that download-jobs can clear a stale decision on a new attempt WITHOUT pulling
+// download-cache's heavy transitive deps (storage/*, which needs child_process)
+// into every consumer's test mocks.
+
+import { createHash } from "node:crypto";
+
+export type ResumeOutcome =
+  | "resumed"
+  /** No validator sidecar existed, so a safe resume couldn't even be attempted;
+   *  the partial was discarded and re-downloaded in full (in-stream restart). */
+  | "declined:no-validator"
+  /** We attempted a conditional resume but the server answered with a full 200
+   *  instead of a 206 — the upstream changed OR the host doesn't support range
+   *  resume; either way the partial was discarded (in-stream restart). */
+  | "declined:full-response"
+  /** A 206 whose content-addressed validator PROVED the upstream object changed
+   *  — refused to avoid a corrupt append; the job errors and a retry restarts. */
+  | "declined:etag-changed"
+  /** A cross-origin (CDN) 206 that carried NO content-addressed validator, so an
+   *  unchanged upstream couldn't be proven — refused for safety; retry restarts. */
+  | "declined:unverifiable";
+
+export interface ResumeDiagnostic {
+  outcome: ResumeOutcome;
+  /** Bytes of pre-existing `.partial` discarded on a declined resume (0 when the
+   *  resume was taken). */
+  discardedBytes: number;
+  /** Epoch ms this decision was made. */
+  at: number;
+}
+
+const resumeDiagnostics = new Map<string, ResumeDiagnostic>();
+
+/** Tray id for a source URL — MUST match download-jobs' downloadIdFor so
+ *  download_status can key a diagnostic off the job it already holds. */
+export function trayIdForUrl(url: string): string {
+  return createHash("sha256").update(url).digest("hex").slice(0, 16);
+}
+
+export function recordResumeDiagnostic(
+  url: string,
+  outcome: ResumeOutcome,
+  discardedBytes: number,
+): void {
+  resumeDiagnostics.set(trayIdForUrl(url), { outcome, discardedBytes, at: Date.now() });
+}
+
+/** Read the last resume decision for a download's tray id (or undefined).
+ *
+ *  Keyed by tray id (URL hash), matching DownloadJob.trayId. Only THIS attempt's
+ *  decision is ever present: startDownloadJob clears any earlier decision for the
+ *  tray id when a fresh job starts (#467 P2), so a stale discard can't be
+ *  misattributed to a later job. Concurrent same-URL jobs to different
+ *  destinations are views of ONE physical cache download (the cache coalesces by
+ *  the URL+representation identity), so sharing the decision is accurate. */
+export function getResumeDiagnostic(trayId: string): ResumeDiagnostic | undefined {
+  return resumeDiagnostics.get(trayId);
+}
+
+/** Clear any prior resume decision for a tray id. Called when a NEW download job
+ *  starts so a decision from an EARLIER attempt for the same URL can never be
+ *  attributed to this one — a per-attempt reset that closes the timestamp-compare
+ *  equality/rollback hole (#467 P2), robust to same-ms Date.now() and wall-clock
+ *  rollback that a `diag.at >= started_at` check misses. */
+export function clearResumeDiagnostic(trayId: string): void {
+  resumeDiagnostics.delete(trayId);
+}
+
+/** Test seam — the diagnostics map is process-global otherwise. */
+export function resetResumeDiagnostics(): void {
+  resumeDiagnostics.clear();
+}

--- a/src/services/download-resume-diag.ts
+++ b/src/services/download-resume-diag.ts
@@ -45,24 +45,40 @@ export function trayIdForUrl(url: string): string {
   return createHash("sha256").update(url).digest("hex").slice(0, 16);
 }
 
+/** The key a resume diagnostic is stored under. It is the tray id (URL hash)
+ *  PLUS a per-representation discriminator when the caller supplied auth — so two
+ *  CONCURRENT same-URL downloads carrying DIFFERENT auth (now separate physical
+ *  cache downloads, #467 P1-2) record and read DISTINCT diagnostics instead of
+ *  clobbering each other. No auth ⇒ bare tray id, so the common case (and the
+ *  panel tray key) is unchanged. `authIdentity` is any stable per-caller string
+ *  (e.g. JSON of the DownloadAuth); the exact value only needs to be identical
+ *  between the recorder (streamUrlToFile) and the reader (download_status), which
+ *  is guaranteed by computing it ONCE per job and threading it to both. */
+export function resumeKeyFor(url: string, authIdentity?: string): string {
+  const tray = trayIdForUrl(url);
+  if (!authIdentity) return tray;
+  const disc = createHash("sha256").update(authIdentity).digest("hex").slice(0, 8);
+  return `${tray}:${disc}`;
+}
+
 export function recordResumeDiagnostic(
-  url: string,
+  key: string,
   outcome: ResumeOutcome,
   discardedBytes: number,
 ): void {
-  resumeDiagnostics.set(trayIdForUrl(url), { outcome, discardedBytes, at: Date.now() });
+  resumeDiagnostics.set(key, { outcome, discardedBytes, at: Date.now() });
 }
 
-/** Read the last resume decision for a download's tray id (or undefined).
+/** Read the last resume decision for a download's resume key (or undefined).
  *
- *  Keyed by tray id (URL hash), matching DownloadJob.trayId. Only THIS attempt's
- *  decision is ever present: startDownloadJob clears any earlier decision for the
- *  tray id when a fresh job starts (#467 P2), so a stale discard can't be
- *  misattributed to a later job. Concurrent same-URL jobs to different
- *  destinations are views of ONE physical cache download (the cache coalesces by
- *  the URL+representation identity), so sharing the decision is accurate. */
-export function getResumeDiagnostic(trayId: string): ResumeDiagnostic | undefined {
-  return resumeDiagnostics.get(trayId);
+ *  Keyed by the resume key (see resumeKeyFor), matching DownloadJob.resumeKey.
+ *  Only THIS attempt's decision is ever present: startDownloadJob clears the key
+ *  when a fresh job starts (#467 P2), so a stale discard can't be misattributed.
+ *  Two concurrent same-URL jobs with DIFFERENT auth get DISTINCT keys (they are
+ *  separate physical cache downloads); same-URL same-auth jobs to different
+ *  destinations share ONE physical download and one key — accurately. */
+export function getResumeDiagnostic(key: string): ResumeDiagnostic | undefined {
+  return resumeDiagnostics.get(key);
 }
 
 /** Clear any prior resume decision for a tray id. Called when a NEW download job

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -747,6 +747,10 @@ export async function downloadModel(
    * evaluate the predicate themselves.
    */
   dispatchToManager?: boolean,
+  /** Representation-aware slot for the resume diagnostic, threaded from the job
+   *  so download_status reads THIS download's decision (#467 P2). Omitted by
+   *  direct callers, which fall back to the URL tray id. */
+  resumeKey?: string,
 ): Promise<string> {
   // Region flags (issue #127) applied at THE choke point every download path
   // funnels through (local disk AND the remote Manager dispatch below).
@@ -816,6 +820,7 @@ export async function downloadModel(
       logUrl,
       storageAuth: auth?.type === "s3" ? { s3: auth } : undefined,
       progress,
+      resumeKey,
     });
   } catch (err) {
     // Surface a failed row in the tray, then rethrow for the tool to report.

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -11,6 +11,7 @@ import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { downloadWithCache } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
+import type { ResumeReporter } from "./download-resume-diag.js";
 import { resolveModelsDir, parseModelsDirFromArgv } from "./output-dir.js";
 import {
   applyDownloadAuth,
@@ -747,10 +748,9 @@ export async function downloadModel(
    * evaluate the predicate themselves.
    */
   dispatchToManager?: boolean,
-  /** Representation-aware slot for the resume diagnostic, threaded from the job
-   *  so download_status reads THIS download's decision (#467 P2). Omitted by
-   *  direct callers, which fall back to the URL tray id. */
-  resumeKey?: string,
+  /** Sink for the resume decision, threaded from the job so the outcome is stored
+   *  on that job (#467). Omitted by direct callers (no job to report to). */
+  onResume?: ResumeReporter,
 ): Promise<string> {
   // Region flags (issue #127) applied at THE choke point every download path
   // funnels through (local disk AND the remote Manager dispatch below).
@@ -820,7 +820,7 @@ export async function downloadModel(
       logUrl,
       storageAuth: auth?.type === "s3" ? { s3: auth } : undefined,
       progress,
-      resumeKey,
+      onResume,
     });
   } catch (err) {
     // Surface a failed row in the tray, then rethrow for the tool to report.

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { ValidationError } from "../../utils/errors.js";
 import { isAzureBlobUrl, downloadAzureBlobToFile, uploadAzureBlobFile } from "./azure-blob.js";
 import { uploadHfFile } from "./hf.js";
@@ -17,6 +18,40 @@ export type UploadDestination =
 
 export function supportsCloudDownload(url: string): boolean {
   return isS3Url(url) || isAzureBlobUrl(url);
+}
+
+/**
+ * A short, stable discriminator for the EFFECTIVE cloud principal/endpoint that
+ * WOULD serve `url` right now — the explicit `auth` MERGED with the same
+ * environment fallbacks the real downloaders use (s3.ts makeS3Client,
+ * azure-blob.ts blobServiceClientFromEnv). Folded into the download cache identity
+ * (#467 P1-B) so a cache entry populated under one principal/endpoint can NEVER be
+ * served later under different or absent credentials (cross-principal leak): if the
+ * effective principal changes, the cache identity changes → cache miss → re-fetch.
+ *
+ * Secrets are hashed here and never leave this module in the clear. Empty string
+ * for a non-cloud URL (the caller omits it from the identity).
+ */
+export function cloudPrincipalKey(url: string, auth: CloudStorageAuth = {}): string {
+  let raw: string | undefined;
+  if (isS3Url(url)) {
+    const s3 = auth.s3;
+    const endpoint = s3?.endpoint ?? process.env.AWS_S3_ENDPOINT ?? "";
+    const region = s3?.region ?? process.env.AWS_REGION ?? "";
+    const accessKeyId = s3?.access_key_id ?? process.env.AWS_ACCESS_KEY_ID ?? "";
+    const secretAccessKey = s3?.secret_access_key ?? process.env.AWS_SECRET_ACCESS_KEY ?? "";
+    const sessionToken = s3?.session_token ?? process.env.AWS_SESSION_TOKEN ?? "";
+    raw = `s3\n${endpoint}\n${region}\n${accessKeyId}\n${secretAccessKey}\n${sessionToken}`;
+  } else if (isAzureBlobUrl(url)) {
+    // Azure download uses env creds (connection string, else account+key), else
+    // anonymous. The blob host already encodes the account (part of `url`), so the
+    // principal here is purely the env credential material.
+    const conn = process.env.AZURE_STORAGE_CONNECTION_STRING ?? "";
+    const account = process.env.AZURE_STORAGE_ACCOUNT ?? "";
+    const key = process.env.AZURE_STORAGE_KEY ?? "";
+    raw = `azure\n${conn}\n${account}\n${key}`;
+  }
+  return raw ? createHash("sha256").update(raw).digest("hex").slice(0, 16) : "";
 }
 
 export async function downloadCloudUrlToFile(

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { ValidationError } from "../../utils/errors.js";
 import { isAzureBlobUrl, downloadAzureBlobToFile, uploadAzureBlobFile } from "./azure-blob.js";
 import { uploadHfFile } from "./hf.js";
@@ -32,6 +32,12 @@ export function supportsCloudDownload(url: string): boolean {
  * Secrets are hashed here and never leave this module in the clear. Empty string
  * for a non-cloud URL (the caller omits it from the identity).
  */
+/** Per-process nonce folded into the S3 identity when the principal is AMBIENT
+ *  (resolved by the AWS SDK's default chain, not observable here) — so such a cache
+ *  entry is never REUSED ACROSS PROCESS RESTARTS under a possibly-different
+ *  principal (#467 P1-B). Regenerated each process start. */
+const AMBIENT_CLOUD_NONCE = randomBytes(12).toString("hex");
+
 export function cloudPrincipalKey(url: string, auth: CloudStorageAuth = {}): string {
   let raw: string | undefined;
   if (isS3Url(url)) {
@@ -41,11 +47,36 @@ export function cloudPrincipalKey(url: string, auth: CloudStorageAuth = {}): str
     const accessKeyId = s3?.access_key_id ?? process.env.AWS_ACCESS_KEY_ID ?? "";
     const secretAccessKey = s3?.secret_access_key ?? process.env.AWS_SECRET_ACCESS_KEY ?? "";
     const sessionToken = s3?.session_token ?? process.env.AWS_SESSION_TOKEN ?? "";
-    raw = `s3\n${endpoint}\n${region}\n${accessKeyId}\n${secretAccessKey}\n${sessionToken}`;
+    // When an explicit/env access-key PAIR is present the principal is fully
+    // observable → hash it and safely reuse the cache across restarts. Otherwise the
+    // SDK resolves an AMBIENT identity (shared profiles, AWS_PROFILE, web-identity/
+    // role, ECS/EC2 metadata) that ISN'T observable here — fold the profile-selecting
+    // env vars AND a per-process nonce so the entry is never reused across processes
+    // under a possibly-different principal. (Within a process the same ambient
+    // identity → same nonce → cache hits remain safe. Instance-role rotation
+    // mid-process isn't distinguished — accepted, as the SDK caches creds similarly.)
+    const explicitPair = Boolean(
+      (s3?.access_key_id ?? process.env.AWS_ACCESS_KEY_ID) &&
+        (s3?.secret_access_key ?? process.env.AWS_SECRET_ACCESS_KEY),
+    );
+    const ambient = explicitPair
+      ? ""
+      : [
+          "ambient",
+          process.env.AWS_PROFILE ?? "",
+          process.env.AWS_ROLE_ARN ?? "",
+          process.env.AWS_WEB_IDENTITY_TOKEN_FILE ?? "",
+          process.env.AWS_SHARED_CREDENTIALS_FILE ?? "",
+          process.env.AWS_CONFIG_FILE ?? "",
+          process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ?? "",
+          process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI ?? "",
+          AMBIENT_CLOUD_NONCE,
+        ].join("\n");
+    raw = `s3\n${endpoint}\n${region}\n${accessKeyId}\n${secretAccessKey}\n${sessionToken}\n${ambient}`;
   } else if (isAzureBlobUrl(url)) {
     // Azure download uses env creds (connection string, else account+key), else
-    // anonymous. The blob host already encodes the account (part of `url`), so the
-    // principal here is purely the env credential material.
+    // anonymous — no hidden ambient chain like AWS, so no nonce needed. The blob host
+    // already encodes the account (part of `url`); this is the env credential material.
     const conn = process.env.AZURE_STORAGE_CONNECTION_STRING ?? "";
     const account = process.env.AZURE_STORAGE_ACCOUNT ?? "";
     const key = process.env.AZURE_STORAGE_KEY ?? "";

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -42,7 +42,15 @@ export function cloudPrincipalKey(url: string, auth: CloudStorageAuth = {}): str
   let raw: string | undefined;
   if (isS3Url(url)) {
     const s3 = auth.s3;
-    const endpoint = s3?.endpoint ?? process.env.AWS_S3_ENDPOINT ?? "";
+    // makeS3Client sets config.endpoint = auth.endpoint ?? AWS_S3_ENDPOINT; when
+    // that's unset the AWS SDK still resolves an endpoint from AWS_ENDPOINT_URL_S3 /
+    // AWS_ENDPOINT_URL — fold ALL of them so changing the effective S3 service behind
+    // one s3:// URL never reuses the prior endpoint's cache entry (#467 P1-B).
+    const endpoint = [
+      s3?.endpoint ?? process.env.AWS_S3_ENDPOINT ?? "",
+      process.env.AWS_ENDPOINT_URL_S3 ?? "",
+      process.env.AWS_ENDPOINT_URL ?? "",
+    ].join("|");
     const region = s3?.region ?? process.env.AWS_REGION ?? "";
     const accessKeyId = s3?.access_key_id ?? process.env.AWS_ACCESS_KEY_ID ?? "";
     const secretAccessKey = s3?.secret_access_key ?? process.env.AWS_SECRET_ACCESS_KEY ?? "";

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -12,6 +12,7 @@ import {
   type DownloadJob,
 } from "../services/download-jobs.js";
 import { readDownloadProgress } from "../services/download-progress.js";
+import { getResumeDiagnostic } from "../services/download-cache.js";
 import { errorToToolResult, ModelError } from "../utils/errors.js";
 
 /**
@@ -230,7 +231,20 @@ export function registerModelManagementTools(server: McpServer): void {
               : j.status === "error"
                 ? `\n    failed: ${j.error}`
                 : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
-          return `${head}${detail}\n    from: ${j.url}`;
+          // Surface a declined resume so the agent/user knows a pre-existing
+          // .partial was discarded and a full re-download is under way, and why
+          // — instead of it being silent (#467).
+          const diag = getResumeDiagnostic(j.trayId);
+          let resumeNote = "";
+          if (diag && diag.outcome !== "resumed") {
+            const gb = (diag.discardedBytes / 1024 ** 3).toFixed(2);
+            const why =
+              diag.outcome === "declined:no-validator"
+                ? "the host sent no ETag/Last-Modified validator to verify a safe resume (common on Hugging Face's Xet/CAS CDN)"
+                : "the upstream file changed since the partial was written (If-Range miss), so appending would corrupt it";
+            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial and is re-downloading in full because ${why}`;
+          }
+          return `${head}${detail}${resumeNote}\n    from: ${j.url}`;
         });
 
         return { content: [{ type: "text", text: `## Downloads\n\n${lines.join("\n")}` }] };

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -232,11 +232,10 @@ export function registerModelManagementTools(server: McpServer): void {
                 ? `\n    failed: ${j.error}`
                 : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
           // Surface a declined resume so the agent/user knows a pre-existing
-          // .partial was discarded and a full re-download is under way, and why
-          // — instead of it being silent (#467).
-          // Only THIS attempt's diagnostic can be present: startDownloadJob clears
-          // any earlier decision for the tray id when a fresh job starts (#467 P2),
-          // so a stale discard from an earlier attempt can't be misattributed here.
+          // .partial was discarded and why — instead of it being silent (#467).
+          // Only THIS attempt's decision can be present: the per-attempt reset in
+          // the physical-download path (and on a cache hit) clears any earlier
+          // decision for this slot, so a stale one can't be misattributed here.
           const diag = getResumeDiagnostic(j.resumeKey);
           let resumeNote = "";
           if (diag && diag.outcome !== "resumed") {
@@ -249,14 +248,17 @@ export function registerModelManagementTools(server: McpServer): void {
                   : diag.outcome === "declined:unverifiable"
                     ? "the resume crossed origins to a CDN that gave no content-addressed validator, so an unchanged upstream couldn't be proven"
                     : "the upstream file changed since the partial was written, so appending would corrupt it";
-            // The 206-refusal paths (etag-changed / unverifiable) error the job —
-            // a clean retry is needed; no-validator and full-response restart
-            // within the same stream. Report each honestly by job status.
+            // Honest about BOTH what happened to the partial and what's next.
+            // A 206 refusal whose removal failed (diag.discarded === false) must
+            // NOT claim the partial was discarded (#467).
+            const fate = diag.discarded
+              ? `discarded ${gb} GB of a prior .partial`
+              : `refused to append a ${gb} GB prior .partial but could NOT remove it (delete the .partial manually if a retry keeps failing)`;
             const next =
               j.status === "error"
                 ? "the resume was REJECTED for safety — re-issue download_model to restart cleanly"
                 : "re-downloading in full";
-            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial because ${why}; ${next}`;
+            resumeNote = `\n    resume: ${diag.outcome} — ${fate} because ${why}; ${next}`;
           }
           return `${head}${detail}${resumeNote}\n    from: ${j.url}`;
         });

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -244,15 +244,19 @@ export function registerModelManagementTools(server: McpServer): void {
             const why =
               diag.outcome === "declined:no-validator"
                 ? "the host sent no ETag/Last-Modified validator to verify a safe resume (common on Hugging Face's Xet/CAS CDN)"
-                : "the upstream file changed since the partial was written, so appending would corrupt it";
-            // A declined:etag-changed via the 206-refusal path errors the job (a
-            // clean retry is needed); the no-validator and If-Range-miss paths
-            // restart within the same stream. Report each honestly.
-            const outcome =
+                : diag.outcome === "declined:full-response"
+                  ? "the host answered with a full response instead of a 206 — the upstream changed, or it doesn't support resuming"
+                  : diag.outcome === "declined:unverifiable"
+                    ? "the resume crossed origins to a CDN that gave no content-addressed validator, so an unchanged upstream couldn't be proven"
+                    : "the upstream file changed since the partial was written, so appending would corrupt it";
+            // The 206-refusal paths (etag-changed / unverifiable) error the job —
+            // a clean retry is needed; no-validator and full-response restart
+            // within the same stream. Report each honestly by job status.
+            const next =
               j.status === "error"
-                ? `the resume was REJECTED — re-issue download_model to restart cleanly`
-                : `re-downloading in full`;
-            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial because ${why}; ${outcome}`;
+                ? "the resume was REJECTED for safety — re-issue download_model to restart cleanly"
+                : "re-downloading in full";
+            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial because ${why}; ${next}`;
           }
           return `${head}${detail}${resumeNote}\n    from: ${j.url}`;
         });

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -12,7 +12,6 @@ import {
   type DownloadJob,
 } from "../services/download-jobs.js";
 import { readDownloadProgress } from "../services/download-progress.js";
-import { getResumeDiagnostic } from "../services/download-cache.js";
 import { errorToToolResult, ModelError } from "../utils/errors.js";
 
 /**
@@ -233,10 +232,9 @@ export function registerModelManagementTools(server: McpServer): void {
                 : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
           // Surface a declined resume so the agent/user knows a pre-existing
           // .partial was discarded and why — instead of it being silent (#467).
-          // Only THIS attempt's decision can be present: the per-attempt reset in
-          // the physical-download path (and on a cache hit) clears any earlier
-          // decision for this slot, so a stale one can't be misattributed here.
-          const diag = getResumeDiagnostic(j.resumeKey);
+          // The decision is stored on THIS job by its own physical download, so it
+          // can never be a stale/other job's.
+          const diag = j.resume;
           let resumeNote = "";
           if (diag && diag.outcome !== "resumed") {
             const gb = (diag.discardedBytes / 1024 ** 3).toFixed(2);

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -234,15 +234,25 @@ export function registerModelManagementTools(server: McpServer): void {
           // Surface a declined resume so the agent/user knows a pre-existing
           // .partial was discarded and a full re-download is under way, and why
           // — instead of it being silent (#467).
+          // Only surface a diagnostic from THIS attempt — the map is keyed by URL
+          // and persists across jobs, so a stale discard from an earlier attempt
+          // for the same URL must not be attributed to this one (#467).
           const diag = getResumeDiagnostic(j.trayId);
           let resumeNote = "";
-          if (diag && diag.outcome !== "resumed") {
+          if (diag && diag.outcome !== "resumed" && diag.at >= j.started_at) {
             const gb = (diag.discardedBytes / 1024 ** 3).toFixed(2);
             const why =
               diag.outcome === "declined:no-validator"
                 ? "the host sent no ETag/Last-Modified validator to verify a safe resume (common on Hugging Face's Xet/CAS CDN)"
-                : "the upstream file changed since the partial was written (If-Range miss), so appending would corrupt it";
-            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial and is re-downloading in full because ${why}`;
+                : "the upstream file changed since the partial was written, so appending would corrupt it";
+            // A declined:etag-changed via the 206-refusal path errors the job (a
+            // clean retry is needed); the no-validator and If-Range-miss paths
+            // restart within the same stream. Report each honestly.
+            const outcome =
+              j.status === "error"
+                ? `the resume was REJECTED — re-issue download_model to restart cleanly`
+                : `re-downloading in full`;
+            resumeNote = `\n    resume: ${diag.outcome} — discarded ${gb} GB of a prior .partial because ${why}; ${outcome}`;
           }
           return `${head}${detail}${resumeNote}\n    from: ${j.url}`;
         });

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -237,7 +237,7 @@ export function registerModelManagementTools(server: McpServer): void {
           // Only THIS attempt's diagnostic can be present: startDownloadJob clears
           // any earlier decision for the tray id when a fresh job starts (#467 P2),
           // so a stale discard from an earlier attempt can't be misattributed here.
-          const diag = getResumeDiagnostic(j.trayId);
+          const diag = getResumeDiagnostic(j.resumeKey);
           let resumeNote = "";
           if (diag && diag.outcome !== "resumed") {
             const gb = (diag.discardedBytes / 1024 ** 3).toFixed(2);

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -234,12 +234,12 @@ export function registerModelManagementTools(server: McpServer): void {
           // Surface a declined resume so the agent/user knows a pre-existing
           // .partial was discarded and a full re-download is under way, and why
           // — instead of it being silent (#467).
-          // Only surface a diagnostic from THIS attempt — the map is keyed by URL
-          // and persists across jobs, so a stale discard from an earlier attempt
-          // for the same URL must not be attributed to this one (#467).
+          // Only THIS attempt's diagnostic can be present: startDownloadJob clears
+          // any earlier decision for the tray id when a fresh job starts (#467 P2),
+          // so a stale discard from an earlier attempt can't be misattributed here.
           const diag = getResumeDiagnostic(j.trayId);
           let resumeNote = "";
-          if (diag && diag.outcome !== "resumed" && diag.at >= j.started_at) {
+          if (diag && diag.outcome !== "resumed") {
             const gb = (diag.discardedBytes / 1024 ** 3).toFixed(2);
             const why =
               diag.outcome === "declined:no-validator"

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -256,7 +256,9 @@ export function registerModelManagementTools(server: McpServer): void {
               : `refused to append a ${gb} GB prior .partial but could NOT remove it (delete the .partial manually if a retry keeps failing)`;
             const next =
               j.status === "error"
-                ? "the resume was REJECTED for safety — re-issue download_model to restart cleanly"
+                ? diag.discarded
+                  ? "the resume was REJECTED for safety — re-issue download_model to restart cleanly"
+                  : "the resume was REJECTED for safety — re-issue download_model to retry"
                 : "re-downloading in full";
             resumeNote = `\n    resume: ${diag.outcome} — ${fate} because ${why}; ${next}`;
           }


### PR DESCRIPTION
## Root cause (#467)
The ETag/If-Range resume gating from #343/#454 is intentionally safety-first and correct — this is **not** a regression. Two real gaps behind the reported "36GB partial silently discarded":

1. **Silent discard.** When a `.partial` existed but resume was declined (no validator sidecar, or an If-Range miss), the partial was thrown away and re-downloaded from byte 0 with **no log and no signal** — indistinguishable from "never resumable".
2. **HF Xet could never resume.** The validator sidecar (`${partial}.etag`) was only written when the *original* response carried `ETag`/`Last-Modified`. Hugging Face's Xet/CAS CDN (`cas-bridge.xethub.hf.co`) returns **neither** on the file body, so no sidecar was ever written → every restart mid-download of a big HF model discarded the partial.

## (a) Surface the discard
- `logger.warn` at both decline points (no-validator and If-Range-miss/etag-changed) naming the bytes discarded and why.
- New in-process **resume diagnostic** (`getResumeDiagnostic(trayId)`) recorded by the streaming layer and surfaced by `download_status` (same MCP process): e.g. `resume: declined:no-validator — discarded 36.47 GB of a prior .partial and is re-downloading in full because the host sent no ETag/Last-Modified validator ...`. A taken resume records `resumed`.

## (b) Enable safe HF Xet resume
- **Capture the validator from the resolve redirect.** HF's `resolve` URL 302s to the CAS CDN carrying `X-Linked-Etag` (the content-addressed object hash) even though the final CAS 200 carries no validator. We now capture it off the redirect chain and persist the sidecar, so Xet partials become resumable.
- **Preserve `Range`/`If-Range` across the cross-origin CAS hop** (still dropping `Authorization` so the HF token never leaks to the third-party CDN). Previously *all* headers were dropped cross-origin, so a resume's byte-range never reached the presigned CDN.

### #343 safety invariant preserved
Append still happens **only** on a validated 206 whose `Content-Range` is complete and anchored at the resume offset. An If-Range miss (200) restarts cleanly — now logged, not silent. `X-Linked-Etag` is content-addressed, so If-Range equality ⇒ identical content; a changed file fails the conditional at the well-behaved `huggingface.co` origin and yields a full 200 (restart), never a mismatched append. A validator-less stale partial (no recorded value to compare) is still fully re-downloaded — but now surfaced.

## Tests
Added to `download-cache.test.ts`: validator-less decline is surfaced (not silent) with `discardedBytes`; X-Linked-Etag captured off the redirect writes a sidecar; Range forwarded across the cross-origin CAS hop and a 206 appends (`resumed`); changed-upstream (If-Range miss) still full-restarts with `declined:etag-changed`. `tsc` clean; full `npm test` green except the pre-existing node-dev ripgrep-vs-builtin environment failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)