### PR TITLE
fix(errors): recompute missing_node_types after node install (#444)

### DIFF
--- a/src/__tests__/services/node-install-invalidates-object-info.test.ts
+++ b/src/__tests__/services/node-install-invalidates-object-info.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression for #444: after a custom-node install completes, the orchestrator's
+// memoized /object_info snapshot must be invalidated so the NEXT validation
+// (validate_workflow / diagnose_run) recomputes `missing_node_types` against the
+// live registry instead of serving the pre-install snapshot that still lists the
+// just-installed type as missing. This drives the REAL installCustomNode +
+// validateWorkflow code paths (only the network boundaries are stubbed).
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>(
+    "../../config.js",
+  );
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    isRemoteMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+    config: { ...actual.config, comfyuiPath: "/fake/comfy", githubToken: undefined },
+  };
+});
+
+// Stub the SDK client so getObjectInfo()'s only data source (getNodeDefs) is
+// controllable and countable, with no network.
+const getNodeDefs = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    getNodeDefs = getNodeDefs;
+    close() {}
+  },
+}));
+
+// Stub the comfy-cli subprocess so the useCmCli install path returns cleanly
+// without spawning anything.
+vi.mock("../../services/comfy-cli.js", () => ({
+  runComfyCliSync: vi.fn(() => ({ stdout: "{}", stderr: "", status: 0 })),
+  assertComfyCliOk: vi.fn(() => ({ data: {} })),
+}));
+
+const { installCustomNode } = await import("../../services/node-management.js");
+const { validateWorkflow } = await import("../../services/workflow-validator.js");
+const { resetObjectInfoCache } = await import("../../comfyui/client.js");
+
+// A registry WITHOUT the custom node type (pre-install) and one WITH it (post-install).
+const REGISTRY_WITHOUT = {
+  KSampler: { input: { required: {} }, output: [] },
+} as const;
+const REGISTRY_WITH = {
+  ...REGISTRY_WITHOUT,
+  SmartImageCrop: { input: { required: {} }, output: ["IMAGE"] },
+} as const;
+
+// Minimal API-format graph that uses the not-yet-installed node type.
+const GRAPH = { "1": { class_type: "SmartImageCrop", inputs: {} } } as const;
+
+const missingNodeTypes = (result: Awaited<ReturnType<typeof validateWorkflow>>) =>
+  result.issues
+    .filter((i) => i.kind === "missing_node_type")
+    .map((i) => i.node_type);
+
+describe("#444 install invalidates the object_info cache", () => {
+  beforeEach(() => {
+    getNodeDefs.mockReset();
+    resetObjectInfoCache();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recomputes missing_node_types after installCustomNode succeeds", async () => {
+    // Pre-install: registry lacks the type → it validates as missing (and caches).
+    getNodeDefs.mockResolvedValue(REGISTRY_WITHOUT as never);
+    const before = await validateWorkflow(GRAPH as never, { health: false });
+    expect(missingNodeTypes(before)).toContain("SmartImageCrop");
+
+    // The pack is now installed; the live registry knows the type.
+    getNodeDefs.mockResolvedValue(REGISTRY_WITH as never);
+
+    // A cache-serving read would STILL return REGISTRY_WITHOUT here; the install
+    // must invalidate the snapshot so the next read refetches.
+    await installCustomNode({ id: "comfyui-smart-image-crop", useCmCli: true });
+
+    const after = await validateWorkflow(GRAPH as never, { health: false });
+    expect(missingNodeTypes(after)).not.toContain("SmartImageCrop");
+    // Proves the refetch actually happened (pre-install fetch + post-install refetch).
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
@@ -987,7 +988,28 @@ export interface InstallOptions {
   useCmCli?: boolean;
 }
 
-export async function installCustomNode(
+/**
+ * Installing/updating/reinstalling/repairing a pack changes which node classes
+ * this ComfyUI can register, so the orchestrator's memoized /object_info snapshot
+ * (getObjectInfo) is now stale — validate_workflow / diagnose_run / get_node_info
+ * would keep reporting the just-installed types as `missing_node_type` in their
+ * top-level summaries until some later reboot bumped the epoch (#444, the residual
+ * of the #235/#247/#352/#364 staleness cluster). Drop the cache the moment a
+ * mutation succeeds so the next read refetches the live registry. Applied via a
+ * single choke point (rather than at every early return) so every install branch —
+ * cm-cli, Manager HTTP, and the git clone fallback — is covered.
+ */
+async function withObjectInfoInvalidation<T>(op: () => Promise<T>): Promise<T> {
+  const result = await op();
+  resetObjectInfoCache();
+  return result;
+}
+
+export function installCustomNode(opts: InstallOptions): Promise<NodeOpResult> {
+  return withObjectInfoInvalidation(() => installCustomNodeImpl(opts));
+}
+
+async function installCustomNodeImpl(
   opts: InstallOptions,
 ): Promise<NodeOpResult> {
   const { id, version, mode = "remote", channel = "default" } = opts;
@@ -1121,7 +1143,11 @@ export interface UpdateOptions {
   useCmCli?: boolean;
 }
 
-export async function updateCustomNode(
+export function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
+  return withObjectInfoInvalidation(() => updateCustomNodeImpl(opts));
+}
+
+async function updateCustomNodeImpl(
   opts: UpdateOptions,
 ): Promise<NodeOpResult> {
   const { id, mode = "remote", channel = "default" } = opts;
@@ -1187,7 +1213,11 @@ export interface ReinstallOptions {
   useCmCli?: boolean;
 }
 
-export async function reinstallCustomNode(
+export function reinstallCustomNode(opts: ReinstallOptions): Promise<NodeOpResult> {
+  return withObjectInfoInvalidation(() => reinstallCustomNodeImpl(opts));
+}
+
+async function reinstallCustomNodeImpl(
   opts: ReinstallOptions,
 ): Promise<NodeOpResult> {
   const { id, version, mode = "remote", channel = "default" } = opts;
@@ -1230,7 +1260,11 @@ export interface FixOptions {
   useCmCli?: boolean;
 }
 
-export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
+export function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
+  return withObjectInfoInvalidation(() => fixCustomNodeImpl(opts));
+}
+
+async function fixCustomNodeImpl(opts: FixOptions): Promise<NodeOpResult> {
   const { id, mode = "remote", channel = "default" } = opts;
   const all = id.trim().toLowerCase() === "all";
 


### PR DESCRIPTION
## Summary
Fixes #444 — the residual of the #235/#247/#352/#364 asset-staleness cluster: the top-level `missing_node_types` array (surfaced via `panel_get_errors` / `validate_workflow` / `diagnose_run`) kept listing a just-installed custom node type as missing until a later full reboot.

## Root cause
The orchestrator memoizes `/object_info` in `src/comfyui/client.ts` (`getObjectInfo()` + `objectInfoCache`). `validateWorkflow()` derives `missing_node_type` issues from that snapshot. The cache was invalidated on **reboot** (`panel_restart_comfyui`, process-control) but **not** when a node install/update/reinstall/fix mutated the registry, so a subsequent validation served the stale pre-install snapshot.

## Fix
In `src/services/node-management.ts`, invalidate the object_info cache the moment a registry-mutating op **succeeds**, via a single `withObjectInfoInvalidation()` choke point wrapping the four exported service functions (`installCustomNode`, `updateCustomNode`, `reinstallCustomNode`, `fixCustomNode`). Each delegates to a private `*Impl` and calls `resetObjectInfoCache()` after it resolves — so every install branch (cm-cli, Manager HTTP, git clone fallback) is covered, and a failed op does **not** reset the cache.

## Test
Added `src/__tests__/services/node-install-invalidates-object-info.test.ts`, which drives the **real** `installCustomNode` + `validateWorkflow` paths (only network boundaries stubbed): validates a graph against a registry without the type (missing + cached), swaps the live registry to include it, installs, then re-validates and asserts the type is no longer missing and a refetch occurred. Verified it **FAILS before** the fix and **PASSES after**.

Full suite: 2195 passed, 1 pre-existing unrelated failure (`node-dev` search-engine test picks `ripgrep` because rg is installed on this machine — fails identically on the base commit).

## Review
codex gate: **VERDICT: PASS** (no correctness/scope issues; confirmed invalidation is success-only and concurrency-safe against the epoch guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
