### PR TITLE
release: 0.48.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.14] - 2026-07-30
+
+### Fixed
+- **`missing_node_types` is recomputed after a custom-node install (#444).** The orchestrator memoizes `/object_info`; `validate_workflow`/`diagnose_run` derive the top-level `missing_node_types` from that snapshot. The cache was invalidated on reboot (the #235/#247/#352/#364 cluster) but not on a node install, so a just-installed type stayed listed as missing until a later reboot. A single `withObjectInfoInvalidation()` choke point now wraps `install`/`update`/`reinstall`/`fix` custom-node ops and resets the object-info cache on success (covering cm-cli, Manager HTTP, and git-clone fallback paths). (#471)
+- **`panel_run` tolerates a mid-command panel reconnect instead of hard-failing (#450).** The UI-bridge socket `close` handler rejected every in-flight command with a generic `panel tab disconnected mid-command` — a false failure for an already-queued `graph_run`, and one that invited a blind retry / double render. It now classifies the disconnect: idempotent reads are parked with a bounded, deadline-clamped grace and re-dispatched only if the tab re-hellos (transient reconnect resumes cleanly); every mutating command rejects with an actionable `OUTCOME UNKNOWN` message and is never auto-retried (at-most-once). (#472)
+
 ## [0.48.13] - 2026-07-30
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.13",
+  "version": "0.48.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.13",
+      "version": "0.48.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.13",
+  "version": "0.48.14",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.14** (already pushed → npm publish fires via release.yml).

## Ships
- **#444 (#471):** `missing_node_types` recomputed after a custom-node install — single `withObjectInfoInvalidation()` choke point resets the object-info cache on successful install/update/reinstall/fix.
- **#450 (#472):** `panel_run` tolerates a mid-command panel reconnect — reads park + resume on re-hello; mutating commands reject `OUTCOME UNKNOWN`, never auto-retry (at-most-once).

Both already merged to main individually; this bumps version + curated CHANGELOG and carries the exact tagged commit. **Merge with a MERGE commit (not squash)** so `v0.48.14` is an ancestor of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)