### PR TITLE
fix(restart): relaunch Desktop-managed ComfyUI via Manager reboot, never kill-without-relaunch (#400)

### DIFF
--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -1,0 +1,148 @@
+// Local Desktop restart (issue #400): a LOCALLY-installed ComfyUI **Desktop**
+// instance is Electron-supervised. restart_comfyui must NOT kill it and re-spawn
+// the exe (that leaves it down — stopped:true, started:false after 60 probes).
+// Instead it fires a ComfyUI-Manager HTTP reboot and polls readiness, exactly
+// like the remote path. Everything runs through mocked comfyuiFetch + execSync +
+// spawn; no real process/port/network is touched.
+
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remoteMode: { value: false },
+  fetchMock: vi.fn(),
+  resetClient: vi.fn(),
+  resetObjectInfoCache: vi.fn(),
+  // argv that marks this as a Comfy Desktop install (see isDesktopApp()).
+  getSystemStats: vi.fn(async () => ({
+    system: {
+      argv: [
+        "C:\\Users\\x\\AppData\\Local\\Programs\\Comfy Desktop\\resources\\ComfyUI\\main.py",
+        "--listen",
+        "127.0.0.1",
+        "--port",
+        "8188",
+      ],
+    },
+  })),
+  execSync: vi.fn(() => ""),
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../config.js", () => ({
+  config: { resolvedPort: 8188, comfyuiPath: "/fake/comfy", comfyuiBasePath: "" },
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  isRemoteMode: () => hoisted.remoteMode.value,
+}));
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (url: string, init?: RequestInit) => hoisted.fetchMock(url, init),
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: hoisted.getSystemStats,
+  resetClient: hoisted.resetClient,
+  resetObjectInfoCache: hoisted.resetObjectInfoCache,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: hoisted.execSync,
+  spawn: hoisted.spawn,
+  execFile: vi.fn(),
+}));
+
+import {
+  restartComfyUI,
+  __processControlTestHooks,
+} from "../../services/process-control.js";
+
+type FetchCall = [string, RequestInit | undefined];
+const pathOf = (u: string): string => new URL(u).pathname;
+const findCall = (pred: (path: string) => boolean): FetchCall | undefined =>
+  (hoisted.fetchMock.mock.calls as FetchCall[]).find(([u]) => pred(pathOf(u)));
+
+beforeEach(() => {
+  hoisted.remoteMode.value = false;
+  hoisted.fetchMock.mockReset();
+  hoisted.resetClient.mockClear();
+  hoisted.resetObjectInfoCache.mockClear();
+  hoisted.getSystemStats.mockClear();
+  hoisted.spawn.mockReset();
+  hoisted.execSync.mockReset();
+  // Map the running Desktop server's :8188 listener to a PID so gatherProcessInfo
+  // resolves a live, Desktop-flagged instance — on either host platform.
+  hoisted.execSync.mockImplementation((cmd: string) => {
+    if (/netstat/i.test(cmd)) {
+      return "  TCP    127.0.0.1:8188    0.0.0.0:0    LISTENING    4321\n";
+    }
+    if (/lsof/i.test(cmd)) return "4321\n";
+    return "";
+  });
+  __processControlTestHooks.reset();
+});
+
+describe("restartComfyUI — local Desktop (Manager reboot, never kill) [#400]", () => {
+  it("reboots the Desktop instance via Manager and never kills/re-spawns it", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    let statsCalls = 0;
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") return new Response("", { status: 200 });
+      if (path === "/system_stats") {
+        statsCalls++;
+        // First probe after firing: origin still going down. Then ready.
+        if (statsCalls <= 1) throw new Error("fetch failed");
+        return new Response(JSON.stringify({ system: {} }), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.stopped).toBe(true);
+    expect(res.started).toBe(true);
+    expect(res.ready).toBe(true);
+    expect(res.message).toContain("rebooted via ComfyUI-Manager");
+    expect(res.message).toContain("Desktop/supervised");
+
+    // The Manager reboot was fired.
+    expect(findCall((p) => p === "/v2/manager/reboot")).toBeDefined();
+    // Crucially: the Desktop app was NEVER killed or re-spawned.
+    expect(hoisted.spawn).not.toHaveBeenCalled();
+    const killed = hoisted.execSync.mock.calls.some(([c]: [string]) =>
+      /taskkill|\bkill\b|pkill/i.test(c),
+    );
+    expect(killed).toBe(false);
+    expect(hoisted.resetClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses without killing when the Manager reboot cannot be fired (403)", async () => {
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 100,
+      intervalMs: 5,
+    });
+    hoisted.fetchMock.mockImplementation(async (url: string) => {
+      if (pathOf(url).endsWith("/manager/reboot")) {
+        return new Response("forbidden", { status: 403 });
+      }
+      return new Response("", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.started).toBe(false);
+    expect(res.stopped).toBe(false);
+    expect(res.message).toContain("403");
+    // Refusal must leave the Desktop instance running — no kill, no re-spawn.
+    expect(hoisted.spawn).not.toHaveBeenCalled();
+    const killed = hoisted.execSync.mock.calls.some(([c]: [string]) =>
+      /taskkill|\bkill\b|pkill/i.test(c),
+    );
+    expect(killed).toBe(false);
+    expect(hoisted.resetClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -424,7 +424,11 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     killSpy.mockRestore();
   });
 
-  it("refuses to stop a Desktop app whose launcher exe cannot be located", async () => {
+  it("reboots a local Desktop app via ComfyUI-Manager instead of killing it (#400)", async () => {
+    // A Desktop install is Electron-supervised: killing it and re-spawning the
+    // exe leaves it down (stopped:true, started:false). It must reboot via the
+    // Manager HTTP endpoint and never be killed. The old behavior (refuse when
+    // the exe can't be located) no longer applies — the exe is irrelevant now.
     mockLivePortNoKill();
     mockGetSystemStats.mockResolvedValue({
       system: {
@@ -435,18 +439,33 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
         ],
       },
     });
-    // Nothing exists on disk — the Desktop exe cannot be located.
+    // Exe cannot be located on disk — under the old path this refused; now it
+    // is never consulted because we reboot via the Manager instead.
     mockExistsSync.mockImplementation(() => false);
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 1000,
+      intervalMs: 5,
+    });
+    const fetchMock = mockFetchOk(true); // reboot fires + /system_stats ready
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     const result = await restartComfyUI();
 
-    expect(result.stopped).toBe(false);
-    expect(result.started).toBe(false);
-    expect(result.message).toMatch(/refusing to restart/i);
-    expect(result.message).toMatch(/desktop/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.message).toMatch(/rebooted via ComfyUI-Manager/i);
+    expect(result.message).toMatch(/Desktop\/supervised/i);
+    // Never killed / re-spawned.
     expect(mockSpawn).not.toHaveBeenCalled();
-    expect(mockResetClient).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([c]) => /taskkill/i.test(String(c))),
+    ).toBe(false);
+    // The Manager reboot endpoint was hit.
+    expect(
+      fetchMock.mock.calls.some(([u]) => String(u).includes("/manager/reboot")),
+    ).toBe(true);
 
     killSpy.mockRestore();
   });

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1142,8 +1142,25 @@ function getRemoteRebootTiming(): RemoteRebootTiming {
   };
 }
 
-async function restartRemoteViaManager(): Promise<RestartResult> {
-  logger.info("Restarting remote ComfyUI via ComfyUI-Manager reboot...");
+/**
+ * Restart via a ComfyUI-Manager HTTP reboot instead of killing a process.
+ *
+ * Used for BOTH the remote target (--comfyui-url) AND a locally-installed
+ * ComfyUI **Desktop** instance. Desktop is Electron-supervised: killing its
+ * Python backend (or even the Electron shell) leaves it down with no reliable
+ * relaunch — spawning "Comfy Desktop.exe" does not deterministically bring the
+ * :PORT listener back, which is exactly issue #400 (stopped:true, started:false
+ * after 60 probes). The Manager `/v2/manager/reboot` handler asks the SAME
+ * supervisor that owns the process to cycle it, so it comes back the way it
+ * started. We therefore NEVER kill a Desktop instance; if the reboot can't be
+ * fired we refuse and leave the server running rather than take it down with no
+ * way back.
+ */
+async function restartViaManagerReboot(context: {
+  /** Human label for logs and the success message ("remote" | "Desktop"). */
+  label: string;
+}): Promise<RestartResult> {
+  logger.info(`Restarting ${context.label} ComfyUI via ComfyUI-Manager reboot...`);
 
   const reboot = await rebootViaManager();
   if (!reboot.rebooting) {
@@ -1194,7 +1211,7 @@ async function restartRemoteViaManager(): Promise<RestartResult> {
     readiness,
     message:
       `ComfyUI rebooted via ComfyUI-Manager and came back ready (${readiness.waited_ms}ms) — ` +
-      "remote/supervised restart.",
+      `${context.label}/supervised restart.`,
   };
 }
 
@@ -1202,7 +1219,7 @@ export async function restartComfyUI(): Promise<RestartResult> {
   if (isRemoteMode()) {
     // Remote target: can't process-control it, but a Manager HTTP reboot brings
     // back a self-supervised ComfyUI (e.g. the tunnelled Desktop app).
-    return restartRemoteViaManager();
+    return restartViaManagerReboot({ label: "remote" });
   }
   logger.info("Restarting ComfyUI...");
 
@@ -1221,6 +1238,16 @@ export async function restartComfyUI(): Promise<RestartResult> {
         `No ComfyUI process found on port ${config.resolvedPort} to restart. Is ComfyUI running?`,
     };
   }
+  // A locally-installed ComfyUI **Desktop** instance is Electron-supervised.
+  // Killing it (Python backend or Electron shell) and re-spawning the exe does
+  // not reliably bring the :PORT listener back (issue #400: stopped:true,
+  // started:false after 60 probes). Route it through the Manager reboot — the
+  // supervisor that owns the process cycles it — and NEVER kill it. Only
+  // self-spawned Python installs fall through to the kill+relaunch path below.
+  if (info.isDesktopApp) {
+    return restartViaManagerReboot({ label: "Desktop" });
+  }
+
   const relaunch = assessRelaunch(info);
   if (!relaunch.ok) {
     return {


### PR DESCRIPTION
## Summary

Fixes #400 — `restart_comfyui` stopped a local Comfy **Desktop**-managed ComfyUI but failed to relaunch the Python server (`stopped:true, started:false, ready:false` after 60 probes).

## Root cause

A locally-installed ComfyUI Desktop instance is Electron-supervised. The restart path treated it like a self-spawned process: it killed it (`killDesktopApp`) and re-spawned `Comfy Desktop.exe`. Launching the Electron shell does not deterministically bring the `:PORT` Python listener back, so the instance stayed down with no relaunch.

## Fix

`restartComfyUI` now distinguishes **managed vs self-spawned** and routes each correctly:

- **Desktop-managed** (`info.isDesktopApp === true`): route through a ComfyUI-Manager HTTP reboot (`POST /v2/manager/reboot`) — the same supervisor that owns the process cycles it — and **never kill** it. If the reboot can't be fired (403 / no reachable endpoint) it refuses and leaves the server running rather than take it down with no way back.
- **Self-spawned Python**: unchanged — the existing relaunch-preflight → stop → start (kill+relaunch) path.

The remote target (`--comfyui-url`) already used this reboot; the helper was generalized from `restartRemoteViaManager()` to `restartViaManagerReboot({ label })` and is now shared by both the remote and local-Desktop cases. No kill-without-relaunch path is introduced for a managed instance.

## Tests

- New `src/__tests__/services/desktop-restart.test.ts`: local Desktop restart reboots via Manager, never kills/re-spawns (success path + 403-refusal-without-kill). Drives the real exported `restartComfyUI`, mocking only the process/HTTP boundary. **Fails before, passes after.**
- Updated the now-obsolete Desktop-exe-preflight test in `process-control.test.ts` to assert the new reboot behavior.
- Full suite green (the single pre-existing `node-dev.test.ts` ripgrep failure is Windows-sandbox only and passes on CI).

## codex review

`VERDICT: PASS` — confirmed the branch on `info.isDesktopApp` precedes any relaunch assessment or process termination (Desktop can only reach Manager reboot, never kill), remote behavior preserved, non-Desktop path unchanged, and the tests fail on the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)