### PR TITLE
fix(restart): live-first script resolution — restart reachable install instead of refusing on stale relative COMFYUI_PATH (#476, #426)

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -22,6 +22,9 @@ vi.mock("../../config.js", () => ({
 vi.mock("node:child_process", () => ({
   execSync: mockExecSync,
   spawn: mockSpawn,
+  // workspace-env (imported transitively for live-first script anchoring)
+  // promisifies execFile at module load, so it must be present.
+  execFile: vi.fn(),
 }));
 
 // assessRelaunch (restart preflight) validates the resolved interpreter/script

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -1,0 +1,231 @@
+// Live-first restart script resolution (#476, #426).
+//
+// A reachable, self-spawned (non-Desktop) ComfyUI whose sys.argv[0] is the
+// RELATIVE portable-launcher path `ComfyUI\main.py` must RESTART — anchored to
+// the canonical ABSOLUTE install that download_model / the environment services
+// already resolved (resolveEffectiveComfyUIBase) — instead of REFUSING because a
+// stale/relative COMFYUI_PATH made the script path look nonexistent. The
+// refuse-safe behavior is preserved when NO valid live script can be resolved.
+//
+// Boundaries only are mocked: config, the env-resolution service (workspace-env),
+// the python resolver (env-capabilities), child_process, node:fs, the ComfyUI
+// client, and global fetch. No real process/port/network/filesystem is touched.
+
+import { EventEmitter } from "node:events";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+}
+
+const mockConfig = vi.hoisted(() => ({
+  resolvedPort: 8188,
+  // #476/#426: COMFYUI_PATH is unset/stale — the canonical absolute install is
+  // known only to the env service (saved default workspace), exactly like the
+  // one download_model wrote into in the same session.
+  comfyuiPath: undefined as string | undefined,
+}));
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockGetSystemStats = vi.hoisted(() => vi.fn());
+const mockResetClient = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
+const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
+const mockLiveRootFromArgv = vi.hoisted(() =>
+  vi.fn<[string[], string?], string | undefined>(),
+);
+
+vi.mock("../../config.js", () => ({
+  config: mockConfig,
+  getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  getComfyUIAuthHeaders: () => ({}),
+  isRemoteMode: () => false,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+  spawn: mockSpawn,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock("../../comfyui/client.js", () => ({
+  getSystemStats: mockGetSystemStats,
+  resetClient: mockResetClient,
+  resetObjectInfoCache: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../services/env-capabilities.js", () => ({
+  findComfyuiPython: mockFindComfyuiPython,
+}));
+
+// The env-resolution service is the boundary: it owns the canonical absolute base
+// (download_model uses the same one) and the argv-derived live root.
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: mockResolveBase,
+  liveRootFromArgv: mockLiveRootFromArgv,
+}));
+
+import {
+  __processControlTestHooks,
+  restartComfyUI,
+} from "../../services/process-control.js";
+
+// The canonical live install — where download_model wrote, and where the running
+// server's python actually lives. HOST-NATIVE absolute so the test is portable:
+// production resolveScriptAnchor uses node:path.isAbsolute, so a hardcoded
+// Windows path would read as relative on Ubuntu/macOS CI.
+const BASE = resolve("ComfyUI_portable", "ComfyUI");
+const ABS_MAIN = join(BASE, "main.py");
+const ABS_PYTHON = join(BASE, "python_embeded", "python.exe");
+
+const ORIGINAL_ENV = { ...process.env };
+
+/**
+ * execSync that reports a live PID on the port until a kill is issued, then
+ * reports the port free — so gatherProcessInfo finds the instance and
+ * waitForPortFree returns promptly after the (mocked) kill.
+ */
+function mockLivePortThenFree(): { killed: () => boolean } {
+  let killed = false;
+  mockExecSync.mockImplementation((cmd: string) => {
+    if (/taskkill|pkill|\bkill\b/i.test(cmd)) {
+      killed = true;
+      return "";
+    }
+    if (/netstat/i.test(cmd)) {
+      return killed
+        ? ""
+        : "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
+    }
+    if (/lsof/i.test(cmd)) {
+      if (killed) throw new Error("not listening");
+      return "4321";
+    }
+    return "";
+  });
+  return { killed: () => killed };
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  process.env.COMFYUI_STARTUP_CHECK_INTERVAL_S = "0.01";
+  process.env.COMFYUI_STARTUP_CHECK_MAX_TRIES = "1";
+  mockConfig.resolvedPort = 8188;
+  mockConfig.comfyuiPath = undefined;
+  mockFindComfyuiPython.mockReturnValue(ABS_PYTHON);
+  // Portable launcher: relative argv → no argv-derived live root.
+  mockLiveRootFromArgv.mockReturnValue(undefined);
+  // The env service knows the canonical absolute install.
+  mockResolveBase.mockReturnValue(BASE);
+  // Everything that resolves to the absolute canonical install exists on disk.
+  mockExistsSync.mockImplementation((p: string) => {
+    const s = String(p);
+    return s === ABS_MAIN || s === ABS_PYTHON;
+  });
+  // Running server exposes the RELATIVE portable-launcher script path.
+  mockGetSystemStats.mockResolvedValue({
+    system: { argv: ["ComfyUI\\main.py", "--port", "8188"] },
+  });
+  __processControlTestHooks.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+  __processControlTestHooks.reset();
+});
+
+describe("restart_comfyui — live-first script resolution (#476, #426)", () => {
+  it("RESTARTS a reachable install, anchoring a relative argv[0] to the canonical absolute base (not refusing on a stale/relative COMFYUI_PATH)", async () => {
+    mockLivePortThenFree();
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    // Relaunch preflight passes, stop frees the port, relaunch spawns, and the
+    // readiness probe sees a live API — a genuine successful restart.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // It did NOT take the refuse-safe branch — it actually restarted.
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.ready).toBe(true);
+
+    // The relaunch spawned the resolved interpreter with the ABSOLUTE main.py —
+    // anchored to the canonical base, not the bare relative "ComfyUI\main.py".
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(ABS_PYTHON);
+    expect(args[0]).toBe(ABS_MAIN);
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES a bare relative `main.py` that cannot be anchored (no canonical base, no live root)", async () => {
+    // Bare "main.py" with nothing to anchor it to is truly unresolvable — refuse
+    // rather than kill a reachable server we cannot relaunch.
+    mockResolveBase.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("still REFUSES (leaves the server running) when no valid live script can be resolved at all", async () => {
+    // No canonical base, no live root, and the relative script does not exist.
+    mockResolveBase.mockReturnValue(undefined);
+    mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/stale/i);
+    // Server left running: no relaunch spawn, no kill.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(
+      mockExecSync.mock.calls.some(([c]) => /taskkill/i.test(String(c))),
+    ).toBe(false);
+
+    killSpy.mockRestore();
+  });
+});

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -8,6 +8,7 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { findComfyuiPython } from "./env-capabilities.js";
+import { liveRootFromArgv, resolveEffectiveComfyUIBase } from "./workspace-env.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -566,6 +567,31 @@ function spawnFromProcessInfo(info: ProcessInfo): ChildProcess | null {
  * argv (main.py + flags) as its args. When argv[0] is already an interpreter
  * (e.g. a supervised child we spawned ourselves), we spawn it verbatim.
  */
+/**
+ * The ABSOLUTE ComfyUI dir (the one directly holding `main.py`) to anchor a
+ * RELATIVE sys.argv[0] against, resolved LIVE-FIRST and consistently with the
+ * canonical base download_model / the environment services already use (#476,
+ * #426). Order, most-trustworthy first:
+ *   1. the LIVE running server's own argv-derived install root (absolute argv[0]);
+ *   2. the canonical effective base — COMFYUI_PATH or the saved default workspace
+ *      — i.e. the exact absolute install download_model wrote into in the same
+ *      session (resolveEffectiveComfyUIBase);
+ *   3. config.comfyuiPath, when absolute, as a last resort.
+ * Returns undefined only when none is absolute; callers then fall back to the raw
+ * (possibly relative) argv and the refuse-safe preflight refuses a genuinely
+ * unresolvable install.
+ */
+function resolveScriptAnchor(argv: string[]): string | undefined {
+  const live = liveRootFromArgv(argv);
+  if (live && isAbsolute(live)) return live;
+  const base = resolveEffectiveComfyUIBase();
+  if (base && isAbsolute(base)) return base;
+  if (config.comfyuiPath && isAbsolute(config.comfyuiPath)) {
+    return config.comfyuiPath;
+  }
+  return undefined;
+}
+
 function resolveLaunchCommand(
   info: ProcessInfo,
 ): { exe: string; args: string[] } | null {
@@ -595,10 +621,21 @@ function resolveLaunchCommand(
     const isWindowsAbsolute =
       /^[a-zA-Z]:[\\/]/.test(firstUnquoted) || /^\\\\/.test(firstUnquoted);
     const scriptBasename = firstUnquoted.split(/[\\/]/).pop() || firstUnquoted;
+    // LIVE-FIRST anchor for a RELATIVE argv[0]: resolve the canonical ABSOLUTE
+    // ComfyUI dir the same way download_model / the env services do, so restart
+    // never refuses on a stale/relative COMFYUI_PATH while the reachable install
+    // lives elsewhere (#476, #426). config.comfyuiPath is only ONE input to that
+    // canonical base (which also honors the saved default workspace), so anchor
+    // to the base — not to config.comfyuiPath directly. When no absolute anchor
+    // exists we keep the raw (possibly relative) script and let assessRelaunch's
+    // refuse-safe preflight catch a truly unresolvable install.
+    const anchor = resolveScriptAnchor(info.argv);
     const script =
-      isAbsolute(firstUnquoted) || isWindowsAbsolute || !config.comfyuiPath
+      isAbsolute(firstUnquoted) || isWindowsAbsolute
         ? firstUnquoted
-        : join(config.comfyuiPath, scriptBasename);
+        : anchor
+          ? join(anchor, scriptBasename)
+          : firstUnquoted;
     return { exe: python, args: [script, ...rest] };
   }
   return { exe: first, args: rest };
@@ -676,13 +713,26 @@ function assessRelaunch(info: ProcessInfo): { ok: boolean; reason?: string } {
     };
   }
   const script = cmd.args[0];
-  if (script && /\.pyw?$/i.test(script) && looksLikePath(script) && !fileExists(script)) {
-    return {
-      ok: false,
-      reason:
-        `Resolved ComfyUI script does not exist on disk: ${script} — ` +
-        "COMFYUI_PATH may point at a stale/old install that has no runnable server.",
-    };
+  if (script && /\.pyw?$/i.test(script)) {
+    // We could only VALIDATE the script when it was resolved to an ABSOLUTE path
+    // (either argv[0] was absolute, or resolveScriptAnchor anchored a relative
+    // argv[0] to a canonical absolute install). A script still RELATIVE here means
+    // the live-first anchor produced nothing absolute — i.e. a truly unresolvable
+    // install (stale/relative COMFYUI_PATH, no saved workspace, no argv root). We
+    // cannot confirm it exists, so REFUSE rather than kill a reachable server we
+    // can't relaunch (#476/#426 refuse-safe; also covers a bare `main.py`).
+    const scriptIsAbsolute =
+      isAbsolute(script) ||
+      /^[a-zA-Z]:[\\/]/.test(script) ||
+      /^\\\\/.test(script);
+    if (!scriptIsAbsolute || !fileExists(script)) {
+      return {
+        ok: false,
+        reason:
+          `Resolved ComfyUI script does not exist on disk: ${script} — ` +
+          "COMFYUI_PATH may point at a stale/old install that has no runnable server.",
+      };
+    }
   }
   return { ok: true };
 }


### PR DESCRIPTION
## Summary

Fixes the #476 + #426 cluster (same root cause): in the **self-spawned (non-Desktop) restart path**, `restart_comfyui` refused to restart a *reachable* local ComfyUI because it resolved the server script as a stale/relative path (`ComfyUI\main.py`) — even though `download_model` had just written successfully into the canonical **absolute** install in the same session.

```
Refusing to restart: Resolved ComfyUI script does not exist on disk: ComfyUI\main.py
— COMFYUI_PATH may point at a stale/old install that has no runnable server.
```

### Root cause
`resolveLaunchCommand` anchored a relative `sys.argv[0]` (the standard Windows portable launcher runs `python ComfyUI\main.py` from the portable root) to `config.comfyuiPath` only. When `COMFYUI_PATH` was unset/stale, the script stayed relative → the preflight saw a nonexistent path → refusal. This was inconsistent with the python resolution and `download_model`, which already resolve the canonical absolute install (incl. the saved default workspace).

### Fix
- New `resolveScriptAnchor(argv)` helper — **live-first**: `liveRootFromArgv` → `resolveEffectiveComfyUIBase()` (the exact canonical base `download_model`/env services use) → `config.comfyuiPath`, taking the first **absolute** one. A relative `argv[0]` is anchored there instead of only `config.comfyuiPath`.
- `assessRelaunch` hardened: a `.py` script still **relative** after anchoring (truly unresolvable — including a bare `main.py`) still **REFUSES** rather than killing a server it can't relaunch.

### Preserved / untouched
- The **#400 Desktop-managed branch** (Desktop → Manager reboot, never kill) is untouched — it returns before the kill/relaunch path.
- **Refuse-safe** behavior for genuinely-missing installs is preserved (absolute `argv[0]` still validated verbatim; stale absolute paths still refuse; server left running, no kill/spawn).

### Tests
`src/__tests__/services/restart-live-first.test.ts` (boundaries mocked only):
- reachable install + relative argv + stale/unset `COMFYUI_PATH` → **RESTARTS** (`started === true`, spawns the interpreter with the anchored absolute `main.py`). Fails before, passes after.
- `ComfyUI\main.py` with no resolvable base → **REFUSES**, no kill/spawn.
- bare `main.py` with nothing to anchor → **REFUSES**, no kill/spawn.

Host-native absolute paths so the suite is portable across Ubuntu CI / macOS / Windows. Full suite green (only the known pre-existing `node-dev.test.ts` ripgrep sandbox failure remains).

### Review
codex review gate: **VERDICT: PASS** (confirmed refuse-safe path preserved and #400 Desktop branch untouched).

Closes #476
Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
