### PR TITLE
release: 0.48.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.15] - 2026-07-30
+
+### Fixed
+- **`restart_comfyui` relaunches a Desktop-managed ComfyUI via the Manager reboot endpoint instead of killing the Electron shell (#400).** A local Comfy **Desktop** instance was treated like a self-spawned one — killed and re-spawned via `Comfy Desktop.exe`, which never reliably brought the `:8188` Python backend back (`stopped:true, started:false`). `restartComfyUI` now branches on `isDesktopApp` before any kill: a Desktop-managed instance routes through `POST /v2/manager/reboot` and is never killed; if the reboot can't be fired (403/no endpoint) it refuses and leaves the server running. Self-spawned Python installs keep the kill+relaunch path. (#477)
+- **`restart_comfyui` uses live-first script resolution instead of refusing on a stale relative `COMFYUI_PATH` (#476, #426).** After `download_model` wrote successfully into the canonical absolute live install, restart could resolve the server script as a stale relative path (`ComfyUI/main.py`) and refuse — inconsistent with the path download just used. A new `resolveScriptAnchor` resolves live-first (`liveRootFromArgv` → saved-default workspace → configured path, first absolute wins) before anchoring a relative launcher script; the refuse-safe behavior is preserved for a genuinely unresolvable/missing install, and the #400 Desktop branch is untouched. (#479)
+
 ## [0.48.14] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.14",
+  "version": "0.48.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.14",
+      "version": "0.48.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.14",
+  "version": "0.48.15",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.15** (pushed → npm publish via release.yml).

## Ships (restart robustness)
- **#400 (#477):** Desktop-managed ComfyUI restarts via `POST /v2/manager/reboot`, never kill-without-relaunch; refuse-safe if Manager blocked.
- **#476/#426 (#479):** live-first restart script resolution — restart a reachable install instead of refusing on a stale relative `COMFYUI_PATH`; refuse-safe preserved; #400 Desktop branch untouched.

Both merged individually; this bumps version + curated CHANGELOG. **Merge with a MERGE commit (not squash)** so v0.48.15 is an ancestor of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)