### PR TITLE
release: 0.48.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.16] - 2026-07-30
+
+### Fixed
+- **`panel_restart_comfyui` no longer reports a false timeout/failure after a reboot that actually succeeded (#493, #222, #263, #266, #306, #307).** The panel path sends `comfy_reboot` over the UI bridge; because the Manager reboot handler returns the moment it accepts the request, ComfyUI (and the tab it serves) drops before it can ack — and the bridge surfaced that expected drop as a mutating-command `OUTCOME UNKNOWN` failure, which the tool returned verbatim. It now classifies the `comfy_reboot` result (confirmed / expected-drop / refusal): on confirmed-or-drop it resets caches and polls readiness (`nodes_queue_status`, auto-healing onto the reconnected tab) up to a generous wall-clock budget, returning success with recovery timing; a genuine refusal is still returned verbatim, and a server that never comes back within the budget still reports a clear failure. The headless `restart_comfyui` path (#400/#476) is untouched. (#497)
+
 ## [0.48.15] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.15",
+  "version": "0.48.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.15",
+      "version": "0.48.16",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.15",
+  "version": "0.48.16",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.16** (pushed → npm publish via release.yml).

## Ships
- **#493/#222/#263/#266/#306/#307 (#497):** `panel_restart_comfyui` polls readiness after the expected reboot connection-drop instead of returning a false `OUTCOME UNKNOWN` timeout. codex PASS (2 rounds); dead-server-still-fails preserved; #400/#476 headless path untouched.

**Live-test note:** the orchestrator-restart live-test (which requires relaunching the running orchestrator + rebooting the shared ComfyUI) was deferred — the rig doesn't reproduce the false-timeout the fix targets and the change is additive/conservative with unit + codex coverage. Merge with a **MERGE commit** so v0.48.16 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)