### PR TITLE
release: 0.48.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.17] - 2026-07-30
+
+### Fixed
+- **`download_model` resume no longer silently discards a near-complete `.partial`, and HF Xet/CAS downloads resume safely (#467, #470).** When the Xet/CAS CDN omits `ETag`/`Last-Modified`, no resume validator was ever written, so a restart silently truncated and re-downloaded a multi-GB partial with no signal. Resume is now surfaced honestly via `download_status` (four outcomes: `declined:no-validator` / `declined:full-response` / `declined:etag-changed` / `declined:unverifiable`), and HF Xet partials resume by capturing the content-addressed `X-Linked-Etag` off the resolve 302 and preserving `Range`/`If-Range` across the cross-origin redirect (dropping `Authorization`). The #343 append invariant is hardened throughout: append happens only on a validated 206 with an exact, end-reaching `Content-Range`; a cross-origin 206 additionally requires a matching content-addressed validator; completion fails **closed** (rejects any size ≠ the authoritative total, derives a 206's total from `Content-Range` and a fresh 200's from `max(Content-Length, X-Linked-Size)`, and refuses an unsolicited 206 on a fresh request); materialize + direct-fallback build into a random `O_EXCL` temp and rename atomically (never writing through a destination hardlink into a cache inode); and the cache identity folds in per-request auth and the effective cloud principal so bytes are never served across an auth boundary. (#469)
+
 ## [0.48.16] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.16",
+  "version": "0.48.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.16",
+      "version": "0.48.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.16",
+  "version": "0.48.17",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.17** (pushed → npm publish via release.yml).

## Ships
- **#467/#470 (#469):** `download_model` no longer silently discards a near-complete `.partial`; HF Xet/CAS downloads resume safely (X-Linked-Etag off the 302, Range/If-Range preserved cross-origin, Authorization dropped); resume declines surfaced via `download_status`. #343 append invariant hardened: fail-closed completion (rejects size ≠ authoritative total; 206 total from Content-Range; fresh-200 total from max(Content-Length, X-Linked-Size); unsolicited fresh-206 refused), atomic O_EXCL temp+rename (no hardlink write-through), auth-aware + effective-cloud-principal cache identity.

**Review depth:** 4 independent adversarial-codex cycles beyond the agent's self-gate caught real corruption/leak paths each time (oversized-body finalize, final-206 etag, fail-open-on-stat, hardlink-through-cache-inode, temp-name inode poison, truncated unsolicited-206 finalize) — all fixed; final pass clean. Merge with a **MERGE commit** so v0.48.17 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)