### PR TITLE
release: 0.48.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.18] - 2026-07-30
+
+### Fixed
+- **`panel_open_workflow` no longer false-fails a switch that actually succeeded (#215, #319, #496).** When the target tab is backgrounded/frozen or the workflow is already open, it may not ACK `workflow_open` within the window even though the switch genuinely happened. On an ack-timeout the tool now polls the authoritative active-workflow signal (a fresh `workflow_list` round-trip, bounded ~6s) and returns success (with a recovered note) if the target became active; a genuinely-failed open (e.g. no matching workflow) is an acked error, not a timeout, so it still fails clearly. Mirrors the #497 restart-readiness pattern. (#502)
+
 ## [0.48.17] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.17",
+  "version": "0.48.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.17",
+      "version": "0.48.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.17",
+  "version": "0.48.18",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.18** (pushed → npm publish via release.yml).

## Ships
- **#215/#319/#496 (#502):** `panel_open_workflow` verifies the active-workflow state after an ack-timeout (fresh `workflow_list` poll) instead of false-failing a switch that succeeded; a genuine open-failure still fails. Same verify-after-timeout pattern as #497. codex PASS.

Merge with a **MERGE commit** so v0.48.18 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)