### PR TITLE
fix(validate): derive valid/ready verdict from errors + surface authoritative combo errors (#342, #505)

### DIFF
--- a/src/__tests__/tools/workflow-validate-render.test.ts
+++ b/src/__tests__/tools/workflow-validate-render.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+// Render-layer regression for #342 / #505: the tool must DERIVE its "ready to
+// execute" verdict from the surfaced errors and must NOT mask authoritative
+// combo/enum/model errors (which carry `kind`) behind "No issues found".
+const validateWorkflowMock = vi.fn();
+vi.mock("../../services/workflow-validator.js", () => ({
+  validateWorkflow: (...a: unknown[]) => validateWorkflowMock(...a),
+}));
+
+import { registerWorkflowValidateTools } from "../../tools/workflow-validate.js";
+import type { ValidationResult } from "../../services/workflow-validator.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowValidateTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+const run = async (result: ValidationResult): Promise<string> => {
+  validateWorkflowMock.mockResolvedValue(result);
+  const handler = getHandler("validate_workflow");
+  const out = await handler({ workflow: { "1": { class_type: "SaveImage", inputs: {} } } });
+  return out.content.map((c) => c.text).join("\n");
+};
+
+beforeEach(() => {
+  validateWorkflowMock.mockReset();
+});
+
+describe("validate_workflow render — verdict is derived from errors (#342)", () => {
+  it("never says 'ready to execute' when the result is invalid with a real error", async () => {
+    const text = await run({
+      valid: false,
+      summary: "Workflow has 1 error(s) and 0 warning(s)",
+      issues: [
+        {
+          severity: "error",
+          node_id: "1",
+          node_type: "KSampler",
+          message: "Missing required input \"model\"",
+        },
+      ],
+    });
+    expect(text).toContain("Workflow has 1 error(s)");
+    expect(text).not.toContain("ready to execute");
+    // The error itself must be listed, not hidden.
+    expect(text).toContain("### Errors");
+    expect(text).toContain('Missing required input "model"');
+  });
+
+  it("a genuinely-valid workflow says ready to execute with no error section", async () => {
+    const text = await run({
+      valid: true,
+      summary: "Workflow is valid",
+      issues: [],
+    });
+    expect(text).toContain("ready to execute");
+    expect(text).not.toContain("### Errors");
+  });
+});
+
+describe("validate_workflow render — authoritative combo errors are surfaced (#505)", () => {
+  it("surfaces a value_not_in_list combo error (which carries `kind`) in the Errors section", async () => {
+    const text = await run({
+      valid: false,
+      summary: "Workflow has 1 error(s) and 0 warning(s)",
+      issues: [
+        {
+          severity: "error",
+          node_id: "1",
+          node_type: "CLIPLoader",
+          kind: "value_not_in_list",
+          input: "type",
+          value: "gemma",
+          message: '"type" = "gemma" is not in the list of valid options (value_not_in_list).',
+        },
+      ],
+    });
+    expect(text).toContain("### Errors");
+    expect(text).toContain("value_not_in_list");
+    // Must NOT be masked behind the "No issues found" summary.
+    expect(text).not.toContain("No issues found");
+    expect(text).not.toContain("ready to execute");
+  });
+
+  it("surfaces a missing_model error (carries `kind`) rather than claiming no issues", async () => {
+    const text = await run({
+      valid: false,
+      summary: "Workflow has 1 error(s) and 0 warning(s)",
+      issues: [
+        {
+          severity: "error",
+          node_id: "2",
+          node_type: "UNETLoader",
+          kind: "missing_model",
+          input: "unet_name",
+          value: "missing.gguf",
+          message: '"unet_name" = "missing.gguf" is not in the list of valid options.',
+        },
+      ],
+    });
+    expect(text).toContain("missing.gguf");
+    expect(text).not.toContain("No issues found");
+  });
+
+  it("keeps graph-health findings (health:true) out of Errors but still shows the health section", async () => {
+    const text = await run({
+      valid: true,
+      summary: "Workflow is valid",
+      issues: [
+        {
+          severity: "info",
+          node_id: "3",
+          node_type: "LoadImage",
+          kind: "disconnected",
+          health: true,
+          message: "Node 3 is disconnected from any output",
+        },
+      ],
+      health: {
+        summary: "1 heuristic finding",
+        findings: [
+          {
+            severity: "info",
+            kind: "disconnected",
+            heuristic: true,
+            detail: "Node 3 is disconnected from any output",
+            node_ids: ["3"],
+            node_type: "LoadImage",
+          },
+        ],
+      } as never,
+    });
+    // Health issue is NOT surfaced as an error, and the valid verdict holds.
+    expect(text).not.toContain("### Errors");
+    expect(text).toContain("ready to execute");
+    expect(text).toContain("### Graph health");
+  });
+});

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -17,6 +17,11 @@ export interface ValidationIssue {
   input?: string;
   /** The offending value (e.g. the model filename that isn't installed). */
   value?: string;
+  /** True only for issues sourced from graph-health heuristics (step 5). These are
+   *  rendered in the "Graph health" section and excluded from Errors/Warnings buckets
+   *  to avoid double-listing. Authoritative validator issues (which also carry `kind`)
+   *  are NOT tagged, so they are never masked from the Errors section. */
+  health?: boolean;
 }
 
 export interface ValidationResult {
@@ -188,6 +193,7 @@ export async function validateWorkflow(
         node_type: f.node_type ?? "",
         message: f.detail,
         kind: f.kind,
+        health: true,
       });
     }
   }

--- a/src/tools/workflow-validate.ts
+++ b/src/tools/workflow-validate.ts
@@ -50,13 +50,22 @@ export function registerWorkflowValidateTools(server: McpServer): void {
 
         // Health findings are rendered in their own "### Graph health" section —
         // exclude them from the Errors/Warnings buckets to avoid double-listing.
-        const nonHealth = result.issues.filter((i) => !i.kind);
-        if (nonHealth.length === 0) {
-          lines.push("No issues found. The workflow is ready to execute.");
-        } else {
-          const errors = nonHealth.filter((i) => i.severity === "error");
-          const warnings = nonHealth.filter((i) => i.severity === "warning");
+        // NOTE: partition on `.health`, NOT `.kind`. Authoritative validator issues
+        // (missing_node_type / missing_model / value_not_in_list) also carry `kind`,
+        // so filtering by `!i.kind` (the old logic) masked real errors behind
+        // "No issues found" while the header still counted them (#342, #505).
+        const nonHealth = result.issues.filter((i) => !i.health);
+        const errors = nonHealth.filter((i) => i.severity === "error");
+        const warnings = nonHealth.filter((i) => i.severity === "warning");
 
+        if (errors.length === 0 && warnings.length === 0) {
+          // Verdict is DERIVED from the surfaced errors, never asserted independently.
+          lines.push(
+            result.valid
+              ? "No issues found. The workflow is ready to execute."
+              : "No errors were surfaced, but the workflow is NOT valid — see the header and graph-health section below.",
+          );
+        } else {
           if (errors.length > 0) {
             lines.push("### Errors");
             for (const issue of errors) {


### PR DESCRIPTION
## Summary
Fixes the `validate_workflow` diagnostic contradiction cluster (#342, #505; #484 closed dup).

The renderer partitioned issues with `result.issues.filter((i) => !i.kind)`. Authoritative validator errors (`missing_node_type`, `missing_model`, `value_not_in_list`) also carry `kind`, so they were stripped from the Errors section — the tool printed "No issues found. The workflow is ready to execute." while the header still counted them.

## Changes
- `services/workflow-validator.ts`: tag ONLY graph-health findings with `health: true` (new field on `ValidationIssue`).
- `tools/workflow-validate.ts`: partition the render on `!i.health` (not `!i.kind`) so authoritative combo/model errors stay surfaced; derive the "ready to execute" verdict from `result.valid`/surfaced errors so it can never contradict the header count.
- New renderer-level regression tests (`__tests__/tools/workflow-validate-render.test.ts`): 1-error workflow ⇒ invalid + error listed (no contradiction); out-of-options combo (`value_not_in_list`) ⇒ surfaced; genuinely-valid workflow ⇒ ready, no false errors; health finding stays out of Errors. Fail before, pass after.

## Verification
- Full suite: 2255 passed (only the known pre-existing `node-dev.test.ts` ripgrep-in-sandbox failure remains).
- codex review gate: **VERDICT: PASS** — confirmed verdict can no longer contradict the header, combo errors are never masked, and a genuinely-valid workflow still passes with no false positives.

Does not bump version. Do not merge without review.