### PR TITLE
release: 0.48.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.19] - 2026-07-30
+
+### Fixed
+- **`validate_workflow` no longer contradicts itself or hides authoritative combo errors (#342, #505).** The renderer partitioned issues on `!i.kind`, which stripped the authoritative validator errors (`missing_node_type`, `missing_model`, `value_not_in_list` — all carry a `kind`) from the Errors section, so the tool printed "No issues found — ready to execute" while the header still counted them. Now only graph-health findings are tagged `health:true` and the render partitions on `!i.health`, so combo/model errors stay surfaced and the "ready to execute" verdict is derived from the actual validity — the header and body can never disagree. (#507)
+
 ## [0.48.18] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.18",
+  "version": "0.48.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.18",
+      "version": "0.48.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.18",
+  "version": "0.48.19",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.19** (pushed → npm publish via release.yml).

## Ships
- **#342/#505 (#507):** `validate_workflow` verdict is derived from the actual error set (header + body can't contradict), and authoritative combo/model errors are no longer stripped from the Errors section. codex PASS.

Merge with a **MERGE commit** so v0.48.19 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)