### PR TITLE
fix(comfy-cli): resolve workspace/venv cli when COMFYUI_PATH unset + server fallback for models + accept promptId (#506, #403, #360, #487)

### DIFF
--- a/src/__tests__/services/comfy-cli.test.ts
+++ b/src/__tests__/services/comfy-cli.test.ts
@@ -1,8 +1,20 @@
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// Keep config.comfyuiPath deterministically unset so the saved-default-workspace
+// resolution path (#506/#403) is what's under test, not any real auto-detected
+// install on the host running the suite.
+vi.mock("../../config.js", () => ({ config: { comfyuiPath: undefined } }));
+
+// Control the saved default workspace resolveEffectiveComfyUIBase() returns.
+const wsMock = vi.hoisted(() => ({ base: undefined as string | undefined }));
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => wsMock.base,
+}));
+
 import {
   assertComfyCliOk,
   awaitProcessWithIdleTimeout,
@@ -19,6 +31,7 @@ const tempDirs: string[] = [];
 afterEach(() => {
   if (originalCliPath === undefined) delete process.env.COMFY_CLI_PATH;
   else process.env.COMFY_CLI_PATH = originalCliPath;
+  wsMock.base = undefined;
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -50,6 +63,20 @@ describe("comfy-cli adapter", () => {
     const executable = join(dir, process.platform === "win32" ? "comfy.exe" : "comfy");
     writeFileSync(executable, "");
     process.env.COMFY_CLI_PATH = executable;
+    expect(resolveComfyCliExecutable()).toBe(executable);
+  });
+
+  it("resolves the workspace-venv comfy-cli from the saved default workspace when COMFYUI_PATH is unset (#506/#403)", () => {
+    delete process.env.COMFY_CLI_PATH;
+    const workspace = mkdtempSync(join(tmpdir(), "comfy-cli-ws-"));
+    tempDirs.push(workspace);
+    const binDir = join(workspace, ".venv", process.platform === "win32" ? "Scripts" : "bin");
+    mkdirSync(binDir, { recursive: true });
+    const executable = join(binDir, process.platform === "win32" ? "comfy.exe" : "comfy");
+    writeFileSync(executable, "");
+    // No explicit workspace passed and COMFYUI_PATH unset — resolution must fall
+    // through to the saved default workspace's venv rather than only scanning PATH.
+    wsMock.base = workspace;
     expect(resolveComfyCliExecutable()).toBe(executable);
   });
 

--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -17,8 +17,21 @@ vi.mock("../../config.js", () => {
   const config: { comfyuiPath: string | undefined; githubToken?: string } = {
     comfyuiPath: undefined,
   };
-  return { config, getComfyUIBaseUrl: () => "http://127.0.0.1:8188" };
+  return {
+    config,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    isRemoteMode: () => false,
+  };
 });
+
+// Control the effective LOCAL base node-dev resolves through, so #506's
+// saved-default-workspace behavior is exercised without touching real user
+// config. resolveEffectiveComfyUIBase() prefers COMFYUI_PATH then the saved
+// default; the mock mirrors that: config.comfyuiPath first, else wsMock.saved.
+const wsMock = vi.hoisted(() => ({ saved: undefined as string | undefined }));
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? wsMock.saved,
+}));
 
 import { config } from "../../config.js";
 import {
@@ -80,6 +93,7 @@ beforeEach(() => {
   customNodes = join(workspace, "custom_nodes");
   mkdirSync(customNodes, { recursive: true });
   config.comfyuiPath = workspace;
+  wsMock.saved = undefined;
   delete process.env.COMFYUI_MCP_ALLOW_GIT_WRITES;
 });
 
@@ -150,9 +164,21 @@ describe("resolveInJail", () => {
     expect(() => resolveInJail("junction/loot.txt")).toThrow(NodeDevError);
   });
 
-  it("refuses when comfyuiPath is unset (remote mode)", () => {
+  it("refuses when no local install is configured (remote mode, no saved default)", () => {
     config.comfyuiPath = undefined;
+    wsMock.saved = undefined;
     expect(() => resolveInJail("MyPack")).toThrow(/local ComfyUI install/);
+  });
+
+  it("resolves against the saved default workspace when COMFYUI_PATH is unset (#506)", () => {
+    // No COMFYUI_PATH, but a saved default workspace is set — a loopback session
+    // must be treated as local, mirroring get_environment/get_workspace, instead
+    // of being rejected as remote.
+    config.comfyuiPath = undefined;
+    wsMock.saved = workspace;
+    mkdirSync(join(customNodes, "MyPack"), { recursive: true });
+    const { rel } = resolveInJail("MyPack");
+    expect(rel).toBe("MyPack");
   });
 });
 

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -33,6 +33,9 @@ vi.mock("../../config.js", () => {
 
 // Mock child_process for the cm-cli subprocess paths.
 vi.mock("node:child_process", () => ({
+  // execFile is needed at module load: workspace-env (pulled in transitively via
+  // comfy-cli) calls promisify(execFile) at top level.
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
   spawnSync: vi.fn(() => ({
     status: 0,

--- a/src/__tests__/tools/comfy-cli.test.ts
+++ b/src/__tests__/tools/comfy-cli.test.ts
@@ -5,12 +5,14 @@ const mocks = vi.hoisted(() => ({
   run: vi.fn(),
   resolve: vi.fn(() => "/bin/comfy"),
   version: vi.fn(() => "1.11.1"),
+  usable: vi.fn(() => true),
 }));
 
 vi.mock("../../services/comfy-cli.js", () => ({
   runComfyCli: mocks.run,
   resolveComfyCliExecutable: mocks.resolve,
   getComfyCliVersion: mocks.version,
+  isComfyCliUsable: mocks.usable,
   assertComfyCliOk: (envelope: { ok: boolean }) => {
     if (!envelope.ok) throw new Error("failed");
     return envelope;
@@ -58,6 +60,8 @@ describe("comfy-cli MCP command construction", () => {
     mocks.resolve.mockReset();
     mocks.resolve.mockReturnValue("/bin/comfy");
     mocks.version.mockClear();
+    mocks.usable.mockReset();
+    mocks.usable.mockReturnValue(true);
     fallbackMocks.fallback.mockReset();
   });
 
@@ -90,6 +94,45 @@ describe("comfy-cli MCP command construction", () => {
       ["jobs", "wait", "a", "b", "--timeout", "30"],
       expect.objectContaining({ where: "cloud", timeoutMs: 40_000 }),
     );
+  });
+
+  it("accepts the documented singular promptId for jobs wait (#360)", async () => {
+    await handlers().get("comfy_cli_jobs")!({
+      action: "wait",
+      promptId: "p1",
+      timeoutSeconds: 20,
+      where: "local",
+    });
+    expect(mocks.run).toHaveBeenCalledWith(
+      ["jobs", "wait", "p1", "--timeout", "20"],
+      expect.objectContaining({ where: "local" }),
+    );
+  });
+
+  it("still rejects jobs wait with neither promptId, promptIds, nor all (#360)", async () => {
+    const result = await handlers().get("comfy_cli_jobs")!({ action: "wait", where: "local" });
+    expect(result.isError).toBe(true);
+    expect(mocks.run).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the live server for models listing when comfy-cli is present but an unsupported version (#487)", async () => {
+    // comfy-cli resolves to an executable, but its version is unrecognized/too
+    // old — read-only listing must fall back rather than surface unsupported_version.
+    mocks.resolve.mockReturnValue("/bin/comfy");
+    mocks.usable.mockReturnValue(false);
+    fallbackMocks.fallback.mockResolvedValue({
+      command: "models list-folder loras",
+      data: { folder: "loras", count: 1, files: ["x.safetensors"] },
+    });
+    const result = await handlers().get("comfy_cli_models")!({
+      action: "list-folder",
+      folder: "loras",
+      where: "local",
+    });
+    expect(mocks.run).not.toHaveBeenCalled();
+    expect(fallbackMocks.fallback).toHaveBeenCalledWith(expect.objectContaining({ action: "list-folder" }));
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed).toMatchObject({ ok: true, source: "local_models" });
   });
 
   it("constructs workflow validation and execution flags", async () => {
@@ -126,6 +169,7 @@ describe("comfy-cli MCP command construction", () => {
 
   it("falls back to the live server for local listing when comfy-cli is absent (#460)", async () => {
     mocks.resolve.mockReturnValue(undefined); // comfy-cli not on PATH
+    mocks.usable.mockReturnValue(false);
     fallbackMocks.fallback.mockResolvedValue({
       command: "models list-folders",
       data: { folders: ["checkpoints", "loras"] },

--- a/src/services/comfy-cli.ts
+++ b/src/services/comfy-cli.ts
@@ -2,6 +2,19 @@ import * as childProcess from "node:child_process";
 import { existsSync } from "node:fs";
 import { delimiter, dirname, extname, join } from "node:path";
 import { config } from "../config.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+
+/**
+ * The LOCAL ComfyUI workspace a comfy-cli invocation should target when the
+ * caller passed no explicit `workspace`. Prefers COMFYUI_PATH, then the saved
+ * default workspace (set via set_default_workspace) when COMFYUI_PATH is unset —
+ * so the workspace-venv `comfy` and `--workspace` routing keep working from the
+ * saved default without COMFYUI_PATH (#506/#403). Never returns a local path in
+ * remote mode (resolveEffectiveComfyUIBase already enforces that).
+ */
+function defaultWorkspace(): string | null {
+  return config.comfyuiPath ?? resolveEffectiveComfyUIBase() ?? null;
+}
 
 export interface ComfyCliError {
   code: string;
@@ -136,7 +149,7 @@ export function resolveComfyCliExecutable(options: { refresh?: boolean; workspac
     return existsSync(explicit) ? explicit : null;
   }
 
-  const workspace = options.workspace ?? config.comfyuiPath;
+  const workspace = options.workspace ?? defaultWorkspace();
   for (const candidate of workspaceCandidates(workspace)) {
     if (existsSync(candidate)) {
       return candidate;
@@ -157,7 +170,7 @@ export function resolveComfyCliExecutable(options: { refresh?: boolean; workspac
 
 function buildArgs(args: readonly string[], options: ComfyCliRunOptions): string[] {
   const result = ["--json"];
-  const workspace = options.workspace === undefined ? config.comfyuiPath : options.workspace;
+  const workspace = options.workspace === undefined ? defaultWorkspace() : options.workspace;
   if (workspace) result.push("--workspace", workspace);
   if (options.where) result.push("--where", options.where);
   result.push("--skip-prompt", ...args);
@@ -416,6 +429,18 @@ function getExecutableVersion(executable: string): string | null {
 export function getComfyCliVersion(options: { workspace?: string | null } = {}): string | null {
   const executable = resolveComfyCliExecutable({ workspace: options.workspace });
   return executable ? getExecutableVersion(executable) : null;
+}
+
+/**
+ * Whether a usable comfy-cli (found AND version-supported) is available for the
+ * given workspace. A found-but-unrecognized/too-old CLI is NOT usable — read-only
+ * tools treat that identically to "absent" so they can fall back to the connected
+ * server instead of surfacing `unsupported_version` (#487).
+ */
+export function isComfyCliUsable(options: { workspace?: string | null } = {}): boolean {
+  const executable = resolveComfyCliExecutable({ workspace: options.workspace });
+  if (!executable) return false;
+  return isSupportedComfyCliVersion(getExecutableVersion(executable));
 }
 
 export function isSupportedComfyCliVersion(version: string | null): boolean {

--- a/src/services/node-dev.ts
+++ b/src/services/node-dev.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { config } from "../config.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import {
   assertSafeRepoName,
   nonInteractiveGitEnv,
@@ -281,14 +281,23 @@ function assertNoWindowsHazards(raw: string): void {
 }
 
 export function customNodesRoot(): string {
-  if (!config.comfyuiPath) {
+  // Resolve the effective LOCAL ComfyUI base the same way every other
+  // filesystem-backed tool does: COMFYUI_PATH first, then the saved default
+  // workspace (set via set_default_workspace) when COMFYUI_PATH is unset. This
+  // is what get_environment / get_workspace already report, so custom-node
+  // source tools no longer reject a loopback session that has a saved default
+  // workspace as if it were remote (#506). Returns undefined only in remote
+  // mode or when no local install is known — then we refuse with a clear error.
+  const base = resolveEffectiveComfyUIBase();
+  if (!base) {
     throw new NodeDevError(
-      "This operation requires a local ComfyUI install, but config.comfyuiPath " +
-        "is not set (running in remote --comfyui-url mode). Set COMFYUI_PATH to " +
-        "your local ComfyUI directory to read, search, or edit custom-node source.",
+      "This operation requires a local ComfyUI install, but none is configured " +
+        "(COMFYUI_PATH is unset, no saved default workspace, or running in remote " +
+        "--comfyui-url mode). Set COMFYUI_PATH or a default workspace " +
+        "(set_default_workspace) to read, search, or edit custom-node source.",
     );
   }
-  return resolve(config.comfyuiPath, "custom_nodes");
+  return resolve(base, "custom_nodes");
 }
 
 function isEscape(root: string, candidate: string): boolean {

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   getComfyCliVersion,
+  isComfyCliUsable,
   resolveComfyCliExecutable,
   runComfyCli,
 } from "../services/comfy-cli.js";
@@ -77,8 +78,8 @@ export function registerComfyCliTools(server: McpServer): void {
     "List, inspect, wait for, watch, or cancel local or Comfy Cloud jobs through official comfy-cli. Local jobs include CLI-tracked async submissions plus the ComfyUI queue/history.",
     {
       action: z.enum(["list", "status", "wait", "watch", "cancel"]),
-      promptId: z.string().optional(),
-      promptIds: z.array(z.string()).optional(),
+      promptId: z.string().optional().describe("Single prompt id. Required for status/watch/cancel; accepted for wait (normalized into a one-element promptIds list)."),
+      promptIds: z.array(z.string()).optional().describe("Prompt ids to wait on. For wait, use this or promptId or all=true."),
       all: z.boolean().optional(),
       limit: z.number().int().min(1).max(100).optional(),
       timeoutSeconds: z.number().int().min(1).optional(),
@@ -93,9 +94,16 @@ export function registerComfyCliTools(server: McpServer): void {
           if (!args.promptId) throw new Error(`promptId is required for jobs ${args.action}`);
           command.push(args.promptId);
         } else if (args.action === "wait") {
+          // Accept the documented singular `promptId` by normalizing it into a
+          // one-element promptIds list before validation (#360).
+          const waitIds = args.promptIds?.length
+            ? args.promptIds
+            : args.promptId
+              ? [args.promptId]
+              : [];
           if (args.all) command.push("--all");
-          else if (args.promptIds?.length) command.push(...args.promptIds);
-          else throw new Error("promptIds or all=true is required for jobs wait");
+          else if (waitIds.length) command.push(...waitIds);
+          else throw new Error("promptId, promptIds, or all=true is required for jobs wait");
         }
         if (args.limit && args.action === "list") command.push("--limit", String(args.limit));
         if (args.timeoutSeconds && ["wait", "watch"].includes(args.action)) command.push("--timeout", String(args.timeoutSeconds));
@@ -132,7 +140,7 @@ export function registerComfyCliTools(server: McpServer): void {
           args.where !== "cloud" &&
           !args.objectInfoPath &&
           !args.workspace &&
-          !resolveComfyCliExecutable({ workspace: args.workspace })
+          !isComfyCliUsable({ workspace: args.workspace })
         ) {
           const results = await searchLiveObjectInfo(args.query, args.limit ?? 20);
           return textEnvelope({
@@ -241,12 +249,17 @@ export function registerComfyCliTools(server: McpServer): void {
         // server, so we don't substitute silently — we fall through and let
         // comfy-cli surface its clear not-found error for that workspace.
         // Mirrors the live /object_info fallback for comfy_cli_search_nodes.
+        // The fallback fires when comfy-cli is UNUSABLE — either absent OR a
+        // found-but-unrecognized/too-old version. An unsupported CLI otherwise
+        // returns `unsupported_version` without attempting the server (#487); the
+        // connected ComfyUI already reports its models via /models (through
+        // listLocalModels), so read-only listing works regardless of the CLI.
         const listAction = isLocalModelsListAction(args.action) ? args.action : undefined;
         if (
           listAction &&
           args.where !== "cloud" &&
           !args.workspace &&
-          !resolveComfyCliExecutable({ workspace: args.workspace })
+          !isComfyCliUsable({ workspace: args.workspace })
         ) {
           const { command, data } = await listLocalModelsFallback({ ...args, action: listAction });
           return textEnvelope({


### PR DESCRIPTION
## comfy_cli_* cluster: workspace/venv resolution, server fallback, promptId

The `comfy_cli_*` tools ignored the saved default workspace / connected server and rejected documented params. This resolves the cluster.

### Fixes
- **#506** — Custom-node source tools (`customNodesRoot` in `node-dev.ts`) now resolve through the shared `resolveEffectiveComfyUIBase()` (COMFYUI_PATH → saved default workspace), so a loopback session with a saved default workspace is treated as local instead of rejected as remote. Mirrors `get_environment` / `get_workspace`.
- **#403 / #506** — `resolveComfyCliExecutable` and `--workspace` routing fall back to the saved default workspace when COMFYUI_PATH is unset, so the workspace-venv `comfy` is found without COMFYUI_PATH.
- **#487** — `comfy_cli_models` (and `comfy_cli_search_nodes`) read-only listings now fall back to the connected server when comfy-cli is **absent OR present-but-unsupported-version**, via a new `isComfyCliUsable` gate. Previously an unrecognized/too-old CLI surfaced `unsupported_version` instead of falling back. The connected-server API path itself already existed (the #460 `listLocalModels` fallback queries the server's `/models` REST endpoint first, then disk); the residual was purely the version-gating trigger, which this widens.
- **#360** — `comfy_cli_jobs` action=wait accepts the documented singular `promptId`, normalized into a one-element `promptIds` list.

### Guarantees
- Mutations (`download`/`remove`) stay CLI-only — fallbacks are read-only listing actions.
- Path jail in `node-dev.ts` is unchanged.
- Reuses existing live-first / workspace-resolution infra (#401/#420/#433) and the #460 local-models fallback — no reinvention.

### Tests
Unit tests added per fix (fail before / pass after), mocking the exec/HTTP boundary:
- workspace-venv comfy-cli resolved via saved default when COMFYUI_PATH unset (`services/comfy-cli.test.ts`)
- node-dev jail resolves against saved default workspace when COMFYUI_PATH unset (`services/node-dev.test.ts`)
- models fallback fires for present-but-unsupported CLI (`tools/comfy-cli.test.ts`)
- jobs wait accepts singular promptId + still rejects when none given (`tools/comfy-cli.test.ts`)

Full suite passes (2260 passed); the single failing `node-dev` builtin-search assertion is the pre-existing ripgrep-sandbox failure — it fails identically on unpatched `main`.

### Codex review
`VERDICT: PASS` — "No findings. The fallback logic, path jail, CLI-only mutations, and regression tests are correct."

Closes #506
Closes #403
Closes #360
Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
