### PR TITLE
fix(manager): detect + route to Manager 3.x-legacy vs v4/Desktop dialects with fallback (list/update/install/reboot/search)

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -1,0 +1,132 @@
+// #425 / panel #253/#266: panel_restart_comfyui must not dead-end when the
+// built-in Manager exposes NO reboot endpoint (legacy Manager 3.x: the v2 route
+// 405s, the legacy route 404s). For a LOCAL, process-controllable target it now
+// falls back to the headless managed restart (kill + relaunch). A busy-guard or
+// security refusal must NOT trigger that fallback (it would abort a running
+// render / defeat Manager security), and a REMOTE target has no local process to
+// restart — both return the refusal verbatim.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  remoteMode: { value: false },
+  restart: vi.fn(async () => ({ stopped: true, started: true, ready: true, message: "restarted" })),
+}));
+
+// isRemoteMode() gates the fallback; keep the rest of config real.
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, isRemoteMode: () => hoisted.remoteMode.value };
+});
+
+// The headless managed restart is the fallback mechanism — stub it so no real
+// process/port is touched, and so we can assert whether it was invoked.
+vi.mock("../../services/process-control.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/process-control.js")>();
+  return { ...actual, restartComfyUI: hoisted.restart };
+});
+
+import {
+  buildPanelToolDefs,
+  rebootNoEndpoint,
+  __panelToolsTestHooks,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+
+const NO_ENDPOINT_TEXT =
+  "Could not reach any ComfyUI-Manager reboot endpoint — ComfyUI was NOT restarted " +
+  "(is the built-in Manager enabled?). Tried: POST /v2/manager/reboot → HTTP 405; " +
+  "GET /manager/reboot → HTTP 404";
+
+function nonError(text: string): ToolResult {
+  return { content: [{ type: "text", text }] };
+}
+
+/** ctx whose comfy_reboot reply is caller-supplied; nodes_queue_status probes
+ *  (readiness) always succeed so recovery resolves ready quickly. */
+function makeCtx(rebootReply: ToolResult): { ctx: PanelToolCtx; calls: string[] } {
+  const calls: string[] = [];
+  const ctx = {
+    call: async (cmd: { cmd: string }) => {
+      calls.push(cmd.cmd);
+      if (cmd.cmd === "comfy_reboot") return rebootReply;
+      return { content: [{ type: "text", text: "{}" }] }; // nodes_queue_status ok
+    },
+    confirm: async () => true,
+    bridge: {} as unknown,
+    tabId: "t",
+  } as unknown as PanelToolCtx;
+  return { ctx, calls };
+}
+
+function restartTool() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_restart_comfyui");
+  if (!def) throw new Error("panel_restart_comfyui not found");
+  return def;
+}
+
+beforeEach(() => {
+  hoisted.remoteMode.value = false;
+  hoisted.restart.mockClear();
+  hoisted.restart.mockResolvedValue({ stopped: true, started: true, ready: true, message: "restarted" });
+  __panelToolsTestHooks.setPanelRebootTiming({
+    settleMs: 0,
+    budgetMs: 50,
+    intervalMs: 1,
+    probeTimeoutMs: 5,
+  });
+});
+
+describe("rebootNoEndpoint classifier", () => {
+  it("matches a genuine no-endpoint refusal", () => {
+    expect(rebootNoEndpoint(nonError(NO_ENDPOINT_TEXT))).toBe(true);
+  });
+  it("does NOT match a busy-guard refusal", () => {
+    expect(
+      rebootNoEndpoint(nonError("Refused: a generation is in progress; restart aborted.")),
+    ).toBe(false);
+  });
+  it("does NOT match a Manager-security refusal", () => {
+    expect(
+      rebootNoEndpoint(nonError("Reboot refused (HTTP 403) — Manager security forbids it.")),
+    ).toBe(false);
+  });
+  it("does NOT match an error ToolResult (in-flight drop)", () => {
+    expect(rebootNoEndpoint({ isError: true, content: [{ type: "text", text: NO_ENDPOINT_TEXT }] })).toBe(false);
+  });
+});
+
+describe("panel_restart_comfyui — legacy no-endpoint fallback", () => {
+  it("LOCAL + no-endpoint → falls back to the headless managed restart and reports success", async () => {
+    const { ctx } = makeCtx(nonError(NO_ENDPOINT_TEXT));
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    expect(hoisted.restart).toHaveBeenCalledTimes(1);
+    const text = res.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/headless-managed-restart|managed restart/i);
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("LOCAL + no-endpoint but the managed restart can't start → actionable error", async () => {
+    hoisted.restart.mockResolvedValue({ stopped: false, started: false, message: "no process found" });
+    const { ctx } = makeCtx(nonError(NO_ENDPOINT_TEXT));
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/no reboot endpoint|no process found/i);
+  });
+
+  it("REMOTE + no-endpoint → does NOT kill+relaunch; returns the refusal verbatim", async () => {
+    hoisted.remoteMode.value = true;
+    const { ctx } = makeCtx(nonError(NO_ENDPOINT_TEXT));
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain("was NOT restarted");
+  });
+
+  it("busy-guard refusal → NEVER falls back (does not abort a running render)", async () => {
+    const { ctx } = makeCtx(nonError("Refused: a generation is in progress."));
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    expect(hoisted.restart).not.toHaveBeenCalled();
+    expect(res.content[0].text).toContain("in progress");
+  });
+});

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1041,6 +1041,36 @@ describe("node-management service", () => {
       );
       expect(probes.length).toBe(1);
     });
+
+    // ── #424: updating ComfyUI-Manager ITSELF on legacy 3.x can't go through the
+    // queue (it 405s the self-update route) → git-pull the local checkout instead.
+    it("update of comfyui-manager self falls back to a local git pull (never the queue)", async () => {
+      const { calls } = stubLegacyFetch();
+      mockedExists.mockReturnValue(true); // custom_nodes/ComfyUI-Manager/.git present
+      mockedExec.mockReturnValue("Already up to date." as unknown as Buffer);
+
+      const res = await updateCustomNode({ id: "comfyui-manager" });
+
+      expect(res.mechanism).toBe("git-clone");
+      // A git pull of the Manager checkout was run …
+      const pull = mockedExec.mock.calls.find(
+        ([bin, args]) =>
+          bin === "git" && Array.isArray(args) && args.includes("pull"),
+      );
+      expect(pull).toBeDefined();
+      // … and the Manager queue update route was NEVER touched.
+      expect(legacyCallTo(calls, "/manager/queue/update")).toBeUndefined();
+    });
+
+    it("update of Manager self with NO local checkout errors actionably (no queue call)", async () => {
+      const { calls } = stubLegacyFetch();
+      mockedExists.mockReturnValue(false); // no on-disk ComfyUI-Manager checkout
+
+      await expect(updateCustomNode({ id: "ComfyUI-Manager" })).rejects.toThrow(
+        /pip install -U comfyui_manager|git pull/i,
+      );
+      expect(legacyCallTo(calls, "/manager/queue/update")).toBeUndefined();
+    });
   });
 
   // ── issue #235: pip Manager in legacy-UI mode = the "v2-batch" dialect ────

--- a/src/__tests__/services/remote-restart.test.ts
+++ b/src/__tests__/services/remote-restart.test.ts
@@ -143,6 +143,84 @@ describe("restartComfyUI — remote (Manager reboot)", () => {
     expect(hoisted.resetClient).not.toHaveBeenCalled();
   });
 
+  it("legacy Manager 3.x (v2 405, legacy 404/405) → no-endpoint, actionable message; tries legacy POST too", async () => {
+    // Reproduces #425/#253/#266 at the reboot boundary: the v2 route 405s and the
+    // legacy GET 404s. Before the fix we stopped there; now we ALSO try POST
+    // /manager/reboot, and when everything fails we return an actionable note.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 50,
+      intervalMs: 5,
+    });
+    const rebootAttempts: string[] = [];
+    hoisted.fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        rebootAttempts.push(`${init?.method} ${path}`);
+        return new Response("405: Method Not Allowed", { status: 405 });
+      }
+      if (path === "/manager/reboot") {
+        rebootAttempts.push(`${init?.method} ${path}`);
+        // GET 404s (classic legacy symptom), POST also unsupported.
+        return new Response("not found", { status: init?.method === "GET" ? 404 : 405 });
+      }
+      return new Response("", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    expect(res.started).toBe(false);
+    // The legacy POST /manager/reboot fallback route is now attempted.
+    expect(rebootAttempts).toContain("POST /manager/reboot");
+    expect(res.message).toMatch(/legacy manager 3\.x/i);
+    expect(res.message).toMatch(/restart_comfyui/i);
+    // No endpoint fired → no readiness poll, no cache reset.
+    expect(findCall((p) => p === "/system_stats")).toBeUndefined();
+    expect(hoisted.resetClient).not.toHaveBeenCalled();
+  });
+
+  it("legacy GET /manager/reboot answered by the SPA catchall (200 HTML) is NOT a false reboot", async () => {
+    // codex P1: ComfyUI's frontend catchall serves the index HTML (200 text/html)
+    // for an unknown GET. A 200 there must NOT be classified as "reboot fired"
+    // (readiness — a still-up server — would rubber-stamp it). The legacy POST
+    // route must still be tried; when all fail → honest no-endpoint.
+    __processControlTestHooks.setRemoteRebootTimingForTests({
+      settleMs: 0,
+      budgetMs: 50,
+      intervalMs: 5,
+    });
+    const attempts: string[] = [];
+    hoisted.fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      const path = pathOf(url);
+      if (path === "/v2/manager/reboot") {
+        attempts.push(`${init?.method} ${path}`);
+        return new Response("405", { status: 405 });
+      }
+      if (path === "/manager/reboot") {
+        attempts.push(`${init?.method} ${path}`);
+        if (init?.method === "GET") {
+          // The SPA index — a 200 that is NOT a reboot.
+          return new Response("<!doctype html><html><body>ComfyUI</body></html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        return new Response("405", { status: 405 });
+      }
+      return new Response("", { status: 404 });
+    });
+
+    const res = await restartComfyUI();
+
+    // Did NOT falsely report a reboot off the HTML 200, and DID try the POST route.
+    expect(res.started).toBe(false);
+    expect(attempts).toContain("POST /manager/reboot");
+    expect(res.message).toMatch(/legacy manager 3\.x|no reachable/i);
+    // No readiness poll fired (nothing rebooted).
+    expect(findCall((p) => p === "/system_stats")).toBeUndefined();
+    expect(hoisted.resetClient).not.toHaveBeenCalled();
+  });
+
   it("local mode routes through stop/start — the remote reboot path is not taken", async () => {
     hoisted.remoteMode.value = false;
     // No PID on the port and no Desktop app process → stopComfyUI can't find it.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -54,6 +54,8 @@ import {
   resetObjectInfoCache,
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
+import { restartComfyUI } from "../services/process-control.js";
+import { isRemoteMode } from "../config.js";
 import { sliceWorkflow } from "../services/workflow-slicer.js";
 import { validateA2UISpecServer } from "../services/a2ui-spec.js";
 import type { UiWorkflow } from "../comfyui/types.js";
@@ -132,6 +134,30 @@ export function rebootDropped(res: ToolResult): boolean {
   return /disconnected mid-command|OUTCOME UNKNOWN|ECONNRESET|socket hang up|premature close|other side closed|ECONNABORTED|EPIPE/i.test(
     text,
   );
+}
+
+/**
+ * True when a comfy_reboot ToolResult is a NON-error, NON-fired refusal whose
+ * cause is that the panel could reach NO ComfyUI-Manager reboot endpoint — i.e.
+ * every Manager reboot route answered 404/405 (the classic legacy Manager 3.x
+ * symptom: `POST /v2/manager/reboot → 405; GET /manager/reboot → 404`,
+ * panel #253/#266 and this repo #425). This is distinct from:
+ *   - a busy-guard refusal (a generation is running) — its text speaks to the
+ *     queue/generation, never to a "reboot endpoint", so it does NOT match; and
+ *   - a Manager-security 403 refusal — that speaks to "security"/"forbidden".
+ * Only a no-endpoint refusal is safe to retry through the headless managed
+ * restart (kill + relaunch), and only for a LOCAL, process-controllable target.
+ */
+export function rebootNoEndpoint(res: ToolResult): boolean {
+  if (res?.isError) return false;
+  const text = res?.content?.find((c) => c.type === "text")?.text ?? "";
+  // A busy-guard / security refusal must never be treated as "no endpoint" — a
+  // kill+relaunch fallback would abort a running render or defeat the security
+  // gate. Require the reboot-endpoint signature AND the absence of those.
+  if (/busy|in progress|generation|queue is|running|security|forbidden|403/i.test(text)) {
+    return false;
+  }
+  return /reboot endpoint|reboot route|was NOT restarted|no reachable .*reboot/i.test(text);
 }
 
 interface PanelRebootTiming {
@@ -2377,6 +2403,56 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         const fired = rebootConfirmed(res);
         const dropped = !fired && rebootDropped(res);
         if (!fired && !dropped) {
+          // The panel could not fire a Manager reboot. If the SOLE reason is that
+          // NO Manager reboot endpoint answered (legacy Manager 3.x: v2 route 405s,
+          // legacy route 404s — #425, panel #253/#266) AND the target is a LOCAL,
+          // process-controllable ComfyUI, fall back to the headless managed restart
+          // (kill + relaunch) — the same mechanism as the `restart_comfyui` tool.
+          // A busy-guard or security refusal is deliberately NOT eligible
+          // (rebootNoEndpoint excludes those), so this never aborts a running
+          // render or bypasses Manager's security gate.
+          if (!isRemoteMode() && rebootNoEndpoint(res)) {
+            let restart: Awaited<ReturnType<typeof restartComfyUI>> | undefined;
+            try {
+              restart = await restartComfyUI();
+            } catch (err) {
+              return fail(
+                "The built-in Manager exposed no reboot endpoint (legacy Manager 3.x), " +
+                  "and the headless managed restart also failed: " +
+                  (err instanceof Error ? err.message : String(err)) +
+                  " — restart ComfyUI on the host, then reconnect.",
+              );
+            }
+            if (!restart.started) {
+              return fail(
+                "The built-in Manager exposed no reboot endpoint (legacy Manager 3.x). " +
+                  "Tried the headless managed restart (kill + relaunch) as a fallback, but it " +
+                  `could not restart ComfyUI: ${restart.message} ` +
+                  "Restart ComfyUI on the host, then reconnect.",
+              );
+            }
+            // A managed kill+relaunch restarts ComfyUI out-of-band from the WS
+            // client, so drop the memoized caches exactly as the Manager-reboot
+            // path does before waiting for the panel to reconnect.
+            resetClient();
+            resetObjectInfoCache();
+            const timing = getPanelRebootTiming();
+            const recovery = await waitForPanelReady(ctx, timing);
+            return ok({
+              rebooting: true,
+              ready: recovery.ready,
+              recovered_ms: recovery.waited_ms,
+              probes: recovery.attempts,
+              via: "headless-managed-restart",
+              note:
+                "ComfyUI-Manager (legacy 3.x) had no reboot endpoint; restarted ComfyUI " +
+                `via the headless managed restart (kill + relaunch)${
+                  recovery.ready
+                    ? ` and it came back ready in ${(recovery.waited_ms / 1000).toFixed(1)}s.`
+                    : " but the panel did not reconnect within the readiness budget — verify with panel_node_queue_status."
+                }`,
+            });
+          }
           // Genuine refusal (or an unrelated error) — do NOT poll or reset caches.
           // Resetting on a refusal would close the shared client mid-generation
           // (codex WS-3 finding #2).

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1143,6 +1143,52 @@ export interface UpdateOptions {
   useCmCli?: boolean;
 }
 
+/** Does this update target refer to ComfyUI-Manager itself (any spelling)? */
+function isManagerSelfTarget(id: string): boolean {
+  const norm = basename(id.trim().toLowerCase()).replace(/[_\s]+/g, "-");
+  return norm === "comfyui-manager" || norm === "comfy-manager";
+}
+
+/**
+ * Directly git-pull the local custom_nodes/ComfyUI-Manager checkout as a
+ * fallback for the one op the legacy 3.x queue can't do — update the running
+ * Manager itself (#424). Returns undefined when there is no local install or no
+ * on-disk Manager checkout (e.g. pip comfyui_manager, which has no custom_nodes
+ * clone), so the caller can surface an actionable error. A NodeManagementError
+ * from the git pull itself propagates.
+ */
+function updateManagerSelfLocally(): NodeOpResult | undefined {
+  if (!config.comfyuiPath) return undefined;
+  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
+  const dir = ["ComfyUI-Manager", "comfyui-manager", "comfyui_manager"]
+    .map((d) => join(customNodesRoot, d))
+    .find((p) => existsSync(join(p, ".git")));
+  if (!dir) return undefined;
+  try {
+    const out = execFileSync("git", ["-C", dir, "pull", "--ff-only"], {
+      cwd: config.comfyuiPath,
+      encoding: "utf-8",
+      timeout: GIT_CLONE_TIMEOUT,
+      env: nonInteractiveGitEnv(),
+    });
+    return {
+      mechanism: "git-clone",
+      message:
+        `Updated ComfyUI-Manager itself via a direct git pull of ${dir} ` +
+        `(the legacy 3.x queue can't self-update the running Manager). ` +
+        `RESTART ComfyUI to load the new Manager.`,
+      details: out.trim(),
+    };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
+    throw new NodeManagementError(
+      `git pull of the local ComfyUI-Manager checkout (${dir}) failed: ${e.message}. ` +
+        `Update it manually (git pull, or pip install -U comfyui_manager) then restart ComfyUI.`,
+      { stdout: e.stdout?.toString() ?? "", stderr: e.stderr?.toString() ?? "" },
+    );
+  }
+}
+
 export function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
   return withObjectInfoInvalidation(() => updateCustomNodeImpl(opts));
 }
@@ -1162,6 +1208,25 @@ async function updateCustomNodeImpl(
         : `Updated "${id}" via official comfy-cli.`,
       details: out.trim(),
     };
+  }
+
+  // Updating ComfyUI-Manager ITSELF through its own task queue is the one op the
+  // queue can't reliably perform: legacy Manager 3.x 405s the update route for
+  // the running Manager pack, so the in-panel 3.x→v4 upgrade path deadlocks
+  // (#424). When the target IS the Manager pack and we have a LOCAL install, do
+  // a direct `git pull` of the custom_nodes/ComfyUI-Manager checkout instead —
+  // the only in-repo way to actually advance it (a restart then loads the new
+  // code). Remote targets can't be git-controlled → clear, actionable error.
+  if (!all && isManagerSelfTarget(id) && (await detectManagerApi()) === "legacy") {
+    const local = updateManagerSelfLocally();
+    if (local) return local;
+    throw new NodeManagementError(
+      `Updating ComfyUI-Manager itself is not supported over the LEGACY Manager 3.x queue ` +
+        `API (it 405s the self-update route — #424), and no LOCAL custom_nodes/ComfyUI-Manager ` +
+        `checkout was found to git-pull directly. Update ComfyUI-Manager on the host ` +
+        `(git pull in custom_nodes/ComfyUI-Manager, or pip install -U comfyui_manager), then ` +
+        `restart ComfyUI.`,
+    );
   }
 
   let status: QueueStatus;

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1084,9 +1084,17 @@ interface RebootResult {
 // getComfyUIBaseUrl() with no `/api` prefix — the panel's `/api/...` form is only
 // because its browser `api.fetchApi` prepends `/api`). Canonical v4 POST route
 // first, then the legacy GET route for older Manager builds.
+// TWO Manager generations serve reboot on DIFFERENT routes+verbs (issue #116):
+//   • v4 lineage (pip comfyui_manager ≥4.x): POST /v2/manager/reboot
+//   • released Manager 3.x legacy: GET /manager/reboot — and some 3.x builds
+//     register it under POST, so we try both verbs on the legacy path before
+//     giving up (panel #253/#266, this repo #425). ComfyUI's frontend catchall
+//     answers unknown GETs 200/404 and unregistered POSTs 405, so a wrong route
+//     surfaces as 404/405 and we fall through to the next candidate.
 const REBOOT_ROUTES: ReadonlyArray<{ path: string; method: "POST" | "GET" }> = [
   { path: "/v2/manager/reboot", method: "POST" },
   { path: "/manager/reboot", method: "GET" },
+  { path: "/manager/reboot", method: "POST" },
 ];
 
 /**
@@ -1114,6 +1122,26 @@ function isConnectionDrop(err: unknown): boolean {
  *   REFUSED (rebooting:false) — HTTP 403 → Manager security forbids remote reboot.
  *   NO-ENDPOINT (rebooting:false) — every route gave a non-firing failure (e.g. 404).
  */
+/**
+ * True when a 200 response is (almost certainly) ComfyUI's frontend SPA catchall
+ * rather than a real Manager reboot ack. The catchall serves the index HTML with
+ * Content-Type text/html; a Manager reboot route either drops the connection or
+ * returns a tiny non-HTML body. Best-effort and defensive: any read error →
+ * treat as NOT a catchall (don't suppress a genuine ack on a transient read
+ * failure).
+ */
+async function looksLikeSpaCatchall(res: Response): Promise<boolean> {
+  try {
+    const ctype = (res.headers.get("content-type") ?? "").toLowerCase();
+    if (ctype.includes("text/html")) return true;
+    // No/unknown content-type: sniff the first bytes for an HTML document.
+    const body = (await res.clone().text()).trimStart().slice(0, 256).toLowerCase();
+    return body.startsWith("<!doctype html") || body.startsWith("<html");
+  } catch {
+    return false;
+  }
+}
+
 async function rebootViaManager(): Promise<RebootResult> {
   const base = getComfyUIBaseUrl();
   const failures: string[] = [];
@@ -1122,7 +1150,21 @@ async function rebootViaManager(): Promise<RebootResult> {
     const url = `${base}${path}`;
     try {
       const res = await comfyuiFetch(url, { method });
-      if (res.ok) return { rebooting: true, endpoint: path, method };
+      if (res.ok) {
+        // GUARD (codex P1): ComfyUI's frontend catchall answers an UNKNOWN GET
+        // with the SPA index — HTTP 200 text/html — so a 200 here does NOT prove
+        // a reboot route exists. A genuine Manager reboot handler exits before it
+        // can respond (→ a connection drop, handled below) or returns a tiny
+        // non-HTML ack; treat a 200 that looks like the HTML catchall as "route
+        // absent" and fall through to the next candidate rather than falsely
+        // reporting a reboot that never fired (which readiness — a still-up
+        // server — would then rubber-stamp as success).
+        if (await looksLikeSpaCatchall(res)) {
+          failures.push(`${method} ${path} → HTTP 200 (frontend catchall, not a reboot route)`);
+          continue;
+        }
+        return { rebooting: true, endpoint: path, method };
+      }
       if (res.status === 403) {
         return {
           rebooting: false,
@@ -1160,9 +1202,12 @@ async function rebootViaManager(): Promise<RebootResult> {
   return {
     rebooting: false,
     reason: "no-endpoint",
-    note: `No reachable ComfyUI-Manager reboot endpoint.${
-      failures.length ? ` Tried: ${failures.join("; ")}` : ""
-    }`,
+    note:
+      `No reachable ComfyUI-Manager reboot endpoint (this ComfyUI likely runs the ` +
+      `LEGACY Manager 3.x, which does not expose an HTTP reboot route).${
+        failures.length ? ` Tried: ${failures.join("; ")}.` : ""
+      } For a LOCAL install, use the headless restart_comfyui tool (kill + relaunch); ` +
+      `otherwise restart ComfyUI on the host, or upgrade to Manager v4+.`,
   };
 }
 


### PR DESCRIPTION
## Manager dialect routing + fallback (3.x-legacy ⇄ v4/Desktop)

The Manager-backed tools failed against **both** ends of the ComfyUI-Manager range: legacy 3.x and v4/Desktop. The dialect detection for list/install/update already existed (`detectManagerApi` → `v2` / `v2-batch` / `legacy`); this PR closes the remaining gaps in **reboot** and **Manager self-update**, and makes every op end in a compatible route, a fallback, or a clear actionable error.

### Changes
- **reboot** (`process-control.ts`): try `POST /v2/manager/reboot`, `GET /manager/reboot`, and (new) `POST /manager/reboot` for legacy 3.x builds. Guard against ComfyUI's SPA catchall answering an unknown GET with `200 text/html` — previously that was misclassified as "reboot fired" and rubber-stamped by readiness (silent false success). No-endpoint failure is now actionable (local → `restart_comfyui`; remote → restart on host / upgrade to v4+).
- **`panel_restart_comfyui`** (`panel-tools.ts`): when the built-in Manager exposes **no** reboot endpoint (legacy 3.x) **and** the target is LOCAL, fall back to the headless managed restart (kill + relaunch). New exported `rebootNoEndpoint()` classifier deliberately **excludes** busy-guard and security-403 refusals, so the fallback never aborts a running render or defeats Manager security.
- **Manager self-update** (`node-management.ts`): updating ComfyUI-Manager itself over the legacy 3.x queue 405s → fall back to a direct `git pull --ff-only` of the local `custom_nodes/ComfyUI-Manager` checkout; no local checkout → actionable error (pip/git instructions).

### Tests
Per-op unit tests covering 3.x-legacy vs v4/Desktop endpoint selection and the 405 / no-endpoint → fallback path (fail-before / pass-after, HTTP boundary mocked): legacy reboot route probing + actionable message, the `200`-HTML catchall regression, the local kill+relaunch fallback, busy-guard/remote non-fallback, and Manager self git-pull. Full suite green except the known node-dev ripgrep sandbox failure.

### Codex review
Read-only codex gate: **VERDICT: PASS** (a first pass caught a P1 — the SPA-catchall false-success — which is fixed in this PR; re-review passed with no findings).

Closes #423
Closes #424
Closes #425
Closes #371
Addresses #366 (external model-search Manager-v4 detection — root cause fixed via shared generation-detection; verify against the live panel before closing, so NOT auto-closing)

### Also fixes (panel repo — close manually):
`artokun/comfyui-mcp-panel#258` `#301` `#253` `#266`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
