### PR TITLE
release: 0.48.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.20] - 2026-07-30
+
+### Fixed
+- **`comfy_cli_*` tools resolve the workspace/venv CLI and fall back to the connected server (#506, #403, #360, #487).** Custom-node source tools now resolve the CLI from the saved default workspace when `COMFYUI_PATH` is unset (#506, #403); `comfy_cli_models` falls back to the connected server's API when the CLI is present-but-unsupported (not only absent — #487); and `comfy_cli_jobs` wait accepts the documented singular `promptId` (#360). (#510)
+- **Graph tools resolve a single authoritative workflow-tab target + rebind after reconnect (#478, #481, #459).** Pinned/active/nested-exec graph calls now resolve to the SAME correct tab (canonical `workflow_path` injection, fail-closed, strict rebind) instead of reading/editing a different workflow, and the session rebinds (with node-info cache invalidation) after a reboot/reload. (#512)
+- **Manager client detects and routes to ComfyUI-Manager 3.x-legacy vs v4/Desktop dialects (#423, #424, #425, #371).** Reboot now probes v2-POST → legacy-GET → legacy-POST with an SPA-catchall guard (a `200 text/html` from an unknown GET is no longer mistaken for a fired reboot); `panel_restart_comfyui` falls back to the headless managed restart for a LOCAL server with no working reboot endpoint (never for remote, never during a render); and legacy Manager self-update falls back to `git pull`. (#513)
+
 ## [0.48.19] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.19",
+  "version": "0.48.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.19",
+      "version": "0.48.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.19",
+  "version": "0.48.20",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.20** (pushed → npm publish via release.yml). Bundles the 3 post-reboot merges.

## Ships
- **#510 (P8):** comfy_cli workspace/venv resolution + connected-server fallback + `promptId` (#506/#403/#360/#487).
- **#512:** single authoritative graph-tool tab-target + session rebind (#478/#481/#459).
- **#513:** Manager 3.x-legacy vs v4/Desktop dialect routing + reboot/self-update fallbacks (#423/#424/#425/#371).

All codex PASS; #512+#513 trial-merged together (132 restart/session tests green, no semantic conflict). Merge with a **MERGE commit** so v0.48.20 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)