### PR TITLE
chore: gitignore /.discord/ (local watchdog toolkit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ orch.err.log
 /design/mobile-agent-client.md
 /design/remote-and-cloud-modes.md
 /blog/comfyui-mcp-tdqs-case-study.md
+
+# Local Discord watchdog/notifier toolkit (token read from ~/.claude.json at runtime; not committed)
+/.discord/


### PR DESCRIPTION
Ignores the local `.discord/` Discord CLI (token read from `~/.claude.json` at runtime — nothing secret on disk). Prevents it being committed and makes the ignore survive `git reset --hard`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)