### PR TITLE
fix(convert): never silently substitute comboOpts[0] for a user-staged value + refresh stale loader dropdowns (#504, #499)

### DIFF
--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -742,6 +742,36 @@ describe("convertUiToApi — true-enum over-preservation guard (P0 regression, #
     expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
   });
 
+  it("WARNS (not silent) when a combo has ZERO options on the server", () => {
+    // An empty option list ([[], {}]) — e.g. no models installed — has nothing to
+    // substitute to. The saved literal is kept, but must be flagged, not silently
+    // emitted as an out-of-list value the server will reject.
+    const info = {
+      EmptyEnum: {
+        input: { required: { mode: [[], {}] } },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 504,
+          type: "EmptyEnum",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["retired"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["504"].inputs.mode).toBe("retired");
+    expect(
+      warnings.some((w) => w.includes("504") && w.includes("retired")),
+    ).toBe(true);
+  });
+
   it("validates has_serialized_properties overwrites too — invalid enum substitutes", () => {
     // Authoritative node.properties overwrite the positional mapping AFTER combo
     // validation; an invalid enum restored there previously leaked unvalidated to
@@ -778,6 +808,929 @@ describe("convertUiToApi — true-enum over-preservation guard (P0 regression, #
     expect(workflow["11"].inputs.mode).not.toBe("z");
     expect(
       warnings.some((w) => w.includes("11") && /substituting/.test(w)),
+    ).toBe(true);
+  });
+});
+
+describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)", () => {
+  // A PrimitiveNode wired into a combo input provides a LITERAL value that is
+  // assigned AFTER the widget-value validation (widgets first, links after), so
+  // it previously bypassed combo validation entirely: an out-of-list literal
+  // overwrote the validated widget value and reached the API unchecked.
+
+  it("SUBSTITUTES+warns an out-of-list enum fed by a linked PrimitiveNode", () => {
+    const info = {
+      KSamplerSelect: {
+        input: { required: { sampler_name: [["euler", "dpmpp_2m"]] } },
+        input_order: { required: ["sampler_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["removed_sampler"], // no longer a valid option
+        },
+        {
+          id: 2,
+          type: "KSamplerSelect",
+          mode: 0,
+          inputs: [{ name: "sampler_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["euler"], // valid, but the link overrides it
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The stale primitive literal must NOT reach the API — substituted to first opt.
+    expect(workflow["2"].inputs.sampler_name).toBe("euler");
+    expect(workflow["2"].inputs.sampler_name).not.toBe("removed_sampler");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("removed_sampler") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("PRESERVES+warns a stale LOADER asset fed by a linked PrimitiveNode", () => {
+    const info = {
+      CheckpointLoaderSimple: {
+        input: { required: { ckpt_name: [["installed.safetensors"]] } },
+        input_order: { required: ["ckpt_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["not_installed.safetensors"],
+        },
+        {
+          id: 2,
+          type: "CheckpointLoaderSimple",
+          mode: 0,
+          inputs: [{ name: "ckpt_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // A loader asset is preserved (honest missing-asset), NOT swapped to opt[0].
+    expect(workflow["2"].inputs.ckpt_name).toBe("not_installed.safetensors");
+    expect(workflow["2"].inputs.ckpt_name).not.toBe("installed.safetensors");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("not_installed.safetensors") &&
+          /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an invalid dynamic-combo NESTED value fed by a linked PrimitiveNode (dotted key)", () => {
+    // A PrimitiveNode wired straight into a dotted "<combo>.<leaf>" nested input:
+    // validateComboWidgetValue's top-level lookup can't find "model.aspect_ratio",
+    // so the resolver must recover the LEAF spec from the selected option.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["4:3"], // invalid aspect_ratio
+        },
+        {
+          id: 2,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2"], // selects the option; leaf is linked
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.aspect_ratio"]).toBe("auto");
+    expect(workflow["2"].inputs["model.aspect_ratio"]).not.toBe("4:3");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("aspect_ratio") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("PRESERVES+warns a stale NESTED loader asset fed by a linked PrimitiveNode (dotted key)", () => {
+    // The leaf name (lora_name) is a model-loader selector, so a stale value must
+    // be preserved (honest missing-asset) even when supplied through the dotted
+    // override path — leaf-name classification must survive the resolver.
+    const info = {
+      DynLoraNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "with-lora",
+                    inputs: {
+                      required: {
+                        lora_name: ["COMBO", { options: ["installed.safetensors"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["not_installed.safetensors"],
+        },
+        {
+          id: 2,
+          type: "DynLoraNode",
+          mode: 0,
+          inputs: [{ name: "model.lora_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["with-lora"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.lora_name"]).toBe("not_installed.safetensors");
+    expect(workflow["2"].inputs["model.lora_name"]).not.toBe("installed.safetensors");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("not_installed.safetensors") &&
+          /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an invalid OPTIONAL dynamic-combo nested leaf fed by a linked PrimitiveNode", () => {
+    // V3 option inputs can live under `optional`, not just `required` — the
+    // resolver must search both or the leaf spec is missing and validation skipped.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      optional: {
+                        output_format: ["COMBO", { options: ["png", "webp"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["gif"], // invalid output_format
+        },
+        {
+          id: 2,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.output_format", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.output_format"]).toBe("png");
+    expect(workflow["2"].inputs["model.output_format"]).not.toBe("gif");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("output_format") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT consume a positional slot for a LINKED nested leaf — trailing widget stays aligned", () => {
+    // model.aspect_ratio is converted-to-input (linked), so it has NO positional
+    // widgets_values entry: ["Nano Banana 2", 12345] = [model, seed]. Consuming a
+    // slot for the linked leaf would steal seed's value. It must be skipped.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2", 12345], // aspect_ratio linked = no slot
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["1:1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // seed keeps its real value — not stolen by the linked nested leaf.
+    expect(workflow["1"].inputs.seed).toBe(12345);
+    // and the nested leaf comes from the link.
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("1:1");
+  });
+
+  it("re-anchors nested leaves when a PrimitiveNode overrides the dynamic PARENT (A -> B)", () => {
+    // Positional mapping emits model="A" and validates model.choice="a1" against
+    // A. A PrimitiveNode then overrides the parent model="B". Without a final
+    // re-anchor, model.choice="a1" (valid for A, invalid for B) reaches the API.
+    const info = {
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["B"], // overrides the parent selection
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"], // saved under option A
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.model).toBe("B");
+    // model.choice must be re-anchored to B's options, NOT left as A's "a1".
+    expect(workflow["3"].inputs["model.choice"]).not.toBe("a1");
+    expect(["b1", "b2"]).toContain(workflow["3"].inputs["model.choice"]);
+  });
+
+  it("drops a wrong-option nested leaf when the dynamic PARENT is fed by a real link", () => {
+    // model is fed by a NON-Primitive link (runtime value unknown), and the saved
+    // nested model.choice="a1" belongs to option A. Since the resolved option
+    // could be B (choice=[b1,b2]), the option-dependent literal must be dropped —
+    // not left as a wrong-option "a1" in the prompt.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // model is a link ref; the wrong-option leaf must be gone.
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("drops a linked-leaf literal under a link-ref parent whose option combo is EMPTY (no silent literal)", () => {
+    // model (parent) is a real link; model.choice (leaf) is a linked PrimitiveNode
+    // "retired"; the option's choice combo is empty [[], {}]. The leaf must NOT be
+    // silently kept — with no valid membership under any option it is dropped.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { choice: [[], {}] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: ["retired"],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // No silent out-of-list "retired" literal on model.choice.
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("leaves a VALID enum fed by a linked PrimitiveNode untouched (no warn)", () => {
+    const info = {
+      KSamplerSelect: {
+        input: { required: { sampler_name: [["euler", "dpmpp_2m"]] } },
+        input_order: { required: ["sampler_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["dpmpp_2m"],
+        },
+        {
+          id: 2,
+          type: "KSamplerSelect",
+          mode: 0,
+          inputs: [{ name: "sampler_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["euler"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs.sampler_name).toBe("dpmpp_2m");
+    expect(warnings.some((w) => /substituting|missing-asset/.test(w))).toBe(
+      false,
+    );
+  });
+});
+
+describe("convertUiToApi — option-bearing / dynamic nested combo validation (P1-B, #504)", () => {
+  // The option-list extraction only read spec[0] as the options array, so it
+  // MISSED the ["COMBO",{options:[...]}] form and V3 dynamic-combo nested combos —
+  // those values were copied raw and reached the API unvalidated.
+
+  it("SUBSTITUTES+warns an out-of-list nested value in a V3 dynamic combo", () => {
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            prompt: ["STRING"],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["prompt", "model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a prompt", "Nano Banana 2", "4:3"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.model).toBe("Nano Banana 2");
+    // The nested "4:3" is not a valid aspect_ratio option — substituted to "auto".
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("auto");
+    expect(workflow["1"].inputs["model.aspect_ratio"]).not.toBe("4:3");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("aspect_ratio") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves a VALID nested dynamic-combo value untouched (no warn)", () => {
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            prompt: ["STRING"],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["prompt", "model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a prompt", "Nano Banana 2", "16:9"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("16:9");
+    expect(warnings.some((w) => /substituting|missing-asset/.test(w))).toBe(
+      false,
+    );
+  });
+
+  it("does NOT consume nested slots for a STALE (substituted) dynamic parent — trailing widget stays aligned", () => {
+    // Saved parent "removed-model" is no longer an option and is substituted to
+    // "new-model". The saved array was serialized against the OLD option's layout
+    // (here: no nested widgets), so its nested arity is unrecoverable. We must
+    // consume NO nested slots against the replacement's layout — doing so would
+    // steal the trailing `seed` value. seed must survive; the required nested
+    // aspect_ratio of the replacement is left to default-fill.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "new-model",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // OLD option had no nested widgets: [model(stale), seed]
+          widgets_values: ["removed-model", 12345],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.model).toBe("new-model");
+    // seed is NOT stolen by an ambiguous nested slot.
+    expect(workflow["1"].inputs.seed).toBe(12345);
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && w.includes("removed-model") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips the phantom control_after_generate slot after a NESTED seed widget", () => {
+    // A dynamic option exposing a nested controlled seed carries a phantom
+    // "fixed"/"randomize" value after it (like top-level seeds). Not skipping it
+    // shifts every following widget: aspect_ratio would eat "fixed" and steps
+    // would eat "16:9".
+    const info = {
+      SeededNanoNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "new-model",
+                    inputs: {
+                      required: {
+                        seed: ["INT", { control_after_generate: true }],
+                        aspect_ratio: ["COMBO", { options: ["1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            steps: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "steps"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "SeededNanoNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // [model, nested seed, phantom "fixed", nested aspect_ratio, steps]
+          widgets_values: ["new-model", 42, "fixed", "16:9", 7],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs["model.seed"]).toBe(42);
+    // aspect_ratio must be "16:9", NOT the phantom "fixed".
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("16:9");
+    // steps must land on 7, not be shifted onto "16:9".
+    expect(workflow["1"].inputs.steps).toBe(7);
+  });
+
+  it("SUBSTITUTES+warns an out-of-list required combo DEFAULT (schema-drift default-fill)", () => {
+    // A required combo whose own schema `default` is not among its options (custom
+    // node version drift). With no saved widget value the default-fill loop emits
+    // it — it must be validated (substituted to first option), not passed raw.
+    const info = {
+      DriftySampler: {
+        input: {
+          required: {
+            sampler_name: [["euler", "dpmpp_2m"], { default: "removed_sampler" }],
+          },
+        },
+        input_order: { required: ["sampler_name"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 77,
+          type: "DriftySampler",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [], // nothing saved -> default-fill path
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["77"].inputs.sampler_name).toBe("euler");
+    expect(workflow["77"].inputs.sampler_name).not.toBe("removed_sampler");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("77") &&
+          w.includes("removed_sampler") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("consumes+validates an OPTIONAL positional nested leaf and keeps later widget index aligned", () => {
+    // A V3 option whose nested widget lives under `optional`. It occupies a
+    // positional widgets_values slot; reading only `required` would skip it and
+    // mis-position the trailing top-level `seed` widget. The nested value must be
+    // validated (substituted) AND the following widget must still land correctly.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      optional: {
+                        output_format: ["COMBO", { options: ["png", "webp"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // model, model.output_format (optional nested), seed
+          widgets_values: ["Nano Banana 2", "gif", 12345],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The optional nested leaf is consumed + validated (gif -> png).
+    expect(workflow["1"].inputs["model.output_format"]).toBe("png");
+    // …and the trailing top-level `seed` still lands on the right slot.
+    expect(workflow["1"].inputs.seed).toBe(12345);
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && w.includes("output_format") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an out-of-list value on a top-level [\"COMBO\",{options}] spec", () => {
+    const info = {
+      ApiImageNode: {
+        input: {
+          required: {
+            response_modalities: [
+              "COMBO",
+              { options: ["IMAGE", "IMAGE+TEXT"] },
+            ],
+          },
+        },
+        input_order: { required: ["response_modalities"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ApiImageNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["AUDIO"], // not an option — helper missed this shape before
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.response_modalities).toBe("IMAGE");
+    expect(workflow["1"].inputs.response_modalities).not.toBe("AUDIO");
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && w.includes("AUDIO") && /substituting/.test(w),
+      ),
     ).toBe(true);
   });
 });

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -456,3 +456,101 @@ describe("convertUiToApi — asset-combo fallback (issue #407)", () => {
     expect(workflow["1"].inputs.ckpt_name).toBe("not-installed.pt2");
   });
 });
+
+describe("convertUiToApi — media-combo fallback (issue #504)", () => {
+  // A LoadImage node whose `image` widget points at a freshly staged upload
+  // (2Dto3D_v2_front_clean.png) that isn't yet in the CONNECTED server's STALE
+  // /object_info combo (which still only lists KENT_concept_00012_.png). Before
+  // the fix, media values failed looksLikeAssetFilename() so comboOpts[0]
+  // silently replaced the user's image — headless execution then ran on the
+  // WRONG source image with no warning.
+  const STALE_INFO = {
+    LoadImage: {
+      input: {
+        required: {
+          image: [["KENT_concept_00012_.png"]],
+          upload: ["IMAGE_UPLOAD"],
+        },
+      },
+    },
+  } as never;
+
+  function loadImageGraph(image: string) {
+    return {
+      nodes: [
+        {
+          id: 12,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [
+            { name: "IMAGE", type: "IMAGE", links: [] },
+            { name: "MASK", type: "MASK", links: [] },
+          ],
+          widgets_values: [image, "image"],
+        },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("PRESERVES a staged LoadImage value NOT in the stale combo (never comboOpts[0])", () => {
+    const staged = "2Dto3D_v2_front_clean.png";
+    const { workflow, warnings } = convertUiToApi(loadImageGraph(staged), STALE_INFO);
+    // The staged image survives — NOT silently rewritten to the first cached file.
+    expect(workflow["12"].inputs.image).toBe(staged);
+    expect(workflow["12"].inputs.image).not.toBe("KENT_concept_00012_.png");
+    // …and the substitution is flagged so it surfaces as an honest missing-asset error.
+    expect(
+      warnings.some(
+        (w) => w.includes("12") && w.includes(staged) && /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn or alter a LoadImage value that IS present on the server", () => {
+    const { workflow, warnings } = convertUiToApi(
+      loadImageGraph("KENT_concept_00012_.png"),
+      STALE_INFO,
+    );
+    expect(workflow["12"].inputs.image).toBe("KENT_concept_00012_.png");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("preserves an extensionless staged image via the media widget-name allowlist", () => {
+    // Some staged inputs carry a subfolder path with no extension; the value has
+    // no file suffix and the stale combo has none either, so detection must fall
+    // back to the `image` widget-name allowlist rather than substituting.
+    const { workflow, warnings } = convertUiToApi(
+      loadImageGraph("clipspace/staged_input"),
+      STALE_INFO,
+    );
+    expect(workflow["12"].inputs.image).toBe("clipspace/staged_input");
+    expect(workflow["12"].inputs.image).not.toBe("KENT_concept_00012_.png");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("preserves a staged .mp4 media value for a video loader (extension coverage)", () => {
+    const info = {
+      VHS_LoadVideo: {
+        input: { required: { video: [["cached_clip.mp4"]] } },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "VHS_LoadVideo",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["freshly_staged.mp4"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.video).toBe("freshly_staged.mp4");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -1746,11 +1746,21 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
         [11, 2, 0, 3, 1, "COMBO"],
       ],
     } as never;
-    const { workflow } = convertUiToApi(ui, info);
+    const { workflow, warnings } = convertUiToApi(ui, info);
     // Parent stays a runtime link ref…
     expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
     // …but the leaf, not defined by every option, is dropped (would orphan under B).
     expect("model.choice" in workflow["3"].inputs).toBe(false);
+    // …and the drop MUST be warned (FIX 2) — a silently removed link is the bug class.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("3") &&
+          w.includes("model.choice") &&
+          w.includes("model") &&
+          /dropped|link/.test(w),
+      ),
+    ).toBe(true);
   });
 
   it("KEEPS a real-LINK dotted leaf under a real-LINK parent when EVERY option defines the leaf", () => {
@@ -2524,6 +2534,81 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
     expect(workflow["1"].inputs.first).toBe("A");
     // The empty-options parent's declared value is preserved, NOT deleted.
     expect(workflow["1"].inputs.second).toBe("my-model");
+  });
+
+  it("does NOT delete VALID earlier values when a LATER combo refuses — a refusal's expected leftover is not a drift signal (#517 FIX 1 no-false-positive)", () => {
+    // `first` is a valid dynamic combo with a correctly-mapped nested leaf
+    // (first.note="hello"); `count`=7 is an ordinary widget after it; `second` is a
+    // dynamic combo whose nested `choice` is LINKED, so it hits the linked-leaf
+    // refusal with saved values remaining. The refusal INTENTIONALLY leaves a
+    // leftover — that leftover must NOT be read as "first drifted" and cause the guard
+    // to delete the perfectly valid first.note and count. (A refusal suppresses the
+    // drift guard for the whole node; earlier drift, if any, is positionally
+    // indistinguishable from this valid layout and falls to the accepted limitation.)
+    const info = {
+      MixedNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { note: ["STRING", {}] } },
+                  },
+                ],
+              },
+            ],
+            count: ["INT", { default: 0 }],
+            second: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Y",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["y1"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["first", "count", "second"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "MixedNode",
+          mode: 0,
+          // second.choice is converted-to-input (linked).
+          inputs: [{ name: "second.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "hello", 7, "Y", 424242],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["y1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The valid earlier nested leaf and widget must be PRESERVED, not deleted.
+    expect(workflow["1"].inputs["first.note"]).toBe("hello");
+    expect(workflow["1"].inputs.count).toBe(7);
+    // The later linked-leaf combo keeps its saved selection.
+    expect(workflow["1"].inputs.second).toBe("Y");
   });
 
   it("PRESERVES a shared SCALAR required leaf under a runtime-linked dynamic parent — not dropped as a non-member (#517 false-positive)", () => {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -2107,6 +2107,60 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
     ).toBe(true);
   });
 
+  it("REFUSES (warn + default) when a stale dynamic parent has an EMPTY current options list — the type marker, not the option-key heuristic, must fire the guard (#517 P0 empty-options)", () => {
+    // The CURRENT schema's dynamic combo has NO options at all
+    // (["COMFY_DYNAMICCOMBO_V3", {options: []}]) — e.g. its option source hasn't
+    // populated yet, or every option was removed. The saved selection is therefore
+    // stale by definition, and the OLD option owned a nested strength=0.75 sitting
+    // between the parent and the trailing `seed`. An empty options array has NO
+    // keyed {key,inputs} entries, so the object-key heuristic reports NOT-dynamic
+    // and the stale-parent guard would be BYPASSED — the loop would silently map
+    // seed=0.75 (the orphaned nested value) and treat 42 as a phantom slot. Keying
+    // the guard off the EXPLICIT type string ("COMFY_DYNAMICCOMBO_V3") fires the
+    // refusal here too: seed keeps its schema default, and 0.75 never lands on it.
+    const info = {
+      EmptyOptsNode: {
+        input: {
+          required: {
+            model: ["COMFY_DYNAMICCOMBO_V3", { options: [] }],
+            seed: ["INT", { default: 0 }],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "EmptyOptsNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // OLD removed option owned strength=0.75; saved
+          // [model, strength(nested), seed, control-phantom].
+          widgets_values: ["removed-option", 0.75, 42, "fixed"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The parent itself is preserved (an empty option list can't substitute it).
+    // The critical invariant: seed is NOT the silently-shifted orphaned 0.75.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    // seed falls to its schema default rather than an ambiguous positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The refusal is warned (not silent) and names the stale selection.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("removed-option") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
   it("PRESERVES a shared SCALAR required leaf under a runtime-linked dynamic parent — not dropped as a non-member (#517 false-positive)", () => {
     // `mode` is fed by a real (non-Primitive) link, so the resolved option is
     // unknown at convert time. BOTH options define a required SCALAR `strength`

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -1889,13 +1889,15 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
     );
   });
 
-  it("does NOT consume nested slots for a STALE (substituted) dynamic parent — trailing widget stays aligned", () => {
+  it("REFUSES to map trailing widgets after a STALE dynamic parent when a trailing widget is control-eligible (ambiguous slot count) — no stale value on seed (#517 P0)", () => {
     // Saved parent "removed-model" is no longer an option and is substituted to
-    // "new-model". The saved array was serialized against the OLD option's layout
-    // (here: no nested widgets), so its nested arity is unrecoverable. We must
-    // consume NO nested slots against the replacement's layout — doing so would
-    // steal the trailing `seed` value. seed must survive; the required nested
-    // aspect_ratio of the replacement is left to default-fill.
+    // "new-model". The array [removed-model, 12345] is AMBIGUOUS: it could be
+    // [parent, seed] (old option had 0 nested) OR [parent, orphaned-nested] (old
+    // option owned 1 nested, seed omitted). Since the trailing `seed` is
+    // control-eligible (variable phantom slot), the removed option's nested arity
+    // can't be reconstructed unambiguously, so we REFUSE: seed is left to default
+    // rather than risk a stale nested value being mapped onto it. This is the safe
+    // contract — a wrong seed is silently wrong; a defaulted seed is warned.
     const info = {
       NanoBananaNode: {
         input: {
@@ -1929,7 +1931,6 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
           mode: 0,
           inputs: [],
           outputs: [],
-          // OLD option had no nested widgets: [model(stale), seed]
           widgets_values: ["removed-model", 12345],
         },
       ],
@@ -1937,13 +1938,297 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
     } as never;
     const { workflow, warnings } = convertUiToApi(ui, info);
     expect(workflow["1"].inputs.model).toBe("new-model");
-    // seed is NOT stolen by an ambiguous nested slot.
-    expect(workflow["1"].inputs.seed).toBe(12345);
+    // seed must NOT hold an ambiguous positional value from the stale layout.
+    expect(workflow["1"].inputs.seed).not.toBe(12345);
+    // The refusal is warned (not silent).
     expect(
       warnings.some(
-        (w) => w.includes("1") && w.includes("removed-model") && /substituting/.test(w),
+        (w) =>
+          w.includes("1") &&
+          w.includes("removed-model") &&
+          /can't be reconstructed|default/.test(w),
       ),
     ).toBe(true);
+  });
+
+  it("REFUSES (never realigns) a STALE dynamic parent even when the CURRENT schema added a trailing widget — an orphaned nested value never lands on a later widget (#517 P0 schema-drift)", () => {
+    // The saved parent option "Removed" is gone; the OLD option owned a nested
+    // `strength` (=0.75) sitting between the parent and the trailing `seed`. The
+    // CURRENT schema has ALSO added a trailing `new_widget`. A naive surplus
+    // arithmetic (values-left minus current-trailing-count) cancels the orphaned
+    // slot to zero and would silently map seed=0.75 and new_widget=42 — the orphan
+    // STILL lands on seed. Since neither the removed option's arity NOR the
+    // trailing schema drift is recoverable, the fix REFUSES all positional mapping
+    // after the stale parent: seed and new_widget default, and the orphaned 0.75
+    // NEVER reaches a later widget.
+    const info = {
+      DriftNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { default: 0 }],
+            new_widget: ["INT", { default: 99 }],
+          },
+        },
+        input_order: { required: ["mode", "seed", "new_widget"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "DriftNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // OLD "Removed" option owned strength=0.75; saved [mode, strength, seed]
+          widgets_values: ["Removed", 0.75, 42],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The orphaned nested value NEVER lands on a later widget.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    expect(workflow["1"].inputs.new_widget).not.toBe(0.75);
+    // seed/new_widget fall to their schema defaults, not a shifted positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    expect(workflow["1"].inputs.new_widget).toBe(99);
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("Removed") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES (warn + default) when a stale dynamic parent is followed by a control-eligible seed — the orphaned nested value never lands on seed (#517 P0)", () => {
+    // Exact P0 repro shape: current option A owns no nested; the OLD option owned a
+    // nested strength=0.75 now sitting before the trailing top-level `seed`. `seed`
+    // is control_after_generate (variable phantom slot), so the surplus is
+    // ambiguous — we can't tell [mode, strength, seed] from [mode, seed, control].
+    // We REFUSE: seed must NOT be silently overwritten by the orphaned 0.75.
+    const info = {
+      StaleSeedNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "StaleSeedNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["Removed", 0.75, 42],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // seed must NOT be the orphaned nested value.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    // The refusal is warned; seed is left to its schema default rather than a
+    // silently-misaligned positional value.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("Removed") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES to reconstruct (warn + default-fill) when a trailing widget after a stale dynamic parent is itself a dynamic combo (#517 P0)", () => {
+    // Two dynamic combos in a row; the FIRST is stale. The trailing one's nested
+    // arity is value-dependent and can't be counted, so the surplus is ambiguous.
+    // Rather than risk misassigning, the remaining widgets are left to defaults.
+    const info = {
+      TwoDynNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            other: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "X",
+                    inputs: { required: { sub: ["COMBO", { options: ["p", "q"] }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode", "other"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoDynNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["Removed", 0.75, "X", "p"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    expect(
+      warnings.some(
+        (w) => w.includes("Removed") && /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("PRESERVES a shared SCALAR required leaf under a runtime-linked dynamic parent — not dropped as a non-member (#517 false-positive)", () => {
+    // `mode` is fed by a real (non-Primitive) link, so the resolved option is
+    // unknown at convert time. BOTH options define a required SCALAR `strength`
+    // (FLOAT, no combo options). The default-deny must NOT drop it: a scalar leaf
+    // has no option list to be an in-list "member" of, so the membership check
+    // must not apply — the leaf is valid whichever option resolves because every
+    // option DEFINES it. Dropping it would cause a missing-required-input failure.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      ScalarLeafNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { strength: ["FLOAT", {}] } },
+                  },
+                  {
+                    key: "B",
+                    inputs: { required: { strength: ["FLOAT", {}] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "ScalarLeafNode",
+          mode: 0,
+          inputs: [{ name: "mode", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", 0.75],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent is a link ref.
+    expect(Array.isArray(workflow["3"].inputs.mode)).toBe(true);
+    // The shared scalar leaf is PRESERVED with its value.
+    expect(workflow["3"].inputs["mode.strength"]).toBe(0.75);
+  });
+
+  it("still DROPS a genuinely orphaned COMBO leaf (value not in an option's list) under a runtime-linked dynamic parent (#517 guard intact)", () => {
+    // Contrast to the scalar case: `choice` IS a combo. The saved literal "a1"
+    // is valid only under option A; option B's `choice` list is ["b1","b2"], so a
+    // runtime resolution to B would orphan it. The default-deny must still drop it.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      ComboLeafNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { choice: ["COMBO", { options: ["a1", "a2"] }] } },
+                  },
+                  {
+                    key: "B",
+                    inputs: { required: { choice: ["COMBO", { options: ["b1", "b2"] }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "ComboLeafNode",
+          mode: 0,
+          inputs: [{ name: "mode", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.mode)).toBe(true);
+    // The option-dependent combo leaf is dropped (not a member of every option).
+    expect("mode.choice" in workflow["3"].inputs).toBe(false);
   });
 
   it("skips the phantom control_after_generate slot after a NESTED seed widget", () => {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -1349,6 +1349,404 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
     expect("model.choice" in workflow["3"].inputs).toBe(false);
   });
 
+  it("drops an ORPHAN dotted leaf LITERAL whose optional dynamic parent is ENTIRELY ABSENT (default-deny)", () => {
+    // `model` is an OPTIONAL COMFY_DYNAMICCOMBO_V3 left completely unset — no
+    // widget value, and optional so it is never default-filled — hence absent
+    // from inputs. A PrimitiveNode feeds a literal straight into the nested dotted
+    // `model.aspect_ratio`. With no parent option selected there is no schema
+    // context for the leaf and ComfyUI would reject the un-parented input, so it
+    // must be dropped rather than left as an orphan literal.
+    const info = {
+      DynOptNode: {
+        input: {
+          required: {},
+          optional: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: [], optional: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["16:9"],
+        },
+        {
+          id: 2,
+          type: "DynOptNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [], // parent `model` never set
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent absent, and the orphan leaf must NOT survive as an un-parented literal.
+    expect("model" in workflow["2"].inputs).toBe(false);
+    expect("model.aspect_ratio" in workflow["2"].inputs).toBe(false);
+  });
+
+  it("drops an ORPHAN dotted leaf LINK-REF whose optional dynamic parent is ENTIRELY ABSENT (default-deny)", () => {
+    // Same orphan shape, but the nested dotted leaf is fed by a REAL (non-Primitive)
+    // node, so it resolves to a [id, slot] link ref instead of a literal. An
+    // un-parented link ref is just as invalid as an un-parented literal — the
+    // parent combo has no selected option — so default-deny drops it too. (The
+    // previous code kept array-valued orphans, leaking a leaf the server rejects.)
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynOptNode: {
+        input: {
+          required: {},
+          optional: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: [], optional: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "DynOptNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [], // parent `model` never set
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // The ComboProvider is still in the prompt (so this is not dangling-ref pruning)…
+    expect(workflow["1"]).toBeDefined();
+    // …but the orphan link-ref leaf under the absent parent must be dropped.
+    expect("model" in workflow["2"].inputs).toBe(false);
+    expect("model.aspect_ratio" in workflow["2"].inputs).toBe(false);
+  });
+
+  it("drops a real-LINK dotted leaf when the PRESENT parent's final option does NOT define it (default-deny)", () => {
+    // model="B" is a present literal parent whose option B does NOT define `choice`
+    // (only option A does). model.choice is fed by a REAL node → a [id, slot] link
+    // ref. It is orphaned under B, and ComfyUI rejects the unknown input, so the
+    // re-anchor pass must DROP it even though it's an array (link) value — the case
+    // that previously slipped through the `Array.isArray(leafVal) continue` guard.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B defines no `choice`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["B"], // final selected option is B
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"]).toBeDefined(); // provider stays — not dangling-ref pruning
+    expect(workflow["3"].inputs.model).toBe("B");
+    // The real-link leaf is orphaned under option B and must be dropped.
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("KEEPS a real-LINK dotted leaf when the PRESENT parent's final option DOES define it", () => {
+    // Guard against over-deletion: model="A" defines `choice`, and model.choice is
+    // a real link into a defined leaf → a valid connection that must be preserved
+    // as-is (its runtime value is validated by ComfyUI, not here).
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.model).toBe("A");
+    // Valid link into a defined leaf — kept as the [id, slot] ref.
+    expect(workflow["3"].inputs["model.choice"]).toEqual(["1", 0]);
+  });
+
+  it("drops a real-LINK dotted leaf under a real-LINK parent when SOME option omits the leaf (runtime-unknown default-deny)", () => {
+    // model (parent) is fed by a REAL link → the resolved option is unknowable.
+    // Option A defines `choice`, option B does NOT. model.choice is fed by another
+    // real link. If the parent resolves to B at runtime, `model.choice` is an
+    // unknown input ComfyUI rejects. Since we can't know the resolution, default-
+    // deny: the leaf must be dropped unless EVERY option defines it.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B omits `choice`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent stays a runtime link ref…
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // …but the leaf, not defined by every option, is dropped (would orphan under B).
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("KEEPS a real-LINK dotted leaf under a real-LINK parent when EVERY option defines the leaf", () => {
+    // Guard against over-deletion: both options A and B define `choice`, so the
+    // linked leaf is valid whichever option resolves and must be preserved.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // Defined by every option → the link ref is preserved.
+    expect(workflow["3"].inputs["model.choice"]).toEqual(["2", 0]);
+  });
+
   it("leaves a VALID enum fed by a linked PrimitiveNode untouched (no warn)", () => {
     const info = {
       KSamplerSelect: {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -1094,10 +1094,16 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
     ).toBe(true);
   });
 
-  it("does NOT consume a positional slot for a LINKED nested leaf — trailing widget stays aligned", () => {
-    // model.aspect_ratio is converted-to-input (linked), so it has NO positional
-    // widgets_values entry: ["Nano Banana 2", 12345] = [model, seed]. Consuming a
-    // slot for the linked leaf would steal seed's value. It must be skipped.
+  it("REFUSES the tail when a LINKED nested leaf precedes trailing widgets — placeholder ambiguity must not shift the seed (#517 P0-A)", () => {
+    // model.aspect_ratio is converted-to-input (linked). widgets_values
+    // ["Nano Banana 2", 12345] is AMBIGUOUS: on a frontend that drops the converted
+    // widget's slot it is [model, seed] (seed=12345); on one that RETAINS a
+    // placeholder it is [model, aspect_ratio-placeholder, seed?] and 12345 is the
+    // placeholder, not the seed. The two can't be told apart positionally, so
+    // consuming vs skipping the linked leaf silently shifts the seed either way.
+    // The safe contract is to REFUSE: warn + leave the trailing widget(s) to their
+    // defaults, and let the link supply the nested leaf. seed must NOT be silently
+    // assigned the ambiguous 12345.
     const info = {
       NanoBananaNode: {
         input: {
@@ -1132,7 +1138,7 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
           mode: 0,
           inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
           outputs: [],
-          widgets_values: ["Nano Banana 2", 12345], // aspect_ratio linked = no slot
+          widgets_values: ["Nano Banana 2", 12345], // aspect_ratio linked = ambiguous slot
         },
         {
           id: 2,
@@ -1145,11 +1151,88 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
       ],
       links: [[10, 2, 0, 1, 0, "COMBO"]],
     } as never;
-    const { workflow } = convertUiToApi(ui, info);
-    // seed keeps its real value — not stolen by the linked nested leaf.
-    expect(workflow["1"].inputs.seed).toBe(12345);
-    // and the nested leaf comes from the link.
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // seed must NOT be silently assigned the ambiguous trailing value.
+    expect(workflow["1"].inputs.seed).not.toBe(12345);
+    // The nested leaf still comes from the link.
     expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("1:1");
+    // The refusal is warned (not silent).
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("model.aspect_ratio") &&
+          /default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT let a RETAINED linked-nested placeholder shift a control-eligible seed (#517 P0-A silent-seed)", () => {
+    // Exact placeholder-retention repro: `multiplier` is a linked nested leaf; the
+    // frontend RETAINED its serialized placeholder, so widgets_values is
+    // ["A", 4(placeholder), 424242(seed), "fixed"]. The pre-fix code skipped the
+    // linked leaf WITHOUT consuming its slot, mapped seed=4, then skipped the real
+    // 424242 as the control_after_generate phantom — the user's seed silently became
+    // 4. The fix REFUSES the tail: seed is left to default, 4 never lands on it.
+    const info = {
+      MultNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { multiplier: ["FLOAT", {}] } },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT", { control_after_generate: true, default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "MultNode",
+          mode: 0,
+          inputs: [{ name: "mode.multiplier", type: "FLOAT", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", 4, 424242, "fixed"],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "FLOAT", type: "FLOAT", links: [10] }],
+          widgets_values: [8],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "FLOAT"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The retained placeholder must NEVER become the seed.
+    expect(workflow["1"].inputs.seed).not.toBe(4);
+    // seed falls to its schema default, not a shifted placeholder value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The linked nested leaf is supplied by its (PrimitiveNode) source, not the
+    // retained placeholder 4.
+    expect(workflow["1"].inputs["mode.multiplier"]).toBe(8);
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("mode.multiplier") &&
+          /default/.test(w),
+      ),
+    ).toBe(true);
   });
 
   it("re-anchors nested leaves when a PrimitiveNode overrides the dynamic PARENT (A -> B)", () => {
@@ -1747,6 +1830,73 @@ describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)"
     expect(workflow["3"].inputs["model.choice"]).toEqual(["2", 0]);
   });
 
+  it("PRESERVES a LITERAL nested leaf defined by SOME (not all) options under a real-LINK parent — no silent user-value drop (#517 P0-B)", () => {
+    // The dynamic parent `model` is fed by a real link (converted to input) but the
+    // frontend RETAINED its widgets_values placeholder ["A", 0.75], so the positional
+    // pass sets model.strength=0.75. Option A DEFINES strength (FLOAT default 0.5),
+    // option B OMITS it. The pre-fix strict default-deny deleted model.strength purely
+    // because B lacks it — silently discarding the user's 0.75 so execution used A's
+    // default 0.5. A LITERAL user value defined by at least one option (and valid where
+    // defined) must be PRESERVED: dropping it on option B, a resolution that may never
+    // occur, is the corruption. (Link-ref leaves — no user scalar to lose — keep the
+    // strict every-option rule; see the two tests above.)
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { strength: ["FLOAT", { default: 0.5 }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B omits `strength`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 5,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [20] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 20 }],
+          outputs: [],
+          // Retained placeholder: parent "A" + nested literal strength 0.75.
+          widgets_values: ["A", 0.75],
+        },
+      ],
+      links: [[20, 5, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent is a runtime link ref…
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // …and the user's literal strength is PRESERVED, not dropped to A's default 0.5.
+    expect(workflow["3"].inputs["model.strength"]).toBe(0.75);
+  });
+
   it("leaves a VALID enum fed by a linked PrimitiveNode untouched (no warn)", () => {
     const info = {
       KSamplerSelect: {
@@ -2159,6 +2309,221 @@ describe("convertUiToApi — option-bearing / dynamic nested combo validation (P
           /can't be reconstructed|default/.test(w),
       ),
     ).toBe(true);
+  });
+
+  it("DEFAULTS the tail when a STILL-VALID dynamic option's nested arity DRIFTED (leftover) — no stale nested value on the seed (#517 P0 arity-drift)", () => {
+    // The saved option key "A" STILL EXISTS, so the stale-parent (removed-key) guard
+    // does NOT fire. But when the graph was saved, option A owned a nested
+    // `multiplier` (=4); the CURRENT schema's option A has REMOVED it. Mapping with
+    // the current (empty) nested layout consumes nothing, so the loop assigns
+    // seed=4 (the stale nested value) and skips the REAL 424242 as the control
+    // phantom — the user's seed silently becomes 4, with a leftover "fixed" proving
+    // the drift. The leftover-drift guard must default the post-combo widgets: seed
+    // must NOT be 4.
+    const info = {
+      DriftArityNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              // Current option A defines NO nested inputs (multiplier was removed).
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { control_after_generate: true, default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "DriftArityNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // Saved under the OLD layout: [mode, multiplier(nested,=4), seed, control].
+          widgets_values: ["A", 4, 424242, "fixed"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // Parent stays "A" (still a valid option).
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The stale nested value must NEVER become the seed.
+    expect(workflow["1"].inputs.seed).not.toBe(4);
+    // seed falls to its schema default, not the shifted positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The drift is warned (not silent).
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && /nested-input layout|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT let the arity-drift guard mis-fire on a LINKED-leaf refusal in a LATER dynamic combo — earlier valid combo must not default the later parent (#517 P0-A/drift interaction)", () => {
+    // Two dynamic combos in order. The FIRST (`first`) is a normal still-valid combo
+    // (sets sawDynamicCombo). The SECOND (`second`) has a LINKED nested leaf
+    // (second.choice), which triggers the P0-A refuse-the-tail path — leaving a
+    // leftover. Without the tailRefused gate, the post-loop drift guard would ALSO
+    // fire, wrongly deleting `second` (a valid parent selection) and defaulting it to
+    // the first option. The gate must suppress the drift guard here: `second` keeps
+    // its saved "Y".
+    const info = {
+      TwoParentNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            second: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "X",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["x1"] }] },
+                    },
+                  },
+                  {
+                    key: "Y",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["y1"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["first", "second"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoParentNode",
+          mode: 0,
+          // second.choice is converted-to-input (linked).
+          inputs: [{ name: "second.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "Y", 424242],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["y1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The later parent must KEEP its saved selection, not be defaulted to "X".
+    expect(workflow["1"].inputs.second).toBe("Y");
+  });
+
+  it("DEFAULTS a shifted NESTED leaf on proven arity-shrink even with NO trailing top-level widget (#517 P0 nested-shrink)", () => {
+    // Old option A owned nested [obsolete, strength]; the CURRENT schema's A dropped
+    // `obsolete`, leaving [strength]. Saved ["A", 4, 0.75] was serialized as
+    // [mode, obsolete=4, strength=0.75]. Mapping with the current layout assigns
+    // strength=4 (the OBSOLETE value!) and leaves 0.75 as a leftover. There is NO
+    // trailing top-level widget, so the guard must STILL fire on the leftover and
+    // default the shifted nested leaf — strength must NOT silently be 4.
+    const info = {
+      NestedShrinkNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    // `obsolete` was removed; only `strength` remains.
+                    inputs: { required: { strength: ["FLOAT", { default: 1 }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NestedShrinkNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["A", 4, 0.75], // [mode, obsolete=4, strength=0.75]
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The shifted OBSOLETE value must NOT survive on the strength leaf.
+    expect(workflow["1"].inputs["mode.strength"]).not.toBe(4);
+    // It is dropped (absent) so ComfyUI supplies the option's runtime default.
+    expect("mode.strength" in workflow["1"].inputs).toBe(false);
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && /nested-input layout|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT default a later EMPTY-OPTIONS V3 parent when an earlier valid combo set the drift flag (#517 P1 empty-options multi-combo)", () => {
+    // An earlier valid dynamic combo (`first`) sets sawDynamicCombo. The later combo
+    // (`second`) is an EMPTY-OPTIONS V3 whose saved selection is stale → the stale-
+    // parent refusal fires. That refusal must set tailRefused so the leftover guard
+    // does NOT delete `second` — an empty options list has no substitution or default
+    // to restore it from, so deleting it would LOSE the declared parent entirely.
+    const info = {
+      TwoWithEmptyNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            second: ["COMFY_DYNAMICCOMBO_V3", { options: [] }],
+          },
+        },
+        input_order: { required: ["first", "second"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoWithEmptyNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["A", "my-model", 42], // first=A, second=my-model + trailing
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The empty-options parent's declared value is preserved, NOT deleted.
+    expect(workflow["1"].inputs.second).toBe("my-model");
   });
 
   it("PRESERVES a shared SCALAR required leaf under a runtime-linked dynamic parent — not dropped as a non-member (#517 false-positive)", () => {

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -461,9 +461,9 @@ describe("convertUiToApi — media-combo fallback (issue #504)", () => {
   // A LoadImage node whose `image` widget points at a freshly staged upload
   // (2Dto3D_v2_front_clean.png) that isn't yet in the CONNECTED server's STALE
   // /object_info combo (which still only lists KENT_concept_00012_.png). Before
-  // the fix, media values failed looksLikeAssetFilename() so comboOpts[0]
-  // silently replaced the user's image — headless execution then ran on the
-  // WRONG source image with no warning.
+  // the fix, LoadImage.image was not recognized as a media selector, so
+  // comboOpts[0] silently replaced the user's image — headless execution then
+  // ran on the WRONG source image with no warning.
   const STALE_INFO = {
     LoadImage: {
       input: {
@@ -517,16 +517,28 @@ describe("convertUiToApi — media-combo fallback (issue #504)", () => {
     expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
   });
 
-  it("preserves an extensionless staged image via the media widget-name allowlist", () => {
-    // Some staged inputs carry a subfolder path with no extension; the value has
-    // no file suffix and the stale combo has none either, so detection must fall
-    // back to the `image` widget-name allowlist rather than substituting.
+  it("preserves an extensionless staged image via the (classType,input) loader allowlist", () => {
+    // Isolate the allowlist: BOTH the staged value AND the stale combo option are
+    // extensionless, so no extension heuristic can carry this — preservation must
+    // come purely from LoadImage.image being a KNOWN loader input. (The prior
+    // fixture's stale combo held a ".png", so the retired regex passed regardless
+    // and never actually exercised the allowlist.)
+    const EXTLESS_INFO = {
+      LoadImage: {
+        input: {
+          required: {
+            image: [["cached_input"]],
+            upload: ["IMAGE_UPLOAD"],
+          },
+        },
+      },
+    } as never;
     const { workflow, warnings } = convertUiToApi(
       loadImageGraph("clipspace/staged_input"),
-      STALE_INFO,
+      EXTLESS_INFO,
     );
     expect(workflow["12"].inputs.image).toBe("clipspace/staged_input");
-    expect(workflow["12"].inputs.image).not.toBe("KENT_concept_00012_.png");
+    expect(workflow["12"].inputs.image).not.toBe("cached_input");
     expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
   });
 
@@ -552,5 +564,220 @@ describe("convertUiToApi — media-combo fallback (issue #504)", () => {
     const { workflow, warnings } = convertUiToApi(ui, info);
     expect(workflow["1"].inputs.video).toBe("freshly_staged.mp4");
     expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("preserves LoadImage.image flagged by object_info upload metadata (no name/ext match)", () => {
+    // The value is extensionless AND arrives on a class NOT in the loader
+    // allowlist by chance — but object_info flags the input `{image_upload:true}`,
+    // the authoritative upload-selector signal — so it must still be preserved.
+    const info = {
+      MyCustomImageLoader: {
+        input: {
+          required: {
+            image: [["on_disk_input"], { image_upload: true }],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 7,
+          type: "MyCustomImageLoader",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["staged_upload"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["7"].inputs.image).toBe("staged_upload");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+});
+
+describe("convertUiToApi — true-enum over-preservation guard (P0 regression, #504)", () => {
+  // The #504 fix must NOT over-correct: a combo merely *named* image/audio/video,
+  // or a media-looking value on a TRUE enum, is NOT an asset selector. Preserving
+  // an out-of-list value there feeds ComfyUI a "Value not in list" it hard-rejects,
+  // breaking conversions that previously substituted comboOpts[0] + warned.
+
+  it("SUBSTITUTES+warns a non-loader enum literally named `image` (not preserved)", () => {
+    // A node whose combo happens to be named `image` but whose options are a real
+    // enum ["foreground","background"] — a value of "mask" is invalid and must be
+    // replaced by the first option, NOT preserved as a phantom missing-asset.
+    const info = {
+      SomeMaskModeNode: {
+        input: {
+          required: {
+            image: [["foreground", "background"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 3,
+          type: "SomeMaskModeNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["mask"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.image).toBe("foreground");
+    expect(workflow["3"].inputs.image).not.toBe("mask");
+    expect(
+      warnings.some(
+        (w) => w.includes("3") && w.includes("mask") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+    // …and it must NOT be misreported as a missing asset (would preserve it).
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("SUBSTITUTES+warns a format `extension` enum with a media-looking value (.bmp not preserved)", () => {
+    // A true format enum [".png",".jpg"] with a ".bmp" value: the retired
+    // extension heuristic wrongly preserved ".bmp" (it matches a media regex);
+    // ComfyUI rejects it. Must substitute the first option instead.
+    const info = {
+      SaveImageFormatNode: {
+        input: {
+          required: {
+            extension: [[".png", ".jpg"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 5,
+          type: "SaveImageFormatNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [".bmp"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["5"].inputs.extension).toBe(".png");
+    expect(workflow["5"].inputs.extension).not.toBe(".bmp");
+    expect(
+      warnings.some(
+        (w) => w.includes("5") && w.includes(".bmp") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("validates object-form widgets_values too — invalid enum substitutes (not copied raw)", () => {
+    // Name->value object form (VHS_VideoCombine shape). This path copied values
+    // straight in WITHOUT combo validation, so an invalid true-enum value on a
+    // combo named `image` leaked through unchanged. It must now substitute+warn.
+    const info = {
+      MaskModeCombine: {
+        input: {
+          required: {
+            image: [["foreground", "background"]],
+            format: [["mp4", "webm"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 9,
+          type: "MaskModeCombine",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { image: "mask", format: "mp4" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["9"].inputs.image).toBe("foreground");
+    expect(workflow["9"].inputs.image).not.toBe("mask");
+    // a VALID value on the same object form is left untouched
+    expect(workflow["9"].inputs.format).toBe("mp4");
+    expect(
+      warnings.some((w) => w.includes("9") && /substituting/.test(w)),
+    ).toBe(true);
+  });
+
+  it("object-form still PRESERVES a real loader asset value (allowlist survives the path)", () => {
+    // The object-form validation must keep the asset-preservation semantics: a
+    // staged LoadImage.image absent from the stale combo is preserved, not swapped.
+    const info = {
+      LoadImage: {
+        input: { required: { image: [["cached.png"]], upload: ["IMAGE_UPLOAD"] } },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 10,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { image: "staged_fresh.png" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["10"].inputs.image).toBe("staged_fresh.png");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("validates has_serialized_properties overwrites too — invalid enum substitutes", () => {
+    // Authoritative node.properties overwrite the positional mapping AFTER combo
+    // validation; an invalid enum restored there previously leaked unvalidated to
+    // ComfyUI. It must be validated (substituted) as well.
+    const info = {
+      SerNode: {
+        input: {
+          required: {
+            mode: [["a", "b"]],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 11,
+          type: "SerNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a"],
+          properties: {
+            has_serialized_properties: true,
+            mode: "z", // stale, out-of-list — must NOT survive
+          },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["11"].inputs.mode).toBe("a");
+    expect(workflow["11"].inputs.mode).not.toBe("z");
+    expect(
+      warnings.some((w) => w.includes("11") && /substituting/.test(w)),
+    ).toBe(true);
   });
 });

--- a/src/__tests__/tools/get-node-info-summary.test.ts
+++ b/src/__tests__/tools/get-node-info-summary.test.ts
@@ -6,8 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // whose enum dropdowns embed the entire local model list (100s of KB per node).
 
 const getObjectInfoMock = vi.fn();
+const resetObjectInfoCacheMock = vi.fn();
+const backfillObjectInfoMock = vi.fn(async (info: unknown) => info);
 vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+  resetObjectInfoCache: (...a: unknown[]) => resetObjectInfoCacheMock(...a),
+  backfillObjectInfo: (...a: unknown[]) => backfillObjectInfoMock(...a),
 }));
 
 import { registerWorkflowComposeTools, summarizeNodeDef } from "../../tools/workflow-compose.js";
@@ -53,6 +57,8 @@ const loaderDef: ComfyUINodeDef = {
 
 beforeEach(() => {
   getObjectInfoMock.mockReset();
+  resetObjectInfoCacheMock.mockReset();
+  backfillObjectInfoMock.mockClear();
   getObjectInfoMock.mockResolvedValue({ CheckpointLoaderSimple: loaderDef });
 });
 
@@ -109,6 +115,50 @@ describe("get_node_info >20 matches (unchanged name-list behavior)", () => {
     expect(parsed.count).toBe(25);
     expect(parsed.nodes[0]).not.toHaveProperty("input_required");
     expect(parsed.hint).toMatch(/more specific/);
+  });
+});
+
+describe("get_node_info refresh after external restart (issue #499)", () => {
+  // A loader whose model dropdown is served from a STALE cache after the ComfyUI
+  // server was restarted externally (systemd) and a new model file was added.
+  // The stale snapshot omits the freshly-installed file; refresh:true must drop
+  // the cache and refetch so the new file shows up in the verbose dropdown.
+  const staleDef: ComfyUINodeDef = {
+    ...loaderDef,
+    input: { required: { clip_name: [["old-clip.gguf"]] } },
+  };
+  const freshDef: ComfyUINodeDef = {
+    ...loaderDef,
+    input: { required: { clip_name: [["old-clip.gguf", "Qwen2.5-VL-7B-Instruct-UD-Q8_0.gguf"]] } },
+  };
+
+  it("does NOT reset the cache when refresh is omitted (serves memoized snapshot)", async () => {
+    getObjectInfoMock.mockResolvedValue({ CLIPLoaderGGUF: staleDef });
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CLIPLoaderGGUF", verbose: true });
+    expect(resetObjectInfoCacheMock).not.toHaveBeenCalled();
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.CLIPLoaderGGUF.input.required.clip_name[0]).toEqual(["old-clip.gguf"]);
+  });
+
+  it("refresh:true invalidates the cache BEFORE fetching, so the live post-restart dropdown surfaces", async () => {
+    // The cache invalidation (resetObjectInfoCache) must happen before the fetch
+    // so getObjectInfo re-reads the live server (which now lists the new file).
+    // The reset→refetch guarantee itself is covered in object-info-cache.test.ts.
+    let resetBeforeFetch = false;
+    resetObjectInfoCacheMock.mockImplementation(() => {
+      resetBeforeFetch = true;
+    });
+    getObjectInfoMock.mockImplementation(async () =>
+      resetBeforeFetch ? { CLIPLoaderGGUF: freshDef } : { CLIPLoaderGGUF: staleDef },
+    );
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CLIPLoaderGGUF", verbose: true, refresh: true });
+    expect(resetObjectInfoCacheMock).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.CLIPLoaderGGUF.input.required.clip_name[0]).toContain(
+      "Qwen2.5-VL-7B-Instruct-UD-Q8_0.gguf",
+    );
   });
 });
 

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1485,7 +1485,8 @@ export function convertUiToApi(
       }
     } else {
     let widgetIdx = 0;
-    for (const name of widgetNames) {
+    for (let nameIdx = 0; nameIdx < widgetNames.length; nameIdx++) {
+      const name = widgetNames[nameIdx];
       if (widgetIdx >= widgetValues.length) break;
       const value = widgetValues[widgetIdx];
       inputs[name] = value;
@@ -1539,15 +1540,72 @@ export function convertUiToApi(
       //
       // Look up the option by the RAW saved `value` (the selection the array was
       // serialized against), NOT the post-validation inputs[name]. If the saved
-      // selection is stale (substituted for a valid one), its ORIGINAL nested
-      // arity is unrecoverable, so we deliberately consume NO nested slots rather
-      // than guess against the replacement option's layout — guessing would
-      // silently steal or drop the trailing top-level widgets (e.g. a seed). The
-      // parent value is still substituted+warned above; required nested inputs of
-      // the replacement simply fall through to default-fill.
-      const selectedInputs = Array.isArray(opts)
-        ? opts.find((o) => o?.key === value)?.inputs
+      // selection is stale (its option was removed/renamed), its ORIGINAL nested
+      // arity is unrecoverable, so consuming zero nested slots while still
+      // advancing the top-level index would silently misassign a leftover nested
+      // value onto the trailing top-level widgets (e.g. a removed option's nested
+      // strength overwriting the user's seed). The stale-parent guard below REFUSES
+      // that case (warn + stop) instead of guessing.
+      // A V3 (object-keyed) dynamic options list has {key, inputs} entries — only
+      // these can add nested positional slots. A classic string-option COMBO
+      // (["a","b"]) never does, and its elements have no `.key`, so it must NOT
+      // trip the stale-parent guard below (which would wrongly refuse a perfectly
+      // valid classic-combo value).
+      const isDynamicOptions =
+        Array.isArray(opts) &&
+        opts.some(
+          (o) =>
+            o != null &&
+            typeof o === "object" &&
+            !Array.isArray(o) &&
+            "key" in (o as Record<string, unknown>),
+        );
+      const savedOption = Array.isArray(opts)
+        ? opts.find((o) => o?.key === value)
         : undefined;
+
+      // P0 (#517): STALE dynamic-combo parent. The saved selection is NOT among
+      // the current dynamic options (the option was removed/renamed, or was
+      // substituted above). The saved array was serialized against the OLD
+      // option's layout: [parent, <OLD option's nested slots>, ...trailing
+      // top-level widgets...]. The OLD nested arity is unknowable from THIS schema,
+      // so the pre-fix code consumed ZERO nested slots while still advancing the
+      // top-level index — silently mapping a leftover stale nested value onto the
+      // next widget (e.g. a removed option's strength=0.75 landing on the user's
+      // seed, discarding the real 42 with no warning).
+      //
+      // The saved array was serialized as
+      //   [parent, <removed option's nested slots>, ...trailing top-level widgets...]
+      // and we CANNOT reconstruct where the orphaned-nested block ends: NEITHER the
+      // removed option's nested arity NOR the trailing widgets' saved-slot count is
+      // recoverable. The trailing count is doubly unknown — a nested seed carries a
+      // variable control_after_generate phantom, a trailing dynamic combo adds a
+      // value-dependent number of slots, AND the current schema may have added or
+      // removed trailing widgets since the graph was saved. A surplus arithmetic
+      // (values-left vs current trailing-widget-count) silently mis-attributes
+      // orphaned slots whenever any of those drift (e.g. a schema-added trailing
+      // widget makes surplus cancel to zero while an orphan still sits before the
+      // seed). Because NO positional reconstruction is provably safe, REFUSE: warn
+      // and stop positional mapping here so an orphaned nested value can NEVER be
+      // silently mapped onto a later top-level widget (such as a seed). The
+      // remaining required inputs then default-fill below. The parent itself was
+      // already substituted + warned via validateComboWidgetValue above.
+      if (
+        isDynamicOptions &&
+        savedOption === undefined &&
+        widgetIdx < widgetValues.length
+      ) {
+        warnings.push(
+          `Node ${nodeId} (${classType}): widget "${name}" saved selection "${String(
+            value,
+          )}" is no longer an available option, so the removed option's nested-input layout can't be reconstructed. The remaining ${
+            widgetValues.length - widgetIdx
+          } saved widget value(s) are left to their defaults rather than risk silently assigning a stale nested value to a later widget (such as a seed).`,
+        );
+        break;
+      }
+
+      const selectedInputs = savedOption?.inputs;
       const nested =
         selectedInputs &&
         (selectedInputs.required || selectedInputs.optional)
@@ -1777,7 +1835,16 @@ export function convertUiToApi(
             }
             if (leafIsLink) continue; // link ref: definition is all we can check
             const optList = getComboOptions(s);
-            if (!Array.isArray(optList) || !optList.includes(leafVal as never)) {
+            // The membership check applies ONLY to COMBO leaves — those that HAVE
+            // an enumerable option list to validate against. A scalar/non-combo
+            // required leaf (INT/FLOAT/STRING; getComboOptions returns undefined)
+            // is a NORMAL required input, valid whichever option resolves as long
+            // as it's DEFINED (checked via `definedEverywhere` above). Treating a
+            // missing option list as a membership failure would DROP a legitimate
+            // required scalar and cause a missing-required-input error (#517). So
+            // only fail membership when there IS an option list and the value is
+            // out-of-list.
+            if (Array.isArray(optList) && !optList.includes(leafVal as never)) {
               memberEverywhere = false;
               break;
             }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1711,16 +1711,26 @@ export function convertUiToApi(
       // Orphaned dotted leaf: its dynamic parent isn't in the prompt (e.g. an
       // optional parent left unset while the leaf was linked). There's no option
       // context to validate against, and the leaf is meaningless without its
-      // parent, so default-deny — drop it rather than let an unvalidated literal
-      // reach the prompt.
+      // parent — ComfyUI has no selected option so "<parent>.<leaf>" is an unknown
+      // input it hard-rejects. Default-DENY: drop the leaf UNCONDITIONALLY,
+      // whether it's an un-parented literal OR a link ref. Keeping a link ref here
+      // (the previous behavior) still emitted an orphan the server would reject.
       if (!(parent in inputs)) {
-        if (!Array.isArray(inputs[key])) delete inputs[key];
+        delete inputs[key];
         continue;
       }
       const leafVal = inputs[key];
-      if (Array.isArray(leafVal)) continue; // leaf itself is a link ref
+      // A leaf can itself be a LINK REF ([id, slot]) — a nested widget converted to
+      // input and wired to a real node. We can't membership-check its runtime
+      // value, but we CAN check whether the FINAL selected option even DEFINES the
+      // leaf: an array leaf under an option that doesn't define it is just as
+      // orphaned as a literal one, and ComfyUI hard-rejects the unknown input. So
+      // link-ref leaves are re-anchored too (previously they short-circuited here
+      // with an unconditional `continue`, leaking an orphan under an incompatible
+      // parent).
+      const leafIsLink = Array.isArray(leafVal);
       // Parent fed by a real (non-Primitive) link → the SELECTED option is only
-      // known at runtime, so a leaf literal saved under one option may be wrong
+      // known at runtime, so a leaf saved/linked under one option may be wrong
       // for the resolved one. Keep it only if it validates under EVERY option
       // that defines the leaf; otherwise drop it (ComfyUI supplies the runtime
       // option's default). This prevents a wrong-option literal (e.g. option-A
@@ -1742,20 +1752,30 @@ export function convertUiToApi(
               })
             : undefined
         )?.options;
-        // Keep the leaf ONLY if its literal is a genuine in-list MEMBER of every
-        // option that defines it (so it's valid whichever option resolves at
-        // runtime). Use a strict membership test — NOT validateComboValueForSpec,
-        // whose asset/empty-combo PRESERVE path would keep an out-of-list literal
-        // and swallow its warning. Anything else (out-of-list, asset, empty combo,
-        // undefined-everywhere) is dropped so no silent wrong-option literal reaches
-        // the prompt; ComfyUI fills the runtime option's default.
-        let definedSomewhere = false;
+        // The resolved option is unknowable at convert time, so KEEP the leaf only
+        // if it stays valid WHICHEVER option resolves — i.e. it must be defined by
+        // EVERY option (definedEverywhere). If ANY option omits the leaf, that
+        // runtime resolution would orphan it (ComfyUI rejects the unknown nested
+        // input), so default-DENY and drop it — the option's default is supplied at
+        // runtime. This holds for a LINK-REF leaf (whose runtime value we can't
+        // membership-check — definition is all we can verify) AND a LITERAL leaf,
+        // which must ALSO be a strict in-list MEMBER of every option. Membership
+        // uses a strict includes() — NOT validateComboValueForSpec, whose
+        // asset/empty-combo PRESERVE path would keep an out-of-list literal and
+        // swallow its warning.
+        let anyOption = false;
+        let definedEverywhere = true;
         let memberEverywhere = true;
         if (Array.isArray(pOpts)) {
           for (const o of pOpts) {
+            anyOption = true;
             const s = o?.inputs?.required?.[leaf] ?? o?.inputs?.optional?.[leaf];
-            if (s === undefined) continue;
-            definedSomewhere = true;
+            if (s === undefined) {
+              // An option that doesn't define the leaf → orphan if it resolves.
+              definedEverywhere = false;
+              break;
+            }
+            if (leafIsLink) continue; // link ref: definition is all we can check
             const optList = getComboOptions(s);
             if (!Array.isArray(optList) || !optList.includes(leafVal as never)) {
               memberEverywhere = false;
@@ -1763,16 +1783,24 @@ export function convertUiToApi(
             }
           }
         }
-        if (!definedSomewhere || !memberEverywhere) delete inputs[key];
+        if (!anyOption || !definedEverywhere || !memberEverywhere)
+          delete inputs[key];
         continue;
       }
       const { leafName, spec } = resolveWidgetSpec(def, key, inputs);
       if (spec === undefined) {
         // The final selected option does not define this leaf — it belongs to the
-        // superseded option and would be an unknown input on the current one.
+        // superseded option and would be an unknown input on the current one. Drop
+        // it whether it's a literal OR a real-link ref (both orphan under the final
+        // option; a link ref is not exempt — the previous `continue` above leaked
+        // exactly this case).
         delete inputs[key];
         continue;
       }
+      // Leaf IS defined by the final selected option. A real-link ref into a defined
+      // leaf is a valid connection whose runtime value ComfyUI validates — keep it
+      // as-is (there's no literal to re-validate here).
+      if (leafIsLink) continue;
       inputs[key] = validateComboValueForSpec(
         leafName,
         leafVal,

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1485,9 +1485,34 @@ export function convertUiToApi(
       }
     } else {
     let widgetIdx = 0;
+    // A still-valid dynamic-combo option whose NESTED arity DRIFTED between save
+    // and load (the option kept its key but added/removed nested inputs) can't be
+    // detected up front — its saved nested slots were serialized against the OLD
+    // arity, but we map using the CURRENT one, so any drift shifts the trailing
+    // top-level widgets (e.g. a since-removed nested "multiplier" leaves its stale
+    // value to land on the seed). The stale-parent guard below only catches a
+    // REMOVED option (key absent). For a still-present option, a LEFTOVER saved
+    // value after the whole positional mapping is the reliable drift signal — a
+    // self-consistent layout consumes exactly. Track whether a still-valid dynamic
+    // combo was processed and which widgets were mapped AFTER it, so on leftover we
+    // can default those (shifted) widgets + warn instead of trusting the shift.
+    let sawDynamicCombo = false;
+    let tailRefused = false;
+    const widgetsAfterDynamicCombo: string[] = [];
+    // Dotted "<combo>.<leaf>" keys assigned positionally from a dynamic combo's
+    // nested layout. On a proven arity drift (leftover) these are ALSO suspect — a
+    // since-removed nested slot shifts every later nested value onto the wrong leaf
+    // (old A=[obsolete, strength], current A=[strength], saved ["A",4,0.75] maps
+    // strength=4, the obsolete value) — so the drift guard defaults them too, not
+    // just the trailing top-level widgets.
+    const nestedKeysFromDynamic: string[] = [];
     for (let nameIdx = 0; nameIdx < widgetNames.length; nameIdx++) {
       const name = widgetNames[nameIdx];
       if (widgetIdx >= widgetValues.length) break;
+      // A widget mapped AFTER a still-valid dynamic combo is positionally
+      // downstream of its (unverifiable) nested arity — record it for the
+      // drift-leftover check below.
+      if (sawDynamicCombo) widgetsAfterDynamicCombo.push(name);
       const value = widgetValues[widgetIdx];
       inputs[name] = value;
       widgetIdx++;
@@ -1617,8 +1642,18 @@ export function convertUiToApi(
             widgetValues.length - widgetIdx
           } saved widget value(s) are left to their defaults rather than risk silently assigning a stale nested value to a later widget (such as a seed).`,
         );
+        // Mark tailRefused so the post-loop leftover drift-guard does NOT ALSO fire
+        // on the leftover this break creates — otherwise, when an EARLIER combo had
+        // set sawDynamicCombo, the guard would delete THIS (stale/empty-options)
+        // parent, which has no substitution or default to be restored from.
+        tailRefused = true;
         break;
       }
+
+      // Still-valid dynamic combo (option key present): its nested arity is trusted
+      // from the CURRENT schema but can't be verified against the save — flag it so
+      // the post-loop leftover check can detect a drift-induced tail shift.
+      if (isDynamicOptions && savedOption !== undefined) sawDynamicCombo = true;
 
       const selectedInputs = savedOption?.inputs;
       const nested =
@@ -1634,12 +1669,35 @@ export function convertUiToApi(
         // non-widget nested inputs (AUTOGROW lists like Nano Banana 2's
         // "images", or IMAGE/link types) have no saved widget value, so skipping
         // them keeps the positional mapping aligned.
+        let refuseTail = false;
         for (const [nName, nSpec] of Object.entries(nested)) {
           if (!isPositionalWidgetSpec(nSpec)) continue;
-          // A linked (converted-to-input) nested leaf has NO positional slot — its
-          // value comes from the link, populated in the link loop below — so it
-          // must NOT consume a widgets_values entry or the tail shifts.
-          if (linkedInputNames.has(`${name}.${nName}`)) continue;
+          // A linked (converted-to-input) nested leaf's value arrives via the link
+          // loop below, NOT the saved array. Other/older frontend versions, though,
+          // RETAIN a serialized placeholder for a converted widget, so the leaf may
+          // OR may not still occupy a widgets_values slot — and that cannot be told
+          // apart positionally. If a placeholder IS present and we skip it without
+          // consuming, the retained value shifts onto the NEXT top-level widget: a
+          // seed silently becomes the placeholder (e.g. widgets_values
+          // [parent, 4(linked-nested placeholder), 424242(seed), "fixed"] would map
+          // seed=4). When trailing saved values remain, the alignment is
+          // unrecoverable, so REFUSE the tail — the same safe pattern as the
+          // stale-parent guard above: warn + leave the remaining top-level widgets
+          // to their defaults rather than risk a silent shift onto a later widget.
+          // (If NO trailing values remain there is nothing to misassign, so the
+          // link simply supplies the leaf and the loop ends.)
+          if (linkedInputNames.has(`${name}.${nName}`)) {
+            if (widgetIdx < widgetValues.length) {
+              warnings.push(
+                `Node ${nodeId} (${classType}): widget "${name}" has a converted-to-input (linked) nested widget "${name}.${nName}" whose widgets_values slot can't be positionally resolved (frontend versions differ on whether a converted widget keeps a placeholder slot), so the remaining ${
+                  widgetValues.length - widgetIdx
+                } saved widget value(s) are left to their defaults rather than risk silently assigning a stale value to a later widget (such as a seed).`,
+              );
+              refuseTail = true;
+              break;
+            }
+            continue;
+          }
           if (widgetIdx >= widgetValues.length) break;
           // Nested leaf values bypass the top-level widget validation, so validate
           // each against ITS OWN leaf spec/name (P1-B). Asset classification keys
@@ -1653,6 +1711,7 @@ export function convertUiToApi(
             nodeId,
             warnings,
           );
+          nestedKeysFromDynamic.push(`${name}.${nName}`);
           widgetIdx++;
           // A nested seed-type / control_after_generate leaf carries a phantom
           // "fixed"/"randomize" value right after it (same as top-level seeds), so
@@ -1664,7 +1723,54 @@ export function convertUiToApi(
             widgetIdx++;
           }
         }
+        // A linked nested leaf with trailing saved values made the alignment
+        // ambiguous — stop mapping the remaining top-level widgets (they
+        // default-fill below) so no retained placeholder can shift onto a seed.
+        // Mark tailRefused so the leftover drift-guard below does NOT ALSO fire on
+        // the leftover this break creates (double-warn + wrongly defaulting a
+        // later dynamic parent when an EARLIER combo had set sawDynamicCombo).
+        if (refuseTail) {
+          tailRefused = true;
+          break;
+        }
       }
+    }
+    // Drift guard: a LEFTOVER saved value after a still-valid dynamic combo means
+    // its nested arity SHRANK since the save (see the sawDynamicCombo note above) —
+    // the current option consumes fewer nested slots than the save held, leaving a
+    // provable leftover. A self-consistent layout consumes exactly; a leftover proves
+    // the positional mapping after (and WITHIN) the drifted combo is shifted: both the
+    // trailing top-level widgets AND the nested dotted leaves may hold a value that
+    // belongs to a since-removed slot (e.g. old A=[obsolete, strength], current
+    // A=[strength], saved ["A",4,0.75] maps strength=4 — the obsolete value). Default
+    // BOTH sets (delete so top-level widgets default-fill below and nested leaves fall
+    // to their runtime option defaults) and warn, rather than trust a silently shifted
+    // value on a later widget (such as a seed) OR a nested leaf. This fires on ANY
+    // leftover — even with no trailing top-level widget — so a shifted nested value
+    // can't survive. (Mirrors the stale-parent + linked-leaf refusals.)
+    //
+    // LIMITATION (accepted): the OPPOSITE drift — the option GAINED nested inputs
+    // since the save — over-consumes trailing values yet often lands on EXACT
+    // consumption, positionally IDENTICAL to a legitimate multi-nested layout (the
+    // canonical Nano Banana node: [prompt, model, aspect_ratio, resolution,
+    // thinking_level, seed, control, response_modalities]). No positional signal
+    // distinguishes the two, so catching arity-GROWTH would require refusing ALL
+    // trailing widgets after every dynamic combo — regressing that real shipping
+    // node. We therefore catch only the provable (leftover) direction. tailRefused
+    // gates out the stale-parent + linked-leaf refusal paths (which already warned +
+    // defaulted the tail) so this guard can't double-warn or default a later, valid
+    // combo parent.
+    if (sawDynamicCombo && !tailRefused && widgetIdx < widgetValues.length) {
+      for (const wn of widgetsAfterDynamicCombo) delete inputs[wn];
+      for (const nk of nestedKeysFromDynamic) delete inputs[nk];
+      const defaulted = [...nestedKeysFromDynamic, ...widgetsAfterDynamicCombo];
+      warnings.push(
+        `Node ${nodeId} (${classType}): a dynamic-combo option's nested-input layout appears to have changed since this workflow was saved (${
+          widgetValues.length - widgetIdx
+        } saved widget value(s) remain unmapped), so its nested leaves and the widget(s) positioned after it${
+          defaulted.length ? ` (${defaulted.join(", ")})` : ""
+        } are left to their defaults rather than risk a silently shifted value on a later widget (such as a seed) or nested leaf.`,
+      );
     }
     }
 
@@ -1838,35 +1944,55 @@ export function convertUiToApi(
         // swallow its warning.
         let anyOption = false;
         let definedEverywhere = true;
-        let memberEverywhere = true;
+        let definedSomewhere = false;
+        // For a LITERAL leaf: it must be an in-list MEMBER of every option that
+        // DEFINES it as a combo. Options that OMIT the leaf are skipped (not failed)
+        // so a leaf defined by only some options is still assessed on the options
+        // that do define it. A scalar/non-combo defining option (getComboOptions
+        // undefined) can't fail membership — it's a normal required input.
+        let memberWhereDefined = true;
         if (Array.isArray(pOpts)) {
           for (const o of pOpts) {
             anyOption = true;
             const s = o?.inputs?.required?.[leaf] ?? o?.inputs?.optional?.[leaf];
             if (s === undefined) {
-              // An option that doesn't define the leaf → orphan if it resolves.
+              // This option omits the leaf entirely (orphan if IT resolves).
               definedEverywhere = false;
-              break;
+              continue;
             }
+            definedSomewhere = true;
             if (leafIsLink) continue; // link ref: definition is all we can check
             const optList = getComboOptions(s);
-            // The membership check applies ONLY to COMBO leaves — those that HAVE
-            // an enumerable option list to validate against. A scalar/non-combo
-            // required leaf (INT/FLOAT/STRING; getComboOptions returns undefined)
-            // is a NORMAL required input, valid whichever option resolves as long
-            // as it's DEFINED (checked via `definedEverywhere` above). Treating a
-            // missing option list as a membership failure would DROP a legitimate
-            // required scalar and cause a missing-required-input error (#517). So
-            // only fail membership when there IS an option list and the value is
-            // out-of-list.
             if (Array.isArray(optList) && !optList.includes(leafVal as never)) {
-              memberEverywhere = false;
-              break;
+              memberWhereDefined = false;
             }
           }
         }
-        if (!anyOption || !definedEverywhere || !memberEverywhere)
-          delete inputs[key];
+        // Decision, split by leaf kind:
+        //  - LINK-REF leaf: its runtime value is unknowable, so the only defense
+        //    against orphaning it under an option that omits the leaf is strict
+        //    default-DENY — keep only if EVERY option defines it. Dropping a link
+        //    ref discards no user-authored scalar (the connection's value is
+        //    runtime), so the strict rule is cheap and safe.
+        //  - LITERAL leaf: it is a concrete USER VALUE. Dropping it just because
+        //    SOME option omits the leaf silently discards the user's input on a
+        //    resolution that may never occur (#517 P0-B: option A defines
+        //    strength=0.75, option B omits it — the strict rule deleted 0.75 even
+        //    though A is the live selection). A deterministic parent never reaches
+        //    this branch (a Primitive/positional parent is a STRING, re-anchored
+        //    against its RESOLVED option in the non-array path above), so here the
+        //    selection is genuinely unknowable — preserve a literal that at least
+        //    one option DEFINES, provided it stays a valid member wherever a
+        //    defining option enumerates options. A wrong-option literal (defined by
+        //    all options but out-of-list for one — the test-1216 case) still fails
+        //    memberWhereDefined and is dropped, so no invalid literal reaches the
+        //    prompt.
+        const drop = !anyOption
+          ? true
+          : leafIsLink
+            ? !definedEverywhere
+            : !definedSomewhere || !memberWhereDefined;
+        if (drop) delete inputs[key];
         continue;
       }
       const { leafName, spec } = resolveWidgetSpec(def, key, inputs);

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -83,37 +83,19 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
 }
 
 /**
- * Model/asset & MEDIA file extensions that appear in ComfyUI loader/input combos
- * (unet_name, ckpt_name, vae_name, lora_name, control_net_name, clip_name, and
- * LoadImage/LoadAudio/LoadVideo's image/audio/video selectors, …). Used to
- * distinguish an asset-selection combo — where substituting a different file
- * silently swaps the user's model OR their input media (issue #504) — from a
- * plain enum combo (sampler_name, a stale "Select to add Wildcard" UI helper)
- * where falling back to the first option is harmless.
- *
- * Media extensions matter because LoadImage's `image` widget lists the input
- * files on the *connected* server; a freshly staged upload (e.g. via
- * stage_output_as_input) isn't in a STALE /object_info combo, and without media
- * coverage here the value was silently rewritten to comboOpts[0] — headless
- * execution then ran on the WRONG source image with no warning (#504).
- */
-const ASSET_FILE_RE =
-  /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml|png|jpe?g|webp|bmp|gif|tiff?|mp4|webm|mov|mkv|m4v|avi|wav|mp3|flac|ogg|m4a)$/i;
-
-function looksLikeAssetFilename(value: unknown): boolean {
-  return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
-}
-
-/**
- * Widget names that are ALWAYS server-side asset selectors, even when their
+ * Widget names that are ALWAYS server-side MODEL asset selectors, even when their
  * options carry no file extension (e.g. DiffusersLoader.model_path lists
  * extensionless directory names). Substituting a different entry here silently
- * swaps the user's model, so these must never take the comboOpts[0] fallback.
- * Deliberately excludes enum-shaped "_name" widgets (sampler_name, scheduler)
- * whose first-option fallback is legitimate. Also covers the MEDIA input
- * selectors (LoadImage.image, LoadAudio.audio, VHS_LoadVideo.video) so a staged
- * upload absent from a stale combo is never silently swapped for comboOpts[0]
- * (issue #504) even when the value carries no recognizable file extension.
+ * swaps the user's model, so these must never take the comboOpts[0] fallback
+ * (issue #407). These "_name"/"model_path" widget names are unambiguous model
+ * selectors on every node that exposes them, so a plain name match is safe.
+ *
+ * Deliberately EXCLUDES generic media names (image/audio/video) and enum-shaped
+ * "_name" widgets (sampler_name, scheduler): those are NOT globally asset
+ * selectors — a combo merely *named* `image` on some non-loader node, or a
+ * `sampler_name`, is a true enum whose first-option fallback is legitimate.
+ * Media/upload selectors are recognized structurally instead (see
+ * LOADER_ASSET_INPUTS and isUploadSelectorSpec).
  */
 const ASSET_WIDGET_NAMES = new Set([
   "ckpt_name",
@@ -133,10 +115,117 @@ const ASSET_WIDGET_NAMES = new Set([
   "clip_vision_name",
   "model_path",
   "diffusion_model",
-  "image",
-  "audio",
-  "video",
 ]);
+
+/**
+ * KNOWN server-side file/upload SELECTORS, keyed by (classType → input name):
+ * real loader nodes whose combo lists media files present on the *connected*
+ * server (uploads or on-disk inputs). For these — and ONLY these, plus the
+ * model-loader widget names in ASSET_WIDGET_NAMES and object_info upload-flag
+ * metadata (isUploadSelectorSpec) — a value absent from a STALE combo is
+ * PRESERVED with a warning rather than silently rewritten to comboOpts[0]
+ * (issue #504). This is deliberately an allowlist, NOT a global name/extension
+ * heuristic: a combo merely *named* `image`/`audio`/`video`/`extension` on some
+ * OTHER node, or a media-looking value (`.bmp`, `.mp4`, …) on a TRUE enum, is
+ * NOT an asset selector and must take the enum fallback (substitute + warn) so
+ * ComfyUI does not hard-reject a "Value not in list".
+ */
+const LOADER_ASSET_INPUTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["LoadImage", new Set(["image"])],
+  ["LoadImageMask", new Set(["image"])],
+  ["LoadImageOutput", new Set(["image"])],
+  ["VHS_LoadVideo", new Set(["video"])],
+  ["VHS_LoadVideoPath", new Set(["video"])],
+  ["VHS_LoadVideoFFmpeg", new Set(["video"])],
+  ["VHS_LoadVideoFFmpegPath", new Set(["video"])],
+  ["LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudioUpload", new Set(["audio"])],
+]);
+
+function isKnownLoaderInput(classType: string, name: string): boolean {
+  return LOADER_ASSET_INPUTS.get(classType)?.has(name) ?? false;
+}
+
+/**
+ * Whether object_info marks this input as an in-browser file/media UPLOAD
+ * selector — the authoritative signal that the combo lists server-side input
+ * files (LoadImage's `image` carries `{image_upload: true}`, audio/video loaders
+ * `{audio_upload|video_upload: true}`). When present this is more reliable than
+ * any name allowlist, so a staged value absent from a stale combo is preserved.
+ */
+function isUploadSelectorSpec(spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  const cfg = spec[1] as Record<string, unknown> | undefined;
+  if (!cfg || typeof cfg !== "object") return false;
+  return (
+    cfg.image_upload === true ||
+    cfg.audio_upload === true ||
+    cfg.video_upload === true
+  );
+}
+
+/**
+ * Validate one saved widget value against its object_info COMBO options and
+ * return the value to store. Non-combo specs and in-list values pass through
+ * unchanged. For an out-of-list value the decision mirrors #407/#504:
+ *
+ *  - genuine ASSET/upload selector (model-loader widget name, (classType,input)
+ *    loader allowlist, or object_info upload flag) → PRESERVE + warn, so a
+ *    staged/absent file surfaces as an honest missing-asset error rather than a
+ *    silent wrong-file swap;
+ *  - true ENUM (sampler_name, scheduler, a stale "Select to add Wildcard"
+ *    helper, a combo merely NAMED image/extension, a media-looking value on a
+ *    non-loader enum) → SUBSTITUTE comboOpts[0] + warn, because ComfyUI hard-
+ *    rejects a "Value not in list".
+ *
+ * Applied on EVERY widget-population path — the positional widgets_values array,
+ * the name→value object form (VHS_VideoCombine, …), AND the
+ * has_serialized_properties overwrite — so an invalid enum value can't leak past
+ * validation on any of them.
+ */
+function validateComboWidgetValue(
+  name: string,
+  value: unknown,
+  def: ComfyUINodeDef,
+  classType: string,
+  nodeId: string,
+  warnings: string[],
+): unknown {
+  const spec =
+    (def.input?.required as Record<string, unknown>)?.[name] ??
+    (def.input?.optional as Record<string, unknown>)?.[name];
+  const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
+  if (
+    !Array.isArray(comboOpts) ||
+    comboOpts.length === 0 ||
+    comboOpts.includes(value as never)
+  ) {
+    return value;
+  }
+  const isAssetCombo =
+    ASSET_WIDGET_NAMES.has(name) ||
+    isKnownLoaderInput(classType, name) ||
+    isUploadSelectorSpec(spec);
+  if (isAssetCombo) {
+    warnings.push(
+      `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+        value,
+      )}" is not installed on the connected server — keeping the declared value so it surfaces as a missing-asset error rather than silently substituting "${String(
+        comboOpts[0],
+      )}".`,
+    );
+    return value;
+  }
+  warnings.push(
+    `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+      value,
+    )}" is not a valid option on the connected server — substituting the first available option "${String(
+      comboOpts[0],
+    )}" so the graph stays runnable (ComfyUI rejects unknown enum values).`,
+  );
+  return comboOpts[0];
+}
 
 /**
  * Check if an input has control_after_generate in its spec config.
@@ -1245,7 +1334,15 @@ export function convertUiToApi(
     if (!Array.isArray(widgetValues)) {
       const wv = widgetValues as Record<string, unknown>;
       for (const name of widgetNames) {
-        if (name in wv) inputs[name] = wv[name];
+        if (name in wv)
+          inputs[name] = validateComboWidgetValue(
+            name,
+            wv[name],
+            def,
+            classType,
+            nodeId,
+            warnings,
+          );
       }
     } else {
     let widgetIdx = 0;
@@ -1269,56 +1366,18 @@ export function convertUiToApi(
       // Classic combo widget: if the saved value isn't one of the valid options
       // (a stale UI-helper combo like Impact's "Select to add Wildcard", or a
       // value from a node version with different options), fall back to the
-      // default first option. ComfyUI hard-rejects "Value not in list" otherwise,
-      // so defaulting is strictly safer than passing the stale value through.
-      //
-      // EXCEPTION (issues #407, #504): an ASSET/MEDIA-selection combo (unet_name,
-      // ckpt_name, vae_name, lora_name, LoadImage.image, …) lists the files
-      // present on the *connected* server. When the declared file isn't there,
-      // comboOpts[0] is a completely unrelated entry — e.g. Krea 2's
-      // "krea2_turbo_fp8.safetensors" silently became "flux-2-klein-9b.safetensors"
-      // (#407), or a freshly staged LoadImage input silently became the first
-      // cached filename (#504). Silently swapping the user's model OR their input
-      // media produces a misleading graph / wrong-source render. For asset & media
-      // combos we KEEP the declared value and warn, so it surfaces as an honest
-      // missing-asset error instead of a wrong-file success.
-      const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
-      if (
-        Array.isArray(comboOpts) &&
-        comboOpts.length > 0 &&
-        !comboOpts.includes(value as never)
-      ) {
-        const isAssetCombo =
-          ASSET_WIDGET_NAMES.has(name) ||
-          looksLikeAssetFilename(value) ||
-          comboOpts.some((opt) => looksLikeAssetFilename(opt));
-        if (isAssetCombo) {
-          warnings.push(
-            `Node ${nodeId} (${classType}): widget "${name}" value "${String(
-              value,
-            )}" is not installed on the connected server — keeping the declared value so it surfaces as a missing-asset error rather than silently substituting "${String(
-              comboOpts[0],
-            )}".`,
-          );
-          // inputs[name] already holds the declared value; leave it untouched.
-        } else {
-          // Non-asset ENUM combo (sampler_name, scheduler, a stale Impact
-          // "Select to add Wildcard" UI-helper value, …). ComfyUI hard-rejects a
-          // "Value not in list", so falling back to the first option keeps the
-          // graph runnable — but the substitution must NOT be silent: the user
-          // set this value, so surface a warning that it was changed. (Only the
-          // fallback direction differs from the asset case above; neither path
-          // overwrites a user-set value without a warning.)
-          warnings.push(
-            `Node ${nodeId} (${classType}): widget "${name}" value "${String(
-              value,
-            )}" is not a valid option on the connected server — substituting the first available option "${String(
-              comboOpts[0],
-            )}" so the graph stays runnable (ComfyUI rejects unknown enum values).`,
-          );
-          inputs[name] = comboOpts[0];
-        }
-      }
+      // default first option — UNLESS it's a genuine asset/upload selector, which
+      // we preserve + warn (#407/#504). See validateComboWidgetValue for the full
+      // classification (model-loader names + (classType,input) loader allowlist +
+      // object_info upload flag — NOT a global name/extension heuristic).
+      inputs[name] = validateComboWidgetValue(
+        name,
+        value,
+        def,
+        classType,
+        nodeId,
+        warnings,
+      );
 
       const opts = (
         Array.isArray(spec)
@@ -1359,7 +1418,15 @@ export function convertUiToApi(
     const serializedProps = node.properties as Record<string, unknown> | undefined;
     if (serializedProps?.has_serialized_properties === true) {
       for (const name of widgetNames) {
-        if (name in serializedProps) inputs[name] = serializedProps[name];
+        if (name in serializedProps)
+          inputs[name] = validateComboWidgetValue(
+            name,
+            serializedProps[name],
+            def,
+            classType,
+            nodeId,
+            warnings,
+          );
       }
     }
 

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1497,7 +1497,16 @@ export function convertUiToApi(
     // combo was processed and which widgets were mapped AFTER it, so on leftover we
     // can default those (shifted) widgets + warn instead of trusting the shift.
     let sawDynamicCombo = false;
-    let tailRefused = false;
+    // Set when ANY combo hits a refusal (stale/empty-options parent, or a linked-
+    // nested leaf). A refusal INTENTIONALLY stops mapping and leaves the tail
+    // unconsumed, so the leftover it creates is EXPECTED — it does NOT prove that an
+    // EARLIER combo drifted. Positionally, a valid layout ([first, first.note,
+    // count, second→refuse]) and a drifted one are IDENTICAL once a refusal is
+    // present, so acting on that leftover would DELETE valid earlier values (a real
+    // regression). Therefore a refusal suppresses the leftover drift guard entirely
+    // for this node; the drift guard fires only on a leftover with NO refusal, where
+    // it unambiguously means the arity shrank.
+    let refusalOccurred = false;
     const widgetsAfterDynamicCombo: string[] = [];
     // Dotted "<combo>.<leaf>" keys assigned positionally from a dynamic combo's
     // nested layout. On a proven arity drift (leftover) these are ALSO suspect — a
@@ -1642,11 +1651,9 @@ export function convertUiToApi(
             widgetValues.length - widgetIdx
           } saved widget value(s) are left to their defaults rather than risk silently assigning a stale nested value to a later widget (such as a seed).`,
         );
-        // Mark tailRefused so the post-loop leftover drift-guard does NOT ALSO fire
-        // on the leftover this break creates — otherwise, when an EARLIER combo had
-        // set sawDynamicCombo, the guard would delete THIS (stale/empty-options)
-        // parent, which has no substitution or default to be restored from.
-        tailRefused = true;
+        // A refusal's leftover is expected and can't be attributed to earlier drift,
+        // so suppress the drift guard for this node (see refusalOccurred note).
+        refusalOccurred = true;
         break;
       }
 
@@ -1726,11 +1733,11 @@ export function convertUiToApi(
         // A linked nested leaf with trailing saved values made the alignment
         // ambiguous — stop mapping the remaining top-level widgets (they
         // default-fill below) so no retained placeholder can shift onto a seed.
-        // Mark tailRefused so the leftover drift-guard below does NOT ALSO fire on
-        // the leftover this break creates (double-warn + wrongly defaulting a
-        // later dynamic parent when an EARLIER combo had set sawDynamicCombo).
+        // This refusal's leftover is expected, so suppress the drift guard for this
+        // node (see refusalOccurred note) — otherwise it would delete valid earlier
+        // widgets/leaves mapped before this refusing combo.
         if (refuseTail) {
-          tailRefused = true;
+          refusalOccurred = true;
           break;
         }
       }
@@ -1749,18 +1756,29 @@ export function convertUiToApi(
     // leftover — even with no trailing top-level widget — so a shifted nested value
     // can't survive. (Mirrors the stale-parent + linked-leaf refusals.)
     //
-    // LIMITATION (accepted): the OPPOSITE drift — the option GAINED nested inputs
-    // since the save — over-consumes trailing values yet often lands on EXACT
-    // consumption, positionally IDENTICAL to a legitimate multi-nested layout (the
-    // canonical Nano Banana node: [prompt, model, aspect_ratio, resolution,
-    // thinking_level, seed, control, response_modalities]). No positional signal
-    // distinguishes the two, so catching arity-GROWTH would require refusing ALL
-    // trailing widgets after every dynamic combo — regressing that real shipping
-    // node. We therefore catch only the provable (leftover) direction. tailRefused
-    // gates out the stale-parent + linked-leaf refusal paths (which already warned +
-    // defaulted the tail) so this guard can't double-warn or default a later, valid
-    // combo parent.
-    if (sawDynamicCombo && !tailRefused && widgetIdx < widgetValues.length) {
+    // LIMITATION (accepted, BROAD): only the direction that nets to a LEFTOVER is
+    // catchable. Any nested-arity drift that nets to EXACT consumption is positionally
+    // INDISTINGUISHABLE from a legitimate layout and CANNOT be caught from
+    // widgets_values alone. That covers not just arity-GROWTH (option gained nested
+    // inputs) but ALSO arity-SHRINK masked by a newly-added TOP-LEVEL widget (a
+    // removed nested slot canceled by an added trailing widget → exact), and the
+    // multi-combo variants of both. Catching any of these would require refusing ALL
+    // trailing widgets after every dynamic combo — which regresses the canonical Nano
+    // Banana multi-nested node ([prompt, model, aspect_ratio, resolution,
+    // thinking_level, seed, control, response_modalities], an existing passing test).
+    // So this guard catches only the provable (leftover) direction.
+    //
+    // ALSO ACCEPTED (undecidable when a REFUSAL is present): a refusal (linked-leaf
+    // or stale/empty-options parent) INTENTIONALLY stops mapping, so the leftover it
+    // creates is EXPECTED and cannot be attributed to an earlier combo's drift — a
+    // valid layout ([first, first.note, count, second→refuse]) and a drifted one are
+    // positionally IDENTICAL once a refusal is present. Acting on that leftover would
+    // DELETE valid earlier values, so `refusalOccurred` suppresses this guard for the
+    // whole node. (Any earlier drift then falls to the accepted exact-consumption
+    // class above — a refusal's leftover is not a reliable drift signal.) The guard
+    // therefore fires ONLY on a leftover with NO refusal, where it unambiguously means
+    // the arity shrank.
+    if (sawDynamicCombo && !refusalOccurred && widgetIdx < widgetValues.length) {
       for (const wn of widgetsAfterDynamicCombo) delete inputs[wn];
       for (const nk of nestedKeysFromDynamic) delete inputs[nk];
       const defaulted = [...nestedKeysFromDynamic, ...widgetsAfterDynamicCombo];
@@ -1992,7 +2010,19 @@ export function convertUiToApi(
           : leafIsLink
             ? !definedEverywhere
             : !definedSomewhere || !memberWhereDefined;
-        if (drop) delete inputs[key];
+        if (drop) {
+          // A dropped LINK-REF leaf is a real connection the user wired — deleting it
+          // silently would make the parent's runtime option fall back to its default
+          // with no trace (FIX 2, #517). Keep the strict default-deny (safest against
+          // orphaning under an option that omits the leaf), but WARN so the removed
+          // link + parent are surfaced rather than silently discarded.
+          if (leafIsLink) {
+            warnings.push(
+              `Node ${nodeId} (${classType}): the linked nested input "${key}" was dropped — its dynamic parent "${parent}" is fed by a runtime link (resolved option unknown) and not every option defines "${leaf}", so keeping the connection could orphan it under an option that omits the leaf. "${leaf}" will use the resolved option's default instead of the wired link.`,
+            );
+          }
+          delete inputs[key];
+        }
         continue;
       }
       const { leafName, spec } = resolveWidgetSpec(def, key, inputs);

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -83,15 +83,22 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
 }
 
 /**
- * Model/asset file extensions that appear in ComfyUI loader combos
- * (unet_name, ckpt_name, vae_name, lora_name, control_net_name, clip_name, …).
- * Used to distinguish an asset-selection combo — where substituting a different
- * installed file silently swaps the user's model — from a plain enum combo
- * (sampler_name, a stale "Select to add Wildcard" UI helper) where falling back
- * to the first option is harmless.
+ * Model/asset & MEDIA file extensions that appear in ComfyUI loader/input combos
+ * (unet_name, ckpt_name, vae_name, lora_name, control_net_name, clip_name, and
+ * LoadImage/LoadAudio/LoadVideo's image/audio/video selectors, …). Used to
+ * distinguish an asset-selection combo — where substituting a different file
+ * silently swaps the user's model OR their input media (issue #504) — from a
+ * plain enum combo (sampler_name, a stale "Select to add Wildcard" UI helper)
+ * where falling back to the first option is harmless.
+ *
+ * Media extensions matter because LoadImage's `image` widget lists the input
+ * files on the *connected* server; a freshly staged upload (e.g. via
+ * stage_output_as_input) isn't in a STALE /object_info combo, and without media
+ * coverage here the value was silently rewritten to comboOpts[0] — headless
+ * execution then ran on the WRONG source image with no warning (#504).
  */
 const ASSET_FILE_RE =
-  /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml)$/i;
+  /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml|png|jpe?g|webp|bmp|gif|tiff?|mp4|webm|mov|mkv|m4v|avi|wav|mp3|flac|ogg|m4a)$/i;
 
 function looksLikeAssetFilename(value: unknown): boolean {
   return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
@@ -103,7 +110,10 @@ function looksLikeAssetFilename(value: unknown): boolean {
  * extensionless directory names). Substituting a different entry here silently
  * swaps the user's model, so these must never take the comboOpts[0] fallback.
  * Deliberately excludes enum-shaped "_name" widgets (sampler_name, scheduler)
- * whose first-option fallback is legitimate.
+ * whose first-option fallback is legitimate. Also covers the MEDIA input
+ * selectors (LoadImage.image, LoadAudio.audio, VHS_LoadVideo.video) so a staged
+ * upload absent from a stale combo is never silently swapped for comboOpts[0]
+ * (issue #504) even when the value carries no recognizable file extension.
  */
 const ASSET_WIDGET_NAMES = new Set([
   "ckpt_name",
@@ -123,6 +133,9 @@ const ASSET_WIDGET_NAMES = new Set([
   "clip_vision_name",
   "model_path",
   "diffusion_model",
+  "image",
+  "audio",
+  "video",
 ]);
 
 /**
@@ -1259,15 +1272,16 @@ export function convertUiToApi(
       // default first option. ComfyUI hard-rejects "Value not in list" otherwise,
       // so defaulting is strictly safer than passing the stale value through.
       //
-      // EXCEPTION (issue #407): an ASSET-selection combo (unet_name, ckpt_name,
-      // vae_name, lora_name, …) lists the files installed on the *connected*
-      // server. When the declared model isn't installed there, comboOpts[0] is a
-      // completely unrelated model — e.g. Krea 2's "krea2_turbo_fp8.safetensors"
-      // silently became "flux-2-klein-9b.safetensors" (the first installed unet).
-      // Silently swapping one model for another produces a misleading graph that
-      // can't render the advertised workflow. For asset combos we KEEP the
-      // declared value and warn, so it surfaces as an honest missing-asset error
-      // instead of a wrong-model success.
+      // EXCEPTION (issues #407, #504): an ASSET/MEDIA-selection combo (unet_name,
+      // ckpt_name, vae_name, lora_name, LoadImage.image, …) lists the files
+      // present on the *connected* server. When the declared file isn't there,
+      // comboOpts[0] is a completely unrelated entry — e.g. Krea 2's
+      // "krea2_turbo_fp8.safetensors" silently became "flux-2-klein-9b.safetensors"
+      // (#407), or a freshly staged LoadImage input silently became the first
+      // cached filename (#504). Silently swapping the user's model OR their input
+      // media produces a misleading graph / wrong-source render. For asset & media
+      // combos we KEEP the declared value and warn, so it surfaces as an honest
+      // missing-asset error instead of a wrong-file success.
       const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
       if (
         Array.isArray(comboOpts) &&
@@ -1288,6 +1302,20 @@ export function convertUiToApi(
           );
           // inputs[name] already holds the declared value; leave it untouched.
         } else {
+          // Non-asset ENUM combo (sampler_name, scheduler, a stale Impact
+          // "Select to add Wildcard" UI-helper value, …). ComfyUI hard-rejects a
+          // "Value not in list", so falling back to the first option keeps the
+          // graph runnable — but the substitution must NOT be silent: the user
+          // set this value, so surface a warning that it was changed. (Only the
+          // fallback direction differs from the asset case above; neither path
+          // overwrites a user-set value without a warning.)
+          warnings.push(
+            `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+              value,
+            )}" is not a valid option on the connected server — substituting the first available option "${String(
+              comboOpts[0],
+            )}" so the graph stays runnable (ComfyUI rejects unknown enum values).`,
+          );
           inputs[name] = comboOpts[0];
         }
       }

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -1546,20 +1546,35 @@ export function convertUiToApi(
       // value onto the trailing top-level widgets (e.g. a removed option's nested
       // strength overwriting the user's seed). The stale-parent guard below REFUSES
       // that case (warn + stop) instead of guessing.
-      // A V3 (object-keyed) dynamic options list has {key, inputs} entries — only
-      // these can add nested positional slots. A classic string-option COMBO
-      // (["a","b"]) never does, and its elements have no `.key`, so it must NOT
+      // A V3 dynamic combo must be identified by its EXPLICIT type string
+      // (spec[0] === "COMFY_DYNAMICCOMBO_V3"), NOT by whether its current options
+      // list happens to contain keyed objects. An EMPTY current options list
+      // (["COMFY_DYNAMICCOMBO_V3", {options: []}]) has NO keyed entries, so the
+      // object-key heuristic alone reports false and the stale-parent guard below
+      // never fires — re-opening the exact silent-positional-shift hole: with an
+      // empty options list every saved selection is stale, and consuming zero
+      // nested slots while advancing the top-level index misassigns a leftover
+      // nested value (e.g. a removed option's strength=0.75) onto the next widget
+      // (e.g. a seed). Keying off the type covers the empty-options case too.
+      //
+      // The object-key heuristic is retained as a fallback for any V3 dynamic list
+      // that carries keyed {key, inputs} entries without the literal type marker.
+      // A classic string-option COMBO (spec[0] is the ["a","b"] options array, not
+      // the "COMFY_DYNAMICCOMBO_V3" string) matches NEITHER branch, so it must NOT
       // trip the stale-parent guard below (which would wrongly refuse a perfectly
       // valid classic-combo value).
+      const specType = Array.isArray(spec) ? spec[0] : undefined;
+      const isDynamicComboType = specType === "COMFY_DYNAMICCOMBO_V3";
       const isDynamicOptions =
-        Array.isArray(opts) &&
-        opts.some(
-          (o) =>
-            o != null &&
-            typeof o === "object" &&
-            !Array.isArray(o) &&
-            "key" in (o as Record<string, unknown>),
-        );
+        isDynamicComboType ||
+        (Array.isArray(opts) &&
+          opts.some(
+            (o) =>
+              o != null &&
+              typeof o === "object" &&
+              !Array.isArray(o) &&
+              "key" in (o as Record<string, unknown>),
+          ));
       const savedOption = Array.isArray(opts)
         ? opts.find((o) => o?.key === value)
         : undefined;

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -166,9 +166,47 @@ function isUploadSelectorSpec(spec: unknown): boolean {
 }
 
 /**
- * Validate one saved widget value against its object_info COMBO options and
- * return the value to store. Non-combo specs and in-list values pass through
- * unchanged. For an out-of-list value the decision mirrors #407/#504:
+ * Extract the selectable option list from a widget spec, covering ALL three
+ * combo shapes so validation never misses one (issue #504 P1-B):
+ *   - inline combo:      [["a","b"], {..}]                 -> spec[0]
+ *   - COMBO w/ options:  ["COMBO", {options:["a","b"]}]    -> spec[1].options
+ *   - V3 dynamic combo:  ["COMFY_DYNAMICCOMBO_V3",         -> the option keys
+ *                          {options:[{key:"K", inputs:{…}}]}]
+ * A plain scalar spec (["INT",{…}]) or a link input carries no enumerable list,
+ * so this returns undefined and the caller passes the value through untouched.
+ * Object-shaped dynamic options are normalized to their `key`.
+ */
+function getComboOptions(spec: unknown): unknown[] | undefined {
+  if (!Array.isArray(spec)) return undefined;
+  const type = spec[0];
+  if (Array.isArray(type)) return type; // inline combo: spec[0] IS the option list
+  const cfg = spec[1] as { options?: unknown } | undefined;
+  const opts = cfg?.options;
+  if (Array.isArray(opts)) {
+    // Flat value list (["auto","1:1"]) or object-keyed dynamic-combo list
+    // ([{key:"Nano Banana 2", …}]). Normalize both to their selectable values.
+    return opts.map((o) =>
+      o &&
+      typeof o === "object" &&
+      !Array.isArray(o) &&
+      "key" in (o as Record<string, unknown>)
+        ? (o as { key: unknown }).key
+        : o,
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Validate one saved combo value against its object_info options (of ANY combo
+ * shape — see getComboOptions) and return the value to store. This is the SINGLE
+ * choke-point every combo-value assignment flows through — direct widget, the
+ * name→value object form, the has_serialized_properties overwrite, a linked
+ * PrimitiveNode literal (P1-A), AND a V3 dynamic-combo nested leaf value (P1-B) —
+ * so no path can emit a value ComfyUI would reject with "Value not in list".
+ *
+ * Non-combo specs and in-list values pass through unchanged. For an out-of-list
+ * value the decision mirrors #407/#504:
  *
  *  - genuine ASSET/upload selector (model-loader widget name, (classType,input)
  *    loader allowlist, or object_info upload flag) → PRESERVE + warn, so a
@@ -176,37 +214,48 @@ function isUploadSelectorSpec(spec: unknown): boolean {
  *    silent wrong-file swap;
  *  - true ENUM (sampler_name, scheduler, a stale "Select to add Wildcard"
  *    helper, a combo merely NAMED image/extension, a media-looking value on a
- *    non-loader enum) → SUBSTITUTE comboOpts[0] + warn, because ComfyUI hard-
- *    rejects a "Value not in list".
+ *    non-loader enum, an out-of-list dynamic/nested key) → SUBSTITUTE
+ *    comboOpts[0] + warn, because ComfyUI hard-rejects a "Value not in list".
  *
- * Applied on EVERY widget-population path — the positional widgets_values array,
- * the name→value object form (VHS_VideoCombine, …), AND the
- * has_serialized_properties overwrite — so an invalid enum value can't leak past
- * validation on any of them.
+ * `name` is the LEAF input name (nested leaf for dynamic combos) so asset
+ * classification keys off the real selector name, and `spec` is that leaf's
+ * spec, never regressing #504/#407.
  */
-function validateComboWidgetValue(
+function validateComboValueForSpec(
   name: string,
   value: unknown,
-  def: ComfyUINodeDef,
+  spec: unknown,
   classType: string,
   nodeId: string,
   warnings: string[],
 ): unknown {
-  const spec =
-    (def.input?.required as Record<string, unknown>)?.[name] ??
-    (def.input?.optional as Record<string, unknown>)?.[name];
-  const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
-  if (
-    !Array.isArray(comboOpts) ||
-    comboOpts.length === 0 ||
-    comboOpts.includes(value as never)
-  ) {
-    return value;
-  }
+  const comboOpts = getComboOptions(spec);
+  // Not an enumerable combo (plain INT/FLOAT/STRING/BOOLEAN or a link input) —
+  // nothing to validate against.
+  if (!Array.isArray(comboOpts)) return value;
+  // Already a valid option — pass through untouched.
+  if (comboOpts.includes(value as never)) return value;
   const isAssetCombo =
     ASSET_WIDGET_NAMES.has(name) ||
     isKnownLoaderInput(classType, name) ||
     isUploadSelectorSpec(spec);
+  // Recognized combo whose option list is EMPTY on the connected server (e.g. no
+  // models/files installed, or a fully-retired enum). There is no valid option to
+  // substitute to, so preserve the declared value and WARN — surfacing an honest
+  // missing-option/asset error rather than SILENTLY emitting an out-of-list
+  // literal. (Previously the length===0 branch returned the value with no warning.)
+  if (comboOpts.length === 0) {
+    warnings.push(
+      isAssetCombo
+        ? `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+            value,
+          )}" — the connected server has no installed options for this asset combo; keeping the declared value so it surfaces as a missing-asset error.`
+        : `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+            value,
+          )}" — the connected server lists no options for this combo, so it cannot be validated; keeping the declared value so it surfaces as an honest error rather than being silently emitted.`,
+    );
+    return value;
+  }
   if (isAssetCombo) {
     warnings.push(
       `Node ${nodeId} (${classType}): widget "${name}" value "${String(
@@ -228,6 +277,96 @@ function validateComboWidgetValue(
 }
 
 /**
+ * Def-keyed wrapper for validateComboValueForSpec: resolves the input's spec from
+ * object_info by name (required then optional) and delegates. Used by the direct
+ * widget paths and the linked-PrimitiveNode path.
+ */
+function validateComboWidgetValue(
+  name: string,
+  value: unknown,
+  def: ComfyUINodeDef,
+  classType: string,
+  nodeId: string,
+  warnings: string[],
+): unknown {
+  const spec =
+    (def.input?.required as Record<string, unknown>)?.[name] ??
+    (def.input?.optional as Record<string, unknown>)?.[name];
+  return validateComboValueForSpec(name, value, spec, classType, nodeId, warnings);
+}
+
+/**
+ * Resolve an input NAME (possibly a V3 dynamic-combo dotted "<combo>.<leaf>"
+ * key) to its LEAF name and object_info spec. A flat name resolves against the
+ * node's top-level required/optional inputs. A dotted name resolves the leaf
+ * against the parent dynamic combo's SELECTED option (looked up from the already
+ * populated `inputs[parent]`), so validation and asset classification key off
+ * the real leaf spec + leaf name — never the dotted name (which no top-level
+ * lookup would find, letting an unvalidated value through). Used by the linked
+ * PrimitiveNode path, where a primitive can feed a nested dotted input directly.
+ */
+function resolveWidgetSpec(
+  def: ComfyUINodeDef,
+  name: string,
+  inputs: Record<string, unknown>,
+): { leafName: string; spec: unknown } {
+  const dot = name.indexOf(".");
+  if (dot < 0) {
+    const spec =
+      (def.input?.required as Record<string, unknown>)?.[name] ??
+      (def.input?.optional as Record<string, unknown>)?.[name];
+    return { leafName: name, spec };
+  }
+  const parent = name.slice(0, dot);
+  const leafName = name.slice(dot + 1);
+  const parentSpec =
+    (def.input?.required as Record<string, unknown>)?.[parent] ??
+    (def.input?.optional as Record<string, unknown>)?.[parent];
+  const opts = (
+    Array.isArray(parentSpec)
+      ? (parentSpec[1] as {
+          options?: Array<{
+            key?: unknown;
+            inputs?: {
+              required?: Record<string, unknown>;
+              optional?: Record<string, unknown>;
+            };
+          }>;
+        })
+      : undefined
+  )?.options;
+  const selectedKey = inputs[parent];
+  // V3 option inputs may live under required OR optional — search both so an
+  // optional nested leaf isn't left unresolved (which would skip validation).
+  const selected = Array.isArray(opts)
+    ? opts.find((o) => o?.key === selectedKey)?.inputs
+    : undefined;
+  const spec = selected?.required?.[leafName] ?? selected?.optional?.[leafName];
+  return { leafName, spec };
+}
+
+/**
+ * Whether a widget SPEC carries a control_after_generate phantom slot — either
+ * flagged in its config, or a seed-type INT the ComfyUI frontend auto-augments.
+ * Works for both top-level inputs and V3 dynamic-combo NESTED leaves (which have
+ * no entry in def.input), so nested controlled seeds skip their phantom
+ * "fixed"/"randomize" slot too instead of shifting every following widget.
+ */
+function specHasControlAfterGenerate(name: string, spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  if ((spec[1] as Record<string, unknown> | undefined)?.control_after_generate === true)
+    return true;
+  // ComfyUI's frontend auto-adds a control_after_generate widget to seed-type INT
+  // widgets even when object_info doesn't flag it (e.g. UltimateSDUpscale.seed,
+  // KSamplerAdvanced.noise_seed). The saved widgets_values then carry the extra
+  // "fixed"/"randomize"/… value that must be skipped during mapping.
+  return (
+    spec[0] === "INT" &&
+    (name === "seed" || name === "noise_seed" || name === "rand_seed")
+  );
+}
+
+/**
  * Check if an input has control_after_generate in its spec config.
  * These inputs (like seed, noise_seed) have a phantom "fixed"/"randomize" widget
  * in the UI's widgets_values array that doesn't correspond to any named input.
@@ -239,18 +378,7 @@ function hasControlAfterGenerate(
   const spec =
     def.input.required?.[inputName] ?? def.input.optional?.[inputName];
   if (!spec) return false;
-  if ((spec[1] as Record<string, unknown> | undefined)?.control_after_generate === true)
-    return true;
-  // ComfyUI's frontend auto-adds a control_after_generate widget to seed-type INT
-  // widgets even when object_info doesn't flag it (e.g. UltimateSDUpscale.seed,
-  // KSamplerAdvanced.noise_seed). The saved widgets_values then carry the extra
-  // "fixed"/"randomize"/… value that must be skipped during mapping.
-  if (
-    spec[0] === "INT" &&
-    (inputName === "seed" || inputName === "noise_seed" || inputName === "rand_seed")
-  )
-    return true;
-  return false;
+  return specHasControlAfterGenerate(inputName, spec);
 }
 
 /**
@@ -1323,6 +1451,17 @@ export function convertUiToApi(
       }
     }
 
+    // Nested widgets that have been "converted to input" (linked) carry NO
+    // positional widgets_values slot — their value arrives via the link, not the
+    // saved array — so consuming a slot for them would steal the next widget's
+    // value and mis-align the whole tail. Track the linked (dotted) input names
+    // to skip their positional consumption below.
+    const linkedInputNames = new Set(
+      (node.inputs ?? [])
+        .filter((i) => i.link != null)
+        .map((i) => i.name),
+    );
+
     // Map widgets_values to named widget inputs.
     // Some INT inputs with "control_after_generate": true (like seed, noise_seed) have
     // a phantom widget value in widgets_values ("fixed"/"randomize"/"increment"/"decrement")
@@ -1381,12 +1520,39 @@ export function convertUiToApi(
 
       const opts = (
         Array.isArray(spec)
-          ? (spec[1] as { options?: Array<{ key?: unknown; inputs?: { required?: Record<string, unknown> } }> })
+          ? (spec[1] as {
+              options?: Array<{
+                key?: unknown;
+                inputs?: {
+                  required?: Record<string, unknown>;
+                  optional?: Record<string, unknown>;
+                };
+              }>;
+            })
           : undefined
       )?.options;
-      const nested = Array.isArray(opts)
-        ? opts.find((o) => o?.key === value)?.inputs?.required
+      // A V3 option's nested widgets can live under required OR optional; both
+      // occupy positional widgets_values slots in serialization order (required
+      // then optional). Merging them keeps the positional index aligned AND
+      // ensures every nested leaf is validated — reading only `required` would
+      // skip an optional leaf and mis-position every later widget.
+      //
+      // Look up the option by the RAW saved `value` (the selection the array was
+      // serialized against), NOT the post-validation inputs[name]. If the saved
+      // selection is stale (substituted for a valid one), its ORIGINAL nested
+      // arity is unrecoverable, so we deliberately consume NO nested slots rather
+      // than guess against the replacement option's layout — guessing would
+      // silently steal or drop the trailing top-level widgets (e.g. a seed). The
+      // parent value is still substituted+warned above; required nested inputs of
+      // the replacement simply fall through to default-fill.
+      const selectedInputs = Array.isArray(opts)
+        ? opts.find((o) => o?.key === value)?.inputs
         : undefined;
+      const nested =
+        selectedInputs &&
+        (selectedInputs.required || selectedInputs.optional)
+          ? { ...selectedInputs.required, ...selectedInputs.optional }
+          : undefined;
       if (nested) {
         // V3 dynamic-combo nested inputs are keyed with the combo's id as a
         // "<combo>.<nested>" prefix (ComfyUI rebuilds the nested dict from these
@@ -1396,10 +1562,34 @@ export function convertUiToApi(
         // "images", or IMAGE/link types) have no saved widget value, so skipping
         // them keeps the positional mapping aligned.
         for (const [nName, nSpec] of Object.entries(nested)) {
-          if (widgetIdx >= widgetValues.length) break;
           if (!isPositionalWidgetSpec(nSpec)) continue;
-          inputs[`${name}.${nName}`] = widgetValues[widgetIdx];
+          // A linked (converted-to-input) nested leaf has NO positional slot — its
+          // value comes from the link, populated in the link loop below — so it
+          // must NOT consume a widgets_values entry or the tail shifts.
+          if (linkedInputNames.has(`${name}.${nName}`)) continue;
+          if (widgetIdx >= widgetValues.length) break;
+          // Nested leaf values bypass the top-level widget validation, so validate
+          // each against ITS OWN leaf spec/name (P1-B). Asset classification keys
+          // off the leaf name + loader/upload allowlist (don't regress #504/#407);
+          // an out-of-list nested enum (e.g. aspect_ratio "4:3") substitutes+warns.
+          inputs[`${name}.${nName}`] = validateComboValueForSpec(
+            nName,
+            widgetValues[widgetIdx],
+            nSpec,
+            classType,
+            nodeId,
+            warnings,
+          );
           widgetIdx++;
+          // A nested seed-type / control_after_generate leaf carries a phantom
+          // "fixed"/"randomize" value right after it (same as top-level seeds), so
+          // skip that slot or every following widget shifts by one.
+          if (
+            specHasControlAfterGenerate(nName, nSpec) &&
+            widgetIdx < widgetValues.length
+          ) {
+            widgetIdx++;
+          }
         }
       }
     }
@@ -1452,7 +1642,21 @@ export function convertUiToApi(
       } else {
         dflt = config?.default;
       }
-      if (dflt !== undefined) inputs[name] = dflt;
+      if (dflt !== undefined) {
+        // A schema `default` can itself be out-of-list (custom-node combo drift,
+        // e.g. sampler_name default "removed_sampler" not in its own options).
+        // Route the derived default through the same choke-point so it can't emit
+        // a value ComfyUI rejects — first-option substitution for a true enum,
+        // leaf-name asset preservation for a loader/upload selector.
+        inputs[name] = validateComboValueForSpec(
+          name,
+          dflt,
+          spec,
+          classType,
+          nodeId,
+          warnings,
+        );
+      }
     }
 
     // Map linked inputs from node's inputs array (bypass/mute resolved)
@@ -1466,12 +1670,117 @@ export function convertUiToApi(
         const srcNode = link ? nodesById.get(link.sourceNodeId) : undefined;
         if (srcNode?.type === "PrimitiveNode") {
           const val = srcNode.widgets_values?.[0];
-          if (val !== undefined) inputs[input.name] = val;
+          // A linked PrimitiveNode literal bypasses the widget-value validation
+          // above (widgets are processed first, links after), so route it through
+          // the same choke-point (P1-A). A stale LOADER asset is preserved+warned;
+          // a true out-of-list ENUM (e.g. sampler_name "removed_sampler") is
+          // substituted+warned rather than reaching the API and being rejected.
+          // input.name may be a dynamic-combo dotted "<combo>.<leaf>" key, so
+          // resolve the leaf spec/name first — a top-level lookup would miss it
+          // and let the value through unvalidated.
+          if (val !== undefined) {
+            const { leafName, spec } = resolveWidgetSpec(def, input.name, inputs);
+            inputs[input.name] = validateComboValueForSpec(
+              leafName,
+              val,
+              spec,
+              classType,
+              nodeId,
+              warnings,
+            );
+          }
           continue;
         }
         const resolved = resolveSource(input.link);
         if (resolved) inputs[input.name] = [resolved.id, resolved.slot];
       }
+    }
+
+    // Final dependency-aware pass over V3 dynamic-combo dotted "<parent>.<leaf>"
+    // inputs: a link/PrimitiveNode override above can change the PARENT selection
+    // AFTER its nested leaves were validated against the ORIGINAL option (e.g.
+    // positional emits model="A"+model.choice="a1", then a primitive overrides
+    // model="B"). Re-anchor every dotted leaf to the FINAL parent value — drop a
+    // leaf that the selected option no longer defines, and revalidate the rest
+    // against the leaf's real spec — so no leaf reaches the prompt validated
+    // against the wrong option.
+    for (const key of Object.keys(inputs)) {
+      const dot = key.indexOf(".");
+      if (dot < 0) continue;
+      const parent = key.slice(0, dot);
+      // Orphaned dotted leaf: its dynamic parent isn't in the prompt (e.g. an
+      // optional parent left unset while the leaf was linked). There's no option
+      // context to validate against, and the leaf is meaningless without its
+      // parent, so default-deny — drop it rather than let an unvalidated literal
+      // reach the prompt.
+      if (!(parent in inputs)) {
+        if (!Array.isArray(inputs[key])) delete inputs[key];
+        continue;
+      }
+      const leafVal = inputs[key];
+      if (Array.isArray(leafVal)) continue; // leaf itself is a link ref
+      // Parent fed by a real (non-Primitive) link → the SELECTED option is only
+      // known at runtime, so a leaf literal saved under one option may be wrong
+      // for the resolved one. Keep it only if it validates under EVERY option
+      // that defines the leaf; otherwise drop it (ComfyUI supplies the runtime
+      // option's default). This prevents a wrong-option literal (e.g. option-A
+      // "a1" left on a parent that resolves to option B) reaching the prompt.
+      if (Array.isArray(inputs[parent])) {
+        const leaf = key.slice(dot + 1);
+        const pSpec =
+          (def.input?.required as Record<string, unknown>)?.[parent] ??
+          (def.input?.optional as Record<string, unknown>)?.[parent];
+        const pOpts = (
+          Array.isArray(pSpec)
+            ? (pSpec[1] as {
+                options?: Array<{
+                  inputs?: {
+                    required?: Record<string, unknown>;
+                    optional?: Record<string, unknown>;
+                  };
+                }>;
+              })
+            : undefined
+        )?.options;
+        // Keep the leaf ONLY if its literal is a genuine in-list MEMBER of every
+        // option that defines it (so it's valid whichever option resolves at
+        // runtime). Use a strict membership test — NOT validateComboValueForSpec,
+        // whose asset/empty-combo PRESERVE path would keep an out-of-list literal
+        // and swallow its warning. Anything else (out-of-list, asset, empty combo,
+        // undefined-everywhere) is dropped so no silent wrong-option literal reaches
+        // the prompt; ComfyUI fills the runtime option's default.
+        let definedSomewhere = false;
+        let memberEverywhere = true;
+        if (Array.isArray(pOpts)) {
+          for (const o of pOpts) {
+            const s = o?.inputs?.required?.[leaf] ?? o?.inputs?.optional?.[leaf];
+            if (s === undefined) continue;
+            definedSomewhere = true;
+            const optList = getComboOptions(s);
+            if (!Array.isArray(optList) || !optList.includes(leafVal as never)) {
+              memberEverywhere = false;
+              break;
+            }
+          }
+        }
+        if (!definedSomewhere || !memberEverywhere) delete inputs[key];
+        continue;
+      }
+      const { leafName, spec } = resolveWidgetSpec(def, key, inputs);
+      if (spec === undefined) {
+        // The final selected option does not define this leaf — it belongs to the
+        // superseded option and would be an unknown input on the current one.
+        delete inputs[key];
+        continue;
+      }
+      inputs[key] = validateComboValueForSpec(
+        leafName,
+        leafVal,
+        spec,
+        classType,
+        nodeId,
+        warnings,
+      );
     }
 
     // rgthree "Power Lora Loader" stores its loras in widgets_values as a list of
@@ -1584,5 +1893,11 @@ export function convertUiToApi(
     `Converted UI workflow: ${nodeCount} nodes (${skipped} skipped)`,
   );
 
-  return { workflow, warnings };
+  // De-duplicate identical warnings. A value can legitimately be validated twice
+  // (positional pass, then the final dynamic-parent re-anchor pass) and produce
+  // the same message; identical strings already embed node id + input, so exact
+  // duplicates are pure noise. Distinct nodes/inputs keep their own warnings.
+  const dedupedWarnings = [...new Set(warnings)];
+
+  return { workflow, warnings: dedupedWarnings };
 }

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -7,7 +7,7 @@ import {
   TEMPLATE_NAMES,
   type ModifyOperation,
 } from "../services/workflow-composer.js";
-import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
+import { getObjectInfo, backfillObjectInfo, resetObjectInfoCache } from "../comfyui/client.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -163,10 +163,26 @@ export function registerWorkflowComposeTools(server: McpServer): void {
             "it when you need the actual enum values (e.g. exact model filenames) and the " +
             "filter matches few nodes. Default false: structural summary with enum value counts.",
         ),
+      refresh: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, discard the memoized /object_info snapshot and refetch live from the " +
+            "connected server before answering. Use after the ComfyUI server was restarted " +
+            "EXTERNALLY (systemd/service manager) or new model files were added out-of-band — " +
+            "the cache is otherwise only invalidated by MCP-managed restarts, so loader " +
+            "dropdowns (model lists) would remain stale for the rest of the session (#499).",
+        ),
     },
-    async ({ node_type, verbose }) => {
+    async ({ node_type, verbose, refresh }) => {
       try {
-        logger.info("Getting node info", { filter: node_type, verbose });
+        logger.info("Getting node info", { filter: node_type, verbose, refresh });
+        // #499: an external (non-MCP) restart or an out-of-band model install
+        // leaves the memoized /object_info snapshot stale, silently serving
+        // pre-restart loader dropdowns. `refresh` forces a fresh live fetch so
+        // newly installed model files show up in the returned combos.
+        if (refresh) resetObjectInfoCache();
         let info = await getObjectInfo();
 
         let entries = Object.entries(info);


### PR DESCRIPTION
## Summary

Silent-wrong-output cluster: the orchestrator served/used STALE combo (dropdown) options and silently substituted the wrong value.

### #504 (SEVERE — silent wrong output)
`convertUiToApi` silently REPLACED a newly-staged LoadImage media value with `comboOpts[0]` (the first cached `/object_info` combo option) when the staged filename wasn't in the stale combo list — the user's actual input image was swapped for an unrelated cached filename with no warning, so headless execution ran on the WRONG source image.

Root cause: `looksLikeAssetFilename()` only recognized MODEL extensions, so media values (`.png`/`.jpg`/`.mp4`/…) fell through the #407 asset-combo guard into the `comboOpts[0]` fallback.

Fix mirrors the #407 pattern:
- Extend `ASSET_FILE_RE` to cover media extensions (png/jpe?g/webp/bmp/gif/tiff/mp4/webm/mov/mkv/m4v/avi/wav/mp3/flac/ogg/m4a).
- Add `image`/`audio`/`video` to `ASSET_WIDGET_NAMES` (extensionless-value robustness).
- The staged value is now PRESERVED and surfaced as an honest missing-asset warning instead of a wrong-source render.
- The remaining non-asset ENUM fallback (`sampler_name`, stale Impact "Select to add Wildcard" UI-helpers) now emits a warning **before** substituting `comboOpts[0]`. The substitution stays (ComfyUI hard-rejects unknown enum values) but is no longer SILENT — so **no** `convertUiToApi` path overwrites a user-set value without a warning.

### #499
`get_node_info` served memoized pre-restart `/object_info` loader dropdowns after an EXTERNAL (systemd) ComfyUI restart, omitting newly installed models. Added a `refresh` option that calls `resetObjectInfoCache()` before fetching, forcing a fresh live read (the reset→refetch guarantee is already covered by `object-info-cache.test.ts`).

## Tests (FAIL before / PASS after)
- Staged LoadImage/video value NOT in the stale combo is PRESERVED (not replaced by `combo[0]`) through `convertUiToApi`, including the extensionless case via the media widget-name allowlist.
- Valid installed value still passes through unwarned.
- `get_node_info` `refresh:true` invalidates the cache before fetch so post-restart dropdowns surface; omitting `refresh` does not reset.
- Full suite green (only the known node-dev ripgrep sandbox test fails, as expected).

## Codex gate
Read-only codex review asked whether ANY `convertUiToApi` path can still silently overwrite a user-set value with `comboOpts[0]`.
**VERDICT: PASS** — no silent `comboOpts[0]` overwrite of a user-set value remains (the first pass caught the non-asset enum path, which was then made non-silent; re-review passed).

Closes #504
Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
