### PR TITLE
fix(templates/lock/runtime): ACE Step 1.5 fields (#501); lock native VAE/UNET loaders (#482); bundled-pack runtime (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.21] - 2026-07-30
+
+### Fixed
+- **SEVERE: `download_model` no longer saves an auth/error response body as a model file and reports success (#473).** A remote CivitAI (or any) download that returned an HTML login/auth page or a JSON error — often with a 200 status — was streamed verbatim into a `.safetensors`/`.ckpt`/model file and reported as a successful download, leaving a corrupt file in the models dir. Every finalize path (HTTP stream, cache-hit, coalesced, cloud, direct-fallback) now runs an authoritative content-type/magic-byte gate BEFORE materializing: HTML/JSON payloads are rejected with an actionable error (Content-Type authority for model destinations + body-magic that handles leading whitespace/control bytes), the cloud/direct path fails **closed** when the payload can't be sniffed, and a poisoned cache entry/partial can't be served on reuse (persisted Content-Type + rejected-marker + body re-sniff). Verified to NOT reject legitimate downloads (real safetensors/GGUF/pickle/ONNX/raw-bin stay binary; sidecar-less cached models still served). (#511)
+- **`panel_run` derives its verdict from ComfyUI's reply instead of a bare `queued` flag (#213, #194, #331, #248).** A rejected prompt (top-level error, or non-empty `node_errors`, even alongside a stale `queued:true`) is now surfaced as a FAILURE rather than a false `queued:true`; a root SaveImage run-to-node is accepted (not mis-rejected as a subgraph node); the "you'll be notified" note is only appended on a genuine queue (not when no tab is connected); and a thrown `app.queuePrompt` preserves its error detail. (#521)
+- **`get_workflow` returns the workflow JSON even when there are conversion warnings (#494); `get_image` is binary-safe (#483); `enqueue_workflow` surfaces ComfyUI's 400 validation details (#485).** (#520)
+
 ## [0.48.20] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.20",
+  "version": "0.48.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.20",
+      "version": "0.48.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.20",
+  "version": "0.48.21",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",

--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComfyUIError } from "../../utils/errors.js";
+
+// #485: when ComfyUI rejects a workflow during prompt validation it answers
+// POST /prompt with HTTP 400 whose JSON body carries the authoritative
+// diagnosis (`error.message` + `node_errors[<id>].{class_type,errors}`).
+// enqueuePrompt must surface those details instead of a generic HTTP status,
+// falling back to the status only when the body is empty/unparseable.
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  };
+});
+
+const comfyuiFetch = vi.fn();
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...a: unknown[]) => comfyuiFetch(...a),
+}));
+
+const { enqueuePrompt } = await import("../../comfyui/client.js");
+
+function res(status: number, body: unknown, statusText = "Bad Request"): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+    headers: new Map(),
+  } as unknown as Response;
+}
+
+const validationBody = {
+  error: {
+    type: "prompt_outputs_failed_validation",
+    message: "Prompt outputs failed validation",
+    details: "",
+    extra_info: {},
+  },
+  node_errors: {
+    "5": {
+      class_type: "LoadImage",
+      errors: [
+        {
+          type: "custom_validation_failed",
+          message: "Custom validation failed for node: image",
+          details: "Invalid image file: missing.png",
+          extra_info: {},
+        },
+      ],
+      dependent_outputs: ["11"],
+    },
+  },
+};
+
+describe("enqueuePrompt — surfaces ComfyUI 400 validation details (#485)", () => {
+  beforeEach(() => comfyuiFetch.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  it("surfaces node_errors (id, class_type, message, details) on a 400", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(400, validationBody));
+
+    const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(ComfyUIError);
+    const message = (err as Error).message;
+    // The authoritative details must appear — not just the bare HTTP status.
+    expect(message).toContain("Prompt outputs failed validation");
+    expect(message).toContain("LoadImage");
+    expect(message).toContain("node 5");
+    expect(message).toContain("Invalid image file: missing.png");
+    // Raw payload preserved for programmatic consumers.
+    expect((err as ComfyUIError).details).toMatchObject({
+      status: 400,
+      node_errors: { "5": { class_type: "LoadImage" } },
+    });
+  });
+
+  it("falls back to the generic HTTP status when the 400 body is empty", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(400, ""));
+    const err = await enqueuePrompt({}).catch((e) => e);
+    expect(err).toBeInstanceOf(ComfyUIError);
+    expect((err as Error).message).toContain("400");
+    expect((err as Error).message).toContain("Bad Request");
+  });
+
+  it("returns prompt_id + the authoritative /queue depth on success", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "abc", number: 42 }, "OK")) // POST /prompt
+      .mockResolvedValueOnce(
+        res(200, { queue_running: [{}], queue_pending: [{}, {}] }, "OK"),
+      ); // GET /queue
+    const out = await enqueuePrompt({ "1": { class_type: "KSampler", inputs: {} } });
+    // queue_remaining is running+pending (1+2=3), NOT ComfyUI's `number` (42).
+    expect(out).toEqual({ prompt_id: "abc", queue_remaining: 3 });
+  });
+
+  it("never surfaces ComfyUI's monotonic `number` (negative for front jobs) as queue_remaining", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "z", number: -17 }, "OK"))
+      .mockResolvedValueOnce(res(200, { queue_running: [{}], queue_pending: [] }, "OK"));
+    const out = await enqueuePrompt({}, undefined, { front: true });
+    expect(out.queue_remaining).toBe(1); // real depth, not -17
+  });
+
+  it("falls back to undefined queue_remaining when /queue can't be read", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "abc", number: 5 }, "OK"))
+      .mockRejectedValueOnce(new Error("network"));
+    const out = await enqueuePrompt({ "1": { class_type: "KSampler", inputs: {} } });
+    expect(out).toEqual({ prompt_id: "abc", queue_remaining: undefined });
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -7,7 +7,7 @@
 // panel JS executors implement), and that the McpServer HTTP path registers the
 // identical set.
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,6 +20,7 @@ import {
   __openWorkflowTestHooks,
   __panelToolsTestHooks,
   __panelRunTestHooks,
+  __panelAskTestHooks,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -1689,5 +1690,161 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("opened");
     expect(listCalls).toBe(0);
+  });
+});
+
+describe("panel_ask surface + late-answer resilience (#300/#486) and set_todo bound (#322)", () => {
+  const REPLY_TIMEOUT_ERR = (cmd: string, ms: number) =>
+    new Error(
+      `Panel tab abcd1234 did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be backgrounded or frozen`,
+    );
+
+  afterEach(() => {
+    // Reset the injected fast ask timing so other suites see the real defaults.
+    __panelAskTestHooks.setAskTiming(null);
+  });
+
+  function askText(res: ToolResult): string {
+    return (res.content[0] as { text: string }).text;
+  }
+
+  // #300 — NO INTERACTIVE SURFACE: a canvas-less/headless client (mobile mirror,
+  // remote viewer, or an exec/headless run) can't render the choice card, so the
+  // ask must FAIL FAST with an actionable error instead of blocking. We must never
+  // even dispatch ask_user in that case.
+  it("panel_ask fails FAST with an actionable error when no interactive surface can render the card (#300)", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(cmd);
+        // Simulate the old hang: never resolve. If the handler awaited this the
+        // test would time out — so a passing test proves we short-circuited.
+        return new Promise<never>(() => {});
+      },
+      canReach: () => true,
+      isHeadless: () => true,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Local or pod?", options: [{ label: "Local" }, { label: "Pod" }] },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(askText(res)).toMatch(/no interactive panel surface|plain chat|headless|exec/i);
+    // Never dispatched — no indefinite block on a surface that can't answer.
+    expect(sent.length).toBe(0);
+  });
+
+  // #486 — LATE-BUT-VALID ANSWER: the card-reply timer fired (bridge.send rejected
+  // with a reply-timeout), but the user validated a pick slightly late. The bridge
+  // buffered it; the handler must poll the buffer and HONOR the answer, not discard
+  // it as a timeout.
+  it("panel_ask honors a late-but-valid answer buffered after a reply timeout (#486)", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 500, pollMs: 2 });
+    let takes = 0;
+    const bridge = {
+      send: async (_cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        // The card timed out before the (slow) user answered.
+        throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => "abcd1234",
+      // The validated answer lands one poll later, after the send already rejected.
+      takeLateAskReply: (_askId: string) => {
+        takes += 1;
+        return takes >= 2 ? "Local GPU + Blender" : undefined;
+      },
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Which?", options: [{ label: "Local GPU + Blender" }, { label: "Cloud" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("Local GPU + Blender");
+  });
+
+  // Codex gate: the clamp must be a HARD ceiling on deadline + grace, not just the
+  // default — a large env override must never be able to recreate #486.
+  it("hard-clamps deadline+grace under the MCP budget even with oversized env overrides (#486)", () => {
+    const prevD = process.env.COMFYUI_PANEL_ASK_DEADLINE_S;
+    const prevG = process.env.COMFYUI_PANEL_ASK_GRACE_S;
+    process.env.COMFYUI_PANEL_ASK_DEADLINE_S = "600"; // 600s
+    process.env.COMFYUI_PANEL_ASK_GRACE_S = "600"; // 600s
+    try {
+      const t = __panelAskTestHooks.getAskTiming();
+      expect(t.deadlineMs).toBeGreaterThan(0);
+      expect(t.deadlineMs + t.graceMs).toBeLessThanOrEqual(
+        __panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS,
+      );
+      expect(t.deadlineMs + t.graceMs).toBeLessThan(300000);
+    } finally {
+      if (prevD === undefined) delete process.env.COMFYUI_PANEL_ASK_DEADLINE_S;
+      else process.env.COMFYUI_PANEL_ASK_DEADLINE_S = prevD;
+      if (prevG === undefined) delete process.env.COMFYUI_PANEL_ASK_GRACE_S;
+      else process.env.COMFYUI_PANEL_ASK_GRACE_S = prevG;
+    }
+  });
+
+  it("panel_ask clamps the card deadline under the ~300s MCP tools/call budget and returns the pick (#486)", async () => {
+    let forwardedTimeout = 0;
+    const bridge = {
+      send: async (_cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        forwardedTimeout = opts?.timeoutMs ?? 0;
+        return "Pod";
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Where?", options: [{ label: "Local" }, { label: "Pod" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("Pod");
+    // Must NOT be the old 600000ms (which outlived the 300s MCP budget → lost answer).
+    expect(forwardedTimeout).toBeGreaterThan(0);
+    expect(forwardedTimeout).toBeLessThan(300000);
+  });
+
+  // #322 — set_todo must not false-timeout a responsive session. Model a tab that
+  // acks in ~8s (momentarily backgrounded): the OLD 5s bound would reject it; the
+  // handler must forward a sane bound (>=15s) so the ack succeeds.
+  it("panel_set_todo does NOT false-timeout a responsive (8s-ack) session — sane bound (#322)", async () => {
+    const RESPONSIVE_ACK_MS = 8000;
+    let forwardedTimeout = 0;
+    const sent: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        forwardedTimeout = opts?.timeoutMs ?? 6000;
+        if (forwardedTimeout < RESPONSIVE_ACK_MS) {
+          throw REPLY_TIMEOUT_ERR("set_todo", forwardedTimeout);
+        }
+        sent.push(cmd);
+        return { ok: true };
+      },
+      canReach: () => true,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const res = await defByName("panel_set_todo").handler(
+      { items: [{ text: "step one", status: "active" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(forwardedTimeout).toBeGreaterThanOrEqual(15000);
+    expect(sent.at(-1)).toMatchObject({ cmd: "set_todo" });
   });
 });

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -19,7 +19,9 @@ import {
   registerPanelTools,
   __openWorkflowTestHooks,
   __panelToolsTestHooks,
+  __panelRunTestHooks,
   type PanelToolCtx,
+  type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
@@ -335,6 +337,200 @@ describe("panel-tools: panel_run (run-to-node partial execution)", () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_run").handler({ to_node_id: 27 }, ctx);
     expect(calls[0]).toMatchObject({ cmd: "graph_run", to_node_id: 27 });
+  });
+});
+
+// A panel_run test ctx whose graph_run reply is fully controllable, so we can
+// drive the four rejection/acceptance edge-cases the panel forwards from
+// ComfyUI's /prompt. Records every forwarded cmd for assertion.
+function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => true,
+    bridge: {} as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  };
+  return { ctx, calls };
+}
+
+/** Extract the joined text of a ToolResult for content assertions. */
+function textOf(res: ToolResult): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+const QUEUED_NOTE = "notified automatically";
+
+describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () => {
+  it("#213: a top-level /prompt error (empty node_errors) is a FAILURE, not queued:true", async () => {
+    // ComfyUI split: a top-level rejection leaves node_errors empty. The panel's
+    // stale guard may still forward queued:true — the orchestrator must NOT trust it.
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: true,
+            error: {
+              type: "prompt_outputs_failed_validation",
+              message: "Prompt outputs failed validation",
+            },
+            node_errors: {},
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("Prompt outputs failed validation");
+    expect(text).toContain("prompt_outputs_failed_validation");
+    // The success-only anti-poll guidance must NOT be appended to a rejection.
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#213: per-node node_errors are surfaced with node id + class_type", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: false,
+            node_errors: {
+              "5": {
+                class_type: "LoadImage",
+                errors: [
+                  { message: "Custom validation failed", details: "Invalid image: missing.png" },
+                ],
+              },
+            },
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("LoadImage");
+    expect(text).toContain("node 5");
+    expect(text).toContain("Invalid image: missing.png");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#194: a root SaveImage run-to-node the panel ACCEPTS is queued success (not subgraph-rejected)", async () => {
+    const reply: ToolResult = {
+      content: [
+        { type: "text", text: JSON.stringify({ queued: true, batch_count: 1, to_node_id: 9 }) },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+    // Forwarded unchanged so the (fixed) panel can resolve the root output node.
+    expect(calls[0]).toMatchObject({ cmd: "graph_run", to_node_id: 9 });
+    expect(res.isError).toBeFalsy();
+    // Accepted -> the anti-poll queued guidance IS appended.
+    expect(textOf(res)).toContain(QUEUED_NOTE);
+  });
+
+  it("#194: a subgraph-rejection reply is surfaced cleanly WITHOUT the false success note", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: false,
+            error:
+              "node 9 is not on the root graph — run-to-node targets a root-level output node",
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("not on the root graph");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#331: no queued-render guidance when no panel tab is connected", async () => {
+    const reply: ToolResult = {
+      content: [
+        { type: "text", text: 'Error: no connected tab with id "tmp:abc". Connected: none' },
+      ],
+      isError: true,
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 25 }, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("no connected tab");
+    // The workflow was never queued — the automatic-delivery note must be absent.
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#248: a thrown app.queuePrompt surfaces the browser stack detail, no success note", async () => {
+    const stack =
+      "app.queuePrompt failed:\n" +
+      "TypeError: Cannot read properties of undefined (reading 'output')\n" +
+      "    at app.graphToPrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)";
+    const reply: ToolResult = {
+      content: [{ type: "text", text: `Error: ${stack}` }],
+      isError: true,
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    // The actionable browser location must survive verbatim.
+    expect(text).toContain("app.graphToPrompt");
+    expect(text).toContain("audio_analyzer_interface.js:102:24");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("a genuine queue (queued:true, no errors) still gets the anti-poll note", async () => {
+    const reply: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ queued: true, batch_count: 1 }) }],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toContain(QUEUED_NOTE);
+  });
+});
+
+describe("panel-tools: detectRunRejection helper", () => {
+  const { detectRunRejection } = __panelRunTestHooks;
+  const jsonReply = (obj: unknown): ToolResult => ({
+    content: [{ type: "text", text: JSON.stringify(obj) }],
+  });
+
+  it("returns null for a clean queued:true reply", () => {
+    expect(detectRunRejection(jsonReply({ queued: true, batch_count: 1 }))).toBeNull();
+  });
+
+  it("returns null for an unparseable non-error reply (no regression)", () => {
+    expect(detectRunRejection({ content: [{ type: "text", text: "plain ok" }] })).toBeNull();
+  });
+
+  it("flags a top-level error even alongside a stale queued:true", () => {
+    const rej = detectRunRejection(
+      jsonReply({ queued: true, error: { type: "missing_node_type", message: "boom" }, node_errors: {} }),
+    );
+    expect(rej?.isError).toBe(true);
+  });
+
+  it("passes an isError reply through verbatim", () => {
+    const err: ToolResult = { content: [{ type: "text", text: "Error: boom" }], isError: true };
+    expect(detectRunRejection(err)).toBe(err);
   });
 });
 

--- a/src/__tests__/services/api-nodes.test.ts
+++ b/src/__tests__/services/api-nodes.test.ts
@@ -20,6 +20,7 @@ import {
   generateWithApiNode,
   buildApiNodeInputs,
   isApiNode,
+  checkWorkflowRuntime,
   type ApiNodesDeps,
 } from "../../services/api-nodes.js";
 import type { ObjectInfo, WorkflowJSON, ComfyUINodeDef } from "../../comfyui/types.js";
@@ -211,6 +212,56 @@ describe("listApiNodes", () => {
       getObjectInfo: async () => ({ KSampler: nodeDef({ category: "sampling" }) }),
     });
     expect(await listApiNodes(undefined, deps)).toEqual([]);
+  });
+});
+
+describe("checkWorkflowRuntime", () => {
+  // A graph whose custom nodes aren't in this server's /object_info.
+  const graphWithUninstalledNodes = {
+    "1": { class_type: "QwenImageEditLoader", inputs: {} },
+    "2": { class_type: "QwenImageSampler", inputs: {} },
+    "3": { class_type: "SaveImage", inputs: {} },
+  } as unknown as WorkflowJSON;
+
+  // Server only knows the core SaveImage node; the two Qwen nodes are absent.
+  const partialObjectInfo = async () => ({ SaveImage: nodeDef({ category: "image" }) });
+
+  it("returns 'unknown' for an arbitrary graph with unclassifiable nodes", async () => {
+    const { deps } = makeDeps({ getObjectInfo: partialObjectInfo });
+    const rt = await checkWorkflowRuntime(graphWithUninstalledNodes, deps);
+    expect(rt.runtime).toBe("unknown");
+    expect(rt.usesApiNodes).toBeNull();
+    expect(rt.unknownNodes).toEqual(
+      expect.arrayContaining(["QwenImageEditLoader", "QwenImageSampler"]),
+    );
+  });
+
+  // Regression for #464: a BUNDLED pack is guaranteed local/free, so uninstalled
+  // custom nodes must not collapse the verdict to "unknown" and wrongly demand a
+  // paid-credits confirmation.
+  it("trusts a bundled pack as local even when its custom nodes aren't installed (#464)", async () => {
+    const { deps } = makeDeps({ getObjectInfo: partialObjectInfo });
+    const rt = await checkWorkflowRuntime(graphWithUninstalledNodes, deps, {
+      bundledLocalPack: true,
+    });
+    expect(rt.runtime).toBe("local");
+    expect(rt.usesApiNodes).toBe(false);
+    // The unclassifiable nodes are still surfaced for transparency.
+    expect(rt.unknownNodes).toEqual(
+      expect.arrayContaining(["QwenImageEditLoader", "QwenImageSampler"]),
+    );
+  });
+
+  it("still reports API nodes in a bundled pack rather than masking them as local", async () => {
+    const graph = {
+      "1": { class_type: "FluxProImageNode", inputs: {} },
+      "2": { class_type: "QwenImageSampler", inputs: {} },
+    } as unknown as WorkflowJSON;
+    const { deps } = makeDeps(); // sampleObjectInfo knows FluxProImageNode as an API node
+    const rt = await checkWorkflowRuntime(graph, deps, { bundledLocalPack: true });
+    expect(rt.usesApiNodes).toBe(true);
+    expect(rt.apiNodes).toContain("FluxProImageNode");
+    expect(["api", "mixed"]).toContain(rt.runtime);
   });
 });
 

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -1303,5 +1303,613 @@ describe("downloadModel cache", () => {
     expect(cacheFiles).toHaveLength(1);
     const remaining = join(cacheDir, cacheFiles[0]);
     expect((await stat(remaining)).size).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #473: an auth/error response BODY (HTML login page / JSON error) must NEVER be
+// finalized as a `.safetensors` (or any binary-model) file under a false success.
+// Before this fix a 200-with-HTML/JSON body of plausible size passed the #467
+// size gate and landed as a corrupt model. These drive the content-type/magic-byte
+// validation: the offending download FAILS with an actionable error and NO file is
+// finalized, while a legitimate binary body still succeeds.
+// ---------------------------------------------------------------------------
+describe("downloadModel model-payload validation (#473)", () => {
+  const HTML_AUTH_PAGE =
+    "<!DOCTYPE html>\n<html><head><title>Sign in</title></head>" +
+    "<body><form>Please log in to CivitAI to download this model.</form></body></html>";
+  const JSON_ERROR = '{"error":"Unauthorized","message":"An API key is required to download this asset."}';
+
+  async function expectRejectedAndNoFile(
+    url: string,
+    subfolder: string,
+    filename: string,
+    response: Response,
+  ) {
+    fetchMock.mockResolvedValueOnce(response);
+    await expect(downloadModel(url, subfolder, filename)).rejects.toThrow(/not a model file|model file/i);
+    // Nothing finalized in the models dir…
+    const modelsDir = join(comfyDir, "models", subfolder);
+    const landed = await readdir(modelsDir).catch(() => [] as string[]);
+    expect(landed).toHaveLength(0);
+    // …and nothing re-servable left in the cache. NOTE: a CivitAI API download URL
+    // (…/api/download/models/<id>) is EXTENSIONLESS, so its cache file has no
+    // `.safetensors` suffix — an `endsWith(".safetensors")` check would miss a
+    // poisoned entry entirely. Assert instead that NO finalized cache entry remains
+    // (any non-dot file) and that any leftover artifact is a neutralized 0-byte file.
+    const cached = await readdir(cacheDir).catch(() => [] as string[]);
+    const finalized = cached.filter((f) => !f.startsWith("."));
+    expect(finalized).toHaveLength(0);
+    // Any leftover payload/sidecar (.partial/.etag) must be neutralized to 0 bytes so
+    // it can't be resumed/re-served. The `.rejected` poison MARKER is EXEMPT — it is a
+    // small non-empty sentinel that exists precisely to block a later resume.
+    for (const f of cached) {
+      if (f.endsWith(".rejected") || f.endsWith(".ct")) continue; // intentional sentinels
+      expect((await stat(join(cacheDir, f))).size).toBe(0);
+    }
+  }
+
+  it("rejects an HTML auth-challenge body saved as .safetensors (text/html)", async () => {
+    await expectRejectedAndNoFile(
+      "https://civitai.com/api/download/models/3174878",
+      "loras",
+      "gated.safetensors",
+      new Response(HTML_AUTH_PAGE, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+  });
+
+  it("rejects an HTML auth-challenge body even when mislabeled as octet-stream (magic bytes win)", async () => {
+    await expectRejectedAndNoFile(
+      "https://example.com/models/mislabeled.safetensors",
+      "checkpoints",
+      "mislabeled.safetensors",
+      new Response(HTML_AUTH_PAGE, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects a UTF-16LE HTML auth page saved as .safetensors", async () => {
+    // A real auth page can be served UTF-16 (bytes FF FE 3C 00 …). Body magic must
+    // decode the BOM and still detect the HTML (codex finding).
+    const utf16 = Buffer.concat([
+      Buffer.from([0xff, 0xfe]), // UTF-16LE BOM
+      Buffer.from(HTML_AUTH_PAGE, "utf16le"),
+    ]);
+    await expectRejectedAndNoFile(
+      "https://example.com/models/u16.safetensors",
+      "checkpoints",
+      "u16.safetensors",
+      new Response(utf16, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html; charset=utf-16le" },
+      }),
+    );
+  });
+
+  it("rejects a JSON error body saved as .safetensors", async () => {
+    await expectRejectedAndNoFile(
+      "https://civitai.com/api/download/models/999",
+      "loras",
+      "err.safetensors",
+      new Response(JSON_ERROR, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("rejects an HTML body saved as .pt2 (a non-safetensors binary model format)", async () => {
+    await expectRejectedAndNoFile(
+      "https://example.com/models/x.pt2",
+      "checkpoints",
+      "x.pt2",
+      new Response(HTML_AUTH_PAGE, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+  });
+
+  it("surfaces an actionable CivitAI token hint for a CivitAI auth challenge", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(HTML_AUTH_PAGE, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    await expect(
+      downloadModel("https://civitai.com/api/download/models/1", "loras", "c.safetensors"),
+    ).rejects.toThrow(/CIVITAI_API_TOKEN/);
+  });
+
+  it("still succeeds for a legitimate binary model body (GGUF magic)", async () => {
+    // A real binary payload — leading "GGUF" magic, then bytes that are not text.
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x00])]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(gguf, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/models/legit.gguf",
+      "checkpoints",
+      "legit.gguf",
+    );
+    expect((await stat(out)).size).toBe(gguf.length);
+  });
+
+  it("does NOT reject a legit safetensors whose LE header length starts with byte 0x3C ('<')", async () => {
+    // A real safetensors with a 60-byte JSON header: first 8 bytes are the LE length
+    // (60 = 0x3C, then NUL padding), so byte 0 is '<'. The NUL bytes that follow prove
+    // it is binary, so it must NOT be misclassified as an HTML page (codex finding).
+    const header = Buffer.from('{"__metadata__":{"format":"pt"},"a":{"x":1}}'.padEnd(60, " "));
+    const lenPrefix = Buffer.alloc(8);
+    lenPrefix.writeUInt32LE(header.length, 0); // 60 -> 0x3C 0x00 0x00 0x00 ...
+    const body = Buffer.concat([lenPrefix, header, Buffer.from([0x00, 0x11, 0x22, 0x33])]);
+    expect(body[0]).toBe(0x3c); // sanity: leading byte is '<'
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/models/hdr60.safetensors",
+      "checkpoints",
+      "hdr60.safetensors",
+    );
+    expect((await stat(out)).size).toBe(body.length);
+  });
+
+  it("does NOT reject a raw .bin binary that happens to start with '<' but is not UTF-8 text", async () => {
+    // A generic binary payload whose first byte is '<' (0x3C) followed by bytes that
+    // are NOT valid UTF-8 text (bare continuation / invalid lead bytes). Must stay
+    // "binary" and download successfully (codex false-positive concern).
+    const body = Buffer.from([
+      0x3c, 0x80, 0x81, 0xff, 0xfe, 0x3c, 0x00, 0x9a, 0xc0, 0xc1, 0x3c, 0x42, 0x13, 0x37,
+    ]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/models/raw.bin",
+      "checkpoints",
+      "raw.bin",
+    );
+    expect((await stat(out)).size).toBe(body.length);
+  });
+
+  it("rejects a cached HTML payload on a later cache-hit (per-caller cache gate)", async () => {
+    // Poison the cache via a NON-model destination (.json — not validated at stream
+    // time), then a .safetensors caller that HITS the same cache entry must still be
+    // rejected by the per-caller cache gate, not served the corrupt bytes.
+    const url = "https://example.com/models/poison.safetensors";
+    fetchMock.mockResolvedValueOnce(
+      new Response(HTML_AUTH_PAGE, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    // First call to a .json destination: not a model-binary ext, so it caches the
+    // HTML body without rejection.
+    await downloadModel(url, "checkpoints", "poison.json");
+    // Second call, SAME url → cache hit, but destination is .safetensors → rejected.
+    await expect(
+      downloadModel(url, "loras", "poison.safetensors"),
+    ).rejects.toThrow(/not a model file|model file/i);
+    const landed = await readdir(join(comfyDir, "models", "loras")).catch(() => [] as string[]);
+    expect(landed).toHaveLength(0);
+  });
+
+  it("rejects a JSON auth/error body with a non-ASCII (UTF-8) message", async () => {
+    await expectRejectedAndNoFile(
+      "https://example.com/models/utf8err.safetensors",
+      "checkpoints",
+      "utf8err.safetensors",
+      new Response('{"error":"Неавторизованный запрос — требуется ключ API"}', {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+    );
+  });
+
+  it("does NOT reject a JSON body for a non-model destination extension (.json config)", async () => {
+    // A legitimate `{...}` JSON download to a `.json` sidecar must be untouched by
+    // the binary-model validation — we validate by what the destination IS.
+    fetchMock.mockResolvedValueOnce(
+      new Response('{"scheduler":"ddim"}', {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/configs/model_index.json",
+      "checkpoints",
+      "model_index.json",
+    );
+    await expect(readFile(out, "utf-8")).resolves.toBe('{"scheduler":"ddim"}');
+  });
+
+  // --- codex re-review regressions (P0-1 / P0-2 / P1) -----------------------
+
+  it("rejects a valid HTML page whose only 'control' byte is a form-feed (P0-1, octet-stream)", async () => {
+    // FF (\f, 0x0C) is valid HTML whitespace. Before the fix the detector treated it
+    // as proof-of-binary and, with a mislabeled octet-stream Content-Type, let the
+    // login page finalize as a model. It must be rejected by BODY MAGIC alone.
+    await expectRejectedAndNoFile(
+      "https://example.com/models/ff.safetensors",
+      "checkpoints",
+      "ff.safetensors",
+      new Response("<html>\f<body>Sign in to download</body></html>", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects an HTML page that LEADS with a form-feed before the tag (P0-1, octet-stream)", async () => {
+    // `\f<!DOCTYPE html>…` — the form-feed comes BEFORE the `<`. The leading-whitespace
+    // skip must treat \f/\v as whitespace so the FIRST scrutinized char is the tag, not
+    // the control byte (else it misclassifies as binary). Rejected by body magic alone.
+    await expectRejectedAndNoFile(
+      "https://example.com/models/leadff.safetensors",
+      "checkpoints",
+      "leadff.safetensors",
+      new Response("\f\v<!DOCTYPE html><html><body>Sign in</body></html>", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects a UTF-16LE HTML page that LEADS with a form-feed (P0-1, decoded path)", async () => {
+    // Same leading-\f case through the UTF-16 decode path (classifyDecodedText).
+    const body = Buffer.concat([
+      Buffer.from([0xff, 0xfe]), // UTF-16LE BOM
+      Buffer.from("\f<!DOCTYPE html><html>Sign in</html>", "utf16le"),
+    ]);
+    await expectRejectedAndNoFile(
+      "https://example.com/models/leadff16.safetensors",
+      "checkpoints",
+      "leadff16.safetensors",
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects a form-feed HTML page served as text/html (P0-1, content-type belt)", async () => {
+    await expectRejectedAndNoFile(
+      "https://civitai.com/api/download/models/3174878",
+      "loras",
+      "ff2.safetensors",
+      new Response("<html>\f<body>Sign in</body></html>", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+  });
+
+  it("rejects a plausibly-sized auth page whose stray control byte breaks the text sniff (P0-1 belt)", async () => {
+    // The body carries a raw NUL (0x00) so it can't sniff as UTF-8 text, yet the
+    // server LABELS it text/html — the Content-Type belt must reject it regardless.
+    await expectRejectedAndNoFile(
+      "https://example.com/models/ctl.safetensors",
+      "checkpoints",
+      "ctl.safetensors",
+      new Response(Buffer.from("<html>\x00<body>Sign in</body></html>"), {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+  });
+
+  it("does NOT reject a raw .bin whose first 64 bytes are printable and START with '<' (P0-2 false-negative)", async () => {
+    // The classic false-negative: `<` + 63 printable chars (a full 64-byte sniff of
+    // pure ASCII) followed by real binary bytes. Looking at only ~64 bytes would
+    // classify it HTML and REJECT a legitimate download. The whole-window text
+    // requirement must see the trailing binary and ACCEPT it.
+    const body = Buffer.concat([
+      Buffer.from("<" + "A".repeat(63)),
+      Buffer.from([0x00, 0x80, 0xff]),
+    ]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/models/printable-prefix.bin",
+      "checkpoints",
+      "printable-prefix.bin",
+    );
+    expect((await stat(out)).size).toBe(body.length);
+  });
+
+  it("rejects a UTF-16BE HTML auth page saved as .safetensors (P0-1 UTF-16 BE)", async () => {
+    // A big-endian UTF-16 auth page: BOM FE FF, then each code unit high-byte first.
+    const le = Buffer.from("<html><body>Sign in</body></html>", "utf16le");
+    const be = Buffer.alloc(le.length);
+    for (let k = 0; k < le.length; k += 2) {
+      be[k] = le[k + 1];
+      be[k + 1] = le[k];
+    }
+    const body = Buffer.concat([Buffer.from([0xfe, 0xff]), be]);
+    await expectRejectedAndNoFile(
+      "https://example.com/models/u16be.safetensors",
+      "checkpoints",
+      "u16be.safetensors",
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects a UTF-16LE JSON error body saved as .safetensors (P0-1 UTF-16 JSON)", async () => {
+    const body = Buffer.concat([
+      Buffer.from([0xff, 0xfe]), // UTF-16LE BOM
+      Buffer.from('{"error":"Unauthorized"}', "utf16le"),
+    ]);
+    await expectRejectedAndNoFile(
+      "https://example.com/models/u16json.safetensors",
+      "checkpoints",
+      "u16json.safetensors",
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("leaves NO resumable poisoned partial after an HTML rejection — a retry restarts clean (P1)", async () => {
+    const url = "https://civitai.com/api/download/models/77777";
+    // First attempt: an HTML auth page carrying an ETag (which would normally seed a
+    // resume sidecar) — it must be rejected and its partial+sidecar discarded.
+    fetchMock.mockResolvedValueOnce(
+      new Response("<!DOCTYPE html><html><body>Sign in</body></html>", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html", etag: '"abc123"' },
+      }),
+    );
+    await expect(
+      downloadModel(url, "loras", "retry.safetensors"),
+    ).rejects.toThrow(/not a model file|model file/i);
+    // No non-dot cache file, and any leftover .partial/.etag is neutralized (0 bytes).
+    const afterReject = await readdir(cacheDir).catch(() => [] as string[]);
+    expect(afterReject.filter((f) => !f.startsWith("."))).toHaveLength(0);
+    for (const f of afterReject) {
+      if (f.endsWith(".rejected") || f.endsWith(".ct")) continue; // intentional sentinels
+      expect((await stat(join(cacheDir, f))).size).toBe(0);
+    }
+    // Second attempt: a real binary model. It must NOT resume onto the poisoned
+    // prefix — it downloads clean and finalizes at the correct size.
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(gguf, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(url, "loras", "retry.safetensors");
+    expect((await stat(out)).size).toBe(gguf.length);
+  });
+
+  it("does NOT resume onto a leftover REJECTED (HTML) partial even if cleanup earlier failed — re-inspects and restarts fresh (P1 worst-case)", async () => {
+    // Simulate the worst case: a prior rejection could NOT remove/truncate the
+    // poisoned partial, so both the HTML .partial AND a resume sidecar survive on
+    // disk. The next attempt must re-inspect the partial's head, refuse to resume onto
+    // the poison, and restart from 0 — regardless of whether cleanup ever succeeded.
+    const url = "https://example.com/models/leftover.safetensors";
+    const hash = cacheHashFor(url);
+    await mkdir(cacheDir, { recursive: true });
+    const partial = join(cacheDir, `.${hash}.safetensors.partial`);
+    await writeFile(partial, "<!DOCTYPE html><html><body>Sign in to download</body></html>");
+    await writeFile(`${partial}.etag`, '"deadbeef"'); // a validator that would enable If-Range
+    // A clean binary model is served now.
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(gguf, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(url, "checkpoints", "leftover.safetensors");
+    expect((await stat(out)).size).toBe(gguf.length);
+    // The request must NOT have carried a Range header — proof we did not resume onto
+    // the poisoned prefix.
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const sentHeaders = (init.headers ?? {}) as Record<string, string>;
+    expect(sentHeaders.Range).toBeUndefined();
+  });
+
+  it("does NOT resume a partial carrying a poison MARKER even when its bytes sniff as binary (P1 content-type-only)", async () => {
+    // The content-type-only rejection case: a prior attempt rejected the download
+    // purely on its Content-Type (gone by retry) and dropped a `.rejected` marker; the
+    // leftover partial's bytes look BINARY (so body-magic alone wouldn't flag them).
+    // The marker guard must still refuse the resume and restart fresh.
+    const url = "https://example.com/models/marked.safetensors";
+    const hash = cacheHashFor(url);
+    await mkdir(cacheDir, { recursive: true });
+    const partial = join(cacheDir, `.${hash}.safetensors.partial`);
+    await writeFile(partial, Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]));
+    await writeFile(`${partial}.etag`, '"cafef00d"'); // would enable If-Range
+    await writeFile(`${partial}.rejected`, "rejected-non-model-payload");
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(gguf, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(url, "checkpoints", "marked.safetensors");
+    expect((await stat(out)).size).toBe(gguf.length);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const sentHeaders = (init.headers ?? {}) as Record<string, string>;
+    expect(sentHeaders.Range).toBeUndefined();
+    // Marker cleaned up after the clean finalize.
+    await expect(stat(`${partial}.rejected`)).rejects.toThrow();
+  });
+
+  it("ACCEPTS a raw .bin whose invalid UTF-8 sequence is cut off at the 512-byte sniff boundary (P0-2 edge)", async () => {
+    // `<` + 509 'A' places byte 510 = 0xE0 (a 3-byte lead) with only 0x80 present after
+    // it — 0xE0 requires A0..BF, so this is INVALID UTF-8, not a truncated-but-valid
+    // run. The text check must validate the present continuation byte and keep it
+    // BINARY (accept the download) rather than wave it through as truncated (reject).
+    const body = Buffer.concat([
+      Buffer.from("<" + "A".repeat(509)), // bytes 0..509
+      Buffer.from([0xe0, 0x80]), // bytes 510,511 — invalid continuation at the boundary
+      Buffer.from([0x11, 0x22, 0x33, 0x44]), // trailing binary (file > sniff window)
+    ]);
+    expect(body.length).toBeGreaterThan(512);
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(
+      "https://example.com/models/edge.bin",
+      "checkpoints",
+      "edge.bin",
+    );
+    expect((await stat(out)).size).toBe(body.length);
+  });
+
+  it("REJECTS a valid UTF-16LE HTML page whose emoji surrogate is split by the 512-byte sniff boundary (P0-1 edge)", async () => {
+    // Pad so a 😀 (surrogate pair D83D DE00) lands its HIGH surrogate at bytes 510–511
+    // and its LOW surrogate at 512–513 (outside the window). Decoding the raw window
+    // yields a trailing lone high surrogate → U+FFFD, which would make a valid auth
+    // page look binary and fail OPEN. Trimming the truncated code unit must let it
+    // still classify as HTML and be REJECTED (served here as octet-stream).
+    const str = "<" + "a".repeat(253) + "\u{1F600}" + "b".repeat(100);
+    const body = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(str, "utf16le")]);
+    // Sanity: the high surrogate's low byte 0x3D sits at index 510.
+    expect(body[510]).toBe(0x3d);
+    expect(body[511]).toBe(0xd8);
+    await expectRejectedAndNoFile(
+      "https://example.com/models/u16emoji.safetensors",
+      "checkpoints",
+      "u16emoji.safetensors",
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+  });
+
+  it("rejects a Content-Type-only auth body on a later cache REUSE via the persisted Content-Type (#473 reuse gap)", async () => {
+    // The body is HTML but carries an embedded NUL, so BODY MAGIC classifies it binary
+    // — only the `text/html` Content-Type flags it. It is first cached through a
+    // NON-model destination (.json — unvalidated), then a `.safetensors` caller reuses
+    // the SAME url cache. The persisted `.ct` Content-Type sidecar must let the reuse
+    // gate reject it even though the live header is gone and the bytes sniff binary.
+    const url = "https://example.com/models/ct-reuse"; // extensionless → shared cache key
+    fetchMock.mockResolvedValueOnce(
+      new Response(Buffer.from("<html>\x00<body>Sign in</body></html>"), {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    // Cold cache via a .json (non-model) destination — no model validation, but the
+    // Content-Type is persisted beside the cache file.
+    await downloadModel(url, "checkpoints", "sidecar-src.json");
+    // Reuse via a .safetensors destination → cache HIT → rejected by persisted CT.
+    await expect(
+      downloadModel(url, "loras", "reuse.safetensors"),
+    ).rejects.toThrow(/not a model file|model file/i);
+    const landed = await readdir(join(comfyDir, "models", "loras")).catch(() => [] as string[]);
+    expect(landed).toHaveLength(0);
+  });
+
+  it("clears a STALE text/html .ct sidecar on a later clean octet-stream fill (no false rejection of a real model)", async () => {
+    // Regression: a `.ct` sidecar from an earlier HTML response must NOT attach to a
+    // later legitimate binary that fills the SAME cache key, or the real model would be
+    // wrongly rejected on reuse. Simulate an orphaned sidecar (payload evicted, .ct
+    // survived) then a clean octet-stream re-fill — it must succeed and clear the tag.
+    const url = "https://example.com/models/stale-ct"; // extensionless → shared key
+    const hash = cacheHashFor(url);
+    await mkdir(cacheDir, { recursive: true });
+    // Cold HTML via a .json (non-model) destination → writes payload + .ct=text/html.
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html>hi</html>", {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    await downloadModel(url, "checkpoints", "s.json");
+    // Simulate LRU evicting the payload but ORPHANING the sidecar (rm .ct swallowed).
+    await rm(join(cacheDir, hash), { force: true });
+    const ct = join(cacheDir, `.${hash}.ct`);
+    expect((await stat(ct)).size).toBeGreaterThan(0); // stale sidecar present
+    // Now a genuine octet-stream model fills the same key (cache miss → fresh fill).
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(gguf, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/octet-stream" },
+      }),
+    );
+    const out = await downloadModel(url, "loras", "clean.safetensors");
+    expect((await stat(out)).size).toBe(gguf.length); // NOT rejected
+    await expect(stat(ct)).rejects.toThrow(); // stale sidecar cleared
+  });
+
+  it("IGNORES a stale text/html .ct even at the SAME payload size (head fingerprint, rm-independent)", async () => {
+    // Even if a stale sidecar SURVIVES on disk (its clearing rm failed) AND the
+    // replacement model happens to have the EXACT same byte length as the prior HTML
+    // page, it must not reject the legitimate model: the payload fingerprint hashes the
+    // sniff HEAD, which differs between a binary model and an HTML page. Pre-seed a real
+    // GGUF cache entry + a stale text/html sidecar whose fingerprint (any prior bytes)
+    // won't match the GGUF head; a cache-HIT .safetensors caller must succeed.
+    const url = "https://example.com/models/sizeguard"; // extensionless → shared key
+    const hash = cacheHashFor(url);
+    await mkdir(cacheDir, { recursive: true });
+    const gguf = Buffer.concat([Buffer.from("GGUF"), Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
+    await writeFile(join(cacheDir, hash), gguf); // valid cached model payload (9 bytes)
+    // Stale sidecar stamped for a DIFFERENT body of the SAME 9-byte length (html head).
+    await writeFile(join(cacheDir, `.${hash}.ct`), "text/html\n9:deadbeefdeadbeef");
+    const out = await downloadModel(url, "loras", "sg.safetensors");
+    expect((await stat(out)).size).toBe(gguf.length); // cache HIT, NOT rejected
   });
 });

--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -15,6 +15,14 @@ const hoisted = vi.hoisted(() => ({
   base: undefined as string | undefined,
   stats: undefined as unknown,
   statsThrows: false,
+  // Whether an argv-derived live root is present on THIS filesystem. A
+  // Docker/forwarded loopback server's container path is not host-local → false.
+  liveRootExists: true,
+}));
+
+// The live-root routing branch only streams local when the root exists locally.
+vi.mock("node:fs", () => ({
+  existsSync: () => hoisted.liveRootExists,
 }));
 
 // isRemoteMode is the first gate; keep every other real config export.
@@ -49,6 +57,7 @@ beforeEach(() => {
   hoisted.base = undefined;
   hoisted.stats = undefined;
   hoisted.statsThrows = false;
+  hoisted.liveRootExists = true;
 });
 
 describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
@@ -70,6 +79,29 @@ describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
     // to — hand the fetch to its Manager rather than failing.
     hoisted.base = undefined;
     hoisted.stats = { system: { argv: ["main.py", "--listen"] } };
+    expect(await shouldDispatchDownloadToManager()).toBe(true);
+  });
+
+  it("#463: no local base + reachable server whose ABSOLUTE main.py root is resolvable → streams local", async () => {
+    // A panel-connected local ComfyUI with no COMFYUI_PATH/default, launched with
+    // an absolute main.py path and NO --base-directory. Its own install root is
+    // derivable from argv (the same live-first root resolveModelsDir writes into),
+    // so stream locally into it instead of bouncing through the Manager (which
+    // would fail when Manager isn't installed).
+    hoisted.base = undefined;
+    hoisted.stats = {
+      system: { argv: ["python", "/opt/ComfyUI/main.py", "--listen"] },
+    };
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+
+  it("no local base + reachable server whose absolute main.py root is NOT present locally (Docker/forwarded) → Manager route", async () => {
+    // Container-side main.py path resolvable but not on the host FS — must NOT be
+    // treated as a local stream target (would create a bogus host dir); route the
+    // fetch through the connected Manager (server-side write) instead.
+    hoisted.base = undefined;
+    hoisted.liveRootExists = false;
+    hoisted.stats = { system: { argv: ["python", "/app/ComfyUI/main.py"] } };
     expect(await shouldDispatchDownloadToManager()).toBe(true);
   });
 

--- a/src/__tests__/services/generate-audio.test.ts
+++ b/src/__tests__/services/generate-audio.test.ts
@@ -139,6 +139,44 @@ describe("generateAudio", () => {
       expect(["V0", "128k", "320k"]).toContain(save?.inputs.quality);
     });
 
+    // Regression for #501 (bug 5): the generate_audio tool/service dropped the
+    // ACE encoder's musical controls (bpm, timesignature, temperature, top_p,
+    // top_k, min_p, generate_audio_codes) and SaveAudioMP3 `quality` — they were
+    // absent from DEFAULTABLE_KEYS and the createWorkflow passthrough, so callers
+    // could never change them off the composer defaults. They must now flow all
+    // the way into the emitted graph.
+    it("threads bpm/timesignature/LLM-sampling controls + audio_quality into the graph (#501)", async () => {
+      const { deps, enqueued } = makeDeps();
+      await generateAudio(
+        {
+          model_family: "ace_step_1.5",
+          prompt: "uptempo synthwave",
+          duration: 40,
+          unet: "ace.safetensors",
+          bpm: 90,
+          timesignature: "3",
+          temperature: 1.1,
+          top_p: 0.8,
+          top_k: 50,
+          min_p: 0.05,
+          generate_audio_codes: false,
+          audio_quality: "V0",
+        },
+        deps,
+      );
+      const wf = JSON.parse(JSON.stringify(enqueued[0])) as WorkflowJSON;
+      const enc = byClass(wf, "TextEncodeAceStepAudio1.5");
+      expect(enc?.inputs.bpm).toBe(90);
+      expect(enc?.inputs.timesignature).toBe("3");
+      expect(enc?.inputs.temperature).toBe(1.1);
+      expect(enc?.inputs.top_p).toBe(0.8);
+      expect(enc?.inputs.top_k).toBe(50);
+      expect(enc?.inputs.min_p).toBe(0.05);
+      expect(enc?.inputs.generate_audio_codes).toBe(false);
+      const save = byClass(wf, "SaveAudioMP3");
+      expect(save?.inputs.quality).toBe("V0");
+    });
+
     it("auto-resolves UNet/VAE/CLIP from local models when not specified", async () => {
       const { deps, resolveFirstModel } = makeDeps();
       await generateAudio({ model_family: "ace_step_1.5", prompt: "p", duration: 10 }, deps);

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -31,6 +31,9 @@ const downloadModelMock = vi.hoisted(() => vi.fn());
 const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
 const listLocalModelsMock = vi.hoisted(() => vi.fn());
 const savedWorkspaceMock = vi.hoisted(() => vi.fn(() => undefined as string | undefined));
+const liveComfyBaseMock = vi.hoisted(() =>
+  vi.fn(async () => undefined as string | undefined),
+);
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -117,6 +120,21 @@ vi.mock("../../services/model-resolver.js", () => ({
 
 vi.mock("../../services/workspace-env.js", () => ({
   getSavedDefaultWorkspaceSync: (...a: unknown[]) => savedWorkspaceMock(...(a as [])),
+  resolveLiveComfyUIBase: (...a: unknown[]) => liveComfyBaseMock(...(a as [])),
+  // Mirrors the real resolver enough for the pip tests: an install-root python.
+  resolveRootInterpreter: (root: string | undefined) =>
+    root ? `${root}/python` : "python",
+}));
+
+// resolveLocalModelPath now roots local_path validation at the SAME live write
+// dir the downloader uses (resolveModelsDir), not <COMFYUI_PATH>/models (#490).
+// Back it with the fake install's models dir so the containment/symlink guards
+// run against the exact root the tests build their symlink fixtures under.
+const modelsDirMock = vi.hoisted(() =>
+  vi.fn(async () => "/fake/ComfyUI/models" as string),
+);
+vi.mock("../../services/output-dir.js", () => ({
+  resolveModelsDir: (...a: unknown[]) => modelsDirMock(...(a as [])),
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -149,6 +167,8 @@ beforeEach(() => {
   resolveExistingModelFileMock.mockReset().mockRejectedValue(new Error("not found"));
   listLocalModelsMock.mockReset().mockResolvedValue([]);
   savedWorkspaceMock.mockReset().mockReturnValue(undefined);
+  liveComfyBaseMock.mockReset().mockResolvedValue(undefined);
+  modelsDirMock.mockReset().mockResolvedValue("/fake/ComfyUI/models");
 });
 
 describe("loadManifestFile", () => {
@@ -534,6 +554,76 @@ describe("applyManifest", () => {
     expect(mockConfig.comfyuiPath).toBeUndefined();
   });
 
+  it("adopts the LIVE connected ComfyUI root when COMFYUI_PATH and saved default are both unset (#463)", async () => {
+    // #463: sidebar panel connected to a live local ComfyUI, no COMFYUI_PATH and
+    // no saved default. Without adoption the session is misclassified "no local
+    // filesystem" and every model is skipped. Adopting the live root (from
+    // /system_stats) gives a local FS target so the model downloads instead.
+    mockConfig.comfyuiPath = undefined;
+    mockConfig.remote = false; // local loopback target reached over the panel session
+    savedWorkspaceMock.mockReturnValue(undefined);
+    liveComfyBaseMock.mockResolvedValue("/live/ComfyUI");
+    existsSyncMock.mockImplementation((p: unknown) => {
+      const s = String(p);
+      return (
+        s.includes("live") &&
+        (s.endsWith("ComfyUI") || s.endsWith("models") || s.endsWith("custom_nodes"))
+      );
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    // Downloaded locally (NOT skipped as "no local filesystem").
+    expect(result.summary).toMatchObject({ applied: 1, failed: 0, skipped: 0 });
+    expect(downloadModelMock).toHaveBeenCalled();
+    // Call-scoped: the adopted live path must NOT persist process-wide.
+    expect(mockConfig.comfyuiPath).toBeUndefined();
+  });
+
+  it("reports a custom_node as PENDING (not failed) when the Manager queue is still installing at the budget (#489)", async () => {
+    // A node install that outlives the wall-clock budget must be reported
+    // "pending" (poll the Manager queue), never "failed" — the install keeps
+    // running server-side — and every not-yet-started node is reported pending too.
+    const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+    process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
+    // First node never settles (simulates the Manager queue still draining); the
+    // budget timer must win and stop us blocking on the rest.
+    installCustomNodeMock.mockReturnValueOnce(new Promise(() => {}));
+
+    try {
+      const result = await applyManifest({
+        manifest: { custom_nodes: ["slow-pack", "next-pack"] },
+      });
+
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+      expect(result.results[0]).toMatchObject({
+        action: "custom_node",
+        item: "slow-pack",
+        status: "pending",
+      });
+      expect(result.results[0].message).toMatch(/still installing/i);
+      // The second node is NOT started once the budget is spent — reported pending.
+      expect(result.results[1]).toMatchObject({
+        action: "custom_node",
+        item: "next-pack",
+        status: "pending",
+      });
+      expect(result.results[1].message).toMatch(/not started/i);
+      expect(installCustomNodeMock).toHaveBeenCalledTimes(1);
+      // Pending is not a failure: success stays true (nothing FAILED).
+      expect(result.success).toBe(true);
+    } finally {
+      if (prevBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = prevBudget;
+    }
+  });
+
   it("hands a slow model download to a background job (pending, not applied) (#362)", async () => {
     const prevGrace = process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
     process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = "0";
@@ -626,6 +716,36 @@ describe("applyManifest", () => {
     expect(result.results).toMatchObject([
       { action: "model", status: "failed", item: "link/model.safetensors" },
     ]);
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("validates local_path symlinks against the LIVE models dir, not a stale COMFYUI_PATH (#490)", async () => {
+    // #490: COMFYUI_PATH is a stale install; the connected server writes under a
+    // DIFFERENT live root. A symlink that escapes the LIVE models dir must be
+    // caught — the guard has to run against the live write root the downloader
+    // uses, NOT <COMFYUI_PATH>/models (which is never written to here).
+    mockConfig.comfyuiPath = "/stale/ComfyUI";
+    const liveModels = resolve("/live/ComfyUI/models");
+    modelsDirMock.mockResolvedValue(liveModels);
+    const linkDir = join(liveModels, "link");
+    const outside = resolve("/tmp/escape");
+    realpathMock.mockImplementation((path: string) => {
+      if (path === liveModels) return Promise.resolve(liveModels);
+      if (path === linkDir) return Promise.resolve(outside);
+      return Promise.resolve(path);
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [{ url: "https://example.com/m.safetensors", local_path: "link/m.safetensors" }],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toMatchObject([
+      { action: "model", status: "failed", item: "link/m.safetensors" },
+    ]);
+    expect(result.results[0].message).toMatch(/escapes the models directory/i);
     expect(downloadModelMock).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { resolve } from "node:path";
 
 // Control config (comfyuiPath + tokens) per test.
 vi.mock("../../config.js", () => {
@@ -24,12 +25,16 @@ vi.mock("../../services/node-management.js", () => ({
 const mkdirMock = vi.fn();
 const rmMock = vi.fn();
 const statMock = vi.fn();
+const lstatMock = vi.fn();
+const realpathMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
   copyFile: vi.fn(),
   link: vi.fn(),
+  lstat: (...a: unknown[]) => lstatMock(...a),
   mkdir: (...a: unknown[]) => mkdirMock(...a),
   readdir: vi.fn(),
   readFile: vi.fn(),
+  realpath: (...a: unknown[]) => realpathMock(...a),
   rename: vi.fn(),
   rm: (...a: unknown[]) => rmMock(...a),
   stat: (...a: unknown[]) => statMock(...a),
@@ -62,6 +67,9 @@ beforeEach(() => {
   mkdirMock.mockReset().mockResolvedValue(undefined);
   rmMock.mockReset().mockResolvedValue(undefined);
   statMock.mockReset().mockRejectedValue(new Error("missing"));
+  // Default: nothing in the path is a symlink (best-effort guard is inert).
+  lstatMock.mockReset().mockResolvedValue({ isSymbolicLink: () => false });
+  realpathMock.mockReset().mockImplementation((p: string) => Promise.resolve(p));
   installModelViaManagerMock.mockReset().mockResolvedValue({
     mechanism: "manager-http",
     message: "queued",
@@ -96,6 +104,62 @@ describe("downloadModel — filename path safety", () => {
       downloadModel("https://example.com/x", "checkpoints", ".."),
     ).rejects.toBeInstanceOf(ModelError);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a destination whose ancestor is a symlink escaping the models dir, and never fetches (#490)", async () => {
+    // The write-target resolver must guard the ACTUAL destination: a symlinked
+    // subfolder that realpaths OUTSIDE models/ can't be used as a write root even
+    // though the path string stays within models/.
+    const escapeDir = resolve("/comfy/models/checkpoints");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === escapeDir }),
+    );
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === escapeDir ? resolve("/tmp/outside") : p),
+    );
+
+    await expect(
+      downloadModel("https://example.com/x.safetensors", "checkpoints", "x.safetensors"),
+    ).rejects.toThrow(/symlink in the path escapes it|outside the models/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a models ROOT that is itself a symlink/junction to another location", async () => {
+    // A ComfyUI install may legitimately junction its whole models dir onto
+    // another drive. The root canonicalizes elsewhere BY DESIGN — that must not
+    // be treated as an escape (only DESCENDANTS are checked, against the canonical
+    // root).
+    const modelsRoot = resolve("/comfy/models");
+    const realModelsRoot = resolve("/mnt/big/models");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === modelsRoot }),
+    );
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === modelsRoot ? realModelsRoot : p),
+    );
+    const target = await resolveDownloadTarget(
+      "https://example.com/x.safetensors",
+      "checkpoints",
+      "x.safetensors",
+    );
+    expect(target.targetDir).toBe(resolve("/comfy/models/checkpoints"));
+  });
+
+  it("allows a symlinked subfolder that stays inside the models dir", async () => {
+    const linkDir = resolve("/comfy/models/checkpoints");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === linkDir }),
+    );
+    // realpath resolves to another location STILL under models/ → allowed.
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === linkDir ? resolve("/comfy/models/_real_ckpts") : p),
+    );
+    const target = await resolveDownloadTarget(
+      "https://example.com/x.safetensors",
+      "checkpoints",
+      "x.safetensors",
+    );
+    expect(target.targetDir).toBe(resolve("/comfy/models/checkpoints"));
   });
 });
 

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -445,6 +445,91 @@ describe("node-management service", () => {
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
+    it("clones an unregistered git pack into opts.comfyuiPath when global COMFYUI_PATH is unset (#463)", async () => {
+      // apply_manifest threads a call-scoped base (adopted saved-default/live root)
+      // WITHOUT mutating global config. The clone fallback must honor it, or an
+      // unregistered git URL fails despite a valid local workspace.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const adoptedNodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      const cloneCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+      );
+      expect(cloneCall).toBeDefined();
+      // Cloned into the ADOPTED base's custom_nodes, not a global path.
+      expect((cloneCall![1] as string[]).at(-1)).toBe(adoptedNodeDir);
+      expect((cloneCall![2] as { cwd?: string }).cwd).toBe(adopted);
+    });
+
+    it("installs a cloned node's requirements.txt under the ADOPTED base's venv python, not bare system python (#463)", async () => {
+      // With no global COMFYUI_PATH, the deps install must target the adopted
+      // workspace's own .venv — otherwise requirements land under a bare system
+      // python, corrupting/missing the real ComfyUI env while we report success.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const IS_WIN = process.platform === "win32";
+      // resolveVenvPython builds this with path.join (NOT resolve), so no drive
+      // letter is prepended — mirror that exactly for the existsSync match.
+      const venvPy = join(
+        adopted,
+        ".venv",
+        IS_WIN ? "Scripts" : "bin",
+        IS_WIN ? "python.exe" : "python",
+      );
+      const nodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      const requirements = join(nodeDir, "requirements.txt");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s === venvPy) return true; // adopted venv python present
+        if (s === requirements) return true; // node ships requirements.txt
+        if (s.includes("install.py") || s.includes("cm-cli.py")) return false;
+        if (s.includes(".venv")) return false; // any OTHER venv path absent
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      const pipCall = mockedExec.mock.calls.find(
+        (c) =>
+          Array.isArray(c[1]) &&
+          (c[1] as string[]).includes("-r") &&
+          (c[1] as string[]).includes(requirements),
+      );
+      expect(pipCall).toBeDefined();
+      // The deps install ran under the ADOPTED venv python, not bare "python".
+      expect(pipCall![0]).toBe(venvPy);
+    });
+
     it("full-clones (no --depth) and checks out an explicit ref on fallback", async () => {
       stubFetch({ installedBody: {} });
       let cloned = false;

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isAbsolute, join, resolve } from "node:path";
 
+let remoteMode = false;
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/comfy" as string | undefined },
+  isRemoteMode: () => remoteMode,
+}));
+
+// resolveModelsDir only adopts an argv-derived live root when it EXISTS locally
+// (a Docker/forwarded server's container path must NOT be treated as host-local).
+// Control existence per test; default true so the live-root paths resolve.
+let liveRootExists = true;
+vi.mock("node:fs", () => ({
+  existsSync: () => liveRootExists,
 }));
 
 const getSystemStats = vi.fn();
@@ -13,10 +23,18 @@ vi.mock("../../comfyui/client.js", () => ({
 // resolveModelsDir's local fallback (COMFYUI_PATH → default workspace) is resolved
 // through the shared helper; back it by the mocked config + a settable default
 // workspace so tests can exercise the "no COMFYUI_PATH but a default workspace" path.
+// liveRootFromArgv is the REAL implementation (pure argv parsing) so the live-first
+// resolution (#490/#463) is exercised end to end, not stubbed away.
 let savedDefaultWorkspace: string | undefined;
-vi.mock("../../services/workspace-env.js", () => ({
-  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
-}));
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/workspace-env.js")
+  >("../../services/workspace-env.js");
+  return {
+    resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
+    liveRootFromArgv: actual.liveRootFromArgv,
+  };
+});
 
 import {
   parseOutputDirFromArgv,
@@ -37,6 +55,8 @@ beforeEach(() => {
   getSystemStats.mockReset();
   (config as { comfyuiPath?: string }).comfyuiPath = "/comfy";
   savedDefaultWorkspace = undefined;
+  remoteMode = false;
+  liveRootExists = true;
 });
 
 afterEach(() => {
@@ -235,6 +255,52 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
 
   it("resolveModelsDir falls back to <COMFYUI_PATH>/models when unreachable", async () => {
     getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveModelsDir()).toBe(resolve("/comfy", "models"));
+  });
+
+  it("resolveModelsDir prefers the LIVE server's own main.py root over a stale COMFYUI_PATH when no --base-directory flag (#490)", async () => {
+    // Reproduces #490: the connected ComfyUI runs from a different install than
+    // the stale COMFYUI_PATH, and was NOT launched with --base-directory. The
+    // download must land in the LIVE install (its main.py root), not COMFYUI_PATH.
+    const liveRoot = resolve("/home/parn/repositories/wet/ComfyUI");
+    (config as { comfyuiPath?: string }).comfyuiPath = resolve("/home/parn/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py"), "--listen"] },
+    });
+    const got = await resolveModelsDir();
+    expect(got).toBe(join(liveRoot, "models"));
+    expect(got).not.toBe(join(resolve("/home/parn/ComfyUI"), "models"));
+  });
+
+  it("resolveModelsDir resolves the live root when COMFYUI_PATH is unset and no default workspace (#463)", async () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    savedDefaultWorkspace = undefined;
+    const liveRoot = resolve("/opt/live/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py")] },
+    });
+    expect(await resolveModelsDir()).toBe(join(liveRoot, "models"));
+  });
+
+  it("resolveModelsDir does NOT adopt an argv live root that isn't present locally (Docker/forwarded server) — falls back to COMFYUI_PATH", async () => {
+    // A loopback ComfyUI inside Docker reports a container-side main.py path that
+    // does not exist on the host; writing there would create a bogus host dir.
+    liveRootExists = false;
+    (config as { comfyuiPath?: string }).comfyuiPath = resolve("/host/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", "/app/ComfyUI/main.py"] },
+    });
+    expect(await resolveModelsDir()).toBe(join(resolve("/host/ComfyUI"), "models"));
+  });
+
+  it("resolveModelsDir does NOT adopt the live argv root in remote mode (remote path isn't a local dir)", async () => {
+    remoteMode = true;
+    const liveRoot = resolve("/remote/host/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py")] },
+    });
+    // Remote mode with a local COMFYUI_PATH: never uses the remote main.py path;
+    // falls back to the local COMFYUI_PATH/models.
     expect(await resolveModelsDir()).toBe(resolve("/comfy", "models"));
   });
 

--- a/src/__tests__/services/storage.test.ts
+++ b/src/__tests__/services/storage.test.ts
@@ -114,6 +114,25 @@ const fsPromisesMocks = vi.hoisted(() => ({
   copyFile: vi.fn(),
   link: vi.fn(),
   mkdir: vi.fn(),
+  // #473 payload validation reads the head of the completed file via fs/promises
+  // `open`. This mock (fs is fully mocked here — no real file is written) returns a
+  // handle that yields BINARY bytes, so a legitimate download passes validation.
+  open: vi.fn(async () => {
+    const src = Buffer.from("MODEL-BINARY-DATA\x00\x01\x02\x03");
+    return {
+      read: async (
+        buf: Buffer,
+        off: number,
+        len: number,
+        pos: number,
+      ): Promise<{ bytesRead: number }> => {
+        if (pos >= src.length) return { bytesRead: 0 };
+        const bytesRead = src.copy(buf, off, pos, Math.min(pos + len, src.length));
+        return { bytesRead };
+      },
+      close: async (): Promise<void> => undefined,
+    };
+  }),
   readdir: vi.fn(),
   rename: vi.fn(),
   realpath: vi.fn(),
@@ -128,6 +147,7 @@ vi.mock("node:fs/promises", () => ({
   copyFile: fsPromisesMocks.copyFile,
   link: fsPromisesMocks.link,
   mkdir: fsPromisesMocks.mkdir,
+  open: fsPromisesMocks.open,
   readdir: fsPromisesMocks.readdir,
   rename: fsPromisesMocks.rename,
   realpath: fsPromisesMocks.realpath,
@@ -329,6 +349,93 @@ describe("cloud storage downloads", () => {
         headers: {},
         redirect: "manual",
       }),
+    );
+  });
+
+  // A handle whose read() yields `bytes` — used to control what #473's payload sniff sees.
+  function openHandleYielding(bytes: Buffer) {
+    return {
+      read: async (buf: Buffer, off: number, len: number, pos: number) => {
+        if (pos >= bytes.length) return { bytesRead: 0 };
+        const bytesRead = bytes.copy(buf, off, pos, Math.min(pos + len, bytes.length));
+        return { bytesRead };
+      },
+      close: async () => undefined,
+    };
+  }
+
+  it("fails CLOSED when a cloud payload cannot be sniffed (#473 P0-3)", async () => {
+    // S3 returns a nonzero object, but the completed file can't be opened to sniff it
+    // (a transient fs failure). Cannot verify ⇒ must NOT finalize — the cloud path
+    // used to fail OPEN here and could install an unsniffable auth/error body.
+    awsMocks.send.mockResolvedValueOnce({ Body: Readable.from("<html>login</html>") });
+    fsPromisesMocks.stat.mockResolvedValue({ size: 4096 });
+    fsPromisesMocks.open.mockRejectedValueOnce(
+      Object.assign(new Error("EACCES"), { code: "EACCES" }),
+    );
+    await expect(
+      downloadUrlToFile(
+        "s3://models/checkpoints/x.safetensors",
+        "/tmp/x.safetensors",
+        {},
+        undefined,
+        { s3: { type: "s3", access_key_id: "A", secret_access_key: "s", region: "us-east-1" } },
+      ),
+    ).rejects.toThrow(/could not be verified|not finalizing/i);
+  });
+
+  it("neutralizes a rejected cloud payload when removal fails (#473 P1)", async () => {
+    // S3 returns an HTML AccessDenied body saved under a .safetensors name; the sniff
+    // sees the HTML and rejects. If the unlink FAILS (EPERM), the impl must truncate
+    // the file to 0 bytes (writeFile(path,"")) so a retry can't re-serve/resume it,
+    // and must LOG the removal failure rather than swallow it.
+    awsMocks.send.mockResolvedValueOnce({ Body: Readable.from("<html>AccessDenied</html>") });
+    fsPromisesMocks.stat.mockResolvedValue({ size: 512 });
+    fsPromisesMocks.open.mockResolvedValueOnce(
+      openHandleYielding(Buffer.from("<html><body>AccessDenied</body></html>")),
+    );
+    fsPromisesMocks.rm.mockRejectedValue(Object.assign(new Error("EPERM"), { code: "EPERM" }));
+    fsPromisesMocks.writeFile.mockResolvedValue(undefined);
+    await expect(
+      downloadUrlToFile(
+        "s3://models/checkpoints/denied.safetensors",
+        "/tmp/denied.safetensors",
+        {},
+        undefined,
+        { s3: { type: "s3", access_key_id: "A", secret_access_key: "s", region: "us-east-1" } },
+      ),
+    ).rejects.toThrow(/not a model file|model file/i);
+    // Neutralized: truncated to 0 bytes.
+    expect(fsPromisesMocks.writeFile).toHaveBeenCalledWith("/tmp/denied.safetensors", "");
+    // Removal failure surfaced, not swallowed.
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to remove a rejected download artifact"),
+      expect.any(Object),
+    );
+  });
+
+  it("logs a hard failure when a rejected cloud payload can be neither removed nor truncated (#473 P1)", async () => {
+    // Worst case: BOTH unlink and truncate are denied. The impl must surface a hard
+    // error (logger.error) rather than swallow it — the poisoned leftover is visible.
+    awsMocks.send.mockResolvedValueOnce({ Body: Readable.from("<html>AccessDenied</html>") });
+    fsPromisesMocks.stat.mockResolvedValue({ size: 512 });
+    fsPromisesMocks.open.mockResolvedValueOnce(
+      openHandleYielding(Buffer.from("<html><body>AccessDenied</body></html>")),
+    );
+    fsPromisesMocks.rm.mockRejectedValue(Object.assign(new Error("EPERM"), { code: "EPERM" }));
+    fsPromisesMocks.writeFile.mockRejectedValue(Object.assign(new Error("EROFS"), { code: "EROFS" }));
+    await expect(
+      downloadUrlToFile(
+        "s3://models/checkpoints/stuck.safetensors",
+        "/tmp/stuck.safetensors",
+        {},
+        undefined,
+        { s3: { type: "s3", access_key_id: "A", secret_access_key: "s", region: "us-east-1" } },
+      ),
+    ).rejects.toThrow(/not a model file|model file/i);
+    expect(loggerMocks.error).toHaveBeenCalledWith(
+      expect.stringContaining("Could not remove OR truncate a rejected download artifact"),
+      expect.any(Object),
     );
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -998,3 +998,51 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     );
   });
 });
+
+// ── #486: a validated ask_user answer that lands AFTER the reply timeout must be
+// buffered (keyed by ask_id) so the caller can still retrieve it, not discarded.
+describe("UiBridge (late ask_user answer buffer — #486)", () => {
+  it("buffers a valid ask_user reply that arrives after the reply timeout", async () => {
+    const sock = await connectPanel("tab-ask", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-ask")).toBe(true));
+    // The panel validates a pick only AFTER the send's short reply timeout fires.
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Late Pick" }));
+        }, 80);
+      }
+    });
+
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "ask-xyz", question: "?", options: [] },
+        { tabId: "tab-ask", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+
+    // The late-but-valid answer must be recoverable via the buffer, then drained.
+    await vi.waitFor(() => expect(bridge.takeLateAskReply("ask-xyz")).toBe("Late Pick"));
+    expect(bridge.takeLateAskReply("ask-xyz")).toBeUndefined(); // drained once
+  });
+
+  it("does not buffer a non-ask command's late reply (no ask_id → dropped)", async () => {
+    const sock = await connectPanel("tab-plain", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-plain")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_outline") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { late: true } }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send({ cmd: "graph_outline" }, { tabId: "tab-plain", timeoutMs: 30 }),
+    ).rejects.toThrow(/did not reply|disconnected|gone/i);
+    // Give the late reply time to land; it must NOT be buffered under any ask id.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(bridge.takeLateAskReply("tab-plain")).toBeUndefined();
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -456,3 +456,2468 @@ describe("convertUiToApi — asset-combo fallback (issue #407)", () => {
     expect(workflow["1"].inputs.ckpt_name).toBe("not-installed.pt2");
   });
 });
+
+describe("convertUiToApi — media-combo fallback (issue #504)", () => {
+  // A LoadImage node whose `image` widget points at a freshly staged upload
+  // (2Dto3D_v2_front_clean.png) that isn't yet in the CONNECTED server's STALE
+  // /object_info combo (which still only lists KENT_concept_00012_.png). Before
+  // the fix, LoadImage.image was not recognized as a media selector, so
+  // comboOpts[0] silently replaced the user's image — headless execution then
+  // ran on the WRONG source image with no warning.
+  const STALE_INFO = {
+    LoadImage: {
+      input: {
+        required: {
+          image: [["KENT_concept_00012_.png"]],
+          upload: ["IMAGE_UPLOAD"],
+        },
+      },
+    },
+  } as never;
+
+  function loadImageGraph(image: string) {
+    return {
+      nodes: [
+        {
+          id: 12,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [
+            { name: "IMAGE", type: "IMAGE", links: [] },
+            { name: "MASK", type: "MASK", links: [] },
+          ],
+          widgets_values: [image, "image"],
+        },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("PRESERVES a staged LoadImage value NOT in the stale combo (never comboOpts[0])", () => {
+    const staged = "2Dto3D_v2_front_clean.png";
+    const { workflow, warnings } = convertUiToApi(loadImageGraph(staged), STALE_INFO);
+    // The staged image survives — NOT silently rewritten to the first cached file.
+    expect(workflow["12"].inputs.image).toBe(staged);
+    expect(workflow["12"].inputs.image).not.toBe("KENT_concept_00012_.png");
+    // …and the substitution is flagged so it surfaces as an honest missing-asset error.
+    expect(
+      warnings.some(
+        (w) => w.includes("12") && w.includes(staged) && /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn or alter a LoadImage value that IS present on the server", () => {
+    const { workflow, warnings } = convertUiToApi(
+      loadImageGraph("KENT_concept_00012_.png"),
+      STALE_INFO,
+    );
+    expect(workflow["12"].inputs.image).toBe("KENT_concept_00012_.png");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("preserves an extensionless staged image via the (classType,input) loader allowlist", () => {
+    // Isolate the allowlist: BOTH the staged value AND the stale combo option are
+    // extensionless, so no extension heuristic can carry this — preservation must
+    // come purely from LoadImage.image being a KNOWN loader input. (The prior
+    // fixture's stale combo held a ".png", so the retired regex passed regardless
+    // and never actually exercised the allowlist.)
+    const EXTLESS_INFO = {
+      LoadImage: {
+        input: {
+          required: {
+            image: [["cached_input"]],
+            upload: ["IMAGE_UPLOAD"],
+          },
+        },
+      },
+    } as never;
+    const { workflow, warnings } = convertUiToApi(
+      loadImageGraph("clipspace/staged_input"),
+      EXTLESS_INFO,
+    );
+    expect(workflow["12"].inputs.image).toBe("clipspace/staged_input");
+    expect(workflow["12"].inputs.image).not.toBe("cached_input");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("preserves a staged .mp4 media value for a video loader (extension coverage)", () => {
+    const info = {
+      VHS_LoadVideo: {
+        input: { required: { video: [["cached_clip.mp4"]] } },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "VHS_LoadVideo",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["freshly_staged.mp4"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.video).toBe("freshly_staged.mp4");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("preserves LoadImage.image flagged by object_info upload metadata (no name/ext match)", () => {
+    // The value is extensionless AND arrives on a class NOT in the loader
+    // allowlist by chance — but object_info flags the input `{image_upload:true}`,
+    // the authoritative upload-selector signal — so it must still be preserved.
+    const info = {
+      MyCustomImageLoader: {
+        input: {
+          required: {
+            image: [["on_disk_input"], { image_upload: true }],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 7,
+          type: "MyCustomImageLoader",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["staged_upload"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["7"].inputs.image).toBe("staged_upload");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+});
+
+describe("convertUiToApi — true-enum over-preservation guard (P0 regression, #504)", () => {
+  // The #504 fix must NOT over-correct: a combo merely *named* image/audio/video,
+  // or a media-looking value on a TRUE enum, is NOT an asset selector. Preserving
+  // an out-of-list value there feeds ComfyUI a "Value not in list" it hard-rejects,
+  // breaking conversions that previously substituted comboOpts[0] + warned.
+
+  it("SUBSTITUTES+warns a non-loader enum literally named `image` (not preserved)", () => {
+    // A node whose combo happens to be named `image` but whose options are a real
+    // enum ["foreground","background"] — a value of "mask" is invalid and must be
+    // replaced by the first option, NOT preserved as a phantom missing-asset.
+    const info = {
+      SomeMaskModeNode: {
+        input: {
+          required: {
+            image: [["foreground", "background"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 3,
+          type: "SomeMaskModeNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["mask"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.image).toBe("foreground");
+    expect(workflow["3"].inputs.image).not.toBe("mask");
+    expect(
+      warnings.some(
+        (w) => w.includes("3") && w.includes("mask") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+    // …and it must NOT be misreported as a missing asset (would preserve it).
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("SUBSTITUTES+warns a format `extension` enum with a media-looking value (.bmp not preserved)", () => {
+    // A true format enum [".png",".jpg"] with a ".bmp" value: the retired
+    // extension heuristic wrongly preserved ".bmp" (it matches a media regex);
+    // ComfyUI rejects it. Must substitute the first option instead.
+    const info = {
+      SaveImageFormatNode: {
+        input: {
+          required: {
+            extension: [[".png", ".jpg"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 5,
+          type: "SaveImageFormatNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [".bmp"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["5"].inputs.extension).toBe(".png");
+    expect(workflow["5"].inputs.extension).not.toBe(".bmp");
+    expect(
+      warnings.some(
+        (w) => w.includes("5") && w.includes(".bmp") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("validates object-form widgets_values too — invalid enum substitutes (not copied raw)", () => {
+    // Name->value object form (VHS_VideoCombine shape). This path copied values
+    // straight in WITHOUT combo validation, so an invalid true-enum value on a
+    // combo named `image` leaked through unchanged. It must now substitute+warn.
+    const info = {
+      MaskModeCombine: {
+        input: {
+          required: {
+            image: [["foreground", "background"]],
+            format: [["mp4", "webm"]],
+          },
+        },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 9,
+          type: "MaskModeCombine",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { image: "mask", format: "mp4" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["9"].inputs.image).toBe("foreground");
+    expect(workflow["9"].inputs.image).not.toBe("mask");
+    // a VALID value on the same object form is left untouched
+    expect(workflow["9"].inputs.format).toBe("mp4");
+    expect(
+      warnings.some((w) => w.includes("9") && /substituting/.test(w)),
+    ).toBe(true);
+  });
+
+  it("object-form still PRESERVES a real loader asset value (allowlist survives the path)", () => {
+    // The object-form validation must keep the asset-preservation semantics: a
+    // staged LoadImage.image absent from the stale combo is preserved, not swapped.
+    const info = {
+      LoadImage: {
+        input: { required: { image: [["cached.png"]], upload: ["IMAGE_UPLOAD"] } },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 10,
+          type: "LoadImage",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { image: "staged_fresh.png" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["10"].inputs.image).toBe("staged_fresh.png");
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(true);
+  });
+
+  it("WARNS (not silent) when a combo has ZERO options on the server", () => {
+    // An empty option list ([[], {}]) — e.g. no models installed — has nothing to
+    // substitute to. The saved literal is kept, but must be flagged, not silently
+    // emitted as an out-of-list value the server will reject.
+    const info = {
+      EmptyEnum: {
+        input: { required: { mode: [[], {}] } },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 504,
+          type: "EmptyEnum",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["retired"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["504"].inputs.mode).toBe("retired");
+    expect(
+      warnings.some((w) => w.includes("504") && w.includes("retired")),
+    ).toBe(true);
+  });
+
+  it("validates has_serialized_properties overwrites too — invalid enum substitutes", () => {
+    // Authoritative node.properties overwrite the positional mapping AFTER combo
+    // validation; an invalid enum restored there previously leaked unvalidated to
+    // ComfyUI. It must be validated (substituted) as well.
+    const info = {
+      SerNode: {
+        input: {
+          required: {
+            mode: [["a", "b"]],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 11,
+          type: "SerNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a"],
+          properties: {
+            has_serialized_properties: true,
+            mode: "z", // stale, out-of-list — must NOT survive
+          },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["11"].inputs.mode).toBe("a");
+    expect(workflow["11"].inputs.mode).not.toBe("z");
+    expect(
+      warnings.some((w) => w.includes("11") && /substituting/.test(w)),
+    ).toBe(true);
+  });
+});
+
+describe("convertUiToApi — linked PrimitiveNode combo validation (P1-A, #504)", () => {
+  // A PrimitiveNode wired into a combo input provides a LITERAL value that is
+  // assigned AFTER the widget-value validation (widgets first, links after), so
+  // it previously bypassed combo validation entirely: an out-of-list literal
+  // overwrote the validated widget value and reached the API unchecked.
+
+  it("SUBSTITUTES+warns an out-of-list enum fed by a linked PrimitiveNode", () => {
+    const info = {
+      KSamplerSelect: {
+        input: { required: { sampler_name: [["euler", "dpmpp_2m"]] } },
+        input_order: { required: ["sampler_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["removed_sampler"], // no longer a valid option
+        },
+        {
+          id: 2,
+          type: "KSamplerSelect",
+          mode: 0,
+          inputs: [{ name: "sampler_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["euler"], // valid, but the link overrides it
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The stale primitive literal must NOT reach the API — substituted to first opt.
+    expect(workflow["2"].inputs.sampler_name).toBe("euler");
+    expect(workflow["2"].inputs.sampler_name).not.toBe("removed_sampler");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("removed_sampler") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("PRESERVES+warns a stale LOADER asset fed by a linked PrimitiveNode", () => {
+    const info = {
+      CheckpointLoaderSimple: {
+        input: { required: { ckpt_name: [["installed.safetensors"]] } },
+        input_order: { required: ["ckpt_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["not_installed.safetensors"],
+        },
+        {
+          id: 2,
+          type: "CheckpointLoaderSimple",
+          mode: 0,
+          inputs: [{ name: "ckpt_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // A loader asset is preserved (honest missing-asset), NOT swapped to opt[0].
+    expect(workflow["2"].inputs.ckpt_name).toBe("not_installed.safetensors");
+    expect(workflow["2"].inputs.ckpt_name).not.toBe("installed.safetensors");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("not_installed.safetensors") &&
+          /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an invalid dynamic-combo NESTED value fed by a linked PrimitiveNode (dotted key)", () => {
+    // A PrimitiveNode wired straight into a dotted "<combo>.<leaf>" nested input:
+    // validateComboWidgetValue's top-level lookup can't find "model.aspect_ratio",
+    // so the resolver must recover the LEAF spec from the selected option.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["4:3"], // invalid aspect_ratio
+        },
+        {
+          id: 2,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2"], // selects the option; leaf is linked
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.aspect_ratio"]).toBe("auto");
+    expect(workflow["2"].inputs["model.aspect_ratio"]).not.toBe("4:3");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("aspect_ratio") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+    expect(warnings.some((w) => /missing-asset/.test(w))).toBe(false);
+  });
+
+  it("PRESERVES+warns a stale NESTED loader asset fed by a linked PrimitiveNode (dotted key)", () => {
+    // The leaf name (lora_name) is a model-loader selector, so a stale value must
+    // be preserved (honest missing-asset) even when supplied through the dotted
+    // override path — leaf-name classification must survive the resolver.
+    const info = {
+      DynLoraNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "with-lora",
+                    inputs: {
+                      required: {
+                        lora_name: ["COMBO", { options: ["installed.safetensors"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["not_installed.safetensors"],
+        },
+        {
+          id: 2,
+          type: "DynLoraNode",
+          mode: 0,
+          inputs: [{ name: "model.lora_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["with-lora"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.lora_name"]).toBe("not_installed.safetensors");
+    expect(workflow["2"].inputs["model.lora_name"]).not.toBe("installed.safetensors");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("not_installed.safetensors") &&
+          /missing-asset/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an invalid OPTIONAL dynamic-combo nested leaf fed by a linked PrimitiveNode", () => {
+    // V3 option inputs can live under `optional`, not just `required` — the
+    // resolver must search both or the leaf spec is missing and validation skipped.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      optional: {
+                        output_format: ["COMBO", { options: ["png", "webp"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["gif"], // invalid output_format
+        },
+        {
+          id: 2,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.output_format", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs["model.output_format"]).toBe("png");
+    expect(workflow["2"].inputs["model.output_format"]).not.toBe("gif");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("2") &&
+          w.includes("output_format") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES the tail when a LINKED nested leaf precedes trailing widgets — placeholder ambiguity must not shift the seed (#517 P0-A)", () => {
+    // model.aspect_ratio is converted-to-input (linked). widgets_values
+    // ["Nano Banana 2", 12345] is AMBIGUOUS: on a frontend that drops the converted
+    // widget's slot it is [model, seed] (seed=12345); on one that RETAINS a
+    // placeholder it is [model, aspect_ratio-placeholder, seed?] and 12345 is the
+    // placeholder, not the seed. The two can't be told apart positionally, so
+    // consuming vs skipping the linked leaf silently shifts the seed either way.
+    // The safe contract is to REFUSE: warn + leave the trailing widget(s) to their
+    // defaults, and let the link supply the nested leaf. seed must NOT be silently
+    // assigned the ambiguous 12345.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["Nano Banana 2", 12345], // aspect_ratio linked = ambiguous slot
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["1:1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // seed must NOT be silently assigned the ambiguous trailing value.
+    expect(workflow["1"].inputs.seed).not.toBe(12345);
+    // The nested leaf still comes from the link.
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("1:1");
+    // The refusal is warned (not silent).
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("model.aspect_ratio") &&
+          /default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT let a RETAINED linked-nested placeholder shift a control-eligible seed (#517 P0-A silent-seed)", () => {
+    // Exact placeholder-retention repro: `multiplier` is a linked nested leaf; the
+    // frontend RETAINED its serialized placeholder, so widgets_values is
+    // ["A", 4(placeholder), 424242(seed), "fixed"]. The pre-fix code skipped the
+    // linked leaf WITHOUT consuming its slot, mapped seed=4, then skipped the real
+    // 424242 as the control_after_generate phantom — the user's seed silently became
+    // 4. The fix REFUSES the tail: seed is left to default, 4 never lands on it.
+    const info = {
+      MultNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { multiplier: ["FLOAT", {}] } },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT", { control_after_generate: true, default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "MultNode",
+          mode: 0,
+          inputs: [{ name: "mode.multiplier", type: "FLOAT", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", 4, 424242, "fixed"],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "FLOAT", type: "FLOAT", links: [10] }],
+          widgets_values: [8],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "FLOAT"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The retained placeholder must NEVER become the seed.
+    expect(workflow["1"].inputs.seed).not.toBe(4);
+    // seed falls to its schema default, not a shifted placeholder value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The linked nested leaf is supplied by its (PrimitiveNode) source, not the
+    // retained placeholder 4.
+    expect(workflow["1"].inputs["mode.multiplier"]).toBe(8);
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("mode.multiplier") &&
+          /default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("re-anchors nested leaves when a PrimitiveNode overrides the dynamic PARENT (A -> B)", () => {
+    // Positional mapping emits model="A" and validates model.choice="a1" against
+    // A. A PrimitiveNode then overrides the parent model="B". Without a final
+    // re-anchor, model.choice="a1" (valid for A, invalid for B) reaches the API.
+    const info = {
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["B"], // overrides the parent selection
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"], // saved under option A
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.model).toBe("B");
+    // model.choice must be re-anchored to B's options, NOT left as A's "a1".
+    expect(workflow["3"].inputs["model.choice"]).not.toBe("a1");
+    expect(["b1", "b2"]).toContain(workflow["3"].inputs["model.choice"]);
+  });
+
+  it("drops a wrong-option nested leaf when the dynamic PARENT is fed by a real link", () => {
+    // model is fed by a NON-Primitive link (runtime value unknown), and the saved
+    // nested model.choice="a1" belongs to option A. Since the resolved option
+    // could be B (choice=[b1,b2]), the option-dependent literal must be dropped —
+    // not left as a wrong-option "a1" in the prompt.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // model is a link ref; the wrong-option leaf must be gone.
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("drops a linked-leaf literal under a link-ref parent whose option combo is EMPTY (no silent literal)", () => {
+    // model (parent) is a real link; model.choice (leaf) is a linked PrimitiveNode
+    // "retired"; the option's choice combo is empty [[], {}]. The leaf must NOT be
+    // silently kept — with no valid membership under any option it is dropped.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { choice: [[], {}] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: ["retired"],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // No silent out-of-list "retired" literal on model.choice.
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("drops an ORPHAN dotted leaf LITERAL whose optional dynamic parent is ENTIRELY ABSENT (default-deny)", () => {
+    // `model` is an OPTIONAL COMFY_DYNAMICCOMBO_V3 left completely unset — no
+    // widget value, and optional so it is never default-filled — hence absent
+    // from inputs. A PrimitiveNode feeds a literal straight into the nested dotted
+    // `model.aspect_ratio`. With no parent option selected there is no schema
+    // context for the leaf and ComfyUI would reject the un-parented input, so it
+    // must be dropped rather than left as an orphan literal.
+    const info = {
+      DynOptNode: {
+        input: {
+          required: {},
+          optional: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: [], optional: ["model"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["16:9"],
+        },
+        {
+          id: 2,
+          type: "DynOptNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [], // parent `model` never set
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent absent, and the orphan leaf must NOT survive as an un-parented literal.
+    expect("model" in workflow["2"].inputs).toBe(false);
+    expect("model.aspect_ratio" in workflow["2"].inputs).toBe(false);
+  });
+
+  it("drops an ORPHAN dotted leaf LINK-REF whose optional dynamic parent is ENTIRELY ABSENT (default-deny)", () => {
+    // Same orphan shape, but the nested dotted leaf is fed by a REAL (non-Primitive)
+    // node, so it resolves to a [id, slot] link ref instead of a literal. An
+    // un-parented link ref is just as invalid as an un-parented literal — the
+    // parent combo has no selected option — so default-deny drops it too. (The
+    // previous code kept array-valued orphans, leaking a leaf the server rejects.)
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynOptNode: {
+        input: {
+          required: {},
+          optional: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: [], optional: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "DynOptNode",
+          mode: 0,
+          inputs: [{ name: "model.aspect_ratio", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: [], // parent `model` never set
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // The ComboProvider is still in the prompt (so this is not dangling-ref pruning)…
+    expect(workflow["1"]).toBeDefined();
+    // …but the orphan link-ref leaf under the absent parent must be dropped.
+    expect("model" in workflow["2"].inputs).toBe(false);
+    expect("model.aspect_ratio" in workflow["2"].inputs).toBe(false);
+  });
+
+  it("drops a real-LINK dotted leaf when the PRESENT parent's final option does NOT define it (default-deny)", () => {
+    // model="B" is a present literal parent whose option B does NOT define `choice`
+    // (only option A does). model.choice is fed by a REAL node → a [id, slot] link
+    // ref. It is orphaned under B, and ComfyUI rejects the unknown input, so the
+    // re-anchor pass must DROP it even though it's an array (link) value — the case
+    // that previously slipped through the `Array.isArray(leafVal) continue` guard.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B defines no `choice`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["B"], // final selected option is B
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"]).toBeDefined(); // provider stays — not dangling-ref pruning
+    expect(workflow["3"].inputs.model).toBe("B");
+    // The real-link leaf is orphaned under option B and must be dropped.
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("KEEPS a real-LINK dotted leaf when the PRESENT parent's final option DOES define it", () => {
+    // Guard against over-deletion: model="A" defines `choice`, and model.choice is
+    // a real link into a defined leaf → a valid connection that must be preserved
+    // as-is (its runtime value is validated by ComfyUI, not here).
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["3"].inputs.model).toBe("A");
+    // Valid link into a defined leaf — kept as the [id, slot] ref.
+    expect(workflow["3"].inputs["model.choice"]).toEqual(["1", 0]);
+  });
+
+  it("drops a real-LINK dotted leaf under a real-LINK parent when SOME option omits the leaf (runtime-unknown default-deny)", () => {
+    // model (parent) is fed by a REAL link → the resolved option is unknowable.
+    // Option A defines `choice`, option B does NOT. model.choice is fed by another
+    // real link. If the parent resolves to B at runtime, `model.choice` is an
+    // unknown input ComfyUI rejects. Since we can't know the resolution, default-
+    // deny: the leaf must be dropped unless EVERY option defines it.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B omits `choice`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // Parent stays a runtime link ref…
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // …but the leaf, not defined by every option, is dropped (would orphan under B).
+    expect("model.choice" in workflow["3"].inputs).toBe(false);
+    // …and the drop MUST be warned (FIX 2) — a silently removed link is the bug class.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("3") &&
+          w.includes("model.choice") &&
+          w.includes("model") &&
+          /dropped|link/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("KEEPS a real-LINK dotted leaf under a real-LINK parent when EVERY option defines the leaf", () => {
+    // Guard against over-deletion: both options A and B define `choice`, so the
+    // linked leaf is valid whichever option resolves and must be preserved.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["a1", "a2"] }] },
+                    },
+                  },
+                  {
+                    key: "B",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["b1", "b2"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 2,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [11] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [
+            { name: "model", type: "COMBO", link: 10 },
+            { name: "model.choice", type: "COMBO", link: 11 },
+          ],
+          outputs: [],
+          widgets_values: [],
+        },
+      ],
+      links: [
+        [10, 1, 0, 3, 0, "COMBO"],
+        [11, 2, 0, 3, 1, "COMBO"],
+      ],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // Defined by every option → the link ref is preserved.
+    expect(workflow["3"].inputs["model.choice"]).toEqual(["2", 0]);
+  });
+
+  it("PRESERVES a LITERAL nested leaf defined by SOME (not all) options under a real-LINK parent — no silent user-value drop (#517 P0-B)", () => {
+    // The dynamic parent `model` is fed by a real link (converted to input) but the
+    // frontend RETAINED its widgets_values placeholder ["A", 0.75], so the positional
+    // pass sets model.strength=0.75. Option A DEFINES strength (FLOAT default 0.5),
+    // option B OMITS it. The pre-fix strict default-deny deleted model.strength purely
+    // because B lacks it — silently discarding the user's 0.75 so execution used A's
+    // default 0.5. A LITERAL user value defined by at least one option (and valid where
+    // defined) must be PRESERVED: dropping it on option B, a resolution that may never
+    // occur, is the corruption. (Link-ref leaves — no user scalar to lose — keep the
+    // strict every-option rule; see the two tests above.)
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      DynParentNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: {
+                      required: { strength: ["FLOAT", { default: 0.5 }] },
+                    },
+                  },
+                  { key: "B", inputs: { required: {} } }, // B omits `strength`
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 5,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [20] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "DynParentNode",
+          mode: 0,
+          inputs: [{ name: "model", type: "COMBO", link: 20 }],
+          outputs: [],
+          // Retained placeholder: parent "A" + nested literal strength 0.75.
+          widgets_values: ["A", 0.75],
+        },
+      ],
+      links: [[20, 5, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent is a runtime link ref…
+    expect(Array.isArray(workflow["3"].inputs.model)).toBe(true);
+    // …and the user's literal strength is PRESERVED, not dropped to A's default 0.5.
+    expect(workflow["3"].inputs["model.strength"]).toBe(0.75);
+  });
+
+  it("leaves a VALID enum fed by a linked PrimitiveNode untouched (no warn)", () => {
+    const info = {
+      KSamplerSelect: {
+        input: { required: { sampler_name: [["euler", "dpmpp_2m"]] } },
+        input_order: { required: ["sampler_name"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["dpmpp_2m"],
+        },
+        {
+          id: 2,
+          type: "KSamplerSelect",
+          mode: 0,
+          inputs: [{ name: "sampler_name", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["euler"],
+        },
+      ],
+      links: [[10, 1, 0, 2, 0, "COMBO"]],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["2"].inputs.sampler_name).toBe("dpmpp_2m");
+    expect(warnings.some((w) => /substituting|missing-asset/.test(w))).toBe(
+      false,
+    );
+  });
+});
+
+describe("convertUiToApi — option-bearing / dynamic nested combo validation (P1-B, #504)", () => {
+  // The option-list extraction only read spec[0] as the options array, so it
+  // MISSED the ["COMBO",{options:[...]}] form and V3 dynamic-combo nested combos —
+  // those values were copied raw and reached the API unvalidated.
+
+  it("SUBSTITUTES+warns an out-of-list nested value in a V3 dynamic combo", () => {
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            prompt: ["STRING"],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["prompt", "model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a prompt", "Nano Banana 2", "4:3"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.model).toBe("Nano Banana 2");
+    // The nested "4:3" is not a valid aspect_ratio option — substituted to "auto".
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("auto");
+    expect(workflow["1"].inputs["model.aspect_ratio"]).not.toBe("4:3");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("aspect_ratio") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves a VALID nested dynamic-combo value untouched (no warn)", () => {
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            prompt: ["STRING"],
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["auto", "1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["prompt", "model"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["a prompt", "Nano Banana 2", "16:9"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("16:9");
+    expect(warnings.some((w) => /substituting|missing-asset/.test(w))).toBe(
+      false,
+    );
+  });
+
+  it("REFUSES to map trailing widgets after a STALE dynamic parent when a trailing widget is control-eligible (ambiguous slot count) — no stale value on seed (#517 P0)", () => {
+    // Saved parent "removed-model" is no longer an option and is substituted to
+    // "new-model". The array [removed-model, 12345] is AMBIGUOUS: it could be
+    // [parent, seed] (old option had 0 nested) OR [parent, orphaned-nested] (old
+    // option owned 1 nested, seed omitted). Since the trailing `seed` is
+    // control-eligible (variable phantom slot), the removed option's nested arity
+    // can't be reconstructed unambiguously, so we REFUSE: seed is left to default
+    // rather than risk a stale nested value being mapped onto it. This is the safe
+    // contract — a wrong seed is silently wrong; a defaulted seed is warned.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "new-model",
+                    inputs: {
+                      required: {
+                        aspect_ratio: ["COMBO", { options: ["1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["removed-model", 12345],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.model).toBe("new-model");
+    // seed must NOT hold an ambiguous positional value from the stale layout.
+    expect(workflow["1"].inputs.seed).not.toBe(12345);
+    // The refusal is warned (not silent).
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("removed-model") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES (never realigns) a STALE dynamic parent even when the CURRENT schema added a trailing widget — an orphaned nested value never lands on a later widget (#517 P0 schema-drift)", () => {
+    // The saved parent option "Removed" is gone; the OLD option owned a nested
+    // `strength` (=0.75) sitting between the parent and the trailing `seed`. The
+    // CURRENT schema has ALSO added a trailing `new_widget`. A naive surplus
+    // arithmetic (values-left minus current-trailing-count) cancels the orphaned
+    // slot to zero and would silently map seed=0.75 and new_widget=42 — the orphan
+    // STILL lands on seed. Since neither the removed option's arity NOR the
+    // trailing schema drift is recoverable, the fix REFUSES all positional mapping
+    // after the stale parent: seed and new_widget default, and the orphaned 0.75
+    // NEVER reaches a later widget.
+    const info = {
+      DriftNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { default: 0 }],
+            new_widget: ["INT", { default: 99 }],
+          },
+        },
+        input_order: { required: ["mode", "seed", "new_widget"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "DriftNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // OLD "Removed" option owned strength=0.75; saved [mode, strength, seed]
+          widgets_values: ["Removed", 0.75, 42],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The orphaned nested value NEVER lands on a later widget.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    expect(workflow["1"].inputs.new_widget).not.toBe(0.75);
+    // seed/new_widget fall to their schema defaults, not a shifted positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    expect(workflow["1"].inputs.new_widget).toBe(99);
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("Removed") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES (warn + default) when a stale dynamic parent is followed by a control-eligible seed — the orphaned nested value never lands on seed (#517 P0)", () => {
+    // Exact P0 repro shape: current option A owns no nested; the OLD option owned a
+    // nested strength=0.75 now sitting before the trailing top-level `seed`. `seed`
+    // is control_after_generate (variable phantom slot), so the surplus is
+    // ambiguous — we can't tell [mode, strength, seed] from [mode, seed, control].
+    // We REFUSE: seed must NOT be silently overwritten by the orphaned 0.75.
+    const info = {
+      StaleSeedNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "StaleSeedNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["Removed", 0.75, 42],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // seed must NOT be the orphaned nested value.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    // The refusal is warned; seed is left to its schema default rather than a
+    // silently-misaligned positional value.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("Removed") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES to reconstruct (warn + default-fill) when a trailing widget after a stale dynamic parent is itself a dynamic combo (#517 P0)", () => {
+    // Two dynamic combos in a row; the FIRST is stale. The trailing one's nested
+    // arity is value-dependent and can't be counted, so the surplus is ambiguous.
+    // Rather than risk misassigning, the remaining widgets are left to defaults.
+    const info = {
+      TwoDynNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            other: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "X",
+                    inputs: { required: { sub: ["COMBO", { options: ["p", "q"] }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode", "other"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoDynNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["Removed", 0.75, "X", "p"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    expect(
+      warnings.some(
+        (w) => w.includes("Removed") && /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("REFUSES (warn + default) when a stale dynamic parent has an EMPTY current options list — the type marker, not the option-key heuristic, must fire the guard (#517 P0 empty-options)", () => {
+    // The CURRENT schema's dynamic combo has NO options at all
+    // (["COMFY_DYNAMICCOMBO_V3", {options: []}]) — e.g. its option source hasn't
+    // populated yet, or every option was removed. The saved selection is therefore
+    // stale by definition, and the OLD option owned a nested strength=0.75 sitting
+    // between the parent and the trailing `seed`. An empty options array has NO
+    // keyed {key,inputs} entries, so the object-key heuristic reports NOT-dynamic
+    // and the stale-parent guard would be BYPASSED — the loop would silently map
+    // seed=0.75 (the orphaned nested value) and treat 42 as a phantom slot. Keying
+    // the guard off the EXPLICIT type string ("COMFY_DYNAMICCOMBO_V3") fires the
+    // refusal here too: seed keeps its schema default, and 0.75 never lands on it.
+    const info = {
+      EmptyOptsNode: {
+        input: {
+          required: {
+            model: ["COMFY_DYNAMICCOMBO_V3", { options: [] }],
+            seed: ["INT", { default: 0 }],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "EmptyOptsNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // OLD removed option owned strength=0.75; saved
+          // [model, strength(nested), seed, control-phantom].
+          widgets_values: ["removed-option", 0.75, 42, "fixed"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The parent itself is preserved (an empty option list can't substitute it).
+    // The critical invariant: seed is NOT the silently-shifted orphaned 0.75.
+    expect(workflow["1"].inputs.seed).not.toBe(0.75);
+    // seed falls to its schema default rather than an ambiguous positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The refusal is warned (not silent) and names the stale selection.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("1") &&
+          w.includes("removed-option") &&
+          /can't be reconstructed|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("DEFAULTS the tail when a STILL-VALID dynamic option's nested arity DRIFTED (leftover) — no stale nested value on the seed (#517 P0 arity-drift)", () => {
+    // The saved option key "A" STILL EXISTS, so the stale-parent (removed-key) guard
+    // does NOT fire. But when the graph was saved, option A owned a nested
+    // `multiplier` (=4); the CURRENT schema's option A has REMOVED it. Mapping with
+    // the current (empty) nested layout consumes nothing, so the loop assigns
+    // seed=4 (the stale nested value) and skips the REAL 424242 as the control
+    // phantom — the user's seed silently becomes 4, with a leftover "fixed" proving
+    // the drift. The leftover-drift guard must default the post-combo widgets: seed
+    // must NOT be 4.
+    const info = {
+      DriftArityNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              // Current option A defines NO nested inputs (multiplier was removed).
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            seed: ["INT", { control_after_generate: true, default: 0 }],
+          },
+        },
+        input_order: { required: ["mode", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "DriftArityNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // Saved under the OLD layout: [mode, multiplier(nested,=4), seed, control].
+          widgets_values: ["A", 4, 424242, "fixed"],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // Parent stays "A" (still a valid option).
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The stale nested value must NEVER become the seed.
+    expect(workflow["1"].inputs.seed).not.toBe(4);
+    // seed falls to its schema default, not the shifted positional value.
+    expect(workflow["1"].inputs.seed).toBe(0);
+    // The drift is warned (not silent).
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && /nested-input layout|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT let the arity-drift guard mis-fire on a LINKED-leaf refusal in a LATER dynamic combo — earlier valid combo must not default the later parent (#517 P0-A/drift interaction)", () => {
+    // Two dynamic combos in order. The FIRST (`first`) is a normal still-valid combo
+    // (sets sawDynamicCombo). The SECOND (`second`) has a LINKED nested leaf
+    // (second.choice), which triggers the P0-A refuse-the-tail path — leaving a
+    // leftover. Without the tailRefused gate, the post-loop drift guard would ALSO
+    // fire, wrongly deleting `second` (a valid parent selection) and defaulting it to
+    // the first option. The gate must suppress the drift guard here: `second` keeps
+    // its saved "Y".
+    const info = {
+      TwoParentNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            second: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "X",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["x1"] }] },
+                    },
+                  },
+                  {
+                    key: "Y",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["y1"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["first", "second"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoParentNode",
+          mode: 0,
+          // second.choice is converted-to-input (linked).
+          inputs: [{ name: "second.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "Y", 424242],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["y1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The later parent must KEEP its saved selection, not be defaulted to "X".
+    expect(workflow["1"].inputs.second).toBe("Y");
+  });
+
+  it("DEFAULTS a shifted NESTED leaf on proven arity-shrink even with NO trailing top-level widget (#517 P0 nested-shrink)", () => {
+    // Old option A owned nested [obsolete, strength]; the CURRENT schema's A dropped
+    // `obsolete`, leaving [strength]. Saved ["A", 4, 0.75] was serialized as
+    // [mode, obsolete=4, strength=0.75]. Mapping with the current layout assigns
+    // strength=4 (the OBSOLETE value!) and leaves 0.75 as a leftover. There is NO
+    // trailing top-level widget, so the guard must STILL fire on the leftover and
+    // default the shifted nested leaf — strength must NOT silently be 4.
+    const info = {
+      NestedShrinkNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    // `obsolete` was removed; only `strength` remains.
+                    inputs: { required: { strength: ["FLOAT", { default: 1 }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NestedShrinkNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["A", 4, 0.75], // [mode, obsolete=4, strength=0.75]
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.mode).toBe("A");
+    // The shifted OBSOLETE value must NOT survive on the strength leaf.
+    expect(workflow["1"].inputs["mode.strength"]).not.toBe(4);
+    // It is dropped (absent) so ComfyUI supplies the option's runtime default.
+    expect("mode.strength" in workflow["1"].inputs).toBe(false);
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && /nested-input layout|default/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT default a later EMPTY-OPTIONS V3 parent when an earlier valid combo set the drift flag (#517 P1 empty-options multi-combo)", () => {
+    // An earlier valid dynamic combo (`first`) sets sawDynamicCombo. The later combo
+    // (`second`) is an EMPTY-OPTIONS V3 whose saved selection is stale → the stale-
+    // parent refusal fires. That refusal must set tailRefused so the leftover guard
+    // does NOT delete `second` — an empty options list has no substitution or default
+    // to restore it from, so deleting it would LOSE the declared parent entirely.
+    const info = {
+      TwoWithEmptyNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "A", inputs: { required: {} } }] },
+            ],
+            second: ["COMFY_DYNAMICCOMBO_V3", { options: [] }],
+          },
+        },
+        input_order: { required: ["first", "second"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "TwoWithEmptyNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["A", "my-model", 42], // first=A, second=my-model + trailing
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The empty-options parent's declared value is preserved, NOT deleted.
+    expect(workflow["1"].inputs.second).toBe("my-model");
+  });
+
+  it("does NOT delete VALID earlier values when a LATER combo refuses — a refusal's expected leftover is not a drift signal (#517 FIX 1 no-false-positive)", () => {
+    // `first` is a valid dynamic combo with a correctly-mapped nested leaf
+    // (first.note="hello"); `count`=7 is an ordinary widget after it; `second` is a
+    // dynamic combo whose nested `choice` is LINKED, so it hits the linked-leaf
+    // refusal with saved values remaining. The refusal INTENTIONALLY leaves a
+    // leftover — that leftover must NOT be read as "first drifted" and cause the guard
+    // to delete the perfectly valid first.note and count. (A refusal suppresses the
+    // drift guard for the whole node; earlier drift, if any, is positionally
+    // indistinguishable from this valid layout and falls to the accepted limitation.)
+    const info = {
+      MixedNode: {
+        input: {
+          required: {
+            first: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { note: ["STRING", {}] } },
+                  },
+                ],
+              },
+            ],
+            count: ["INT", { default: 0 }],
+            second: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Y",
+                    inputs: {
+                      required: { choice: ["COMBO", { options: ["y1"] }] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["first", "count", "second"] },
+      },
+      PrimitiveNode: { input: { required: {} } },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "MixedNode",
+          mode: 0,
+          // second.choice is converted-to-input (linked).
+          inputs: [{ name: "second.choice", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "hello", 7, "Y", 424242],
+        },
+        {
+          id: 2,
+          type: "PrimitiveNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: ["y1"],
+        },
+      ],
+      links: [[10, 2, 0, 1, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.first).toBe("A");
+    // The valid earlier nested leaf and widget must be PRESERVED, not deleted.
+    expect(workflow["1"].inputs["first.note"]).toBe("hello");
+    expect(workflow["1"].inputs.count).toBe(7);
+    // The later linked-leaf combo keeps its saved selection.
+    expect(workflow["1"].inputs.second).toBe("Y");
+  });
+
+  it("PRESERVES a shared SCALAR required leaf under a runtime-linked dynamic parent — not dropped as a non-member (#517 false-positive)", () => {
+    // `mode` is fed by a real (non-Primitive) link, so the resolved option is
+    // unknown at convert time. BOTH options define a required SCALAR `strength`
+    // (FLOAT, no combo options). The default-deny must NOT drop it: a scalar leaf
+    // has no option list to be an in-list "member" of, so the membership check
+    // must not apply — the leaf is valid whichever option resolves because every
+    // option DEFINES it. Dropping it would cause a missing-required-input failure.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      ScalarLeafNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { strength: ["FLOAT", {}] } },
+                  },
+                  {
+                    key: "B",
+                    inputs: { required: { strength: ["FLOAT", {}] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "ScalarLeafNode",
+          mode: 0,
+          inputs: [{ name: "mode", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", 0.75],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    // Parent is a link ref.
+    expect(Array.isArray(workflow["3"].inputs.mode)).toBe(true);
+    // The shared scalar leaf is PRESERVED with its value.
+    expect(workflow["3"].inputs["mode.strength"]).toBe(0.75);
+  });
+
+  it("still DROPS a genuinely orphaned COMBO leaf (value not in an option's list) under a runtime-linked dynamic parent (#517 guard intact)", () => {
+    // Contrast to the scalar case: `choice` IS a combo. The saved literal "a1"
+    // is valid only under option A; option B's `choice` list is ["b1","b2"], so a
+    // runtime resolution to B would orphan it. The default-deny must still drop it.
+    const info = {
+      ComboProvider: {
+        input: { required: {} },
+        output: ["COMBO"],
+        output_name: ["COMBO"],
+      },
+      ComboLeafNode: {
+        input: {
+          required: {
+            mode: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "A",
+                    inputs: { required: { choice: ["COMBO", { options: ["a1", "a2"] }] } },
+                  },
+                  {
+                    key: "B",
+                    inputs: { required: { choice: ["COMBO", { options: ["b1", "b2"] }] } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["mode"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ComboProvider",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "COMBO", type: "COMBO", links: [10] }],
+          widgets_values: [],
+        },
+        {
+          id: 3,
+          type: "ComboLeafNode",
+          mode: 0,
+          inputs: [{ name: "mode", type: "COMBO", link: 10 }],
+          outputs: [],
+          widgets_values: ["A", "a1"],
+        },
+      ],
+      links: [[10, 1, 0, 3, 0, "COMBO"]],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(Array.isArray(workflow["3"].inputs.mode)).toBe(true);
+    // The option-dependent combo leaf is dropped (not a member of every option).
+    expect("mode.choice" in workflow["3"].inputs).toBe(false);
+  });
+
+  it("skips the phantom control_after_generate slot after a NESTED seed widget", () => {
+    // A dynamic option exposing a nested controlled seed carries a phantom
+    // "fixed"/"randomize" value after it (like top-level seeds). Not skipping it
+    // shifts every following widget: aspect_ratio would eat "fixed" and steps
+    // would eat "16:9".
+    const info = {
+      SeededNanoNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "new-model",
+                    inputs: {
+                      required: {
+                        seed: ["INT", { control_after_generate: true }],
+                        aspect_ratio: ["COMBO", { options: ["1:1", "16:9"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            steps: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "steps"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "SeededNanoNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // [model, nested seed, phantom "fixed", nested aspect_ratio, steps]
+          widgets_values: ["new-model", 42, "fixed", "16:9", 7],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs["model.seed"]).toBe(42);
+    // aspect_ratio must be "16:9", NOT the phantom "fixed".
+    expect(workflow["1"].inputs["model.aspect_ratio"]).toBe("16:9");
+    // steps must land on 7, not be shifted onto "16:9".
+    expect(workflow["1"].inputs.steps).toBe(7);
+  });
+
+  it("SUBSTITUTES+warns an out-of-list required combo DEFAULT (schema-drift default-fill)", () => {
+    // A required combo whose own schema `default` is not among its options (custom
+    // node version drift). With no saved widget value the default-fill loop emits
+    // it — it must be validated (substituted to first option), not passed raw.
+    const info = {
+      DriftySampler: {
+        input: {
+          required: {
+            sampler_name: [["euler", "dpmpp_2m"], { default: "removed_sampler" }],
+          },
+        },
+        input_order: { required: ["sampler_name"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 77,
+          type: "DriftySampler",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: [], // nothing saved -> default-fill path
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["77"].inputs.sampler_name).toBe("euler");
+    expect(workflow["77"].inputs.sampler_name).not.toBe("removed_sampler");
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("77") &&
+          w.includes("removed_sampler") &&
+          /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("consumes+validates an OPTIONAL positional nested leaf and keeps later widget index aligned", () => {
+    // A V3 option whose nested widget lives under `optional`. It occupies a
+    // positional widgets_values slot; reading only `required` would skip it and
+    // mis-position the trailing top-level `seed` widget. The nested value must be
+    // validated (substituted) AND the following widget must still land correctly.
+    const info = {
+      NanoBananaNode: {
+        input: {
+          required: {
+            model: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "Nano Banana 2",
+                    inputs: {
+                      optional: {
+                        output_format: ["COMBO", { options: ["png", "webp"] }],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            seed: ["INT"],
+          },
+        },
+        input_order: { required: ["model", "seed"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "NanoBananaNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // model, model.output_format (optional nested), seed
+          widgets_values: ["Nano Banana 2", "gif", 12345],
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    // The optional nested leaf is consumed + validated (gif -> png).
+    expect(workflow["1"].inputs["model.output_format"]).toBe("png");
+    // …and the trailing top-level `seed` still lands on the right slot.
+    expect(workflow["1"].inputs.seed).toBe(12345);
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && w.includes("output_format") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+
+  it("SUBSTITUTES+warns an out-of-list value on a top-level [\"COMBO\",{options}] spec", () => {
+    const info = {
+      ApiImageNode: {
+        input: {
+          required: {
+            response_modalities: [
+              "COMBO",
+              { options: ["IMAGE", "IMAGE+TEXT"] },
+            ],
+          },
+        },
+        input_order: { required: ["response_modalities"] },
+      },
+    } as never;
+    const ui = {
+      nodes: [
+        {
+          id: 1,
+          type: "ApiImageNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: ["AUDIO"], // not an option — helper missed this shape before
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(ui, info);
+    expect(workflow["1"].inputs.response_modalities).toBe("IMAGE");
+    expect(workflow["1"].inputs.response_modalities).not.toBe("AUDIO");
+    expect(
+      warnings.some(
+        (w) => w.includes("1") && w.includes("AUDIO") && /substituting/.test(w),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/services/workflow-lock.test.ts
+++ b/src/__tests__/services/workflow-lock.test.ts
@@ -106,6 +106,182 @@ describe("generateLock", () => {
     });
   });
 
+  // Regression for #482: a UI-format saved workflow (nodes[]/links[] with
+  // `type` + widgets_values, NOT class_type + inputs) referencing native
+  // VAELoader (`vae_name`) + UNETLoader (`unet_name`) locked 0 models because
+  // extraction only understood API/prompt format. generateLock must normalize
+  // UI format first so both native loader models are captured and hashed.
+  it("captures native VAELoader + UNETLoader models from a UI-format workflow (#482)", async () => {
+    await mkdir(join(tempDir, "models", "vae"), { recursive: true });
+    await mkdir(join(tempDir, "models", "diffusion_models"), { recursive: true });
+    await mkdir(join(tempDir, "models", "upscale_models"), { recursive: true });
+    await writeFile(
+      join(tempDir, "models", "vae", "seedvr2_ema_vae_fp16.safetensors"),
+      "vae-bytes",
+    );
+    await writeFile(
+      join(tempDir, "models", "diffusion_models", "seedvr2_3b_fp8_e4m3fn.safetensors"),
+      "unet-bytes",
+    );
+    // A non-.safetensors asset extension (.pt2) must also be recognized.
+    await writeFile(join(tempDir, "models", "upscale_models", "4x_realesrgan.pt2"), "up-bytes");
+
+    // /object_info supplies the widget schema the UI→API converter needs to map
+    // each node's positional widgets_values to its named inputs.
+    getObjectInfo.mockResolvedValue({
+      VAELoader: {
+        python_module: "nodes",
+        input: { required: { vae_name: [["seedvr2_ema_vae_fp16.safetensors"], {}] } },
+        input_order: { required: ["vae_name"] },
+      },
+      UNETLoader: {
+        python_module: "nodes",
+        input: {
+          required: {
+            unet_name: [["seedvr2_3b_fp8_e4m3fn.safetensors"], {}],
+            weight_dtype: [["default", "fp8_e4m3fn"], { default: "default" }],
+          },
+        },
+        input_order: { required: ["unet_name", "weight_dtype"] },
+      },
+    });
+
+    // A ComfyUI-UI-saved graph: nodes[] with `type` + widgets_values, links[].
+    const uiWorkflow = {
+      last_node_id: 2,
+      last_link_id: 0,
+      nodes: [
+        {
+          id: 1,
+          type: "VAELoader",
+          pos: [0, 0],
+          widgets_values: ["seedvr2_ema_vae_fp16.safetensors"],
+          outputs: [{ name: "VAE", type: "VAE", links: null }],
+        },
+        {
+          id: 2,
+          type: "UNETLoader",
+          pos: [0, 200],
+          widgets_values: ["seedvr2_3b_fp8_e4m3fn.safetensors", "default"],
+          outputs: [{ name: "MODEL", type: "MODEL", links: null }],
+        },
+        {
+          id: 3,
+          type: "UpscaleModelLoader",
+          pos: [0, 400],
+          widgets_values: ["4x_realesrgan.pt2"],
+          outputs: [{ name: "UPSCALE_MODEL", type: "UPSCALE_MODEL", links: null }],
+        },
+      ],
+      links: [],
+    } as never;
+
+    const lock = await generateLock(uiWorkflow);
+
+    expect(lock.models).toHaveLength(3);
+    const upscale = lock.models.find((m) => m.name === "4x_realesrgan.pt2");
+    expect(upscale).toBeDefined();
+    expect(upscale!.type).toBe("upscale_models");
+    expect(upscale!.sha256).toMatch(/^[0-9a-f]{64}$/);
+    const vae = lock.models.find((m) => m.name === "seedvr2_ema_vae_fp16.safetensors");
+    const unet = lock.models.find((m) => m.name === "seedvr2_3b_fp8_e4m3fn.safetensors");
+    expect(vae).toBeDefined();
+    expect(vae!.type).toBe("vae");
+    expect(vae!.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(unet).toBeDefined();
+    expect(unet!.type).toBe("diffusion_models");
+    expect(unet!.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // A UI-saved graph may bypass/mute a loader (mode 2/4) or reference a native
+  // loader whose class isn't in /object_info. A whole-graph UI→API conversion
+  // would drop such nodes and silently omit their models from the lock; reading
+  // UI nodes directly must still capture them (provenance = every referenced
+  // model, regardless of mute state — matches the API-format walk).
+  it("still captures a bypassed loader's model in a UI-format workflow (#482)", async () => {
+    await mkdir(join(tempDir, "models", "vae"), { recursive: true });
+    await writeFile(join(tempDir, "models", "vae", "bypassed_vae.safetensors"), "vae-bytes");
+    getObjectInfo.mockResolvedValue({}); // loader class absent from /object_info
+
+    const uiWorkflow = {
+      nodes: [
+        {
+          id: 1,
+          type: "VAELoader",
+          mode: 4, // bypassed
+          pos: [0, 0],
+          widgets_values: ["bypassed_vae.safetensors"],
+        },
+      ],
+      links: [],
+    } as never;
+
+    const lock = await generateLock(uiWorkflow);
+    expect(lock.models).toHaveLength(1);
+    expect(lock.models[0]).toMatchObject({
+      name: "bypassed_vae.safetensors",
+      type: "vae",
+    });
+    expect(lock.models[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  // A loader nested inside a subgraph definition (definitions.subgraphs[].nodes)
+  // must also be captured — otherwise a component's model silently vanishes from
+  // the lock. The top-level subgraph INSTANCE (type = the def's UUID) is
+  // structural and must NOT be treated as a real node.
+  it("captures a loader nested inside a UI subgraph definition, and does NOT treat the instance UUID as a real node (#482)", async () => {
+    await mkdir(join(tempDir, "models", "vae"), { recursive: true });
+    await writeFile(join(tempDir, "models", "vae", "nested_vae.safetensors"), "vae-bytes");
+
+    // Give the subgraph-INSTANCE UUID a (bogus) custom-pack origin. If the walk
+    // wrongly treated the structural instance as a real node, this phantom pack
+    // would be recorded in node_packs. The skip must keep it out.
+    const instanceId = "1111aaaa-2222-bbbb-3333-cccc4444dddd";
+    getObjectInfo.mockResolvedValue({
+      VAELoader: { python_module: "nodes" },
+      [instanceId]: { python_module: "custom_nodes.PhantomPack.foo" },
+    });
+    await mkdir(join(tempDir, "custom_nodes", "PhantomPack", ".git"), { recursive: true });
+    await writeFile(
+      join(tempDir, "custom_nodes", "PhantomPack", ".git", "HEAD"),
+      "feedface0000000000000000000000000000face\n",
+    );
+
+    const uiWorkflow = {
+      nodes: [
+        // A subgraph instance: its `type` is the definition id (a UUID). Not a
+        // real node — must be skipped, not mistaken for a class_type/loader.
+        { id: 10, type: instanceId, pos: [0, 0] },
+      ],
+      links: [],
+      definitions: {
+        subgraphs: [
+          {
+            id: instanceId,
+            name: "MyComponent",
+            nodes: [
+              {
+                id: 1,
+                type: "VAELoader",
+                pos: [0, 0],
+                widgets_values: ["nested_vae.safetensors"],
+              },
+            ],
+            links: [],
+          },
+        ],
+      },
+    } as never;
+
+    const lock = await generateLock(uiWorkflow);
+    expect(lock.models).toHaveLength(1);
+    expect(lock.models[0]).toMatchObject({ name: "nested_vae.safetensors", type: "vae" });
+    expect(lock.models[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+    // The structural instance UUID must never surface as a custom pack.
+    expect(lock.node_packs.map((p) => p.id)).not.toContain("PhantomPack");
+    expect(lock.node_packs).toHaveLength(0);
+  });
+
   it("marks missing models with `missing: true` instead of failing", async () => {
     getObjectInfo.mockResolvedValue({
       CheckpointLoaderSimple: { python_module: "nodes" },

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -81,6 +81,8 @@ import {
   getEnvironment,
   liveRootFromArgv,
   resolveComfyuiPython,
+  resolveLiveComfyUIBase,
+  resolveRootInterpreter,
 } from "../../services/workspace-env.js";
 
 async function tmpDir(): Promise<string> {
@@ -666,6 +668,67 @@ describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
   it("returns undefined for missing/empty argv", () => {
     expect(liveRootFromArgv(undefined)).toBeUndefined();
     expect(liveRootFromArgv([])).toBeUndefined();
+  });
+});
+
+describe("resolveRootInterpreter (portable + venv layouts)", () => {
+  it("finds the install's own .venv interpreter on disk", async () => {
+    const root = await tmpDir();
+    try {
+      const py = await makeVenvPython(root);
+      expect(resolveRootInterpreter(root)).toBe(py);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers a portable python_embeded layout on Windows", async () => {
+    if (!IS_WIN) return; // python_embeded candidates are Windows-only
+    const root = await tmpDir();
+    try {
+      const embDir = join(root, "python_embeded");
+      await mkdir(embDir, { recursive: true });
+      const emb = join(embDir, "python.exe");
+      await writeFile(emb, "", "utf-8");
+      expect(resolveRootInterpreter(root)).toBe(emb);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a bare platform python when nothing is on disk / root is undefined", async () => {
+    const root = await tmpDir();
+    try {
+      expect(resolveRootInterpreter(root)).toBe(IS_WIN ? "python.exe" : "python3");
+      expect(resolveRootInterpreter(undefined)).toBe(IS_WIN ? "python.exe" : "python3");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveLiveComfyUIBase (#490 / #463 — live connected install root)", () => {
+  it("derives the live root from the running server's main.py argv", async () => {
+    const root = IS_WIN ? "C:\\live\\ComfyUI" : "/live/ComfyUI";
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join(root, "main.py"), "--listen"] },
+    });
+    expect(await resolveLiveComfyUIBase()).toBe(root);
+  });
+
+  it("returns undefined in remote mode (the live root is on the remote host)", async () => {
+    h.remoteMode.value = true;
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [IS_WIN ? "C:\\remote\\main.py" : "/remote/main.py"] },
+    });
+    expect(await resolveLiveComfyUIBase()).toBeUndefined();
+    // Never even probes /system_stats when remote.
+    expect(mockGetSystemStats).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined (never throws) when the server is unreachable", async () => {
+    mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(resolveLiveComfyUIBase()).resolves.toBeUndefined();
   });
 });
 

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComfyUIError } from "../../utils/errors.js";
+
+// #483: get_image for a valid `type:"input"` image must return the binary
+// bytes as an inline image, and a non-image/empty /view body must yield a
+// structured not-found — never an uncaught "Unexpected end of JSON input"
+// from JSON-parsing a binary response. The binary-safe read + guard live in
+// getOutputImage (service, covered in image-management-traversal.test.ts);
+// this locks the TOOL handler contract on top of it.
+
+const getOutputImageMock = vi.fn();
+vi.mock("../../services/image-management.js", () => ({
+  extractWorkflowFromImage: vi.fn(),
+  listOutputImages: vi.fn(),
+  getOutputImage: (...a: unknown[]) => getOutputImageMock(...a),
+  uploadImageAuto: vi.fn(),
+  uploadVideoAuto: vi.fn(),
+  uploadAudioAuto: vi.fn(),
+  stageOutputAsInput: vi.fn(),
+}));
+
+// Don't actually touch disk when the handler saves the file.
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return { ...actual, mkdir: vi.fn(async () => undefined), writeFile: vi.fn(async () => undefined) };
+});
+
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+describe("get_image — binary-safe (#483)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns an inline image block for a valid type:input image", async () => {
+    const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    getOutputImageMock.mockResolvedValue({ base64, mimeType: "image/png", filename: "src.png" });
+
+    const out = await getHandler("get_image")({
+      filename: "RogueTD_Ara_Locomotion_Source.png",
+      type: "input",
+      save_dir: "/tmp/x",
+    });
+
+    const image = out.content.find((c) => c.type === "image");
+    expect(image).toBeDefined();
+    expect(image?.data).toBe(base64);
+    expect(image?.mimeType).toBe("image/png");
+  });
+
+  it("returns a structured error (not a JSON-parse crash) for an empty/non-image body", async () => {
+    getOutputImageMock.mockRejectedValue(
+      new ComfyUIError(
+        'ComfyUI /view did not return an image for "x.png" (input); got an empty response.',
+        "IMAGE_NOT_FOUND",
+      ),
+    );
+
+    const out = await getHandler("get_image")({ filename: "x.png", type: "input" });
+    expect(out.isError).toBe(true);
+    const text = out.content.map((c) => c.text ?? "").join("");
+    expect(text).toContain("IMAGE_NOT_FOUND");
+    expect(text).not.toContain("Unexpected end of JSON input");
+  });
+});

--- a/src/__tests__/tools/get-node-info-summary.test.ts
+++ b/src/__tests__/tools/get-node-info-summary.test.ts
@@ -6,8 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // whose enum dropdowns embed the entire local model list (100s of KB per node).
 
 const getObjectInfoMock = vi.fn();
+const resetObjectInfoCacheMock = vi.fn();
+const backfillObjectInfoMock = vi.fn(async (info: unknown) => info);
 vi.mock("../../comfyui/client.js", () => ({
   getObjectInfo: (...a: unknown[]) => getObjectInfoMock(...a),
+  resetObjectInfoCache: (...a: unknown[]) => resetObjectInfoCacheMock(...a),
+  backfillObjectInfo: (...a: unknown[]) => backfillObjectInfoMock(...a),
 }));
 
 import { registerWorkflowComposeTools, summarizeNodeDef } from "../../tools/workflow-compose.js";
@@ -53,6 +57,8 @@ const loaderDef: ComfyUINodeDef = {
 
 beforeEach(() => {
   getObjectInfoMock.mockReset();
+  resetObjectInfoCacheMock.mockReset();
+  backfillObjectInfoMock.mockClear();
   getObjectInfoMock.mockResolvedValue({ CheckpointLoaderSimple: loaderDef });
 });
 
@@ -109,6 +115,50 @@ describe("get_node_info >20 matches (unchanged name-list behavior)", () => {
     expect(parsed.count).toBe(25);
     expect(parsed.nodes[0]).not.toHaveProperty("input_required");
     expect(parsed.hint).toMatch(/more specific/);
+  });
+});
+
+describe("get_node_info refresh after external restart (issue #499)", () => {
+  // A loader whose model dropdown is served from a STALE cache after the ComfyUI
+  // server was restarted externally (systemd) and a new model file was added.
+  // The stale snapshot omits the freshly-installed file; refresh:true must drop
+  // the cache and refetch so the new file shows up in the verbose dropdown.
+  const staleDef: ComfyUINodeDef = {
+    ...loaderDef,
+    input: { required: { clip_name: [["old-clip.gguf"]] } },
+  };
+  const freshDef: ComfyUINodeDef = {
+    ...loaderDef,
+    input: { required: { clip_name: [["old-clip.gguf", "Qwen2.5-VL-7B-Instruct-UD-Q8_0.gguf"]] } },
+  };
+
+  it("does NOT reset the cache when refresh is omitted (serves memoized snapshot)", async () => {
+    getObjectInfoMock.mockResolvedValue({ CLIPLoaderGGUF: staleDef });
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CLIPLoaderGGUF", verbose: true });
+    expect(resetObjectInfoCacheMock).not.toHaveBeenCalled();
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.CLIPLoaderGGUF.input.required.clip_name[0]).toEqual(["old-clip.gguf"]);
+  });
+
+  it("refresh:true invalidates the cache BEFORE fetching, so the live post-restart dropdown surfaces", async () => {
+    // The cache invalidation (resetObjectInfoCache) must happen before the fetch
+    // so getObjectInfo re-reads the live server (which now lists the new file).
+    // The reset→refetch guarantee itself is covered in object-info-cache.test.ts.
+    let resetBeforeFetch = false;
+    resetObjectInfoCacheMock.mockImplementation(() => {
+      resetBeforeFetch = true;
+    });
+    getObjectInfoMock.mockImplementation(async () =>
+      resetBeforeFetch ? { CLIPLoaderGGUF: freshDef } : { CLIPLoaderGGUF: staleDef },
+    );
+    const handler = getHandler("get_node_info");
+    const res = await handler({ node_type: "CLIPLoaderGGUF", verbose: true, refresh: true });
+    expect(resetObjectInfoCacheMock).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(res.content[0].text);
+    expect(parsed.CLIPLoaderGGUF.input.required.clip_name[0]).toContain(
+      "Qwen2.5-VL-7B-Instruct-UD-Q8_0.gguf",
+    );
   });
 });
 

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+// #494: get_workflow(format:"api") must return the workflow JSON as the PRIMARY
+// (first) content block, with conversion warnings appended as a separate
+// trailing block. Consumers that read the first text result must always receive
+// parseable JSON — never Markdown warnings — so passing it straight to
+// JSON.parse / check_workflow_runtime works even when there are convert warnings.
+
+const fetchApiMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApiMock(...a) }),
+  getObjectInfo: vi.fn(async () => ({})),
+  backfillObjectInfo: vi.fn(async (bulk: unknown) => bulk),
+}));
+
+const convertUiToApiMock = vi.fn();
+vi.mock("../../services/workflow-converter.js", () => ({
+  isUiFormat: () => true,
+  isApiFormat: () => false,
+  convertUiToApi: (...a: unknown[]) => convertUiToApiMock(...a),
+  convertApiToUi: vi.fn(),
+  collectNodeTypes: () => [],
+}));
+
+// Unused-by-this-test services still imported by the module under test.
+vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
+vi.mock("../../services/graph-query.js", () => ({ queryApiGraph: vi.fn() }));
+vi.mock("../../services/workflow-sections.js", () => ({ detectSections: vi.fn() }));
+vi.mock("../../services/hierarchical-mermaid.js", () => ({
+  generateOverview: vi.fn(),
+  generateSectionDetail: vi.fn(),
+  listSections: vi.fn(),
+  generateSummary: vi.fn(),
+}));
+vi.mock("../../services/mermaid-converter.js", () => ({ convertToMermaid: vi.fn() }));
+vi.mock("../../services/workflow-health.js", () => ({ analyzeGraphHealth: vi.fn() }));
+
+import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }> }>;
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowLibraryTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+describe("get_workflow — JSON before conversion warnings (#494)", () => {
+  it("returns parseable JSON as the FIRST content block even with warnings", async () => {
+    const apiWorkflow = { "3": { class_type: "KSampler", inputs: { seed: 1 } } };
+    fetchApiMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ nodes: [] }) });
+    convertUiToApiMock.mockReturnValue({
+      workflow: apiWorkflow,
+      warnings: ["Node 7 (Reroute) dropped: no resolvable target"],
+    });
+
+    const { content } = await getHandler("get_workflow")({ filename: "w.json", format: "api" });
+
+    // First block MUST be the JSON graph — parsing it must not throw.
+    expect(content[0].type).toBe("text");
+    expect(() => JSON.parse(content[0].text)).not.toThrow();
+    expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
+
+    // Warnings preserved, but as a SEPARATE trailing block.
+    expect(content).toHaveLength(2);
+    expect(content[1].text).toContain("Conversion warnings");
+    expect(content[1].text).toContain("Reroute");
+  });
+
+  it("returns only the JSON block when there are no warnings", async () => {
+    const apiWorkflow = { "1": { class_type: "CheckpointLoaderSimple", inputs: {} } };
+    fetchApiMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ nodes: [] }) });
+    convertUiToApiMock.mockReturnValue({ workflow: apiWorkflow, warnings: [] });
+
+    const { content } = await getHandler("get_workflow")({ filename: "w.json", format: "api" });
+    expect(content).toHaveLength(1);
+    expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -8,7 +8,7 @@ import {
   isRemoteMode,
 } from "../config.js";
 import { logger } from "../utils/logger.js";
-import { ComfyUIError, ConnectionError } from "../utils/errors.js";
+import { ComfyUIError, ConnectionError, WorkflowExecutionError } from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
 import * as cloudClient from "./cloud-client.js";
 import type { ObjectInfo, SystemStats, QueueStatus } from "./types.js";
@@ -298,39 +298,129 @@ export async function enqueuePrompt(
   opts?: { front?: boolean },
 ): Promise<{ prompt_id: string; queue_remaining?: number }> {
   if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData);
-  const client = getClient();
 
-  // The SDK's _enqueue_prompt does not forward `extra_data`, which is how
-  // comfy.org API-node credentials (api_key_comfy_org / auth_token_comfy_org)
-  // must travel to the server. It also cannot enqueue at the front. When either
-  // is needed, POST /prompt directly.
-  if ((extraData && Object.keys(extraData).length > 0) || opts?.front) {
-    const url = `${getComfyUIBaseUrl()}/prompt`;
-    const res = await comfyuiFetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        prompt: workflow,
-        client_id: "comfyui-mcp",
-        ...(extraData ? { extra_data: extraData } : {}),
-        ...(opts?.front ? { front: true } : {}),
-      }),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      throw new ConnectionError(
-        `ComfyUI /prompt returned ${res.status} ${res.statusText}: ${body.slice(0, 500)}`,
-      );
-    }
-    const data = (await res.json()) as { prompt_id: string; number?: number };
-    return { prompt_id: data.prompt_id, queue_remaining: data.number };
+  // POST /prompt directly (rather than the SDK's _enqueue_prompt) for two
+  // reasons: (1) the SDK does not forward `extra_data` — how comfy.org API-node
+  // credentials must travel — nor can it enqueue at the front; and (2) on an
+  // HTTP 400 the SDK throws a generic "Endpoint Bad Request" that discards
+  // ComfyUI's authoritative prompt-validation body (`node_errors`), so callers
+  // never learn which node/input was invalid (#485). Going direct lets us read
+  // and surface that body. `comfyuiFetch` applies the same auth headers the SDK
+  // would (CF Access / COMFYUI_AUTH_*).
+  const url = `${getComfyUIBaseUrl()}/prompt`;
+  const res = await comfyuiFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      prompt: workflow,
+      client_id: "comfyui-mcp",
+      ...(extraData ? { extra_data: extraData } : {}),
+      ...(opts?.front ? { front: true } : {}),
+    }),
+  });
+  if (!res.ok) {
+    throw await buildEnqueueError(res);
+  }
+  const data = (await res.json()) as { prompt_id: string; number?: number };
+  // NB: `data.number` is ComfyUI's monotonic priority counter (and is NEGATIVE
+  // for front-inserted jobs) — NOT the remaining queue depth. The old SDK path
+  // returned exec_info.queue_remaining; to preserve an accurate count now that
+  // we POST directly, read /queue for the authoritative running+pending total.
+  // Fall back to undefined (never the misleading counter) if that read fails.
+  return { prompt_id: data.prompt_id, queue_remaining: await queueRemainingCount() };
+}
+
+/**
+ * Authoritative "jobs still in the queue" count (running + pending) via a direct
+ * /queue read. Returns undefined if the queue can't be read, so callers never
+ * surface ComfyUI's monotonic `number` counter as a remaining-count. Only
+ * reachable on the local/remote path — enqueuePrompt returns early in cloud mode.
+ */
+async function queueRemainingCount(): Promise<number | undefined> {
+  try {
+    const res = await comfyuiFetch(`${getComfyUIBaseUrl()}/queue`);
+    if (!res.ok) return undefined;
+    const q = (await res.json()) as {
+      queue_running?: unknown[];
+      queue_pending?: unknown[];
+      Running?: unknown[];
+      Pending?: unknown[];
+    };
+    const running = (q.queue_running ?? q.Running ?? []).length;
+    const pending = (q.queue_pending ?? q.Pending ?? []).length;
+    return running + pending;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a non-OK /prompt response into a rich error. On the HTTP 400 that
+ * ComfyUI returns when prompt validation fails, the JSON body carries the
+ * authoritative diagnosis:
+ *   {
+ *     error: { type, message, details, extra_info },
+ *     node_errors: { "<id>": { class_type, errors: [{ message, details, ... }] } }
+ *   }
+ * We format the top-level message plus one line per offending node
+ * (`ClassType (node <id>): <message>`), and stash the raw payload in `details`.
+ * Falls back to the generic HTTP status only when the body is empty or is not
+ * the expected validation JSON (#485).
+ */
+async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
+  const bodyText = await res.text().catch(() => "");
+  const generic = `ComfyUI /prompt returned ${res.status} ${res.statusText}`;
+
+  let parsed: unknown;
+  try {
+    parsed = bodyText ? JSON.parse(bodyText) : undefined;
+  } catch {
+    parsed = undefined;
   }
 
-  const result = await client._enqueue_prompt(workflow);
-  return {
-    prompt_id: result.prompt_id,
-    queue_remaining: result.exec_info?.queue_remaining,
-  };
+  if (parsed && typeof parsed === "object") {
+    const payload = parsed as {
+      error?: { message?: string; details?: string };
+      node_errors?: Record<
+        string,
+        { class_type?: string; errors?: Array<{ message?: string; details?: string }> }
+      >;
+    };
+    const nodeErrors = payload.node_errors ?? {};
+    const lines: string[] = [];
+    for (const [nodeId, info] of Object.entries(nodeErrors)) {
+      const cls = info?.class_type ?? "node";
+      const errs = Array.isArray(info?.errors) ? info.errors : [];
+      if (errs.length === 0) {
+        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        continue;
+      }
+      for (const e of errs) {
+        const detail = e?.details ? ` (${e.details})` : "";
+        lines.push(`- ${cls} (node ${nodeId}): ${e?.message ?? "validation failed"}${detail}`);
+      }
+    }
+
+    const headline = payload.error?.message
+      ? `ComfyUI rejected the workflow (${res.status}): ${payload.error.message}`
+      : `ComfyUI rejected the workflow (${res.status})`;
+
+    if (lines.length > 0 || payload.error?.message) {
+      const message =
+        lines.length > 0 ? `${headline}\n${lines.join("\n")}` : headline;
+      return new WorkflowExecutionError(message, {
+        status: res.status,
+        error: payload.error,
+        node_errors: nodeErrors,
+      });
+    }
+  }
+
+  // Empty or unexpected body: fall back to the generic HTTP status, but keep
+  // any raw text so nothing is silently dropped.
+  return new ConnectionError(
+    bodyText ? `${generic}: ${bodyText.slice(0, 500)}` : generic,
+  );
 }
 
 /**

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -364,6 +364,116 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
   }
 }
 
+// ---- panel_run reply interpretation (#213/#331/#248/#194) -------------------
+// `panel_run` forwards `graph_run` to the panel, which drives `app.queuePrompt`
+// and forwards ComfyUI's /prompt outcome back. ComfyUI splits a rejection into
+// TWO channels:
+//   • per-node problems      -> `node_errors` (a map keyed by node id)
+//   • TOP-LEVEL problems     -> `error`       (e.g. prompt_outputs_failed_validation,
+//                                              missing_node_type) — leaves node_errors EMPTY
+// #213: the panel's success guard looked ONLY at node_errors, so a top-level
+// rejection (empty node_errors) slipped through as `queued:true` — a FALSE
+// success the agent then waited a whole turn on. We therefore DERIVE the verdict
+// from the authoritative fields (mirroring the #485 enqueue-validation parsing):
+// a reply is a rejection when it carries a non-empty `error`, a non-empty
+// `node_errors`, or an explicit `queued:false` — regardless of any `queued:true`
+// flag that may accompany it. Only a reply with NONE of those is a real queue.
+
+/** True when a graph_run reply's top-level `error` channel is populated (an
+ *  object with any keys, or a non-blank string). Empty object / "" / absent = no. */
+function hasTopLevelError(error: unknown): boolean {
+  if (typeof error === "string") return error.trim().length > 0;
+  if (error != null && typeof error === "object") return Object.keys(error as object).length > 0;
+  return false;
+}
+
+/** True when a graph_run reply's `node_errors` channel names at least one node. */
+function hasNodeErrors(nodeErrors: unknown): boolean {
+  return (
+    nodeErrors != null &&
+    typeof nodeErrors === "object" &&
+    Object.keys(nodeErrors as object).length > 0
+  );
+}
+
+/**
+ * Format a ComfyUI /prompt rejection payload (the top-level `error` object plus
+ * per-node `node_errors`) into a human-readable failure — the same shape the
+ * #485 HTTP enqueue path surfaces, so panel_run and enqueue_workflow read alike.
+ */
+function formatRunRejection(payload: { error?: unknown; node_errors?: unknown }): string {
+  let headline = "ComfyUI refused to queue the workflow";
+  const topError = payload.error;
+  const extraLines: string[] = [];
+  if (topError && typeof topError === "object") {
+    const te = topError as { type?: unknown; message?: unknown; details?: unknown };
+    const msg = typeof te.message === "string" ? te.message.trim() : "";
+    const type = typeof te.type === "string" ? te.type.trim() : "";
+    if (msg) headline = `ComfyUI refused to queue the workflow: ${msg}${type ? ` (${type})` : ""}`;
+    else if (type) headline = `ComfyUI refused to queue the workflow (${type})`;
+    const details = typeof te.details === "string" ? te.details.trim() : "";
+    if (details) extraLines.push(details);
+  } else if (typeof topError === "string" && topError.trim()) {
+    headline = `ComfyUI refused to queue the workflow: ${topError.trim()}`;
+  }
+
+  const lines: string[] = [...extraLines];
+  const ne = payload.node_errors;
+  if (ne && typeof ne === "object") {
+    for (const [nodeId, info] of Object.entries(ne as Record<string, unknown>)) {
+      const i = (info ?? {}) as { class_type?: unknown; errors?: unknown };
+      const cls = typeof i.class_type === "string" ? i.class_type : "node";
+      const errs = Array.isArray(i.errors) ? i.errors : [];
+      if (errs.length === 0) {
+        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        continue;
+      }
+      for (const e of errs as Array<{ message?: unknown; details?: unknown }>) {
+        const detail = typeof e?.details === "string" && e.details ? ` (${e.details})` : "";
+        const m = typeof e?.message === "string" ? e.message : "validation failed";
+        lines.push(`- ${cls} (node ${nodeId}): ${m}${detail}`);
+      }
+    }
+  }
+  return lines.length ? `${headline}\n${lines.join("\n")}` : headline;
+}
+
+/**
+ * Inspect a graph_run ToolResult and return a FAILURE ToolResult when the run
+ * did NOT genuinely enter ComfyUI's queue, or `null` when it is a real queue
+ * (so the caller may append the success/anti-poll guidance).
+ *
+ *  - An isError reply (no connected tab #331, a thrown app.queuePrompt #248, a
+ *    transport drop) is passed through VERBATIM — its full detail/browser stack
+ *    is preserved and the success-only "you'll be notified" note is NOT added.
+ *  - A NON-error reply is parsed: a top-level `error`, a non-empty `node_errors`,
+ *    or an explicit `queued:false` is surfaced as a formatted failure (#213) —
+ *    even when a stale `queued:true` accompanies it.
+ *  - Anything else (a plain `queued:true`, or an unparseable reply we must not
+ *    regress) returns null and is treated as a genuine queue.
+ */
+function detectRunRejection(res: ToolResult): ToolResult | null {
+  // Bridge/transport/executor error: never a queue. Preserve it verbatim (#248),
+  // no success note (#331). fail() already carries err.message (incl. any stack).
+  if (res?.isError) return res;
+
+  const parsed = parseToolResultJson(res);
+  if (!parsed) return null; // unparseable non-error reply — don't regress a success
+
+  const topError = parsed.error;
+  const nodeErrors = parsed.node_errors;
+  const rejected =
+    hasTopLevelError(topError) || hasNodeErrors(nodeErrors) || parsed.queued === false;
+  if (!rejected) return null; // genuine queue (queued:true / no rejection signal)
+
+  return fail(formatRunRejection({ error: topError, node_errors: nodeErrors }));
+}
+
+export const __panelRunTestHooks = {
+  detectRunRejection,
+  formatRunRejection,
+};
+
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
 function stripJsonExt(s: unknown): string | null {
   return typeof s === "string" ? s.replace(/\.json$/i, "") : null;
@@ -1504,7 +1614,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_run",
-      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). Returns queued:true, or queued:false with node_errors when frontend validation fails. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. Omit it to run the whole graph. Use this so the render runs on THEIR canvas and they see the result.",
+      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. Omit it to run the whole graph. Use this so the render runs on THEIR canvas and they see the result.",
       {
         batch_count: z
           .number()
@@ -1530,6 +1640,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           { cmd: "graph_run", batch_count: args.batch_count, to_node_id: args.to_node_id },
           20000,
         );
+        // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`
+        // flag. A rejection — a no-connected-tab / thrown-queuePrompt error
+        // (#331/#248), or a ComfyUI /prompt refusal on EITHER channel
+        // (top-level `error` with empty node_errors #213, or per-node
+        // node_errors) — is surfaced as a failure WITHOUT the success-only
+        // "you'll be notified automatically" guidance. Only a genuine queue
+        // gets the anti-poll note below.
+        const rejection = detectRunRejection(res);
+        if (rejection) return rejection;
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         const note =

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -24,6 +24,7 @@
 // so parity is automatic — neither path reimplements a tool.
 
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1081,6 +1082,174 @@ async function resolveWorkflowInput(
   return wf as Record<string, unknown>;
 }
 
+// ---- panel_ask surface + late-answer resilience (#300/#486) ----------------
+// panel_ask renders an interactive choice card in the panel and BLOCKS on the
+// user's pick. Two failure modes are handled here, localized to the ask path:
+//
+//  • #300 — NO INTERACTIVE SURFACE: when the only reachable client is canvas-less
+//    (a mobile mirror / remote/headless viewer, or an exec/headless run), the card
+//    can't render, so the ask would block for the whole deadline with no way to
+//    answer. We DETECT that up front (bridge.isHeadless on the tab the ask would
+//    target) and FAIL FAST with an actionable error telling the agent to ask in
+//    plain text or call panel_ask from an interactive tab — never an indefinite
+//    block.
+//
+//  • #486 — LATE-BUT-VALID ANSWER: the enclosing MCP `tools/call` has its own
+//    budget (~300s). A card wait longer than that guarantees the tool is killed
+//    before a slow user answers, DISCARDING a validated pick. We (a) CLAMP the card
+//    deadline safely under the MCP budget, and (b) after a card-reply timeout, poll
+//    the bridge's short-lived late-reply buffer for a bounded grace so an answer
+//    that validated slightly after the deadline is HONORED, not lost.
+
+interface AskTiming {
+  /** bridge.send reply timeout for the ask card — clamped under the MCP budget. */
+  deadlineMs: number;
+  /** How long to keep polling the late-reply buffer after a card-reply timeout. */
+  graceMs: number;
+  /** Interval between late-reply buffer polls. */
+  pollMs: number;
+}
+
+let askTimingOverride: AskTiming | null = null;
+
+// The enclosing MCP `tools/call` is killed at ~300s. The card deadline PLUS the
+// late-answer grace poll must finish UNDER that, or a slow-but-valid pick is lost
+// to the framework before we can honor it (#486). This is the HARD ceiling on the
+// total ask budget — applied even when env overrides ask for more, so a
+// misconfigured COMFYUI_PANEL_ASK_DEADLINE_S/GRACE_S can never recreate #486.
+const ASK_TOTAL_BUDGET_CAP_MS = 285_000;
+
+function getAskTiming(): AskTiming {
+  if (askTimingOverride) return askTimingOverride;
+  const pollMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_POLL_S", 0.5) * 1000);
+  // Defaults keep deadline + grace comfortably under the budget (240 + up to 45 =
+  // 285s). Env overrides are HARD-clamped: the deadline is capped first (leaving at
+  // least a 1s slice), then the grace gets only whatever budget remains, so
+  // deadline + grace is guaranteed ≤ ASK_TOTAL_BUDGET_CAP_MS regardless of input.
+  let deadlineMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_DEADLINE_S", 240) * 1000);
+  let graceMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_GRACE_S", 45) * 1000);
+  deadlineMs = Math.min(deadlineMs, ASK_TOTAL_BUDGET_CAP_MS - 1000);
+  graceMs = Math.min(graceMs, Math.max(0, ASK_TOTAL_BUDGET_CAP_MS - deadlineMs));
+  return { deadlineMs, graceMs, pollMs };
+}
+
+/** True when an error is the bridge's reply-TIMEOUT for a card (the tab never
+ *  replied within the window), NOT a genuine transport/command error. Only a
+ *  timeout warrants polling the late-reply buffer for a slow-but-valid answer. */
+function isReplyTimeoutError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /did not reply to .* within \d+\s*ms|backgrounded or frozen/i.test(msg);
+}
+
+/**
+ * Actionable error string when THIS session has no interactive surface able to
+ * render an ask card (so the ask would block with no way to answer), or `null`
+ * when a card can render. Uses the bridge's `isHeadless` on the tab the ask would
+ * target (the current tab if reachable, else the resolved active tab). Defensive:
+ * an unknown/lightweight bridge, or an ambiguous active-tab resolution, returns
+ * null so the normal send path surfaces its own clear error instead.
+ */
+function askSurfaceError(ctx: PanelToolCtx): string | null {
+  const b = ctx.bridge as unknown as {
+    isHeadless?: (id: string) => boolean;
+    canReach?: (id: string) => boolean;
+    resolveActiveTabId?: () => string;
+  };
+  if (typeof b.isHeadless !== "function") return null; // lightweight/unknown bridge
+  let targetId = ctx.tabId;
+  if (typeof b.canReach === "function" && !b.canReach(targetId)) {
+    if (typeof b.resolveActiveTabId !== "function") return null;
+    try {
+      targetId = b.resolveActiveTabId();
+    } catch {
+      return null; // no single active tab — let the send path report it clearly
+    }
+  }
+  if (!b.isHeadless(targetId)) return null;
+  return (
+    "No interactive panel surface can render a choice card in this session — the " +
+    "connected client is canvas-less (a mobile mirror, a remote/headless viewer, or " +
+    "an exec/headless run), so panel_ask can't be answered here and would block. Ask " +
+    "the user directly in plain chat text, or invoke panel_ask from an interactive " +
+    "ComfyUI browser tab (not nested inside an exec/headless call)."
+  );
+}
+
+/** Poll the bridge's late-reply buffer for a validated ask answer that arrived
+ *  after the card-reply timeout, up to the grace budget. undefined if none. */
+async function pollLateAskReply(
+  bridge: PanelToolCtx["bridge"],
+  askId: string,
+  timing: AskTiming,
+): Promise<unknown | undefined> {
+  const take = (bridge as unknown as { takeLateAskReply?: (id: string) => unknown })
+    .takeLateAskReply;
+  if (typeof take !== "function") return undefined;
+  const deadline = Date.now() + timing.graceMs;
+  for (;;) {
+    const late = take.call(bridge, askId);
+    if (late !== undefined) return late;
+    const left = deadline - Date.now();
+    if (left <= 0) return undefined;
+    await sleep(Math.max(1, Math.min(timing.pollMs, left)));
+  }
+}
+
+/**
+ * Run a panel_ask: render the choice card and return the user's pick. Clamps the
+ * card deadline under the MCP tools/call budget and, on a reply-timeout, honors a
+ * late-but-valid answer from the bridge's late-reply buffer before failing (#486).
+ * Sent DIRECTLY over the bridge (like the confirm/consent cards) so a stable
+ * `ask_id` can key the late-reply buffer.
+ */
+async function askUserWithGrace(
+  ctx: PanelToolCtx,
+  ask: { question: string; options: unknown; header?: unknown; multi_select?: unknown },
+): Promise<ToolResult> {
+  const timing = getAskTiming();
+  const askId = randomUUID();
+  const cmd = {
+    cmd: "ask_user",
+    ask_id: askId,
+    question: ask.question,
+    options: ask.options,
+    header: ask.header,
+    multi_select: ask.multi_select,
+  };
+  try {
+    ctx.ensureReachable?.();
+    const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
+      tabId: ctx.tabId,
+      timeoutMs: timing.deadlineMs,
+    });
+    return ok(reply);
+  } catch (err) {
+    if (isReplyTimeoutError(err)) {
+      const late = await pollLateAskReply(ctx.bridge, askId, timing);
+      if (late !== undefined) return ok(late);
+      return fail(
+        "The question card was not answered in time (or no interactive panel surface " +
+          "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
+          "still need the decision, ask the user directly in plain chat text, or " +
+          "re-invoke panel_ask from an interactive ComfyUI tab.",
+      );
+    }
+    return fail(err);
+  }
+}
+
+export const __panelAskTestHooks = {
+  /** Inject fast ask timing so tests don't wait the real deadline/grace. */
+  setAskTiming(timing: AskTiming | null): void {
+    askTimingOverride = timing;
+  },
+  /** The env-derived (hard-clamped) ask timing, for the budget-cap test. */
+  getAskTiming,
+  ASK_TOTAL_BUDGET_CAP_MS,
+  askSurfaceError,
+  isReplyTimeoutError,
+};
+
 /** One shared tool definition: name, description, zod raw-shape schema, and a
  *  transport-agnostic handler that receives parsed args + the tab-bound context. */
 export interface PanelToolDef {
@@ -1945,7 +2114,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           )
           .describe("The full ordered checklist (replaces the current one). Empty array clears the tray."),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "set_todo", items: args.items }, 5000),
+      // #322: a 5s ack deadline false-timed-out a responsive session whose tab was
+      // momentarily backgrounded. set_todo is a non-destructive, idempotent full-
+      // replace UI write (already in RETRY_SAFE_CMDS), so give it the same sane 15s
+      // bound as the other UI-state writes (workflow_save) instead of a tight 5s.
+      async (args: A, ctx) => ctx.call({ cmd: "set_todo", items: args.items }, 15000),
     ),
     def(
       "panel_open_civitai",
@@ -2203,18 +2376,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         header: z.string().optional().describe("Very short label/chip for the card (e.g. 'Sampler')."),
         multi_select: z.boolean().optional().describe("Allow selecting multiple options (default false)."),
       },
-      async (args: A, ctx) =>
-        ctx.call(
-          {
-            cmd: "ask_user",
-            question: args.question,
-            options: args.options,
-            header: args.header,
-            multi_select: args.multi_select,
-          },
-          // Human-in-the-loop: wait up to 10 minutes for a pick.
-          600000,
-        ),
+      async (args: A, ctx) => {
+        // #300: fail FAST with an actionable error when there is no interactive
+        // surface to render the card (a canvas-less/headless client, or an exec/
+        // headless run), rather than blocking with no way to answer.
+        const surfaceErr = askSurfaceError(ctx);
+        if (surfaceErr) return fail(surfaceErr);
+        // #486: clamp the card deadline under the MCP tools/call budget and honor a
+        // late-but-valid answer via the bridge's late-reply buffer.
+        return askUserWithGrace(ctx, {
+          question: args.question as string,
+          options: args.options,
+          header: args.header,
+          multi_select: args.multi_select,
+        });
+      },
     ),
     def(
       "panel_save_workflow",

--- a/src/services/api-nodes.ts
+++ b/src/services/api-nodes.ts
@@ -200,9 +200,21 @@ export interface WorkflowRuntime {
  * node class_types against the connected ComfyUI's /object_info (the same signal
  * isApiNode uses). Works on UI or API/prompt format graphs.
  */
+export interface CheckWorkflowRuntimeOptions {
+  /** The graph is one of the repo's BUNDLED installer packs, which are
+   *  guaranteed local-GPU/free (no hosted API nodes). When set, class_types that
+   *  aren't in the connected server's /object_info (uninstalled custom nodes) are
+   *  trusted as LOCAL instead of collapsing the verdict to "unknown" — as long as
+   *  NO recognized API node is present. This resolves the contradiction where a
+   *  known-local pack read back as "unknown" merely because its custom nodes
+   *  weren't installed (issue #464). Arbitrary/ad-hoc graphs must NOT set this. */
+  bundledLocalPack?: boolean;
+}
+
 export async function checkWorkflowRuntime(
   graph: unknown,
   deps: ApiNodesDeps = defaultDeps,
+  opts: CheckWorkflowRuntimeOptions = {},
 ): Promise<WorkflowRuntime> {
   const classTypes = extractWorkflowClassTypes(graph);
   const objectInfo = await deps.getObjectInfo();
@@ -224,12 +236,15 @@ export async function checkWorkflowRuntime(
   if (hasApiNodes) {
     runtime = apiNodes.length >= classifiable && classifiable > 0 ? "api" : "mixed";
     usesApiNodes = true;
-  } else if (unknownNodes.length > 0) {
+  } else if (unknownNodes.length > 0 && !opts.bundledLocalPack) {
     // No recognized API nodes, but some class_types aren't in /object_info — they
     // COULD be paid API/partner nodes the server doesn't expose. Don't claim free.
     runtime = "unknown";
     usesApiNodes = null;
   } else {
+    // Either everything classified as local, OR this is a bundled pack (declared
+    // local/free) whose only unclassifiable nodes are its own uninstalled custom
+    // nodes — never API nodes. Trust the pack's local guarantee (#464).
     runtime = "local";
     usesApiNodes = false;
   }

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -4,6 +4,7 @@ import {
   copyFile,
   link,
   mkdir,
+  open,
   readFile,
   readdir,
   rename,
@@ -13,7 +14,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, dirname, extname, join, resolve } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { ModelError } from "../utils/errors.js";
@@ -43,6 +44,170 @@ async function safeRm(path: string): Promise<void> {
   }
 }
 
+/** Remove `path`, returning true iff it is confirmed gone. Unlike `safeRm` this
+ *  LOGS a removal failure (EPERM/EACCES/…) instead of swallowing it silently — a
+ *  left-behind rejected artifact (a poisoned partial / cache entry) must at least be
+ *  visible, since a later cache-hit or resume could otherwise re-hit it (#473 P1). */
+async function rmOrLog(path: string, logUrl: string): Promise<boolean> {
+  try {
+    await rm(path, { force: true });
+    return true;
+  } catch (err) {
+    logger.warn(
+      `Failed to remove a rejected download artifact "${path}" — a retry may re-hit it; ` +
+        `delete it manually if the same rejection repeats.`,
+      { url: logUrl, error: err instanceof Error ? err.message : String(err) },
+    );
+    return false;
+  }
+}
+
+/** Remove `path`; if removal fails, NEUTRALIZE it by truncating to 0 bytes. Returns
+ *  true iff the path ends up removed OR emptied. A 0-byte partial is treated as fresh
+ *  (not resumed) and a 0-byte cache/sidecar entry carries no resumable state, so
+ *  zeroing is as safe as deleting. Logs (error) only when it can do NEITHER (#473 P1). */
+async function rmOrTruncate(path: string, logUrl: string): Promise<boolean> {
+  if (await rmOrLog(path, logUrl)) return true;
+  try {
+    await writeFile(path, "");
+    return true;
+  } catch (err) {
+    logger.error(
+      `Could not remove OR truncate a rejected download artifact "${path}"; a retry may re-serve ` +
+        `or resume it. Delete this file manually.`,
+      { url: logUrl, error: err instanceof Error ? err.message : String(err) },
+    );
+    return false;
+  }
+}
+
+/** Discard a payload that was REJECTED as a non-model (HTML/JSON auth/error) body.
+ *  Neutralizes BOTH the payload file AND its resume sidecar (remove, else truncate to
+ *  0). A resume requires a NONZERO partial AND a valid (nonempty) sidecar, so zeroing
+ *  or removing EITHER makes a retry decline the resume and restart clean — the
+ *  guarantee holds as long as at least one of the two can be neutralized, not only
+ *  when the partial itself can be deleted (#473 P1). A hard failure to neutralize is
+ *  surfaced via the log inside rmOrTruncate. */
+async function discardRejectedPayload(
+  path: string,
+  sidecarPath: string | undefined,
+  logUrl: string,
+): Promise<boolean> {
+  const neutralized = await rmOrTruncate(path, logUrl);
+  if (sidecarPath) await rmOrTruncate(sidecarPath, logUrl);
+  return neutralized;
+}
+
+/** Drop a tiny "this partial was rejected as a non-model body" MARKER next to a
+ *  resumable partial. Best-effort. It is the cleanup-INDEPENDENT signal that lets a
+ *  later attempt refuse to resume even when the rejection was based ONLY on the
+ *  response Content-Type (gone by retry) and both removal and truncation of the
+ *  partial+sidecar failed — a case body-magic alone can't re-derive (#473 P1). */
+async function writePoisonMarker(markerPath: string, logUrl: string): Promise<void> {
+  try {
+    await writeFile(markerPath, "rejected-non-model-payload");
+  } catch (err) {
+    logger.warn(`Could not write a poison marker "${markerPath}" for a rejected partial`, {
+      url: logUrl,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Path of the Content-Type sidecar beside a finalized CACHE file. A hidden dotfile
+ *  (so LRU/readdir scans skip it) that records the response Content-Type, letting a
+ *  later cache-HIT / coalesced caller re-run the #473 model-payload check WITH the
+ *  original Content-Type instead of only body magic — closing the reuse gap where a
+ *  Content-Type-only-flaggable body (its bytes don't sniff as text) could otherwise
+ *  finalize as a model on a subsequent request. */
+function cacheCtSidecar(cacheFilePath: string): string {
+  return join(dirname(cacheFilePath), `.${basename(cacheFilePath)}.ct`);
+}
+
+/** True when a Content-Type is one the #473 gate would reject for a binary-model
+ *  destination (an HTML page or a JSON document). Kept in lockstep with the
+ *  Content-Type belt in detectNonModelPayload. */
+function isRejectableContentType(contentType: string): boolean {
+  return (
+    /text\/html|application\/xhtml/i.test(contentType) || /(^|[/+])json\b/i.test(contentType)
+  );
+}
+
+/** Reconcile the Content-Type sidecar beside a freshly-finalized cache file. Writes it
+ *  ONLY for the reject-worthy shapes (text/html, application/json) — persisting every
+ *  octet-stream/text-plain type would add a useless sidecar per cache entry, and only
+ *  an HTML/JSON label can flag a body that body-magic alone would miss on reuse. For a
+ *  NON-reject-worthy (e.g. octet-stream) fill it REMOVES any pre-existing sidecar: a
+ *  clean model landing under a cache key that a prior HTML response had tagged
+ *  `text/html` must not inherit that stale tag and be wrongly rejected on reuse (#473 —
+ *  a false-positive against a legitimate model). */
+async function writeCacheContentType(cacheFilePath: string, contentType: string): Promise<void> {
+  const sidecar = cacheCtSidecar(cacheFilePath);
+  if (!contentType || !isRejectableContentType(contentType)) {
+    // Clear any stale sidecar so it can't attach to these clean bytes. Even if this
+    // rm fails, the SIZE stamp below makes a stale sidecar self-invalidate on read.
+    await rm(sidecar, { force: true }).catch(() => undefined);
+    return;
+  }
+  try {
+    // Stamp a fingerprint of the payload (size + a hash of its sniff head) alongside
+    // the Content-Type. On read we honor the type only when that fingerprint still
+    // matches the cache file — so a stale sidecar left behind after a clean re-fill
+    // (different bytes ⇒ different head/size) is ignored and can NEVER reject a
+    // legitimate model, regardless of whether the clearing rm above succeeded, AND
+    // even in the astronomically-unlikely case where the replacement model has the
+    // exact same byte LENGTH as the prior page (the head hash still differs) (#473 —
+    // robust against the swallowed-delete false-positive).
+    await writeFile(sidecar, `${contentType}\n${await payloadFingerprint(cacheFilePath)}`);
+  } catch (err) {
+    // Best effort — reuse falls back to body-magic-only validation, which still
+    // catches every well-formed HTML/JSON page (only a synthetic body that sniffs
+    // binary yet carries a text Content-Type would evade). Surface it rather than
+    // swallow so the degraded reuse check is at least visible (#473).
+    logger.warn(
+      `Could not persist the Content-Type for a cached download at "${cacheFilePath}"; ` +
+        `cache-reuse validation falls back to body magic only.`,
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+}
+
+/** Read the persisted Content-Type for a cache file, or "" when absent/unreadable OR
+ *  STALE. The sidecar stamps the payload size it was written for; if that size no
+ *  longer matches the cache file on disk the sidecar describes DIFFERENT (since
+ *  replaced) bytes and is ignored — so a leftover `text/html` tag can't reject a
+ *  legitimate model that later re-filled the same cache slot (#473). */
+async function readCacheContentType(cacheFilePath: string): Promise<string> {
+  try {
+    const raw = await readFile(cacheCtSidecar(cacheFilePath), "utf-8");
+    const nl = raw.indexOf("\n");
+    if (nl < 0) return ""; // no fingerprint (unexpected) → don't trust it
+    const contentType = raw.slice(0, nl).trim();
+    const stamped = raw.slice(nl + 1).trim();
+    if (!contentType || !stamped) return "";
+    const current = await payloadFingerprint(cacheFilePath);
+    // Only honor the tag when it was stamped for the bytes currently on disk. A
+    // mismatch (stale sidecar over re-filled bytes, or an unreadable head) yields "",
+    // falling back to body magic — this can only ADD safety, never reject a real model.
+    return stamped === current ? contentType : "";
+  } catch {
+    return "";
+  }
+}
+
+/** A cheap content fingerprint of a cache file: its size plus a short hash of its
+ *  sniff head. Distinguishes a re-filled cache slot from the bytes a Content-Type
+ *  sidecar was written for — even at an identical byte length — without hashing a
+ *  multi-GB payload in full. "" when the head can't be read (caller treats a
+ *  mismatch as "don't trust the sidecar"). */
+async function payloadFingerprint(cacheFilePath: string): Promise<string> {
+  const size = await fileSizeOrUndefined(cacheFilePath);
+  const head = await readHead(cacheFilePath);
+  if (head === undefined) return "";
+  const headHash = createHash("sha256").update(head).digest("hex").slice(0, 16);
+  return `${size ?? ""}:${headHash}`;
+}
+
 /** On-disk size, or undefined when it can't be determined (fs layer stubbed in
  *  tests, or a stat hiccup) — callers must not block a download over a missing
  *  number, only over a number that proves corruption. */
@@ -53,6 +218,342 @@ async function fileSizeOrUndefined(path: string): Promise<number | undefined> {
   } catch {
     return undefined;
   }
+}
+
+/** Destination extensions whose bytes MUST be a binary model payload — never an
+ *  HTML page or a JSON document. A download that lands under one of these but whose
+ *  body is actually an auth-challenge / error page is the #473 false-success class:
+ *  a login HTML or `{"error":...}` JSON saved as `.safetensors`, reported as a green
+ *  success, then failing at load time ("header too large"). Extensions NOT in this
+ *  set (e.g. `.json`, `.yaml`, `.txt`, config sidecars) are left unvalidated so a
+ *  legitimate text/JSON download is never rejected. */
+// Superset of every BINARY model format the repo recognizes as a downloadable
+// weight file — kept in sync with the recognizers in missing-models.ts (MODEL_EXTS)
+// and workflow-converter.ts (the model-file regex). Intentionally EXCLUDES the
+// textual formats those recognizers also allow (`.yaml`, `.json`): those legitimately
+// contain text, so validating them as binary would reject a valid download.
+const MODEL_BINARY_EXTS = new Set([
+  ".safetensors",
+  ".safetensor",
+  ".sft",
+  ".ckpt",
+  ".pt",
+  ".pt2",
+  ".pth",
+  ".bin",
+  ".gguf",
+  ".onnx",
+  ".vae",
+  ".pkl",
+  ".npz",
+  ".msgpack",
+]);
+
+/** How many leading bytes to sniff for a payload's shape. Enough to see an HTML
+ *  doctype/tag or a JSON error envelope's opening structure without reading a
+ *  multi-GB model in full. */
+const PAYLOAD_SNIFF_BYTES = 512;
+
+/** Read the first `n` bytes of a file WITHOUT loading the whole thing (models are
+ *  multi-GB) — used to sniff a completed download's shape. Best-effort: returns
+ *  undefined if the file can't be opened/read (never blocks a download over a read
+ *  hiccup — the size gate has already run). */
+async function readHead(path: string, n = PAYLOAD_SNIFF_BYTES): Promise<Buffer | undefined> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(path, "r");
+    const buf = Buffer.alloc(n);
+    // Loop: a single read() can return fewer bytes than requested even when more
+    // are available; fill up to n (or EOF) so a short first read can't truncate the
+    // sniff window and hide an HTML/JSON body after byte ~1.
+    let off = 0;
+    while (off < n) {
+      const { bytesRead } = await fh.read(buf, off, n - off, off);
+      if (bytesRead === 0) break; // EOF
+      off += bytesRead;
+    }
+    return buf.subarray(0, off);
+  } catch {
+    return undefined;
+  } finally {
+    await fh?.close().catch(() => undefined);
+  }
+}
+
+/** True when a run of bytes reads as a valid UTF-8 TEXT document (what an HTML page
+ *  or JSON error IS) rather than binary model bytes. This is a real UTF-8 validation,
+ *  not "any high byte counts as text": each non-ASCII byte must be a well-formed
+ *  UTF-8 lead followed by valid continuation bytes, and NUL / C0 control bytes
+ *  (except the text whitespace controls TAB/LF/VT/FF/CR) hard-fail. Random binary that happens to start with `<`/`{`/`[`
+ *  almost immediately hits an invalid UTF-8 lead byte (0x80–0xC1 and 0xF5–0xFF — ~26%
+ *  of all byte values) or a control byte, so it is correctly kept binary; a safetensors
+ *  whose LE header length is 60 (0x3C='<') is followed by NUL padding and fails at once.
+ *  A multibyte sequence truncated by the end of the sniff window is accepted (we only
+ *  sampled a prefix), never treated as invalid. */
+function looksLikeText(slice: Buffer): boolean {
+  const n = slice.length;
+  if (n === 0) return false;
+  let i = 0;
+  while (i < n) {
+    const b = slice[i];
+    if (b < 0x80) {
+      // ASCII: printable + the standard text whitespace controls TAB(0x09) LF(0x0a)
+      // VT(0x0b) FF(0x0c) CR(0x0d). A form-feed / vertical-tab is valid HTML/XML
+      // whitespace, so a real login page like `<html>\f<body>…` MUST still read as
+      // text (else it slips through as "binary" and finalizes as a model — #473
+      // P0-1). Any OTHER C0 control (NUL etc.) ⇒ not text.
+      if ((b >= 0x09 && b <= 0x0d) || (b >= 0x20 && b <= 0x7e)) {
+        i += 1;
+        continue;
+      }
+      return false;
+    }
+    // Multibyte lead byte → determine the sequence length; invalid leads reject.
+    let len: number;
+    if (b >= 0xc2 && b <= 0xdf) len = 2;
+    else if (b >= 0xe0 && b <= 0xef) len = 3;
+    else if (b >= 0xf0 && b <= 0xf4) len = 4;
+    else return false; // 0x80–0xC1 (bare continuation / overlong) or 0xF5–0xFF
+    // Strict continuation ranges reject overlong / surrogate / out-of-range forms:
+    //   E0 → A0..BF (else overlong), ED → 80..9F (else surrogate),
+    //   F0 → 90..BF (else overlong), F4 → 80..8F (else > U+10FFFF).
+    const lo = b === 0xe0 ? 0xa0 : b === 0xf0 ? 0x90 : 0x80;
+    const hi = b === 0xed ? 0x9f : b === 0xf4 ? 0x8f : 0xbf;
+    // Validate EVERY continuation byte that is PRESENT, even when the sequence is
+    // truncated by the sniff window: an already-visible byte that violates its range
+    // (e.g. `E0 80` — E0 requires A0..BF) proves the run is NOT valid UTF-8 and must
+    // reject, rather than being waved through as "truncated". Only a genuinely
+    // cut-off sequence — where we simply ran out of bytes before an INVALID one — is
+    // accepted (we only sampled a prefix). This closes a boundary false-positive that
+    // would misclassify a raw `.bin` as text/HTML (#473 P0-2 sniff-edge).
+    for (let k = 1; k < len; k += 1) {
+      if (i + k >= n) return true; // ran out of bytes with everything valid so far
+      const cont = slice[i + k];
+      const clo = k === 1 ? lo : 0x80;
+      const chi = k === 1 ? hi : 0xbf;
+      if (cont < clo || cont > chi) return false; // present-but-invalid continuation
+    }
+    i += len;
+  }
+  return true;
+}
+
+/** Classify a sniffed payload head as an HTML page, a JSON document, or opaque
+ *  binary. Skips a UTF-8 BOM and leading ASCII whitespace, then requires the run
+ *  that follows to read as TEXT before declaring html/json — so a binary model that
+ *  merely starts with byte `<`/`{`/`[` (e.g. a safetensors whose LE header length is
+ *  60=0x3C or 91=0x5B, followed by NUL padding) is correctly kept as "binary":
+ *   - leading `<` + text ⇒ "html"
+ *   - leading `{`/`[` + text ⇒ "json"
+ *   - anything else ⇒ "binary" (a real model payload). */
+/** Classify an already-DECODED text string (used for UTF-16 bodies): skips leading
+ *  whitespace, then a `<` ⇒ html / `{`|`[` ⇒ json when the run that follows is clean
+ *  text (no NUL / C0 control). A binary payload that merely decoded to a leading
+ *  `<`/`{` (e.g. a safetensors whose UTF-16 decode yields `<` then U+0000) fails the
+ *  text check and stays binary. */
+function classifyDecodedText(s: string): "html" | "json" | "binary" {
+  let j = 0;
+  // Skip leading text whitespace INCLUDING VT/FF (\v \f) — an auth page can begin with
+  // a form-feed before the `<`/`{` (`\f<!DOCTYPE html>`); if we stopped at it the char
+  // scrutinized would be the control byte, not the tag, and the page would misclassify
+  // as binary (#473 P0-1).
+  while (j < s.length) {
+    const cp = s.charCodeAt(j);
+    if (cp === 0x20 || (cp >= 0x09 && cp <= 0x0d)) j += 1;
+    else break;
+  }
+  if (j >= s.length) return "binary";
+  const ch = s[j];
+  // Require the WHOLE decoded run (not just the first 64 chars) to be clean text
+  // before declaring html/json: a binary payload that merely decoded to a leading
+  // `<`/`{` but then hits control/replacement chars must stay binary (#473 P0-2).
+  const rest = s.slice(j);
+  const isText = (() => {
+    for (const c of rest) {
+      const cp = c.codePointAt(0)!;
+      if (cp >= 0x09 && cp <= 0x0d) continue; // TAB/LF/VT/FF/CR — text whitespace
+      if (cp < 0x20 || cp === 0xfffd) return false; // NUL/C0 control or replacement char
+    }
+    return true;
+  })();
+  if (ch === "<") return isText ? "html" : "binary";
+  if (ch === "{" || ch === "[") return isText ? "json" : "binary";
+  return "binary";
+}
+
+function classifyPayload(buf: Buffer): "html" | "json" | "binary" {
+  // A UTF-16 BOM (FF FE = LE, FE FF = BE) marks a text document — an HTML/JSON auth
+  // page can be served UTF-16 (e.g. `text/html; charset=utf-16`, bytes FF FE 3C 00).
+  // Decode and classify as text so it isn't mistaken for binary. A binary model that
+  // coincidentally starts with a BOM byte pair decodes to control chars → stays binary.
+  if (
+    buf.length >= 2 &&
+    ((buf[0] === 0xff && buf[1] === 0xfe) || (buf[0] === 0xfe && buf[1] === 0xff))
+  ) {
+    try {
+      const label = buf[0] === 0xff ? "utf-16le" : "utf-16be";
+      // Trim bytes the sniff window cut mid-code-unit BEFORE decoding, so a truncation
+      // artifact doesn't decode to U+FFFD and make a valid UTF-16 page look binary:
+      //  (1) an odd trailing byte (a half code unit), and (2) a trailing UNPAIRED high
+      //  surrogate (0xD800–0xDBFF) whose low half fell outside the window — e.g. an
+      //  emoji split across the 512-byte boundary. A mid-document U+FFFD (genuine
+      //  binary) is still caught by classifyDecodedText (#473 P0-1 sniff-edge).
+      let end = buf.length - (buf.length % 2);
+      if (end >= 2) {
+        const hi = label === "utf-16le" ? buf[end - 1] : buf[end - 2];
+        const loB = label === "utf-16le" ? buf[end - 2] : buf[end - 1];
+        const lastUnit = (hi << 8) | loB;
+        if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) end -= 2; // drop lone high surrogate
+      }
+      return classifyDecodedText(new TextDecoder(label).decode(buf.subarray(0, end)));
+    } catch {
+      return "binary";
+    }
+  }
+  let i = 0;
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) i = 3; // UTF-8 BOM
+  // Skip leading text whitespace INCLUDING VT(0x0b)/FF(0x0c) — a login page may open
+  // with a form-feed before the `<` (`\f<!DOCTYPE html>`). Stopping at that control
+  // byte would scrutinize it instead of the tag and misclassify the page as binary
+  // (#473 P0-1).
+  while (
+    i < buf.length &&
+    (buf[i] === 0x20 || (buf[i] >= 0x09 && buf[i] <= 0x0d))
+  ) {
+    i += 1;
+  }
+  if (i >= buf.length) return "binary";
+  const c = buf[i];
+  // Require the WHOLE sniffed run — the entire remaining head, not just the first 64
+  // bytes — to read as valid text before declaring html/json. A raw binary whose head
+  // merely STARTS with `<`/`{`/`[` but turns to non-text bytes further in (e.g. a .bin
+  // that begins `<AAA…` then has NUL/high bytes) must be ACCEPTED as a model, not
+  // rejected on a one-byte lead over a tiny window (#473 P0-2). A genuine HTML/JSON
+  // auth page is text throughout the sniff window, so it still classifies correctly.
+  const rest = buf.subarray(i);
+  if (c === 0x3c) return looksLikeText(rest) ? "html" : "binary"; // '<'
+  if (c === 0x7b || c === 0x5b) return looksLikeText(rest) ? "json" : "binary"; // '{' or '['
+  return "binary";
+}
+
+/** Given a completed download's sniffed head + Content-Type, decide whether the
+ *  bytes are an auth/error page masquerading as a model file (#473). Returns the
+ *  offending kind, or null when the payload is an acceptable model binary (or the
+ *  destination isn't a model-binary extension, so this validation doesn't apply).
+ *
+ *  Two independent signals, EITHER of which rejects:
+ *   1. Body magic — an HTML page's leading `<` (over a whole-window text run) and a
+ *      JSON error's leading `{`/`[` are present regardless of how the server labels
+ *      the response, so body magic catches an auth/error page even when mislabeled
+ *      `application/octet-stream`. (fetch() transparently decompresses gzip/br, so a
+ *      compressed error page still sniffs as its decoded HTML/JSON here.)
+ *   2. Content-Type — a `text/html`/`application/xhtml` or `application/json` label
+ *      on a binary-model destination is itself proof of an auth/error document, so it
+ *      rejects EVEN when the body failed to sniff as text (a stray control byte, an
+ *      exotic charset, or a truncating proxy — #473 P0-1). Real model hosts never
+ *      label a weight file text/html or application/json, so this can't reject a
+ *      legitimate binary (whose Content-Type is octet-stream or similar). */
+function detectNonModelPayload(
+  head: Buffer | undefined,
+  contentType: string,
+  modelExt: string,
+): "html" | "json" | null {
+  if (!modelExt || !MODEL_BINARY_EXTS.has(modelExt.toLowerCase())) return null;
+  const kind = head ? classifyPayload(head) : "binary";
+  if (kind === "html") return "html";
+  if (kind === "json") return "json";
+  // Content-Type is AUTHORITATIVE for the two textual auth/error shapes. A server
+  // that LABELS a response `text/html`/`application/xhtml` or `application/json` for
+  // a binary-model destination is serving a login/auth or API-error document, never
+  // a weight file — so reject it EVEN when the body itself failed to sniff as text
+  // (a stray control byte, an exotic charset, or a truncating proxy could otherwise
+  // let a genuine HTML/JSON page slip through as "binary" — #473 P0-1). Real model
+  // hosts serve weights as application/octet-stream (or similar), never as text/html
+  // or application/json, so this can't reject a legitimate binary. (The body-magic
+  // checks above already caught the common octet-stream-mislabeled auth page.)
+  if (/text\/html|application\/xhtml/i.test(contentType)) return "html";
+  if (/(^|[/+])json\b/i.test(contentType)) return "json";
+  return null;
+}
+
+/** Actionable error for a rejected auth/error payload (#473). Names the concrete
+ *  failure (an HTML page / JSON error saved as a model) and, for CivitAI, the exact
+ *  fix (set/refresh the API token) — because a 200-with-auth-challenge is precisely
+ *  what CivitAI returns for a missing/invalid key or a gated model, and Manager /
+ *  a bare fetch would otherwise save that page under the `.safetensors` name. */
+function nonModelPayloadError(
+  kind: "html" | "json",
+  url: string,
+  logUrl: string,
+): ModelError {
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    /* logUrl is used for reporting; host is only for the CivitAI hint */
+  }
+  const isCivitai = /(^|\.)civitai\.com$/i.test(host);
+  const what =
+    kind === "html"
+      ? "an HTML page (an authentication/login or error page)"
+      : "a JSON document (an API error or auth challenge)";
+  const civitaiHint = isCivitai
+    ? " CivitAI returns an auth challenge like this when no valid token is sent — set or refresh " +
+      "CIVITAI_API_TOKEN (panel Settings › “Set CivitAI token…”, or the env var; create one at " +
+      "civitai.com/user/account) and retry. Note: on a REMOTE ComfyUI target the token is NOT " +
+      "forwarded to ComfyUI-Manager, so a locally-set token does not fix a remote Manager download."
+    : "";
+  return new ModelError(
+    `Download rejected: the server returned ${what}, not a model file, but the destination is a ` +
+      `binary model file. Refusing to save it as a model (it would land as a corrupt file under a ` +
+      `false success and fail at load time, e.g. "header too large").${civitaiHint}`,
+    { url: logUrl },
+  );
+}
+
+/** Validate that a COMPLETED file at `targetPath` is a real model payload — not an
+ *  HTML/JSON auth/error page — when the destination is a binary-model extension
+ *  (#473). FAILS CLOSED: an offending payload OR an unreadable-for-sniffing file (we
+ *  can't confirm it) throws, after `onReject` cleans up, so a corrupt file is never
+ *  finalized under a success. A no-op for non-model destinations. `contentType` is a
+ *  secondary signal (empty on cache-hit/cloud paths, where only the bytes are known). */
+async function assertModelPayloadOrThrow(opts: {
+  targetPath: string;
+  modelExt: string;
+  contentType: string;
+  url: string;
+  logUrl: string;
+  onReject?: () => Promise<void>;
+  /** Defaults to TRUE for every finalize path (HTTP, cache-hit, cloud S3/Azure): an
+   *  unreadable/empty sniff head leaves the payload UNVERIFIED and is REJECTED —
+   *  cannot verify ⇒ do not finalize (#473 P0-3). (A genuinely 0-byte download is
+   *  already rejected upstream by assertComplete / the cache-hit 0-byte guard, so
+   *  fail-closed here only trips on a nonzero file we couldn't read.) The flag is kept
+   *  as a seam for callers/tests that need best-effort behavior, but no production
+   *  path passes false. */
+  failClosed?: boolean;
+}): Promise<void> {
+  const { targetPath, modelExt, contentType, url, logUrl, failClosed = true } = opts;
+  if (!modelExt || !MODEL_BINARY_EXTS.has(modelExt.toLowerCase())) return;
+  const head = await readHead(targetPath);
+  // An unreadable OR unexpectedly-empty head (a non-empty file that read 0 bytes
+  // under an fs race) leaves the payload UNVERIFIED. On the fail-closed paths refuse
+  // to finalize it rather than trust it (#473/#467); on the best-effort cloud path,
+  // skip. (A genuinely 0-byte download is already rejected upstream by assertComplete
+  // / the cache-hit 0-byte guard.)
+  if (head === undefined || head.length === 0) {
+    if (!failClosed) return;
+    await opts.onReject?.();
+    throw new ModelError(
+      `Download could not be verified: the completed file could not be read to confirm it is a ` +
+        `model payload (and not an HTML/JSON auth/error page). Not finalizing it as a model; retry.`,
+      { url: logUrl },
+    );
+  }
+  const kind = detectNonModelPayload(head, contentType, modelExt);
+  if (!kind) return;
+  await opts.onReject?.();
+  throw nonModelPayloadError(kind, url, logUrl);
 }
 
 /** POSITIVELY true only when `path` is confirmed discarded — it no longer exists
@@ -314,7 +815,13 @@ async function streamUrlToFile(
    *  the outcome is stored on that job — never in a shared keyed map that could
    *  misattribute it to another job (#467). Absent for internal/direct callers. */
   onResume?: ResumeReporter,
-): Promise<void> {
+  /** Extension of the FINAL destination (e.g. ".safetensors"), NOT of the .partial
+   *  we stream into. When it's a binary-model extension the completed payload is
+   *  validated as a real model — an HTML/JSON auth/error body is rejected rather
+   *  than finalized as a corrupt model under a false success (#473). Empty ⇒ no
+   *  payload validation (unknown/non-model destination). */
+  modelExt = "",
+): Promise<string> {
   if (supportsCloudDownload(url)) {
     // Cloud downloaders (S3/Azure) don't range-resume — they overwrite the target.
     // If a partial exists it's being discarded; surface that (#467) instead of a
@@ -353,7 +860,26 @@ async function streamUrlToFile(
         { url: logUrl },
       );
     }
-    return;
+    // A cloud (S3/Azure) object can also be an error document — e.g. an XML
+    // AccessDenied body saved under a `.safetensors` name. No HTTP Content-Type is
+    // available here, so sniff the body alone (an XML/HTML error starts with `<`).
+    await assertModelPayloadOrThrow({
+      targetPath,
+      modelExt,
+      contentType: "",
+      url,
+      logUrl,
+      onReject: async () => {
+        await discardRejectedPayload(targetPath, undefined, logUrl);
+      },
+      // FAIL CLOSED, same as the HTTP path: a cloud (S3/Azure) object can be an XML/
+      // HTML AccessDenied body saved under a `.safetensors` name, and if we CAN'T
+      // sniff the completed file (a transient open/read failure) we must NOT finalize
+      // it — cannot verify ⇒ do not finalize (#473 P0-3). Previously this was a
+      // best-effort skip, which let an unsniffable auth/error body get renamed in.
+      failClosed: true,
+    });
+    return ""; // cloud (S3/Azure) has no HTTP Content-Type to persist
   }
 
   // Resumable downloads: when a partial file exists at targetPath we ask the
@@ -855,13 +1381,45 @@ async function streamUrlToFile(
     }
   };
 
+  // Reject a completed body that is an HTML/JSON auth/error page rather than a
+  // model file (#473). Runs AFTER assertComplete (size is right) but BEFORE the
+  // .partial is renamed into place / the sidecar is dropped — a plausibly-sized
+  // login page or `{"error":...}` would otherwise pass the size gate and finalize
+  // as a corrupt model under a green success. Removes the bad partial + sidecar so
+  // a retry starts clean, and surfaces an actionable (CivitAI-aware) error.
+  // The response Content-Type — used now for the stream-time check AND returned to
+  // the cache layer so it can persist it beside the cache file. A later cache-HIT /
+  // coalesced caller re-validates with contentType "" (the header is long gone), so
+  // without persisting it a body that only a Content-Type could flag (e.g. an
+  // HTML/JSON page whose bytes don't sniff as text) could slip through on reuse (#473).
+  const responseContentType = res.headers.get("content-type") || "";
+  const assertModelPayload = (): Promise<void> =>
+    assertModelPayloadOrThrow({
+      targetPath,
+      modelExt,
+      contentType: responseContentType,
+      url,
+      logUrl,
+      // Remove the rejected partial + its resume sidecar, and if removal fails,
+      // NEUTRALIZE the partial (truncate to 0) so a retry can't resume onto the
+      // poisoned HTML/JSON prefix (#473 P1). safeRm alone would swallow an EPERM and
+      // leave a resumable poisoned partial behind. When resumable, ALSO drop a poison
+      // marker so a content-type-only rejection (whose body may sniff as binary on
+      // retry) still can't be resumed even if neutralization failed.
+      onReject: async () => {
+        await discardRejectedPayload(targetPath, resumable ? validatorSidecar : undefined, logUrl);
+        if (resumable) await writePoisonMarker(`${targetPath}.rejected`, logUrl);
+      },
+    });
+
   // No progress wanted (internal/cache caller, or not under the panel) → straight pipe.
   if (!progress) {
     await pipeline(nodeStream, fileStream);
     await assertComplete();
+    await assertModelPayload();
     // Complete: the validator sidecar is only needed to guard a resume, so drop it.
     if (resumable) await safeRm(validatorSidecar);
-    return;
+    return responseContentType;
   }
 
   // Tally bytes as they flow and report throughput to the panel tray.
@@ -893,9 +1451,11 @@ async function streamUrlToFile(
   try {
     await pipeline(nodeStream, counter, fileStream);
     await assertComplete();
+    await assertModelPayload();
     if (resumable) await safeRm(validatorSidecar);
     bytesPerSec = 0;
     emit("done", true);
+    return responseContentType;
   } catch (err) {
     emit("error", true);
     throw err;
@@ -909,6 +1469,7 @@ async function downloadIntoCache(
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
   onResume?: ResumeReporter,
+  modelExt = "",
 ): Promise<string> {
   // Representation-aware identity (#467): a same-URL download with different HTTP
   // auth headers OR different cloud (S3/Azure) credentials gets its OWN cache file,
@@ -935,6 +1496,8 @@ async function downloadIntoCache(
         // materializing an empty file that reports success.
         if (info.size === 0) {
           await downloadCacheFs.rm(target, { force: true }).catch(() => undefined);
+          // Drop its stale Content-Type sidecar too — it now describes nothing.
+          await downloadCacheFs.rm(cacheCtSidecar(target), { force: true }).catch(() => undefined);
         } else {
           await touch(target);
           // Cache hit ⇒ no resume/discard this attempt; onResume is never called,
@@ -951,6 +1514,7 @@ async function downloadIntoCache(
     // restarting from zero. (See streamUrlToFile for the Range + flags
     // handshake.) Cleanup on terminal failure stays unchanged.
     const partial = join(cacheDir(), `.${basename(target)}.partial`);
+    const rejectedMarker = `${partial}.rejected`;
     let resumeFromBytes = 0;
     try {
       const existing = await downloadCacheFs.stat(partial);
@@ -965,8 +1529,64 @@ async function downloadIntoCache(
       // No partial — fresh download.
     }
 
+    // #473 P1 — poison MARKER guard (cleanup- AND content-type-independent). A prior
+    // attempt that REJECTED this download (even solely on the response Content-Type,
+    // which is gone now) drops a `.rejected` marker next to the partial. If it's
+    // present, the leftover partial is poison regardless of what its bytes sniff as —
+    // never resume onto it. Discard everything and restart from 0.
+    let markerPresent = false;
     try {
-      await streamUrlToFile(
+      markerPresent = (await downloadCacheFs.stat(rejectedMarker)).isFile();
+    } catch {
+      /* no marker */
+    }
+    if (markerPresent) {
+      if (resumeFromBytes > 0) {
+        logger.warn(
+          `Discarding a previously-rejected (${resumeFromBytes}-byte) partial before resume: a ` +
+            `poison marker from an earlier non-model rejection is present — restarting from 0 (#473).`,
+          { url: logUrl, bytes: resumeFromBytes },
+        );
+      }
+      const neutralized = await discardRejectedPayload(
+        partial,
+        `${partial}.etag`,
+        logUrl ?? redactUrlForLogs(url),
+      );
+      // Keep the marker if the partial could NOT be neutralized (rm AND truncate both
+      // failed), so a still-poisoned leftover stays flagged for the next attempt.
+      // resumeFromBytes = 0 forces this attempt to re-download fresh ("w" truncates the
+      // leftover), so the poison is cleared here regardless.
+      if (neutralized) await safeRm(rejectedMarker);
+      resumeFromBytes = 0;
+    }
+
+    // #473 P1 — cleanup-INDEPENDENT poison guard (body-magic). A prior attempt may have REJECTED
+    // this download as an HTML/JSON auth/error body and then been UNABLE to remove or
+    // truncate the leftover .partial (a denied rm AND a denied truncate). Re-inspect
+    // the partial's HEAD here, before deciding to resume: if it is itself a non-model
+    // (HTML/JSON) body for a binary-model destination, it is poison — NEVER resume
+    // onto it. Reset to a fresh download (resumeFromBytes = 0 ⇒ no Range ⇒ the "w"
+    // open truncates the poisoned bytes) and best-effort discard the sidecar, so the
+    // invariant "a rejected leftover can't be treated as resumable" holds even when
+    // both cleanup mechanisms failed. A legitimate in-progress partial sniffs as
+    // binary (null) and resumes normally.
+    if (resumeFromBytes > 0 && modelExt) {
+      const partialHead = await readHead(partial);
+      if (detectNonModelPayload(partialHead, "", modelExt)) {
+        logger.warn(
+          `Discarding a previously-rejected non-model (${resumeFromBytes}-byte) partial before ` +
+            `resume: its head is an HTML/JSON auth/error body, not a model — restarting from 0 so ` +
+            `the poisoned bytes can't be resumed onto (#473).`,
+          { url: logUrl, bytes: resumeFromBytes },
+        );
+        await discardRejectedPayload(partial, `${partial}.etag`, logUrl ?? redactUrlForLogs(url));
+        resumeFromBytes = 0;
+      }
+    }
+
+    try {
+      const contentType = await streamUrlToFile(
         url,
         partial,
         headers,
@@ -976,9 +1596,16 @@ async function downloadIntoCache(
         progress,
         true, // resumable: cache partials use the .partial + If-Range resume handshake
         onResume,
+        modelExt,
       );
       await downloadCacheFs.rename(partial, target);
       await touch(target);
+      // Persist the response Content-Type beside the cache file so a later cache-HIT /
+      // coalesced caller re-validates with it (#473 reuse gap).
+      await writeCacheContentType(target, contentType);
+      // Clean any stale poison marker now that a CLEAN payload finalized under this
+      // key — the partial is gone (renamed) and the bytes passed validation.
+      await safeRm(rejectedMarker);
       return target;
     } catch (err) {
       // Leave the partial on disk for a future resume; only nuke it if it
@@ -1177,6 +1804,8 @@ async function evictLruIfNeeded(): Promise<void> {
   files.sort((a, b) => a.time - b.time);
   for (const file of files) {
     await downloadCacheFs.rm(file.path, { force: true });
+    // Evict the Content-Type sidecar with its cache file so it can't outlive it.
+    await downloadCacheFs.rm(cacheCtSidecar(file.path), { force: true }).catch(() => undefined);
     total -= file.size;
     if (total <= limit) break;
   }
@@ -1189,14 +1818,31 @@ export async function downloadUrlToFile(
   logUrl?: string,
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
+  modelExt = extname(targetPath),
 ): Promise<void> {
-  await streamUrlToFile(url, targetPath, headers, logUrl, storageAuth, 0, progress);
+  await streamUrlToFile(
+    url,
+    targetPath,
+    headers,
+    logUrl,
+    storageAuth,
+    0,
+    progress,
+    false,
+    undefined,
+    modelExt,
+  );
 }
 
 export async function downloadWithCache(
   options: DownloadCacheOptions,
 ): Promise<DownloadCacheResult> {
   const logUrl = options.logUrl ?? redactUrlForLogs(options.url);
+  // The FINAL destination extension drives model-payload validation (#473). Derived
+  // from the real targetPath here — NOT from the .partial / random temp we actually
+  // stream into (those carry `.partial`/`.tmp`) — and threaded down so the completed
+  // body is checked against what the destination IS (a `.safetensors` etc.).
+  const modelExt = extname(options.targetPath);
   try {
     const cachePath = await downloadIntoCache(
       options.url,
@@ -1205,7 +1851,39 @@ export async function downloadWithCache(
       options.storageAuth,
       options.progress,
       options.onResume,
+      modelExt,
     );
+    // Validate the CACHE FILE itself before materializing it to this destination —
+    // this is the authoritative per-caller gate (#473). It covers four cases the
+    // stream-time check can't: (1) a CACHE HIT that skipped streaming entirely,
+    // (2) a COALESCED caller whose .safetensors destination consumed a stream that
+    // ran under a different (e.g. non-model) caller's modelExt, (3) a legacy cache
+    // entry poisoned before this fix, and (4) a body that ONLY the Content-Type could
+    // flag (its bytes don't sniff as text). The live Content-Type header is gone by
+    // now, so we recover it from the `.ct` sidecar persisted at download time —
+    // otherwise a Content-Type-only-flaggable body could finalize as a model on reuse.
+    const cachedContentType = await readCacheContentType(cachePath);
+    await assertModelPayloadOrThrow({
+      targetPath: cachePath,
+      modelExt,
+      contentType: cachedContentType,
+      url: options.url,
+      logUrl,
+      // Drop the poisoned cache entry (+ its Content-Type sidecar) so a retry
+      // re-downloads clean rather than re-serving the same bad bytes on every call.
+      // Truncate-to-0 fallback if rm fails (a 0-byte cache entry is treated as a
+      // miss), and log if even that fails, so a poisoned cache entry can't silently
+      // re-poison cache hits (#473 P1).
+      onReject: async () => {
+        const neutralized = await discardRejectedPayload(cachePath, undefined, logUrl);
+        // Only drop the Content-Type sidecar once the poisoned cache file is actually
+        // gone/emptied. If the cache file SURVIVED (rm AND truncate both failed), KEEP
+        // the `.ct` so the NEXT caller can still reject it by its persisted
+        // Content-Type — deleting the evidence would let a Content-Type-only poison be
+        // re-served as a model on a later cache hit (#473 P1).
+        if (neutralized) await safeRm(cacheCtSidecar(cachePath));
+      },
+    });
     const materializedBy = await materializeCacheFile(cachePath, options.targetPath);
     await evictLruIfNeeded();
     return {
@@ -1237,6 +1915,7 @@ export async function downloadWithCache(
         logUrl,
         options.storageAuth,
         options.progress,
+        modelExt,
       );
       await renameTempOverDestination(tmp, options.targetPath);
     } catch (e) {

--- a/src/services/generate-audio.ts
+++ b/src/services/generate-audio.ts
@@ -26,6 +26,14 @@ export interface GenerateAudioArgs {
   musical_key?: string;
   shift?: number;
   guidance_scale?: number;
+  bpm?: number;
+  timesignature?: string;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  min_p?: number;
+  generate_audio_codes?: boolean;
+  audio_quality?: string;
 
   // Stable Audio 3 specific
   checkpoint?: string;
@@ -60,6 +68,14 @@ const DEFAULTABLE_KEYS = [
   "musical_key",
   "shift",
   "guidance_scale",
+  "bpm",
+  "timesignature",
+  "temperature",
+  "top_p",
+  "top_k",
+  "min_p",
+  "generate_audio_codes",
+  "audio_quality",
   "checkpoint",
   "clip",
   "negative_prompt",
@@ -120,6 +136,14 @@ export async function generateAudio(
       language: resolved.language as string | undefined,
       musical_key: resolved.musical_key as string | undefined,
       guidance_scale: resolved.guidance_scale as number | undefined,
+      bpm: resolved.bpm as number | undefined,
+      timesignature: resolved.timesignature as string | undefined,
+      temperature: resolved.temperature as number | undefined,
+      top_p: resolved.top_p as number | undefined,
+      top_k: resolved.top_k as number | undefined,
+      min_p: resolved.min_p as number | undefined,
+      generate_audio_codes: resolved.generate_audio_codes as boolean | undefined,
+      audio_quality: resolved.audio_quality as string | undefined,
       filename_prefix: resolved.filename_prefix as string | undefined,
     });
 

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -30,7 +30,12 @@ import {
   type ModelType,
 } from "./model-resolver.js";
 import { startDownloadJob, type DownloadJob } from "./download-jobs.js";
-import { getSavedDefaultWorkspaceSync } from "./workspace-env.js";
+import { resolveModelsDir } from "./output-dir.js";
+import {
+  getSavedDefaultWorkspaceSync,
+  resolveLiveComfyUIBase,
+  resolveRootInterpreter,
+} from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -40,6 +45,51 @@ import { logger } from "../utils/logger.js";
 function manifestDownloadGraceMs(): number {
   const raw = Number(process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS);
   return Number.isFinite(raw) && raw >= 0 ? raw : 15_000;
+}
+
+/** Overall wall-clock budget (ms) for the custom-node install phase. Node installs
+ *  drive the ComfyUI-Manager queue, which can legitimately run for minutes on a
+ *  big pack. Blocking apply_manifest until it drains blows past the MCP tools/call
+ *  timeout (300s) and the caller sees a FALSE failure while the Manager keeps
+ *  installing (#489). Bounding the phase well under that cap lets us hand back a
+ *  "pending" result (poll the Manager queue) instead. Env-tunable; default 240s. */
+function manifestNodeBudgetMs(): number {
+  const raw = Number(process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 240_000;
+}
+
+/** Sentinel returned by raceDeadline when the wall-clock deadline wins. */
+const BUDGET_TIMEOUT = Symbol("manifest-node-budget-timeout");
+
+/**
+ * Await `p` but never past the absolute `deadline` (Date.now() ms). Returns the
+ * resolved value, or BUDGET_TIMEOUT if the deadline elapses first. Bounds EVERY
+ * async wait in the custom-node phase (#489) — the install itself AND the
+ * surrounding listInstalledNodes round-trips — so a slow Manager can never push
+ * apply_manifest past the MCP tools/call timeout; it hands back "pending" instead.
+ *
+ * CAVEAT (single-threaded runtime): this bounds ASYNC work only. A SYNCHRONOUS
+ * subprocess install unit — the git-clone / cm-cli fallback (execFileSync), like
+ * pip — blocks the event loop, so the timer cannot preempt one already running;
+ * each is instead bounded by its OWN execFileSync timeout. The race is what fixes
+ * #489's actual case: the ASYNC Manager-queue polling that keeps running for
+ * minutes. `p` must not reject (callers pass a pre-caught promise).
+ */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadline: number,
+): Promise<T | typeof BUDGET_TIMEOUT> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return BUDGET_TIMEOUT;
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<typeof BUDGET_TIMEOUT>((resolve) => {
+    timer = setTimeout(() => resolve(BUDGET_TIMEOUT), remaining);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 const IS_WIN = platform() === "win32";
@@ -150,13 +200,10 @@ function commandExists(cmd: string): boolean {
 
 function resolveWorkspacePython(comfyuiPath: string): string {
   if (process.env.COMFYUI_PYTHON) return process.env.COMFYUI_PYTHON;
-  for (const venv of [".venv", "venv"]) {
-    const py = IS_WIN
-      ? join(comfyuiPath, venv, "Scripts", "python.exe")
-      : join(comfyuiPath, venv, "bin", "python");
-    if (existsSync(py)) return py;
-  }
-  return IS_WIN ? "python" : "python3";
+  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
+  // so a manifest pip install targets the install's OWN interpreter, never a bare
+  // system python that would contaminate the host env (#463 codex review).
+  return resolveRootInterpreter(comfyuiPath);
 }
 
 function validatePipPackageSpec(pkg: string): void {
@@ -259,10 +306,6 @@ function nodeAlreadyInstalled(id: string, installed: InstalledNode[]): boolean {
   });
 }
 
-function modelsRoot(comfyuiPath: string): string {
-  return join(comfyuiPath, "models");
-}
-
 function defaultFilenameForUrl(url: string): string {
   return basename(new URL(url).pathname) || "model.safetensors";
 }
@@ -319,10 +362,16 @@ async function validateExistingModelAncestors(
 }
 
 async function resolveLocalModelPath(
-  comfyuiPath: string,
   model: ComfyManifest["models"][number],
 ): Promise<{ targetSubfolder: string; filename: string; targetPath: string }> {
-  const root = resolve(modelsRoot(comfyuiPath));
+  // Root the target — and therefore the local_path symlink/containment guards
+  // below — at the SAME directory the downloader actually writes to: the live
+  // connected server's models dir (resolveModelsDir, live-first), NOT
+  // <COMFYUI_PATH>/models. When the connected install differs from a stale
+  // COMFYUI_PATH (#490), validating against COMFYUI_PATH/models would leave a
+  // symlink that escapes the LIVE models dir unchecked and redirect the write
+  // outside it. Same canonical root as the writer = one authoritative guard.
+  const root = resolve(await resolveModelsDir());
 
   if (model.local_path) {
     if (isAbsolute(model.local_path)) {
@@ -563,46 +612,70 @@ export async function applyManifest(
 ): Promise<ApplyManifestResult> {
   const manifest = await resolveManifest(opts);
 
-  // #390 (call-scoped): adopt a saved default workspace as the local FS target
-  // for THIS call ONLY — never persist it process-wide. Persisting
-  // config.comfyuiPath would make a later apply route to a stale/other workspace
-  // (and would never re-read a changed default), and would leak the adopted path
-  // to every other tab/tool sharing this process. Temp-set for the duration of
-  // the apply and always restore in finally. Safe for the background downloads
-  // enqueued below: downloadModel resolves its destination from the LIVE server's
-  // models dir (resolveModelSubfolderPreferServer), not config.comfyuiPath, so a
-  // restore before a job finishes cannot misplace the file.
-  const adopted = adoptableLocalWorkspace();
-  const priorComfyuiPath = config.comfyuiPath;
-  if (adopted) {
+  // Resolve the LOCAL ComfyUI base this call should target, WITHOUT mutating the
+  // process-global config.comfyuiPath (a global temp-set would leak the path to
+  // every concurrent tab/tool and could be clobbered by an interleaved restore —
+  // #490/#463 codex review). We thread it explicitly to applyManifestSections
+  // instead. Precedence, local mode only:
+  //   1. config.comfyuiPath (COMFYUI_PATH / auto-detect) — unchanged, wins.
+  //   2. saved default workspace (#390).
+  //   3. the LIVE connected server's own install root from /system_stats argv
+  //      (#463) — a panel-connected local session with no COMFYUI_PATH still has
+  //      a real FS target, so models/pip aren't skipped as "no local filesystem".
+  // The actual on-disk model DESTINATION is always re-derived live-first by the
+  // downloader (resolveModelsDir), so this base only governs the local-vs-remote
+  // classification + pip's interpreter, never where a model lands.
+  const localBase = await resolveLocalManifestBase();
+
+  return applyManifestSections(manifest, localBase);
+}
+
+/**
+ * The effective LOCAL ComfyUI base for an apply_manifest call. Never mutates
+ * global config. Returns undefined in remote/cloud mode or when no local install
+ * can be found (COMFYUI_PATH unset, no saved default, no reachable live server).
+ */
+async function resolveLocalManifestBase(): Promise<string | undefined> {
+  if (config.comfyuiPath) return config.comfyuiPath;
+  if (isRemoteMode()) return undefined;
+  const saved = adoptableLocalWorkspace();
+  if (saved) return saved;
+  // #463: a live LOCAL ComfyUI is connected but COMFYUI_PATH/default are unset.
+  // Adopt its own install root (from /system_stats argv) only when it exists and
+  // looks like a ComfyUI install.
+  const liveBase = await resolveLiveComfyUIBase();
+  if (
+    liveBase &&
+    existsSync(liveBase) &&
+    (existsSync(join(liveBase, "models")) ||
+      existsSync(join(liveBase, "custom_nodes")))
+  ) {
     logger.info(
-      "apply_manifest: adopting saved default workspace as the local ComfyUI path for this call (COMFYUI_PATH unset)",
-      { path: adopted },
+      "apply_manifest: targeting the live connected ComfyUI root for this call (COMFYUI_PATH unset)",
+      { path: liveBase },
     );
-    config.comfyuiPath = adopted;
+    return liveBase;
   }
-  try {
-    return await applyManifestSections(manifest);
-  } finally {
-    if (adopted) config.comfyuiPath = priorComfyuiPath;
-  }
+  return undefined;
 }
 
 async function applyManifestSections(
   manifest: ComfyManifest,
+  localBase: string | undefined,
 ): Promise<ApplyManifestResult> {
   const results: ManifestItemReport[] = [];
 
   // Per-section mode handling. A LOCAL filesystem is usable only when we are NOT
-  // in remote (or cloud) mode AND COMFYUI_PATH is set (possibly a call-scoped
-  // adopted workspace, see applyManifest); otherwise we are targeting a
-  // remote/cloud ComfyUI over HTTP. Keying off isRemoteMode() (rather than mere
-  // comfyuiPath presence) matters because a remote target can coexist with an
-  // unrelated COMFYUI_PATH on this machine — in that case we must still route
-  // pip/model handling remotely instead of touching the local install/disk.
+  // in remote (or cloud) mode AND a local base was resolved (COMFYUI_PATH, saved
+  // default, or the live connected server's own root — see resolveLocalManifestBase,
+  // threaded here as `localBase` WITHOUT any global config mutation). Otherwise we
+  // are targeting a remote/cloud ComfyUI over HTTP. Keying off isRemoteMode()
+  // (rather than mere base presence) matters because a remote target can coexist
+  // with an unrelated COMFYUI_PATH on this machine — in that case we must still
+  // route pip/model handling remotely instead of touching the local install/disk.
   // custom_nodes and models can still be handled remotely through ComfyUI-Manager's
   // HTTP API, but pip/apt have no remote equivalent.
-  const comfyuiPath = config.comfyuiPath;
+  const comfyuiPath = localBase;
   const hasLocalFs = !isRemoteMode() && Boolean(comfyuiPath);
 
   for (const pkg of manifest.apt) {
@@ -645,43 +718,98 @@ async function applyManifestSections(
     }
   }
 
-  const installedNodes = await installedNodesOrEmpty();
+  // #489: bound the whole custom-node phase by a wall-clock budget. Each install
+  // drives the shared ComfyUI-Manager queue, which can legitimately run for
+  // minutes on a big pack; blocking until every one drains overruns the MCP
+  // tools/call timeout (300s) and the caller sees a FALSE failure while the
+  // Manager keeps installing. So we mirror the model-download grace pattern:
+  // install sequentially, but RACE each install against the remaining budget. If
+  // the budget wins, the install keeps running SERVER-SIDE (we stop awaiting it,
+  // swallowing its late result) and is reported "pending" — never failed — and
+  // every not-yet-started node is reported "pending" too. The caller polls the
+  // Manager queue / re-runs apply_manifest to finish. A node that SETTLES within
+  // budget is verified and reported applied/failed exactly as before.
+  const nodeDeadline = Date.now() + manifestNodeBudgetMs();
+  const pendingBudgetMessage = (started: boolean): string =>
+    started
+      ? "Still installing on the ComfyUI-Manager queue when the apply_manifest time " +
+        "budget elapsed. This is NOT a failure — the install continues server-side. " +
+        "Poll the Manager queue for completion; do not re-issue this node."
+      : "Not started: the apply_manifest time budget elapsed while ComfyUI-Manager " +
+        "was still installing earlier packs. This is NOT a failure — poll the " +
+        "Manager queue for completion, then re-run apply_manifest to continue.";
+  let nodeBudgetSpent = false;
+  // Even the INITIAL installed-list probe is budget-bounded — a hung Manager here
+  // must not blow the tools/call timeout before we can report anything.
+  const initialList = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+  const installedNodes = initialList === BUDGET_TIMEOUT ? [] : initialList;
+  if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
     if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
     }
-    try {
-      const res = await installCustomNode({ id });
-      // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it
-      // cloned NOTHING — e.g. a repo not in its registry resolves to nothing, no
-      // dir is created, but the queue still empties cleanly. So a successful
-      // installCustomNode() call is NOT proof of install. Re-query the installed
-      // list (it reflects on-disk custom_nodes via Manager's
-      // /v2/customnode/installed, so a freshly-cloned node shows up even before a
-      // reboot) and confirm the node is actually present before reporting success.
-      const verified = await installedNodesOrEmpty();
-      if (nodeAlreadyInstalled(id, verified)) {
-        installedNodes.length = 0;
-        installedNodes.push(...verified);
-        results.push(report("custom_node", id, "applied", res.message));
-      } else {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "failed",
-            `ComfyUI-Manager reported the install as queued/done, but the node is not present afterward — the source likely resolved to nothing (a git URL that isn't in the Manager registry won't clone). Install it directly (git clone into custom_nodes) or use a registry id. ${res.message}`,
-          ),
-        );
-      }
-    } catch (err) {
+    if (nodeBudgetSpent || Date.now() >= nodeDeadline) {
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(false)));
+      continue;
+    }
+
+    // Never REJECTS: fold success/failure into a tagged value so the un-awaited
+    // promise (when the deadline wins) can't surface as an unhandled rejection.
+    // Thread the call-scoped local base (no global config mutation) so the
+    // git-clone / ref-checkout fallback works for an adopted saved-default/live
+    // workspace when COMFYUI_PATH is unset (#463).
+    const installOutcome = installCustomNode({ id, comfyuiPath: localBase })
+      .then((res) => ({ kind: "settled" as const, res }))
+      .catch((err) => ({ kind: "error" as const, err }));
+    const outcome = await raceDeadline(installOutcome, nodeDeadline);
+
+    if (outcome === BUDGET_TIMEOUT) {
+      // Budget spent mid-install: leave it running server-side (installOutcome
+      // already has a .catch, so its eventual settle is safely ignored) and stop
+      // blocking on the remaining nodes.
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
+      continue;
+    }
+    if (outcome.kind === "error") {
       results.push(
         report(
           "custom_node",
           id,
           "failed",
-          err instanceof Error ? err.message : String(err),
+          outcome.err instanceof Error ? outcome.err.message : String(outcome.err),
+        ),
+      );
+      continue;
+    }
+    // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it
+    // cloned NOTHING — e.g. a repo not in its registry resolves to nothing, no
+    // dir is created, but the queue still empties cleanly. So a successful
+    // installCustomNode() call is NOT proof of install. Re-query the installed
+    // list (it reflects on-disk custom_nodes via Manager's
+    // /v2/customnode/installed, so a freshly-cloned node shows up even before a
+    // reboot) and confirm the node is actually present before reporting success.
+    // Budget-bounded too: if the confirm can't complete in time we report pending
+    // (conservative — the install itself already settled) rather than overrun.
+    const verified = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+    if (verified === BUDGET_TIMEOUT) {
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
+      continue;
+    }
+    if (nodeAlreadyInstalled(id, verified)) {
+      installedNodes.length = 0;
+      installedNodes.push(...verified);
+      results.push(report("custom_node", id, "applied", outcome.res.message));
+    } else {
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          `ComfyUI-Manager reported the install as queued/done, but the node is not present afterward — the source likely resolved to nothing (a git URL that isn't in the Manager registry won't clone). Install it directly (git clone into custom_nodes) or use a registry id. ${outcome.res.message}`,
         ),
       );
     }
@@ -729,7 +857,7 @@ async function applyManifestSections(
         results.push(report("model", item, "applied", res.message));
         continue;
       }
-      const target = await resolveLocalModelPath(comfyuiPath!, model);
+      const target = await resolveLocalModelPath(model);
       const existing = await findExistingModel(target);
       if (existing) {
         results.push(report("model", item, "skipped", `Model already exists at ${existing}.`));

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
-import type { Stats } from "node:fs";
-import { readdir, stat, mkdir, readFile } from "node:fs/promises";
-import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
+import { existsSync, type Stats } from "node:fs";
+import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
+import { dirname, join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
-import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+import { resolveEffectiveComfyUIBase, liveRootFromArgv } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -406,7 +406,62 @@ export async function resolveModelSubfolderPreferServer(
   if (targetDir !== modelsRoot && !targetDir.startsWith(modelsRoot + sep)) {
     throw new ModelError(`Refusing to write outside the models directory: ${raw}`);
   }
+  // Path-string containment (above) is not enough: an EXISTING symlink somewhere
+  // between modelsRoot and targetDir could redirect the real write OUTSIDE the
+  // models dir. Because THIS resolver is the single canonical write-target for
+  // every local download (startDownloadJob keying AND downloadModel's write), the
+  // guard belongs here — co-located with the resolution the write actually uses —
+  // so it can never diverge from a caller's separate pre-validation (e.g.
+  // apply_manifest resolving the root a second time; #490 codex review).
+  await assertNoEscapingSymlinkAncestor(modelsRoot, targetDir, raw);
   return targetDir;
+}
+
+/**
+ * Reject when any EXISTING directory STRICTLY BETWEEN `root` and `target` (a
+ * descendant of root, not root itself) is a symlink whose real location escapes
+ * root. The models root ITSELF is intentionally NOT checked: a ComfyUI install
+ * may legitimately symlink/junction its whole models dir onto another drive, so
+ * the root canonicalizes elsewhere by design — that is allowed. Descendants are
+ * compared against the CANONICAL root (realpath of root) so a subfolder that
+ * resolves back inside the real models tree is fine, while one escaping it is
+ * rejected. Best-effort: a not-yet-created segment is fine (the download mkdirs it
+ * inside root); never throws for a missing path — only for a genuine escape.
+ */
+async function assertNoEscapingSymlinkAncestor(
+  root: string,
+  target: string,
+  label: string,
+): Promise<void> {
+  // Canonical root: if the models dir is itself a symlink/junction, resolve it so
+  // descendants are checked against where it REALLY lives (not the lexical path).
+  let realRoot: string;
+  try {
+    realRoot = resolve(await realpath(root));
+  } catch {
+    realRoot = root; // root not yet created — lexical containment is all we can check.
+  }
+  // Walk descendants only: from target up to (but NOT including) root.
+  let cursor = target;
+  while (cursor !== root && cursor.startsWith(root + sep)) {
+    try {
+      const info = await lstat(cursor);
+      if (info.isSymbolicLink()) {
+        const real = resolve(await realpath(cursor));
+        if (real !== realRoot && !real.startsWith(realRoot + sep)) {
+          throw new ModelError(
+            `Refusing to write outside the models directory (a symlink in the path escapes it): ${label}`,
+          );
+        }
+      }
+    } catch (err) {
+      if (err instanceof ModelError) throw err;
+      // ENOENT / not yet created — safe; the writer will create it inside root.
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
 }
 
 export interface ResolvedDownloadTarget {
@@ -724,9 +779,27 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   if (resolveEffectiveComfyUIBase()) return false;
   try {
     const stats = await getSystemStats();
-    // Reachable server: stream locally only if it exposes a base/models dir we can
-    // write to; otherwise hand the fetch to its ComfyUI-Manager (reconnect-safe).
-    return !parseModelsDirFromArgv(stats.system?.argv);
+    const argv = stats.system?.argv;
+    // Reachable server: stream locally when it exposes a base/models dir we can
+    // write to (--base-directory/--models-directory) OR when we can derive its own
+    // install root from argv (its main.py path) — the SAME live-first root the
+    // downloader writes into (resolveModelsDir). Keeping this in lockstep with
+    // resolveModelsDir is what lets a panel-connected local server with no
+    // COMFYUI_PATH stream models into its live install (#463) instead of bouncing
+    // through the Manager (which then fails when Manager isn't installed). Only
+    // dispatch to the Manager when NEITHER is discoverable (#420 reconnect with an
+    // opaque/relative argv we can't resolve).
+    if (parseModelsDirFromArgv(argv)) return false;
+    // Derive the server's own install root from argv (its main.py). Only treat it
+    // as a LOCAL stream target when that path ACTUALLY EXISTS on this filesystem:
+    // a loopback ComfyUI inside Docker / behind an SSH port-forward reports a
+    // container-side main.py path that is NOT the host's, so writing there would
+    // create a bogus host directory instead of reaching the server. When the root
+    // isn't locally present, hand the fetch to the connected Manager (server-side
+    // write), which lands in the real install regardless.
+    const liveRoot = liveRootFromArgv(argv, (stats.system as { cwd?: string })?.cwd);
+    if (liveRoot && existsSync(liveRoot)) return false;
+    return true;
   } catch {
     // No reachable server → nothing to dispatch to. Let the local resolver throw.
     return false;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -6,6 +6,7 @@ import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
+import { resolveRootInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -704,11 +705,15 @@ function gitCheckoutDir(baseUrl: string): string {
   return basename(clean).replace(/\.git$/i, "");
 }
 
-function runGitCheckout(baseUrl: string, ref: string): void {
-  if (!config.comfyuiPath) {
+function runGitCheckout(baseUrl: string, ref: string, basePath?: string): void {
+  // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
+  // adopted saved-default/live root WITHOUT mutating global config); fall back to
+  // config.comfyuiPath. Either may be unset in remote mode → clear error.
+  const comfyuiBase = basePath ?? config.comfyuiPath;
+  if (!comfyuiBase) {
     throw new ProcessControlError(
       "Checking out a custom-node git ref requires a local ComfyUI install, " +
-        "but config.comfyuiPath is not set.",
+        "but no ComfyUI path is set.",
     );
   }
 
@@ -719,7 +724,7 @@ function runGitCheckout(baseUrl: string, ref: string): void {
   assertSafeGitUrl(baseUrl);
   const repoName = gitCheckoutDir(baseUrl);
   assertSafeRepoName(repoName);
-  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
+  const customNodesRoot = resolve(comfyuiBase, "custom_nodes");
   const nodeDir = resolve(customNodesRoot, repoName);
   const rel = relative(customNodesRoot, nodeDir);
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
@@ -735,13 +740,13 @@ function runGitCheckout(baseUrl: string, ref: string): void {
 
   try {
     execFileSync("git", ["-C", nodeDir, "fetch", "--all", "--tags"], {
-      cwd: config.comfyuiPath,
+      cwd: comfyuiBase,
       encoding: "utf-8",
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
     });
     execFileSync("git", ["-C", nodeDir, "checkout", "--detach", "--end-of-options", ref], {
-      cwd: config.comfyuiPath,
+      cwd: comfyuiBase,
       encoding: "utf-8",
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
@@ -790,16 +795,18 @@ function nodeInstalledMatches(
 /**
  * Resolve the ComfyUI venv python for installing a cloned node's deps. Prefers
  * the install's own `.venv` (Windows Scripts/ or POSIX bin/), falling back to a
- * bare "python" on PATH.
+ * bare "python" on PATH. `basePath` is the CALL-SCOPED install root (apply_manifest
+ * threads an adopted saved-default/live root without mutating global config); when
+ * omitted it falls back to config.comfyuiPath. Passing it matters: otherwise a
+ * cloned node's requirements.txt / install.py would run under a BARE system python
+ * for an adopted workspace, corrupting/ missing the real ComfyUI environment while
+ * the node is still reported installed (#463 codex review).
  */
-function resolveVenvPython(): string {
-  if (config.comfyuiPath) {
-    const winPy = join(config.comfyuiPath, ".venv", "Scripts", "python.exe");
-    if (existsSync(winPy)) return winPy;
-    const posixPy = join(config.comfyuiPath, ".venv", "bin", "python");
-    if (existsSync(posixPy)) return posixPy;
-  }
-  return "python";
+function resolveVenvPython(basePath?: string): string {
+  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
+  // via the shared resolver, so a cloned node's deps target the install's OWN
+  // interpreter rather than a bare system python (#463 codex review).
+  return resolveRootInterpreter(basePath ?? config.comfyuiPath);
 }
 
 /**
@@ -859,11 +866,17 @@ function cloneCustomNodeFallback(
   repoName: string,
   gitRef: string | undefined,
   managerStatus: unknown,
+  basePath?: string,
 ): NodeOpResult {
-  if (!config.comfyuiPath) {
+  // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
+  // adopted saved-default/live root here WITHOUT mutating global config, so a
+  // panel-connected local session with no COMFYUI_PATH can still clone an
+  // unregistered git pack); fall back to config.comfyuiPath.
+  const comfyuiBase = basePath ?? config.comfyuiPath;
+  if (!comfyuiBase) {
     throw new ProcessControlError(
       `"${repoName}" is not in the ComfyUI-Manager registry and cloning it ` +
-        `requires a local ComfyUI install, but config.comfyuiPath is not set ` +
+        `requires a local ComfyUI install, but no ComfyUI path is set ` +
         `(running in remote --comfyui-url mode). Install it on the ComfyUI host, ` +
         `or pass a registered pack id.`,
     );
@@ -874,10 +887,10 @@ function cloneCustomNodeFallback(
   assertSafeGitUrl(gitId);
   assertSafeRepoName(repoName);
 
-  // Resolve the target and ASSERT it stays inside <comfyuiPath>/custom_nodes,
+  // Resolve the target and ASSERT it stays inside <comfyuiBase>/custom_nodes,
   // mirroring manifest.ts's isWithinRoot containment check (defense in depth on
   // top of the repoName validation above).
-  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
+  const customNodesRoot = resolve(comfyuiBase, "custom_nodes");
   const nodeDir = resolve(customNodesRoot, repoName);
   const rel = relative(customNodesRoot, nodeDir);
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
@@ -898,7 +911,7 @@ function cloneCustomNodeFallback(
     logger.info("Cloning unregistered custom node", { gitId, nodeDir, gitRef });
     try {
       execFileSync("git", cloneArgs, {
-        cwd: config.comfyuiPath,
+        cwd: comfyuiBase,
         encoding: "utf-8",
         timeout: GIT_CLONE_TIMEOUT,
         env: nonInteractiveGitEnv(),
@@ -916,7 +929,7 @@ function cloneCustomNodeFallback(
         },
       );
     }
-    if (gitRef) runGitCheckout(gitId, gitRef);
+    if (gitRef) runGitCheckout(gitId, gitRef, comfyuiBase);
   }
 
   // VERIFY the clone landed before attempting deps.
@@ -930,7 +943,7 @@ function cloneCustomNodeFallback(
   const requirements = join(nodeDir, "requirements.txt");
   const installScript = join(nodeDir, "install.py");
   if (existsSync(requirements) || existsSync(installScript)) {
-    const python = resolveVenvPython();
+    const python = resolveVenvPython(comfyuiBase);
     if (existsSync(requirements)) {
       try {
         execFileSync(python, ["-m", "pip", "install", "-r", requirements], {
@@ -986,6 +999,11 @@ export interface InstallOptions {
   channel?: string;
   /** Force the official comfy-cli subprocess instead of the HTTP API. */
   useCmCli?: boolean;
+  /** CALL-SCOPED local ComfyUI root for the git-clone / ref-checkout fallback,
+   *  threaded by callers (e.g. apply_manifest) that resolve an adopted
+   *  saved-default/live root WITHOUT mutating global config.comfyuiPath. Falls
+   *  back to config.comfyuiPath when omitted. */
+  comfyuiPath?: string;
 }
 
 /**
@@ -1013,6 +1031,7 @@ async function installCustomNodeImpl(
   opts: InstallOptions,
 ): Promise<NodeOpResult> {
   const { id, version, mode = "remote", channel = "default" } = opts;
+  const basePath = opts.comfyuiPath ?? config.comfyuiPath;
   const parsedGit = parseGitUrl(id);
   const gitId = parsedGit.baseUrl;
   const gitRefCandidate = opts.ref ?? parsedGit.ref ?? version;
@@ -1039,7 +1058,7 @@ async function installCustomNodeImpl(
     const installId = source === "git" ? gitId : id;
     const out = runCmCli(["install", installId, "--mode", mode, "--channel", channel]);
     if (source === "git" && gitRef) {
-      runGitCheckout(gitId, gitRef);
+      runGitCheckout(gitId, gitRef, basePath);
     }
     return {
       mechanism: "comfy-cli",
@@ -1097,7 +1116,7 @@ async function installCustomNodeImpl(
         details: status,
       };
     }
-    return cloneCustomNodeFallback(gitId, repoName, gitRef, status);
+    return cloneCustomNodeFallback(gitId, repoName, gitRef, status, basePath);
   }
 
   // Registry (plain CNR id). Keep the prior defaults channel "default" /

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,7 +1,8 @@
+import { existsSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { config } from "../config.js";
+import { config, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
-import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+import { resolveEffectiveComfyUIBase, liveRootFromArgv } from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -138,12 +139,47 @@ export function parseExtraModelPathsConfigsFromArgv(argv: string[] | undefined):
 export async function resolveModelsDir(): Promise<string> {
   try {
     const stats = await getSystemStats();
-    const fromArgv = parseModelsDirFromArgv(stats.system?.argv);
+    const argv = stats.system?.argv;
+    const fromArgv = parseModelsDirFromArgv(argv);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI models directory from launch argv", {
         modelsDir: fromArgv,
       });
       return fromArgv;
+    }
+    // No explicit --base-directory/--models-directory flag: derive the models
+    // root from the LIVE connected server's OWN install root (its main.py path in
+    // argv). That is the ComfyUI actually running, so a download lands where it
+    // reads models — NOT in a stale/other COMFYUI_PATH that points at a different
+    // install (#490/#463). Skip in remote mode: the live root is a path on the
+    // remote host, not a local directory we can write to.
+    //
+    // LIMITATION: this needs an ABSOLUTE main.py in argv (or a server-reported
+    // cwd). A server launched as `python main.py` reports a bare/relative argv[0]
+    // and ComfyUI does not currently report cwd, so the root is UNRESOLVABLE — we
+    // then fall through to the COMFYUI_PATH/default below. That's the safe default
+    // (there is no information to do better); when COMFYUI_PATH is unset, the
+    // download instead routes through the connected server's Manager, which writes
+    // into the real install regardless (see shouldDispatchDownloadToManager).
+    if (!isRemoteMode()) {
+      const liveRoot = liveRootFromArgv(
+        argv,
+        (stats.system as { cwd?: string })?.cwd,
+      );
+      // Only adopt the live root when it ACTUALLY EXISTS on this filesystem. A
+      // loopback ComfyUI inside Docker / behind an SSH port-forward reports a
+      // container-side main.py path that is not the host's — writing there would
+      // create a bogus host dir the server never reads. When it isn't locally
+      // present we fall through to COMFYUI_PATH/default (and shouldDispatchDownload-
+      // ToManager routes the fetch through the server's Manager instead).
+      if (liveRoot && existsSync(liveRoot)) {
+        const dir = join(liveRoot, "models");
+        logger.debug(
+          "Resolved ComfyUI models directory from the live server's main.py root",
+          { modelsDir: dir },
+        );
+        return dir;
+      }
     }
   } catch (err) {
     logger.debug(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -226,6 +226,20 @@ export class UiBridge {
   private missedFrames = new Map<string, Record<string, unknown>[]>();
   private static readonly MAX_MISSED_FRAMES = 100;
   private pending = new Map<string, Pending>();
+  /** ask_user card sends (rid → {ask_id, ts}): lets a reply that validates AFTER
+   *  the reply timer fired (dropped from `pending`) still be buffered for the
+   *  caller, instead of being discarded as a "late reply for a timed-out command"
+   *  (#486). Timestamped so an abandoned mapping (timeout/disconnect/send-failure
+   *  whose late reply never arrives) is TTL-pruned rather than kept forever. */
+  private askRidToId = new Map<string, { askId: string; ts: number }>();
+  /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
+   *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
+   *  answer is pruned rather than kept forever. */
+  private lateAskReplies = new Map<string, { result: unknown; ts: number }>();
+  /** TTL for a buffered late ask answer / an unresolved rid→ask_id mapping. Long
+   *  enough to cover a slow human pick within the MCP tools/call budget, short
+   *  enough that abandoned entries don't accumulate. */
+  private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
@@ -665,9 +679,24 @@ export class UiBridge {
       const rid = typeof msg.rid === "string" ? msg.rid : undefined;
       if (rid) {
         const p = this.pending.get(rid);
-        if (!p) return; // late reply for a timed-out command
+        if (!p) {
+          // Late reply for a timed-out command. If it was an ask_user card whose
+          // caller may still be within the MCP tools/call budget, BUFFER the
+          // validated answer keyed by its ask_id so the caller can retrieve it via
+          // takeLateAskReply() instead of losing it (#486). Everything else drops.
+          const entry = this.askRidToId.get(rid);
+          if (entry) {
+            this.askRidToId.delete(rid);
+            if (msg.ok) {
+              this.pruneLateAsk();
+              this.lateAskReplies.set(entry.askId, { result: msg.result, ts: Date.now() });
+            }
+          }
+          return;
+        }
         clearTimeout(p.timer);
         this.pending.delete(rid);
+        this.askRidToId.delete(rid);
         if (msg.ok) {
           p.resolve(msg.result);
         } else {
@@ -836,6 +865,43 @@ export class UiBridge {
     // offline, so a render finishing during a disconnect is byte-inlined (not a
     // bytes-less viewRef) and is renderable when the mailbox flushes to the phone.
     return this.conns.get(tabId)?.headless === true || this.headlessSeen.has(tabId);
+  }
+
+  /** Drop expired late-ask entries (buffered answers + unresolved rid mappings) so
+   *  an abandoned card never leaks memory. Cheap; called on each ask send/take. */
+  private pruneLateAsk(): void {
+    const now = Date.now();
+    for (const [id, e] of this.lateAskReplies) {
+      if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.lateAskReplies.delete(id);
+    }
+    // TTL-prune abandoned rid→ask_id mappings (a card that timed out / dropped and
+    // whose late reply never came), so they don't linger past the window a caller
+    // could still claim them.
+    for (const [rid, e] of this.askRidToId) {
+      if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.askRidToId.delete(rid);
+    }
+    // Belt-and-suspenders cardinality cap in case of a burst of asks within one TTL
+    // window — drop the oldest-inserted mappings so the map can never grow unbounded.
+    if (this.askRidToId.size > 256) {
+      const excess = this.askRidToId.size - 256;
+      let i = 0;
+      for (const rid of this.askRidToId.keys()) {
+        if (i++ >= excess) break;
+        this.askRidToId.delete(rid);
+      }
+    }
+  }
+
+  /** Retrieve (and remove) a late-but-valid ask_user answer buffered for `askId`
+   *  after the card-reply timeout, or undefined if none arrived. The panel_ask
+   *  handler polls this for a bounded grace so a slow-but-valid pick is honored
+   *  rather than discarded (#486). */
+  takeLateAskReply(askId: string): unknown | undefined {
+    this.pruneLateAsk();
+    const e = this.lateAskReplies.get(askId);
+    if (!e) return undefined;
+    this.lateAskReplies.delete(askId);
+    return e.result;
   }
 
   /** All currently connected tabs, most recent hello last. */
@@ -1008,6 +1074,14 @@ export class UiBridge {
     }
     const replyTimeoutMs = Math.min(ctx.timeoutMs, remaining);
     const rid = randomUUID();
+    // Track an ask_user card's stable ask_id against this attempt's rid so a reply
+    // that validates AFTER the reply timer fires (and drops out of `pending`) can
+    // still be buffered for the caller by rid, not discarded (#486 late answer).
+    const askId = (cmd as { ask_id?: unknown }).ask_id;
+    if (typeof askId === "string" && askId) {
+      this.pruneLateAsk();
+      this.askRidToId.set(rid, { askId, ts: Date.now() });
+    }
     // Rewrite an old-panel "Unknown command" rejection into an actionable
     // update-your-panel message (see makeUnknownCommandError). Applied to the
     // reply-error path only; the happy path and genuine command errors are

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -93,7 +93,7 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
 const ASSET_FILE_RE =
   /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml)$/i;
 
-function looksLikeAssetFilename(value: unknown): boolean {
+export function looksLikeAssetFilename(value: unknown): boolean {
   return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
 }
 

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -83,27 +83,19 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
 }
 
 /**
- * Model/asset file extensions that appear in ComfyUI loader combos
- * (unet_name, ckpt_name, vae_name, lora_name, control_net_name, clip_name, …).
- * Used to distinguish an asset-selection combo — where substituting a different
- * installed file silently swaps the user's model — from a plain enum combo
- * (sampler_name, a stale "Select to add Wildcard" UI helper) where falling back
- * to the first option is harmless.
- */
-const ASSET_FILE_RE =
-  /\.(safetensors|safetensor|sft|ckpt|pt|pt2|pth|bin|gguf|onnx|vae|pkl|npz|yaml)$/i;
-
-function looksLikeAssetFilename(value: unknown): boolean {
-  return typeof value === "string" && ASSET_FILE_RE.test(value.trim());
-}
-
-/**
- * Widget names that are ALWAYS server-side asset selectors, even when their
+ * Widget names that are ALWAYS server-side MODEL asset selectors, even when their
  * options carry no file extension (e.g. DiffusersLoader.model_path lists
  * extensionless directory names). Substituting a different entry here silently
- * swaps the user's model, so these must never take the comboOpts[0] fallback.
- * Deliberately excludes enum-shaped "_name" widgets (sampler_name, scheduler)
- * whose first-option fallback is legitimate.
+ * swaps the user's model, so these must never take the comboOpts[0] fallback
+ * (issue #407). These "_name"/"model_path" widget names are unambiguous model
+ * selectors on every node that exposes them, so a plain name match is safe.
+ *
+ * Deliberately EXCLUDES generic media names (image/audio/video) and enum-shaped
+ * "_name" widgets (sampler_name, scheduler): those are NOT globally asset
+ * selectors — a combo merely *named* `image` on some non-loader node, or a
+ * `sampler_name`, is a true enum whose first-option fallback is legitimate.
+ * Media/upload selectors are recognized structurally instead (see
+ * LOADER_ASSET_INPUTS and isUploadSelectorSpec).
  */
 const ASSET_WIDGET_NAMES = new Set([
   "ckpt_name",
@@ -126,6 +118,255 @@ const ASSET_WIDGET_NAMES = new Set([
 ]);
 
 /**
+ * KNOWN server-side file/upload SELECTORS, keyed by (classType → input name):
+ * real loader nodes whose combo lists media files present on the *connected*
+ * server (uploads or on-disk inputs). For these — and ONLY these, plus the
+ * model-loader widget names in ASSET_WIDGET_NAMES and object_info upload-flag
+ * metadata (isUploadSelectorSpec) — a value absent from a STALE combo is
+ * PRESERVED with a warning rather than silently rewritten to comboOpts[0]
+ * (issue #504). This is deliberately an allowlist, NOT a global name/extension
+ * heuristic: a combo merely *named* `image`/`audio`/`video`/`extension` on some
+ * OTHER node, or a media-looking value (`.bmp`, `.mp4`, …) on a TRUE enum, is
+ * NOT an asset selector and must take the enum fallback (substitute + warn) so
+ * ComfyUI does not hard-reject a "Value not in list".
+ */
+const LOADER_ASSET_INPUTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["LoadImage", new Set(["image"])],
+  ["LoadImageMask", new Set(["image"])],
+  ["LoadImageOutput", new Set(["image"])],
+  ["VHS_LoadVideo", new Set(["video"])],
+  ["VHS_LoadVideoPath", new Set(["video"])],
+  ["VHS_LoadVideoFFmpeg", new Set(["video"])],
+  ["VHS_LoadVideoFFmpegPath", new Set(["video"])],
+  ["LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudio", new Set(["audio"])],
+  ["VHS_LoadAudioUpload", new Set(["audio"])],
+]);
+
+function isKnownLoaderInput(classType: string, name: string): boolean {
+  return LOADER_ASSET_INPUTS.get(classType)?.has(name) ?? false;
+}
+
+/**
+ * Whether object_info marks this input as an in-browser file/media UPLOAD
+ * selector — the authoritative signal that the combo lists server-side input
+ * files (LoadImage's `image` carries `{image_upload: true}`, audio/video loaders
+ * `{audio_upload|video_upload: true}`). When present this is more reliable than
+ * any name allowlist, so a staged value absent from a stale combo is preserved.
+ */
+function isUploadSelectorSpec(spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  const cfg = spec[1] as Record<string, unknown> | undefined;
+  if (!cfg || typeof cfg !== "object") return false;
+  return (
+    cfg.image_upload === true ||
+    cfg.audio_upload === true ||
+    cfg.video_upload === true
+  );
+}
+
+/**
+ * Extract the selectable option list from a widget spec, covering ALL three
+ * combo shapes so validation never misses one (issue #504 P1-B):
+ *   - inline combo:      [["a","b"], {..}]                 -> spec[0]
+ *   - COMBO w/ options:  ["COMBO", {options:["a","b"]}]    -> spec[1].options
+ *   - V3 dynamic combo:  ["COMFY_DYNAMICCOMBO_V3",         -> the option keys
+ *                          {options:[{key:"K", inputs:{…}}]}]
+ * A plain scalar spec (["INT",{…}]) or a link input carries no enumerable list,
+ * so this returns undefined and the caller passes the value through untouched.
+ * Object-shaped dynamic options are normalized to their `key`.
+ */
+function getComboOptions(spec: unknown): unknown[] | undefined {
+  if (!Array.isArray(spec)) return undefined;
+  const type = spec[0];
+  if (Array.isArray(type)) return type; // inline combo: spec[0] IS the option list
+  const cfg = spec[1] as { options?: unknown } | undefined;
+  const opts = cfg?.options;
+  if (Array.isArray(opts)) {
+    // Flat value list (["auto","1:1"]) or object-keyed dynamic-combo list
+    // ([{key:"Nano Banana 2", …}]). Normalize both to their selectable values.
+    return opts.map((o) =>
+      o &&
+      typeof o === "object" &&
+      !Array.isArray(o) &&
+      "key" in (o as Record<string, unknown>)
+        ? (o as { key: unknown }).key
+        : o,
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Validate one saved combo value against its object_info options (of ANY combo
+ * shape — see getComboOptions) and return the value to store. This is the SINGLE
+ * choke-point every combo-value assignment flows through — direct widget, the
+ * name→value object form, the has_serialized_properties overwrite, a linked
+ * PrimitiveNode literal (P1-A), AND a V3 dynamic-combo nested leaf value (P1-B) —
+ * so no path can emit a value ComfyUI would reject with "Value not in list".
+ *
+ * Non-combo specs and in-list values pass through unchanged. For an out-of-list
+ * value the decision mirrors #407/#504:
+ *
+ *  - genuine ASSET/upload selector (model-loader widget name, (classType,input)
+ *    loader allowlist, or object_info upload flag) → PRESERVE + warn, so a
+ *    staged/absent file surfaces as an honest missing-asset error rather than a
+ *    silent wrong-file swap;
+ *  - true ENUM (sampler_name, scheduler, a stale "Select to add Wildcard"
+ *    helper, a combo merely NAMED image/extension, a media-looking value on a
+ *    non-loader enum, an out-of-list dynamic/nested key) → SUBSTITUTE
+ *    comboOpts[0] + warn, because ComfyUI hard-rejects a "Value not in list".
+ *
+ * `name` is the LEAF input name (nested leaf for dynamic combos) so asset
+ * classification keys off the real selector name, and `spec` is that leaf's
+ * spec, never regressing #504/#407.
+ */
+function validateComboValueForSpec(
+  name: string,
+  value: unknown,
+  spec: unknown,
+  classType: string,
+  nodeId: string,
+  warnings: string[],
+): unknown {
+  const comboOpts = getComboOptions(spec);
+  // Not an enumerable combo (plain INT/FLOAT/STRING/BOOLEAN or a link input) —
+  // nothing to validate against.
+  if (!Array.isArray(comboOpts)) return value;
+  // Already a valid option — pass through untouched.
+  if (comboOpts.includes(value as never)) return value;
+  const isAssetCombo =
+    ASSET_WIDGET_NAMES.has(name) ||
+    isKnownLoaderInput(classType, name) ||
+    isUploadSelectorSpec(spec);
+  // Recognized combo whose option list is EMPTY on the connected server (e.g. no
+  // models/files installed, or a fully-retired enum). There is no valid option to
+  // substitute to, so preserve the declared value and WARN — surfacing an honest
+  // missing-option/asset error rather than SILENTLY emitting an out-of-list
+  // literal. (Previously the length===0 branch returned the value with no warning.)
+  if (comboOpts.length === 0) {
+    warnings.push(
+      isAssetCombo
+        ? `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+            value,
+          )}" — the connected server has no installed options for this asset combo; keeping the declared value so it surfaces as a missing-asset error.`
+        : `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+            value,
+          )}" — the connected server lists no options for this combo, so it cannot be validated; keeping the declared value so it surfaces as an honest error rather than being silently emitted.`,
+    );
+    return value;
+  }
+  if (isAssetCombo) {
+    warnings.push(
+      `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+        value,
+      )}" is not installed on the connected server — keeping the declared value so it surfaces as a missing-asset error rather than silently substituting "${String(
+        comboOpts[0],
+      )}".`,
+    );
+    return value;
+  }
+  warnings.push(
+    `Node ${nodeId} (${classType}): widget "${name}" value "${String(
+      value,
+    )}" is not a valid option on the connected server — substituting the first available option "${String(
+      comboOpts[0],
+    )}" so the graph stays runnable (ComfyUI rejects unknown enum values).`,
+  );
+  return comboOpts[0];
+}
+
+/**
+ * Def-keyed wrapper for validateComboValueForSpec: resolves the input's spec from
+ * object_info by name (required then optional) and delegates. Used by the direct
+ * widget paths and the linked-PrimitiveNode path.
+ */
+function validateComboWidgetValue(
+  name: string,
+  value: unknown,
+  def: ComfyUINodeDef,
+  classType: string,
+  nodeId: string,
+  warnings: string[],
+): unknown {
+  const spec =
+    (def.input?.required as Record<string, unknown>)?.[name] ??
+    (def.input?.optional as Record<string, unknown>)?.[name];
+  return validateComboValueForSpec(name, value, spec, classType, nodeId, warnings);
+}
+
+/**
+ * Resolve an input NAME (possibly a V3 dynamic-combo dotted "<combo>.<leaf>"
+ * key) to its LEAF name and object_info spec. A flat name resolves against the
+ * node's top-level required/optional inputs. A dotted name resolves the leaf
+ * against the parent dynamic combo's SELECTED option (looked up from the already
+ * populated `inputs[parent]`), so validation and asset classification key off
+ * the real leaf spec + leaf name — never the dotted name (which no top-level
+ * lookup would find, letting an unvalidated value through). Used by the linked
+ * PrimitiveNode path, where a primitive can feed a nested dotted input directly.
+ */
+function resolveWidgetSpec(
+  def: ComfyUINodeDef,
+  name: string,
+  inputs: Record<string, unknown>,
+): { leafName: string; spec: unknown } {
+  const dot = name.indexOf(".");
+  if (dot < 0) {
+    const spec =
+      (def.input?.required as Record<string, unknown>)?.[name] ??
+      (def.input?.optional as Record<string, unknown>)?.[name];
+    return { leafName: name, spec };
+  }
+  const parent = name.slice(0, dot);
+  const leafName = name.slice(dot + 1);
+  const parentSpec =
+    (def.input?.required as Record<string, unknown>)?.[parent] ??
+    (def.input?.optional as Record<string, unknown>)?.[parent];
+  const opts = (
+    Array.isArray(parentSpec)
+      ? (parentSpec[1] as {
+          options?: Array<{
+            key?: unknown;
+            inputs?: {
+              required?: Record<string, unknown>;
+              optional?: Record<string, unknown>;
+            };
+          }>;
+        })
+      : undefined
+  )?.options;
+  const selectedKey = inputs[parent];
+  // V3 option inputs may live under required OR optional — search both so an
+  // optional nested leaf isn't left unresolved (which would skip validation).
+  const selected = Array.isArray(opts)
+    ? opts.find((o) => o?.key === selectedKey)?.inputs
+    : undefined;
+  const spec = selected?.required?.[leafName] ?? selected?.optional?.[leafName];
+  return { leafName, spec };
+}
+
+/**
+ * Whether a widget SPEC carries a control_after_generate phantom slot — either
+ * flagged in its config, or a seed-type INT the ComfyUI frontend auto-augments.
+ * Works for both top-level inputs and V3 dynamic-combo NESTED leaves (which have
+ * no entry in def.input), so nested controlled seeds skip their phantom
+ * "fixed"/"randomize" slot too instead of shifting every following widget.
+ */
+function specHasControlAfterGenerate(name: string, spec: unknown): boolean {
+  if (!Array.isArray(spec)) return false;
+  if ((spec[1] as Record<string, unknown> | undefined)?.control_after_generate === true)
+    return true;
+  // ComfyUI's frontend auto-adds a control_after_generate widget to seed-type INT
+  // widgets even when object_info doesn't flag it (e.g. UltimateSDUpscale.seed,
+  // KSamplerAdvanced.noise_seed). The saved widgets_values then carry the extra
+  // "fixed"/"randomize"/… value that must be skipped during mapping.
+  return (
+    spec[0] === "INT" &&
+    (name === "seed" || name === "noise_seed" || name === "rand_seed")
+  );
+}
+
+/**
  * Check if an input has control_after_generate in its spec config.
  * These inputs (like seed, noise_seed) have a phantom "fixed"/"randomize" widget
  * in the UI's widgets_values array that doesn't correspond to any named input.
@@ -137,18 +378,7 @@ function hasControlAfterGenerate(
   const spec =
     def.input.required?.[inputName] ?? def.input.optional?.[inputName];
   if (!spec) return false;
-  if ((spec[1] as Record<string, unknown> | undefined)?.control_after_generate === true)
-    return true;
-  // ComfyUI's frontend auto-adds a control_after_generate widget to seed-type INT
-  // widgets even when object_info doesn't flag it (e.g. UltimateSDUpscale.seed,
-  // KSamplerAdvanced.noise_seed). The saved widgets_values then carry the extra
-  // "fixed"/"randomize"/… value that must be skipped during mapping.
-  if (
-    spec[0] === "INT" &&
-    (inputName === "seed" || inputName === "noise_seed" || inputName === "rand_seed")
-  )
-    return true;
-  return false;
+  return specHasControlAfterGenerate(inputName, spec);
 }
 
 /**
@@ -1221,6 +1451,17 @@ export function convertUiToApi(
       }
     }
 
+    // Nested widgets that have been "converted to input" (linked) carry NO
+    // positional widgets_values slot — their value arrives via the link, not the
+    // saved array — so consuming a slot for them would steal the next widget's
+    // value and mis-align the whole tail. Track the linked (dotted) input names
+    // to skip their positional consumption below.
+    const linkedInputNames = new Set(
+      (node.inputs ?? [])
+        .filter((i) => i.link != null)
+        .map((i) => i.name),
+    );
+
     // Map widgets_values to named widget inputs.
     // Some INT inputs with "control_after_generate": true (like seed, noise_seed) have
     // a phantom widget value in widgets_values ("fixed"/"randomize"/"increment"/"decrement")
@@ -1232,12 +1473,55 @@ export function convertUiToApi(
     if (!Array.isArray(widgetValues)) {
       const wv = widgetValues as Record<string, unknown>;
       for (const name of widgetNames) {
-        if (name in wv) inputs[name] = wv[name];
+        if (name in wv)
+          inputs[name] = validateComboWidgetValue(
+            name,
+            wv[name],
+            def,
+            classType,
+            nodeId,
+            warnings,
+          );
       }
     } else {
     let widgetIdx = 0;
-    for (const name of widgetNames) {
+    // A still-valid dynamic-combo option whose NESTED arity DRIFTED between save
+    // and load (the option kept its key but added/removed nested inputs) can't be
+    // detected up front — its saved nested slots were serialized against the OLD
+    // arity, but we map using the CURRENT one, so any drift shifts the trailing
+    // top-level widgets (e.g. a since-removed nested "multiplier" leaves its stale
+    // value to land on the seed). The stale-parent guard below only catches a
+    // REMOVED option (key absent). For a still-present option, a LEFTOVER saved
+    // value after the whole positional mapping is the reliable drift signal — a
+    // self-consistent layout consumes exactly. Track whether a still-valid dynamic
+    // combo was processed and which widgets were mapped AFTER it, so on leftover we
+    // can default those (shifted) widgets + warn instead of trusting the shift.
+    let sawDynamicCombo = false;
+    // Set when ANY combo hits a refusal (stale/empty-options parent, or a linked-
+    // nested leaf). A refusal INTENTIONALLY stops mapping and leaves the tail
+    // unconsumed, so the leftover it creates is EXPECTED — it does NOT prove that an
+    // EARLIER combo drifted. Positionally, a valid layout ([first, first.note,
+    // count, second→refuse]) and a drifted one are IDENTICAL once a refusal is
+    // present, so acting on that leftover would DELETE valid earlier values (a real
+    // regression). Therefore a refusal suppresses the leftover drift guard entirely
+    // for this node; the drift guard fires only on a leftover with NO refusal, where
+    // it unambiguously means the arity shrank.
+    let refusalOccurred = false;
+    const widgetsAfterDynamicCombo: string[] = [];
+    // Dotted "<combo>.<leaf>" keys assigned positionally from a dynamic combo's
+    // nested layout. On a proven arity drift (leftover) these are ALSO suspect — a
+    // since-removed nested slot shifts every later nested value onto the wrong leaf
+    // (old A=[obsolete, strength], current A=[strength], saved ["A",4,0.75] maps
+    // strength=4, the obsolete value) — so the drift guard defaults them too, not
+    // just the trailing top-level widgets.
+    const nestedKeysFromDynamic: string[] = [];
+    for (let nameIdx = 0; nameIdx < widgetNames.length; nameIdx++) {
+      const name = widgetNames[nameIdx];
       if (widgetIdx >= widgetValues.length) break;
+      // A widget mapped AFTER a still-valid dynamic combo is positionally
+      // downstream of its (unverifiable) nested arity — record it for the
+      // drift-leftover check below.
+      if (sawDynamicCombo) widgetsAfterDynamicCombo.push(name);
       const value = widgetValues[widgetIdx];
       inputs[name] = value;
       widgetIdx++;
@@ -1256,50 +1540,134 @@ export function convertUiToApi(
       // Classic combo widget: if the saved value isn't one of the valid options
       // (a stale UI-helper combo like Impact's "Select to add Wildcard", or a
       // value from a node version with different options), fall back to the
-      // default first option. ComfyUI hard-rejects "Value not in list" otherwise,
-      // so defaulting is strictly safer than passing the stale value through.
-      //
-      // EXCEPTION (issue #407): an ASSET-selection combo (unet_name, ckpt_name,
-      // vae_name, lora_name, …) lists the files installed on the *connected*
-      // server. When the declared model isn't installed there, comboOpts[0] is a
-      // completely unrelated model — e.g. Krea 2's "krea2_turbo_fp8.safetensors"
-      // silently became "flux-2-klein-9b.safetensors" (the first installed unet).
-      // Silently swapping one model for another produces a misleading graph that
-      // can't render the advertised workflow. For asset combos we KEEP the
-      // declared value and warn, so it surfaces as an honest missing-asset error
-      // instead of a wrong-model success.
-      const comboOpts = Array.isArray(spec) ? spec[0] : undefined;
-      if (
-        Array.isArray(comboOpts) &&
-        comboOpts.length > 0 &&
-        !comboOpts.includes(value as never)
-      ) {
-        const isAssetCombo =
-          ASSET_WIDGET_NAMES.has(name) ||
-          looksLikeAssetFilename(value) ||
-          comboOpts.some((opt) => looksLikeAssetFilename(opt));
-        if (isAssetCombo) {
-          warnings.push(
-            `Node ${nodeId} (${classType}): widget "${name}" value "${String(
-              value,
-            )}" is not installed on the connected server — keeping the declared value so it surfaces as a missing-asset error rather than silently substituting "${String(
-              comboOpts[0],
-            )}".`,
-          );
-          // inputs[name] already holds the declared value; leave it untouched.
-        } else {
-          inputs[name] = comboOpts[0];
-        }
-      }
+      // default first option — UNLESS it's a genuine asset/upload selector, which
+      // we preserve + warn (#407/#504). See validateComboWidgetValue for the full
+      // classification (model-loader names + (classType,input) loader allowlist +
+      // object_info upload flag — NOT a global name/extension heuristic).
+      inputs[name] = validateComboWidgetValue(
+        name,
+        value,
+        def,
+        classType,
+        nodeId,
+        warnings,
+      );
 
       const opts = (
         Array.isArray(spec)
-          ? (spec[1] as { options?: Array<{ key?: unknown; inputs?: { required?: Record<string, unknown> } }> })
+          ? (spec[1] as {
+              options?: Array<{
+                key?: unknown;
+                inputs?: {
+                  required?: Record<string, unknown>;
+                  optional?: Record<string, unknown>;
+                };
+              }>;
+            })
           : undefined
       )?.options;
-      const nested = Array.isArray(opts)
-        ? opts.find((o) => o?.key === value)?.inputs?.required
+      // A V3 option's nested widgets can live under required OR optional; both
+      // occupy positional widgets_values slots in serialization order (required
+      // then optional). Merging them keeps the positional index aligned AND
+      // ensures every nested leaf is validated — reading only `required` would
+      // skip an optional leaf and mis-position every later widget.
+      //
+      // Look up the option by the RAW saved `value` (the selection the array was
+      // serialized against), NOT the post-validation inputs[name]. If the saved
+      // selection is stale (its option was removed/renamed), its ORIGINAL nested
+      // arity is unrecoverable, so consuming zero nested slots while still
+      // advancing the top-level index would silently misassign a leftover nested
+      // value onto the trailing top-level widgets (e.g. a removed option's nested
+      // strength overwriting the user's seed). The stale-parent guard below REFUSES
+      // that case (warn + stop) instead of guessing.
+      // A V3 dynamic combo must be identified by its EXPLICIT type string
+      // (spec[0] === "COMFY_DYNAMICCOMBO_V3"), NOT by whether its current options
+      // list happens to contain keyed objects. An EMPTY current options list
+      // (["COMFY_DYNAMICCOMBO_V3", {options: []}]) has NO keyed entries, so the
+      // object-key heuristic alone reports false and the stale-parent guard below
+      // never fires — re-opening the exact silent-positional-shift hole: with an
+      // empty options list every saved selection is stale, and consuming zero
+      // nested slots while advancing the top-level index misassigns a leftover
+      // nested value (e.g. a removed option's strength=0.75) onto the next widget
+      // (e.g. a seed). Keying off the type covers the empty-options case too.
+      //
+      // The object-key heuristic is retained as a fallback for any V3 dynamic list
+      // that carries keyed {key, inputs} entries without the literal type marker.
+      // A classic string-option COMBO (spec[0] is the ["a","b"] options array, not
+      // the "COMFY_DYNAMICCOMBO_V3" string) matches NEITHER branch, so it must NOT
+      // trip the stale-parent guard below (which would wrongly refuse a perfectly
+      // valid classic-combo value).
+      const specType = Array.isArray(spec) ? spec[0] : undefined;
+      const isDynamicComboType = specType === "COMFY_DYNAMICCOMBO_V3";
+      const isDynamicOptions =
+        isDynamicComboType ||
+        (Array.isArray(opts) &&
+          opts.some(
+            (o) =>
+              o != null &&
+              typeof o === "object" &&
+              !Array.isArray(o) &&
+              "key" in (o as Record<string, unknown>),
+          ));
+      const savedOption = Array.isArray(opts)
+        ? opts.find((o) => o?.key === value)
         : undefined;
+
+      // P0 (#517): STALE dynamic-combo parent. The saved selection is NOT among
+      // the current dynamic options (the option was removed/renamed, or was
+      // substituted above). The saved array was serialized against the OLD
+      // option's layout: [parent, <OLD option's nested slots>, ...trailing
+      // top-level widgets...]. The OLD nested arity is unknowable from THIS schema,
+      // so the pre-fix code consumed ZERO nested slots while still advancing the
+      // top-level index — silently mapping a leftover stale nested value onto the
+      // next widget (e.g. a removed option's strength=0.75 landing on the user's
+      // seed, discarding the real 42 with no warning).
+      //
+      // The saved array was serialized as
+      //   [parent, <removed option's nested slots>, ...trailing top-level widgets...]
+      // and we CANNOT reconstruct where the orphaned-nested block ends: NEITHER the
+      // removed option's nested arity NOR the trailing widgets' saved-slot count is
+      // recoverable. The trailing count is doubly unknown — a nested seed carries a
+      // variable control_after_generate phantom, a trailing dynamic combo adds a
+      // value-dependent number of slots, AND the current schema may have added or
+      // removed trailing widgets since the graph was saved. A surplus arithmetic
+      // (values-left vs current trailing-widget-count) silently mis-attributes
+      // orphaned slots whenever any of those drift (e.g. a schema-added trailing
+      // widget makes surplus cancel to zero while an orphan still sits before the
+      // seed). Because NO positional reconstruction is provably safe, REFUSE: warn
+      // and stop positional mapping here so an orphaned nested value can NEVER be
+      // silently mapped onto a later top-level widget (such as a seed). The
+      // remaining required inputs then default-fill below. The parent itself was
+      // already substituted + warned via validateComboWidgetValue above.
+      if (
+        isDynamicOptions &&
+        savedOption === undefined &&
+        widgetIdx < widgetValues.length
+      ) {
+        warnings.push(
+          `Node ${nodeId} (${classType}): widget "${name}" saved selection "${String(
+            value,
+          )}" is no longer an available option, so the removed option's nested-input layout can't be reconstructed. The remaining ${
+            widgetValues.length - widgetIdx
+          } saved widget value(s) are left to their defaults rather than risk silently assigning a stale nested value to a later widget (such as a seed).`,
+        );
+        // A refusal's leftover is expected and can't be attributed to earlier drift,
+        // so suppress the drift guard for this node (see refusalOccurred note).
+        refusalOccurred = true;
+        break;
+      }
+
+      // Still-valid dynamic combo (option key present): its nested arity is trusted
+      // from the CURRENT schema but can't be verified against the save — flag it so
+      // the post-loop leftover check can detect a drift-induced tail shift.
+      if (isDynamicOptions && savedOption !== undefined) sawDynamicCombo = true;
+
+      const selectedInputs = savedOption?.inputs;
+      const nested =
+        selectedInputs &&
+        (selectedInputs.required || selectedInputs.optional)
+          ? { ...selectedInputs.required, ...selectedInputs.optional }
+          : undefined;
       if (nested) {
         // V3 dynamic-combo nested inputs are keyed with the combo's id as a
         // "<combo>.<nested>" prefix (ComfyUI rebuilds the nested dict from these
@@ -1308,13 +1676,119 @@ export function convertUiToApi(
         // non-widget nested inputs (AUTOGROW lists like Nano Banana 2's
         // "images", or IMAGE/link types) have no saved widget value, so skipping
         // them keeps the positional mapping aligned.
+        let refuseTail = false;
         for (const [nName, nSpec] of Object.entries(nested)) {
-          if (widgetIdx >= widgetValues.length) break;
           if (!isPositionalWidgetSpec(nSpec)) continue;
-          inputs[`${name}.${nName}`] = widgetValues[widgetIdx];
+          // A linked (converted-to-input) nested leaf's value arrives via the link
+          // loop below, NOT the saved array. Other/older frontend versions, though,
+          // RETAIN a serialized placeholder for a converted widget, so the leaf may
+          // OR may not still occupy a widgets_values slot — and that cannot be told
+          // apart positionally. If a placeholder IS present and we skip it without
+          // consuming, the retained value shifts onto the NEXT top-level widget: a
+          // seed silently becomes the placeholder (e.g. widgets_values
+          // [parent, 4(linked-nested placeholder), 424242(seed), "fixed"] would map
+          // seed=4). When trailing saved values remain, the alignment is
+          // unrecoverable, so REFUSE the tail — the same safe pattern as the
+          // stale-parent guard above: warn + leave the remaining top-level widgets
+          // to their defaults rather than risk a silent shift onto a later widget.
+          // (If NO trailing values remain there is nothing to misassign, so the
+          // link simply supplies the leaf and the loop ends.)
+          if (linkedInputNames.has(`${name}.${nName}`)) {
+            if (widgetIdx < widgetValues.length) {
+              warnings.push(
+                `Node ${nodeId} (${classType}): widget "${name}" has a converted-to-input (linked) nested widget "${name}.${nName}" whose widgets_values slot can't be positionally resolved (frontend versions differ on whether a converted widget keeps a placeholder slot), so the remaining ${
+                  widgetValues.length - widgetIdx
+                } saved widget value(s) are left to their defaults rather than risk silently assigning a stale value to a later widget (such as a seed).`,
+              );
+              refuseTail = true;
+              break;
+            }
+            continue;
+          }
+          if (widgetIdx >= widgetValues.length) break;
+          // Nested leaf values bypass the top-level widget validation, so validate
+          // each against ITS OWN leaf spec/name (P1-B). Asset classification keys
+          // off the leaf name + loader/upload allowlist (don't regress #504/#407);
+          // an out-of-list nested enum (e.g. aspect_ratio "4:3") substitutes+warns.
+          inputs[`${name}.${nName}`] = validateComboValueForSpec(
+            nName,
+            widgetValues[widgetIdx],
+            nSpec,
+            classType,
+            nodeId,
+            warnings,
+          );
+          nestedKeysFromDynamic.push(`${name}.${nName}`);
           widgetIdx++;
+          // A nested seed-type / control_after_generate leaf carries a phantom
+          // "fixed"/"randomize" value right after it (same as top-level seeds), so
+          // skip that slot or every following widget shifts by one.
+          if (
+            specHasControlAfterGenerate(nName, nSpec) &&
+            widgetIdx < widgetValues.length
+          ) {
+            widgetIdx++;
+          }
+        }
+        // A linked nested leaf with trailing saved values made the alignment
+        // ambiguous — stop mapping the remaining top-level widgets (they
+        // default-fill below) so no retained placeholder can shift onto a seed.
+        // This refusal's leftover is expected, so suppress the drift guard for this
+        // node (see refusalOccurred note) — otherwise it would delete valid earlier
+        // widgets/leaves mapped before this refusing combo.
+        if (refuseTail) {
+          refusalOccurred = true;
+          break;
         }
       }
+    }
+    // Drift guard: a LEFTOVER saved value after a still-valid dynamic combo means
+    // its nested arity SHRANK since the save (see the sawDynamicCombo note above) —
+    // the current option consumes fewer nested slots than the save held, leaving a
+    // provable leftover. A self-consistent layout consumes exactly; a leftover proves
+    // the positional mapping after (and WITHIN) the drifted combo is shifted: both the
+    // trailing top-level widgets AND the nested dotted leaves may hold a value that
+    // belongs to a since-removed slot (e.g. old A=[obsolete, strength], current
+    // A=[strength], saved ["A",4,0.75] maps strength=4 — the obsolete value). Default
+    // BOTH sets (delete so top-level widgets default-fill below and nested leaves fall
+    // to their runtime option defaults) and warn, rather than trust a silently shifted
+    // value on a later widget (such as a seed) OR a nested leaf. This fires on ANY
+    // leftover — even with no trailing top-level widget — so a shifted nested value
+    // can't survive. (Mirrors the stale-parent + linked-leaf refusals.)
+    //
+    // LIMITATION (accepted, BROAD): only the direction that nets to a LEFTOVER is
+    // catchable. Any nested-arity drift that nets to EXACT consumption is positionally
+    // INDISTINGUISHABLE from a legitimate layout and CANNOT be caught from
+    // widgets_values alone. That covers not just arity-GROWTH (option gained nested
+    // inputs) but ALSO arity-SHRINK masked by a newly-added TOP-LEVEL widget (a
+    // removed nested slot canceled by an added trailing widget → exact), and the
+    // multi-combo variants of both. Catching any of these would require refusing ALL
+    // trailing widgets after every dynamic combo — which regresses the canonical Nano
+    // Banana multi-nested node ([prompt, model, aspect_ratio, resolution,
+    // thinking_level, seed, control, response_modalities], an existing passing test).
+    // So this guard catches only the provable (leftover) direction.
+    //
+    // ALSO ACCEPTED (undecidable when a REFUSAL is present): a refusal (linked-leaf
+    // or stale/empty-options parent) INTENTIONALLY stops mapping, so the leftover it
+    // creates is EXPECTED and cannot be attributed to an earlier combo's drift — a
+    // valid layout ([first, first.note, count, second→refuse]) and a drifted one are
+    // positionally IDENTICAL once a refusal is present. Acting on that leftover would
+    // DELETE valid earlier values, so `refusalOccurred` suppresses this guard for the
+    // whole node. (Any earlier drift then falls to the accepted exact-consumption
+    // class above — a refusal's leftover is not a reliable drift signal.) The guard
+    // therefore fires ONLY on a leftover with NO refusal, where it unambiguously means
+    // the arity shrank.
+    if (sawDynamicCombo && !refusalOccurred && widgetIdx < widgetValues.length) {
+      for (const wn of widgetsAfterDynamicCombo) delete inputs[wn];
+      for (const nk of nestedKeysFromDynamic) delete inputs[nk];
+      const defaulted = [...nestedKeysFromDynamic, ...widgetsAfterDynamicCombo];
+      warnings.push(
+        `Node ${nodeId} (${classType}): a dynamic-combo option's nested-input layout appears to have changed since this workflow was saved (${
+          widgetValues.length - widgetIdx
+        } saved widget value(s) remain unmapped), so its nested leaves and the widget(s) positioned after it${
+          defaulted.length ? ` (${defaulted.join(", ")})` : ""
+        } are left to their defaults rather than risk a silently shifted value on a later widget (such as a seed) or nested leaf.`,
+      );
     }
     }
 
@@ -1331,7 +1805,15 @@ export function convertUiToApi(
     const serializedProps = node.properties as Record<string, unknown> | undefined;
     if (serializedProps?.has_serialized_properties === true) {
       for (const name of widgetNames) {
-        if (name in serializedProps) inputs[name] = serializedProps[name];
+        if (name in serializedProps)
+          inputs[name] = validateComboWidgetValue(
+            name,
+            serializedProps[name],
+            def,
+            classType,
+            nodeId,
+            warnings,
+          );
       }
     }
 
@@ -1357,7 +1839,21 @@ export function convertUiToApi(
       } else {
         dflt = config?.default;
       }
-      if (dflt !== undefined) inputs[name] = dflt;
+      if (dflt !== undefined) {
+        // A schema `default` can itself be out-of-list (custom-node combo drift,
+        // e.g. sampler_name default "removed_sampler" not in its own options).
+        // Route the derived default through the same choke-point so it can't emit
+        // a value ComfyUI rejects — first-option substitution for a true enum,
+        // leaf-name asset preservation for a loader/upload selector.
+        inputs[name] = validateComboValueForSpec(
+          name,
+          dflt,
+          spec,
+          classType,
+          nodeId,
+          warnings,
+        );
+      }
     }
 
     // Map linked inputs from node's inputs array (bypass/mute resolved)
@@ -1371,12 +1867,186 @@ export function convertUiToApi(
         const srcNode = link ? nodesById.get(link.sourceNodeId) : undefined;
         if (srcNode?.type === "PrimitiveNode") {
           const val = srcNode.widgets_values?.[0];
-          if (val !== undefined) inputs[input.name] = val;
+          // A linked PrimitiveNode literal bypasses the widget-value validation
+          // above (widgets are processed first, links after), so route it through
+          // the same choke-point (P1-A). A stale LOADER asset is preserved+warned;
+          // a true out-of-list ENUM (e.g. sampler_name "removed_sampler") is
+          // substituted+warned rather than reaching the API and being rejected.
+          // input.name may be a dynamic-combo dotted "<combo>.<leaf>" key, so
+          // resolve the leaf spec/name first — a top-level lookup would miss it
+          // and let the value through unvalidated.
+          if (val !== undefined) {
+            const { leafName, spec } = resolveWidgetSpec(def, input.name, inputs);
+            inputs[input.name] = validateComboValueForSpec(
+              leafName,
+              val,
+              spec,
+              classType,
+              nodeId,
+              warnings,
+            );
+          }
           continue;
         }
         const resolved = resolveSource(input.link);
         if (resolved) inputs[input.name] = [resolved.id, resolved.slot];
       }
+    }
+
+    // Final dependency-aware pass over V3 dynamic-combo dotted "<parent>.<leaf>"
+    // inputs: a link/PrimitiveNode override above can change the PARENT selection
+    // AFTER its nested leaves were validated against the ORIGINAL option (e.g.
+    // positional emits model="A"+model.choice="a1", then a primitive overrides
+    // model="B"). Re-anchor every dotted leaf to the FINAL parent value — drop a
+    // leaf that the selected option no longer defines, and revalidate the rest
+    // against the leaf's real spec — so no leaf reaches the prompt validated
+    // against the wrong option.
+    for (const key of Object.keys(inputs)) {
+      const dot = key.indexOf(".");
+      if (dot < 0) continue;
+      const parent = key.slice(0, dot);
+      // Orphaned dotted leaf: its dynamic parent isn't in the prompt (e.g. an
+      // optional parent left unset while the leaf was linked). There's no option
+      // context to validate against, and the leaf is meaningless without its
+      // parent — ComfyUI has no selected option so "<parent>.<leaf>" is an unknown
+      // input it hard-rejects. Default-DENY: drop the leaf UNCONDITIONALLY,
+      // whether it's an un-parented literal OR a link ref. Keeping a link ref here
+      // (the previous behavior) still emitted an orphan the server would reject.
+      if (!(parent in inputs)) {
+        delete inputs[key];
+        continue;
+      }
+      const leafVal = inputs[key];
+      // A leaf can itself be a LINK REF ([id, slot]) — a nested widget converted to
+      // input and wired to a real node. We can't membership-check its runtime
+      // value, but we CAN check whether the FINAL selected option even DEFINES the
+      // leaf: an array leaf under an option that doesn't define it is just as
+      // orphaned as a literal one, and ComfyUI hard-rejects the unknown input. So
+      // link-ref leaves are re-anchored too (previously they short-circuited here
+      // with an unconditional `continue`, leaking an orphan under an incompatible
+      // parent).
+      const leafIsLink = Array.isArray(leafVal);
+      // Parent fed by a real (non-Primitive) link → the SELECTED option is only
+      // known at runtime, so a leaf saved/linked under one option may be wrong
+      // for the resolved one. Keep it only if it validates under EVERY option
+      // that defines the leaf; otherwise drop it (ComfyUI supplies the runtime
+      // option's default). This prevents a wrong-option literal (e.g. option-A
+      // "a1" left on a parent that resolves to option B) reaching the prompt.
+      if (Array.isArray(inputs[parent])) {
+        const leaf = key.slice(dot + 1);
+        const pSpec =
+          (def.input?.required as Record<string, unknown>)?.[parent] ??
+          (def.input?.optional as Record<string, unknown>)?.[parent];
+        const pOpts = (
+          Array.isArray(pSpec)
+            ? (pSpec[1] as {
+                options?: Array<{
+                  inputs?: {
+                    required?: Record<string, unknown>;
+                    optional?: Record<string, unknown>;
+                  };
+                }>;
+              })
+            : undefined
+        )?.options;
+        // The resolved option is unknowable at convert time, so KEEP the leaf only
+        // if it stays valid WHICHEVER option resolves — i.e. it must be defined by
+        // EVERY option (definedEverywhere). If ANY option omits the leaf, that
+        // runtime resolution would orphan it (ComfyUI rejects the unknown nested
+        // input), so default-DENY and drop it — the option's default is supplied at
+        // runtime. This holds for a LINK-REF leaf (whose runtime value we can't
+        // membership-check — definition is all we can verify) AND a LITERAL leaf,
+        // which must ALSO be a strict in-list MEMBER of every option. Membership
+        // uses a strict includes() — NOT validateComboValueForSpec, whose
+        // asset/empty-combo PRESERVE path would keep an out-of-list literal and
+        // swallow its warning.
+        let anyOption = false;
+        let definedEverywhere = true;
+        let definedSomewhere = false;
+        // For a LITERAL leaf: it must be an in-list MEMBER of every option that
+        // DEFINES it as a combo. Options that OMIT the leaf are skipped (not failed)
+        // so a leaf defined by only some options is still assessed on the options
+        // that do define it. A scalar/non-combo defining option (getComboOptions
+        // undefined) can't fail membership — it's a normal required input.
+        let memberWhereDefined = true;
+        if (Array.isArray(pOpts)) {
+          for (const o of pOpts) {
+            anyOption = true;
+            const s = o?.inputs?.required?.[leaf] ?? o?.inputs?.optional?.[leaf];
+            if (s === undefined) {
+              // This option omits the leaf entirely (orphan if IT resolves).
+              definedEverywhere = false;
+              continue;
+            }
+            definedSomewhere = true;
+            if (leafIsLink) continue; // link ref: definition is all we can check
+            const optList = getComboOptions(s);
+            if (Array.isArray(optList) && !optList.includes(leafVal as never)) {
+              memberWhereDefined = false;
+            }
+          }
+        }
+        // Decision, split by leaf kind:
+        //  - LINK-REF leaf: its runtime value is unknowable, so the only defense
+        //    against orphaning it under an option that omits the leaf is strict
+        //    default-DENY — keep only if EVERY option defines it. Dropping a link
+        //    ref discards no user-authored scalar (the connection's value is
+        //    runtime), so the strict rule is cheap and safe.
+        //  - LITERAL leaf: it is a concrete USER VALUE. Dropping it just because
+        //    SOME option omits the leaf silently discards the user's input on a
+        //    resolution that may never occur (#517 P0-B: option A defines
+        //    strength=0.75, option B omits it — the strict rule deleted 0.75 even
+        //    though A is the live selection). A deterministic parent never reaches
+        //    this branch (a Primitive/positional parent is a STRING, re-anchored
+        //    against its RESOLVED option in the non-array path above), so here the
+        //    selection is genuinely unknowable — preserve a literal that at least
+        //    one option DEFINES, provided it stays a valid member wherever a
+        //    defining option enumerates options. A wrong-option literal (defined by
+        //    all options but out-of-list for one — the test-1216 case) still fails
+        //    memberWhereDefined and is dropped, so no invalid literal reaches the
+        //    prompt.
+        const drop = !anyOption
+          ? true
+          : leafIsLink
+            ? !definedEverywhere
+            : !definedSomewhere || !memberWhereDefined;
+        if (drop) {
+          // A dropped LINK-REF leaf is a real connection the user wired — deleting it
+          // silently would make the parent's runtime option fall back to its default
+          // with no trace (FIX 2, #517). Keep the strict default-deny (safest against
+          // orphaning under an option that omits the leaf), but WARN so the removed
+          // link + parent are surfaced rather than silently discarded.
+          if (leafIsLink) {
+            warnings.push(
+              `Node ${nodeId} (${classType}): the linked nested input "${key}" was dropped — its dynamic parent "${parent}" is fed by a runtime link (resolved option unknown) and not every option defines "${leaf}", so keeping the connection could orphan it under an option that omits the leaf. "${leaf}" will use the resolved option's default instead of the wired link.`,
+            );
+          }
+          delete inputs[key];
+        }
+        continue;
+      }
+      const { leafName, spec } = resolveWidgetSpec(def, key, inputs);
+      if (spec === undefined) {
+        // The final selected option does not define this leaf — it belongs to the
+        // superseded option and would be an unknown input on the current one. Drop
+        // it whether it's a literal OR a real-link ref (both orphan under the final
+        // option; a link ref is not exempt — the previous `continue` above leaked
+        // exactly this case).
+        delete inputs[key];
+        continue;
+      }
+      // Leaf IS defined by the final selected option. A real-link ref into a defined
+      // leaf is a valid connection whose runtime value ComfyUI validates — keep it
+      // as-is (there's no literal to re-validate here).
+      if (leafIsLink) continue;
+      inputs[key] = validateComboValueForSpec(
+        leafName,
+        leafVal,
+        spec,
+        classType,
+        nodeId,
+        warnings,
+      );
     }
 
     // rgthree "Power Lora Loader" stores its loras in widgets_values as a list of
@@ -1489,5 +2159,11 @@ export function convertUiToApi(
     `Converted UI workflow: ${nodeCount} nodes (${skipped} skipped)`,
   );
 
-  return { workflow, warnings };
+  // De-duplicate identical warnings. A value can legitimately be validated twice
+  // (positional pass, then the final dynamic-parent re-anchor pass) and produce
+  // the same message; identical strings already embed node id + input, so exact
+  // duplicates are pure noise. Distinct nodes/inputs keep their own warnings.
+  const dedupedWarnings = [...new Set(warnings)];
+
+  return { workflow, warnings: dedupedWarnings };
 }

--- a/src/services/workflow-lock.ts
+++ b/src/services/workflow-lock.ts
@@ -17,12 +17,13 @@ import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { getObjectInfo, getSystemStats } from "../comfyui/client.js";
-import type { WorkflowJSON } from "../comfyui/types.js";
+import type { ObjectInfo, WorkflowJSON } from "../comfyui/types.js";
 import { config } from "../config.js";
 import { ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
 import { MODEL_SUBDIRS } from "./model-resolver.js";
+import { isUiFormat, looksLikeAssetFilename } from "./workflow-converter.js";
 
 export interface LockedModel {
   name: string;
@@ -65,20 +66,32 @@ export interface LockDrift {
 // covers the loaders ComfyUI core ships; custom packs are walked best-effort
 // via the same input-field heuristic (any string input ending in a model
 // extension that resolves under <models>/<subdir>/).
-const KNOWN_LOADERS: Array<{ classType: string; field: string; modelType: string }> = [
-  { classType: "CheckpointLoaderSimple", field: "ckpt_name", modelType: "checkpoints" },
-  { classType: "UNETLoader", field: "unet_name", modelType: "diffusion_models" },
-  { classType: "VAELoader", field: "vae_name", modelType: "vae" },
-  { classType: "CLIPLoader", field: "clip_name", modelType: "text_encoders" },
-  { classType: "DualCLIPLoader", field: "clip_name1", modelType: "text_encoders" },
-  { classType: "DualCLIPLoader", field: "clip_name2", modelType: "text_encoders" },
-  { classType: "LoraLoader", field: "lora_name", modelType: "loras" },
-  { classType: "LoraLoaderModelOnly", field: "lora_name", modelType: "loras" },
-  { classType: "ControlNetLoader", field: "control_net_name", modelType: "controlnet" },
-  { classType: "UpscaleModelLoader", field: "model_name", modelType: "upscale_models" },
-  { classType: "CLIPVisionLoader", field: "clip_name", modelType: "clip_vision" },
-  { classType: "StyleModelLoader", field: "style_model_name", modelType: "style_models" },
+//
+// `widgetIndex` is the field's position in a UI-format node's `widgets_values`
+// array — needed because UI-saved graphs carry values positionally with no
+// field names. For every core loader here the model filename is the FIRST
+// widget (index 0); the one exception is DualCLIPLoader's second encoder
+// (clip_name2 at index 1).
+const KNOWN_LOADERS: Array<{
+  classType: string;
+  field: string;
+  modelType: string;
+  widgetIndex: number;
+}> = [
+  { classType: "CheckpointLoaderSimple", field: "ckpt_name", modelType: "checkpoints", widgetIndex: 0 },
+  { classType: "UNETLoader", field: "unet_name", modelType: "diffusion_models", widgetIndex: 0 },
+  { classType: "VAELoader", field: "vae_name", modelType: "vae", widgetIndex: 0 },
+  { classType: "CLIPLoader", field: "clip_name", modelType: "text_encoders", widgetIndex: 0 },
+  { classType: "DualCLIPLoader", field: "clip_name1", modelType: "text_encoders", widgetIndex: 0 },
+  { classType: "DualCLIPLoader", field: "clip_name2", modelType: "text_encoders", widgetIndex: 1 },
+  { classType: "LoraLoader", field: "lora_name", modelType: "loras", widgetIndex: 0 },
+  { classType: "LoraLoaderModelOnly", field: "lora_name", modelType: "loras", widgetIndex: 0 },
+  { classType: "ControlNetLoader", field: "control_net_name", modelType: "controlnet", widgetIndex: 0 },
+  { classType: "UpscaleModelLoader", field: "model_name", modelType: "upscale_models", widgetIndex: 0 },
+  { classType: "CLIPVisionLoader", field: "clip_name", modelType: "clip_vision", widgetIndex: 0 },
+  { classType: "StyleModelLoader", field: "style_model_name", modelType: "style_models", widgetIndex: 0 },
 ];
+
 
 function requireLocal(op: string): string {
   if (!config.comfyuiPath) {
@@ -89,17 +102,93 @@ function requireLocal(op: string): string {
   return config.comfyuiPath;
 }
 
-function extractReferencedModels(workflow: WorkflowJSON): Array<{ name: string; type: string }> {
-  const seen = new Map<string, string>(); // key: `${type}/${name}` → type
-  for (const node of Object.values(workflow)) {
-    if (!node?.class_type || !node.inputs) continue;
-    const classMatches = KNOWN_LOADERS.filter((l) => l.classType === node.class_type);
-    for (const match of classMatches) {
-      const value = (node.inputs as Record<string, unknown>)[match.field];
-      if (typeof value !== "string" || !value) continue;
-      seen.set(`${match.modelType}/${value}`, match.modelType);
+/**
+ * Flatten a UI-format workflow to every REAL node — top-level nodes PLUS the
+ * nodes inside every subgraph definition (`definitions.subgraphs[].nodes`). A
+ * top-level node whose `type` is a subgraph-definition id is a structural
+ * INSTANCE, not a real node, so it's skipped; its inner nodes are walked from
+ * the definition instead. Without this, a loader or custom node nested inside a
+ * subgraph/component would silently disappear from the lock (models + packs).
+ * Mirrors the subgraph-aware walk in api-nodes.extractWorkflowClassTypes.
+ */
+function collectUiNodes(workflow: WorkflowJSON): Array<Record<string, unknown>> {
+  const g = workflow as unknown as Record<string, unknown>;
+  const defs = (g.definitions as { subgraphs?: unknown[] } | undefined)?.subgraphs;
+  const defIds = new Set<string>();
+  const defNodeLists: unknown[] = [];
+  if (Array.isArray(defs)) {
+    for (const sg of defs) {
+      const s = sg as Record<string, unknown> | null;
+      const id = s?.id;
+      if (typeof id === "string" && id.length > 0) defIds.add(id);
+      if (Array.isArray(s?.nodes)) defNodeLists.push(s!.nodes);
     }
   }
+  const out: Array<Record<string, unknown>> = [];
+  const push = (nodes: unknown): void => {
+    if (!Array.isArray(nodes)) return;
+    for (const n of nodes) {
+      const node = n as Record<string, unknown> | null;
+      const t = node?.type;
+      if (typeof t !== "string" || t.length === 0) continue;
+      if (defIds.has(t)) continue; // subgraph instance — structural, not a real node
+      out.push(node as Record<string, unknown>);
+    }
+  };
+  push(g.nodes);
+  for (const nl of defNodeLists) push(nl);
+  return out;
+}
+
+/**
+ * Extract referenced model files from a saved workflow, handling BOTH formats.
+ *
+ * Workflows saved from the ComfyUI UI are stored in UI format
+ * (`{ nodes: [...], links: [...] }` with `type` + positional `widgets_values`),
+ * NOT the API/prompt format (`{ "1": { class_type, inputs: {...} } }`). The old
+ * walk only understood API format, so a UI-saved graph exposed neither
+ * `class_type` nor `inputs` and lock generation silently found 0 models — e.g.
+ * native VAELoader (`vae_name`) / UNETLoader (`unet_name`) went uncaptured
+ * (issue #482).
+ *
+ * Reading UI nodes directly (rather than round-tripping through a UI→API
+ * converter) is deliberate: the converter drops bypassed/muted nodes and nodes
+ * absent from /object_info, which would silently omit their models from the
+ * lock. Provenance must capture every referenced model regardless of a node's
+ * mute state or whether its (native) loader happens to be installed, matching
+ * the API-format behavior.
+ */
+function extractReferencedModels(workflow: WorkflowJSON): Array<{ name: string; type: string }> {
+  const seen = new Map<string, string>(); // key: `${type}/${name}` → type
+  const add = (modelType: string, value: unknown): void => {
+    if (typeof value !== "string" || !value) return;
+    seen.set(`${modelType}/${value}`, modelType);
+  };
+
+  if (isUiFormat(workflow)) {
+    for (const n of collectUiNodes(workflow)) {
+      const type = n.type as string; // collectUiNodes guarantees a non-empty string
+      const widgets = Array.isArray(n.widgets_values) ? n.widgets_values : null;
+      if (!widgets) continue;
+      for (const match of KNOWN_LOADERS.filter((l) => l.classType === type)) {
+        const value = widgets[match.widgetIndex];
+        // Positional read: guard with the shared asset-filename predicate so an
+        // unusual widget order can't misread a non-filename widget (e.g.
+        // UNETLoader's "default" weight_dtype) as a model.
+        if (looksLikeAssetFilename(value)) {
+          add(match.modelType, value);
+        }
+      }
+    }
+  } else {
+    for (const node of Object.values(workflow)) {
+      if (!node?.class_type || !node.inputs) continue;
+      for (const match of KNOWN_LOADERS.filter((l) => l.classType === node.class_type)) {
+        add(match.modelType, (node.inputs as Record<string, unknown>)[match.field]);
+      }
+    }
+  }
+
   return Array.from(seen.entries()).map(([key, type]) => ({
     name: key.slice(type.length + 1),
     type,
@@ -177,9 +266,9 @@ interface ClassTypeOriginMap {
   byClass: Map<string, { pack: string | null; builtin: boolean }>;
 }
 
-async function buildClassTypeOriginMap(): Promise<ClassTypeOriginMap> {
+function buildClassTypeOriginMap(objectInfo: ObjectInfo): ClassTypeOriginMap {
   const byClass = new Map<string, { pack: string | null; builtin: boolean }>();
-  const info = (await getObjectInfo()) as unknown as Record<string, { python_module?: string }>;
+  const info = objectInfo as unknown as Record<string, { python_module?: string }>;
   for (const [classType, def] of Object.entries(info ?? {})) {
     const mod = def?.python_module ?? "";
     // `python_module` is e.g. "custom_nodes.ComfyUI-WanVideoWrapper.nodes" for
@@ -194,14 +283,24 @@ async function buildClassTypeOriginMap(): Promise<ClassTypeOriginMap> {
   return { byClass };
 }
 
+// Every node's class_type, reading UI format (`node.type`, subgraph-aware) or
+// API/prompt format (`node.class_type`). Bypassed/muted nodes are included on
+// purpose: their pack is still a provenance dependency of the saved graph.
+function workflowClassTypes(workflow: WorkflowJSON): string[] {
+  if (isUiFormat(workflow)) {
+    return collectUiNodes(workflow).map((n) => n.type as string);
+  }
+  return Object.values(workflow)
+    .map((n) => n?.class_type)
+    .filter((t): t is string => typeof t === "string" && t.length > 0);
+}
+
 async function packsReferencedByWorkflow(
   workflow: WorkflowJSON,
   origins: ClassTypeOriginMap,
 ): Promise<string[]> {
   const packs = new Set<string>();
-  for (const node of Object.values(workflow)) {
-    const classType = node?.class_type;
-    if (!classType) continue;
+  for (const classType of workflowClassTypes(workflow)) {
     const origin = origins.byClass.get(classType);
     if (origin?.pack) packs.add(origin.pack);
   }
@@ -212,6 +311,11 @@ export async function generateLock(workflow: WorkflowJSON): Promise<WorkflowLock
   const comfyPath = requireLocal("generateLock");
   const stats = (await getSystemStats()) as unknown as { system?: { comfyui_version?: string } };
   const comfyuiVersion = stats.system?.comfyui_version ?? "unknown";
+
+  // /object_info maps class_types to their originating packs. Model + pack
+  // discovery read UI and API/prompt formats directly (see extractReferencedModels
+  // / workflowClassTypes), so no whole-graph conversion is needed.
+  const objectInfo = await getObjectInfo();
 
   const models = extractReferencedModels(workflow);
   const lockedModels: LockedModel[] = [];
@@ -233,7 +337,7 @@ export async function generateLock(workflow: WorkflowJSON): Promise<WorkflowLock
     }
   }
 
-  const origins = await buildClassTypeOriginMap();
+  const origins = buildClassTypeOriginMap(objectInfo);
   const packIds = await packsReferencedByWorkflow(workflow, origins);
   const lockedPacks: LockedNodePack[] = [];
   for (const id of packIds) {

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -92,6 +92,29 @@ export function resolveEffectiveComfyUIBase(): string | undefined {
   return getSavedDefaultWorkspaceSync();
 }
 
+/**
+ * The LIVE connected server's own install root, derived from its /system_stats
+ * launch argv (the `main.py` path — see liveRootFromArgv). This is the ComfyUI
+ * that is ACTUALLY running, so it is the source of truth for where a download /
+ * node install must land — even when COMFYUI_PATH is unset, OR points at a
+ * DIFFERENT, stale install than the connected one (#490/#463). Returns undefined
+ * in remote mode (the live root is a path on the REMOTE host, not usable as a
+ * local target), when the server is unreachable, or when argv yields no
+ * resolvable absolute root. Best-effort and NEVER throws.
+ */
+export async function resolveLiveComfyUIBase(): Promise<string | undefined> {
+  if (isRemoteMode()) return undefined;
+  try {
+    const stats = await getSystemStats();
+    return liveRootFromArgv(
+      stats.system?.argv,
+      (stats.system as { cwd?: string })?.cwd,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 async function readWorkspaceConfig(): Promise<WorkspaceConfig> {
   const path = workspaceConfigPath();
   if (!existsSync(path)) return {};
@@ -352,6 +375,31 @@ export function liveRootFromArgv(
     return undefined; // cannot resolve to an absolute dir → UNRESOLVED
   }
   return undefined;
+}
+
+/**
+ * Resolve the Python interpreter that ACTUALLY belongs to a ComfyUI install
+ * `root`, honoring EVERY layout ComfyUI ships with — portable Windows builds keep
+ * python under `standalone-env` / `python_embeded` (NOT just `.venv`/`venv`). Used
+ * by apply_manifest's pip installs and the cloned-node deps installer so those run
+ * under the install's OWN interpreter, not a bare system `python` that would
+ * contaminate the host env while reporting success (#463 codex review). Returns
+ * the first candidate present on disk, else a bare platform python name as a last
+ * resort. `undefined` root → bare python.
+ */
+export function resolveRootInterpreter(root: string | undefined): string {
+  const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
+  if (root) {
+    for (const c of interpreterCandidates(root)) {
+      if (/^\\\\/.test(c)) continue; // skip UNC (existsSync can block on dead shares)
+      try {
+        if (existsSync(c)) return c;
+      } catch {
+        // ignore and continue
+      }
+    }
+  }
+  return names[0];
 }
 
 /** Platform interpreter candidates under a ComfyUI install root, most-preferred first. */

--- a/src/tools/generate-audio.ts
+++ b/src/tools/generate-audio.ts
@@ -84,6 +84,50 @@ export function registerGenerateAudioTool(server: McpServer): void {
         .describe(
           "TextEncodeAceStepAudio1.5 cfg_scale — text encoder guidance scale (ACE only, default: 2)",
         ),
+      bpm: z
+        .number()
+        .int()
+        .min(10)
+        .max(300)
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 tempo in beats per minute (ACE only, 10-300, default: 120)"),
+      timesignature: z
+        .enum(["2", "3", "4", "6"])
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 time signature (ACE only, one of '2'/'3'/'4'/'6', default: '4')"),
+      temperature: z
+        .number()
+        .min(0)
+        .max(2)
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 LLM sampling temperature (ACE only, 0-2, default: 0.85)"),
+      top_p: z
+        .number()
+        .min(0)
+        .max(2000)
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 LLM top-p nucleus sampling (ACE only, 0-2000, default: 0.9)"),
+      top_k: z
+        .number()
+        .int()
+        .min(0)
+        .max(100)
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 LLM top-k sampling (ACE only, 0-100, default: 0 = disabled)"),
+      min_p: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 LLM min-p sampling (ACE only, 0-1, default: 0)"),
+      generate_audio_codes: z
+        .boolean()
+        .optional()
+        .describe("TextEncodeAceStepAudio1.5 — generate audio codes via the LLM (ACE only, default: true)"),
+      audio_quality: z
+        .enum(["V0", "128k", "320k"])
+        .optional()
+        .describe("SaveAudioMP3 bitrate/quality (ACE only, one of 'V0'/'128k'/'320k', default: '320k')"),
 
       // Stable Audio 3 specific
       checkpoint: z

--- a/src/tools/skills-access.ts
+++ b/src/tools/skills-access.ts
@@ -439,6 +439,7 @@ export function registerSkillsAccessTools(server: McpServer): void {
       try {
         traceToolCall("check_workflow_runtime", { pack: args.pack });
         let graph: unknown;
+        let bundledLocalPack = false;
         if (args.pack) {
           const wfFile = resolvePackWorkflowFile(args.pack);
           if (!wfFile) {
@@ -454,6 +455,10 @@ export function registerSkillsAccessTools(server: McpServer): void {
             };
           }
           graph = JSON.parse(readFileSync(wfFile, "utf8"));
+          // Bundled packs are guaranteed local/free (list_packs contract). Trust
+          // that so an uninstalled custom node doesn't read back as "unknown" and
+          // wrongly demand a paid-credits confirmation (#464).
+          bundledLocalPack = true;
         } else if (args.graph != null) {
           graph = typeof args.graph === "string" ? JSON.parse(args.graph) : args.graph;
         } else {
@@ -472,7 +477,7 @@ export function registerSkillsAccessTools(server: McpServer): void {
         // return SOMETHING useful even if the live /object_info is unreachable.
         const classTypes = extractWorkflowClassTypes(graph);
         try {
-          const runtime = await checkWorkflowRuntime(graph);
+          const runtime = await checkWorkflowRuntime(graph, undefined, { bundledLocalPack });
           const guidance =
             runtime.runtime === "local"
               ? "Local-GPU / free — every node runs on the user's own GPU, no paid credits."

--- a/src/tools/workflow-compose.ts
+++ b/src/tools/workflow-compose.ts
@@ -7,7 +7,7 @@ import {
   TEMPLATE_NAMES,
   type ModifyOperation,
 } from "../services/workflow-composer.js";
-import { getObjectInfo, backfillObjectInfo } from "../comfyui/client.js";
+import { getObjectInfo, backfillObjectInfo, resetObjectInfoCache } from "../comfyui/client.js";
 import { errorToToolResult, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -163,10 +163,26 @@ export function registerWorkflowComposeTools(server: McpServer): void {
             "it when you need the actual enum values (e.g. exact model filenames) and the " +
             "filter matches few nodes. Default false: structural summary with enum value counts.",
         ),
+      refresh: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "If true, discard the memoized /object_info snapshot and refetch live from the " +
+            "connected server before answering. Use after the ComfyUI server was restarted " +
+            "EXTERNALLY (systemd/service manager) or new model files were added out-of-band — " +
+            "the cache is otherwise only invalidated by MCP-managed restarts, so loader " +
+            "dropdowns (model lists) would remain stale for the rest of the session (#499).",
+        ),
     },
-    async ({ node_type, verbose }) => {
+    async ({ node_type, verbose, refresh }) => {
       try {
-        logger.info("Getting node info", { filter: node_type, verbose });
+        logger.info("Getting node info", { filter: node_type, verbose, refresh });
+        // #499: an external (non-MCP) restart or an out-of-band model install
+        // leaves the memoized /object_info snapshot stale, silently serving
+        // pre-restart loader dropdowns. `refresh` forces a fresh live fetch so
+        // newly installed model files show up in the returned combos.
+        if (refresh) resetObjectInfoCache();
         let info = await getObjectInfo();
 
         let entries = Object.entries(info);

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -109,17 +109,22 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
           const { workflow, warnings } = convertUiToApi(raw, objectInfo);
 
-          const content: Array<{ type: "text"; text: string }> = [];
+          // Return the JSON workflow as the primary/first content block so
+          // consumers that read the first text result always receive the graph
+          // (not Markdown). Conversion warnings are appended as a separate
+          // trailing block and never replace or precede the JSON (#494).
+          const content: Array<{ type: "text"; text: string }> = [
+            {
+              type: "text",
+              text: JSON.stringify(workflow, null, 2),
+            },
+          ];
           if (warnings.length > 0) {
             content.push({
               type: "text",
               text: `**Conversion warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join("\n")}`,
             });
           }
-          content.push({
-            type: "text",
-            text: JSON.stringify(workflow, null, 2),
-          });
           return { content };
         }
 


### PR DESCRIPTION
## Summary

A small bug cluster across three areas. Each fix ships with a fail-before/pass-after regression test.

### #501 — ACE Step 1.5 template fields + missing generate_audio params
The `ace_step_15` workflow-composer template field names (`tags`/`keyscale`/`cfg_scale`/`unet_name`/`quality`) were already corrected on main (#453). What remained (issue bug #5): the `generate_audio` tool/service never exposed the ACE encoder controls. Added `bpm`, `timesignature`, `temperature`, `top_p`, `top_k`, `min_p`, `generate_audio_codes`, and SaveAudioMP3 `audio_quality` to `GenerateAudioArgs`, `DEFAULTABLE_KEYS`, the `createWorkflow` passthrough, and the tool's zod schema — with bounds/enums enforced to match `comfy_extras/nodes_ace.py` (bpm 10-300, temperature 0-2, top_p 0-2000, top_k 0-100, min_p 0-1, timesignature 2/3/4/6, audio_quality V0/128k/320k, verified against upstream source).

### #482 — lock_workflow misses native VAELoader/UNETLoader models
`UNETLoader`/`VAELoader` were already in `KNOWN_LOADERS`; the real cause was that lock model/pack discovery only understood API/prompt format, so UI-saved workflows (`nodes[]`/`links[]` with positional `widgets_values`) yielded 0 models. `extractReferencedModels` + `workflowClassTypes` now read UI format directly — subgraph-aware (`collectUiNodes` flattens `definitions.subgraphs[].nodes` and skips structural subgraph instances), bypass/uninstalled-safe (no lossy UI→API conversion), guarded by the shared `looksLikeAssetFilename` predicate.

### #464 — check_workflow_runtime "unknown" for a bundled local-only pack
Added a `bundledLocalPack` option to `checkWorkflowRuntime`, set by the tool when a `pack` is passed. Unclassifiable (uninstalled) nodes are trusted as local **only when no recognized API node is present**; arbitrary `graph` inputs keep the honest `unknown` behavior, and any recognized paid API node still wins.

## Testing
- Full suite passes (2290 passed, 1 skipped; only the pre-existing unrelated node-dev ripgrep-sandbox failure remains).
- Each regression test verified fail-before / pass-after.
- Codex adversarial review (codex exec, read-only) — **VERDICT: PASS** after 5 rounds (found and fixed: UI→API conversion lossiness, `.pt2`/`.pkl` guard, subgraph traversal gap, ACE numeric bounds, and test rigor for the subgraph-instance skip).

Closes #501
Closes #482
Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)