### PR TITLE
fix(tools): get_workflow returns JSON with warnings (#494); get_image binary-safe (#483); enqueue surfaces 400 validation (#485)

### DIFF
--- a/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
+++ b/src/__tests__/comfyui/enqueue-prompt-validation.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComfyUIError } from "../../utils/errors.js";
+
+// #485: when ComfyUI rejects a workflow during prompt validation it answers
+// POST /prompt with HTTP 400 whose JSON body carries the authoritative
+// diagnosis (`error.message` + `node_errors[<id>].{class_type,errors}`).
+// enqueuePrompt must surface those details instead of a generic HTTP status,
+// falling back to the status only when the body is empty/unparseable.
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>("../../config.js");
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+  };
+});
+
+const comfyuiFetch = vi.fn();
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: (...a: unknown[]) => comfyuiFetch(...a),
+}));
+
+const { enqueuePrompt } = await import("../../comfyui/client.js");
+
+function res(status: number, body: unknown, statusText = "Bad Request"): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+    headers: new Map(),
+  } as unknown as Response;
+}
+
+const validationBody = {
+  error: {
+    type: "prompt_outputs_failed_validation",
+    message: "Prompt outputs failed validation",
+    details: "",
+    extra_info: {},
+  },
+  node_errors: {
+    "5": {
+      class_type: "LoadImage",
+      errors: [
+        {
+          type: "custom_validation_failed",
+          message: "Custom validation failed for node: image",
+          details: "Invalid image file: missing.png",
+          extra_info: {},
+        },
+      ],
+      dependent_outputs: ["11"],
+    },
+  },
+};
+
+describe("enqueuePrompt — surfaces ComfyUI 400 validation details (#485)", () => {
+  beforeEach(() => comfyuiFetch.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  it("surfaces node_errors (id, class_type, message, details) on a 400", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(400, validationBody));
+
+    const err = await enqueuePrompt({ "5": { class_type: "LoadImage", inputs: {} } }).catch(
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(ComfyUIError);
+    const message = (err as Error).message;
+    // The authoritative details must appear — not just the bare HTTP status.
+    expect(message).toContain("Prompt outputs failed validation");
+    expect(message).toContain("LoadImage");
+    expect(message).toContain("node 5");
+    expect(message).toContain("Invalid image file: missing.png");
+    // Raw payload preserved for programmatic consumers.
+    expect((err as ComfyUIError).details).toMatchObject({
+      status: 400,
+      node_errors: { "5": { class_type: "LoadImage" } },
+    });
+  });
+
+  it("falls back to the generic HTTP status when the 400 body is empty", async () => {
+    comfyuiFetch.mockResolvedValueOnce(res(400, ""));
+    const err = await enqueuePrompt({}).catch((e) => e);
+    expect(err).toBeInstanceOf(ComfyUIError);
+    expect((err as Error).message).toContain("400");
+    expect((err as Error).message).toContain("Bad Request");
+  });
+
+  it("returns prompt_id + the authoritative /queue depth on success", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "abc", number: 42 }, "OK")) // POST /prompt
+      .mockResolvedValueOnce(
+        res(200, { queue_running: [{}], queue_pending: [{}, {}] }, "OK"),
+      ); // GET /queue
+    const out = await enqueuePrompt({ "1": { class_type: "KSampler", inputs: {} } });
+    // queue_remaining is running+pending (1+2=3), NOT ComfyUI's `number` (42).
+    expect(out).toEqual({ prompt_id: "abc", queue_remaining: 3 });
+  });
+
+  it("never surfaces ComfyUI's monotonic `number` (negative for front jobs) as queue_remaining", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "z", number: -17 }, "OK"))
+      .mockResolvedValueOnce(res(200, { queue_running: [{}], queue_pending: [] }, "OK"));
+    const out = await enqueuePrompt({}, undefined, { front: true });
+    expect(out.queue_remaining).toBe(1); // real depth, not -17
+  });
+
+  it("falls back to undefined queue_remaining when /queue can't be read", async () => {
+    comfyuiFetch
+      .mockResolvedValueOnce(res(200, { prompt_id: "abc", number: 5 }, "OK"))
+      .mockRejectedValueOnce(new Error("network"));
+    const out = await enqueuePrompt({ "1": { class_type: "KSampler", inputs: {} } });
+    expect(out).toEqual({ prompt_id: "abc", queue_remaining: undefined });
+  });
+});

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComfyUIError } from "../../utils/errors.js";
+
+// #483: get_image for a valid `type:"input"` image must return the binary
+// bytes as an inline image, and a non-image/empty /view body must yield a
+// structured not-found — never an uncaught "Unexpected end of JSON input"
+// from JSON-parsing a binary response. The binary-safe read + guard live in
+// getOutputImage (service, covered in image-management-traversal.test.ts);
+// this locks the TOOL handler contract on top of it.
+
+const getOutputImageMock = vi.fn();
+vi.mock("../../services/image-management.js", () => ({
+  extractWorkflowFromImage: vi.fn(),
+  listOutputImages: vi.fn(),
+  getOutputImage: (...a: unknown[]) => getOutputImageMock(...a),
+  uploadImageAuto: vi.fn(),
+  uploadVideoAuto: vi.fn(),
+  uploadAudioAuto: vi.fn(),
+  stageOutputAsInput: vi.fn(),
+}));
+
+// Don't actually touch disk when the handler saves the file.
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return { ...actual, mkdir: vi.fn(async () => undefined), writeFile: vi.fn(async () => undefined) };
+});
+
+import { registerImageManagementTools } from "../../tools/image-management.js";
+
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerImageManagementTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+describe("get_image — binary-safe (#483)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("returns an inline image block for a valid type:input image", async () => {
+    const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64");
+    getOutputImageMock.mockResolvedValue({ base64, mimeType: "image/png", filename: "src.png" });
+
+    const out = await getHandler("get_image")({
+      filename: "RogueTD_Ara_Locomotion_Source.png",
+      type: "input",
+      save_dir: "/tmp/x",
+    });
+
+    const image = out.content.find((c) => c.type === "image");
+    expect(image).toBeDefined();
+    expect(image?.data).toBe(base64);
+    expect(image?.mimeType).toBe("image/png");
+  });
+
+  it("returns a structured error (not a JSON-parse crash) for an empty/non-image body", async () => {
+    getOutputImageMock.mockRejectedValue(
+      new ComfyUIError(
+        'ComfyUI /view did not return an image for "x.png" (input); got an empty response.',
+        "IMAGE_NOT_FOUND",
+      ),
+    );
+
+    const out = await getHandler("get_image")({ filename: "x.png", type: "input" });
+    expect(out.isError).toBe(true);
+    const text = out.content.map((c) => c.text ?? "").join("");
+    expect(text).toContain("IMAGE_NOT_FOUND");
+    expect(text).not.toContain("Unexpected end of JSON input");
+  });
+});

--- a/src/__tests__/tools/get-workflow-warnings.test.ts
+++ b/src/__tests__/tools/get-workflow-warnings.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+// #494: get_workflow(format:"api") must return the workflow JSON as the PRIMARY
+// (first) content block, with conversion warnings appended as a separate
+// trailing block. Consumers that read the first text result must always receive
+// parseable JSON — never Markdown warnings — so passing it straight to
+// JSON.parse / check_workflow_runtime works even when there are convert warnings.
+
+const fetchApiMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApiMock(...a) }),
+  getObjectInfo: vi.fn(async () => ({})),
+  backfillObjectInfo: vi.fn(async (bulk: unknown) => bulk),
+}));
+
+const convertUiToApiMock = vi.fn();
+vi.mock("../../services/workflow-converter.js", () => ({
+  isUiFormat: () => true,
+  isApiFormat: () => false,
+  convertUiToApi: (...a: unknown[]) => convertUiToApiMock(...a),
+  convertApiToUi: vi.fn(),
+  collectNodeTypes: () => [],
+}));
+
+// Unused-by-this-test services still imported by the module under test.
+vi.mock("../../services/workflow-slicer.js", () => ({ sliceWorkflow: vi.fn() }));
+vi.mock("../../services/graph-query.js", () => ({ queryApiGraph: vi.fn() }));
+vi.mock("../../services/workflow-sections.js", () => ({ detectSections: vi.fn() }));
+vi.mock("../../services/hierarchical-mermaid.js", () => ({
+  generateOverview: vi.fn(),
+  generateSectionDetail: vi.fn(),
+  listSections: vi.fn(),
+  generateSummary: vi.fn(),
+}));
+vi.mock("../../services/mermaid-converter.js", () => ({ convertToMermaid: vi.fn() }));
+vi.mock("../../services/workflow-health.js", () => ({ analyzeGraphHealth: vi.fn() }));
+
+import { registerWorkflowLibraryTools } from "../../tools/workflow-library.js";
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+) => Promise<{ content: Array<{ type: string; text: string }> }>;
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerWorkflowLibraryTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+describe("get_workflow — JSON before conversion warnings (#494)", () => {
+  it("returns parseable JSON as the FIRST content block even with warnings", async () => {
+    const apiWorkflow = { "3": { class_type: "KSampler", inputs: { seed: 1 } } };
+    fetchApiMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ nodes: [] }) });
+    convertUiToApiMock.mockReturnValue({
+      workflow: apiWorkflow,
+      warnings: ["Node 7 (Reroute) dropped: no resolvable target"],
+    });
+
+    const { content } = await getHandler("get_workflow")({ filename: "w.json", format: "api" });
+
+    // First block MUST be the JSON graph — parsing it must not throw.
+    expect(content[0].type).toBe("text");
+    expect(() => JSON.parse(content[0].text)).not.toThrow();
+    expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
+
+    // Warnings preserved, but as a SEPARATE trailing block.
+    expect(content).toHaveLength(2);
+    expect(content[1].text).toContain("Conversion warnings");
+    expect(content[1].text).toContain("Reroute");
+  });
+
+  it("returns only the JSON block when there are no warnings", async () => {
+    const apiWorkflow = { "1": { class_type: "CheckpointLoaderSimple", inputs: {} } };
+    fetchApiMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ nodes: [] }) });
+    convertUiToApiMock.mockReturnValue({ workflow: apiWorkflow, warnings: [] });
+
+    const { content } = await getHandler("get_workflow")({ filename: "w.json", format: "api" });
+    expect(content).toHaveLength(1);
+    expect(JSON.parse(content[0].text)).toEqual(apiWorkflow);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -8,7 +8,7 @@ import {
   isRemoteMode,
 } from "../config.js";
 import { logger } from "../utils/logger.js";
-import { ComfyUIError, ConnectionError } from "../utils/errors.js";
+import { ComfyUIError, ConnectionError, WorkflowExecutionError } from "../utils/errors.js";
 import { comfyuiFetch } from "./fetch.js";
 import * as cloudClient from "./cloud-client.js";
 import type { ObjectInfo, SystemStats, QueueStatus } from "./types.js";
@@ -298,39 +298,129 @@ export async function enqueuePrompt(
   opts?: { front?: boolean },
 ): Promise<{ prompt_id: string; queue_remaining?: number }> {
   if (isCloudMode()) return cloudClient.enqueuePrompt(workflow, extraData);
-  const client = getClient();
 
-  // The SDK's _enqueue_prompt does not forward `extra_data`, which is how
-  // comfy.org API-node credentials (api_key_comfy_org / auth_token_comfy_org)
-  // must travel to the server. It also cannot enqueue at the front. When either
-  // is needed, POST /prompt directly.
-  if ((extraData && Object.keys(extraData).length > 0) || opts?.front) {
-    const url = `${getComfyUIBaseUrl()}/prompt`;
-    const res = await comfyuiFetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        prompt: workflow,
-        client_id: "comfyui-mcp",
-        ...(extraData ? { extra_data: extraData } : {}),
-        ...(opts?.front ? { front: true } : {}),
-      }),
-    });
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      throw new ConnectionError(
-        `ComfyUI /prompt returned ${res.status} ${res.statusText}: ${body.slice(0, 500)}`,
-      );
-    }
-    const data = (await res.json()) as { prompt_id: string; number?: number };
-    return { prompt_id: data.prompt_id, queue_remaining: data.number };
+  // POST /prompt directly (rather than the SDK's _enqueue_prompt) for two
+  // reasons: (1) the SDK does not forward `extra_data` — how comfy.org API-node
+  // credentials must travel — nor can it enqueue at the front; and (2) on an
+  // HTTP 400 the SDK throws a generic "Endpoint Bad Request" that discards
+  // ComfyUI's authoritative prompt-validation body (`node_errors`), so callers
+  // never learn which node/input was invalid (#485). Going direct lets us read
+  // and surface that body. `comfyuiFetch` applies the same auth headers the SDK
+  // would (CF Access / COMFYUI_AUTH_*).
+  const url = `${getComfyUIBaseUrl()}/prompt`;
+  const res = await comfyuiFetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      prompt: workflow,
+      client_id: "comfyui-mcp",
+      ...(extraData ? { extra_data: extraData } : {}),
+      ...(opts?.front ? { front: true } : {}),
+    }),
+  });
+  if (!res.ok) {
+    throw await buildEnqueueError(res);
+  }
+  const data = (await res.json()) as { prompt_id: string; number?: number };
+  // NB: `data.number` is ComfyUI's monotonic priority counter (and is NEGATIVE
+  // for front-inserted jobs) — NOT the remaining queue depth. The old SDK path
+  // returned exec_info.queue_remaining; to preserve an accurate count now that
+  // we POST directly, read /queue for the authoritative running+pending total.
+  // Fall back to undefined (never the misleading counter) if that read fails.
+  return { prompt_id: data.prompt_id, queue_remaining: await queueRemainingCount() };
+}
+
+/**
+ * Authoritative "jobs still in the queue" count (running + pending) via a direct
+ * /queue read. Returns undefined if the queue can't be read, so callers never
+ * surface ComfyUI's monotonic `number` counter as a remaining-count. Only
+ * reachable on the local/remote path — enqueuePrompt returns early in cloud mode.
+ */
+async function queueRemainingCount(): Promise<number | undefined> {
+  try {
+    const res = await comfyuiFetch(`${getComfyUIBaseUrl()}/queue`);
+    if (!res.ok) return undefined;
+    const q = (await res.json()) as {
+      queue_running?: unknown[];
+      queue_pending?: unknown[];
+      Running?: unknown[];
+      Pending?: unknown[];
+    };
+    const running = (q.queue_running ?? q.Running ?? []).length;
+    const pending = (q.queue_pending ?? q.Pending ?? []).length;
+    return running + pending;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a non-OK /prompt response into a rich error. On the HTTP 400 that
+ * ComfyUI returns when prompt validation fails, the JSON body carries the
+ * authoritative diagnosis:
+ *   {
+ *     error: { type, message, details, extra_info },
+ *     node_errors: { "<id>": { class_type, errors: [{ message, details, ... }] } }
+ *   }
+ * We format the top-level message plus one line per offending node
+ * (`ClassType (node <id>): <message>`), and stash the raw payload in `details`.
+ * Falls back to the generic HTTP status only when the body is empty or is not
+ * the expected validation JSON (#485).
+ */
+async function buildEnqueueError(res: Response): Promise<ComfyUIError> {
+  const bodyText = await res.text().catch(() => "");
+  const generic = `ComfyUI /prompt returned ${res.status} ${res.statusText}`;
+
+  let parsed: unknown;
+  try {
+    parsed = bodyText ? JSON.parse(bodyText) : undefined;
+  } catch {
+    parsed = undefined;
   }
 
-  const result = await client._enqueue_prompt(workflow);
-  return {
-    prompt_id: result.prompt_id,
-    queue_remaining: result.exec_info?.queue_remaining,
-  };
+  if (parsed && typeof parsed === "object") {
+    const payload = parsed as {
+      error?: { message?: string; details?: string };
+      node_errors?: Record<
+        string,
+        { class_type?: string; errors?: Array<{ message?: string; details?: string }> }
+      >;
+    };
+    const nodeErrors = payload.node_errors ?? {};
+    const lines: string[] = [];
+    for (const [nodeId, info] of Object.entries(nodeErrors)) {
+      const cls = info?.class_type ?? "node";
+      const errs = Array.isArray(info?.errors) ? info.errors : [];
+      if (errs.length === 0) {
+        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        continue;
+      }
+      for (const e of errs) {
+        const detail = e?.details ? ` (${e.details})` : "";
+        lines.push(`- ${cls} (node ${nodeId}): ${e?.message ?? "validation failed"}${detail}`);
+      }
+    }
+
+    const headline = payload.error?.message
+      ? `ComfyUI rejected the workflow (${res.status}): ${payload.error.message}`
+      : `ComfyUI rejected the workflow (${res.status})`;
+
+    if (lines.length > 0 || payload.error?.message) {
+      const message =
+        lines.length > 0 ? `${headline}\n${lines.join("\n")}` : headline;
+      return new WorkflowExecutionError(message, {
+        status: res.status,
+        error: payload.error,
+        node_errors: nodeErrors,
+      });
+    }
+  }
+
+  // Empty or unexpected body: fall back to the generic HTTP status, but keep
+  // any raw text so nothing is silently dropped.
+  return new ConnectionError(
+    bodyText ? `${generic}: ${bodyText.slice(0, 500)}` : generic,
+  );
 }
 
 /**

--- a/src/tools/workflow-library.ts
+++ b/src/tools/workflow-library.ts
@@ -109,17 +109,22 @@ export function registerWorkflowLibraryTools(server: McpServer): void {
           const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(raw));
           const { workflow, warnings } = convertUiToApi(raw, objectInfo);
 
-          const content: Array<{ type: "text"; text: string }> = [];
+          // Return the JSON workflow as the primary/first content block so
+          // consumers that read the first text result always receive the graph
+          // (not Markdown). Conversion warnings are appended as a separate
+          // trailing block and never replace or precede the JSON (#494).
+          const content: Array<{ type: "text"; text: string }> = [
+            {
+              type: "text",
+              text: JSON.stringify(workflow, null, 2),
+            },
+          ];
           if (warnings.length > 0) {
             content.push({
               type: "text",
               text: `**Conversion warnings (${warnings.length}):**\n${warnings.map((w) => `- ${w}`).join("\n")}`,
             });
           }
-          content.push({
-            type: "text",
-            text: JSON.stringify(workflow, null, 2),
-          });
           return { content };
         }
 


### PR DESCRIPTION
Closes #494
Closes #483
Closes #485

## Summary

Three independent tool bug fixes, each with a regression test (fail before / pass after where applicable; HTTP boundary mocked).

- **#494 — get_workflow returns JSON before/alongside warnings.** `get_workflow(format:"api")` previously emitted the conversion-warnings Markdown as the FIRST content block and the JSON second, so consumers reading the primary result got `**Conversi...` and `JSON.parse` failed with `Unexpected token '*'`. The workflow JSON is now the first block; warnings are appended as a separate trailing block. (`src/tools/workflow-library.ts`)

- **#483 — get_image binary-safe.** Already fixed on `main` by #435 (`getOutputImage` reads `/view` as bytes and guards non-image/empty bodies with a structured `IMAGE_NOT_FOUND` instead of a JSON-parse crash). This PR adds a tool-level regression test locking the contract. (`src/__tests__/tools/get-image-binary-safe.test.ts`)

- **#485 — enqueue_workflow surfaces ComfyUI's 400 validation details.** The default enqueue path used the SDK's `_enqueue_prompt`, which on HTTP 400 threw a generic `Endpoint Bad Request` and discarded ComfyUI's authoritative `node_errors` body. `enqueuePrompt` now POSTs `/prompt` directly (auth-aware via `comfyuiFetch`) and parses the 400 body, surfacing `error.message` plus one line per offending node (`ClassType (node <id>): <message> (<details>)`), with the raw payload in `details`. Falls back to the generic HTTP status only when the body is empty/unparseable. (`src/comfyui/client.ts`)

## Notes

- Going direct meant the SDK's `exec_info.queue_remaining` was no longer available. `queue_remaining` is now derived from an authoritative `/queue` read (running + pending); ComfyUI's monotonic `number` counter (negative for front-inserted jobs) is never surfaced. Returns `undefined` if `/queue` can't be read.
- No version bump.

## Testing

- `npx vitest run` — 2292 passed, 1 skipped; only the known node-dev ripgrep sandbox test fails (unrelated to this change).
- `npx tsc --noEmit` clean.
- Codex adversarial review: **VERDICT: PASS** (no P0/P1 findings). An earlier pass caught a real P1 — the `queue_remaining`/`number` regression above — which was fixed and re-reviewed to PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)