### PR TITLE
fix(panel-run): surface ComfyUI rejection instead of false queued:true (#213); accept root SaveImage (#194); no queued-render text without a tab (#331); include error detail on queuePrompt throw (#248)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -19,7 +19,9 @@ import {
   registerPanelTools,
   __openWorkflowTestHooks,
   __panelToolsTestHooks,
+  __panelRunTestHooks,
   type PanelToolCtx,
+  type ToolResult,
 } from "../../orchestrator/panel-tools.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
 
@@ -335,6 +337,200 @@ describe("panel-tools: panel_run (run-to-node partial execution)", () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_run").handler({ to_node_id: 27 }, ctx);
     expect(calls[0]).toMatchObject({ cmd: "graph_run", to_node_id: 27 });
+  });
+});
+
+// A panel_run test ctx whose graph_run reply is fully controllable, so we can
+// drive the four rejection/acceptance edge-cases the panel forwards from
+// ComfyUI's /prompt. Records every forwarded cmd for assertion.
+function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx: PanelToolCtx = {
+    call: async (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+    confirm: async () => true,
+    bridge: {} as unknown as PanelToolCtx["bridge"],
+    tabId: "test-tab",
+  };
+  return { ctx, calls };
+}
+
+/** Extract the joined text of a ToolResult for content assertions. */
+function textOf(res: ToolResult): string {
+  return (res.content ?? [])
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}
+
+const QUEUED_NOTE = "notified automatically";
+
+describe("panel-tools: panel_run verdict is derived from the ComfyUI reply", () => {
+  it("#213: a top-level /prompt error (empty node_errors) is a FAILURE, not queued:true", async () => {
+    // ComfyUI split: a top-level rejection leaves node_errors empty. The panel's
+    // stale guard may still forward queued:true — the orchestrator must NOT trust it.
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: true,
+            error: {
+              type: "prompt_outputs_failed_validation",
+              message: "Prompt outputs failed validation",
+            },
+            node_errors: {},
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("Prompt outputs failed validation");
+    expect(text).toContain("prompt_outputs_failed_validation");
+    // The success-only anti-poll guidance must NOT be appended to a rejection.
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#213: per-node node_errors are surfaced with node id + class_type", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: false,
+            node_errors: {
+              "5": {
+                class_type: "LoadImage",
+                errors: [
+                  { message: "Custom validation failed", details: "Invalid image: missing.png" },
+                ],
+              },
+            },
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("LoadImage");
+    expect(text).toContain("node 5");
+    expect(text).toContain("Invalid image: missing.png");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#194: a root SaveImage run-to-node the panel ACCEPTS is queued success (not subgraph-rejected)", async () => {
+    const reply: ToolResult = {
+      content: [
+        { type: "text", text: JSON.stringify({ queued: true, batch_count: 1, to_node_id: 9 }) },
+      ],
+    };
+    const { ctx, calls } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+    // Forwarded unchanged so the (fixed) panel can resolve the root output node.
+    expect(calls[0]).toMatchObject({ cmd: "graph_run", to_node_id: 9 });
+    expect(res.isError).toBeFalsy();
+    // Accepted -> the anti-poll queued guidance IS appended.
+    expect(textOf(res)).toContain(QUEUED_NOTE);
+  });
+
+  it("#194: a subgraph-rejection reply is surfaced cleanly WITHOUT the false success note", async () => {
+    const reply: ToolResult = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            queued: false,
+            error:
+              "node 9 is not on the root graph — run-to-node targets a root-level output node",
+          }),
+        },
+      ],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 9 }, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("not on the root graph");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#331: no queued-render guidance when no panel tab is connected", async () => {
+    const reply: ToolResult = {
+      content: [
+        { type: "text", text: 'Error: no connected tab with id "tmp:abc". Connected: none' },
+      ],
+      isError: true,
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({ to_node_id: 25 }, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    expect(text).toContain("no connected tab");
+    // The workflow was never queued — the automatic-delivery note must be absent.
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("#248: a thrown app.queuePrompt surfaces the browser stack detail, no success note", async () => {
+    const stack =
+      "app.queuePrompt failed:\n" +
+      "TypeError: Cannot read properties of undefined (reading 'output')\n" +
+      "    at app.graphToPrompt (http://127.0.0.1:8188/extensions/tts_audio_suite/audio_analyzer_interface.js:102:24)";
+    const reply: ToolResult = {
+      content: [{ type: "text", text: `Error: ${stack}` }],
+      isError: true,
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    // The actionable browser location must survive verbatim.
+    expect(text).toContain("app.graphToPrompt");
+    expect(text).toContain("audio_analyzer_interface.js:102:24");
+    expect(text).not.toContain(QUEUED_NOTE);
+  });
+
+  it("a genuine queue (queued:true, no errors) still gets the anti-poll note", async () => {
+    const reply: ToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ queued: true, batch_count: 1 }) }],
+    };
+    const { ctx } = makeRunCtx(reply);
+    const res = await defByName("panel_run").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(textOf(res)).toContain(QUEUED_NOTE);
+  });
+});
+
+describe("panel-tools: detectRunRejection helper", () => {
+  const { detectRunRejection } = __panelRunTestHooks;
+  const jsonReply = (obj: unknown): ToolResult => ({
+    content: [{ type: "text", text: JSON.stringify(obj) }],
+  });
+
+  it("returns null for a clean queued:true reply", () => {
+    expect(detectRunRejection(jsonReply({ queued: true, batch_count: 1 }))).toBeNull();
+  });
+
+  it("returns null for an unparseable non-error reply (no regression)", () => {
+    expect(detectRunRejection({ content: [{ type: "text", text: "plain ok" }] })).toBeNull();
+  });
+
+  it("flags a top-level error even alongside a stale queued:true", () => {
+    const rej = detectRunRejection(
+      jsonReply({ queued: true, error: { type: "missing_node_type", message: "boom" }, node_errors: {} }),
+    );
+    expect(rej?.isError).toBe(true);
+  });
+
+  it("passes an isError reply through verbatim", () => {
+    const err: ToolResult = { content: [{ type: "text", text: "Error: boom" }], isError: true };
+    expect(detectRunRejection(err)).toBe(err);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -364,6 +364,116 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
   }
 }
 
+// ---- panel_run reply interpretation (#213/#331/#248/#194) -------------------
+// `panel_run` forwards `graph_run` to the panel, which drives `app.queuePrompt`
+// and forwards ComfyUI's /prompt outcome back. ComfyUI splits a rejection into
+// TWO channels:
+//   • per-node problems      -> `node_errors` (a map keyed by node id)
+//   • TOP-LEVEL problems     -> `error`       (e.g. prompt_outputs_failed_validation,
+//                                              missing_node_type) — leaves node_errors EMPTY
+// #213: the panel's success guard looked ONLY at node_errors, so a top-level
+// rejection (empty node_errors) slipped through as `queued:true` — a FALSE
+// success the agent then waited a whole turn on. We therefore DERIVE the verdict
+// from the authoritative fields (mirroring the #485 enqueue-validation parsing):
+// a reply is a rejection when it carries a non-empty `error`, a non-empty
+// `node_errors`, or an explicit `queued:false` — regardless of any `queued:true`
+// flag that may accompany it. Only a reply with NONE of those is a real queue.
+
+/** True when a graph_run reply's top-level `error` channel is populated (an
+ *  object with any keys, or a non-blank string). Empty object / "" / absent = no. */
+function hasTopLevelError(error: unknown): boolean {
+  if (typeof error === "string") return error.trim().length > 0;
+  if (error != null && typeof error === "object") return Object.keys(error as object).length > 0;
+  return false;
+}
+
+/** True when a graph_run reply's `node_errors` channel names at least one node. */
+function hasNodeErrors(nodeErrors: unknown): boolean {
+  return (
+    nodeErrors != null &&
+    typeof nodeErrors === "object" &&
+    Object.keys(nodeErrors as object).length > 0
+  );
+}
+
+/**
+ * Format a ComfyUI /prompt rejection payload (the top-level `error` object plus
+ * per-node `node_errors`) into a human-readable failure — the same shape the
+ * #485 HTTP enqueue path surfaces, so panel_run and enqueue_workflow read alike.
+ */
+function formatRunRejection(payload: { error?: unknown; node_errors?: unknown }): string {
+  let headline = "ComfyUI refused to queue the workflow";
+  const topError = payload.error;
+  const extraLines: string[] = [];
+  if (topError && typeof topError === "object") {
+    const te = topError as { type?: unknown; message?: unknown; details?: unknown };
+    const msg = typeof te.message === "string" ? te.message.trim() : "";
+    const type = typeof te.type === "string" ? te.type.trim() : "";
+    if (msg) headline = `ComfyUI refused to queue the workflow: ${msg}${type ? ` (${type})` : ""}`;
+    else if (type) headline = `ComfyUI refused to queue the workflow (${type})`;
+    const details = typeof te.details === "string" ? te.details.trim() : "";
+    if (details) extraLines.push(details);
+  } else if (typeof topError === "string" && topError.trim()) {
+    headline = `ComfyUI refused to queue the workflow: ${topError.trim()}`;
+  }
+
+  const lines: string[] = [...extraLines];
+  const ne = payload.node_errors;
+  if (ne && typeof ne === "object") {
+    for (const [nodeId, info] of Object.entries(ne as Record<string, unknown>)) {
+      const i = (info ?? {}) as { class_type?: unknown; errors?: unknown };
+      const cls = typeof i.class_type === "string" ? i.class_type : "node";
+      const errs = Array.isArray(i.errors) ? i.errors : [];
+      if (errs.length === 0) {
+        lines.push(`- ${cls} (node ${nodeId}): validation failed`);
+        continue;
+      }
+      for (const e of errs as Array<{ message?: unknown; details?: unknown }>) {
+        const detail = typeof e?.details === "string" && e.details ? ` (${e.details})` : "";
+        const m = typeof e?.message === "string" ? e.message : "validation failed";
+        lines.push(`- ${cls} (node ${nodeId}): ${m}${detail}`);
+      }
+    }
+  }
+  return lines.length ? `${headline}\n${lines.join("\n")}` : headline;
+}
+
+/**
+ * Inspect a graph_run ToolResult and return a FAILURE ToolResult when the run
+ * did NOT genuinely enter ComfyUI's queue, or `null` when it is a real queue
+ * (so the caller may append the success/anti-poll guidance).
+ *
+ *  - An isError reply (no connected tab #331, a thrown app.queuePrompt #248, a
+ *    transport drop) is passed through VERBATIM — its full detail/browser stack
+ *    is preserved and the success-only "you'll be notified" note is NOT added.
+ *  - A NON-error reply is parsed: a top-level `error`, a non-empty `node_errors`,
+ *    or an explicit `queued:false` is surfaced as a formatted failure (#213) —
+ *    even when a stale `queued:true` accompanies it.
+ *  - Anything else (a plain `queued:true`, or an unparseable reply we must not
+ *    regress) returns null and is treated as a genuine queue.
+ */
+function detectRunRejection(res: ToolResult): ToolResult | null {
+  // Bridge/transport/executor error: never a queue. Preserve it verbatim (#248),
+  // no success note (#331). fail() already carries err.message (incl. any stack).
+  if (res?.isError) return res;
+
+  const parsed = parseToolResultJson(res);
+  if (!parsed) return null; // unparseable non-error reply — don't regress a success
+
+  const topError = parsed.error;
+  const nodeErrors = parsed.node_errors;
+  const rejected =
+    hasTopLevelError(topError) || hasNodeErrors(nodeErrors) || parsed.queued === false;
+  if (!rejected) return null; // genuine queue (queued:true / no rejection signal)
+
+  return fail(formatRunRejection({ error: topError, node_errors: nodeErrors }));
+}
+
+export const __panelRunTestHooks = {
+  detectRunRejection,
+  formatRunRejection,
+};
+
 /** Drop a trailing .json (case-insensitive) so filename/path forms compare equal. */
 function stripJsonExt(s: unknown): string | null {
   return typeof s === "string" ? s.replace(/\.json$/i, "") : null;
@@ -1504,7 +1614,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_run",
-      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). Returns queued:true, or queued:false with node_errors when frontend validation fails. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. Omit it to run the whole graph. Use this so the render runs on THEIR canvas and they see the result.",
+      "Queue the workflow the user has OPEN — exactly like them pressing Queue Prompt (current widget values, the live graph they can see). On success it confirms the run was queued; if ComfyUI REFUSES the prompt (validation failure on either channel — per-node node_errors OR a top-level error like a missing node type) it returns a FAILURE with that rejection detail, never a false 'queued'. Pass to_node_id to RUN ONLY ONE BRANCH ('run to node'): ComfyUI renders just that output node plus everything upstream of it and SKIPS every other output branch — handy for previewing or debugging part of a big graph without rendering the whole thing. to_node_id MUST be an OUTPUT node (SaveImage, PreviewImage, SaveVideo, …) — pick the one at the END of the branch you want; nodes are tagged is_output:true in panel_query_graph's detail rows. Omit it to run the whole graph. Use this so the render runs on THEIR canvas and they see the result.",
       {
         batch_count: z
           .number()
@@ -1530,6 +1640,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           { cmd: "graph_run", batch_count: args.batch_count, to_node_id: args.to_node_id },
           20000,
         );
+        // Derive the verdict from the AUTHORITATIVE reply, not a bare `queued`
+        // flag. A rejection — a no-connected-tab / thrown-queuePrompt error
+        // (#331/#248), or a ComfyUI /prompt refusal on EITHER channel
+        // (top-level `error` with empty node_errors #213, or per-node
+        // node_errors) — is surfaced as a failure WITHOUT the success-only
+        // "you'll be notified automatically" guidance. Only a genuine queue
+        // gets the anti-poll note below.
+        const rejection = detectRunRejection(res);
+        if (rejection) return rejection;
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         const note =


### PR DESCRIPTION
## Summary

`panel_run` forwards `graph_run` to the browser panel and previously appended the success-only "you'll be notified automatically" anti-poll note to **any** text reply — including error results and prompt rejections — and trusted a bare `queued` flag. This surfaced four bugs. The fix centralizes verdict derivation in a new `detectRunRejection(res)` helper so the note is appended **only** on a genuine queue.

The actual browser-JS root fixes for these four live in the panel repo (`comfyui-mcp-panel`, `graph_run` executor); this PR is the orchestrator-side hardening: interpret the panel's reply authoritatively so a rejection is never masked as success.

### What changed
- **#213 false `queued:true`** — ComfyUI splits rejections into two channels: per-node `node_errors`, and a **top-level `error`** (e.g. `prompt_outputs_failed_validation`, `missing_node_type`) that leaves `node_errors` empty. The old node_errors-only guard let a top-level rejection report `queued:true`. `detectRunRejection` now flags a non-empty top-level `error`, a non-empty `node_errors`, **or** an explicit `queued:false` — even when a stale `queued:true` accompanies it — and formats the failure the same way the #485 enqueue-validation path does.
- **#331 no queued note without a tab** — an isError reply (no connected tab → nothing queued) now passes through verbatim with **no** success note.
- **#248 preserve error detail on `app.queuePrompt` throw** — a thrown executor error passes through verbatim, so the full browser stack the panel forwards is surfaced (no success note masking it).
- **#194 accept root SaveImage** — a root-output run-to-node the (fixed) panel accepts (`queued:true`, no errors) reports queued success; a subgraph-rejection reply is surfaced cleanly without the false note.

### Tests
New coverage in `panel-tools.test.ts` mocks the bridge boundary, FAIL-before/PASS-after: top-level `/prompt` error → failure not queued; per-node `node_errors` surfaced with node id + class_type; root SaveImage accepted + subgraph-rejection surfaced without the false note; no queued note when no tab connected; `queuePrompt` throw surfaces the browser stack; plus `detectRunRejection` unit coverage. Full suite passes (only the pre-existing node-dev ripgrep sandbox test fails, unrelated). No version bump.

### Codex review gate — VERDICT: PASS
> No — under the stated panel reply contract, a genuine ComfyUI rejection cannot receive the success anti-poll note. (a) non-empty `error` → rejected regardless of `queued:true`; (b) non-empty `node_errors` → rejected; (c) `queued:false` → rejected; (f) an unparseable non-error reply is treated as success (deliberate compatibility, only masks if the panel violates its JSON-object reply contract); (g) `{queued:true}` → legitimate success. `hasTopLevelError`/`hasNodeErrors` correctly handle the documented shapes; legit success unaffected; transport/executor errors (incl. browser stack) pass through verbatim.

## Issues

_No THIS-repo issues to auto-close._

Also fixes (panel repo — close manually): artokun/comfyui-mcp-panel#213 #194 #331 #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
