### PR TITLE
fix(strip): graph-capture fallback + correct dynamic-widget/Get-Set link mapping (#384, #361)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1848,3 +1848,143 @@ describe("panel_ask surface + late-answer resilience (#300/#486) and set_todo bo
     expect(sent.at(-1)).toMatchObject({ cmd: "set_todo" });
   });
 });
+
+describe("panel_strip_workflow live-canvas fallback (issue #384)", () => {
+  it("reconstructUiFromState rebuilds nodes + links with name-keyed widgets", () => {
+    const state = {
+      nodes: [
+        {
+          id: 1,
+          type: "CheckpointLoaderSimple",
+          widgets: { ckpt_name: "m.ckpt" },
+          inputs: [],
+          outputs: [{ name: "MODEL", type: "MODEL" }],
+        },
+        {
+          id: 2,
+          type: "KSampler",
+          widgets: { seed: 42, steps: 20 },
+          inputs: [
+            { name: "model", type: "MODEL", connected_from: { node_id: 1, output_slot: 0 } },
+          ],
+          outputs: [],
+        },
+      ],
+    };
+    const ui = __panelToolsTestHooks.reconstructUiFromState(state) as {
+      nodes: Array<{ id: number; inputs: Array<{ link: number | null }>; widgets_values: unknown }>;
+      links: unknown[];
+    } | null;
+    expect(ui).not.toBeNull();
+    expect(ui!.nodes.length).toBe(2);
+    expect(ui!.links.length).toBe(1);
+    const ks = ui!.nodes.find((n) => n.id === 2)!;
+    expect(ks.inputs[0].link).not.toBeNull();
+    // widgets survive keyed BY NAME (convertUiToApi maps them by name)
+    expect(ks.widgets_values).toEqual({ seed: 42, steps: 20 });
+  });
+
+  it("returns null when the state reply has no nodes", () => {
+    expect(__panelToolsTestHooks.reconstructUiFromState({ nodes: [] })).toBeNull();
+    expect(__panelToolsTestHooks.reconstructUiFromState({})).toBeNull();
+  });
+
+  it("refuses a TRUNCATED state reply rather than stripping a partial graph", () => {
+    const partial = {
+      truncated: true,
+      node_count: 250,
+      nodes: [{ id: 1, type: "SaveImage", widgets: {}, inputs: [], outputs: [] }],
+    };
+    expect(__panelToolsTestHooks.reconstructUiFromState(partial)).toBeNull();
+    // also caught by the node_count > nodes.length guard alone
+    expect(
+      __panelToolsTestHooks.reconstructUiFromState({
+        node_count: 3,
+        nodes: [{ id: 1, type: "SaveImage", widgets: {}, inputs: [], outputs: [] }],
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to graph_get_state when graph_serialize is an unknown command", async () => {
+    const sent: string[] = [];
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          if (cmd.cmd === "graph_serialize") {
+            throw new Error('Unknown command "graph_serialize"');
+          }
+          if (cmd.cmd === "graph_get_state") {
+            return {
+              nodes: [
+                { id: 1, type: "SaveImage", widgets: { filename_prefix: "out" }, inputs: [], outputs: [] },
+              ],
+            };
+          }
+          return {};
+        },
+      },
+    } as unknown as PanelToolCtx;
+    const wf = (await __panelToolsTestHooks.resolveWorkflowInput({}, ctx)) as {
+      nodes: Array<{ type: string }>;
+    };
+    expect(sent).toContain("graph_serialize");
+    expect(sent).toContain("graph_get_state");
+    expect(wf.nodes[0].type).toBe("SaveImage");
+  });
+
+  it("surfaces the actionable error when neither serialize nor state is available", async () => {
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          throw new Error(`Unknown command "${cmd.cmd}"`);
+        },
+      },
+    } as unknown as PanelToolCtx;
+    await expect(
+      __panelToolsTestHooks.resolveWorkflowInput({}, ctx),
+    ).rejects.toThrow(/pass pack, path, or graph/);
+  });
+
+  it("does NOT fall back when allowStateFallback is false (flatten/slice keep the actionable error)", async () => {
+    const sent: string[] = [];
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          throw new Error('Unknown command "graph_serialize"');
+        },
+      },
+    } as unknown as PanelToolCtx;
+    await expect(
+      __panelToolsTestHooks.resolveWorkflowInput({}, ctx, false),
+    ).rejects.toThrow(/pass pack, path, or graph/);
+    // the lossy state reconstruction must NOT run for flatten/slice
+    expect(sent).not.toContain("graph_get_state");
+  });
+
+  it("does NOT fall back on a genuine transport error (surfaces as-is)", async () => {
+    const sent: string[] = [];
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          throw new Error("disconnected mid-command — genuinely gone");
+        },
+      },
+    } as unknown as PanelToolCtx;
+    await expect(
+      __panelToolsTestHooks.resolveWorkflowInput({}, ctx),
+    ).rejects.toThrow(/Couldn't capture the live canvas/);
+    // never attempted the state fallback for a non-unknown-command failure
+    expect(sent).not.toContain("graph_get_state");
+  });
+});

--- a/src/__tests__/services/workflow-converter.test.ts
+++ b/src/__tests__/services/workflow-converter.test.ts
@@ -317,6 +317,403 @@ describe("convertUiToApi — serialized-widget nodes (has_serialized_properties)
   });
 });
 
+describe("convertUiToApi — combined-type widget (issue #193, LTXVEmptyLatentAudio)", () => {
+  // Real /object_info: frame_rate is declared with the COMBINED type "FLOAT,INT"
+  // (accepts either) plus a widgetType hint. Before the fix isWidgetInput only
+  // matched the exact scalar types, so frame_rate was treated as a LINK input,
+  // dropped from the widget list, and batch_size stole frame_rate's slot value
+  // while frame_rate fell back to its default (25).
+  const LTXV_INFO = {
+    LTXVEmptyLatentAudio: {
+      input: {
+        required: {
+          frames_number: ["INT", { default: 97 }],
+          frame_rate: ["FLOAT,INT", { default: 25, widgetType: "FLOAT" }],
+          batch_size: ["INT", { default: 1 }],
+          audio_vae: ["VAE", {}],
+        },
+      },
+      input_order: {
+        required: ["frames_number", "frame_rate", "batch_size", "audio_vae"],
+      },
+    },
+  } as never;
+
+  function ltxvGraph() {
+    return {
+      nodes: [
+        {
+          id: 5,
+          type: "LTXVEmptyLatentAudio",
+          mode: 0,
+          // audio_vae is a real VAE link slot; the three scalars live in widgets_values
+          // in UI widget order: frames_number, frame_rate, batch_size.
+          inputs: [{ name: "audio_vae", type: "VAE", link: null }],
+          outputs: [{ name: "Latent", type: "LATENT", links: [] }],
+          widgets_values: [121, 24, 1],
+        },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("maps frames_number/frame_rate/batch_size positionally (frame_rate is a FLOAT,INT widget)", () => {
+    const { workflow } = convertUiToApi(ltxvGraph(), LTXV_INFO);
+    const inputs = (workflow["5"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.frames_number).toBe(121);
+    expect(inputs.frame_rate).toBe(24);
+    expect(inputs.batch_size).toBe(1);
+  });
+
+  // Cross-repo regression for panel#193 (same root cause, live-canvas strip):
+  // reproduce the EXACT reported symptom to prove it never recurs — the pre-fix
+  // converter emitted {frames_number:121, batch_size:24, frame_rate:25}, i.e.
+  // batch_size stole frame_rate's 24 and frame_rate fell back to its default 25.
+  it("panel#193 exact symptom: batch_size no longer steals frame_rate's value, frame_rate not defaulted", () => {
+    const { workflow } = convertUiToApi(ltxvGraph(), LTXV_INFO);
+    const inputs = (workflow["5"] as { inputs: Record<string, unknown> }).inputs;
+    // pre-fix (buggy) values must NOT appear
+    expect(inputs.batch_size).not.toBe(24);
+    expect(inputs.frame_rate).not.toBe(25);
+    // exactly the live-canvas values
+    expect(inputs).toMatchObject({ frames_number: 121, frame_rate: 24, batch_size: 1 });
+  });
+
+  // A widgetType hint alone (type is a bare link-shaped string) is enough to treat
+  // the slot as a positional scalar widget — guards the second recognition path in
+  // isScalarWidgetType so a hint-only frontend build can't reintroduce the shift.
+  it("recognizes a widgetType-hint-only scalar widget (no combined type)", () => {
+    const HINT_INFO = {
+      LTXVEmptyLatentAudio: {
+        input: {
+          required: {
+            frames_number: ["INT", { default: 97 }],
+            frame_rate: ["FLOAT", { default: 25, widgetType: "FLOAT" }],
+            batch_size: ["INT", { default: 1 }],
+            audio_vae: ["VAE", {}],
+          },
+        },
+        input_order: {
+          required: ["frames_number", "frame_rate", "batch_size", "audio_vae"],
+        },
+      },
+    } as never;
+    const { workflow } = convertUiToApi(ltxvGraph(), HINT_INFO);
+    const inputs = (workflow["5"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs).toMatchObject({ frames_number: 121, frame_rate: 24, batch_size: 1 });
+  });
+});
+
+describe("convertUiToApi — name-keyed widgets carry dynamic-combo nested values (issue #384 fallback)", () => {
+  // The live-canvas fallback reconstructs widgets_values as a name->value OBJECT.
+  // A V3 dynamic combo's selected-option nested inputs must still be emitted as
+  // "<combo>.<nested>" from that object form (not only from the positional array).
+  const DYN_INFO = {
+    MyDynNode: {
+      input: {
+        required: {
+          method: [
+            "COMFY_DYNAMICCOMBO_V3",
+            {
+              options: [
+                { key: "rcas", inputs: { required: { strength: ["FLOAT", { default: 0.5 }] } } },
+                { key: "none", inputs: { required: {} } },
+              ],
+            },
+          ],
+        },
+      },
+      input_order: { required: ["method"] },
+    },
+  } as never;
+
+  it("emits <combo>.<nested> from object-form widgets_values", () => {
+    const graph = {
+      nodes: [
+        {
+          id: 7,
+          type: "MyDynNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // object (name-keyed) form, as produced by the graph_get_state fallback
+          widgets_values: { method: "rcas", strength: 0.8 },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(graph, DYN_INFO);
+    const inputs = (workflow["7"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.method).toBe("rcas");
+    expect(inputs["method.strength"]).toBe(0.8);
+  });
+
+  // An option's nested input may live under `inputs.optional` (e.g. an asset
+  // selector). The object-form fallback must merge required+optional like the
+  // positional branch, or it silently drops the optional nested value — a #504/#407
+  // regression on the live-canvas fallback path.
+  it("emits an OPTIONAL nested <combo>.<nested> from object-form widgets_values", () => {
+    const OPT_INFO = {
+      OptDynNode: {
+        input: {
+          required: {
+            method: [
+              "COMFY_DYNAMICCOMBO_V3",
+              {
+                options: [
+                  {
+                    key: "load",
+                    inputs: {
+                      required: { strength: ["FLOAT", { default: 0.5 }] },
+                      optional: { vae_name: [["a.safetensors", "b.safetensors"], {}] },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        input_order: { required: ["method"] },
+      },
+    } as never;
+    const graph = {
+      nodes: [
+        {
+          id: 9,
+          type: "OptDynNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { method: "load", strength: 0.6, vae_name: "b.safetensors" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(graph, OPT_INFO);
+    const inputs = (workflow["9"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs["method.strength"]).toBe(0.6);
+    // the optional nested asset selector must survive (kept-declared, not dropped)
+    expect(inputs["method.vae_name"]).toBe("b.safetensors");
+  });
+});
+
+describe("convertUiToApi — name-keyed nested-leaf name collisions must FAIL CLOSED (P0)", () => {
+  // Two dynamic-combo parents each exposing a nested leaf of the SAME name. The
+  // flat name→value capture (graph_get_state fallback) can only hold ONE "strength"
+  // slot, so reading nested values by leaf name would push it onto BOTH controls —
+  // a silent wrong-value regression (the #504/#499 bug class).
+  const TWO_COMBO_INFO = {
+    TwoComboNode: {
+      input: {
+        required: {
+          first: [
+            "COMFY_DYNAMICCOMBO_V3",
+            { options: [{ key: "on", inputs: { required: { strength: ["FLOAT", { default: 0.5 }] } } }] },
+          ],
+          second: [
+            "COMFY_DYNAMICCOMBO_V3",
+            { options: [{ key: "on", inputs: { required: { strength: ["FLOAT", { default: 0.5 }] } } }] },
+          ],
+        },
+      },
+      input_order: { required: ["first", "second"] },
+    },
+  } as never;
+
+  function twoComboGraph(widgets: Record<string, unknown>) {
+    return {
+      nodes: [
+        { id: 3, type: "TwoComboNode", mode: 0, inputs: [], outputs: [], widgets_values: widgets },
+      ],
+      links: [],
+    } as never;
+  }
+
+  it("REFUSES a collapsed flat leaf shared by two dynamic-combo parents (never emits both to one value)", () => {
+    // pre-fix: BOTH first.strength AND second.strength came out 0.8 (collapsed).
+    const { workflow, warnings } = convertUiToApi(
+      twoComboGraph({ first: "on", second: "on", strength: 0.8 }),
+      TWO_COMBO_INFO,
+    );
+    const inputs = (workflow["3"] as { inputs: Record<string, unknown> }).inputs;
+    // must NOT silently collapse the same value onto both controls
+    expect(inputs["first.strength"]).toBeUndefined();
+    expect(inputs["second.strength"]).toBeUndefined();
+    expect(warnings.some((w) => /more than one control/i.test(w))).toBe(true);
+  });
+
+  it("uses PARENT-QUALIFIED keys when the capture provides them (both correct, distinct)", () => {
+    const { workflow } = convertUiToApi(
+      twoComboGraph({
+        first: "on",
+        second: "on",
+        "first.strength": 0.2,
+        "second.strength": 0.8,
+      }),
+      TWO_COMBO_INFO,
+    );
+    const inputs = (workflow["3"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs["first.strength"]).toBe(0.2);
+    expect(inputs["second.strength"]).toBe(0.8);
+  });
+
+  it("REFUSES a nested leaf that shadows a top-level widget of the same name", () => {
+    const SHADOW_INFO = {
+      ShadowNode: {
+        input: {
+          required: {
+            strength: ["FLOAT", { default: 1 }], // top-level widget
+            method: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "load", inputs: { required: { strength: ["FLOAT", { default: 0.5 }] } } }] },
+            ],
+          },
+        },
+        input_order: { required: ["strength", "method"] },
+      },
+    } as never;
+    const graph = {
+      nodes: [
+        {
+          id: 4,
+          type: "ShadowNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          widgets_values: { strength: 0.9, method: "load" },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow, warnings } = convertUiToApi(graph, SHADOW_INFO);
+    const inputs = (workflow["4"] as { inputs: Record<string, unknown> }).inputs;
+    // The single flat "strength" slot can't be attributed to EITHER the top-level
+    // widget or the nested leaf, so BOTH destinations must fail closed — the
+    // top-level is left to its NODE DEFAULT (1), never the untrusted stored 0.9,
+    // and the nested leaf is not emitted at all.
+    expect(inputs.strength).not.toBe(0.9); // must not trust the collapsed value
+    expect(inputs.strength).toBe(1); // filled with the widget's declared default
+    expect(inputs["method.strength"]).toBeUndefined();
+    expect(warnings.some((w) => /more than one control/i.test(w))).toBe(true);
+  });
+
+  it("a top-level widget stays safe when the nested leaf is PARENT-QUALIFIED (not competing for the flat slot)", () => {
+    const SHADOW_INFO = {
+      ShadowNode: {
+        input: {
+          required: {
+            strength: ["FLOAT", { default: 1 }],
+            method: [
+              "COMFY_DYNAMICCOMBO_V3",
+              { options: [{ key: "load", inputs: { required: { strength: ["FLOAT", { default: 0.5 }] } } }] },
+            ],
+          },
+        },
+        input_order: { required: ["strength", "method"] },
+      },
+    } as never;
+    const graph = {
+      nodes: [
+        {
+          id: 6,
+          type: "ShadowNode",
+          mode: 0,
+          inputs: [],
+          outputs: [],
+          // nested value is parent-qualified, so the flat "strength" is unambiguously
+          // the top-level widget's.
+          widgets_values: { strength: 0.9, method: "load", "method.strength": 0.2 },
+        },
+      ],
+      links: [],
+    } as never;
+    const { workflow } = convertUiToApi(graph, SHADOW_INFO);
+    const inputs = (workflow["6"] as { inputs: Record<string, unknown> }).inputs;
+    expect(inputs.strength).toBe(0.9);
+    expect(inputs["method.strength"]).toBe(0.2);
+  });
+});
+
+describe("convertUiToApi — Set/Get bus resolution (issue #361)", () => {
+  const GETSET_INFO = {
+    CheckpointLoaderSimple: {
+      input: { required: { ckpt_name: [["a.ckpt", "b.ckpt"], {}] } },
+    },
+    KSampler: {
+      input: { required: { model: ["MODEL"], seed: ["INT"] } },
+    },
+  } as never;
+
+  // Loader(1).MODEL --link10--> SetNode(2) "mdl"
+  //   GetNode(3) "mdl" --link12--> KSampler(4).model       (resolved via the bus)
+  //   SetNode(2) passthrough output --link11--> KSampler(5).model  (direct off Set)
+  function busGraph() {
+    return {
+      nodes: [
+        {
+          id: 1,
+          type: "CheckpointLoaderSimple",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "MODEL", type: "MODEL", links: [10] }],
+          widgets_values: ["a.ckpt"],
+        },
+        {
+          id: 2,
+          type: "SetNode",
+          mode: 0,
+          inputs: [{ name: "MODEL", type: "MODEL", link: 10 }],
+          outputs: [{ name: "*", type: "MODEL", links: [11] }],
+          widgets_values: ["mdl"],
+        },
+        {
+          id: 3,
+          type: "GetNode",
+          mode: 0,
+          inputs: [],
+          outputs: [{ name: "*", type: "MODEL", links: [12] }],
+          widgets_values: ["mdl"],
+        },
+        {
+          id: 4,
+          type: "KSampler",
+          mode: 0,
+          inputs: [{ name: "model", type: "MODEL", link: 12 }],
+          outputs: [],
+          widgets_values: [123],
+        },
+        {
+          id: 5,
+          type: "KSampler",
+          mode: 0,
+          inputs: [{ name: "model", type: "MODEL", link: 11 }],
+          outputs: [],
+          widgets_values: [456],
+        },
+      ],
+      links: [
+        [10, 1, 0, 2, 0, "MODEL"],
+        [11, 2, 0, 5, 0, "MODEL"],
+        [12, 3, 0, 4, 0, "MODEL"],
+      ],
+    } as never;
+  }
+
+  it("resolves a GetNode consumer through the bus to the real source", () => {
+    const { workflow } = convertUiToApi(busGraph(), GETSET_INFO);
+    expect(workflow["4"].inputs.model).toEqual(["1", 0]);
+    expect(workflow["4"].inputs.seed).toBe(123);
+  });
+
+  it("preserves a link taken directly off a SetNode passthrough output (was dropped)", () => {
+    const { workflow } = convertUiToApi(busGraph(), GETSET_INFO);
+    expect(workflow["5"].inputs.model).toEqual(["1", 0]);
+    // virtual bus nodes never appear in the prompt
+    expect(workflow["2"]).toBeUndefined();
+    expect(workflow["3"]).toBeUndefined();
+  });
+});
+
 describe("convertUiToApi — asset-combo fallback (issue #407)", () => {
   // Real Krea 2 manual-pack shape: node 54 is a UNETLoader whose saved
   // unet_name is the advertised Krea Turbo model, but the CONNECTED server only

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -208,6 +208,13 @@ export const __panelToolsTestHooks = {
   },
   isRetrySafeCmd,
   isTransientReconnectError,
+  // #384 live-canvas capture fallback (defined later in the module).
+  reconstructUiFromState: (reply: unknown) => reconstructUiFromState(reply),
+  resolveWorkflowInput: (
+    args: Record<string, unknown>,
+    ctx: PanelToolCtx,
+    allowStateFallback = true,
+  ) => resolveWorkflowInput(args, ctx, allowStateFallback),
 };
 
 function sleep(ms: number): Promise<void> {
@@ -1126,9 +1133,103 @@ export function makePanelToolCtx(
  * what I have open" is the common ask, and requiring a save-to-disk round trip
  * first derailed real sessions (deleted placeholder files, 404 tabs).
  */
+/**
+ * Rebuild a UI-format workflow ({ nodes, links }) from the panel's back-compat
+ * `graph_get_state` reply (the #384 fallback). Each summarized node carries its
+ * widget values keyed BY NAME (`widgets`) and its inputs' upstream source
+ * (`connected_from`), so we materialize:
+ *   - nodes with `widgets_values` as the name→value OBJECT — convertUiToApi maps
+ *     those by name, which also sidesteps the positional widget-order pitfalls,
+ *   - a synthetic links array + per-input `link` ids from `connected_from`.
+ * Returns null when the reply has no usable nodes.
+ */
+function reconstructUiFromState(reply: unknown): Record<string, unknown> | null {
+  const r = reply as { nodes?: unknown[]; truncated?: boolean; node_count?: number } | null;
+  const nodesIn = r?.nodes;
+  if (!Array.isArray(nodesIn) || nodesIn.length === 0) return null;
+  // graph_get_state caps at MAX_STATE_NODES (100) and flags the overflow. A
+  // truncated capture would silently yield an INCOMPLETE executable graph, so
+  // refuse it — the caller then surfaces the actionable "pass pack/path/graph"
+  // error rather than stripping a partial workflow.
+  if (r?.truncated === true) return null;
+  if (typeof r?.node_count === "number" && r.node_count > nodesIn.length) return null;
+
+  type StateNode = {
+    id: number;
+    type: string;
+    title?: string;
+    mode?: string;
+    widgets?: Record<string, unknown>;
+    inputs?: {
+      name: string;
+      type?: string;
+      connected_from?: { node_id: number; output_slot?: number } | null;
+    }[];
+    outputs?: { name: string; type?: string }[];
+  };
+
+  const uiNodes = nodesIn.map((raw) => {
+    const n = raw as StateNode;
+    const mode = n.mode === "mute" ? 2 : n.mode === "bypass" ? 4 : 0;
+    return {
+      id: n.id,
+      type: n.type,
+      mode,
+      pos: [0, 0] as [number, number],
+      inputs: (n.inputs ?? []).map((inp) => ({
+        name: inp.name,
+        type: inp.type ?? "*",
+        link: null as number | null,
+      })),
+      outputs: (n.outputs ?? []).map((o) => ({
+        name: o.name,
+        type: o.type ?? "*",
+        links: [] as number[],
+      })),
+      widgets_values:
+        n.widgets && typeof n.widgets === "object"
+          ? (n.widgets as unknown as unknown[])
+          : ([] as unknown[]),
+      properties: {} as Record<string, unknown>,
+      ...(n.title ? { title: n.title } : {}),
+    };
+  });
+
+  const byId = new Map(uiNodes.map((n) => [n.id, n]));
+  const links: [number, number, number, number, number, string][] = [];
+  let linkId = 0;
+  nodesIn.forEach((raw, idx) => {
+    const inputs = (raw as StateNode).inputs ?? [];
+    const tgt = uiNodes[idx];
+    inputs.forEach((inp, slot) => {
+      const from = inp.connected_from;
+      if (!from || from.node_id == null || !byId.has(from.node_id)) return;
+      const id = ++linkId;
+      tgt.inputs[slot].link = id;
+      const srcNode = byId.get(from.node_id)!;
+      const srcSlot = from.output_slot ?? 0;
+      while (srcNode.outputs.length <= srcSlot) {
+        srcNode.outputs.push({ name: `out_${srcNode.outputs.length}`, type: "*", links: [] });
+      }
+      srcNode.outputs[srcSlot].links.push(id);
+      links.push([id, from.node_id, srcSlot, tgt.id, slot, inp.type ?? "*"]);
+    });
+  });
+
+  return { nodes: uiNodes, links } as unknown as Record<string, unknown>;
+}
+
 async function resolveWorkflowInput(
   args: Record<string, unknown>,
   ctx: PanelToolCtx,
+  // The live-canvas graph_get_state fallback (#384) is LOSSY: it reconstructs
+  // only nodes/links/widgets (name-keyed) — no layout, groups, properties, or
+  // subgraph definitions. That's fine for panel_strip_workflow (API/prompt output
+  // for inspection/execution), but panel_flatten_workflow LOADS its result back
+  // ONTO the canvas and panel_slice_workflow needs groups to find its seeds, so
+  // they must NOT take this fallback — they keep the actionable "update your
+  // panel" error instead. Only strip opts in.
+  allowStateFallback = false,
 ): Promise<Record<string, unknown>> {
   if (args.pack) return readPackWorkflow(args.pack as string);
   if (args.path) return await readWorkflowFromPath(args.path as string);
@@ -1153,8 +1254,30 @@ async function resolveWorkflowInput(
       timeoutMs: 30000,
     });
   } catch (err) {
+    // #384: a panel too old to register graph_serialize (added at 0.11.4) still
+    // answers the back-compat `graph_get_state`. On an "Unknown command" rejection
+    // ONLY (a genuine transport/timeout error must surface as-is), fall back to it
+    // and reconstruct the graph so "strip the live canvas" works without a
+    // save-to-disk round trip.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (allowStateFallback && /unknown command/i.test(msg)) {
+      try {
+        const target = ctx.workflowTarget?.get(ctx.tabId);
+        const stateCmd = target
+          ? withWorkflowTarget({ cmd: "graph_get_state" }, target)
+          : { cmd: "graph_get_state" };
+        const stateReply = await ctx.bridge.send(stateCmd as { cmd: string }, {
+          tabId: ctx.tabId,
+          timeoutMs: 30000,
+        });
+        const rebuilt = reconstructUiFromState(stateReply);
+        if (rebuilt) return rebuilt;
+      } catch {
+        /* fall through to the actionable error below */
+      }
+    }
     throw new Error(
-      `Couldn't capture the live canvas (${err instanceof Error ? err.message : String(err)}). ` +
+      `Couldn't capture the live canvas (${msg}). ` +
         `An older panel version may not support graph_serialize — pass pack, path, or graph instead.`,
     );
   }
@@ -1578,7 +1701,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .describe("Inline UI workflow (object or JSON string) to strip instead of a pack/path."),
       },
       async (args: A, ctx) => {
-        const raw = await resolveWorkflowInput(args, ctx);
+        // strip opts into the lossy live-canvas fallback (#384) — its API/prompt
+        // output is for inspection/execution, never reloaded onto the canvas.
+        const raw = await resolveWorkflowInput(args, ctx, true);
         const ui = raw as unknown as UiWorkflow;
         const bulk = await getObjectInfo();
         const objectInfo = await backfillObjectInfo(bulk, collectNodeTypes(ui));

--- a/src/services/workflow-converter.ts
+++ b/src/services/workflow-converter.ts
@@ -36,6 +36,30 @@ export function isUiFormat(obj: unknown): obj is UiWorkflow {
   return Array.isArray(record.nodes) && Array.isArray(record.links);
 }
 
+/** The primitive scalar widget types that occupy a widgets_values slot. */
+const SCALAR_WIDGET_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);
+
+/**
+ * Whether a (type, cfg) pair describes a scalar widget input. Beyond the plain
+ * "INT"/"FLOAT"/… types this also recognizes:
+ *  - a `widgetType` config hint (the frontend's authoritative "render this as a
+ *    FLOAT/INT widget" flag), and
+ *  - a COMBINED type string like "FLOAT,INT" (ComfyUI declares widgets whose value
+ *    may be either — e.g. LTXVEmptyLatentAudio.frame_rate is `["FLOAT,INT", …]`).
+ * Without this, a combined-type widget is misread as a LINK input, dropped from
+ * the widget list, and every following widget value shifts by one slot (issue
+ * #193: frame_rate 24 landed on batch_size and frame_rate fell back to default 25).
+ */
+function isScalarWidgetType(type: unknown, cfg?: unknown): boolean {
+  const wt = (cfg as { widgetType?: unknown } | undefined)?.widgetType;
+  if (typeof wt === "string" && SCALAR_WIDGET_TYPES.has(wt)) return true;
+  if (typeof type !== "string") return false;
+  if (SCALAR_WIDGET_TYPES.has(type)) return true;
+  if (!type.includes(",")) return false;
+  const parts = type.split(",").map((s) => s.trim()).filter(Boolean);
+  return parts.length > 0 && parts.every((p) => SCALAR_WIDGET_TYPES.has(p));
+}
+
 /**
  * Check if an input spec represents a widget (value input) vs a link (connection input).
  * Widget inputs have an array type spec like ["INT", {...}] or ["STRING", {...}].
@@ -56,15 +80,8 @@ function isWidgetInput(
   // COMFY_DYNAMICCOMBO_V3) — the selected option's key is a widget value.
   const cfg = spec[1] as { options?: unknown } | undefined;
   if (Array.isArray(cfg?.options)) return true;
-  // Standard widget types
-  const WIDGET_TYPES = new Set([
-    "INT",
-    "FLOAT",
-    "STRING",
-    "BOOLEAN",
-    "COMBO",
-  ]);
-  return WIDGET_TYPES.has(typeSpec);
+  // Standard + combined + widgetType-hinted scalar widgets.
+  return isScalarWidgetType(typeSpec, cfg);
 }
 
 /**
@@ -79,7 +96,7 @@ function isPositionalWidgetSpec(spec: unknown): boolean {
   if (Array.isArray(type)) return true; // inline combo options
   const cfg = spec[1] as { options?: unknown } | undefined;
   if (Array.isArray(cfg?.options)) return true; // dynamic combo (options-carrying)
-  return ["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"].includes(String(type));
+  return isScalarWidgetType(type, cfg);
 }
 
 /**
@@ -426,6 +443,22 @@ const isWiringVirtual = (t: string | undefined) =>
   t != null && (t === "Reroute" || isGetVirtual(t) || isSetVirtual(t));
 
 /**
+ * The bus name (the "Constant" widget) that keys a Set/Get virtual node. Usually
+ * widgets_values[0] on a serialized graph, but the live-canvas reconstruction
+ * fallback (#384) keys widget values BY NAME, so widgets_values can be an object
+ * ({ Constant: "…" }) instead of a positional array. Read both shapes so Set/Get
+ * resolution survives the fallback path.
+ */
+function busKey(wv: unknown): unknown {
+  if (Array.isArray(wv)) return wv[0];
+  if (wv && typeof wv === "object") {
+    const o = wv as Record<string, unknown>;
+    return o.Constant ?? o.constant ?? Object.values(o)[0];
+  }
+  return undefined;
+}
+
+/**
  * Pre-pass: strip the pure "wiring" virtual nodes — KJNodes **Get/Set** bus nodes
  * and **Reroute** — by rewriting each consumer's link straight to the real
  * upstream source (following chains, and Get→bus→Set→source). Runs on the
@@ -456,7 +489,7 @@ function deVirtualizeGraph(
   const busSet = new Map<string, UiNode>();
   for (const n of nodes) {
     if (isSetVirtual(n.type)) {
-      const b = n.widgets_values?.[0];
+      const b = busKey(n.widgets_values);
       if (b != null) busSet.set(String(b), n);
     }
   }
@@ -478,10 +511,19 @@ function deVirtualizeGraph(
       return s ? resolveReal(s.node, s.slot, depth + 1) : null;
     }
     if (isGetVirtual(node.type)) {
-      const b = node.widgets_values?.[0];
+      const b = busKey(node.widgets_values);
       const setN = b != null ? busSet.get(String(b)) : undefined;
       if (!setN) return null;
       const s = incoming(setN);
+      return s ? resolveReal(s.node, s.slot, depth + 1) : null;
+    }
+    // SetNode passthrough: rgthree/KJNodes Set nodes expose an output that mirrors
+    // their value input, so a consumer can wire straight off the SetNode (not only
+    // via a GetNode). Follow the Set's value input to the real source — otherwise
+    // the link is left pointing at the (removed) virtual and gets dropped, losing
+    // the connection (issue #361: Set/Get-resolved links missing on downstream nodes).
+    if (isSetVirtual(node.type)) {
+      const s = incoming(node);
       return s ? resolveReal(s.node, s.slot, depth + 1) : null;
     }
     return { node: nodeId, slot };
@@ -490,7 +532,10 @@ function deVirtualizeGraph(
   const drop = new Set<unknown>();
   for (const l of links as any[]) {
     const srcType = byId.get(lsrc(l))?.type;
-    if (srcType === "Reroute" || (srcType && isGetVirtual(srcType))) {
+    if (
+      srcType === "Reroute" ||
+      (srcType && (isGetVirtual(srcType) || isSetVirtual(srcType)))
+    ) {
       const real = resolveReal(lsrc(l), lsrcSlot(l));
       if (real && !isWiringVirtual(byId.get(real.node as number)?.type)) {
         setLsrc(l, real.node, real.slot);
@@ -972,7 +1017,12 @@ export function isLinkRef(v: unknown, nodeKeys: Set<string>): v is [string | num
 /** The UI slot `type` string for a widget input spec. */
 function widgetSlotType(spec: NodeInputSpec): string {
   const t = spec[0];
-  return Array.isArray(t) ? "COMBO" : t;
+  if (Array.isArray(t)) return "COMBO";
+  const wt = (spec[1] as { widgetType?: unknown } | undefined)?.widgetType;
+  if (typeof wt === "string") return wt;
+  // Combined type like "FLOAT,INT" → the first member is the concrete slot type.
+  if (typeof t === "string" && t.includes(",")) return t.split(",")[0].trim();
+  return t;
 }
 
 /**
@@ -1371,7 +1421,7 @@ export function convertUiToApi(
   const busSource = new Map<string, number>();
   for (const n of expanded.nodes) {
     if (!isSetType(n.type)) continue;
-    const bus = n.widgets_values?.[0];
+    const bus = busKey(n.widgets_values);
     const inp = (n.inputs ?? []).find((i) => i.link != null);
     if (bus != null && inp?.link != null) busSource.set(String(bus), inp.link);
   }
@@ -1395,7 +1445,7 @@ export function convertUiToApi(
     }
     // Virtual GetNode: follow the bus to the SetNode that wrote it.
     if (isGetType(src.type)) {
-      const bus = src.widgets_values?.[0];
+      const bus = busKey(src.widgets_values);
       const setLink = bus != null ? busSource.get(String(bus)) : undefined;
       return setLink != null ? resolveSource(setLink, depth + 1) : null;
     }
@@ -1484,19 +1534,139 @@ export function convertUiToApi(
     const widgetValues = node.widgets_values ?? [];
 
     // Some nodes (e.g. VHS_VideoCombine) store widgets_values as a name->value
-    // object instead of a positional array. Map those by name directly.
+    // object instead of a positional array — as does the #384 live-canvas
+    // fallback (graph_get_state keys every widget by name). Map those by name
+    // directly; no positional drift means the values are authoritative (no
+    // combo-validity re-resolution or phantom control_after_generate slot needed).
     if (!Array.isArray(widgetValues)) {
       const wv = widgetValues as Record<string, unknown>;
+
+      // Resolve a top-level dynamic combo's SELECTED-option nested inputs (merged
+      // required + optional — an asset selector may live under `optional`, and
+      // reading only `required` would drop it, regressing #504/#407). Mirrors the
+      // positional branch's nested lookup.
+      const nestedFor = (name: string): Record<string, unknown> | undefined => {
+        const spec =
+          (def.input?.required as Record<string, unknown>)?.[name] ??
+          (def.input?.optional as Record<string, unknown>)?.[name];
+        const opts = (
+          Array.isArray(spec)
+            ? (spec[1] as {
+                options?: Array<{
+                  key?: unknown;
+                  inputs?: {
+                    required?: Record<string, unknown>;
+                    optional?: Record<string, unknown>;
+                  };
+                }>;
+              })
+            : undefined
+        )?.options;
+        const selInputs = Array.isArray(opts)
+          ? opts.find((o) => o?.key === wv[name])?.inputs
+          : undefined;
+        return selInputs && (selInputs.required || selInputs.optional)
+          ? { ...selInputs.required, ...selInputs.optional }
+          : undefined;
+      };
+
+      // A name-keyed capture (the #384 graph_get_state fallback, or a natively
+      // name-keyed widgets_values) stores EVERY widget in ONE FLAT name→value map.
+      // That is only authoritative when names are GLOBALLY UNIQUE. When more than
+      // one control claims the SAME flat slot — two dynamic-combo parents each with
+      // a nested "strength", OR a nested "strength" shadowing a top-level widget
+      // "strength" — the single stored value can't be attributed to ANY of them, so
+      // reading by leaf name would silently push one control's value onto another
+      // (the #504/#499 wrong-value bug class). A control claims the flat slot L when
+      // it needs L and the capture did NOT parent-qualify it ("first.strength"); a
+      // PARENT-QUALIFIED key is always unambiguous and consumes its own slot, never
+      // the flat one. Count the claimants of each flat slot up front so the emit
+      // loop can FAIL CLOSED — refuse EVERY control competing for an over-subscribed
+      // slot (top-level AND nested), leaving each to its node default — rather than
+      // trust a value that might belong to a different control.
+      const nestedByParent = new Map<string, Record<string, unknown>>();
       for (const name of widgetNames) {
-        if (name in wv)
-          inputs[name] = validateComboWidgetValue(
-            name,
-            wv[name],
-            def,
-            classType,
-            nodeId,
-            warnings,
-          );
+        const nested = nestedFor(name);
+        if (nested) nestedByParent.set(name, nested);
+      }
+      // flat-slot claimant count, keyed by leaf name.
+      const flatClaimants = new Map<string, number>();
+      const claimFlat = (leaf: string) =>
+        flatClaimants.set(leaf, (flatClaimants.get(leaf) ?? 0) + 1);
+      for (const name of widgetNames) {
+        if (name in wv) claimFlat(name); // top-level widget claims its own flat slot
+      }
+      for (const [parent, nested] of nestedByParent) {
+        for (const [nName, nSpec] of Object.entries(nested)) {
+          if (!isPositionalWidgetSpec(nSpec)) continue;
+          // a nested leaf claims the flat slot only when it FALLS BACK to it
+          // (no parent-qualified key present in the capture).
+          if (`${parent}.${nName}` in wv) continue;
+          if (nName in wv) claimFlat(nName);
+        }
+      }
+      const flatAmbiguous = (leaf: string) => (flatClaimants.get(leaf) ?? 0) > 1;
+      const ambiguityWarning = (target: string, leaf: string) =>
+        `Node ${nodeId} (${classType}): widget "${target}" could not be resolved from the name-keyed capture because the flat slot "${leaf}" is claimed by more than one control (multiple dynamic-combo nested leaves of the same name, or a nested leaf shadowing a top-level widget), so the single stored value can't be attributed to the right control. Left to the node default rather than risk assigning another control's value. Re-capture with a panel that emits parent-qualified widget names, or pass pack/path/graph.`;
+
+      for (const name of widgetNames) {
+        if (name in wv) {
+          // A top-level widget whose flat slot is over-subscribed (a nested leaf of
+          // the same name also falls back to it) is itself ambiguous — the stored
+          // value might be the nested control's — so refuse it too, don't trust it.
+          if (flatAmbiguous(name)) {
+            warnings.push(ambiguityWarning(name, name));
+          } else {
+            inputs[name] = validateComboWidgetValue(
+              name,
+              wv[name],
+              def,
+              classType,
+              nodeId,
+              warnings,
+            );
+          }
+        }
+
+        // V3 dynamic-combo nested inputs: the selected option adds required
+        // sub-inputs whose live values are ALSO keyed in wv. Emit them as
+        // "<combo>.<nested>" so the prompt matches the array-branch shape (ComfyUI
+        // rebuilds the nested dict from these dotted keys). Each nested leaf is
+        // validated against ITS OWN spec/name (mirrors the array branch — don't
+        // regress #504/#407 asset preservation for nested combos).
+        const nested = nestedByParent.get(name);
+        if (nested) {
+          for (const [nName, nSpec] of Object.entries(nested)) {
+            if (!isPositionalWidgetSpec(nSpec)) continue;
+            const qualified = `${name}.${nName}`;
+            // Preferred: the capture already parent-qualified the key — unambiguous.
+            if (qualified in wv) {
+              inputs[qualified] = validateComboValueForSpec(
+                nName,
+                wv[qualified],
+                nSpec,
+                classType,
+                nodeId,
+                warnings,
+              );
+              continue;
+            }
+            if (!(nName in wv)) continue;
+            // Flat leaf: safe ONLY when it is the SOLE claimant of that flat slot.
+            if (flatAmbiguous(nName)) {
+              warnings.push(ambiguityWarning(qualified, nName));
+              continue;
+            }
+            inputs[qualified] = validateComboValueForSpec(
+              nName,
+              wv[nName],
+              nSpec,
+              classType,
+              nodeId,
+              warnings,
+            );
+          }
+        }
       }
     } else {
     let widgetIdx = 0;


### PR DESCRIPTION
## Summary

`panel_strip_workflow` had three defects in the UI→API conversion path. All fixed here in **comfyui-mcp** (orchestrator + workflow converter). Regression tests fail-before / pass-after; full suite green except the pre-existing node-dev ripgrep sandbox failure.

Closes #384
Closes #361
Closes artokun/comfyui-mcp-panel#193

### #384 — live-canvas capture had no fallback
When the connected panel is too old to register `graph_serialize`, capture failed hard. `resolveWorkflowInput` now falls back — **only on an "Unknown command" rejection** — to the back-compat `graph_get_state` and reconstructs the graph with widgets keyed **by name** (which also sidesteps positional widget-order pitfalls). The fallback is lossy (no layout/groups/subgraph defs), so it is **gated to `panel_strip_workflow` only** via `allowStateFallback`; `panel_flatten_workflow` (reloads onto canvas) and `panel_slice_workflow` (needs groups to seed) keep the actionable upgrade error. A **truncated** state reply (`graph_get_state` caps at 100 nodes) is refused rather than stripped into a partial graph.

### #361 — dropped Set/Get links
A link taken directly off an rgthree/KJNodes **SetNode passthrough** output was dropped (only `GetNode`/`Reroute` sources were resolved). `deVirtualizeGraph` now resolves SetNode-passthrough sources through the Set's value input. The *wrong dynamic-COMBO widget values* from the same report were already fixed on `main` via the #407 asset-combo keep-declared logic.

### panel#193 — LTXVEmptyLatentAudio mis-mapped widgets
`frame_rate` is declared with the **combined type `"FLOAT,INT"`** (+ `widgetType` hint), which the widget detector didn't recognize — so `frame_rate` was misread as a link input, dropping it from the widget list and shifting every following value (`frame_rate` 24 landed on `batch_size`; `frame_rate` fell back to default 25 — exactly the reported symptom). `isScalarWidgetType` now recognizes combined / `widgetType` scalar widgets across `isWidgetInput` / `isPositionalWidgetSpec` / `widgetSlotType`. (This is the cross-repo `artokun/comfyui-mcp-panel#193`; comfyui-mcp #193 is an unrelated merged PR.)

### Supporting changes
- Object-form (name-keyed) `widgets_values` branch now emits V3 dynamic-combo nested `<combo>.<nested>` values, **merging the selected option's `required` + `optional` nested specs** (an optional nested asset selector must not be dropped — #504/#407) and validating each nested leaf against its own spec.
- **Fail-closed flat-slot disambiguation (P0).** The name-keyed capture stores every widget in ONE flat `name→value` map, which is only authoritative when names are globally unique. When more than one control competes for the same flat slot — two dynamic-combo parents each exposing a nested leaf of the same name, or a nested leaf shadowing a top-level widget of the same name — the single stored value can't be attributed to any of them. The converter now counts the *claimants* of each flat slot (a top-level widget claims its own slot; a nested leaf claims the flat slot only when it is not parent-qualified in the capture) and **refuses every control competing for an over-subscribed slot** (top-level and nested), leaving each to its node default with a warning, rather than silently pushing one control's value onto another (the #504/#499 wrong-value bug class). A **parent-qualified** key (`first.strength`) is always unambiguous and used directly.
- `busKey` reads Set/Get bus names from both array and object widget shapes (needed by the #384 fallback path).

## Tests
- `panel#193`: LTXVEmptyLatentAudio maps `frames_number:121, frame_rate:24, batch_size:1` (was `frame_rate:25, batch_size:24`); plus an exact-symptom guard and a `widgetType`-hint-only variant.
- `#361`: SetNode-passthrough link preserved (was dropped); GetNode bus resolution unchanged.
- `#384`: serialize-unsupported → `graph_get_state` fallback capture; strip-only gating; truncated-reply refusal; transport errors surface as-is.
- Object-form dynamic-combo nested-key emission, including an **optional** nested asset selector.
- **Flat-slot collision (P0), fail-before/pass-after:** two dynamic-combo parents sharing a nested leaf name → both refused (or both correct when parent-qualified); a nested leaf shadowing a top-level widget → both refused, top-level filled with its node default (never the collapsed value); a parent-qualified nested key keeps the top-level widget safe.

## Rebase (onto current `main`)
Rebased onto `main` past the SEVERE converter fixes (#504/#499 positional mapping + dynamic-combo refusal, #407 asset-selector preservation, #526 gguf listing, #482 lock). Conflicts resolved in `workflow-converter.ts` (object-form branch now keeps `validateComboWidgetValue` from `main` AND layers the nested emission on top) and the panel-tools test file (both new describe blocks kept). Verified none of `main`'s fixes regressed.

## Codex review
`VERDICT: PASS`. Post-rebase adversarial re-review caught, in successive rounds: (1) a P1 where the object-form fallback read only nested `required`, dropping optional nested asset selectors (#504/#407 regression on the fallback path); (2) a P0 where the flat name-keyed capture collapsed same-named controls onto one value; and (3) the deeper facet of that P0 — a top-level widget shadowed by a nested leaf was still trusted. All fixed with fail-before/pass-after tests; final review found no findings.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
