### PR TITLE
release: 0.48.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.21] - 2026-07-30
+
+### Fixed
+- **SEVERE: `download_model` no longer saves an auth/error response body as a model file and reports success (#473).** A remote CivitAI (or any) download that returned an HTML login/auth page or a JSON error — often with a 200 status — was streamed verbatim into a `.safetensors`/`.ckpt`/model file and reported as a successful download, leaving a corrupt file in the models dir. Every finalize path (HTTP stream, cache-hit, coalesced, cloud, direct-fallback) now runs an authoritative content-type/magic-byte gate BEFORE materializing: HTML/JSON payloads are rejected with an actionable error (Content-Type authority for model destinations + body-magic that handles leading whitespace/control bytes), the cloud/direct path fails **closed** when the payload can't be sniffed, and a poisoned cache entry/partial can't be served on reuse (persisted Content-Type + rejected-marker + body re-sniff). Verified to NOT reject legitimate downloads (real safetensors/GGUF/pickle/ONNX/raw-bin stay binary; sidecar-less cached models still served). (#511)
+- **`panel_run` derives its verdict from ComfyUI's reply instead of a bare `queued` flag (#213, #194, #331, #248).** A rejected prompt (top-level error, or non-empty `node_errors`, even alongside a stale `queued:true`) is now surfaced as a FAILURE rather than a false `queued:true`; a root SaveImage run-to-node is accepted (not mis-rejected as a subgraph node); the "you'll be notified" note is only appended on a genuine queue (not when no tab is connected); and a thrown `app.queuePrompt` preserves its error detail. (#521)
+- **`get_workflow` returns the workflow JSON even when there are conversion warnings (#494); `get_image` is binary-safe (#483); `enqueue_workflow` surfaces ComfyUI's 400 validation details (#485).** (#520)
+
 ## [0.48.20] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.20",
+  "version": "0.48.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.20",
+      "version": "0.48.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.20",
+  "version": "0.48.21",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Reconcile `main` with tag **v0.48.21** (pushed → npm publish via release.yml).

## Ships
- **SEVERE #473 (#511):** `download_model` rejects HTML/JSON auth/error bodies on every finalize path instead of saving them as a corrupt model + reporting success. Gated through my prior codex (3 P0s fixed) + the agent's 8-round self-gate + an independent full-file review (both bad-body and false-positive axes PASS, 75/75 tests). 2 documented fs-failure-gated NUL-in-HTML residuals left (non-exploitable; closing them would reject legit cached models).
- **#213/#194/#331/#248 (#521):** panel_run derives its verdict authoritatively (no false queued:true on a rejection; root SaveImage accepted; no queued note without a tab; error detail preserved).
- **#494/#483/#485 (#520):** get_workflow JSON-with-warnings; get_image binary-safe; enqueue surfaces 400 validation.

Merge with a **MERGE commit** so v0.48.21 is an ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)