### PR TITLE
fix(apply-manifest): live-first download target + poll Manager queue instead of 300s false timeout (#490, #463, #489)

### DIFF
--- a/src/__tests__/services/download-manager-routing.test.ts
+++ b/src/__tests__/services/download-manager-routing.test.ts
@@ -15,6 +15,14 @@ const hoisted = vi.hoisted(() => ({
   base: undefined as string | undefined,
   stats: undefined as unknown,
   statsThrows: false,
+  // Whether an argv-derived live root is present on THIS filesystem. A
+  // Docker/forwarded loopback server's container path is not host-local → false.
+  liveRootExists: true,
+}));
+
+// The live-root routing branch only streams local when the root exists locally.
+vi.mock("node:fs", () => ({
+  existsSync: () => hoisted.liveRootExists,
 }));
 
 // isRemoteMode is the first gate; keep every other real config export.
@@ -49,6 +57,7 @@ beforeEach(() => {
   hoisted.base = undefined;
   hoisted.stats = undefined;
   hoisted.statsThrows = false;
+  hoisted.liveRootExists = true;
 });
 
 describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
@@ -70,6 +79,29 @@ describe("shouldDispatchDownloadToManager (#420 reconnect routing)", () => {
     // to — hand the fetch to its Manager rather than failing.
     hoisted.base = undefined;
     hoisted.stats = { system: { argv: ["main.py", "--listen"] } };
+    expect(await shouldDispatchDownloadToManager()).toBe(true);
+  });
+
+  it("#463: no local base + reachable server whose ABSOLUTE main.py root is resolvable → streams local", async () => {
+    // A panel-connected local ComfyUI with no COMFYUI_PATH/default, launched with
+    // an absolute main.py path and NO --base-directory. Its own install root is
+    // derivable from argv (the same live-first root resolveModelsDir writes into),
+    // so stream locally into it instead of bouncing through the Manager (which
+    // would fail when Manager isn't installed).
+    hoisted.base = undefined;
+    hoisted.stats = {
+      system: { argv: ["python", "/opt/ComfyUI/main.py", "--listen"] },
+    };
+    expect(await shouldDispatchDownloadToManager()).toBe(false);
+  });
+
+  it("no local base + reachable server whose absolute main.py root is NOT present locally (Docker/forwarded) → Manager route", async () => {
+    // Container-side main.py path resolvable but not on the host FS — must NOT be
+    // treated as a local stream target (would create a bogus host dir); route the
+    // fetch through the connected Manager (server-side write) instead.
+    hoisted.base = undefined;
+    hoisted.liveRootExists = false;
+    hoisted.stats = { system: { argv: ["python", "/app/ComfyUI/main.py"] } };
     expect(await shouldDispatchDownloadToManager()).toBe(true);
   });
 

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -31,6 +31,9 @@ const downloadModelMock = vi.hoisted(() => vi.fn());
 const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
 const listLocalModelsMock = vi.hoisted(() => vi.fn());
 const savedWorkspaceMock = vi.hoisted(() => vi.fn(() => undefined as string | undefined));
+const liveComfyBaseMock = vi.hoisted(() =>
+  vi.fn(async () => undefined as string | undefined),
+);
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -117,6 +120,21 @@ vi.mock("../../services/model-resolver.js", () => ({
 
 vi.mock("../../services/workspace-env.js", () => ({
   getSavedDefaultWorkspaceSync: (...a: unknown[]) => savedWorkspaceMock(...(a as [])),
+  resolveLiveComfyUIBase: (...a: unknown[]) => liveComfyBaseMock(...(a as [])),
+  // Mirrors the real resolver enough for the pip tests: an install-root python.
+  resolveRootInterpreter: (root: string | undefined) =>
+    root ? `${root}/python` : "python",
+}));
+
+// resolveLocalModelPath now roots local_path validation at the SAME live write
+// dir the downloader uses (resolveModelsDir), not <COMFYUI_PATH>/models (#490).
+// Back it with the fake install's models dir so the containment/symlink guards
+// run against the exact root the tests build their symlink fixtures under.
+const modelsDirMock = vi.hoisted(() =>
+  vi.fn(async () => "/fake/ComfyUI/models" as string),
+);
+vi.mock("../../services/output-dir.js", () => ({
+  resolveModelsDir: (...a: unknown[]) => modelsDirMock(...(a as [])),
 }));
 
 vi.mock("../../utils/logger.js", () => ({
@@ -149,6 +167,8 @@ beforeEach(() => {
   resolveExistingModelFileMock.mockReset().mockRejectedValue(new Error("not found"));
   listLocalModelsMock.mockReset().mockResolvedValue([]);
   savedWorkspaceMock.mockReset().mockReturnValue(undefined);
+  liveComfyBaseMock.mockReset().mockResolvedValue(undefined);
+  modelsDirMock.mockReset().mockResolvedValue("/fake/ComfyUI/models");
 });
 
 describe("loadManifestFile", () => {
@@ -534,6 +554,76 @@ describe("applyManifest", () => {
     expect(mockConfig.comfyuiPath).toBeUndefined();
   });
 
+  it("adopts the LIVE connected ComfyUI root when COMFYUI_PATH and saved default are both unset (#463)", async () => {
+    // #463: sidebar panel connected to a live local ComfyUI, no COMFYUI_PATH and
+    // no saved default. Without adoption the session is misclassified "no local
+    // filesystem" and every model is skipped. Adopting the live root (from
+    // /system_stats) gives a local FS target so the model downloads instead.
+    mockConfig.comfyuiPath = undefined;
+    mockConfig.remote = false; // local loopback target reached over the panel session
+    savedWorkspaceMock.mockReturnValue(undefined);
+    liveComfyBaseMock.mockResolvedValue("/live/ComfyUI");
+    existsSyncMock.mockImplementation((p: unknown) => {
+      const s = String(p);
+      return (
+        s.includes("live") &&
+        (s.endsWith("ComfyUI") || s.endsWith("models") || s.endsWith("custom_nodes"))
+      );
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [
+          { url: "https://example.com/m.safetensors", model_type: "loras", filename: "m.safetensors" },
+        ],
+      },
+    });
+
+    // Downloaded locally (NOT skipped as "no local filesystem").
+    expect(result.summary).toMatchObject({ applied: 1, failed: 0, skipped: 0 });
+    expect(downloadModelMock).toHaveBeenCalled();
+    // Call-scoped: the adopted live path must NOT persist process-wide.
+    expect(mockConfig.comfyuiPath).toBeUndefined();
+  });
+
+  it("reports a custom_node as PENDING (not failed) when the Manager queue is still installing at the budget (#489)", async () => {
+    // A node install that outlives the wall-clock budget must be reported
+    // "pending" (poll the Manager queue), never "failed" — the install keeps
+    // running server-side — and every not-yet-started node is reported pending too.
+    const prevBudget = process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+    process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = "40";
+    // First node never settles (simulates the Manager queue still draining); the
+    // budget timer must win and stop us blocking on the rest.
+    installCustomNodeMock.mockReturnValueOnce(new Promise(() => {}));
+
+    try {
+      const result = await applyManifest({
+        manifest: { custom_nodes: ["slow-pack", "next-pack"] },
+      });
+
+      expect(result.summary).toMatchObject({ applied: 0, failed: 0, pending: 2 });
+      expect(result.results[0]).toMatchObject({
+        action: "custom_node",
+        item: "slow-pack",
+        status: "pending",
+      });
+      expect(result.results[0].message).toMatch(/still installing/i);
+      // The second node is NOT started once the budget is spent — reported pending.
+      expect(result.results[1]).toMatchObject({
+        action: "custom_node",
+        item: "next-pack",
+        status: "pending",
+      });
+      expect(result.results[1].message).toMatch(/not started/i);
+      expect(installCustomNodeMock).toHaveBeenCalledTimes(1);
+      // Pending is not a failure: success stays true (nothing FAILED).
+      expect(result.success).toBe(true);
+    } finally {
+      if (prevBudget === undefined) delete process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS;
+      else process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS = prevBudget;
+    }
+  });
+
   it("hands a slow model download to a background job (pending, not applied) (#362)", async () => {
     const prevGrace = process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS;
     process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS = "0";
@@ -626,6 +716,36 @@ describe("applyManifest", () => {
     expect(result.results).toMatchObject([
       { action: "model", status: "failed", item: "link/model.safetensors" },
     ]);
+    expect(downloadModelMock).not.toHaveBeenCalled();
+  });
+
+  it("validates local_path symlinks against the LIVE models dir, not a stale COMFYUI_PATH (#490)", async () => {
+    // #490: COMFYUI_PATH is a stale install; the connected server writes under a
+    // DIFFERENT live root. A symlink that escapes the LIVE models dir must be
+    // caught — the guard has to run against the live write root the downloader
+    // uses, NOT <COMFYUI_PATH>/models (which is never written to here).
+    mockConfig.comfyuiPath = "/stale/ComfyUI";
+    const liveModels = resolve("/live/ComfyUI/models");
+    modelsDirMock.mockResolvedValue(liveModels);
+    const linkDir = join(liveModels, "link");
+    const outside = resolve("/tmp/escape");
+    realpathMock.mockImplementation((path: string) => {
+      if (path === liveModels) return Promise.resolve(liveModels);
+      if (path === linkDir) return Promise.resolve(outside);
+      return Promise.resolve(path);
+    });
+
+    const result = await applyManifest({
+      manifest: {
+        models: [{ url: "https://example.com/m.safetensors", local_path: "link/m.safetensors" }],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toMatchObject([
+      { action: "model", status: "failed", item: "link/m.safetensors" },
+    ]);
+    expect(result.results[0].message).toMatch(/escapes the models directory/i);
     expect(downloadModelMock).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { resolve } from "node:path";
 
 // Control config (comfyuiPath + tokens) per test.
 vi.mock("../../config.js", () => {
@@ -24,12 +25,16 @@ vi.mock("../../services/node-management.js", () => ({
 const mkdirMock = vi.fn();
 const rmMock = vi.fn();
 const statMock = vi.fn();
+const lstatMock = vi.fn();
+const realpathMock = vi.fn();
 vi.mock("node:fs/promises", () => ({
   copyFile: vi.fn(),
   link: vi.fn(),
+  lstat: (...a: unknown[]) => lstatMock(...a),
   mkdir: (...a: unknown[]) => mkdirMock(...a),
   readdir: vi.fn(),
   readFile: vi.fn(),
+  realpath: (...a: unknown[]) => realpathMock(...a),
   rename: vi.fn(),
   rm: (...a: unknown[]) => rmMock(...a),
   stat: (...a: unknown[]) => statMock(...a),
@@ -62,6 +67,9 @@ beforeEach(() => {
   mkdirMock.mockReset().mockResolvedValue(undefined);
   rmMock.mockReset().mockResolvedValue(undefined);
   statMock.mockReset().mockRejectedValue(new Error("missing"));
+  // Default: nothing in the path is a symlink (best-effort guard is inert).
+  lstatMock.mockReset().mockResolvedValue({ isSymbolicLink: () => false });
+  realpathMock.mockReset().mockImplementation((p: string) => Promise.resolve(p));
   installModelViaManagerMock.mockReset().mockResolvedValue({
     mechanism: "manager-http",
     message: "queued",
@@ -96,6 +104,62 @@ describe("downloadModel — filename path safety", () => {
       downloadModel("https://example.com/x", "checkpoints", ".."),
     ).rejects.toBeInstanceOf(ModelError);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a destination whose ancestor is a symlink escaping the models dir, and never fetches (#490)", async () => {
+    // The write-target resolver must guard the ACTUAL destination: a symlinked
+    // subfolder that realpaths OUTSIDE models/ can't be used as a write root even
+    // though the path string stays within models/.
+    const escapeDir = resolve("/comfy/models/checkpoints");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === escapeDir }),
+    );
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === escapeDir ? resolve("/tmp/outside") : p),
+    );
+
+    await expect(
+      downloadModel("https://example.com/x.safetensors", "checkpoints", "x.safetensors"),
+    ).rejects.toThrow(/symlink in the path escapes it|outside the models/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a models ROOT that is itself a symlink/junction to another location", async () => {
+    // A ComfyUI install may legitimately junction its whole models dir onto
+    // another drive. The root canonicalizes elsewhere BY DESIGN — that must not
+    // be treated as an escape (only DESCENDANTS are checked, against the canonical
+    // root).
+    const modelsRoot = resolve("/comfy/models");
+    const realModelsRoot = resolve("/mnt/big/models");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === modelsRoot }),
+    );
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === modelsRoot ? realModelsRoot : p),
+    );
+    const target = await resolveDownloadTarget(
+      "https://example.com/x.safetensors",
+      "checkpoints",
+      "x.safetensors",
+    );
+    expect(target.targetDir).toBe(resolve("/comfy/models/checkpoints"));
+  });
+
+  it("allows a symlinked subfolder that stays inside the models dir", async () => {
+    const linkDir = resolve("/comfy/models/checkpoints");
+    lstatMock.mockImplementation((p: string) =>
+      Promise.resolve({ isSymbolicLink: () => p === linkDir }),
+    );
+    // realpath resolves to another location STILL under models/ → allowed.
+    realpathMock.mockImplementation((p: string) =>
+      Promise.resolve(p === linkDir ? resolve("/comfy/models/_real_ckpts") : p),
+    );
+    const target = await resolveDownloadTarget(
+      "https://example.com/x.safetensors",
+      "checkpoints",
+      "x.safetensors",
+    );
+    expect(target.targetDir).toBe(resolve("/comfy/models/checkpoints"));
   });
 });
 

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -445,6 +445,91 @@ describe("node-management service", () => {
       expect(cloneEnv?.GIT_ASKPASS).toBe("echo");
     });
 
+    it("clones an unregistered git pack into opts.comfyuiPath when global COMFYUI_PATH is unset (#463)", async () => {
+      // apply_manifest threads a call-scoped base (adopted saved-default/live root)
+      // WITHOUT mutating global config. The clone fallback must honor it, or an
+      // unregistered git URL fails despite a valid local workspace.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const adoptedNodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s.includes("requirements.txt") || s.includes("install.py")) return false;
+        if (s.includes(".venv") || s.includes("cm-cli.py")) return false;
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      const cloneCall = mockedExec.mock.calls.find(
+        (c) => c[0] === "git" && (c[1] as string[])[0] === "clone",
+      );
+      expect(cloneCall).toBeDefined();
+      // Cloned into the ADOPTED base's custom_nodes, not a global path.
+      expect((cloneCall![1] as string[]).at(-1)).toBe(adoptedNodeDir);
+      expect((cloneCall![2] as { cwd?: string }).cwd).toBe(adopted);
+    });
+
+    it("installs a cloned node's requirements.txt under the ADOPTED base's venv python, not bare system python (#463)", async () => {
+      // With no global COMFYUI_PATH, the deps install must target the adopted
+      // workspace's own .venv — otherwise requirements land under a bare system
+      // python, corrupting/missing the real ComfyUI env while we report success.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const IS_WIN = process.platform === "win32";
+      // resolveVenvPython builds this with path.join (NOT resolve), so no drive
+      // letter is prepended — mirror that exactly for the existsSync match.
+      const venvPy = join(
+        adopted,
+        ".venv",
+        IS_WIN ? "Scripts" : "bin",
+        IS_WIN ? "python.exe" : "python",
+      );
+      const nodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      const requirements = join(nodeDir, "requirements.txt");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s === venvPy) return true; // adopted venv python present
+        if (s === requirements) return true; // node ships requirements.txt
+        if (s.includes("install.py") || s.includes("cm-cli.py")) return false;
+        if (s.includes(".venv")) return false; // any OTHER venv path absent
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      const pipCall = mockedExec.mock.calls.find(
+        (c) =>
+          Array.isArray(c[1]) &&
+          (c[1] as string[]).includes("-r") &&
+          (c[1] as string[]).includes(requirements),
+      );
+      expect(pipCall).toBeDefined();
+      // The deps install ran under the ADOPTED venv python, not bare "python".
+      expect(pipCall![0]).toBe(venvPy);
+    });
+
     it("full-clones (no --depth) and checks out an explicit ref on fallback", async () => {
       stubFetch({ installedBody: {} });
       let cloned = false;

--- a/src/__tests__/services/output-dir.test.ts
+++ b/src/__tests__/services/output-dir.test.ts
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isAbsolute, join, resolve } from "node:path";
 
+let remoteMode = false;
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: "/comfy" as string | undefined },
+  isRemoteMode: () => remoteMode,
+}));
+
+// resolveModelsDir only adopts an argv-derived live root when it EXISTS locally
+// (a Docker/forwarded server's container path must NOT be treated as host-local).
+// Control existence per test; default true so the live-root paths resolve.
+let liveRootExists = true;
+vi.mock("node:fs", () => ({
+  existsSync: () => liveRootExists,
 }));
 
 const getSystemStats = vi.fn();
@@ -13,10 +23,18 @@ vi.mock("../../comfyui/client.js", () => ({
 // resolveModelsDir's local fallback (COMFYUI_PATH → default workspace) is resolved
 // through the shared helper; back it by the mocked config + a settable default
 // workspace so tests can exercise the "no COMFYUI_PATH but a default workspace" path.
+// liveRootFromArgv is the REAL implementation (pure argv parsing) so the live-first
+// resolution (#490/#463) is exercised end to end, not stubbed away.
 let savedDefaultWorkspace: string | undefined;
-vi.mock("../../services/workspace-env.js", () => ({
-  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
-}));
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/workspace-env.js")
+  >("../../services/workspace-env.js");
+  return {
+    resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? savedDefaultWorkspace,
+    liveRootFromArgv: actual.liveRootFromArgv,
+  };
+});
 
 import {
   parseOutputDirFromArgv,
@@ -37,6 +55,8 @@ beforeEach(() => {
   getSystemStats.mockReset();
   (config as { comfyuiPath?: string }).comfyuiPath = "/comfy";
   savedDefaultWorkspace = undefined;
+  remoteMode = false;
+  liveRootExists = true;
 });
 
 afterEach(() => {
@@ -235,6 +255,52 @@ describe("models dir + extra-config argv parsing (#345/#346/#369)", () => {
 
   it("resolveModelsDir falls back to <COMFYUI_PATH>/models when unreachable", async () => {
     getSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await resolveModelsDir()).toBe(resolve("/comfy", "models"));
+  });
+
+  it("resolveModelsDir prefers the LIVE server's own main.py root over a stale COMFYUI_PATH when no --base-directory flag (#490)", async () => {
+    // Reproduces #490: the connected ComfyUI runs from a different install than
+    // the stale COMFYUI_PATH, and was NOT launched with --base-directory. The
+    // download must land in the LIVE install (its main.py root), not COMFYUI_PATH.
+    const liveRoot = resolve("/home/parn/repositories/wet/ComfyUI");
+    (config as { comfyuiPath?: string }).comfyuiPath = resolve("/home/parn/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py"), "--listen"] },
+    });
+    const got = await resolveModelsDir();
+    expect(got).toBe(join(liveRoot, "models"));
+    expect(got).not.toBe(join(resolve("/home/parn/ComfyUI"), "models"));
+  });
+
+  it("resolveModelsDir resolves the live root when COMFYUI_PATH is unset and no default workspace (#463)", async () => {
+    (config as { comfyuiPath?: string }).comfyuiPath = undefined;
+    savedDefaultWorkspace = undefined;
+    const liveRoot = resolve("/opt/live/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py")] },
+    });
+    expect(await resolveModelsDir()).toBe(join(liveRoot, "models"));
+  });
+
+  it("resolveModelsDir does NOT adopt an argv live root that isn't present locally (Docker/forwarded server) — falls back to COMFYUI_PATH", async () => {
+    // A loopback ComfyUI inside Docker reports a container-side main.py path that
+    // does not exist on the host; writing there would create a bogus host dir.
+    liveRootExists = false;
+    (config as { comfyuiPath?: string }).comfyuiPath = resolve("/host/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", "/app/ComfyUI/main.py"] },
+    });
+    expect(await resolveModelsDir()).toBe(join(resolve("/host/ComfyUI"), "models"));
+  });
+
+  it("resolveModelsDir does NOT adopt the live argv root in remote mode (remote path isn't a local dir)", async () => {
+    remoteMode = true;
+    const liveRoot = resolve("/remote/host/ComfyUI");
+    getSystemStats.mockResolvedValue({
+      system: { argv: ["python", join(liveRoot, "main.py")] },
+    });
+    // Remote mode with a local COMFYUI_PATH: never uses the remote main.py path;
+    // falls back to the local COMFYUI_PATH/models.
     expect(await resolveModelsDir()).toBe(resolve("/comfy", "models"));
   });
 

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -81,6 +81,8 @@ import {
   getEnvironment,
   liveRootFromArgv,
   resolveComfyuiPython,
+  resolveLiveComfyUIBase,
+  resolveRootInterpreter,
 } from "../../services/workspace-env.js";
 
 async function tmpDir(): Promise<string> {
@@ -666,6 +668,67 @@ describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
   it("returns undefined for missing/empty argv", () => {
     expect(liveRootFromArgv(undefined)).toBeUndefined();
     expect(liveRootFromArgv([])).toBeUndefined();
+  });
+});
+
+describe("resolveRootInterpreter (portable + venv layouts)", () => {
+  it("finds the install's own .venv interpreter on disk", async () => {
+    const root = await tmpDir();
+    try {
+      const py = await makeVenvPython(root);
+      expect(resolveRootInterpreter(root)).toBe(py);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers a portable python_embeded layout on Windows", async () => {
+    if (!IS_WIN) return; // python_embeded candidates are Windows-only
+    const root = await tmpDir();
+    try {
+      const embDir = join(root, "python_embeded");
+      await mkdir(embDir, { recursive: true });
+      const emb = join(embDir, "python.exe");
+      await writeFile(emb, "", "utf-8");
+      expect(resolveRootInterpreter(root)).toBe(emb);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a bare platform python when nothing is on disk / root is undefined", async () => {
+    const root = await tmpDir();
+    try {
+      expect(resolveRootInterpreter(root)).toBe(IS_WIN ? "python.exe" : "python3");
+      expect(resolveRootInterpreter(undefined)).toBe(IS_WIN ? "python.exe" : "python3");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveLiveComfyUIBase (#490 / #463 — live connected install root)", () => {
+  it("derives the live root from the running server's main.py argv", async () => {
+    const root = IS_WIN ? "C:\\live\\ComfyUI" : "/live/ComfyUI";
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [join(root, "main.py"), "--listen"] },
+    });
+    expect(await resolveLiveComfyUIBase()).toBe(root);
+  });
+
+  it("returns undefined in remote mode (the live root is on the remote host)", async () => {
+    h.remoteMode.value = true;
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [IS_WIN ? "C:\\remote\\main.py" : "/remote/main.py"] },
+    });
+    expect(await resolveLiveComfyUIBase()).toBeUndefined();
+    // Never even probes /system_stats when remote.
+    expect(mockGetSystemStats).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined (never throws) when the server is unreachable", async () => {
+    mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(resolveLiveComfyUIBase()).resolves.toBeUndefined();
   });
 });
 

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -30,7 +30,12 @@ import {
   type ModelType,
 } from "./model-resolver.js";
 import { startDownloadJob, type DownloadJob } from "./download-jobs.js";
-import { getSavedDefaultWorkspaceSync } from "./workspace-env.js";
+import { resolveModelsDir } from "./output-dir.js";
+import {
+  getSavedDefaultWorkspaceSync,
+  resolveLiveComfyUIBase,
+  resolveRootInterpreter,
+} from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -40,6 +45,51 @@ import { logger } from "../utils/logger.js";
 function manifestDownloadGraceMs(): number {
   const raw = Number(process.env.COMFYUI_MCP_DOWNLOAD_GRACE_MS);
   return Number.isFinite(raw) && raw >= 0 ? raw : 15_000;
+}
+
+/** Overall wall-clock budget (ms) for the custom-node install phase. Node installs
+ *  drive the ComfyUI-Manager queue, which can legitimately run for minutes on a
+ *  big pack. Blocking apply_manifest until it drains blows past the MCP tools/call
+ *  timeout (300s) and the caller sees a FALSE failure while the Manager keeps
+ *  installing (#489). Bounding the phase well under that cap lets us hand back a
+ *  "pending" result (poll the Manager queue) instead. Env-tunable; default 240s. */
+function manifestNodeBudgetMs(): number {
+  const raw = Number(process.env.COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 240_000;
+}
+
+/** Sentinel returned by raceDeadline when the wall-clock deadline wins. */
+const BUDGET_TIMEOUT = Symbol("manifest-node-budget-timeout");
+
+/**
+ * Await `p` but never past the absolute `deadline` (Date.now() ms). Returns the
+ * resolved value, or BUDGET_TIMEOUT if the deadline elapses first. Bounds EVERY
+ * async wait in the custom-node phase (#489) — the install itself AND the
+ * surrounding listInstalledNodes round-trips — so a slow Manager can never push
+ * apply_manifest past the MCP tools/call timeout; it hands back "pending" instead.
+ *
+ * CAVEAT (single-threaded runtime): this bounds ASYNC work only. A SYNCHRONOUS
+ * subprocess install unit — the git-clone / cm-cli fallback (execFileSync), like
+ * pip — blocks the event loop, so the timer cannot preempt one already running;
+ * each is instead bounded by its OWN execFileSync timeout. The race is what fixes
+ * #489's actual case: the ASYNC Manager-queue polling that keeps running for
+ * minutes. `p` must not reject (callers pass a pre-caught promise).
+ */
+async function raceDeadline<T>(
+  p: Promise<T>,
+  deadline: number,
+): Promise<T | typeof BUDGET_TIMEOUT> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return BUDGET_TIMEOUT;
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<typeof BUDGET_TIMEOUT>((resolve) => {
+    timer = setTimeout(() => resolve(BUDGET_TIMEOUT), remaining);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 const IS_WIN = platform() === "win32";
@@ -150,13 +200,10 @@ function commandExists(cmd: string): boolean {
 
 function resolveWorkspacePython(comfyuiPath: string): string {
   if (process.env.COMFYUI_PYTHON) return process.env.COMFYUI_PYTHON;
-  for (const venv of [".venv", "venv"]) {
-    const py = IS_WIN
-      ? join(comfyuiPath, venv, "Scripts", "python.exe")
-      : join(comfyuiPath, venv, "bin", "python");
-    if (existsSync(py)) return py;
-  }
-  return IS_WIN ? "python" : "python3";
+  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
+  // so a manifest pip install targets the install's OWN interpreter, never a bare
+  // system python that would contaminate the host env (#463 codex review).
+  return resolveRootInterpreter(comfyuiPath);
 }
 
 function validatePipPackageSpec(pkg: string): void {
@@ -259,10 +306,6 @@ function nodeAlreadyInstalled(id: string, installed: InstalledNode[]): boolean {
   });
 }
 
-function modelsRoot(comfyuiPath: string): string {
-  return join(comfyuiPath, "models");
-}
-
 function defaultFilenameForUrl(url: string): string {
   return basename(new URL(url).pathname) || "model.safetensors";
 }
@@ -319,10 +362,16 @@ async function validateExistingModelAncestors(
 }
 
 async function resolveLocalModelPath(
-  comfyuiPath: string,
   model: ComfyManifest["models"][number],
 ): Promise<{ targetSubfolder: string; filename: string; targetPath: string }> {
-  const root = resolve(modelsRoot(comfyuiPath));
+  // Root the target — and therefore the local_path symlink/containment guards
+  // below — at the SAME directory the downloader actually writes to: the live
+  // connected server's models dir (resolveModelsDir, live-first), NOT
+  // <COMFYUI_PATH>/models. When the connected install differs from a stale
+  // COMFYUI_PATH (#490), validating against COMFYUI_PATH/models would leave a
+  // symlink that escapes the LIVE models dir unchecked and redirect the write
+  // outside it. Same canonical root as the writer = one authoritative guard.
+  const root = resolve(await resolveModelsDir());
 
   if (model.local_path) {
     if (isAbsolute(model.local_path)) {
@@ -563,46 +612,70 @@ export async function applyManifest(
 ): Promise<ApplyManifestResult> {
   const manifest = await resolveManifest(opts);
 
-  // #390 (call-scoped): adopt a saved default workspace as the local FS target
-  // for THIS call ONLY — never persist it process-wide. Persisting
-  // config.comfyuiPath would make a later apply route to a stale/other workspace
-  // (and would never re-read a changed default), and would leak the adopted path
-  // to every other tab/tool sharing this process. Temp-set for the duration of
-  // the apply and always restore in finally. Safe for the background downloads
-  // enqueued below: downloadModel resolves its destination from the LIVE server's
-  // models dir (resolveModelSubfolderPreferServer), not config.comfyuiPath, so a
-  // restore before a job finishes cannot misplace the file.
-  const adopted = adoptableLocalWorkspace();
-  const priorComfyuiPath = config.comfyuiPath;
-  if (adopted) {
+  // Resolve the LOCAL ComfyUI base this call should target, WITHOUT mutating the
+  // process-global config.comfyuiPath (a global temp-set would leak the path to
+  // every concurrent tab/tool and could be clobbered by an interleaved restore —
+  // #490/#463 codex review). We thread it explicitly to applyManifestSections
+  // instead. Precedence, local mode only:
+  //   1. config.comfyuiPath (COMFYUI_PATH / auto-detect) — unchanged, wins.
+  //   2. saved default workspace (#390).
+  //   3. the LIVE connected server's own install root from /system_stats argv
+  //      (#463) — a panel-connected local session with no COMFYUI_PATH still has
+  //      a real FS target, so models/pip aren't skipped as "no local filesystem".
+  // The actual on-disk model DESTINATION is always re-derived live-first by the
+  // downloader (resolveModelsDir), so this base only governs the local-vs-remote
+  // classification + pip's interpreter, never where a model lands.
+  const localBase = await resolveLocalManifestBase();
+
+  return applyManifestSections(manifest, localBase);
+}
+
+/**
+ * The effective LOCAL ComfyUI base for an apply_manifest call. Never mutates
+ * global config. Returns undefined in remote/cloud mode or when no local install
+ * can be found (COMFYUI_PATH unset, no saved default, no reachable live server).
+ */
+async function resolveLocalManifestBase(): Promise<string | undefined> {
+  if (config.comfyuiPath) return config.comfyuiPath;
+  if (isRemoteMode()) return undefined;
+  const saved = adoptableLocalWorkspace();
+  if (saved) return saved;
+  // #463: a live LOCAL ComfyUI is connected but COMFYUI_PATH/default are unset.
+  // Adopt its own install root (from /system_stats argv) only when it exists and
+  // looks like a ComfyUI install.
+  const liveBase = await resolveLiveComfyUIBase();
+  if (
+    liveBase &&
+    existsSync(liveBase) &&
+    (existsSync(join(liveBase, "models")) ||
+      existsSync(join(liveBase, "custom_nodes")))
+  ) {
     logger.info(
-      "apply_manifest: adopting saved default workspace as the local ComfyUI path for this call (COMFYUI_PATH unset)",
-      { path: adopted },
+      "apply_manifest: targeting the live connected ComfyUI root for this call (COMFYUI_PATH unset)",
+      { path: liveBase },
     );
-    config.comfyuiPath = adopted;
+    return liveBase;
   }
-  try {
-    return await applyManifestSections(manifest);
-  } finally {
-    if (adopted) config.comfyuiPath = priorComfyuiPath;
-  }
+  return undefined;
 }
 
 async function applyManifestSections(
   manifest: ComfyManifest,
+  localBase: string | undefined,
 ): Promise<ApplyManifestResult> {
   const results: ManifestItemReport[] = [];
 
   // Per-section mode handling. A LOCAL filesystem is usable only when we are NOT
-  // in remote (or cloud) mode AND COMFYUI_PATH is set (possibly a call-scoped
-  // adopted workspace, see applyManifest); otherwise we are targeting a
-  // remote/cloud ComfyUI over HTTP. Keying off isRemoteMode() (rather than mere
-  // comfyuiPath presence) matters because a remote target can coexist with an
-  // unrelated COMFYUI_PATH on this machine — in that case we must still route
-  // pip/model handling remotely instead of touching the local install/disk.
+  // in remote (or cloud) mode AND a local base was resolved (COMFYUI_PATH, saved
+  // default, or the live connected server's own root — see resolveLocalManifestBase,
+  // threaded here as `localBase` WITHOUT any global config mutation). Otherwise we
+  // are targeting a remote/cloud ComfyUI over HTTP. Keying off isRemoteMode()
+  // (rather than mere base presence) matters because a remote target can coexist
+  // with an unrelated COMFYUI_PATH on this machine — in that case we must still
+  // route pip/model handling remotely instead of touching the local install/disk.
   // custom_nodes and models can still be handled remotely through ComfyUI-Manager's
   // HTTP API, but pip/apt have no remote equivalent.
-  const comfyuiPath = config.comfyuiPath;
+  const comfyuiPath = localBase;
   const hasLocalFs = !isRemoteMode() && Boolean(comfyuiPath);
 
   for (const pkg of manifest.apt) {
@@ -645,43 +718,98 @@ async function applyManifestSections(
     }
   }
 
-  const installedNodes = await installedNodesOrEmpty();
+  // #489: bound the whole custom-node phase by a wall-clock budget. Each install
+  // drives the shared ComfyUI-Manager queue, which can legitimately run for
+  // minutes on a big pack; blocking until every one drains overruns the MCP
+  // tools/call timeout (300s) and the caller sees a FALSE failure while the
+  // Manager keeps installing. So we mirror the model-download grace pattern:
+  // install sequentially, but RACE each install against the remaining budget. If
+  // the budget wins, the install keeps running SERVER-SIDE (we stop awaiting it,
+  // swallowing its late result) and is reported "pending" — never failed — and
+  // every not-yet-started node is reported "pending" too. The caller polls the
+  // Manager queue / re-runs apply_manifest to finish. A node that SETTLES within
+  // budget is verified and reported applied/failed exactly as before.
+  const nodeDeadline = Date.now() + manifestNodeBudgetMs();
+  const pendingBudgetMessage = (started: boolean): string =>
+    started
+      ? "Still installing on the ComfyUI-Manager queue when the apply_manifest time " +
+        "budget elapsed. This is NOT a failure — the install continues server-side. " +
+        "Poll the Manager queue for completion; do not re-issue this node."
+      : "Not started: the apply_manifest time budget elapsed while ComfyUI-Manager " +
+        "was still installing earlier packs. This is NOT a failure — poll the " +
+        "Manager queue for completion, then re-run apply_manifest to continue.";
+  let nodeBudgetSpent = false;
+  // Even the INITIAL installed-list probe is budget-bounded — a hung Manager here
+  // must not blow the tools/call timeout before we can report anything.
+  const initialList = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+  const installedNodes = initialList === BUDGET_TIMEOUT ? [] : initialList;
+  if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
     if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
     }
-    try {
-      const res = await installCustomNode({ id });
-      // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it
-      // cloned NOTHING — e.g. a repo not in its registry resolves to nothing, no
-      // dir is created, but the queue still empties cleanly. So a successful
-      // installCustomNode() call is NOT proof of install. Re-query the installed
-      // list (it reflects on-disk custom_nodes via Manager's
-      // /v2/customnode/installed, so a freshly-cloned node shows up even before a
-      // reboot) and confirm the node is actually present before reporting success.
-      const verified = await installedNodesOrEmpty();
-      if (nodeAlreadyInstalled(id, verified)) {
-        installedNodes.length = 0;
-        installedNodes.push(...verified);
-        results.push(report("custom_node", id, "applied", res.message));
-      } else {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "failed",
-            `ComfyUI-Manager reported the install as queued/done, but the node is not present afterward — the source likely resolved to nothing (a git URL that isn't in the Manager registry won't clone). Install it directly (git clone into custom_nodes) or use a registry id. ${res.message}`,
-          ),
-        );
-      }
-    } catch (err) {
+    if (nodeBudgetSpent || Date.now() >= nodeDeadline) {
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(false)));
+      continue;
+    }
+
+    // Never REJECTS: fold success/failure into a tagged value so the un-awaited
+    // promise (when the deadline wins) can't surface as an unhandled rejection.
+    // Thread the call-scoped local base (no global config mutation) so the
+    // git-clone / ref-checkout fallback works for an adopted saved-default/live
+    // workspace when COMFYUI_PATH is unset (#463).
+    const installOutcome = installCustomNode({ id, comfyuiPath: localBase })
+      .then((res) => ({ kind: "settled" as const, res }))
+      .catch((err) => ({ kind: "error" as const, err }));
+    const outcome = await raceDeadline(installOutcome, nodeDeadline);
+
+    if (outcome === BUDGET_TIMEOUT) {
+      // Budget spent mid-install: leave it running server-side (installOutcome
+      // already has a .catch, so its eventual settle is safely ignored) and stop
+      // blocking on the remaining nodes.
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
+      continue;
+    }
+    if (outcome.kind === "error") {
       results.push(
         report(
           "custom_node",
           id,
           "failed",
-          err instanceof Error ? err.message : String(err),
+          outcome.err instanceof Error ? outcome.err.message : String(outcome.err),
+        ),
+      );
+      continue;
+    }
+    // ComfyUI-Manager marks a git-URL task "done" (queue drained) even when it
+    // cloned NOTHING — e.g. a repo not in its registry resolves to nothing, no
+    // dir is created, but the queue still empties cleanly. So a successful
+    // installCustomNode() call is NOT proof of install. Re-query the installed
+    // list (it reflects on-disk custom_nodes via Manager's
+    // /v2/customnode/installed, so a freshly-cloned node shows up even before a
+    // reboot) and confirm the node is actually present before reporting success.
+    // Budget-bounded too: if the confirm can't complete in time we report pending
+    // (conservative — the install itself already settled) rather than overrun.
+    const verified = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
+    if (verified === BUDGET_TIMEOUT) {
+      nodeBudgetSpent = true;
+      results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
+      continue;
+    }
+    if (nodeAlreadyInstalled(id, verified)) {
+      installedNodes.length = 0;
+      installedNodes.push(...verified);
+      results.push(report("custom_node", id, "applied", outcome.res.message));
+    } else {
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          `ComfyUI-Manager reported the install as queued/done, but the node is not present afterward — the source likely resolved to nothing (a git URL that isn't in the Manager registry won't clone). Install it directly (git clone into custom_nodes) or use a registry id. ${outcome.res.message}`,
         ),
       );
     }
@@ -729,7 +857,7 @@ async function applyManifestSections(
         results.push(report("model", item, "applied", res.message));
         continue;
       }
-      const target = await resolveLocalModelPath(comfyuiPath!, model);
+      const target = await resolveLocalModelPath(model);
       const existing = await findExistingModel(target);
       if (existing) {
         results.push(report("model", item, "skipped", `Model already exists at ${existing}.`));

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
-import type { Stats } from "node:fs";
-import { readdir, stat, mkdir, readFile } from "node:fs/promises";
-import { join, basename, resolve, relative, sep, isAbsolute } from "node:path";
+import { existsSync, type Stats } from "node:fs";
+import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
+import { dirname, join, basename, resolve, relative, sep, isAbsolute } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
-import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+import { resolveEffectiveComfyUIBase, liveRootFromArgv } from "./workspace-env.js";
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -406,7 +406,62 @@ export async function resolveModelSubfolderPreferServer(
   if (targetDir !== modelsRoot && !targetDir.startsWith(modelsRoot + sep)) {
     throw new ModelError(`Refusing to write outside the models directory: ${raw}`);
   }
+  // Path-string containment (above) is not enough: an EXISTING symlink somewhere
+  // between modelsRoot and targetDir could redirect the real write OUTSIDE the
+  // models dir. Because THIS resolver is the single canonical write-target for
+  // every local download (startDownloadJob keying AND downloadModel's write), the
+  // guard belongs here — co-located with the resolution the write actually uses —
+  // so it can never diverge from a caller's separate pre-validation (e.g.
+  // apply_manifest resolving the root a second time; #490 codex review).
+  await assertNoEscapingSymlinkAncestor(modelsRoot, targetDir, raw);
   return targetDir;
+}
+
+/**
+ * Reject when any EXISTING directory STRICTLY BETWEEN `root` and `target` (a
+ * descendant of root, not root itself) is a symlink whose real location escapes
+ * root. The models root ITSELF is intentionally NOT checked: a ComfyUI install
+ * may legitimately symlink/junction its whole models dir onto another drive, so
+ * the root canonicalizes elsewhere by design — that is allowed. Descendants are
+ * compared against the CANONICAL root (realpath of root) so a subfolder that
+ * resolves back inside the real models tree is fine, while one escaping it is
+ * rejected. Best-effort: a not-yet-created segment is fine (the download mkdirs it
+ * inside root); never throws for a missing path — only for a genuine escape.
+ */
+async function assertNoEscapingSymlinkAncestor(
+  root: string,
+  target: string,
+  label: string,
+): Promise<void> {
+  // Canonical root: if the models dir is itself a symlink/junction, resolve it so
+  // descendants are checked against where it REALLY lives (not the lexical path).
+  let realRoot: string;
+  try {
+    realRoot = resolve(await realpath(root));
+  } catch {
+    realRoot = root; // root not yet created — lexical containment is all we can check.
+  }
+  // Walk descendants only: from target up to (but NOT including) root.
+  let cursor = target;
+  while (cursor !== root && cursor.startsWith(root + sep)) {
+    try {
+      const info = await lstat(cursor);
+      if (info.isSymbolicLink()) {
+        const real = resolve(await realpath(cursor));
+        if (real !== realRoot && !real.startsWith(realRoot + sep)) {
+          throw new ModelError(
+            `Refusing to write outside the models directory (a symlink in the path escapes it): ${label}`,
+          );
+        }
+      }
+    } catch (err) {
+      if (err instanceof ModelError) throw err;
+      // ENOENT / not yet created — safe; the writer will create it inside root.
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
 }
 
 export interface ResolvedDownloadTarget {
@@ -724,9 +779,27 @@ export async function shouldDispatchDownloadToManager(): Promise<boolean> {
   if (resolveEffectiveComfyUIBase()) return false;
   try {
     const stats = await getSystemStats();
-    // Reachable server: stream locally only if it exposes a base/models dir we can
-    // write to; otherwise hand the fetch to its ComfyUI-Manager (reconnect-safe).
-    return !parseModelsDirFromArgv(stats.system?.argv);
+    const argv = stats.system?.argv;
+    // Reachable server: stream locally when it exposes a base/models dir we can
+    // write to (--base-directory/--models-directory) OR when we can derive its own
+    // install root from argv (its main.py path) — the SAME live-first root the
+    // downloader writes into (resolveModelsDir). Keeping this in lockstep with
+    // resolveModelsDir is what lets a panel-connected local server with no
+    // COMFYUI_PATH stream models into its live install (#463) instead of bouncing
+    // through the Manager (which then fails when Manager isn't installed). Only
+    // dispatch to the Manager when NEITHER is discoverable (#420 reconnect with an
+    // opaque/relative argv we can't resolve).
+    if (parseModelsDirFromArgv(argv)) return false;
+    // Derive the server's own install root from argv (its main.py). Only treat it
+    // as a LOCAL stream target when that path ACTUALLY EXISTS on this filesystem:
+    // a loopback ComfyUI inside Docker / behind an SSH port-forward reports a
+    // container-side main.py path that is NOT the host's, so writing there would
+    // create a bogus host directory instead of reaching the server. When the root
+    // isn't locally present, hand the fetch to the connected Manager (server-side
+    // write), which lands in the real install regardless.
+    const liveRoot = liveRootFromArgv(argv, (stats.system as { cwd?: string })?.cwd);
+    if (liveRoot && existsSync(liveRoot)) return false;
+    return true;
   } catch {
     // No reachable server → nothing to dispatch to. Let the local resolver throw.
     return false;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -6,6 +6,7 @@ import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
+import { resolveRootInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -704,11 +705,15 @@ function gitCheckoutDir(baseUrl: string): string {
   return basename(clean).replace(/\.git$/i, "");
 }
 
-function runGitCheckout(baseUrl: string, ref: string): void {
-  if (!config.comfyuiPath) {
+function runGitCheckout(baseUrl: string, ref: string, basePath?: string): void {
+  // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
+  // adopted saved-default/live root WITHOUT mutating global config); fall back to
+  // config.comfyuiPath. Either may be unset in remote mode → clear error.
+  const comfyuiBase = basePath ?? config.comfyuiPath;
+  if (!comfyuiBase) {
     throw new ProcessControlError(
       "Checking out a custom-node git ref requires a local ComfyUI install, " +
-        "but config.comfyuiPath is not set.",
+        "but no ComfyUI path is set.",
     );
   }
 
@@ -719,7 +724,7 @@ function runGitCheckout(baseUrl: string, ref: string): void {
   assertSafeGitUrl(baseUrl);
   const repoName = gitCheckoutDir(baseUrl);
   assertSafeRepoName(repoName);
-  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
+  const customNodesRoot = resolve(comfyuiBase, "custom_nodes");
   const nodeDir = resolve(customNodesRoot, repoName);
   const rel = relative(customNodesRoot, nodeDir);
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
@@ -735,13 +740,13 @@ function runGitCheckout(baseUrl: string, ref: string): void {
 
   try {
     execFileSync("git", ["-C", nodeDir, "fetch", "--all", "--tags"], {
-      cwd: config.comfyuiPath,
+      cwd: comfyuiBase,
       encoding: "utf-8",
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
     });
     execFileSync("git", ["-C", nodeDir, "checkout", "--detach", "--end-of-options", ref], {
-      cwd: config.comfyuiPath,
+      cwd: comfyuiBase,
       encoding: "utf-8",
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
@@ -790,16 +795,18 @@ function nodeInstalledMatches(
 /**
  * Resolve the ComfyUI venv python for installing a cloned node's deps. Prefers
  * the install's own `.venv` (Windows Scripts/ or POSIX bin/), falling back to a
- * bare "python" on PATH.
+ * bare "python" on PATH. `basePath` is the CALL-SCOPED install root (apply_manifest
+ * threads an adopted saved-default/live root without mutating global config); when
+ * omitted it falls back to config.comfyuiPath. Passing it matters: otherwise a
+ * cloned node's requirements.txt / install.py would run under a BARE system python
+ * for an adopted workspace, corrupting/ missing the real ComfyUI environment while
+ * the node is still reported installed (#463 codex review).
  */
-function resolveVenvPython(): string {
-  if (config.comfyuiPath) {
-    const winPy = join(config.comfyuiPath, ".venv", "Scripts", "python.exe");
-    if (existsSync(winPy)) return winPy;
-    const posixPy = join(config.comfyuiPath, ".venv", "bin", "python");
-    if (existsSync(posixPy)) return posixPy;
-  }
-  return "python";
+function resolveVenvPython(basePath?: string): string {
+  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
+  // via the shared resolver, so a cloned node's deps target the install's OWN
+  // interpreter rather than a bare system python (#463 codex review).
+  return resolveRootInterpreter(basePath ?? config.comfyuiPath);
 }
 
 /**
@@ -859,11 +866,17 @@ function cloneCustomNodeFallback(
   repoName: string,
   gitRef: string | undefined,
   managerStatus: unknown,
+  basePath?: string,
 ): NodeOpResult {
-  if (!config.comfyuiPath) {
+  // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
+  // adopted saved-default/live root here WITHOUT mutating global config, so a
+  // panel-connected local session with no COMFYUI_PATH can still clone an
+  // unregistered git pack); fall back to config.comfyuiPath.
+  const comfyuiBase = basePath ?? config.comfyuiPath;
+  if (!comfyuiBase) {
     throw new ProcessControlError(
       `"${repoName}" is not in the ComfyUI-Manager registry and cloning it ` +
-        `requires a local ComfyUI install, but config.comfyuiPath is not set ` +
+        `requires a local ComfyUI install, but no ComfyUI path is set ` +
         `(running in remote --comfyui-url mode). Install it on the ComfyUI host, ` +
         `or pass a registered pack id.`,
     );
@@ -874,10 +887,10 @@ function cloneCustomNodeFallback(
   assertSafeGitUrl(gitId);
   assertSafeRepoName(repoName);
 
-  // Resolve the target and ASSERT it stays inside <comfyuiPath>/custom_nodes,
+  // Resolve the target and ASSERT it stays inside <comfyuiBase>/custom_nodes,
   // mirroring manifest.ts's isWithinRoot containment check (defense in depth on
   // top of the repoName validation above).
-  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
+  const customNodesRoot = resolve(comfyuiBase, "custom_nodes");
   const nodeDir = resolve(customNodesRoot, repoName);
   const rel = relative(customNodesRoot, nodeDir);
   if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
@@ -898,7 +911,7 @@ function cloneCustomNodeFallback(
     logger.info("Cloning unregistered custom node", { gitId, nodeDir, gitRef });
     try {
       execFileSync("git", cloneArgs, {
-        cwd: config.comfyuiPath,
+        cwd: comfyuiBase,
         encoding: "utf-8",
         timeout: GIT_CLONE_TIMEOUT,
         env: nonInteractiveGitEnv(),
@@ -916,7 +929,7 @@ function cloneCustomNodeFallback(
         },
       );
     }
-    if (gitRef) runGitCheckout(gitId, gitRef);
+    if (gitRef) runGitCheckout(gitId, gitRef, comfyuiBase);
   }
 
   // VERIFY the clone landed before attempting deps.
@@ -930,7 +943,7 @@ function cloneCustomNodeFallback(
   const requirements = join(nodeDir, "requirements.txt");
   const installScript = join(nodeDir, "install.py");
   if (existsSync(requirements) || existsSync(installScript)) {
-    const python = resolveVenvPython();
+    const python = resolveVenvPython(comfyuiBase);
     if (existsSync(requirements)) {
       try {
         execFileSync(python, ["-m", "pip", "install", "-r", requirements], {
@@ -986,6 +999,11 @@ export interface InstallOptions {
   channel?: string;
   /** Force the official comfy-cli subprocess instead of the HTTP API. */
   useCmCli?: boolean;
+  /** CALL-SCOPED local ComfyUI root for the git-clone / ref-checkout fallback,
+   *  threaded by callers (e.g. apply_manifest) that resolve an adopted
+   *  saved-default/live root WITHOUT mutating global config.comfyuiPath. Falls
+   *  back to config.comfyuiPath when omitted. */
+  comfyuiPath?: string;
 }
 
 /**
@@ -1013,6 +1031,7 @@ async function installCustomNodeImpl(
   opts: InstallOptions,
 ): Promise<NodeOpResult> {
   const { id, version, mode = "remote", channel = "default" } = opts;
+  const basePath = opts.comfyuiPath ?? config.comfyuiPath;
   const parsedGit = parseGitUrl(id);
   const gitId = parsedGit.baseUrl;
   const gitRefCandidate = opts.ref ?? parsedGit.ref ?? version;
@@ -1039,7 +1058,7 @@ async function installCustomNodeImpl(
     const installId = source === "git" ? gitId : id;
     const out = runCmCli(["install", installId, "--mode", mode, "--channel", channel]);
     if (source === "git" && gitRef) {
-      runGitCheckout(gitId, gitRef);
+      runGitCheckout(gitId, gitRef, basePath);
     }
     return {
       mechanism: "comfy-cli",
@@ -1097,7 +1116,7 @@ async function installCustomNodeImpl(
         details: status,
       };
     }
-    return cloneCustomNodeFallback(gitId, repoName, gitRef, status);
+    return cloneCustomNodeFallback(gitId, repoName, gitRef, status, basePath);
   }
 
   // Registry (plain CNR id). Keep the prior defaults channel "default" /

--- a/src/services/output-dir.ts
+++ b/src/services/output-dir.ts
@@ -1,7 +1,8 @@
+import { existsSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { config } from "../config.js";
+import { config, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
-import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
+import { resolveEffectiveComfyUIBase, liveRootFromArgv } from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -138,12 +139,47 @@ export function parseExtraModelPathsConfigsFromArgv(argv: string[] | undefined):
 export async function resolveModelsDir(): Promise<string> {
   try {
     const stats = await getSystemStats();
-    const fromArgv = parseModelsDirFromArgv(stats.system?.argv);
+    const argv = stats.system?.argv;
+    const fromArgv = parseModelsDirFromArgv(argv);
     if (fromArgv) {
       logger.debug("Resolved ComfyUI models directory from launch argv", {
         modelsDir: fromArgv,
       });
       return fromArgv;
+    }
+    // No explicit --base-directory/--models-directory flag: derive the models
+    // root from the LIVE connected server's OWN install root (its main.py path in
+    // argv). That is the ComfyUI actually running, so a download lands where it
+    // reads models — NOT in a stale/other COMFYUI_PATH that points at a different
+    // install (#490/#463). Skip in remote mode: the live root is a path on the
+    // remote host, not a local directory we can write to.
+    //
+    // LIMITATION: this needs an ABSOLUTE main.py in argv (or a server-reported
+    // cwd). A server launched as `python main.py` reports a bare/relative argv[0]
+    // and ComfyUI does not currently report cwd, so the root is UNRESOLVABLE — we
+    // then fall through to the COMFYUI_PATH/default below. That's the safe default
+    // (there is no information to do better); when COMFYUI_PATH is unset, the
+    // download instead routes through the connected server's Manager, which writes
+    // into the real install regardless (see shouldDispatchDownloadToManager).
+    if (!isRemoteMode()) {
+      const liveRoot = liveRootFromArgv(
+        argv,
+        (stats.system as { cwd?: string })?.cwd,
+      );
+      // Only adopt the live root when it ACTUALLY EXISTS on this filesystem. A
+      // loopback ComfyUI inside Docker / behind an SSH port-forward reports a
+      // container-side main.py path that is not the host's — writing there would
+      // create a bogus host dir the server never reads. When it isn't locally
+      // present we fall through to COMFYUI_PATH/default (and shouldDispatchDownload-
+      // ToManager routes the fetch through the server's Manager instead).
+      if (liveRoot && existsSync(liveRoot)) {
+        const dir = join(liveRoot, "models");
+        logger.debug(
+          "Resolved ComfyUI models directory from the live server's main.py root",
+          { modelsDir: dir },
+        );
+        return dir;
+      }
     }
   } catch (err) {
     logger.debug(

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -92,6 +92,29 @@ export function resolveEffectiveComfyUIBase(): string | undefined {
   return getSavedDefaultWorkspaceSync();
 }
 
+/**
+ * The LIVE connected server's own install root, derived from its /system_stats
+ * launch argv (the `main.py` path — see liveRootFromArgv). This is the ComfyUI
+ * that is ACTUALLY running, so it is the source of truth for where a download /
+ * node install must land — even when COMFYUI_PATH is unset, OR points at a
+ * DIFFERENT, stale install than the connected one (#490/#463). Returns undefined
+ * in remote mode (the live root is a path on the REMOTE host, not usable as a
+ * local target), when the server is unreachable, or when argv yields no
+ * resolvable absolute root. Best-effort and NEVER throws.
+ */
+export async function resolveLiveComfyUIBase(): Promise<string | undefined> {
+  if (isRemoteMode()) return undefined;
+  try {
+    const stats = await getSystemStats();
+    return liveRootFromArgv(
+      stats.system?.argv,
+      (stats.system as { cwd?: string })?.cwd,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 async function readWorkspaceConfig(): Promise<WorkspaceConfig> {
   const path = workspaceConfigPath();
   if (!existsSync(path)) return {};
@@ -352,6 +375,31 @@ export function liveRootFromArgv(
     return undefined; // cannot resolve to an absolute dir → UNRESOLVED
   }
   return undefined;
+}
+
+/**
+ * Resolve the Python interpreter that ACTUALLY belongs to a ComfyUI install
+ * `root`, honoring EVERY layout ComfyUI ships with — portable Windows builds keep
+ * python under `standalone-env` / `python_embeded` (NOT just `.venv`/`venv`). Used
+ * by apply_manifest's pip installs and the cloned-node deps installer so those run
+ * under the install's OWN interpreter, not a bare system `python` that would
+ * contaminate the host env while reporting success (#463 codex review). Returns
+ * the first candidate present on disk, else a bare platform python name as a last
+ * resort. `undefined` root → bare python.
+ */
+export function resolveRootInterpreter(root: string | undefined): string {
+  const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
+  if (root) {
+    for (const c of interpreterCandidates(root)) {
+      if (/^\\\\/.test(c)) continue; // skip UNC (existsSync can block on dead shares)
+      try {
+        if (existsSync(c)) return c;
+      } catch {
+        // ignore and continue
+      }
+    }
+  }
+  return names[0];
 }
 
 /** Platform interpreter candidates under a ComfyUI install root, most-preferred first. */


### PR DESCRIPTION
## Problem

`apply_manifest` had a path/timeout bug cluster:

- **#490** — downloaded models into a STALE local `COMFYUI_PATH` instead of the live/connected install when the connected server ran from a different directory and wasn't launched with `--base-directory`.
- **#463** — could not use a panel-connected LOCAL ComfyUI when `COMFYUI_PATH` was unavailable: the session was misclassified as "no local filesystem" and every model/pip install was skipped.
- **#489** — hit a false 300s `tools/call` timeout while ComfyUI-Manager kept installing; the caller saw a failure even though the install was progressing server-side.

## Fix

**Live-first download target (#490/#463)**
- `resolveModelsDir` prefers the LIVE connected server's own install root (its `main.py` path from `/system_stats` argv, via `liveRootFromArgv`) over a stale `COMFYUI_PATH` when there's no `--base-directory`/`--models-directory` flag — but only when that root **exists locally**. A Docker/SSH-forwarded loopback server reports a container-side path that isn't the host's, so those route through the connected Manager (server-side write) instead. Skipped in remote mode.
- `shouldDispatchDownloadToManager` is kept in lockstep (live-root aware + `existsSync`-gated) so a panel-connected local server with no `COMFYUI_PATH` streams into its live install (#463) rather than failing on an absent Manager.
- `applyManifest` resolves a **call-scoped** local base (`COMFYUI_PATH` → saved default → live root) and threads it **explicitly** — no global `config.comfyuiPath` mutation. The git-clone / ref-checkout fallback and its deps installer honor it, and pip/deps resolve the interpreter via the shared `resolveRootInterpreter` (venv + portable `python_embeded`/`standalone-env`), never a bare system python.
- The write-target resolver rejects a destination whose **descendant** is a symlink escaping the canonicalized models root (a legitimately symlinked/junctioned root is allowed), so the actual write is guarded regardless of any caller pre-validation.

**Poll the Manager queue instead of a false 300s timeout (#489)**
- The custom-node phase is bounded by an env-tunable wall-clock budget (`COMFYUI_MCP_MANIFEST_NODE_BUDGET_MS`, default 240s, under the 300s MCP cap). **Every** async wait — the initial installed-list probe, each install, and the post-install verify — is raced against the deadline. A still-installing node is reported **pending** (poll the Manager queue; re-run to continue) and never **failed**, while the install keeps running server-side. Not-started nodes are reported pending too. (Synchronous `execFileSync` install units — git clone / pip — are inherently unpreemptable in a single-threaded runtime and remain bounded by their own subprocess timeout.)

## Tests

Regression tests fail before / pass after, mocking the fs/HTTP/queue boundary:
- download target resolves to the live install with a stale/unset `COMFYUI_PATH`, and does NOT adopt a non-local (Docker/forwarded) argv root (`output-dir`, `download-manager-routing`, `workspace-env`);
- a long-running Manager install polls to completion, and at a budget returns pending — not a false timeout, not "applied" (`manifest`);
- `local_path` / write-target symlink escape is caught against the (canonical) live models dir, a symlinked root is allowed (`manifest`, `model-resolver`);
- an unregistered git pack clones into, and its deps install under the venv of, the adopted base when `COMFYUI_PATH` is unset (`node-management`).

Full suite passes except the pre-existing node-dev ripgrep sandbox failure (unrelated). No version bump.

Codex review gate: **VERDICT: PASS** ("No genuine new correctness or safety regressions found in the diff.").

Closes #490
Closes #463
Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
