### PR TITLE
fix(panel-ask): fail-fast when no interactive surface (#300); don't drop a late-but-valid answer (#486); saner set_todo deadline (#322)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -7,7 +7,7 @@
 // panel JS executors implement), and that the McpServer HTTP path registers the
 // identical set.
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -20,6 +20,7 @@ import {
   __openWorkflowTestHooks,
   __panelToolsTestHooks,
   __panelRunTestHooks,
+  __panelAskTestHooks,
   type PanelToolCtx,
   type ToolResult,
 } from "../../orchestrator/panel-tools.js";
@@ -1689,5 +1690,161 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("opened");
     expect(listCalls).toBe(0);
+  });
+});
+
+describe("panel_ask surface + late-answer resilience (#300/#486) and set_todo bound (#322)", () => {
+  const REPLY_TIMEOUT_ERR = (cmd: string, ms: number) =>
+    new Error(
+      `Panel tab abcd1234 did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be backgrounded or frozen`,
+    );
+
+  afterEach(() => {
+    // Reset the injected fast ask timing so other suites see the real defaults.
+    __panelAskTestHooks.setAskTiming(null);
+  });
+
+  function askText(res: ToolResult): string {
+    return (res.content[0] as { text: string }).text;
+  }
+
+  // #300 — NO INTERACTIVE SURFACE: a canvas-less/headless client (mobile mirror,
+  // remote viewer, or an exec/headless run) can't render the choice card, so the
+  // ask must FAIL FAST with an actionable error instead of blocking. We must never
+  // even dispatch ask_user in that case.
+  it("panel_ask fails FAST with an actionable error when no interactive surface can render the card (#300)", async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        sent.push(cmd);
+        // Simulate the old hang: never resolve. If the handler awaited this the
+        // test would time out — so a passing test proves we short-circuited.
+        return new Promise<never>(() => {});
+      },
+      canReach: () => true,
+      isHeadless: () => true,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Local or pod?", options: [{ label: "Local" }, { label: "Pod" }] },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(askText(res)).toMatch(/no interactive panel surface|plain chat|headless|exec/i);
+    // Never dispatched — no indefinite block on a surface that can't answer.
+    expect(sent.length).toBe(0);
+  });
+
+  // #486 — LATE-BUT-VALID ANSWER: the card-reply timer fired (bridge.send rejected
+  // with a reply-timeout), but the user validated a pick slightly late. The bridge
+  // buffered it; the handler must poll the buffer and HONOR the answer, not discard
+  // it as a timeout.
+  it("panel_ask honors a late-but-valid answer buffered after a reply timeout (#486)", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 500, pollMs: 2 });
+    let takes = 0;
+    const bridge = {
+      send: async (_cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        // The card timed out before the (slow) user answered.
+        throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => "abcd1234",
+      // The validated answer lands one poll later, after the send already rejected.
+      takeLateAskReply: (_askId: string) => {
+        takes += 1;
+        return takes >= 2 ? "Local GPU + Blender" : undefined;
+      },
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Which?", options: [{ label: "Local GPU + Blender" }, { label: "Cloud" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("Local GPU + Blender");
+  });
+
+  // Codex gate: the clamp must be a HARD ceiling on deadline + grace, not just the
+  // default — a large env override must never be able to recreate #486.
+  it("hard-clamps deadline+grace under the MCP budget even with oversized env overrides (#486)", () => {
+    const prevD = process.env.COMFYUI_PANEL_ASK_DEADLINE_S;
+    const prevG = process.env.COMFYUI_PANEL_ASK_GRACE_S;
+    process.env.COMFYUI_PANEL_ASK_DEADLINE_S = "600"; // 600s
+    process.env.COMFYUI_PANEL_ASK_GRACE_S = "600"; // 600s
+    try {
+      const t = __panelAskTestHooks.getAskTiming();
+      expect(t.deadlineMs).toBeGreaterThan(0);
+      expect(t.deadlineMs + t.graceMs).toBeLessThanOrEqual(
+        __panelAskTestHooks.ASK_TOTAL_BUDGET_CAP_MS,
+      );
+      expect(t.deadlineMs + t.graceMs).toBeLessThan(300000);
+    } finally {
+      if (prevD === undefined) delete process.env.COMFYUI_PANEL_ASK_DEADLINE_S;
+      else process.env.COMFYUI_PANEL_ASK_DEADLINE_S = prevD;
+      if (prevG === undefined) delete process.env.COMFYUI_PANEL_ASK_GRACE_S;
+      else process.env.COMFYUI_PANEL_ASK_GRACE_S = prevG;
+    }
+  });
+
+  it("panel_ask clamps the card deadline under the ~300s MCP tools/call budget and returns the pick (#486)", async () => {
+    let forwardedTimeout = 0;
+    const bridge = {
+      send: async (_cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        forwardedTimeout = opts?.timeoutMs ?? 0;
+        return "Pod";
+      },
+      canReach: () => true,
+      isHeadless: () => false,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx: PanelToolCtx = { bridge, tabId: "abcd1234" } as unknown as PanelToolCtx;
+
+    const res = await defByName("panel_ask").handler(
+      { question: "Where?", options: [{ label: "Local" }, { label: "Pod" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(askText(res)).toBe("Pod");
+    // Must NOT be the old 600000ms (which outlived the 300s MCP budget → lost answer).
+    expect(forwardedTimeout).toBeGreaterThan(0);
+    expect(forwardedTimeout).toBeLessThan(300000);
+  });
+
+  // #322 — set_todo must not false-timeout a responsive session. Model a tab that
+  // acks in ~8s (momentarily backgrounded): the OLD 5s bound would reject it; the
+  // handler must forward a sane bound (>=15s) so the ack succeeds.
+  it("panel_set_todo does NOT false-timeout a responsive (8s-ack) session — sane bound (#322)", async () => {
+    const RESPONSIVE_ACK_MS = 8000;
+    let forwardedTimeout = 0;
+    const sent: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        forwardedTimeout = opts?.timeoutMs ?? 6000;
+        if (forwardedTimeout < RESPONSIVE_ACK_MS) {
+          throw REPLY_TIMEOUT_ERR("set_todo", forwardedTimeout);
+        }
+        sent.push(cmd);
+        return { ok: true };
+      },
+      canReach: () => true,
+      resolveActiveTabId: () => "abcd1234",
+      push: () => 1,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const res = await defByName("panel_set_todo").handler(
+      { items: [{ text: "step one", status: "active" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(forwardedTimeout).toBeGreaterThanOrEqual(15000);
+    expect(sent.at(-1)).toMatchObject({ cmd: "set_todo" });
   });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -998,3 +998,51 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     );
   });
 });
+
+// ── #486: a validated ask_user answer that lands AFTER the reply timeout must be
+// buffered (keyed by ask_id) so the caller can still retrieve it, not discarded.
+describe("UiBridge (late ask_user answer buffer — #486)", () => {
+  it("buffers a valid ask_user reply that arrives after the reply timeout", async () => {
+    const sock = await connectPanel("tab-ask", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-ask")).toBe(true));
+    // The panel validates a pick only AFTER the send's short reply timeout fires.
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "ask_user") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: "Late Pick" }));
+        }, 80);
+      }
+    });
+
+    await expect(
+      bridge.send(
+        { cmd: "ask_user", ask_id: "ask-xyz", question: "?", options: [] },
+        { tabId: "tab-ask", timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/did not reply/i);
+
+    // The late-but-valid answer must be recoverable via the buffer, then drained.
+    await vi.waitFor(() => expect(bridge.takeLateAskReply("ask-xyz")).toBe("Late Pick"));
+    expect(bridge.takeLateAskReply("ask-xyz")).toBeUndefined(); // drained once
+  });
+
+  it("does not buffer a non-ask command's late reply (no ask_id → dropped)", async () => {
+    const sock = await connectPanel("tab-plain", "wf");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-plain")).toBe(true));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd === "graph_outline") {
+        setTimeout(() => {
+          sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { late: true } }));
+        }, 80);
+      }
+    });
+    await expect(
+      bridge.send({ cmd: "graph_outline" }, { tabId: "tab-plain", timeoutMs: 30 }),
+    ).rejects.toThrow(/did not reply|disconnected|gone/i);
+    // Give the late reply time to land; it must NOT be buffered under any ask id.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(bridge.takeLateAskReply("tab-plain")).toBeUndefined();
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -24,6 +24,7 @@
 // so parity is automatic — neither path reimplements a tool.
 
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { extname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1081,6 +1082,174 @@ async function resolveWorkflowInput(
   return wf as Record<string, unknown>;
 }
 
+// ---- panel_ask surface + late-answer resilience (#300/#486) ----------------
+// panel_ask renders an interactive choice card in the panel and BLOCKS on the
+// user's pick. Two failure modes are handled here, localized to the ask path:
+//
+//  • #300 — NO INTERACTIVE SURFACE: when the only reachable client is canvas-less
+//    (a mobile mirror / remote/headless viewer, or an exec/headless run), the card
+//    can't render, so the ask would block for the whole deadline with no way to
+//    answer. We DETECT that up front (bridge.isHeadless on the tab the ask would
+//    target) and FAIL FAST with an actionable error telling the agent to ask in
+//    plain text or call panel_ask from an interactive tab — never an indefinite
+//    block.
+//
+//  • #486 — LATE-BUT-VALID ANSWER: the enclosing MCP `tools/call` has its own
+//    budget (~300s). A card wait longer than that guarantees the tool is killed
+//    before a slow user answers, DISCARDING a validated pick. We (a) CLAMP the card
+//    deadline safely under the MCP budget, and (b) after a card-reply timeout, poll
+//    the bridge's short-lived late-reply buffer for a bounded grace so an answer
+//    that validated slightly after the deadline is HONORED, not lost.
+
+interface AskTiming {
+  /** bridge.send reply timeout for the ask card — clamped under the MCP budget. */
+  deadlineMs: number;
+  /** How long to keep polling the late-reply buffer after a card-reply timeout. */
+  graceMs: number;
+  /** Interval between late-reply buffer polls. */
+  pollMs: number;
+}
+
+let askTimingOverride: AskTiming | null = null;
+
+// The enclosing MCP `tools/call` is killed at ~300s. The card deadline PLUS the
+// late-answer grace poll must finish UNDER that, or a slow-but-valid pick is lost
+// to the framework before we can honor it (#486). This is the HARD ceiling on the
+// total ask budget — applied even when env overrides ask for more, so a
+// misconfigured COMFYUI_PANEL_ASK_DEADLINE_S/GRACE_S can never recreate #486.
+const ASK_TOTAL_BUDGET_CAP_MS = 285_000;
+
+function getAskTiming(): AskTiming {
+  if (askTimingOverride) return askTimingOverride;
+  const pollMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_POLL_S", 0.5) * 1000);
+  // Defaults keep deadline + grace comfortably under the budget (240 + up to 45 =
+  // 285s). Env overrides are HARD-clamped: the deadline is capped first (leaving at
+  // least a 1s slice), then the grace gets only whatever budget remains, so
+  // deadline + grace is guaranteed ≤ ASK_TOTAL_BUDGET_CAP_MS regardless of input.
+  let deadlineMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_DEADLINE_S", 240) * 1000);
+  let graceMs = Math.round(parsePositiveNumberEnv("COMFYUI_PANEL_ASK_GRACE_S", 45) * 1000);
+  deadlineMs = Math.min(deadlineMs, ASK_TOTAL_BUDGET_CAP_MS - 1000);
+  graceMs = Math.min(graceMs, Math.max(0, ASK_TOTAL_BUDGET_CAP_MS - deadlineMs));
+  return { deadlineMs, graceMs, pollMs };
+}
+
+/** True when an error is the bridge's reply-TIMEOUT for a card (the tab never
+ *  replied within the window), NOT a genuine transport/command error. Only a
+ *  timeout warrants polling the late-reply buffer for a slow-but-valid answer. */
+function isReplyTimeoutError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  return /did not reply to .* within \d+\s*ms|backgrounded or frozen/i.test(msg);
+}
+
+/**
+ * Actionable error string when THIS session has no interactive surface able to
+ * render an ask card (so the ask would block with no way to answer), or `null`
+ * when a card can render. Uses the bridge's `isHeadless` on the tab the ask would
+ * target (the current tab if reachable, else the resolved active tab). Defensive:
+ * an unknown/lightweight bridge, or an ambiguous active-tab resolution, returns
+ * null so the normal send path surfaces its own clear error instead.
+ */
+function askSurfaceError(ctx: PanelToolCtx): string | null {
+  const b = ctx.bridge as unknown as {
+    isHeadless?: (id: string) => boolean;
+    canReach?: (id: string) => boolean;
+    resolveActiveTabId?: () => string;
+  };
+  if (typeof b.isHeadless !== "function") return null; // lightweight/unknown bridge
+  let targetId = ctx.tabId;
+  if (typeof b.canReach === "function" && !b.canReach(targetId)) {
+    if (typeof b.resolveActiveTabId !== "function") return null;
+    try {
+      targetId = b.resolveActiveTabId();
+    } catch {
+      return null; // no single active tab — let the send path report it clearly
+    }
+  }
+  if (!b.isHeadless(targetId)) return null;
+  return (
+    "No interactive panel surface can render a choice card in this session — the " +
+    "connected client is canvas-less (a mobile mirror, a remote/headless viewer, or " +
+    "an exec/headless run), so panel_ask can't be answered here and would block. Ask " +
+    "the user directly in plain chat text, or invoke panel_ask from an interactive " +
+    "ComfyUI browser tab (not nested inside an exec/headless call)."
+  );
+}
+
+/** Poll the bridge's late-reply buffer for a validated ask answer that arrived
+ *  after the card-reply timeout, up to the grace budget. undefined if none. */
+async function pollLateAskReply(
+  bridge: PanelToolCtx["bridge"],
+  askId: string,
+  timing: AskTiming,
+): Promise<unknown | undefined> {
+  const take = (bridge as unknown as { takeLateAskReply?: (id: string) => unknown })
+    .takeLateAskReply;
+  if (typeof take !== "function") return undefined;
+  const deadline = Date.now() + timing.graceMs;
+  for (;;) {
+    const late = take.call(bridge, askId);
+    if (late !== undefined) return late;
+    const left = deadline - Date.now();
+    if (left <= 0) return undefined;
+    await sleep(Math.max(1, Math.min(timing.pollMs, left)));
+  }
+}
+
+/**
+ * Run a panel_ask: render the choice card and return the user's pick. Clamps the
+ * card deadline under the MCP tools/call budget and, on a reply-timeout, honors a
+ * late-but-valid answer from the bridge's late-reply buffer before failing (#486).
+ * Sent DIRECTLY over the bridge (like the confirm/consent cards) so a stable
+ * `ask_id` can key the late-reply buffer.
+ */
+async function askUserWithGrace(
+  ctx: PanelToolCtx,
+  ask: { question: string; options: unknown; header?: unknown; multi_select?: unknown },
+): Promise<ToolResult> {
+  const timing = getAskTiming();
+  const askId = randomUUID();
+  const cmd = {
+    cmd: "ask_user",
+    ask_id: askId,
+    question: ask.question,
+    options: ask.options,
+    header: ask.header,
+    multi_select: ask.multi_select,
+  };
+  try {
+    ctx.ensureReachable?.();
+    const reply = await ctx.bridge.send(cmd as unknown as { cmd: string }, {
+      tabId: ctx.tabId,
+      timeoutMs: timing.deadlineMs,
+    });
+    return ok(reply);
+  } catch (err) {
+    if (isReplyTimeoutError(err)) {
+      const late = await pollLateAskReply(ctx.bridge, askId, timing);
+      if (late !== undefined) return ok(late);
+      return fail(
+        "The question card was not answered in time (or no interactive panel surface " +
+          "rendered it — e.g. an exec/headless run), so nothing was selected. If you " +
+          "still need the decision, ask the user directly in plain chat text, or " +
+          "re-invoke panel_ask from an interactive ComfyUI tab.",
+      );
+    }
+    return fail(err);
+  }
+}
+
+export const __panelAskTestHooks = {
+  /** Inject fast ask timing so tests don't wait the real deadline/grace. */
+  setAskTiming(timing: AskTiming | null): void {
+    askTimingOverride = timing;
+  },
+  /** The env-derived (hard-clamped) ask timing, for the budget-cap test. */
+  getAskTiming,
+  ASK_TOTAL_BUDGET_CAP_MS,
+  askSurfaceError,
+  isReplyTimeoutError,
+};
+
 /** One shared tool definition: name, description, zod raw-shape schema, and a
  *  transport-agnostic handler that receives parsed args + the tab-bound context. */
 export interface PanelToolDef {
@@ -1945,7 +2114,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           )
           .describe("The full ordered checklist (replaces the current one). Empty array clears the tray."),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "set_todo", items: args.items }, 5000),
+      // #322: a 5s ack deadline false-timed-out a responsive session whose tab was
+      // momentarily backgrounded. set_todo is a non-destructive, idempotent full-
+      // replace UI write (already in RETRY_SAFE_CMDS), so give it the same sane 15s
+      // bound as the other UI-state writes (workflow_save) instead of a tight 5s.
+      async (args: A, ctx) => ctx.call({ cmd: "set_todo", items: args.items }, 15000),
     ),
     def(
       "panel_open_civitai",
@@ -2203,18 +2376,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         header: z.string().optional().describe("Very short label/chip for the card (e.g. 'Sampler')."),
         multi_select: z.boolean().optional().describe("Allow selecting multiple options (default false)."),
       },
-      async (args: A, ctx) =>
-        ctx.call(
-          {
-            cmd: "ask_user",
-            question: args.question,
-            options: args.options,
-            header: args.header,
-            multi_select: args.multi_select,
-          },
-          // Human-in-the-loop: wait up to 10 minutes for a pick.
-          600000,
-        ),
+      async (args: A, ctx) => {
+        // #300: fail FAST with an actionable error when there is no interactive
+        // surface to render the card (a canvas-less/headless client, or an exec/
+        // headless run), rather than blocking with no way to answer.
+        const surfaceErr = askSurfaceError(ctx);
+        if (surfaceErr) return fail(surfaceErr);
+        // #486: clamp the card deadline under the MCP tools/call budget and honor a
+        // late-but-valid answer via the bridge's late-reply buffer.
+        return askUserWithGrace(ctx, {
+          question: args.question as string,
+          options: args.options,
+          header: args.header,
+          multi_select: args.multi_select,
+        });
+      },
     ),
     def(
       "panel_save_workflow",

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -226,6 +226,20 @@ export class UiBridge {
   private missedFrames = new Map<string, Record<string, unknown>[]>();
   private static readonly MAX_MISSED_FRAMES = 100;
   private pending = new Map<string, Pending>();
+  /** ask_user card sends (rid → {ask_id, ts}): lets a reply that validates AFTER
+   *  the reply timer fired (dropped from `pending`) still be buffered for the
+   *  caller, instead of being discarded as a "late reply for a timed-out command"
+   *  (#486). Timestamped so an abandoned mapping (timeout/disconnect/send-failure
+   *  whose late reply never arrives) is TTL-pruned rather than kept forever. */
+  private askRidToId = new Map<string, { askId: string; ts: number }>();
+  /** Buffered late-but-valid ask_user answers (ask_id → result), drained by the
+   *  caller via takeLateAskReply(). Bounded by a short TTL — a stale unclaimed
+   *  answer is pruned rather than kept forever. */
+  private lateAskReplies = new Map<string, { result: unknown; ts: number }>();
+  /** TTL for a buffered late ask answer / an unresolved rid→ask_id mapping. Long
+   *  enough to cover a slow human pick within the MCP tools/call budget, short
+   *  enough that abandoned entries don't accumulate. */
+  private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
@@ -665,9 +679,24 @@ export class UiBridge {
       const rid = typeof msg.rid === "string" ? msg.rid : undefined;
       if (rid) {
         const p = this.pending.get(rid);
-        if (!p) return; // late reply for a timed-out command
+        if (!p) {
+          // Late reply for a timed-out command. If it was an ask_user card whose
+          // caller may still be within the MCP tools/call budget, BUFFER the
+          // validated answer keyed by its ask_id so the caller can retrieve it via
+          // takeLateAskReply() instead of losing it (#486). Everything else drops.
+          const entry = this.askRidToId.get(rid);
+          if (entry) {
+            this.askRidToId.delete(rid);
+            if (msg.ok) {
+              this.pruneLateAsk();
+              this.lateAskReplies.set(entry.askId, { result: msg.result, ts: Date.now() });
+            }
+          }
+          return;
+        }
         clearTimeout(p.timer);
         this.pending.delete(rid);
+        this.askRidToId.delete(rid);
         if (msg.ok) {
           p.resolve(msg.result);
         } else {
@@ -836,6 +865,43 @@ export class UiBridge {
     // offline, so a render finishing during a disconnect is byte-inlined (not a
     // bytes-less viewRef) and is renderable when the mailbox flushes to the phone.
     return this.conns.get(tabId)?.headless === true || this.headlessSeen.has(tabId);
+  }
+
+  /** Drop expired late-ask entries (buffered answers + unresolved rid mappings) so
+   *  an abandoned card never leaks memory. Cheap; called on each ask send/take. */
+  private pruneLateAsk(): void {
+    const now = Date.now();
+    for (const [id, e] of this.lateAskReplies) {
+      if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.lateAskReplies.delete(id);
+    }
+    // TTL-prune abandoned rid→ask_id mappings (a card that timed out / dropped and
+    // whose late reply never came), so they don't linger past the window a caller
+    // could still claim them.
+    for (const [rid, e] of this.askRidToId) {
+      if (now - e.ts > UiBridge.LATE_ASK_TTL_MS) this.askRidToId.delete(rid);
+    }
+    // Belt-and-suspenders cardinality cap in case of a burst of asks within one TTL
+    // window — drop the oldest-inserted mappings so the map can never grow unbounded.
+    if (this.askRidToId.size > 256) {
+      const excess = this.askRidToId.size - 256;
+      let i = 0;
+      for (const rid of this.askRidToId.keys()) {
+        if (i++ >= excess) break;
+        this.askRidToId.delete(rid);
+      }
+    }
+  }
+
+  /** Retrieve (and remove) a late-but-valid ask_user answer buffered for `askId`
+   *  after the card-reply timeout, or undefined if none arrived. The panel_ask
+   *  handler polls this for a bounded grace so a slow-but-valid pick is honored
+   *  rather than discarded (#486). */
+  takeLateAskReply(askId: string): unknown | undefined {
+    this.pruneLateAsk();
+    const e = this.lateAskReplies.get(askId);
+    if (!e) return undefined;
+    this.lateAskReplies.delete(askId);
+    return e.result;
   }
 
   /** All currently connected tabs, most recent hello last. */
@@ -1008,6 +1074,14 @@ export class UiBridge {
     }
     const replyTimeoutMs = Math.min(ctx.timeoutMs, remaining);
     const rid = randomUUID();
+    // Track an ask_user card's stable ask_id against this attempt's rid so a reply
+    // that validates AFTER the reply timer fires (and drops out of `pending`) can
+    // still be buffered for the caller by rid, not discarded (#486 late answer).
+    const askId = (cmd as { ask_id?: unknown }).ask_id;
+    if (typeof askId === "string" && askId) {
+      this.pruneLateAsk();
+      this.askRidToId.set(rid, { askId, ts: Date.now() });
+    }
     // Rewrite an old-panel "Unknown command" rejection into an actionable
     // update-your-panel message (see makeUnknownCommandError). Applied to the
     // reply-error path only; the happy path and genuine command errors are


### PR DESCRIPTION
Fixes a `panel_ask` / `panel_set_todo` cluster orchestrator-side (`src/orchestrator/panel-tools.ts` + the `UiBridge` boundary). Changes are localized to the `panel_ask` / `panel_set_todo` handlers to minimize conflict with in-flight PR #522.

## What & why

### #300 — panel_ask fails fast when no interactive surface can render the card
When the only reachable client is canvas-less (a mobile mirror, a remote/headless viewer, or an exec/headless run), the choice card can't render, so the ask blocked for the whole deadline with no way to answer. `panel_ask` now detects this up front (`askSurfaceError` → `bridge.isHeadless` on the tab it would target) and **fails fast with an actionable error** ("ask in plain chat text, or invoke from an interactive ComfyUI tab") — never an indefinite block. The #486 deadline clamp also bounds any residual wait.

### #486 — a late-but-valid answer is honored, not discarded
The enclosing MCP `tools/call` is killed at ~300s, but the card wait was 600s, so a slow-but-valid pick was lost. Now:
- The card deadline is **hard-clamped** so `deadline + late-answer grace ≤ 285s < 300s`, even when `COMFYUI_PANEL_ASK_DEADLINE_S` / `_GRACE_S` env overrides ask for more.
- On a reply-timeout the handler polls a new **short-lived bridge late-reply buffer** (keyed by a stable `ask_id`) for a bounded grace, so an answer that validated slightly after the deadline is **honored**. The buffer (`askRidToId` / `lateAskReplies`) is TTL-pruned; late replies are drained once; `panel_ask` is never retried (no double-apply).

### #322 — panel_set_todo no longer false-timeouts a responsive session
The 5s ack deadline false-timed-out a responsive session whose tab was momentarily backgrounded. Raised to the same **15s** bound the other UI-state writes use (`set_todo` is already idempotent + retry-safe).

## Tests (FAIL-before / PASS-after, bridge boundary mocked)
- exec/no-surface ask → fast actionable error, `ask_user` never dispatched (not a hang)
- a late-but-valid ask answer is honored (handler test + a **real `UiBridge`** buffering test: send `ask_user`, let it time out, deliver a late reply, assert `takeLateAskReply` returns it; and a non-ask late reply is NOT buffered)
- deadline is clamped under the 300s budget even with oversized env overrides
- `set_todo` to a responsive 8s-ack session succeeds within a sane bound

Full suite green except the unrelated pre-existing `node-dev` ripgrep sandbox test. Codex review gate: **VERDICT: PASS** (after one FAIL round that caught the env-unbounded deadline + the missing `askRidToId` TTL — both fixed here).

## Also fixes (panel repo — close manually)
artokun/comfyui-mcp-panel#300 #486 #322

_Note: #300 and #322 live in the panel repo; #486 was filed in this (comfyui-mcp) repo. The behavior for all three is fixed by this orchestrator-side change; close the panel-repo issues manually._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #486
