### PR TITLE
chore(packs): remove ComfyUI-Manager dep from all bundled pack manifests + guard test

### DIFF
--- a/packs/anima-img2img/install-runpod.sh
+++ b/packs/anima-img2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-img2img/install-windows.bat
+++ b/packs/anima-img2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 call :clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-img2img/manifest.yaml
+++ b/packs/anima-img2img/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/ltdrdata/ComfyUI-Impact-Pack
   - https://github.com/ltdrdata/ComfyUI-Impact-Subpack
   - https://github.com/rgthree/rgthree-comfy

--- a/packs/anima-inpaint/install-runpod.sh
+++ b/packs/anima-inpaint/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-inpaint/install-windows.bat
+++ b/packs/anima-inpaint/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 call :clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-inpaint/manifest.yaml
+++ b/packs/anima-inpaint/manifest.yaml
@@ -8,7 +8,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/ltdrdata/ComfyUI-Impact-Pack
   - https://github.com/ltdrdata/ComfyUI-Impact-Subpack
   - https://github.com/rgthree/rgthree-comfy

--- a/packs/anima-txt2img/install-runpod.sh
+++ b/packs/anima-txt2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-txt2img/install-windows.bat
+++ b/packs/anima-txt2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 call :clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima-txt2img/manifest.yaml
+++ b/packs/anima-txt2img/manifest.yaml
@@ -8,7 +8,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/ltdrdata/ComfyUI-Impact-Pack
   - https://github.com/ltdrdata/ComfyUI-Impact-Subpack
   - https://github.com/rgthree/rgthree-comfy

--- a/packs/anima/install-runpod.sh
+++ b/packs/anima/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima/install-windows.bat
+++ b/packs/anima/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-Impact-Pack" "https://github.com/ltdrdata/ComfyUI-Impact-Pack"
 call :clone "ComfyUI-Impact-Subpack" "https://github.com/ltdrdata/ComfyUI-Impact-Subpack"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"

--- a/packs/anima/manifest.yaml
+++ b/packs/anima/manifest.yaml
@@ -6,7 +6,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/ltdrdata/ComfyUI-Impact-Pack
   - https://github.com/ltdrdata/ComfyUI-Impact-Subpack
   - https://github.com/rgthree/rgthree-comfy

--- a/packs/artokun-flow/install-runpod.sh
+++ b/packs/artokun-flow/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 clone "ComfyUI-WanAnimatePreprocess" "https://github.com/kijai/ComfyUI-WanAnimatePreprocess"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/artokun-flow/install-windows.bat
+++ b/packs/artokun-flow/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 call :clone "ComfyUI-WanAnimatePreprocess" "https://github.com/kijai/ComfyUI-WanAnimatePreprocess"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/artokun-flow/manifest.yaml
+++ b/packs/artokun-flow/manifest.yaml
@@ -24,7 +24,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/kijai/ComfyUI-WanVideoWrapper        # WanVideo* (model/vae/lora/sampler/decode/animate/uni3c/blockswap)
   - https://github.com/kijai/ComfyUI-WanAnimatePreprocess   # PoseAndFaceDetection, OnnxDetectionModelLoader
   - https://github.com/kijai/ComfyUI-KJNodes               # ImageResizeKJv2, GetImageSizeAndCount, DrawMaskOnImage, ImageConcatMulti, PreviewAnimation

--- a/packs/ernie-combo/install-runpod.sh
+++ b/packs/ernie-combo/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-combo/install-windows.bat
+++ b/packs/ernie-combo/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-combo/manifest.yaml
+++ b/packs/ernie-combo/manifest.yaml
@@ -10,7 +10,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ernie-img2img/install-runpod.sh
+++ b/packs/ernie-img2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-img2img/install-windows.bat
+++ b/packs/ernie-img2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-img2img/manifest.yaml
+++ b/packs/ernie-img2img/manifest.yaml
@@ -10,7 +10,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ernie-txt2img/install-runpod.sh
+++ b/packs/ernie-txt2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-txt2img/install-windows.bat
+++ b/packs/ernie-txt2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie-txt2img/manifest.yaml
+++ b/packs/ernie-txt2img/manifest.yaml
@@ -10,7 +10,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ernie/install-runpod.sh
+++ b/packs/ernie/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie/install-windows.bat
+++ b/packs/ernie/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ernie/manifest.yaml
+++ b/packs/ernie/manifest.yaml
@@ -18,7 +18,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ideogram-img2img/install-runpod.sh
+++ b/packs/ideogram-img2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram-img2img/install-windows.bat
+++ b/packs/ideogram-img2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram-img2img/manifest.yaml
+++ b/packs/ideogram-img2img/manifest.yaml
@@ -11,7 +11,6 @@ pip: []
 
 # Full custom-node superset copied from packs/ideogram/manifest.yaml (safe).
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/kijai/ComfyUI-KJNodes
   - https://github.com/cubiq/ComfyUI_essentials

--- a/packs/ideogram-txt2img/install-runpod.sh
+++ b/packs/ideogram-txt2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram-txt2img/install-windows.bat
+++ b/packs/ideogram-txt2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram-txt2img/manifest.yaml
+++ b/packs/ideogram-txt2img/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 
 # Full custom-node superset copied from packs/ideogram/manifest.yaml (safe).
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/kijai/ComfyUI-KJNodes
   - https://github.com/cubiq/ComfyUI_essentials

--- a/packs/ideogram/install-runpod.sh
+++ b/packs/ideogram/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram/install-windows.bat
+++ b/packs/ideogram/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI_essentials" "https://github.com/cubiq/ComfyUI_essentials"

--- a/packs/ideogram/manifest.yaml
+++ b/packs/ideogram/manifest.yaml
@@ -6,7 +6,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/kijai/ComfyUI-KJNodes
   - https://github.com/cubiq/ComfyUI_essentials

--- a/packs/ltx-2.3-extender-no-audio/install-runpod.sh
+++ b/packs/ltx-2.3-extender-no-audio/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-extender-no-audio/install-windows.bat
+++ b/packs/ltx-2.3-extender-no-audio/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-extender-no-audio/manifest.yaml
+++ b/packs/ltx-2.3-extender-no-audio/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ltx-2.3-extender/install-runpod.sh
+++ b/packs/ltx-2.3-extender/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-extender/install-windows.bat
+++ b/packs/ltx-2.3-extender/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-extender/manifest.yaml
+++ b/packs/ltx-2.3-extender/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ltx-2.3-flf/install-runpod.sh
+++ b/packs/ltx-2.3-flf/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-flf/install-windows.bat
+++ b/packs/ltx-2.3-flf/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-flf/manifest.yaml
+++ b/packs/ltx-2.3-flf/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ltx-2.3-img2vid/install-runpod.sh
+++ b/packs/ltx-2.3-img2vid/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- pip (manifest extras) --------"
 "$PY" -m pip install "imageio-ffmpeg"

--- a/packs/ltx-2.3-img2vid/install-windows.bat
+++ b/packs/ltx-2.3-img2vid/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- pip (manifest extras) --------
 "%PY%" -m pip install "imageio-ffmpeg"

--- a/packs/ltx-2.3-img2vid/manifest.yaml
+++ b/packs/ltx-2.3-img2vid/manifest.yaml
@@ -13,9 +13,9 @@
 pip:
   - imageio-ffmpeg   # CreateVideo/SaveVideo need an ffmpeg for the mux
 
-custom_nodes:
-  # All LTX 2.3 nodes are native to current ComfyUI (comfy_extras). Manager is
-  # only for install tooling; update ComfyUI itself to a recent build.
+# All LTX 2.3 nodes are native to current ComfyUI (comfy_extras); this pack
+# needs no custom nodes. Update ComfyUI itself to a recent build.
+custom_nodes: []
 
 models:
   # --- Main checkpoint: 22B dev transformer + audio VAE (~46 GB) ---

--- a/packs/ltx-2.3-img2vid/manifest.yaml
+++ b/packs/ltx-2.3-img2vid/manifest.yaml
@@ -16,7 +16,6 @@ pip:
 custom_nodes:
   # All LTX 2.3 nodes are native to current ComfyUI (comfy_extras). Manager is
   # only for install tooling; update ComfyUI itself to a recent build.
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- Main checkpoint: 22B dev transformer + audio VAE (~46 GB) ---

--- a/packs/ltx-2.3-txt2vid/install-runpod.sh
+++ b/packs/ltx-2.3-txt2vid/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- pip (manifest extras) --------"
 "$PY" -m pip install "imageio-ffmpeg"

--- a/packs/ltx-2.3-txt2vid/install-windows.bat
+++ b/packs/ltx-2.3-txt2vid/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- pip (manifest extras) --------
 "%PY%" -m pip install "imageio-ffmpeg"

--- a/packs/ltx-2.3-txt2vid/manifest.yaml
+++ b/packs/ltx-2.3-txt2vid/manifest.yaml
@@ -12,9 +12,9 @@
 pip:
   - imageio-ffmpeg   # CreateVideo/SaveVideo need an ffmpeg for the mux
 
-custom_nodes:
-  # All LTX 2.3 nodes are native to current ComfyUI (comfy_extras). Manager is
-  # only for install tooling; update ComfyUI itself to a recent build.
+# All LTX 2.3 nodes are native to current ComfyUI (comfy_extras); this pack
+# needs no custom nodes. Update ComfyUI itself to a recent build.
+custom_nodes: []
 
 models:
   # --- Main checkpoint: 22B dev transformer + audio VAE (~46 GB) ---

--- a/packs/ltx-2.3-txt2vid/manifest.yaml
+++ b/packs/ltx-2.3-txt2vid/manifest.yaml
@@ -15,7 +15,6 @@ pip:
 custom_nodes:
   # All LTX 2.3 nodes are native to current ComfyUI (comfy_extras). Manager is
   # only for install tooling; update ComfyUI itself to a recent build.
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- Main checkpoint: 22B dev transformer + audio VAE (~46 GB) ---

--- a/packs/ltx-2.3-xy-plot/install-runpod.sh
+++ b/packs/ltx-2.3-xy-plot/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-xy-plot/install-windows.bat
+++ b/packs/ltx-2.3-xy-plot/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3-xy-plot/manifest.yaml
+++ b/packs/ltx-2.3-xy-plot/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ltx-2.3/install-runpod.sh
+++ b/packs/ltx-2.3/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3/install-windows.bat
+++ b/packs/ltx-2.3/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx-2.3/manifest.yaml
+++ b/packs/ltx-2.3/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/ltx23-distill-3stage/install-runpod.sh
+++ b/packs/ltx23-distill-3stage/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx23-distill-3stage/install-windows.bat
+++ b/packs/ltx23-distill-3stage/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/ltx23-distill-3stage/manifest.yaml
+++ b/packs/ltx23-distill-3stage/manifest.yaml
@@ -16,7 +16,6 @@ pip:
 # (Power Lora Loader), VHS (LoadImagePath/VideoCombine), ComfyMath, plus the rest
 # of the shared ULTRA toolchain (ResizeImagesByLongerEdge et al.).
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/qwen-image-edit-edit/install-runpod.sh
+++ b/packs/qwen-image-edit-edit/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image-edit-edit/install-windows.bat
+++ b/packs/qwen-image-edit-edit/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image-edit-edit/manifest.yaml
+++ b/packs/qwen-image-edit-edit/manifest.yaml
@@ -13,7 +13,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   # ComfyUI-GGUF (city96) — provides UnetLoaderGGUF + CLIPLoaderGGUF.
   - https://github.com/city96/ComfyUI-GGUF
   # rgthree-comfy — Power Lora Loader, Image Comparer, Label, Fast Groups Bypasser.

--- a/packs/qwen-image-edit/install-runpod.sh
+++ b/packs/qwen-image-edit/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image-edit/install-windows.bat
+++ b/packs/qwen-image-edit/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image-edit/manifest.yaml
+++ b/packs/qwen-image-edit/manifest.yaml
@@ -13,7 +13,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   # ComfyUI-GGUF (city96) — provides UnetLoaderGGUF + CLIPLoaderGGUF used by both workflows.
   - https://github.com/city96/ComfyUI-GGUF
   # rgthree-comfy — Power Lora Loader, Image Comparer, Label, Fast Groups Bypasser.

--- a/packs/qwen-image/install-runpod.sh
+++ b/packs/qwen-image/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image/install-windows.bat
+++ b/packs/qwen-image/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/qwen-image/manifest.yaml
+++ b/packs/qwen-image/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/wan-animate-character/install-runpod.sh
+++ b/packs/wan-animate-character/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/wan-animate-character/install-windows.bat
+++ b/packs/wan-animate-character/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/wan-animate-character/manifest.yaml
+++ b/packs/wan-animate-character/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 # Full superset from the wan-animate monolith (safe — the slice spans WanVideo
 # sampler/decode, SeC segmentation, WanAnimate pose/face preprocess, and VHS I/O).
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/kijai/ComfyUI-WanVideoWrapper
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/kijai/ComfyUI-KJNodes

--- a/packs/wan-animate-ofm/install-runpod.sh
+++ b/packs/wan-animate-ofm/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI-WanAnimatePreprocess" "https://github.com/kijai/ComfyUI-WanAnimatePreprocess"

--- a/packs/wan-animate-ofm/install-windows.bat
+++ b/packs/wan-animate-ofm/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI-WanAnimatePreprocess" "https://github.com/kijai/ComfyUI-WanAnimatePreprocess"

--- a/packs/wan-animate-ofm/manifest.yaml
+++ b/packs/wan-animate-ofm/manifest.yaml
@@ -19,7 +19,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/kijai/ComfyUI-WanVideoWrapper        # WanVideo* (model/vae/lora/sampler/decode/animate/uni3c)
   - https://github.com/kijai/ComfyUI-KJNodes               # DrawMaskOnImage, BlockifyMask, GrowMaskWithBlur, ImageResizeKJv2, GetImageSizeAndCount
   - https://github.com/kijai/ComfyUI-WanAnimatePreprocess  # PoseAndFaceDetection, OnnxDetectionModelLoader (vitpose+yolov10m auto-download)

--- a/packs/wan-animate/install-runpod.sh
+++ b/packs/wan-animate/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/wan-animate/install-windows.bat
+++ b/packs/wan-animate/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"

--- a/packs/wan-animate/manifest.yaml
+++ b/packs/wan-animate/manifest.yaml
@@ -8,7 +8,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/kijai/ComfyUI-WanVideoWrapper
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/kijai/ComfyUI-KJNodes

--- a/packs/wan-longer-videos-i2v-96gb/install-runpod.sh
+++ b/packs/wan-longer-videos-i2v-96gb/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-i2v-96gb/install-windows.bat
+++ b/packs/wan-longer-videos-i2v-96gb/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-i2v-96gb/manifest.yaml
+++ b/packs/wan-longer-videos-i2v-96gb/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos-i2v/install-runpod.sh
+++ b/packs/wan-longer-videos-i2v/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-i2v/install-windows.bat
+++ b/packs/wan-longer-videos-i2v/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-i2v/manifest.yaml
+++ b/packs/wan-longer-videos-i2v/manifest.yaml
@@ -9,7 +9,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos-t2v-96gb/install-runpod.sh
+++ b/packs/wan-longer-videos-t2v-96gb/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-t2v-96gb/install-windows.bat
+++ b/packs/wan-longer-videos-t2v-96gb/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-t2v-96gb/manifest.yaml
+++ b/packs/wan-longer-videos-t2v-96gb/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos-t2v/install-runpod.sh
+++ b/packs/wan-longer-videos-t2v/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-t2v/install-windows.bat
+++ b/packs/wan-longer-videos-t2v/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-t2v/manifest.yaml
+++ b/packs/wan-longer-videos-t2v/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos-v2v-96gb/install-runpod.sh
+++ b/packs/wan-longer-videos-v2v-96gb/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-v2v-96gb/install-windows.bat
+++ b/packs/wan-longer-videos-v2v-96gb/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-v2v-96gb/manifest.yaml
+++ b/packs/wan-longer-videos-v2v-96gb/manifest.yaml
@@ -10,7 +10,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos-v2v/install-runpod.sh
+++ b/packs/wan-longer-videos-v2v/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-v2v/install-windows.bat
+++ b/packs/wan-longer-videos-v2v/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos-v2v/manifest.yaml
+++ b/packs/wan-longer-videos-v2v/manifest.yaml
@@ -9,7 +9,6 @@ pip: []
 custom_nodes:
   # Full superset from the monolith manifest (safe — covers every node type the
   # slice could reference plus the shared post-proc the closure may pull in).
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (combine/select/load)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-longer-videos/install-runpod.sh
+++ b/packs/wan-longer-videos/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos/install-windows.bat
+++ b/packs/wan-longer-videos/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"
 call :clone "ComfyUI-Frame-Interpolation" "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation"

--- a/packs/wan-longer-videos/manifest.yaml
+++ b/packs/wan-longer-videos/manifest.yaml
@@ -19,7 +19,6 @@ custom_nodes:
   # (The full installer also clones controlnet_aux, UltimateSDUpscale, essentials,
   #  MagCache, wlsh_nodes, comfyui-vrgamedevgirl, RES4LYF, Impact-Pack and
   #  WanVideoWrapper, but the Longer-Videos workflow does not use those node types.)
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF            # UnetLoaderGGUF / CLIPLoaderGGUF
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_* (load/combine/select)
   - https://github.com/Fannovel16/ComfyUI-Frame-Interpolation # RIFE VFI (auto-downloads rife49.pth)

--- a/packs/wan-multitalk/install-runpod.sh
+++ b/packs/wan-multitalk/install-runpod.sh
@@ -28,7 +28,6 @@ echo "-------- custom nodes --------"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper.git"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes.git"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- pip (manifest extras) --------"
 "$PY" -m pip install "imageio-ffmpeg"

--- a/packs/wan-multitalk/install-windows.bat
+++ b/packs/wan-multitalk/install-windows.bat
@@ -18,7 +18,6 @@ echo -------- custom nodes --------
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper.git"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes.git"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git"
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- pip (manifest extras) --------
 "%PY%" -m pip install "imageio-ffmpeg"

--- a/packs/wan-multitalk/manifest.yaml
+++ b/packs/wan-multitalk/manifest.yaml
@@ -20,7 +20,6 @@ custom_nodes:
   - https://github.com/kijai/ComfyUI-WanVideoWrapper.git   # WanVideo*/MultiTalk*/Wav2Vec/T5 nodes
   - https://github.com/kijai/ComfyUI-KJNodes.git           # ImageResizeKJv2
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git  # VHS_VideoCombine
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- WAN 2.1 14B Image-to-Video 480p, GGUF Q8 (main transformer) ---

--- a/packs/wan-pusa-extend/install-runpod.sh
+++ b/packs/wan-pusa-extend/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"

--- a/packs/wan-pusa-extend/install-windows.bat
+++ b/packs/wan-pusa-extend/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-WanVideoWrapper" "https://github.com/kijai/ComfyUI-WanVideoWrapper"
 call :clone "ComfyUI-KJNodes" "https://github.com/kijai/ComfyUI-KJNodes"
 call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite"

--- a/packs/wan-pusa-extend/manifest.yaml
+++ b/packs/wan-pusa-extend/manifest.yaml
@@ -12,7 +12,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/kijai/ComfyUI-WanVideoWrapper         # WanVideo* (model loader / sampler / encode / AddPusaNoise / scheduler / text encode)
   - https://github.com/kijai/ComfyUI-KJNodes                 # ColorMatchV2, ImageResizeKJv2, GetImageRangeFromBatch, CreateScheduleFloatList, GetLatentSizeAndCount, ImageBatchMulti/ImageConcatMulti, Get/SetNode
   - https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite  # VHS_LoadVideo / VHS_VideoCombine

--- a/packs/wan-transparent-img2vid-96gb/install-runpod.sh
+++ b/packs/wan-transparent-img2vid-96gb/install-runpod.sh
@@ -31,7 +31,6 @@ clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHe
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- models --------"
 grab "models/vae/wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent-img2vid-96gb/install-windows.bat
+++ b/packs/wan-transparent-img2vid-96gb/install-windows.bat
@@ -21,7 +21,6 @@ call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-V
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 call :clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- models --------
 call :grab "models\vae\wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent-img2vid-96gb/manifest.yaml
+++ b/packs/wan-transparent-img2vid-96gb/manifest.yaml
@@ -18,7 +18,6 @@ custom_nodes:
   - https://github.com/yolain/ComfyUI-Easy-Use        # easy cleanGpuUsed / clearCacheAll / wildcards
   - https://github.com/TinyTerra/ComfyUI_tinyterraNodes # ttN text
   # From the ULTRA installer (base WAN 2.2 stack / manager):
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- VAE (ULTRA installer) ---

--- a/packs/wan-transparent-img2vid/install-runpod.sh
+++ b/packs/wan-transparent-img2vid/install-runpod.sh
@@ -31,7 +31,6 @@ clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-VideoHe
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- models --------"
 grab "models/vae/wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent-img2vid/install-windows.bat
+++ b/packs/wan-transparent-img2vid/install-windows.bat
@@ -21,7 +21,6 @@ call :clone "ComfyUI-VideoHelperSuite" "https://github.com/Kosinkadink/ComfyUI-V
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 call :clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- models --------
 call :grab "models\vae\wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent-img2vid/manifest.yaml
+++ b/packs/wan-transparent-img2vid/manifest.yaml
@@ -17,7 +17,6 @@ custom_nodes:
   - https://github.com/yolain/ComfyUI-Easy-Use        # easy cleanGpuUsed / clearCacheAll / wildcards
   - https://github.com/TinyTerra/ComfyUI_tinyterraNodes # ttN text
   # From the ULTRA installer (base WAN 2.2 stack / manager):
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- VAE (ULTRA installer) ---

--- a/packs/wan-transparent/install-runpod.sh
+++ b/packs/wan-transparent/install-runpod.sh
@@ -32,7 +32,6 @@ clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 clone "was-node-suite-comfyui" "https://github.com/ltdrdata/was-node-suite-comfyui"
 clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo "-------- models --------"
 grab "models/vae/wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent/install-windows.bat
+++ b/packs/wan-transparent/install-windows.bat
@@ -22,7 +22,6 @@ call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"
 call :clone "was-node-suite-comfyui" "https://github.com/ltdrdata/was-node-suite-comfyui"
 call :clone "ComfyUI_tinyterraNodes" "https://github.com/TinyTerra/ComfyUI_tinyterraNodes"
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 
 echo -------- models --------
 call :grab "models\vae\wan_2.1_vae.safetensors" "https://huggingface.co/Aitrepreneur/FLX/resolve/main/wan_2.1_vae.safetensors"

--- a/packs/wan-transparent/manifest.yaml
+++ b/packs/wan-transparent/manifest.yaml
@@ -18,7 +18,6 @@ custom_nodes:
   - https://github.com/ltdrdata/was-node-suite-comfyui # String to Text, RegexExtract
   - https://github.com/TinyTerra/ComfyUI_tinyterraNodes # ttN text
   # From the ULTRA installer (base WAN 2.2 stack / manager):
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
 
 models:
   # --- VAE (ULTRA installer) ---

--- a/packs/z-image-base-combo/install-runpod.sh
+++ b/packs/z-image-base-combo/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-combo/install-windows.bat
+++ b/packs/z-image-base-combo/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-combo/manifest.yaml
+++ b/packs/z-image-base-combo/manifest.yaml
@@ -11,7 +11,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-base-controlnet/install-runpod.sh
+++ b/packs/z-image-base-controlnet/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-controlnet/install-windows.bat
+++ b/packs/z-image-base-controlnet/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-controlnet/manifest.yaml
+++ b/packs/z-image-base-controlnet/manifest.yaml
@@ -13,7 +13,6 @@ pip:
   - scikit-image   # DWPreprocessor (DWPose) needs skimage or it silently fails to register
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-base-img2img/install-runpod.sh
+++ b/packs/z-image-base-img2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-img2img/install-windows.bat
+++ b/packs/z-image-base-img2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-img2img/manifest.yaml
+++ b/packs/z-image-base-img2img/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-base-inpaint/install-runpod.sh
+++ b/packs/z-image-base-inpaint/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-inpaint/install-windows.bat
+++ b/packs/z-image-base-inpaint/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-inpaint/manifest.yaml
+++ b/packs/z-image-base-inpaint/manifest.yaml
@@ -6,7 +6,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-base-txt2img/install-runpod.sh
+++ b/packs/z-image-base-txt2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-txt2img/install-windows.bat
+++ b/packs/z-image-base-txt2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base-txt2img/manifest.yaml
+++ b/packs/z-image-base-txt2img/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-base/install-runpod.sh
+++ b/packs/z-image-base/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base/install-windows.bat
+++ b/packs/z-image-base/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-base/manifest.yaml
+++ b/packs/z-image-base/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-combo/install-runpod.sh
+++ b/packs/z-image-turbo-combo/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-combo/install-windows.bat
+++ b/packs/z-image-turbo-combo/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-combo/manifest.yaml
+++ b/packs/z-image-turbo-combo/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-controlnet/install-runpod.sh
+++ b/packs/z-image-turbo-controlnet/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-controlnet/install-windows.bat
+++ b/packs/z-image-turbo-controlnet/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-controlnet/manifest.yaml
+++ b/packs/z-image-turbo-controlnet/manifest.yaml
@@ -11,7 +11,6 @@ pip:
   - scikit-image   # DWPreprocessor (DWPose) needs skimage or it silently fails to register
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-detail-daemon/install-runpod.sh
+++ b/packs/z-image-turbo-detail-daemon/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-detail-daemon/install-windows.bat
+++ b/packs/z-image-turbo-detail-daemon/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-detail-daemon/manifest.yaml
+++ b/packs/z-image-turbo-detail-daemon/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-img2img/install-runpod.sh
+++ b/packs/z-image-turbo-img2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-img2img/install-windows.bat
+++ b/packs/z-image-turbo-img2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-img2img/manifest.yaml
+++ b/packs/z-image-turbo-img2img/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-inpainting/install-runpod.sh
+++ b/packs/z-image-turbo-inpainting/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-inpainting/install-windows.bat
+++ b/packs/z-image-turbo-inpainting/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-inpainting/manifest.yaml
+++ b/packs/z-image-turbo-inpainting/manifest.yaml
@@ -6,7 +6,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo-txt2img/install-runpod.sh
+++ b/packs/z-image-turbo-txt2img/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-txt2img/install-windows.bat
+++ b/packs/z-image-turbo-txt2img/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo-txt2img/manifest.yaml
+++ b/packs/z-image-turbo-txt2img/manifest.yaml
@@ -9,7 +9,6 @@ pip:
   - librosa
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-turbo/install-runpod.sh
+++ b/packs/z-image-turbo/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo/install-windows.bat
+++ b/packs/z-image-turbo/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-turbo/manifest.yaml
+++ b/packs/z-image-turbo/manifest.yaml
@@ -11,7 +11,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/packs/z-image-xy-plot/install-runpod.sh
+++ b/packs/z-image-xy-plot/install-runpod.sh
@@ -25,7 +25,6 @@ grab() { # relpath url
 }
 
 echo "-------- custom nodes --------"
-clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-xy-plot/install-windows.bat
+++ b/packs/z-image-xy-plot/install-windows.bat
@@ -15,7 +15,6 @@ if not exist "%PY%" set "PY=python"
 echo using python: %PY%
 
 echo -------- custom nodes --------
-call :clone "ComfyUI-Manager" "https://github.com/ltdrdata/ComfyUI-Manager.git"
 call :clone "ComfyUI-GGUF" "https://github.com/city96/ComfyUI-GGUF"
 call :clone "rgthree-comfy" "https://github.com/rgthree/rgthree-comfy"
 call :clone "ComfyUI-Easy-Use" "https://github.com/yolain/ComfyUI-Easy-Use"

--- a/packs/z-image-xy-plot/manifest.yaml
+++ b/packs/z-image-xy-plot/manifest.yaml
@@ -18,7 +18,6 @@
 pip: []
 
 custom_nodes:
-  - https://github.com/ltdrdata/ComfyUI-Manager.git
   - https://github.com/city96/ComfyUI-GGUF
   - https://github.com/rgthree/rgthree-comfy
   - https://github.com/yolain/ComfyUI-Easy-Use

--- a/scripts/test-packs.sh
+++ b/scripts/test-packs.sh
@@ -43,9 +43,14 @@ for dir in "$PACKS"/*/; do
   ( cd "$root" && PATH="$BIN:$PATH" bash "$sh" ) > "$WORK/r1.log" 2>&1
   nodes=$(find "$root/custom_nodes" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
   models=$(find "$root/models" -type f | wc -l | tr -d ' ')
-  echo "   nodes=$nodes models=$models"
-  if [ "$nodes" -lt 1 ] || [ "$models" -lt 1 ]; then
-    echo "   [FAIL] expected >=1 node and >=1 model staged"; fail=1
+  # Expected node count is derived from the generated installer itself (one
+  # `clone` invocation per custom_nodes entry). A pack may legitimately declare
+  # zero custom nodes (all nodes native to core ComfyUI) — assert the installer
+  # staged exactly what it declares rather than a blanket >=1.
+  want_nodes=$(grep -cE '^clone ' "$sh" || true)
+  echo "   nodes=$nodes/$want_nodes models=$models"
+  if [ "$nodes" -ne "$want_nodes" ] || [ "$models" -lt 1 ]; then
+    echo "   [FAIL] expected $want_nodes node(s) and >=1 model staged"; fail=1
   fi
 
   echo "== $name: second run (idempotency) =="

--- a/src/__tests__/packs/no-manager-dep.test.ts
+++ b/src/__tests__/packs/no-manager-dep.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
+
+// Guard (#441/#423 cluster): ComfyUI-Manager is an ENVIRONMENT prerequisite, not
+// a per-pack custom-node dependency. Listing it in a pack manifest's custom_nodes
+// causes install/verify churn (Manager reinstalling itself, verification loops).
+// Every bundled pack manifest must therefore be free of a ComfyUI-Manager entry.
+// This test FAILS before the sweep (52 manifests listed it) and PASSES after.
+
+const packsRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "packs");
+// Match ComfyUI-Manager only as the REPO BASENAME (last path segment) — a bare
+// registry id, or a git URL/shorthand ending in the repo, with an optional
+// `.git`, trailing slash, and `@ref`/`#ref`/`?query` suffix. Anchoring to the
+// end of the segment avoids false positives where "ComfyUI-Manager" is merely an
+// OWNER path segment of an unrelated repo (e.g. .../ComfyUI-Manager/SomeNode.git).
+const MANAGER_RE = /(?:^|[/:])ComfyUI-Manager(?:\.git)?\/?(?:[@#?].*)?$/i;
+
+function packManifests(): string[] {
+  return readdirSync(packsRoot)
+    .map((name) => join(packsRoot, name, "manifest.yaml"))
+    .filter((p) => existsSync(p) && statSync(p).isFile());
+}
+
+describe("bundled pack manifests", () => {
+  const manifests = packManifests();
+
+  it("discovers the bundled manifests to scan", () => {
+    expect(manifests.length).toBeGreaterThan(0);
+  });
+
+  it("guard regex matches only ComfyUI-Manager as the repo basename", () => {
+    // Must flag (the forms that actually appear / could appear as a dep):
+    for (const dep of [
+      "https://github.com/ltdrdata/ComfyUI-Manager.git",
+      "https://github.com/ltdrdata/ComfyUI-Manager",
+      "https://github.com/ltdrdata/ComfyUI-Manager.git@v1.2.3",
+      "https://github.com/ltdrdata/ComfyUI-Manager/",
+      "ltdrdata/ComfyUI-Manager",
+      "comfyui-manager",
+    ]) {
+      expect(MANAGER_RE.test(dep), `should flag: ${dep}`).toBe(true);
+    }
+    // Must NOT flag (unrelated repos where ComfyUI-Manager is an owner/prefix):
+    for (const dep of [
+      "https://github.com/ComfyUI-Manager/SomeOtherNode.git",
+      "https://github.com/ltdrdata/ComfyUI-Manager-Extras.git",
+      "https://github.com/someone/Not-ComfyUI-Manager-Really/nested.git",
+    ]) {
+      expect(MANAGER_RE.test(dep), `should NOT flag: ${dep}`).toBe(false);
+    }
+  });
+
+  it("do not list ComfyUI-Manager as a custom-node dependency", () => {
+    const offenders: string[] = [];
+    for (const file of manifests) {
+      const parsed = (parse(readFileSync(file, "utf8")) ?? {}) as {
+        custom_nodes?: unknown;
+      };
+      const nodes = Array.isArray(parsed.custom_nodes)
+        ? (parsed.custom_nodes as unknown[])
+        : [];
+      for (const node of nodes) {
+        if (typeof node === "string" && MANAGER_RE.test(node)) {
+          offenders.push(`${file} -> ${node}`);
+        }
+      }
+    }
+    expect(offenders, `ComfyUI-Manager must not be a pack custom-node dep:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

ComfyUI-Manager is an **environment prerequisite**, not a per-pack custom-node dependency. It was listed as a `custom_nodes` entry in every bundled pack manifest, which caused install/verify churn (Manager reinstalling itself, verification loops) — the root of the #441/#423 cluster.

This removes ComfyUI-Manager from **all 52 bundled pack manifests** and adds a guard test so it can't creep back.

## Changes

- **52 `packs/*/manifest.yaml`**: removed the single `- https://github.com/ltdrdata/ComfyUI-Manager.git` line from `custom_nodes`. Exactly one line removed per manifest — no other custom_node, `pip`, `apt`, `models`, or workflow definition touched (verified: every manifest hunk is `0 added / 1 removed`).
- **104 generated installers** (`install-runpod.sh` + `install-windows.bat`): regenerated via `npm run packs:gen` so they no longer clone Manager and the CI drift gate (`packs.yml`) stays green. Each hunk is a faithful `0 added / 1 removed` of the Manager clone line.
- **`scripts/test-packs.sh`**: the node-staging assertion now derives the expected count from the generated installer (one `clone` per `custom_nodes` entry) instead of a blanket `>= 1`. Two packs (`ltx-2.3-img2vid`, `ltx-2.3-txt2vid`) listed Manager as their *only* custom node — all their real nodes are native `comfy_extras` — so they legitimately drop to zero custom nodes and must still pass. Models are still asserted `>= 1`.
- **`src/__tests__/packs/no-manager-dep.test.ts`** (new): scans the real bundled manifests and fails if any lists ComfyUI-Manager as a `custom_nodes` dep. Basename-anchored regex (won't false-positive on an unrelated repo whose *owner* is named ComfyUI-Manager) with its own regex-behavior unit test. **Fails-before / passes-after.**

No version bump.

## Validation

- `npm run build` + `npm run packs:validate` — all 55 manifests valid.
- Guard test: **fails** against the pre-sweep tree (all 52 flagged), **passes** after (3 tests).
- Full vitest suite: **2363 passed / 1 skipped**; the only failure is the known node-dev ripgrep sandbox test (`expected 'ripgrep' to be 'builtin'`), unrelated to this change.
- `scripts/test-packs.sh` (offline dry-run): **ALL PACK TESTS PASSED**, including the two zero-node packs at `nodes=0/0 models=5`.
- Codex review gate: **VERDICT PASS** — confirmed only the Manager entry was removed per manifest, installers are faithful regenerations, and the guard is correctly scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
