### PR TITLE
fix(object-info): TTL-bounded cache so out-of-band ComfyUI restart/install self-heals (#528)

### DIFF
--- a/src/__tests__/comfyui/object-info-ttl.test.ts
+++ b/src/__tests__/comfyui/object-info-ttl.test.ts
@@ -85,6 +85,33 @@ describe("#528 object_info TTL self-heals after an out-of-band restart", () => {
     expect(getNodeDefs).toHaveBeenCalledTimes(2);
   });
 
+  it("treats a backward system-clock jump as expired (rollback can't extend the window)", async () => {
+    // 1. Cache is populated while the server exposes the ORIGINAL node set.
+    getNodeDefs.mockResolvedValueOnce({ KSampler: {} });
+    await expect(getObjectInfo()).resolves.toEqual({ KSampler: {} });
+
+    // 2. ComfyUI is restarted OUT OF BAND with a new pack installed.
+    getNodeDefs.mockResolvedValue({ KSampler: {}, UnetLoaderGGUF: {} });
+
+    // 3. The system clock steps BACKWARD by an hour (NTP step / VM snapshot
+    //    restore / manual correction) — far more than the 5 s TTL. With a raw
+    //    Date.now() age this goes negative and the stale snapshot would read
+    //    "fresh" for ~an hour, so the out-of-band change would stay stale.
+    vi.setSystemTime(new Date("2026-07-29T23:00:00Z")); // 1 h before the base time
+
+    // 4. The next call must treat the negative age as expired, refetch, and
+    //    reflect the LIVE node set rather than the stuck snapshot.
+    const fresh = await getObjectInfo();
+    expect(fresh).toHaveProperty("UnetLoaderGGUF");
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+
+    // 5. The refetch re-stamps the timestamp against the corrected clock, so
+    //    normal within-window caching resumes immediately (no per-call refetch).
+    const again = await getObjectInfo();
+    expect(again).toBe(fresh);
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+  });
+
   it("coalesces the post-window refetch so concurrent callers share one fetch", async () => {
     getNodeDefs.mockResolvedValueOnce({ KSampler: {} });
     await getObjectInfo();

--- a/src/__tests__/comfyui/object-info-ttl.test.ts
+++ b/src/__tests__/comfyui/object-info-ttl.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression for #528: the runtime checker / validator kept serving a stale
+// /object_info snapshot after an OUT-OF-BAND ComfyUI restart or custom-node
+// install (Desktop Manager reboot, a manual restart — anything that does NOT go
+// through an mcp tool and so never calls resetObjectInfoCache()). The old cache
+// was memoized for the whole process lifetime, so get_node_info /
+// check_workflow_runtime / validate_workflow reported the newly-installed nodes
+// as unknown forever. A bounded freshness window (TTL) must let the NEXT call
+// after the window pick up the live server's changed node set on its own.
+
+// A short TTL keeps the test fast; it is read once at module load, so it must be
+// set BEFORE the dynamic import below.
+process.env.COMFYUI_MCP_OBJECT_INFO_TTL_MS = "5000";
+
+vi.mock("../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config.js")>(
+    "../../config.js",
+  );
+  return {
+    ...actual,
+    isCloudMode: () => false,
+    getComfyUIApiHost: () => "127.0.0.1:8188",
+  };
+});
+
+const getNodeDefs = vi.fn();
+vi.mock("@stable-canvas/comfyui-client", () => ({
+  Client: class {
+    getNodeDefs = getNodeDefs;
+    close() {}
+  },
+}));
+
+const { getObjectInfo, resetObjectInfoCache } = await import(
+  "../../comfyui/client.js"
+);
+
+describe("#528 object_info TTL self-heals after an out-of-band restart", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-30T00:00:00Z"));
+    getNodeDefs.mockReset();
+    resetObjectInfoCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("keeps serving the cache WITHIN the freshness window (no per-call refetch)", async () => {
+    getNodeDefs.mockResolvedValue({ KSampler: {} });
+    await getObjectInfo();
+    vi.advanceTimersByTime(4_000); // still inside the 5 s window
+    const again = await getObjectInfo();
+    expect(again).toEqual({ KSampler: {} });
+    expect(getNodeDefs).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the NEW node set after the window lapses (out-of-band install)", async () => {
+    // 1. Cache is populated while the server exposes the ORIGINAL node set.
+    getNodeDefs.mockResolvedValueOnce({ KSampler: {} });
+    await expect(getObjectInfo()).resolves.toEqual({ KSampler: {} });
+
+    // 2. ComfyUI is restarted OUT OF BAND with ComfyUI-GGUF + VideoHelperSuite
+    //    installed. No mcp tool ran, so resetObjectInfoCache() was NEVER called.
+    getNodeDefs.mockResolvedValue({
+      KSampler: {},
+      UnetLoaderGGUF: {},
+      VHS_VideoCombine: {},
+    });
+
+    // 3. Still inside the window: the pre-restart snapshot is (correctly) served.
+    vi.advanceTimersByTime(4_000);
+    await expect(getObjectInfo()).resolves.not.toHaveProperty("UnetLoaderGGUF");
+    expect(getNodeDefs).toHaveBeenCalledTimes(1);
+
+    // 4. Once the window lapses, the next call refetches and reflects the LIVE
+    //    node set — the newly-installed nodes are now known.
+    vi.advanceTimersByTime(2_000); // total 6 s > 5 s TTL
+    const fresh = await getObjectInfo();
+    expect(fresh).toHaveProperty("UnetLoaderGGUF");
+    expect(fresh).toHaveProperty("VHS_VideoCombine");
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces the post-window refetch so concurrent callers share one fetch", async () => {
+    getNodeDefs.mockResolvedValueOnce({ KSampler: {} });
+    await getObjectInfo();
+
+    vi.advanceTimersByTime(6_000); // window lapsed
+
+    let release!: (v: unknown) => void;
+    getNodeDefs.mockReturnValueOnce(new Promise((r) => (release = r)));
+    const p1 = getObjectInfo();
+    const p2 = getObjectInfo();
+    release({ KSampler: {}, NewNode: {} });
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe(b);
+    // One initial fetch + exactly one refetch shared by both concurrent callers.
+    expect(getNodeDefs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -167,10 +167,16 @@ let objectInfoInflight: Promise<ObjectInfo> | null = null;
 let objectInfoEpoch = 0;
 
 function objectInfoCacheFresh(): boolean {
-  return (
-    objectInfoCache !== null &&
-    Date.now() - objectInfoCachedAt < OBJECT_INFO_TTL_MS
-  );
+  if (objectInfoCache === null) return false;
+  const age = Date.now() - objectInfoCachedAt;
+  // A NEGATIVE age means the system clock moved backward since we cached (manual
+  // correction, VM snapshot restore, NTP step). Without this guard the snapshot
+  // would read "fresh" until wall time catches back up — a 1 h rollback would
+  // extend a 30 s TTL by ~an hour, so an out-of-band restart stays stale far past
+  // the window (#528 review P2). Treat a backward jump as EXPIRED: the next call
+  // refetches and re-stamps objectInfoCachedAt against the corrected clock, so
+  // normal within-window caching resumes immediately after the single refetch.
+  return age >= 0 && age < OBJECT_INFO_TTL_MS;
 }
 
 export async function getObjectInfo(): Promise<ObjectInfo> {

--- a/src/comfyui/client.ts
+++ b/src/comfyui/client.ts
@@ -131,11 +131,33 @@ export async function getSystemStats(): Promise<SystemStats> {
 }
 
 // /object_info is large (~MBs) and slow (300-800 ms) but only changes when
-// ComfyUI restarts or a custom node is (un)installed. Memoize it for the
-// life of the server process; restartComfyUI()/stopComfyUI() reset it.
-// In-flight coalescing prevents a thundering herd on the first fetch.
-// Perf gap flagged by josephoibrahim/comfy-cozy (re-validate ~7 s → ~0.5 s).
+// ComfyUI restarts or a custom node is (un)installed. Memoize it, but only for a
+// bounded FRESHNESS WINDOW rather than the whole process lifetime: an out-of-band
+// ComfyUI restart/install (Desktop Manager reboot, a manual restart, a node pack
+// installed outside an mcp tool) never calls resetObjectInfoCache(), so a
+// lifetime cache serves the PRE-restart schema forever — get_node_info /
+// check_workflow_runtime / validate_workflow all report the new nodes as unknown
+// (#528). A TTL bounds that staleness: within the window we serve the cached
+// snapshot (so a burst of validations stays ~0.5 s, the perf win flagged by
+// josephoibrahim/comfy-cozy), and the FIRST call after the window does a single
+// coalesced refetch that picks up whatever the live server now exposes. No cheap
+// per-call probe is added — ComfyUI's /object_info has no ETag/Last-Modified and
+// no node-set-identity endpoint, so a TTL is the lightest mechanism that both
+// self-heals after an out-of-band change and never fetches the heavy payload on
+// every call. Managed restart/install paths still call resetObjectInfoCache() for
+// an immediate refresh; the TTL is the backstop for the out-of-band case.
+//
+// Override with COMFYUI_MCP_OBJECT_INFO_TTL_MS (0 disables caching entirely; a
+// large value restores the old lifetime behavior for latency-sensitive setups).
+const OBJECT_INFO_TTL_MS = (() => {
+  const raw = process.env.COMFYUI_MCP_OBJECT_INFO_TTL_MS;
+  if (raw === undefined || raw.trim() === "") return 30_000;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 30_000;
+})();
+
 let objectInfoCache: ObjectInfo | null = null;
+let objectInfoCachedAt = 0;
 let objectInfoInflight: Promise<ObjectInfo> | null = null;
 // Invalidation epoch. resetObjectInfoCache() bumps it; a fetch that STARTED under
 // an older epoch must not commit its result to the cache — otherwise a request
@@ -144,9 +166,18 @@ let objectInfoInflight: Promise<ObjectInfo> | null = null;
 // stale value (codex WS-3 finding #1).
 let objectInfoEpoch = 0;
 
+function objectInfoCacheFresh(): boolean {
+  return (
+    objectInfoCache !== null &&
+    Date.now() - objectInfoCachedAt < OBJECT_INFO_TTL_MS
+  );
+}
+
 export async function getObjectInfo(): Promise<ObjectInfo> {
   if (isCloudMode()) return cloudClient.getObjectInfo();
-  if (objectInfoCache) return objectInfoCache;
+  // Serve from cache only while still inside the freshness window; once it lapses
+  // we fall through to a refetch so an out-of-band restart/install is picked up.
+  if (objectInfoCacheFresh()) return objectInfoCache as ObjectInfo;
   if (objectInfoInflight) return objectInfoInflight;
 
   const startEpoch = objectInfoEpoch;
@@ -154,7 +185,10 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
   // fetching. Awaiters of this promise still get the value (they asked before
   // the reset), but the cache is not poisoned for callers that arrive after.
   const commit = (info: ObjectInfo): ObjectInfo => {
-    if (objectInfoEpoch === startEpoch) objectInfoCache = info;
+    if (objectInfoEpoch === startEpoch) {
+      objectInfoCache = info;
+      objectInfoCachedAt = Date.now();
+    }
     return info;
   };
 
@@ -197,6 +231,7 @@ export async function getObjectInfo(): Promise<ObjectInfo> {
  */
 export function resetObjectInfoCache(): void {
   objectInfoCache = null;
+  objectInfoCachedAt = 0;
   objectInfoInflight = null;
   objectInfoEpoch++;
   logger.debug("object_info cache reset", { epoch: objectInfoEpoch });


### PR DESCRIPTION
## Problem (#528)

`getObjectInfo()` memoized `/object_info` for the whole server-process lifetime and was only invalidated by mcp-tool-driven restart/install paths (`resetObjectInfoCache()`). An **out-of-band** ComfyUI restart or custom-node install — a Desktop Manager reboot, a manual restart, a pack installed outside an mcp tool — never calls that reset. So after installing e.g. ComfyUI-GGUF + VideoHelperSuite and restarting ComfyUI, the checker/validator kept serving the **pre-restart** schema indefinitely: `get_node_info('GGUF')` found nothing, `check_workflow_runtime` flagged `UnetLoaderGGUF`/`VHS_VideoCombine` as unknown, and `validate_workflow` claimed the graph had no output node.

## Fix

Bound the cache to a **freshness window** instead of the process lifetime.

- `COMFYUI_MCP_OBJECT_INFO_TTL_MS` (default **30s**; `0` disables caching, a large value restores the old lifetime behavior).
- Within the window: calls are served instantly from the cached snapshot, so a burst of validations stays ~0.5s (the perf win the cache was added for).
- First call **after** the window: a single coalesced refetch that reflects the live server's current node set — the out-of-band change self-heals.
- The epoch-guarded commit now also stamps the cache timestamp, so a fetch that was in flight when an invalidation fired still cannot repopulate the cache.

### Why a TTL and not a per-call validator
ComfyUI's `/object_info` has no ETag/Last-Modified and there is no cheap node-set-identity endpoint to probe. A TTL is therefore the lightest mechanism that (a) returns fresh schemas after an out-of-band change, (b) never fetches the heavy `/object_info` payload on every call, and (c) still serves cache within a freshness window. Managed restart/install paths still call `resetObjectInfoCache()` for an immediate refresh; the TTL is the backstop for the out-of-band case only.

## Test

`src/__tests__/comfyui/object-info-ttl.test.ts`: cache populated with the original node set → live server changes out of band (no reset call) → a call within the window still serves the snapshot → the first call after the window returns the newly-installed nodes; concurrent post-window refetches coalesce into one request. **Fails against the old lifetime cache (2/3), passes with the TTL.** Full suite green except the pre-existing ripgrep-sandbox exception (`searchNodePacks` engine).

## Codex self-gate
Adversarial review: VERDICT: PASS (freshness bounded by TTL as designed, refetch coalesces, epoch guard prevents half-invalidated repopulation, normal cached/cloud paths unchanged).

Closes #528
