### PR TITLE
feat(report_issue): async AI-triage client — versions, upgrade advice, no double-file

### DIFF
--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -165,6 +165,31 @@ describe("submitAndPoll — async triage contract", () => {
     ).rejects.toThrow(/401/);
   });
 
+  it("a 2xx submit whose body STALLS → pending (worker took it) — does NOT throw/prefill", async () => {
+    const fetchImpl = (async (_url: string, init: RequestInit) => ({
+      ok: true, // 2xx = accepted
+      json: () =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    })) as unknown as typeof fetch;
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, timeoutMs: 10 });
+    expect(out.kind).toBe("pending"); // NOT a throw → the tool won't prefill
+  });
+
+  it("a 2xx submit with no job_id and no inline result → pending (accepted, cannot poll, no prefill)", async () => {
+    const fetchImpl = (async () => res({ ok: true, versions: {}, up_to_date: true })) as unknown as typeof fetch;
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(out.kind).toBe("pending");
+  });
+
+  it("CLOSED unfiled_needs_manual (agent_message but NO issue) → unfiled (not a false success)", async () => {
+    const fetchImpl = (async () =>
+      res({ state: "CLOSED", payload: { action_taken: "unfiled_needs_manual", issue: null, agent_message: "filing failed" } })) as unknown as typeof fetch;
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(out.kind).toBe("unfiled"); // agent_message alone must NOT count as filed
+  });
+
   it("a terminal job ERROR without an issue → kind:unfiled (worker gave up, caller prefills)", async () => {
     const fetchImpl = (async (url: string) => {
       if (url === "https://w") return res({ job_id: "j3", state: "PENDING", status: "PENDING" });
@@ -197,17 +222,13 @@ describe("submitAndPoll — async triage contract", () => {
     expect(polls).toBe(3); // it kept trying
   });
 
-  it("timeout: a SUBMIT whose .json() stalls until the AbortController fires → throws", async () => {
-    const fetchImpl = (async (_url: string, init: RequestInit) => ({
-      ok: true,
-      json: () =>
-        new Promise((_resolve, reject) => {
-          init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
-        }),
-    })) as unknown as typeof fetch;
+  it("a network failure BEFORE any 2xx (fetch rejects) → throws so the caller prefills", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
     await expect(
-      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, timeoutMs: 10 }),
-    ).rejects.toThrow();
+      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep }),
+    ).rejects.toThrow(/ECONNREFUSED/);
   });
 
   it("timeout: a POLL whose .json() stalls is transient → keeps polling → pending", async () => {
@@ -342,6 +363,33 @@ describe("report_issue tool (registered handler)", () => {
     expect(json.url).toContain("/issues/new");
   });
 
+  it("our repo, CLOSED unfiled_needs_manual (no issue) → prefilled fallback, not a lost report", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => res({ state: "CLOSED", payload: { action_taken: "unfiled_needs_manual", issue: null, agent_message: "filing failed" } })),
+    );
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("a huge MAX_POLLS env is clamped so a running job still returns pending promptly", async () => {
+    let polls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (!String(url).includes("/status/")) return res({ job_id: "jc", state: "PENDING", status: "PENDING" });
+        polls++;
+        return res({ state: "INVESTIGATING", status: "queued" });
+      }),
+    );
+    process.env.COMFYUI_MCP_ISSUE_MAX_POLLS = "1000000000"; // absurd
+    process.env.COMFYUI_MCP_ISSUE_POLL_MS = "0";
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false, pending: true });
+    expect(polls).toBeLessThanOrEqual(200); // clamped, not a billion
+  });
+
   it("mixed-case owner (Artokun/comfyui-mcp) is treated as OURS and hits the worker", async () => {
     const spy = vi.fn(async () =>
       res({ state: "CLOSED", payload: { action_taken: "created", issue: { number: 60, url: "https://github.com/Artokun/comfyui-mcp/issues/60" }, agent_message: "ok" }, url: "https://github.com/Artokun/comfyui-mcp/issues/60", number: 60 }),
@@ -352,14 +400,14 @@ describe("report_issue tool (registered handler)", () => {
     expect(json).toMatchObject({ filed: true, number: 60 });
   });
 
-  it("timeout regression (SUBMIT .json() stalls) → prefilled fallback", async () => {
+  it("SUBMIT 2xx then body stalls → pending (worker took it), NOT a prefill/double-file", async () => {
     process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "15";
     vi.stubGlobal(
       "fetch",
       vi.fn(
         async (_url: string, init: RequestInit) =>
           ({
-            ok: true,
+            ok: true, // 2xx = accepted
             json: () =>
               new Promise((_resolve, reject) => {
                 init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
@@ -368,8 +416,8 @@ describe("report_issue tool (registered handler)", () => {
       ),
     );
     const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
+    expect(json).toMatchObject({ filed: false, pending: true });
+    expect(String(json.url ?? "")).not.toContain("/issues/new"); // did NOT prefill
   });
 
   it("our repo, worker returns non-OK (500) → falls back to prefilled URL", async () => {

--- a/src/tools/report-issue.test.ts
+++ b/src/tools/report-issue.test.ts
@@ -44,7 +44,6 @@ describe("normalizeRepo / buildIssueUrl / isOurRepo", () => {
   it("recognizes our repos only, case-insensitively", () => {
     expect(isOurRepo("artokun/comfyui-mcp")).toBe(true);
     expect(isOurRepo("artokun/comfyui-mcp-panel")).toBe(true);
-    // git config / this repo use a capital A — must still be ours.
     expect(isOurRepo("Artokun/comfyui-mcp")).toBe(true);
     expect(isOurRepo("ARTOKUN/ComfyUI-MCP-Panel")).toBe(true);
     expect(isOurRepo("artokun/other")).toBe(false);
@@ -59,37 +58,103 @@ describe("normalizeRepo / buildIssueUrl / isOurRepo", () => {
   });
 });
 
-describe("submitAndPoll", () => {
-  it("returns the issue link inline when the fast path already filed", async () => {
-    const fetchImpl = (async () => res({ ok: true, job_id: "j1", status: "done", url: "https://gh/10", number: 10 })) as unknown as typeof fetch;
-    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
-    expect(r).toMatchObject({ status: "done", url: "https://gh/10", number: 10 });
+describe("submitAndPoll — async triage contract", () => {
+  it("sends X-Triage-Async + reporter_versions on submit", async () => {
+    let sentHeaders: Record<string, string> = {};
+    let sentBody: Record<string, unknown> = {};
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      sentHeaders = init.headers as Record<string, string>;
+      sentBody = JSON.parse(init.body as string);
+      return res({ state: "CLOSED", payload: { issue: { number: 1, url: "https://gh/1" }, agent_message: "done" }, url: "https://gh/1", number: 1 });
+    }) as unknown as typeof fetch;
+    await submitAndPoll({
+      workerUrl: "https://w",
+      clientKey: "k",
+      repoName: "comfyui-mcp",
+      title: "t",
+      body: "b",
+      reporterVersions: { mcp: "0.48.10", panel: "0.11.0" },
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(sentHeaders["X-Triage-Async"]).toBe("1");
+    expect(sentHeaders["X-Client-Key"]).toBe("k");
+    expect(sentBody.reporter_versions).toEqual({ mcp: "0.48.10", panel: "0.11.0" });
   });
 
-  it("OLD-SYNC fixture: { ok, url, number } with NO job_id/status returns immediately (no poll)", async () => {
+  it("CLOSED payload → kind:closed with the flattened rich result", async () => {
+    const fetchImpl = (async () =>
+      res({
+        state: "CLOSED",
+        payload: {
+          classification: "duplicate_closed",
+          action_taken: "advised_upgrade",
+          issue: { number: 505, url: "https://gh/505", state: "closed" },
+          fixed_in_version: "0.48.19",
+          fix_pr_url: "https://gh/pull/507",
+          recommend_upgrade: true,
+          agent_message: "upgrade to 0.48.21",
+          possible_duplicate: false,
+        },
+      })) as unknown as typeof fetch;
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(out.kind).toBe("closed");
+    if (out.kind !== "closed") throw new Error("expected closed");
+    expect(out.result).toMatchObject({
+      url: "https://gh/505",
+      number: 505,
+      classification: "duplicate_closed",
+      action_taken: "advised_upgrade",
+      fixed_in_version: "0.48.19",
+      fix_pr_url: "https://gh/pull/507",
+      recommend_upgrade: true,
+      agent_message: "upgrade to 0.48.21",
+    });
+  });
+
+  it("returns the version-ack from submit on every outcome", async () => {
+    const fetchImpl = (async () =>
+      res({
+        job_id: "ja",
+        state: "PENDING",
+        status: "PENDING",
+        versions: { mcp: { reporter: "0.48.10", latest: "0.48.21", up_to_date: false } },
+        up_to_date: false,
+        upgrade_hint: "comfyui-mcp is behind (0.48.10 → 0.48.21)",
+      })) as unknown as typeof fetch;
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, maxPolls: 1, pollDelayMs: 0 });
+    expect(out.kind).toBe("pending"); // still PENDING at budget
+    expect(out.ack.up_to_date).toBe(false);
+    expect(out.ack.upgrade_hint).toContain("behind");
+  });
+
+  it("legacy SYNC fixture: { ok, url, number } (no lifecycle field) → closed inline, no poll", async () => {
     let calls = 0;
     const fetchImpl = (async () => {
       calls++;
       return res({ ok: true, url: "https://gh/3", number: 3 });
     }) as unknown as typeof fetch;
-    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
-    expect(r).toMatchObject({ status: "done", url: "https://gh/3", number: 3 });
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep });
+    expect(out.kind).toBe("closed");
+    if (out.kind !== "closed") throw new Error("expected closed");
+    expect(out.result).toMatchObject({ url: "https://gh/3", number: 3 });
     expect(calls).toBe(1); // submit only — never polled
   });
 
-  it("polls /status until done when the submit is queued", async () => {
+  it("polls /status until CLOSED when the submit is PENDING", async () => {
     const calls: string[] = [];
     let polls = 0;
     const fetchImpl = (async (url: string) => {
       calls.push(url);
-      if (url === "https://w") return res({ ok: true, job_id: "j2", status: "queued" });
-      // /status/j2 — queued twice, then done
+      if (url === "https://w") return res({ job_id: "j2", state: "PENDING", status: "PENDING" });
       polls++;
-      if (polls < 3) return res({ status: "queued" });
-      return res({ status: "done", url: "https://gh/22", number: 22, deduped: true });
+      if (polls < 3) return res({ state: "INVESTIGATING", status: "queued" });
+      return res({ state: "CLOSED", payload: { issue: { number: 22, url: "https://gh/22" }, deduped: true, agent_message: "filed" }, url: "https://gh/22", number: 22 });
     }) as unknown as typeof fetch;
-    const r = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
-    expect(r).toMatchObject({ status: "done", url: "https://gh/22", number: 22, deduped: true, job_id: "j2" });
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
+    expect(out.kind).toBe("closed");
+    if (out.kind !== "closed") throw new Error("expected closed");
+    expect(out.result).toMatchObject({ url: "https://gh/22", number: 22, deduped: true });
     expect(calls.filter((c) => c.includes("/status/j2")).length).toBe(3);
   });
 
@@ -100,34 +165,36 @@ describe("submitAndPoll", () => {
     ).rejects.toThrow(/401/);
   });
 
-  it("THROWS on a server-side error status from polling (→ caller falls back)", async () => {
+  it("a terminal job ERROR without an issue → kind:unfiled (worker gave up, caller prefills)", async () => {
     const fetchImpl = (async (url: string) => {
-      if (url === "https://w") return res({ ok: true, job_id: "j3", status: "queued" });
+      if (url === "https://w") return res({ job_id: "j3", state: "PENDING", status: "PENDING" });
       return res({ status: "error", error: "GitHub API error" });
     }) as unknown as typeof fetch;
-    await expect(
-      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 }),
-    ).rejects.toThrow(/errored/);
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 });
+    expect(out.kind).toBe("unfiled");
   });
 
-  it("THROWS when polling never resolves (exhausts retries) instead of claiming queued success", async () => {
+  it("still running at the budget → kind:pending (NOT prefill — worker finishes async)", async () => {
     const fetchImpl = (async (url: string) => {
-      if (url === "https://w") return res({ ok: true, job_id: "j4", status: "queued" });
-      return res({ status: "queued" });
+      if (url === "https://w") return res({ job_id: "j4", state: "PENDING", status: "PENDING" });
+      return res({ state: "INVESTIGATING", status: "queued" });
     }) as unknown as typeof fetch;
-    await expect(
-      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 }),
-    ).rejects.toThrow(/did not complete/);
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 });
+    expect(out.kind).toBe("pending");
+    if (out.kind !== "pending") throw new Error("expected pending");
+    expect(out.job_id).toBe("j4");
   });
 
-  it("THROWS on a poll transport failure (HTTP error) → caller falls back", async () => {
+  it("a transient POLL transport error does NOT end the job — keeps polling, then pending", async () => {
+    let polls = 0;
     const fetchImpl = (async (url: string) => {
-      if (url === "https://w") return res({ ok: true, job_id: "j5", status: "queued" });
-      return res({ error: "boom" }, 503);
+      if (url === "https://w") return res({ job_id: "j5", state: "PENDING", status: "PENDING" });
+      polls++;
+      return res({ error: "boom" }, 503); // every poll a transport error
     }) as unknown as typeof fetch;
-    await expect(
-      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0 }),
-    ).rejects.toThrow(/poll failed/);
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, maxPolls: 3 });
+    expect(out.kind).toBe("pending"); // transient errors did not throw
+    expect(polls).toBe(3); // it kept trying
   });
 
   it("timeout: a SUBMIT whose .json() stalls until the AbortController fires → throws", async () => {
@@ -143,9 +210,9 @@ describe("submitAndPoll", () => {
     ).rejects.toThrow();
   });
 
-  it("timeout: a POLL whose .json() stalls until the AbortController fires → throws", async () => {
+  it("timeout: a POLL whose .json() stalls is transient → keeps polling → pending", async () => {
     const fetchImpl = (async (url: string, init: RequestInit) => {
-      if (url === "https://w") return res({ ok: true, job_id: "j6", status: "queued" });
+      if (url === "https://w") return res({ job_id: "j6", state: "PENDING", status: "PENDING" });
       return {
         ok: true,
         json: () =>
@@ -154,9 +221,8 @@ describe("submitAndPoll", () => {
           }),
       };
     }) as unknown as typeof fetch;
-    await expect(
-      submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, timeoutMs: 10 }),
-    ).rejects.toThrow();
+    const out = await submitAndPoll({ workerUrl: "https://w", clientKey: "k", repoName: "comfyui-mcp", title: "t", body: "b", fetchImpl, sleep: noSleep, pollDelayMs: 0, timeoutMs: 10, maxPolls: 2 });
+    expect(out.kind).toBe("pending");
   });
 });
 
@@ -166,6 +232,8 @@ describe("report_issue tool (registered handler)", () => {
     vi.unstubAllGlobals();
     if (savedTimeout === undefined) delete process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS;
     else process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = savedTimeout;
+    delete process.env.COMFYUI_MCP_ISSUE_MAX_POLLS;
+    delete process.env.COMFYUI_MCP_ISSUE_POLL_MS;
   });
 
   it("third-party repo → prefilled URL, filed:false, no network", async () => {
@@ -186,21 +254,101 @@ describe("report_issue tool (registered handler)", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("our repo, Worker files → returns the real issue link, filed:true", async () => {
+  it("our repo, worker CLOSED (created) → filed:true with the real issue link + agent_message", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => res({ ok: true, url: "https://github.com/artokun/comfyui-mcp/issues/50", number: 50, job_id: "jx" })),
+      vi.fn(async () =>
+        res({
+          state: "CLOSED",
+          payload: { classification: "new", action_taken: "created", issue: { number: 50, url: "https://github.com/artokun/comfyui-mcp/issues/50" }, agent_message: "Filed as #50" },
+          url: "https://github.com/artokun/comfyui-mcp/issues/50",
+          number: 50,
+        }),
+      ),
     );
-    const { json } = await callTool({ title: "t", body: "b" }); // default our repo
-    expect(json).toMatchObject({ filed: true, number: 50 });
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: true, number: 50, action_taken: "created", agent_message: "Filed as #50" });
     expect(json.url).toBe("https://github.com/artokun/comfyui-mcp/issues/50");
   });
 
-  it("mixed-case owner (Artokun/comfyui-mcp) is treated as OURS and files via the Worker", async () => {
-    const spy = vi.fn(async () => res({ ok: true, url: "https://github.com/Artokun/comfyui-mcp/issues/60", number: 60, job_id: "jm" }));
+  it("our repo, worker CLOSED (advised_upgrade) → filed:false, surfaces fix PR + version + upgrade advice", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        res({
+          state: "CLOSED",
+          payload: {
+            classification: "duplicate_closed",
+            action_taken: "advised_upgrade",
+            issue: { number: 505, url: "https://github.com/artokun/comfyui-mcp/issues/505", state: "closed" },
+            fixed_in_version: "0.48.19",
+            fix_pr_url: "https://github.com/artokun/comfyui-mcp/pull/507",
+            recommend_upgrade: true,
+            agent_message: "Duplicate of closed #505 — upgrade to 0.48.21 (fixed in 0.48.19 via PR #507).",
+          },
+        }),
+      ),
+    );
+    const { json } = await callTool({ title: "t", body: "b", mcp_version: "0.48.10" });
+    expect(json).toMatchObject({
+      filed: false, // advised_upgrade files nothing
+      action_taken: "advised_upgrade",
+      fixed_in_version: "0.48.19",
+      fix_pr_url: "https://github.com/artokun/comfyui-mcp/pull/507",
+      recommend_upgrade: true,
+    });
+    expect(json.agent_message).toContain("upgrade");
+  });
+
+  it("passes mcp_version/panel_version through as reporter_versions", async () => {
+    let sentBody: Record<string, unknown> = {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        sentBody = JSON.parse(init.body as string);
+        return res({ state: "CLOSED", payload: { action_taken: "created", issue: { number: 9, url: "https://github.com/artokun/comfyui-mcp/issues/9" }, agent_message: "ok" }, url: "https://github.com/artokun/comfyui-mcp/issues/9", number: 9 });
+      }),
+    );
+    await callTool({ title: "t", body: "b", mcp_version: "0.48.10", panel_version: "0.11.3" });
+    expect(sentBody.reporter_versions).toEqual({ mcp: "0.48.10", panel: "0.11.3" });
+  });
+
+  it("our repo, still triaging at budget → filed:false, pending:true, NO prefill", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (!String(url).includes("/status/")) return res({ job_id: "jq", state: "PENDING", status: "PENDING", up_to_date: false, upgrade_hint: "behind" });
+        return res({ state: "INVESTIGATING", status: "queued" });
+      }),
+    );
+    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "50";
+    process.env.COMFYUI_MCP_ISSUE_MAX_POLLS = "2";
+    process.env.COMFYUI_MCP_ISSUE_POLL_MS = "0";
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false, pending: true, job_id: "jq" });
+    expect(String(json.url ?? "")).not.toContain("/issues/new"); // did NOT prefill
+  });
+
+  it("our repo, worker terminally couldn't file (unfiled) → prefilled fallback", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (!String(url).includes("/status/")) return res({ job_id: "ju", state: "PENDING", status: "PENDING" });
+        return res({ status: "error", error: "GitHub API error" });
+      }),
+    );
+    const { json } = await callTool({ title: "t", body: "b" });
+    expect(json).toMatchObject({ filed: false });
+    expect(json.url).toContain("/issues/new");
+  });
+
+  it("mixed-case owner (Artokun/comfyui-mcp) is treated as OURS and hits the worker", async () => {
+    const spy = vi.fn(async () =>
+      res({ state: "CLOSED", payload: { action_taken: "created", issue: { number: 60, url: "https://github.com/Artokun/comfyui-mcp/issues/60" }, agent_message: "ok" }, url: "https://github.com/Artokun/comfyui-mcp/issues/60", number: 60 }),
+    );
     vi.stubGlobal("fetch", spy);
     const { json } = await callTool({ title: "t", body: "b", repo: "Artokun/comfyui-mcp" });
-    expect(spy).toHaveBeenCalled(); // hit the Worker, not the prefilled path
+    expect(spy).toHaveBeenCalled();
     expect(json).toMatchObject({ filed: true, number: 60 });
   });
 
@@ -224,58 +372,17 @@ describe("report_issue tool (registered handler)", () => {
     expect(json.url).toContain("/issues/new");
   });
 
-  it("timeout regression (POLL .json() stalls) → prefilled fallback", async () => {
-    process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS = "15";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string, init: RequestInit) => {
-        if (!String(url).includes("/status/")) return res({ ok: true, job_id: "jp2", status: "queued" });
-        return {
-          ok: true,
-          json: () =>
-            new Promise((_resolve, reject) => {
-              init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
-            }),
-        } as unknown as Response;
-      }),
-    );
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
-  it("our repo, Worker returns non-OK (500) → falls back to prefilled URL (generic, not just 401)", async () => {
+  it("our repo, worker returns non-OK (500) → falls back to prefilled URL", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => res({ error: "boom" }, 500)));
     const { json } = await callTool({ title: "t", body: "b" });
     expect(json).toMatchObject({ filed: false });
     expect(json.url).toContain("https://github.com/artokun/comfyui-mcp/issues/new");
   });
 
-  it("our repo, Worker returns 401 → falls back to prefilled URL", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => res({ error: "unauthorized" }, 401)));
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
   it("our repo, network failure (fetch rejects) → falls back to prefilled URL", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => {
       throw new Error("ECONNREFUSED");
     }));
-    const { json } = await callTool({ title: "t", body: "b" });
-    expect(json).toMatchObject({ filed: false });
-    expect(json.url).toContain("/issues/new");
-  });
-
-  it("our repo, submit ok but polling errors → surfaces prefilled fallback (filed:false)", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (String(url).endsWith("/status/" + "jp")) return res({ status: "error", error: "GitHub API error" });
-        // submit: queued with a job_id but no url → forces a poll
-        return res({ ok: true, job_id: "jp", status: "queued" });
-      }),
-    );
     const { json } = await callTool({ title: "t", body: "b" });
     expect(json).toMatchObject({ filed: false });
     expect(json.url).toContain("/issues/new");

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { detectInstallMode } from "../services/self-update.js";
 
-// Issue reporting. For OUR repos (comfyui-mcp / comfyui-mcp-panel) this now
-// *files* the issue through the async intake Worker — submit → get a job_id →
-// poll /status/<job_id> for the created issue link. For third-party repos, or
-// when the Worker is unreachable, it falls back to a PREFILLED GitHub "new
-// issue" URL the user can review and submit in one click (no auth, no network).
+// Issue reporting. For OUR repos (comfyui-mcp / comfyui-mcp-panel) this FILES the
+// issue through the async AI-triage Worker: submit (with the reporter's versions)
+// → get an instant version-ack + job_id → poll /status/<job_id> until the triage
+// agent CLOSEs the job, then surface its result (a new issue, a dedup, a reopen,
+// or an "already fixed — upgrade" answer with the fixing PR + version). For
+// third-party repos, or when the Worker is unreachable, it falls back to a
+// PREFILLED GitHub "new issue" URL the user can review and submit in one click.
 
 const DEFAULT_REPO = "artokun/comfyui-mcp";
 
@@ -44,18 +47,69 @@ export function isOurRepo(repo: string): boolean {
   return owner?.toLowerCase() === OUR_OWNER && OUR_REPO_NAMES.has(name?.toLowerCase());
 }
 
-export interface WorkerFileResult {
-  status: "done" | "queued" | "error";
+/** Reporter's installed versions, sent so the worker can version-match. */
+export interface ReporterVersions {
+  mcp?: string;
+  panel?: string;
+}
+
+/** The instant, mechanical version-ack the worker returns on submit. */
+export interface TriageAck {
+  job_id?: string;
+  versions?: unknown; // { mcp: {reporter,latest,up_to_date}, panel: {...} }
+  up_to_date?: boolean | null;
+  upgrade_hint?: string;
+}
+
+/** The triage agent's terminal result (from the CLOSED job payload). */
+export interface TriageResult {
   url?: string;
   number?: number;
   deduped?: boolean;
-  job_id?: string;
-  error?: string;
+  classification?: string;
+  action_taken?: string;
+  fixed_in_version?: string | null;
+  fix_pr_url?: string | null;
+  recommend_upgrade?: boolean;
+  agent_message?: string;
+  possible_duplicate?: boolean;
 }
 
-// Submit to the async intake Worker and poll /status/<job_id> a few times for
-// the created issue link. Injectable fetch/sleep for testing. Throws on network
-// failure or non-OK submit so the caller can fall back to a prefilled URL.
+/**
+ * Outcome of submitAndPoll:
+ *  - "closed": the triage agent finished — full result (issue link or upgrade
+ *    advice) + the version-ack.
+ *  - "unfiled": the job reached a TERMINAL state without producing an issue
+ *    (the worker's own triage AND its never-lose fallback both gave up). Nothing
+ *    was filed, so the caller SHOULD prefill a URL as the last resort — there is
+ *    no double-file risk.
+ *  - "pending": submit succeeded (we have the ack + a job_id) but the triage was
+ *    still running when the poll budget ran out. The worker WILL finish and
+ *    file/dedup autonomously, so the caller must NOT also prefill (that would
+ *    double-file) — it surfaces the ack + "still triaging".
+ * A SUBMIT failure (worker unreachable / non-OK) throws instead, so the caller
+ * falls back to a prefilled URL (there too, the worker never took the report).
+ */
+export type SubmitOutcome =
+  | { kind: "closed"; ack: TriageAck; result: TriageResult }
+  | { kind: "unfiled"; ack: TriageAck }
+  | { kind: "pending"; ack: TriageAck; job_id: string };
+
+interface StatusFrame {
+  state?: string; // PENDING | INVESTIGATING | CLOSED
+  status?: string; // legacy: queued | done | error
+  url?: string;
+  number?: number;
+  error?: string;
+  payload?: TriageResult & { issue?: { number?: number; url?: string; state?: string } };
+}
+
+/**
+ * Submit to the async AI-triage Worker and poll /status/<job_id> until the job
+ * CLOSEs or the budget runs out. Injectable fetch/sleep for testing.
+ * THROWS only on a submit failure (so the caller uses the prefilled fallback);
+ * a still-running job at the budget returns { kind: "pending" }.
+ */
 export async function submitAndPoll(opts: {
   workerUrl: string;
   clientKey: string;
@@ -63,21 +117,22 @@ export async function submitAndPoll(opts: {
   title: string;
   body: string;
   labels?: string[];
+  reporterVersions?: ReporterVersions;
   fetchImpl?: typeof fetch;
   sleep?: (ms: number) => Promise<void>;
   maxPolls?: number;
   pollDelayMs?: number;
   timeoutMs?: number;
-}): Promise<WorkerFileResult> {
+}): Promise<SubmitOutcome> {
   const doFetch = opts.fetchImpl ?? fetch;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
-  const maxPolls = opts.maxPolls ?? 5;
-  const pollDelayMs = opts.pollDelayMs ?? 1000;
-  const timeoutMs = opts.timeoutMs ?? 8000;
+  // AI triage runs ~30-120s; poll patiently but bounded. ~40 * 3s ≈ 2 min.
+  const maxPolls = opts.maxPolls ?? 40;
+  const pollDelayMs = opts.pollDelayMs ?? 3000;
+  const timeoutMs = opts.timeoutMs ?? 15000; // per-request cap (not the whole job)
 
   // Keep the abort active through BOTH the fetch AND the body parse — otherwise
-  // a hung `.json()` after headers arrive would never time out. The whole
-  // request+parse runs under one AbortController + a hard timeout.
+  // a hung `.json()` after headers arrive would never time out.
   const withTimeout = async <T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> => {
     const ac = new AbortController();
     const t = setTimeout(() => ac.abort(), timeoutMs);
@@ -88,50 +143,125 @@ export async function submitAndPoll(opts: {
     }
   };
 
-  const submit = await withTimeout(async (signal): Promise<WorkerFileResult> => {
+  const submit = await withTimeout(async (signal): Promise<StatusFrame & TriageAck> => {
     const r = await doFetch(opts.workerUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json", "X-Client-Key": opts.clientKey },
-      body: JSON.stringify({ repo: opts.repoName, title: opts.title, body: opts.body, labels: opts.labels }),
+      headers: {
+        "Content-Type": "application/json",
+        "X-Client-Key": opts.clientKey,
+        // Opt into the async AI-triage contract. Absent this header the worker
+        // runs its legacy synchronous dumb-file path (old clients stay working).
+        "X-Triage-Async": "1",
+      },
+      body: JSON.stringify({
+        repo: opts.repoName,
+        title: opts.title,
+        body: opts.body,
+        labels: opts.labels,
+        reporter_versions: opts.reporterVersions ?? {},
+      }),
       signal,
     });
     if (!r.ok) throw new Error(`worker submit failed: HTTP ${r.status}`);
-    return (await r.json()) as WorkerFileResult;
+    return (await r.json()) as StatusFrame & TriageAck;
   });
 
-  // Common path: the Worker files synchronously and returns the link inline.
-  if (submit.url) return { ...submit, status: submit.status ?? "done" };
-  const jobId = submit.job_id;
-  if (!jobId) {
-    // No url AND no job to poll — nothing we can surface. Throw so the caller
-    // falls back to the prefilled link.
-    throw new Error("worker returned neither a url nor a job_id");
+  const ack: TriageAck = {
+    job_id: submit.job_id,
+    versions: submit.versions,
+    up_to_date: submit.up_to_date,
+    upgrade_hint: submit.upgrade_hint,
+  };
+
+  // A synchronous worker (legacy / very fast) may return the result inline.
+  if (isClosedFrame(submit)) {
+    const inline = frameToResult(submit);
+    return inline ? { kind: "closed", ack, result: inline } : { kind: "unfiled", ack };
   }
 
-  // Fallback poll (only if the submit somehow lacked a url): /status/<job_id>.
-  // A 200 "queued" is retried; ANY hard poll failure (transport error, timeout,
-  // non-OK HTTP, body-parse failure) or a "done" without a url, or exhausting
-  // the retries, THROWS — so the caller uses the prefilled-URL fallback rather
-  // than claiming success without a link.
+  const jobId = submit.job_id;
+  if (!jobId) throw new Error("worker returned neither a result nor a job_id");
+
   const base = opts.workerUrl.replace(/\/+$/, "");
   for (let i = 0; i < maxPolls; i++) {
     await sleep(pollDelayMs);
-    const parsed = await withTimeout(async (signal): Promise<WorkerFileResult> => {
-      const r = await doFetch(`${base}/status/${jobId}`, { signal });
-      if (!r.ok) throw new Error(`poll failed: HTTP ${r.status}`);
-      return (await r.json()) as WorkerFileResult;
-    });
-    if (parsed.status === "done" && parsed.url) return { ...parsed, job_id: jobId };
-    if (parsed.status === "error") throw new Error(`worker filing errored: ${parsed.error || "unknown"}`);
-    // else "queued" (or done-without-url) → keep polling
+    let parsed: StatusFrame;
+    try {
+      parsed = await withTimeout(async (signal): Promise<StatusFrame> => {
+        const r = await doFetch(`${base}/status/${jobId}`, {
+          signal,
+          headers: { "X-Client-Key": opts.clientKey },
+        });
+        if (!r.ok) throw new Error(`poll failed: HTTP ${r.status}`);
+        return (await r.json()) as StatusFrame;
+      });
+    } catch {
+      // A transient poll error does NOT mean the job failed — the worker keeps
+      // running. Keep polling; only a real terminal frame or the budget ends it.
+      continue;
+    }
+    if (isClosedFrame(parsed) || isTerminalError(parsed)) {
+      const result = frameToResult(parsed);
+      // Terminal WITH a usable issue/answer → closed; terminal WITHOUT one
+      // (unfiled_needs_manual / hard error) → the worker gave up filing, so the
+      // caller may safely prefill (nothing was written → no double-file).
+      return result ? { kind: "closed", ack, result } : { kind: "unfiled", ack };
+    }
+    // else PENDING / INVESTIGATING → keep polling
   }
-  throw new Error("worker filing did not complete before polling gave up");
+  // Still running at the budget: the worker will finish autonomously — do NOT
+  // prefill (that duplicates). Surface the ack + job id.
+  return { kind: "pending", ack, job_id: jobId };
+}
+
+/** A frame is TERMINAL (job finished) iff CLOSED, a legacy done, or a legacy
+ *  sync response that carries a url with no lifecycle field at all. */
+function isClosedFrame(frame: StatusFrame): boolean {
+  return (
+    frame.state === "CLOSED" ||
+    frame.status === "done" ||
+    (frame.state == null && frame.status == null && !!frame.url)
+  );
+}
+
+/** Flatten a terminal frame to a TriageResult, or null if it carries no usable
+ *  issue link / answer (→ the caller treats it as "unfiled"). */
+function frameToResult(frame: StatusFrame): TriageResult | null {
+  const p = frame.payload;
+  const issueUrl = p?.issue?.url ?? frame.url;
+  const issueNumber = p?.issue?.number ?? frame.number;
+  if (!issueUrl && !p?.agent_message) return null; // nothing useful to surface
+  return {
+    url: issueUrl,
+    number: issueNumber,
+    deduped: p?.deduped,
+    classification: p?.classification,
+    action_taken: p?.action_taken,
+    fixed_in_version: p?.fixed_in_version ?? null,
+    fix_pr_url: p?.fix_pr_url ?? null,
+    recommend_upgrade: p?.recommend_upgrade,
+    agent_message: p?.agent_message,
+    possible_duplicate: p?.possible_duplicate,
+  };
+}
+
+function isTerminalError(frame: StatusFrame): boolean {
+  return frame.status === "error" && !frame.url && !frame.payload;
+}
+
+/** The running comfyui-mcp version (best-effort; undefined if undetectable). */
+function detectMcpVersion(): string | undefined {
+  try {
+    return detectInstallMode().currentVersion ?? undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function registerReportIssueTools(server: McpServer): void {
   server.tool(
     "report_issue",
-    "File or link a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp itself). For OUR repos (artokun/comfyui-mcp, artokun/comfyui-mcp-panel) it FILES the issue via the intake Worker and returns the created issue link (no end-user GitHub auth needed); if the Worker is unreachable it falls back to a prefilled GitHub 'new issue' URL. For third-party repos it returns a prefilled URL to SHARE with the user (it does not auto-file). Pass repo='owner/name' for third-party projects. The filing is autonomous — surface the resulting link to the user only if they want it.",
+    "File or triage a GitHub issue for a bug/problem you hit (ComfyUI, a workflow, a model, custom nodes, or comfyui-mcp/its panel). For OUR repos (artokun/comfyui-mcp, artokun/comfyui-mcp-panel) it sends the report to the AI triage worker, which searches existing OPEN and CLOSED issues, version-matches, and either files a new issue, adds context to an existing one, or — if the problem was already FIXED in a newer version than the user runs — answers with the fixing PR + fixed-in version and a recommendation to upgrade (no new issue). It returns that triage result plus an instant check of whether the user is on the latest versions. If the worker is unreachable it falls back to a prefilled GitHub 'new issue' URL. For third-party repos it returns a prefilled URL to SHARE (it does not auto-file). ALWAYS pass mcp_version and panel_version from the known environment (the env line in your context, e.g. 'mcp=… panel=…') so the worker can tell the user if simply upgrading fixes it — the single most common resolution. Surface the worker's agent_message / upgrade advice to the user.",
     {
       title: z.string().min(1).describe("Short, specific issue title."),
       body: z
@@ -145,6 +275,14 @@ export function registerReportIssueTools(server: McpServer): void {
         .optional()
         .describe("owner/repo (default 'artokun/comfyui-mcp'; use 'artokun/comfyui-mcp-panel' for the sidebar panel)."),
       labels: z.array(z.string()).optional().describe("Optional GitHub label names to prefill."),
+      mcp_version: z
+        .string()
+        .optional()
+        .describe("The running comfyui-mcp version (from the env line in your context). Auto-detected if omitted."),
+      panel_version: z
+        .string()
+        .optional()
+        .describe("The running comfyui-mcp-panel (sidebar) version, from the env line in your context, if known."),
       no_file: z
         .boolean()
         .optional()
@@ -165,45 +303,94 @@ export function registerReportIssueTools(server: McpServer): void {
           });
         }
 
-        // Our repo: file via the intake Worker (submit + poll for the link).
         const workerUrl = process.env.COMFYUI_MCP_ISSUE_WORKER_URL || DEFAULT_WORKER_URL;
         const clientKey = process.env.COMFYUI_MCP_ISSUE_CLIENT_KEY || DEFAULT_CLIENT_KEY;
         const timeoutEnv = Number(process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS);
         const timeoutMs = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : undefined;
+        const maxPollsEnv = Number(process.env.COMFYUI_MCP_ISSUE_MAX_POLLS);
+        const maxPolls = Number.isFinite(maxPollsEnv) && maxPollsEnv > 0 ? maxPollsEnv : undefined;
+        const pollMsEnv = Number(process.env.COMFYUI_MCP_ISSUE_POLL_MS);
+        const pollDelayMs = Number.isFinite(pollMsEnv) && pollMsEnv >= 0 ? pollMsEnv : undefined;
         const repoName = repo.split("/")[1];
+
+        const reporterVersions: ReporterVersions = {
+          mcp: args.mcp_version ?? detectMcpVersion(),
+          panel: args.panel_version ?? process.env.COMFYUI_MCP_PANEL_VERSION ?? undefined,
+        };
+
         try {
-          // submitAndPoll ONLY resolves with a done result carrying a real url;
-          // any failure (non-OK submit, transport/timeout, poll error/exhaustion)
-          // throws → we fall back to the prefilled link below.
-          const result = await submitAndPoll({
+          const outcome = await submitAndPoll({
             workerUrl,
             clientKey,
             repoName,
             title: args.title,
             body: args.body,
             labels: args.labels,
+            reporterVersions,
             timeoutMs,
+            maxPolls,
+            pollDelayMs,
           });
+
+          if (outcome.kind === "closed") {
+            const r = outcome.result;
+            return jsonResult({
+              filed: r.action_taken !== "advised_upgrade",
+              repo,
+              url: r.url,
+              number: r.number,
+              classification: r.classification,
+              action_taken: r.action_taken,
+              deduped: r.deduped,
+              fixed_in_version: r.fixed_in_version,
+              fix_pr_url: r.fix_pr_url,
+              recommend_upgrade: r.recommend_upgrade,
+              possible_duplicate: r.possible_duplicate,
+              versions: outcome.ack.versions,
+              up_to_date: outcome.ack.up_to_date,
+              upgrade_hint: outcome.ack.upgrade_hint,
+              // The one line to relay to the user.
+              agent_message: r.agent_message,
+              note: "Triaged by the AI issue worker. Relay agent_message (and the upgrade advice) to the user.",
+            });
+          }
+
+          // Terminal without an issue: the worker's triage AND its own fallback
+          // both gave up — nothing was filed, so a prefilled URL is the safe
+          // last resort (no double-file risk).
+          if (outcome.kind === "unfiled") {
+            return jsonResult({
+              url: prefilledUrl,
+              repo,
+              filed: false,
+              versions: outcome.ack.versions,
+              up_to_date: outcome.ack.up_to_date,
+              upgrade_hint: outcome.ack.upgrade_hint,
+              note: "The triage worker could not file this report. Fallback: prefilled issue link for the user to submit in one click.",
+            });
+          }
+
+          // Still triaging at the budget: the worker WILL finish + file/dedup on
+          // its own. Do NOT prefill (would double-file). Surface the version-ack.
           return jsonResult({
-            url: result.url,
-            number: result.number,
-            deduped: result.deduped,
+            filed: false,
+            pending: true,
             repo,
-            filed: true,
-            job_id: result.job_id,
-            note: result.deduped
-              ? "Filed via intake Worker (matched an existing open issue). Share the link only if the user wants it."
-              : "Filed via intake Worker. Share the link only if the user wants it.",
+            job_id: outcome.job_id,
+            versions: outcome.ack.versions,
+            up_to_date: outcome.ack.up_to_date,
+            upgrade_hint: outcome.ack.upgrade_hint,
+            agent_message: outcome.ack.upgrade_hint,
+            note: "The AI triage is still running; the worker will file or dedup this report autonomously. If the user is behind on versions (see upgrade_hint), suggest upgrading first — that often resolves it.",
           });
         } catch (workerErr) {
-          // ANY submit OR poll failure (non-OK, timeout, unreachable, parse
-          // stall, server error) → prefilled URL fallback. Never claim success
-          // without a real issue link.
+          // SUBMIT failed (worker unreachable / non-OK) → the worker never took
+          // the report, so a prefilled URL is safe (no double-file risk).
           return jsonResult({
             url: prefilledUrl,
             repo,
             filed: false,
-            note: `Could not file via the intake Worker (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
+            note: `Could not reach the AI triage worker (${workerErr instanceof Error ? workerErr.message : String(workerErr)}). Fallback: prefilled issue link for the user to submit in one click.`,
           });
         }
       } catch (err) {

--- a/src/tools/report-issue.ts
+++ b/src/tools/report-issue.ts
@@ -93,7 +93,10 @@ export interface TriageResult {
 export type SubmitOutcome =
   | { kind: "closed"; ack: TriageAck; result: TriageResult }
   | { kind: "unfiled"; ack: TriageAck }
-  | { kind: "pending"; ack: TriageAck; job_id: string };
+  // job_id is optional: an accepted (HTTP 2xx) submit whose body stalled or
+  // omitted a job_id still means the worker TOOK the report — we can't poll but
+  // must NOT prefill (that would double-file).
+  | { kind: "pending"; ack: TriageAck; job_id?: string };
 
 interface StatusFrame {
   state?: string; // PENDING | INVESTIGATING | CLOSED
@@ -143,28 +146,42 @@ export async function submitAndPoll(opts: {
     }
   };
 
-  const submit = await withTimeout(async (signal): Promise<StatusFrame & TriageAck> => {
-    const r = await doFetch(opts.workerUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Client-Key": opts.clientKey,
-        // Opt into the async AI-triage contract. Absent this header the worker
-        // runs its legacy synchronous dumb-file path (old clients stay working).
-        "X-Triage-Async": "1",
-      },
-      body: JSON.stringify({
-        repo: opts.repoName,
-        title: opts.title,
-        body: opts.body,
-        labels: opts.labels,
-        reporter_versions: opts.reporterVersions ?? {},
-      }),
-      signal,
+  // `accepted` flips true the instant the worker returns a 2xx — from that point
+  // the worker HAS the report and is filing autonomously, so a later body
+  // stall/parse failure must NOT throw into a prefill (that would double-file).
+  let accepted = false;
+  let submit: StatusFrame & TriageAck;
+  try {
+    submit = await withTimeout(async (signal): Promise<StatusFrame & TriageAck> => {
+      const r = await doFetch(opts.workerUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Client-Key": opts.clientKey,
+          // Opt into the async AI-triage contract. Absent this header the worker
+          // runs its legacy synchronous dumb-file path (old clients stay working).
+          "X-Triage-Async": "1",
+        },
+        body: JSON.stringify({
+          repo: opts.repoName,
+          title: opts.title,
+          body: opts.body,
+          labels: opts.labels,
+          reporter_versions: opts.reporterVersions ?? {},
+        }),
+        signal,
+      });
+      if (!r.ok) throw new Error(`worker submit failed: HTTP ${r.status}`);
+      accepted = true; // 2xx → the worker took the report
+      return (await r.json()) as StatusFrame & TriageAck;
     });
-    if (!r.ok) throw new Error(`worker submit failed: HTTP ${r.status}`);
-    return (await r.json()) as StatusFrame & TriageAck;
-  });
+  } catch (err) {
+    // A 2xx whose body stalled/was malformed: the worker still took it and is
+    // filing — surface pending (no job_id, no ack) so the caller does NOT
+    // prefill. A pre-2xx failure (network / non-OK) rethrows → caller prefills.
+    if (accepted) return { kind: "pending", ack: {} };
+    throw err;
+  }
 
   const ack: TriageAck = {
     job_id: submit.job_id,
@@ -180,7 +197,9 @@ export async function submitAndPoll(opts: {
   }
 
   const jobId = submit.job_id;
-  if (!jobId) throw new Error("worker returned neither a result nor a job_id");
+  // Accepted (2xx) but no job_id and no inline result → we can't poll, but the
+  // worker took it and is filing. Surface pending (never prefill → no double).
+  if (!jobId) return { kind: "pending", ack };
 
   const base = opts.workerUrl.replace(/\/+$/, "");
   for (let i = 0; i < maxPolls; i++) {
@@ -230,7 +249,13 @@ function frameToResult(frame: StatusFrame): TriageResult | null {
   const p = frame.payload;
   const issueUrl = p?.issue?.url ?? frame.url;
   const issueNumber = p?.issue?.number ?? frame.number;
-  if (!issueUrl && !p?.agent_message) return null; // nothing useful to surface
+  // "Usable" = there is a real issue link, OR it is the advise-upgrade answer
+  // (no created issue, but real fix guidance). A terminal frame WITHOUT either —
+  // e.g. unfiled_needs_manual, which still carries an agent_message — is NOT a
+  // success: return null so the caller treats it as "unfiled" and prefills. (Do
+  // NOT key this on agent_message; the worker sets one even on failure.)
+  const usable = !!issueUrl || p?.action_taken === "advised_upgrade";
+  if (!usable) return null;
   return {
     url: issueUrl,
     number: issueNumber,
@@ -307,10 +332,12 @@ export function registerReportIssueTools(server: McpServer): void {
         const clientKey = process.env.COMFYUI_MCP_ISSUE_CLIENT_KEY || DEFAULT_CLIENT_KEY;
         const timeoutEnv = Number(process.env.COMFYUI_MCP_ISSUE_TIMEOUT_MS);
         const timeoutMs = Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : undefined;
-        const maxPollsEnv = Number(process.env.COMFYUI_MCP_ISSUE_MAX_POLLS);
-        const maxPolls = Number.isFinite(maxPollsEnv) && maxPollsEnv > 0 ? maxPollsEnv : undefined;
+        const maxPollsEnv = Math.floor(Number(process.env.COMFYUI_MCP_ISSUE_MAX_POLLS));
+        // Clamp to a sane ceiling so a mis-set env can't poll for hours.
+        const maxPolls = Number.isFinite(maxPollsEnv) && maxPollsEnv > 0 ? Math.min(maxPollsEnv, 200) : undefined;
         const pollMsEnv = Number(process.env.COMFYUI_MCP_ISSUE_POLL_MS);
-        const pollDelayMs = Number.isFinite(pollMsEnv) && pollMsEnv >= 0 ? pollMsEnv : undefined;
+        const pollDelayMs =
+          Number.isFinite(pollMsEnv) && pollMsEnv >= 0 ? Math.min(pollMsEnv, 60000) : undefined;
         const repoName = repo.split("/")[1];
 
         const reporterVersions: ReporterVersions = {
@@ -335,7 +362,10 @@ export function registerReportIssueTools(server: McpServer): void {
           if (outcome.kind === "closed") {
             const r = outcome.result;
             return jsonResult({
-              filed: r.action_taken !== "advised_upgrade",
+              // "filed" means a real issue was created/updated. advised_upgrade
+              // files nothing; and a closed result always has a url here (a
+              // no-url terminal is routed to "unfiled" above).
+              filed: !!r.url && r.action_taken !== "advised_upgrade",
               repo,
               url: r.url,
               number: r.number,


### PR DESCRIPTION
Wires the `report_issue` tool to the AI-triage worker's async contract so the panel agent actually uses the new brain.

**What it does**
- Sends `X-Triage-Async: 1` + `reporter_versions {mcp, panel}` (mcp auto-detected via `detectInstallMode`; both fillable by the agent from its env-caps line).
- Polls `PENDING → INVESTIGATING → CLOSED` with a bounded, env-tunable budget (`COMFYUI_MCP_ISSUE_{MAX_POLLS,POLL_MS,TIMEOUT_MS}`; max_polls floored + clamped ≤200).
- Surfaces the rich triage result — `agent_message`, `classification`, `action_taken`, `fixed_in_version`, `fix_pr_url`, `recommend_upgrade` — plus the instant version-ack (`versions`/`up_to_date`/`upgrade_hint`) on every outcome. Tool description tells the agent to pass versions and relay the upgrade advice.

**Correctness (double-file / never-lose)**
- Prefill a GitHub URL **only** when the worker never took the report (pre-2xx submit failure) or terminally gave up filing (`unfiled`). A still-running job at the poll budget returns `pending` and **never** prefills (the worker finishes autonomously). A 2xx submit whose body stalls/omits `job_id` is treated as accepted → pending (no double-file). Transient poll errors keep polling. `advised_upgrade` → `filed:false`.

**Requires** the AI-triage worker deployed (separate repo, already live).

Verification: 31/31 report-issue tests, `tsc --noEmit` clean, full `build` clean, asset-counts consistent. Independent codex review: **VERDICT: PASS** (after one round that caught 3 real edge-cases — 200-then-stall double-file, unfiled-with-agent_message lost report, unbounded max_polls — all fixed + tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)