### PR TITLE
fix(panel): secret-notice correlation (#164), stall false-positive (#183), load_workflow custom user-dir (#202)

### DIFF
--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -1,0 +1,240 @@
+// panel_load_workflow — relative names resolve through the connected ComfyUI's
+// userdata API when the guessed local disk path misses (#202).
+//
+// Root cause: comfyWorkflowsDirs() hardcodes COMFYUI_PATH/user/default/workflows
+// (and user/workflows), so a ComfyUI launched with a CUSTOM --user-directory
+// keeps its workflows somewhere the orchestrator can't guess — a relative
+// panel_load_workflow name then fell through to a "no workflow file" error even
+// though list_workflows/panel_open_workflow (which read the userdata API) could
+// see it. readWorkflowFromPath now falls back to that same userdata API.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Stub ONLY getClient so no real ComfyUI connection is attempted; every other
+// client export keeps its real implementation (panel-tools' module graph uses
+// several of them at import time).
+const fetchApi = vi.fn();
+vi.mock("../../comfyui/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../comfyui/client.js")>();
+  return {
+    ...actual,
+    getClient: () => ({ fetchApi: (...a: unknown[]) => fetchApi(...a) }),
+  };
+});
+
+const { buildPanelToolDefs } = await import("../../orchestrator/panel-tools.js");
+import type { PanelToolCtx } from "../../orchestrator/panel-tools.js";
+
+type Forwarded = Record<string, unknown>;
+function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
+  const calls: Forwarded[] = [];
+  const ctx = {
+    call: async (cmd: Forwarded) => {
+      calls.push(cmd);
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+    confirm: async () => true,
+    bridge: { send: async (cmd: Forwarded) => { calls.push(cmd); return {}; } },
+    tabId: "test-tab",
+  } as unknown as PanelToolCtx;
+  return { ctx, calls };
+}
+
+function loadWorkflow() {
+  const def = buildPanelToolDefs().find((d) => d.name === "panel_load_workflow");
+  if (!def) throw new Error("panel_load_workflow not found");
+  return def;
+}
+
+let savedComfyPath: string | undefined;
+beforeEach(() => {
+  fetchApi.mockReset();
+  savedComfyPath = process.env.COMFYUI_PATH;
+  // No local COMFYUI_PATH → the guessed workflows dirs are empty, so a relative
+  // name misses on disk and MUST fall through to the userdata API.
+  delete process.env.COMFYUI_PATH;
+});
+afterEach(() => {
+  if (savedComfyPath === undefined) delete process.env.COMFYUI_PATH;
+  else process.env.COMFYUI_PATH = savedComfyPath;
+});
+
+describe("panel_load_workflow: userdata fallback for a custom --user-directory (#202)", () => {
+  it("resolves a relative name via the userdata API and loads it onto the canvas", async () => {
+    const graph = { nodes: [{ id: 1, type: "KSampler" }], links: [] };
+    fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(graph) });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler(
+      { path: "722-gordo-10Eros_10SNodes_I2V_DMD_v1.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    // Fetched from the userdata library under the runtime user-directory.
+    expect(fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/722-gordo-10Eros_10SNodes_I2V_DMD_v1.json")}`,
+    );
+    // And the fetched graph was dropped on the canvas.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ cmd: "graph_load" });
+    expect(calls[0].graph).toMatchObject(graph);
+  });
+
+  it("fails LOUDLY (no graph_load) when the userdata library 404s the name", async () => {
+    fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "nope-not-here.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    const text = JSON.stringify(res);
+    expect(text).toMatch(/userdata library/i);
+    expect(text).toMatch(/panel_list_workflows/);
+  });
+
+  it("surfaces an honest error (no graph_load) when the userdata file is not a UI workflow", async () => {
+    // API/prompt format (numeric keys) — not a litegraph UI workflow.
+    fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify({ "1": { class_type: "KSampler" } }) });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "api-format.json" }, ctx);
+
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/not a UI workflow/i);
+  });
+
+  it("the RUNTIME userdata file wins over a stale same-named file in the guessed default dir", async () => {
+    // Collision: COMFYUI_PATH's default workflows dir has a foo.json (graph A),
+    // but the connected ComfyUI runs a CUSTOM --user-directory whose foo.json is
+    // graph B. The authoritative userdata API must win — never the stale disk
+    // file (#202).
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const stale = { nodes: [{ id: 99, type: "StaleDefaultDirNode" }], links: [] };
+      writeFileSync(join(defaultDir, "foo.json"), JSON.stringify(stale), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      const runtime = { nodes: [{ id: 1, type: "RuntimeUserDirNode" }], links: [] };
+      fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(runtime) });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBeUndefined();
+      expect(fetchApi).toHaveBeenCalled(); // authoritative source was consulted first
+      expect(calls).toHaveLength(1);
+      expect(calls[0].graph).toMatchObject(runtime); // NOT the stale default-dir file
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT fall back to a colliding local file when the server REFUSES (non-404)", async () => {
+    // A reachable server that returns 403/500 must surface honestly — NOT silently
+    // load a possibly-stale same-named local file (#202).
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "StaleNode" }] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // never loaded the stale local file
+      expect(JSON.stringify(res)).toMatch(/HTTP 500/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces malformed userdata JSON as its own error (not mislabeled unreachable)", async () => {
+    // A colliding local file exists, but a malformed 2xx must NOT fall back to it.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(defaultDir, "foo.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "StaleNode" }] }),
+        "utf8",
+      );
+      process.env.COMFYUI_PATH = root;
+
+      // Non-empty body that isn't JSON → malformed (NOT an empty-body absence).
+      fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => "<html>not json</html>" });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBe(true);
+      expect(calls).toHaveLength(0); // did not load the stale local file
+      expect(JSON.stringify(res)).toMatch(/not valid JSON/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an EMPTY 200 body as absence and falls back to the local disk file", async () => {
+    // ComfyUI's "200 + empty body = file does not exist" convention (some builds)
+    // must be an ABSENCE (local fallback), NOT a malformed error (#202).
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const staged = { nodes: [{ id: 5, type: "EmptyBodyFallbackNode" }], links: [] };
+      writeFileSync(join(defaultDir, "foo.json"), JSON.stringify(staged), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => "   " });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "foo.json" }, ctx);
+
+      expect(res.isError).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].graph).toMatchObject(staged); // local fallback loaded it
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the local disk file when the server doesn't have the name (404)", async () => {
+    // A file staged straight to the default workflows dir, absent from the
+    // runtime userdata library → the local fallback still opens it.
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const staged = { nodes: [{ id: 7, type: "StagedNode" }], links: [] };
+      writeFileSync(join(defaultDir, "staged.json"), JSON.stringify(staged), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "staged.json" }, ctx);
+
+      expect(res.isError).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].graph).toMatchObject(staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/orchestrator/restart-coalesce.test.ts
+++ b/src/__tests__/orchestrator/restart-coalesce.test.ts
@@ -151,4 +151,55 @@ describe("coalesced effort + comfyui-MCP-env restart (P1b)", () => {
     expect(backend.efforts[1]).toBe("low"); // unchanged effort
     expect(backend.turnTexts.filter((t) => t === "RETRY")).toHaveLength(1);
   });
+
+  // #164 — a queued per-request secret nudge must SURVIVE a concurrent SILENT
+  // env respawn: a broadcast restartAllForMcpEnv() (no nudge) and a single-tab
+  // restartForMcpEnv() (no nudge, e.g. a blind-mode toggle / provider-key
+  // refresh) must NOT downgrade the tab's pending nudge to null.
+  describe("silent restart preserves a queued secret nudge (#164)", () => {
+    it("restartAllForMcpEnv() (no nudge) does not erase a tab's pending nudge", async () => {
+      const backend = new RecordingBackend();
+      backend.autoComplete = false; // first turn hangs → agent stays BUSY
+      const manager = makeManager(backend, "low");
+      const tab = "tab-preserve-all";
+
+      manager.send(tab, "hello");
+      await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+
+      // A panel_request_secret resolved → this tab gets the retry nudge queued.
+      manager.restartForMcpEnv(tab, "RETRY the download");
+      // An UNRELATED secret change now respawns every tab's env SILENTLY.
+      manager.restartAllForMcpEnv();
+
+      backend.autoComplete = true;
+      backend.release();
+      await waitFor(() => backend.runCount >= 2);
+      await new Promise((r) => setTimeout(r, 100));
+      expect(backend.runCount).toBe(2);
+      // The nudge survived the silent respawn and was delivered exactly once.
+      expect(backend.turnTexts.filter((t) => t === "RETRY the download")).toHaveLength(1);
+    });
+
+    it("restartForMcpEnv() (no nudge) does not erase a tab's pending nudge", async () => {
+      const backend = new RecordingBackend();
+      backend.autoComplete = false;
+      const manager = makeManager(backend, "low");
+      const tab = "tab-preserve-single";
+
+      manager.send(tab, "hello");
+      await waitFor(() => backend.runCount >= 1 && backend.turnTexts.length >= 1);
+
+      manager.restartForMcpEnv(tab, "RETRY the download");
+      // A silent single-tab restart (blind toggle / provider-key refresh) on the
+      // SAME tab must keep the nudge.
+      manager.restartForMcpEnv(tab);
+
+      backend.autoComplete = true;
+      backend.release();
+      await waitFor(() => backend.runCount >= 2);
+      await new Promise((r) => setTimeout(r, 100));
+      expect(backend.runCount).toBe(2);
+      expect(backend.turnTexts.filter((t) => t === "RETRY the download")).toHaveLength(1);
+    });
+  });
 });

--- a/src/__tests__/services/panel-secrets.test.ts
+++ b/src/__tests__/services/panel-secrets.test.ts
@@ -115,6 +115,57 @@ describe("panel-secrets (canonical .env store)", () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
+  // #164 — the "token is now active, retry the action" nudge must be gated on an
+  // OUTSTANDING panel_request_secret. The correlation rides the change event as
+  // `requested`: only an agent-driven request (panel_request_secret) sets it; a
+  // Settings-panel slot save, a background reload, or a revoke leaves it false.
+  describe("change event carries request correlation (#164)", () => {
+    it("marks a Settings-style save (no opts) as NOT requested → no retry nudge", () => {
+      const cb = vi.fn();
+      const off = onComfyuiSecretsChanged(cb);
+      setComfyuiSecret("CIVITAI_API_TOKEN", "tok"); // Settings slot path omits opts
+      off();
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenLastCalledWith({ requested: false });
+    });
+
+    it("marks a panel_request_secret save (requested:true) as requested → nudge eligible", () => {
+      const cb = vi.fn();
+      const off = onComfyuiSecretsChanged(cb);
+      setComfyuiSecret("CIVITAI_API_TOKEN", "tok", { requested: true });
+      off();
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenLastCalledWith({ requested: true });
+    });
+
+    it("carries the requesting tabId so ONLY that tab is nudged (never a broadcast)", () => {
+      const cb = vi.fn();
+      const off = onComfyuiSecretsChanged(cb);
+      setComfyuiSecret("CIVITAI_API_TOKEN", "tok", { requested: true, tabId: "tab-xyz" });
+      off();
+      expect(cb).toHaveBeenLastCalledWith({ requested: true, tabId: "tab-xyz" });
+    });
+
+    it("drops tabId for a NON-requested change (a stray tabId can't smuggle a nudge)", () => {
+      const cb = vi.fn();
+      const off = onComfyuiSecretsChanged(cb);
+      // Not requested, but a tabId is present on the raw event — must be ignored.
+      setComfyuiSecret("CIVITAI_API_TOKEN", "tok", { tabId: "tab-xyz" });
+      off();
+      expect(cb).toHaveBeenLastCalledWith({ requested: false, tabId: undefined });
+    });
+
+    it("marks a REVOKE as NOT requested → a removed token never nudges 'retry'", () => {
+      setComfyuiSecret("CIVITAI_API_TOKEN", "tok", { requested: true });
+      const cb = vi.fn();
+      const off = onComfyuiSecretsChanged(cb);
+      expect(removeComfyuiSecret("CIVITAI_API_TOKEN")).toBe(true);
+      off();
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenLastCalledWith({ requested: false });
+    });
+  });
+
   it("removes a secret from .env + process.env and reports absence", () => {
     setComfyuiSecret("CIVITAI_API_TOKEN", "tok");
     expect(removeComfyuiSecret("CIVITAI_API_TOKEN")).toBe(true);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2042,13 +2042,24 @@ export async function runPanelOrchestrator(): Promise<void> {
   // idle so the LIVE comfyui MCP subprocess is recreated WITH the new env, and
   // nudge it to retry the action the secret unblocked. No process restart, no
   // reload fight. The value is never logged — only the env-var KEYS.
-  const unsubscribeSecrets = onComfyuiSecretsChanged(() => {
+  const SECRET_RETRY_NUDGE =
+    "🔑 The API token you just provided is now active for the comfyui tools — retry the action that needed it (e.g. the download that returned 401).";
+  const unsubscribeSecrets = onComfyuiSecretsChanged((change) => {
     manager.setMcpServers(buildMcpServers());
-    manager.restartAllForMcpEnv(
-      "🔑 The API token you just provided is now active for the comfyui tools — retry the action that needed it (e.g. the download that returned 401).",
-    );
+    // EVERY tab's comfyui child needs the new/removed env, so respawn each at its
+    // next idle — but SILENTLY (no nudge). The env rebuild is shared; the "retry
+    // the action" nudge is not, so it must never broadcast to unrelated tabs.
+    // restartAllForMcpEnv() is nudge-preserving, so this can't erase a per-request
+    // nudge already queued on another tab (#164).
+    manager.restartAllForMcpEnv();
+    // NUDGE only the tab whose panel_request_secret this change answers — a
+    // Settings slot save, a background token (re)load, or a revoke leaves
+    // `requested` false and nudges nothing. The per-tab pending-restart map
+    // coalesces, so a repeat event for the same tab can't double-inject (#164).
+    const nudgedTab = change.requested && change.tabId ? change.tabId : null;
+    if (nudgedTab) manager.restartForMcpEnv(agentKeyFor(nudgedTab), SECRET_RETRY_NUDGE);
     logger.info(
-      `[panel-orchestrator] tool secret saved → comfyui MCP env updated + agents respawn on idle (keys: ${comfyuiSecretKeys().join(", ") || "none"})`,
+      `[panel-orchestrator] tool secret ${change.requested ? "saved (requested)" : "changed"} → comfyui MCP env updated + agents respawn on idle${nudgedTab ? ` + retry nudge → tab ${nudgedTab.slice(0, 8)}` : ""} (keys: ${comfyuiSecretKeys().join(", ") || "none"})`,
     );
   });
 

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1275,6 +1275,14 @@ export class PanelAgentManager {
    *  agent so it auto-continues (e.g. retries the download the secret unblocked). */
   restartAllForMcpEnv(nudge?: string): void {
     for (const tabId of this.agents.keys()) {
+      // A SILENT env respawn (no nudge) must NOT downgrade a tab that already has
+      // a retry nudge queued (#164): a concurrent env change on another tab, or a
+      // retarget, would otherwise erase a still-pending per-request nudge before
+      // its busy agent could apply it. Keep the existing nudge; still coalesce.
+      if (nudge === undefined && this.pendingMcpRestart.get(tabId)) {
+        this.applyPendingRestarts(tabId);
+        continue;
+      }
       this.pendingMcpRestart.set(tabId, nudge ?? null);
       // Apply immediately when the tab is already idle; otherwise it fires on the
       // next turn-done via applyPendingRestarts().
@@ -1287,6 +1295,13 @@ export class PanelAgentManager {
    *  at-idle replacement; no-op when the tab has no live agent. */
   restartForMcpEnv(key: string, nudge?: string): void {
     if (!this.agents.has(key)) return;
+    // A SILENT restart (no nudge — a blind-mode toggle #90, a provider-key
+    // refresh #278) must NOT erase a per-request secret nudge already queued for
+    // this tab (#164). A real nudge still replaces/refreshes any existing one.
+    if (nudge === undefined && this.pendingMcpRestart.get(key)) {
+      this.applyPendingRestarts(key);
+      return;
+    }
     this.pendingMcpRestart.set(key, nudge ?? null);
     this.applyPendingRestarts(key);
   }

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -49,6 +49,7 @@ import { flattenUiWorkflow } from "../services/flatten-workflow.js";
 import { getNsfwConsent, setNsfwConsent } from "../services/panel-settings.js";
 import { QueueMonitor } from "../services/queue-monitor.js";
 import {
+  getClient,
   getObjectInfo,
   backfillObjectInfo,
   resetClient,
@@ -773,54 +774,136 @@ function comfyWorkflowsDirs(): string[] {
   ];
 }
 
-/** Read + parse a UI workflow JSON from disk by path. Resolves an absolute path,
- *  OR a path relative to a ComfyUI workflows dir (COMFYUI_PATH/user/default/workflows,
- *  then user/workflows). Guards: must be .json, must exist/be readable, and must
- *  parse to a UI workflow (a top-level `nodes` array). */
-function readWorkflowFromPath(rawPath: string): Record<string, unknown> {
+/** Validate a parsed value is a UI/litegraph workflow (a top-level `nodes`
+ *  array), throwing a source-labelled error otherwise. */
+function assertUiWorkflow(parsed: unknown, sourceLabel: string): Record<string, unknown> {
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`${sourceLabel} did not parse to a workflow object.`);
+  }
+  if (!Array.isArray((parsed as Record<string, unknown>).nodes)) {
+    throw new Error(
+      `${sourceLabel} is not a UI workflow (missing a top-level \`nodes\` array). ` +
+        `Provide a UI/litegraph workflow JSON, not API/prompt format.`,
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Read + parse a UI workflow JSON by path. Resolves an ABSOLUTE path off the
+ *  orchestrator's disk, or a RELATIVE name authoritatively through the CONNECTED
+ *  ComfyUI's userdata API — which resolves under the server's RUNTIME
+ *  `--user-directory` (custom or default), so the RIGHT file always wins and a
+ *  stale same-named file under the guessed default dir can never shadow it
+ *  (#202). Only when the server can't serve the name (404 / unreachable) does it
+ *  fall back to the orchestrator's guessed local workflows dirs, so a
+ *  disk-staged file still opens. Guards: must be .json and must parse to a UI
+ *  workflow (a top-level `nodes` array). Fails loudly (never loads the wrong
+ *  file) when the name resolves nowhere. */
+async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unknown>> {
   const p = (rawPath ?? "").trim();
   if (!p) throw new Error("Provide a non-empty `path` to a workflow .json file.");
   if (!/\.json$/i.test(p)) {
     throw new Error(`"${p}" is not a .json file — pass the path to a ComfyUI workflow JSON.`);
   }
 
-  // Build the candidate absolute paths to try, in order.
-  const candidates: string[] = [];
+  const readLocal = (resolved: string): Record<string, unknown> => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(resolved, "utf8"));
+    } catch (err) {
+      throw new Error(`"${resolved}" is not valid JSON: ${(err as Error).message}`);
+    }
+    return assertUiWorkflow(parsed, `"${resolved}"`);
+  };
+
+  // ABSOLUTE path → the orchestrator's own disk, unchanged.
   if (isAbsolute(p)) {
-    candidates.push(resolve(p));
-  } else {
-    // Relative to each ComfyUI workflows dir (the common case — a just-staged file).
-    for (const dir of comfyWorkflowsDirs()) candidates.push(resolve(dir, p));
-    // Also relative to the orchestrator's CWD as a last resort.
-    candidates.push(resolve(process.cwd(), p));
-  }
-
-  const resolved = candidates.find((c) => existsSync(c) && statSync(c).isFile());
-  if (!resolved) {
-    const where = isAbsolute(p)
-      ? candidates[0]
-      : `the ComfyUI workflows dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}) or an absolute path`;
+    const resolved = resolve(p);
+    if (existsSync(resolved) && statSync(resolved).isFile()) return readLocal(resolved);
     throw new Error(
-      `No workflow file at "${p}". Looked under ${where}. Pass an absolute path, or a name relative to the ComfyUI workflows folder.`,
+      `No workflow file at "${p}". Looked under ${resolved}. ` +
+        `Pass an absolute path, or a name relative to the ComfyUI workflows folder.`,
     );
   }
 
-  let parsed: unknown;
+  // RELATIVE name → the AUTHORITATIVE source is the connected ComfyUI's userdata
+  // API (the SAME source list_workflows / panel_open_workflow read): it resolves
+  // under the runtime `--user-directory`, so a CUSTOM user-dir loads the correct
+  // file and a stale same-named file under the orchestrator's guessed default
+  // dir can't shadow it (#202). Try it FIRST; fall back to local disk ONLY when
+  // the server genuinely lacks the name (404) or can't be reached — NOT when it
+  // refuses (401/403/5xx) or returns a malformed file, which must surface their
+  // own honest error rather than silently loading a possibly-stale local file.
+  type Outcome =
+    | { kind: "found"; parsed: unknown }
+    | { kind: "malformed"; detail: string } // 2xx but bad JSON → error, no fallback
+    | { kind: "refused"; detail: string } // non-404 HTTP error → error, no fallback
+    | { kind: "absent"; detail: string } // 404 → local fallback allowed
+    | { kind: "unreachable"; detail: string }; // transport failure → local fallback allowed
+  let outcome: Outcome;
   try {
-    parsed = JSON.parse(readFileSync(resolved, "utf8"));
+    const client = getClient();
+    const encoded = encodeURIComponent(`workflows/${p.replace(/^[\\/]+/, "")}`);
+    const res = await client.fetchApi(`/api/userdata/${encoded}`);
+    if (res.ok) {
+      // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its
+      // OWN error (no fallback), while ComfyUI's "200 + EMPTY body = file does
+      // not exist" convention (some builds; see parseWorkflowLock) is treated as
+      // an ABSENCE that DOES allow the local fallback — not a malformed error.
+      const body = (await res.text()).trim();
+      if (body === "") {
+        outcome = { kind: "absent", detail: "was not in the ComfyUI userdata library (empty 200 response)" };
+      } else {
+        try {
+          outcome = { kind: "found", parsed: JSON.parse(body) };
+        } catch (err) {
+          outcome = { kind: "malformed", detail: err instanceof Error ? err.message : String(err) };
+        }
+      }
+    } else if (res.status === 404) {
+      outcome = { kind: "absent", detail: "was not in the ComfyUI userdata library (HTTP 404)" };
+    } else {
+      outcome = { kind: "refused", detail: `ComfyUI userdata library returned HTTP ${res.status}` };
+    }
   } catch (err) {
-    throw new Error(`"${resolved}" is not valid JSON: ${(err as Error).message}`);
+    outcome = {
+      kind: "unreachable",
+      detail: `ComfyUI userdata library was unreachable (${err instanceof Error ? err.message : String(err)})`,
+    };
   }
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error(`"${resolved}" did not parse to a workflow object.`);
+
+  if (outcome.kind === "found") {
+    // A found-but-non-UI file must surface its own honest error, not silence.
+    return assertUiWorkflow(outcome.parsed, `The workflow "${p}" from the ComfyUI userdata library`);
   }
-  if (!Array.isArray((parsed as Record<string, unknown>).nodes)) {
+  if (outcome.kind === "malformed") {
+    throw new Error(`The workflow "${p}" in the ComfyUI userdata library is not valid JSON: ${outcome.detail}`);
+  }
+  if (outcome.kind === "refused") {
+    // Server is reachable but did not serve the file — do NOT fall back to a
+    // possibly-stale local file; report the status honestly.
     throw new Error(
-      `"${resolved}" is not a UI workflow (missing a top-level \`nodes\` array). ` +
-        `Provide a UI/litegraph workflow JSON, not API/prompt format.`,
+      `Could not read "${p}" from the connected ComfyUI: ${outcome.detail}. ` +
+        `Pass an absolute path, or a name shown by panel_list_workflows.`,
     );
   }
-  return parsed as Record<string, unknown>;
+
+  // outcome.kind is "absent" (404) or "unreachable" — fall back to the
+  // orchestrator's guessed local workflows dirs (best-effort; only meaningful on
+  // a same-machine ComfyUI whose user-dir matches the default layout, or a file
+  // staged straight to disk).
+  const localCandidates = [
+    ...comfyWorkflowsDirs().map((dir) => resolve(dir, p)),
+    resolve(process.cwd(), p), // orchestrator CWD as a last local resort
+  ];
+  const local = localCandidates.find((c) => existsSync(c) && statSync(c).isFile());
+  if (local) return readLocal(local);
+
+  throw new Error(
+    `No workflow file at "${p}". It ${outcome.detail}, and it is not under the orchestrator's workflows ` +
+      `dir (${comfyWorkflowsDirs().join(" or ") || "COMFYUI_PATH not set"}). ` +
+      `Pass an absolute path, or a name shown by panel_list_workflows.`,
+  );
 }
 
 // IMPORTANT (Codex parity): use `z.array(z.number())` — NOT `z.tuple([...])` — for
@@ -1048,7 +1131,7 @@ async function resolveWorkflowInput(
   ctx: PanelToolCtx,
 ): Promise<Record<string, unknown>> {
   if (args.pack) return readPackWorkflow(args.pack as string);
-  if (args.path) return readWorkflowFromPath(args.path as string);
+  if (args.path) return await readWorkflowFromPath(args.path as string);
   if (args.graph != null) {
     return (typeof args.graph === "string"
       ? JSON.parse(args.graph as string)
@@ -1641,9 +1724,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Read the (large) pack graph SERVER-SIDE so it never enters the agent's context.
             data = readPackWorkflow(args.pack as string);
           } else if (args.path) {
-            // Read an arbitrary workflow JSON off the orchestrator's local disk —
-            // same server-side-read pattern as `pack`, keeping the big JSON out of chat.
-            data = readWorkflowFromPath(args.path as string);
+            // Read an arbitrary workflow JSON server-side — a local disk path, or
+            // (for a relative name under a custom --user-directory) the connected
+            // ComfyUI's userdata API — keeping the big JSON out of chat (#202).
+            data = await readWorkflowFromPath(args.path as string);
           } else if (args.graph != null) {
             data = typeof args.graph === "string" ? JSON.parse(args.graph as string) : args.graph;
           } else {
@@ -2001,7 +2085,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
                 "The built-in comfyui server takes secrets as env vars — use target_kind 'env' (e.g. key 'CIVITAI_API_TOKEN').",
               );
             }
-            setComfyuiSecret(args.key as string, `${(args.value_prefix as string) ?? ""}${secret}`);
+            setComfyuiSecret(args.key as string, `${(args.value_prefix as string) ?? ""}${secret}`, {
+              // This save ANSWERS an outstanding agent secret request — mark it so
+              // the orchestrator injects the "retry the action" nudge, and carry
+              // the requesting tab so ONLY that tab's agent is nudged (never a
+              // broadcast to unrelated tabs). A Settings-panel slot save omits
+              // both and never nudges (#164).
+              requested: true,
+              tabId: ctx.tabId,
+            });
             // Redacted ack ONLY — the secret never enters the agent's context. The
             // respawn is deferred to this turn's end, so this is accurate.
             return ok(

--- a/src/services/panel-secrets.ts
+++ b/src/services/panel-secrets.ts
@@ -113,11 +113,32 @@ export function panelSecretsPath(): string {
 // emitter is enough to tell the orchestrator to re-inject + respawn.
 const emitter = new EventEmitter();
 
-/** Subscribe to "a comfyui tool secret changed". Returns an unsubscribe fn. */
-export function onComfyuiSecretsChanged(cb: () => void): () => void {
-  emitter.on("change", cb);
+/** Payload for a comfyui tool-secret change. `requested` is true ONLY when the
+ *  change ANSWERS an outstanding panel_request_secret (the agent asked the user
+ *  for a token to unblock an action) — a Settings-panel slot save, a background
+ *  (re)load/migration, or a revoke is `false`. The orchestrator gates the
+ *  "token active — retry the action" nudge on this so it is never injected when
+ *  no request was outstanding (#164). */
+export interface ComfyuiSecretChange {
+  requested: boolean;
+  /** The panel tab whose panel_request_secret this change answers, when
+   *  `requested` — so the orchestrator can nudge ONLY that tab's agent to retry
+   *  (never a broadcast to unrelated tabs). Undefined for non-request changes. */
+  tabId?: string;
+}
+
+/** Subscribe to "a comfyui tool secret changed". The callback receives whether
+ *  the change answered an outstanding secret REQUEST and, if so, the requesting
+ *  tab (see ComfyuiSecretChange). Returns an unsubscribe fn. */
+export function onComfyuiSecretsChanged(cb: (change: ComfyuiSecretChange) => void): () => void {
+  const handler = (payload?: Partial<ComfyuiSecretChange>) =>
+    cb({
+      requested: payload?.requested === true,
+      tabId: payload?.requested === true ? payload?.tabId : undefined,
+    });
+  emitter.on("change", handler);
   return () => {
-    emitter.off("change", cb);
+    emitter.off("change", handler);
   };
 }
 
@@ -227,7 +248,11 @@ export function isAllowedSecretKey(key: string): boolean {
  * on idle (the respawn reloads .env → the child gets the new key). Rejects a
  * non-allowlisted key so a stray key can never be written.
  */
-export function setEnvSecret(key: string, value: string): void {
+export function setEnvSecret(
+  key: string,
+  value: string,
+  opts: { requested?: boolean; tabId?: string } = {},
+): void {
   const trimmed = key.trim();
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
     throw new Error(`Invalid env var name "${key}" — use a valid shell identifier.`);
@@ -244,7 +269,11 @@ export function setEnvSecret(key: string, value: string): void {
   // agent-ONLY provider key (OPENROUTER/GLM/KIMI…) previously restarted every
   // agent with that nonsensical download-retry message. Agent-only keys fire
   // just "agentChange" (readiness/model refresh) below.
-  if (isAllowedComfyuiSecretKey(trimmed)) emitter.emit("change");
+  // `requested` rides the change so the orchestrator only injects the retry
+  // nudge when this save ANSWERS an outstanding panel_request_secret — a
+  // Settings slot save / background reload / revoke leaves it false (#164).
+  if (isAllowedComfyuiSecretKey(trimmed))
+    emitter.emit("change", { requested: opts.requested === true, tabId: opts.tabId });
   if (isAllowedAgentSecretKey(trimmed)) emitter.emit("agentChange"); // flip provider readiness live
 }
 
@@ -374,7 +403,11 @@ export function comfyuiSecretKeys(): string[] {
  * a change so the orchestrator re-injects it and respawns the server. `value` is
  * the raw secret (the caller already applied any prefix); it is never logged.
  */
-export function setComfyuiSecret(key: string, value: string): void {
+export function setComfyuiSecret(
+  key: string,
+  value: string,
+  opts: { requested?: boolean; tabId?: string } = {},
+): void {
   const trimmed = key.trim();
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
     throw new Error(`Invalid env var name "${key}" — use a valid shell identifier (letters, digits, underscore).`);
@@ -385,7 +418,10 @@ export function setComfyuiSecret(key: string, value: string): void {
       `Env var "${trimmed}" is not an accepted comfyui tool secret. Allowed: ${COMFYUI_SECRET_ENV_ALLOWLIST.join(", ")}.`,
     );
   }
-  setEnvSecret(trimmed, value); // canonical store = ~/.comfyui-mcp/.env
+  // `opts.requested` is set ONLY by panel_request_secret (an agent-driven token
+  // ask) so the orchestrator can nudge "retry the action"; the Settings slot
+  // save path (setPanelSecret) omits it → no spurious nudge (#164).
+  setEnvSecret(trimmed, value, opts); // canonical store = ~/.comfyui-mcp/.env
 }
 
 /** Remove a stored comfyui secret. Returns false if absent. Emits on removal. */

--- a/src/services/queue-monitor.stall.test.ts
+++ b/src/services/queue-monitor.stall.test.ts
@@ -1,0 +1,108 @@
+// queue-monitor.stall.test.ts — the liveness-gated stall verdict (#183).
+//
+// The old heuristic flagged a stall on a flat "no FORWARD progress for N
+// seconds", which false-fires on a legitimately long, progress-silent node
+// (tiled VAE decode, audio/video sampling, a big model load): ComfyUI emits no
+// progress tick for minutes while genuinely busy. report() now gates the verdict
+// on server LIVENESS — a job is stalled only when the server has ALSO gone dark
+// here (no ws frame + no successful /queue poll within the window). A reachable
+// ComfyUI keeps the 1 Hz poll fresh, so a busy decode stays live; a crashed /
+// wedged server lets the heartbeat lapse → a real stall still surfaces. A hard
+// floor of 30 min backstops a genuine in-node deadlock on a reachable server.
+import { beforeEach, describe, expect, it } from "vitest";
+import { QueueMonitor, type CompletionEvent, type StallReport } from "./queue-monitor.js";
+
+type Priv = {
+  url: string | null;
+  stopped: boolean;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    currentNode: string | null;
+    progressValue: number | null;
+    progressMax: number | null;
+    queueRemaining: number;
+    lastActivityTs: number | null;
+    lastFrameTs: number | null;
+    lastServerAliveTs: number | null;
+    lastCompleted: CompletionEvent | null;
+  };
+  report(stallMs: number): StallReport;
+};
+const priv = QueueMonitor as unknown as Priv;
+
+const STALL_MS = 180_000; // the default 180s threshold
+const HARD_FLOOR_MS = 30 * 60 * 1000;
+
+/** Put the monitor into "a job has been running, last forward progress was
+ *  `idleForMs` ago" and set the two liveness heartbeats explicitly. */
+function primeRunning(opts: {
+  idleForMs: number;
+  serverAliveAgoMs: number | null; // null = never / stale beyond memory
+  wsFrameAgoMs: number | null;
+  currentNode?: string | null;
+}): void {
+  const now = Date.now();
+  priv.state.runningPromptId = "prompt-1";
+  priv.state.currentNode = opts.currentNode ?? "42";
+  priv.state.progressValue = 4;
+  priv.state.progressMax = 8;
+  priv.state.queueRemaining = 1;
+  priv.state.lastActivityTs = now - opts.idleForMs;
+  priv.state.lastServerAliveTs = opts.serverAliveAgoMs == null ? null : now - opts.serverAliveAgoMs;
+  priv.state.lastFrameTs = opts.wsFrameAgoMs == null ? null : now - opts.wsFrameAgoMs;
+}
+
+beforeEach(() => {
+  priv.url = "http://127.0.0.1:9999";
+  priv.stopped = false;
+  priv.state.connected = true;
+  priv.state.runningPromptId = null;
+  priv.state.currentNode = null;
+  priv.state.progressValue = null;
+  priv.state.progressMax = null;
+  priv.state.queueRemaining = 0;
+  priv.state.lastActivityTs = null;
+  priv.state.lastFrameTs = null;
+  priv.state.lastServerAliveTs = null;
+  priv.state.lastCompleted = null;
+});
+
+describe("QueueMonitor.report — liveness-gated stall (#183)", () => {
+  it("does NOT flag a busy long node: no forward progress but the /queue poll is fresh", () => {
+    // The reporter's case: an LTX video/VAE step ran ~443s with no panel-visible
+    // progress while ComfyUI was perfectly alive (answering /queue every second).
+    primeRunning({ idleForMs: 443_000, serverAliveAgoMs: 800, wsFrameAgoMs: null });
+    const rep = priv.report(STALL_MS);
+    expect(rep.stalled).toBe(false);
+    expect(rep.stalledForMs).toBe(0);
+  });
+
+  it("does NOT flag a busy node kept alive by ws frames alone (poll heartbeat absent)", () => {
+    primeRunning({ idleForMs: 443_000, serverAliveAgoMs: null, wsFrameAgoMs: 1_000 });
+    expect(priv.report(STALL_MS).stalled).toBe(false);
+  });
+
+  it("DOES flag a real stall: no forward progress AND the server has gone dark here", () => {
+    // Server stopped answering /queue and stopped sending ws frames well beyond
+    // the window — a crashed / event-loop-wedged ComfyUI, not a slow node.
+    primeRunning({ idleForMs: STALL_MS + 60_000, serverAliveAgoMs: STALL_MS + 60_000, wsFrameAgoMs: STALL_MS + 60_000 });
+    const rep = priv.report(STALL_MS);
+    expect(rep.stalled).toBe(true);
+    expect(rep.stalledForMs).toBeGreaterThanOrEqual(STALL_MS);
+    expect(rep.runningPromptId).toBe("prompt-1");
+  });
+
+  it("hard-floor backstop: an in-node deadlock on a still-reachable server flags after 30 min", () => {
+    // Server still answering (fresh poll) but ZERO forward progress for > 30 min
+    // — a genuine deadlock that must not be suppressed forever.
+    primeRunning({ idleForMs: HARD_FLOOR_MS + 60_000, serverAliveAgoMs: 500, wsFrameAgoMs: null });
+    expect(priv.report(STALL_MS).stalled).toBe(true);
+  });
+
+  it("never flags when nothing is running", () => {
+    priv.state.runningPromptId = null;
+    priv.state.lastActivityTs = Date.now() - 10 * HARD_FLOOR_MS;
+    expect(priv.report(STALL_MS).stalled).toBe(false);
+  });
+});

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -46,6 +46,15 @@ interface MonitorState {
   // progress value ticked up) while a job runs. A stuck step re-emits the same
   // progress value, which must NOT refresh this — that's how we see the stall.
   lastActivityTs: number | null;
+  // LIVENESS heartbeats — the server is alive here (even if a long node emits no
+  // FORWARD progress) when EITHER is fresh (#183):
+  //   lastFrameTs      — any ws frame of any type arrived (server socket alive).
+  //   lastServerAliveTs — a /queue HTTP poll SUCCEEDED (server answered).
+  // A busy, progress-silent node (tiled VAE decode, audio/video sampling, a big
+  // model load) keeps the 1 Hz poll fresh, so it is NOT mistaken for a wedge; a
+  // server that stops answering lets both lapse → a real stall still surfaces.
+  lastFrameTs: number | null;
+  lastServerAliveTs: number | null;
   // The most recent completed run (from the /history tail diff or, on older
   // ComfyUI, the execution_success/error WS events). Sticky: survives idle so a
   // tab that connects late still learns what just finished.
@@ -99,6 +108,12 @@ const RECONNECT_MS = 5000;
 // still saturates it (every entry new), we log the potential gap instead of
 // silently claiming coverage.
 const HISTORY_TAIL_ITEMS = 32;
+// Absolute floor of zero-forward-progress time after which a running job is
+// flagged as stalled EVEN when the server still looks alive here — the backstop
+// for a genuine in-node deadlock on a reachable ComfyUI (#183). Far beyond any
+// legitimate single-node runtime (a long tiled VAE decode / video sample is
+// minutes, not half an hour), so it never trips on a healthy render.
+const HARD_STALL_FLOOR_MS = 30 * 60 * 1000; // 30 minutes
 
 class QueueMonitorImpl {
   private ws: WebSocket | null = null;
@@ -120,6 +135,8 @@ class QueueMonitorImpl {
     progressMax: null,
     queueRemaining: 0,
     lastActivityTs: null,
+    lastFrameTs: null,
+    lastServerAliveTs: null,
     lastCompleted: null,
   };
   // ---- HTTP-poll bookkeeping (the broadcast-safe channel on modern ComfyUI) ----
@@ -163,6 +180,10 @@ class QueueMonitorImpl {
     this.completedReported.clear();
     this.pendingCompletions.length = 0;
     this.state.lastCompleted = null;
+    // Liveness heartbeats belong to the OLD target — reset so a fresh target's
+    // stall clock doesn't inherit a stale "alive" (or a stale "dark") reading.
+    this.state.lastFrameTs = null;
+    this.state.lastServerAliveTs = null;
     this.connect();
   }
 
@@ -314,6 +335,10 @@ class QueueMonitorImpl {
     } catch {
       return;
     }
+    // Any decodable frame proves the server's ws is alive right now — a liveness
+    // heartbeat independent of FORWARD progress, so a long progress-silent node
+    // isn't mistaken for a wedge (#183).
+    this.state.lastFrameTs = Date.now();
     const data = (msg.data ?? {}) as Record<string, unknown>;
     switch (msg.type) {
       case "status": {
@@ -498,6 +523,11 @@ class QueueMonitorImpl {
   private applyQueue(raw: unknown, fetchStart: number): void {
     const q = raw as { queue_running?: unknown; queue_pending?: unknown } | null;
     if (!q || typeof q !== "object") return;
+    // The server answered this /queue poll → it's alive here right now. This is
+    // the heartbeat that keeps a long, progress-silent node (VAE decode, model
+    // load) from being flagged as stalled — and that lapses when the server
+    // stops answering, letting a real stall surface (#183).
+    this.state.lastServerAliveTs = fetchStart;
     const running = Array.isArray(q.queue_running) ? q.queue_running : [];
     const pending = Array.isArray(q.queue_pending) ? q.queue_pending : [];
     this.state.queueRemaining = running.length + pending.length;
@@ -609,9 +639,31 @@ class QueueMonitorImpl {
   /** Stall/backlog report for the turn-start injector. */
   report(stallMs: number): StallReport {
     const running = this.state.runningPromptId !== null;
+    const now = Date.now();
     const queueDepth = Math.max(running ? 1 : 0, this.state.queueRemaining);
-    const idleFor = running && this.state.lastActivityTs ? Date.now() - this.state.lastActivityTs : 0;
-    const stalled = running && idleFor >= stallMs;
+    const idleFor = running && this.state.lastActivityTs ? now - this.state.lastActivityTs : 0;
+    // LIVENESS GATE (#183): a legitimately long node emits NO forward progress
+    // for minutes (tiled VAE decode, audio/video sampling, a big model load), so
+    // "no progress for N seconds" alone false-flagged healthy renders. A job is
+    // only stalled when the server has ALSO gone dark HERE — no ws frame and no
+    // successful /queue poll within the window. A reachable ComfyUI keeps the
+    // 1 Hz poll fresh, so a busy decode stays live and is NOT flagged; a server
+    // that stops answering (crashed / event-loop wedged) lets the heartbeat
+    // lapse → a real stall still surfaces.
+    const heartbeatTs = Math.max(this.state.lastServerAliveTs ?? 0, this.state.lastFrameTs ?? 0);
+    const serverAlive = heartbeatTs > 0 && now - heartbeatTs < stallMs;
+    // Backstop so a genuine in-node DEADLOCK on a still-reachable server isn't
+    // suppressed FOREVER: after a long hard floor of zero forward progress, flag
+    // regardless of liveness. A real deadlock usually holds Python's GIL, which
+    // also freezes ComfyUI's own HTTP handler → the /queue heartbeat lapses and
+    // `serverAlive` catches it at stallMs without this floor; the floor only
+    // covers the rarer non-GIL wedge (a node stuck in a network/IO wait) that
+    // keeps HTTP alive. The floor is a deliberate finite tradeoff: a healthy but
+    // progress-silent node exceeding it is re-flagged (unavoidable — "busy" and
+    // "wedged" are indistinguishable from outside past some horizon), so it is
+    // set far beyond any legitimate single-node runtime.
+    const hardStalled = running && idleFor >= Math.max(stallMs, HARD_STALL_FLOOR_MS);
+    const stalled = running && idleFor >= stallMs && (!serverAlive || hardStalled);
     const progress =
       this.state.progressValue !== null && this.state.progressMax !== null
         ? `${this.state.progressValue}/${this.state.progressMax}`


### PR DESCRIPTION
Fixes a cluster of three independent, stale panel-tracker bugs whose fix code lives in this orchestrator. Each is isolated and independently verified against `main`.

The issues are filed on the **comfyui-mcp-panel** tracker (umbrella), so the closing refs below are cross-repo:

Closes artokun/comfyui-mcp-panel#164
Closes artokun/comfyui-mcp-panel#183
Closes artokun/comfyui-mcp-panel#202

**Dropped from this PR: comfyui-mcp-panel#209** (storyboard preview frames left in ComfyUI `input/`). Its code (`uploadBlobToInput` + storyboard contact-sheet generation) lives entirely in the **separate comfyui-mcp-panel browser-JS repo** (`web/js/comfyui-mcp-panel.js`), not in this orchestrator — the orchestrator never receives the uploaded input filename to clean it up. It needs its own panel-repo PR and cannot land here.

## #164 — spurious "🔑 API token is now active — retry the action" notice
`onComfyuiSecretsChanged` fired the retry nudge on **any** comfyui secret change (a Settings slot save, a background reload, a revoke) and **broadcast it to every tab**, with no correlation to an outstanding `panel_request_secret`. The change now carries `requested` + the requesting `tabId`; the nudge is injected **only** for a request-answering change and **only** to that tab's agent. All tabs still respawn silently to pick up the new env, and `restartAllForMcpEnv()`/`restartForMcpEnv()` are now **nudge-preserving** so a silent restart (blind-mode toggle, provider-key refresh, unrelated env change) can't erase a queued per-request nudge. Per-tab coalescing dedupes repeat fires.

## #183 — stall monitor falsely flagged busy long-running nodes
A flat "no forward progress for 180s" mis-fired on legitimately long, progress-silent steps (tiled VAE decode, audio/video sampling, big model loads). `report()` now gates the stall verdict on server **liveness**: stalled only when the server has also gone dark here (no WS frame **and** no successful `/queue` poll within the window). A reachable ComfyUI keeps the 1 Hz poll fresh → a busy decode stays live; a crashed/wedged server still stalls at the threshold. A 30-min hard floor backstops a genuine in-node deadlock on a reachable server so detection is never suppressed forever.

## #202 — panel_load_workflow relative paths broke under a custom --user-directory
`comfyWorkflowsDirs()` only guessed `COMFYUI_PATH/user/default/workflows`, ignoring the runtime `--user-directory`. `readWorkflowFromPath` now resolves a relative name **authoritatively** through the connected ComfyUI's userdata API (which honors the runtime user-dir), so the right file wins and a stale same-named default-dir file can't shadow it. Local disk is a fallback **only** on a genuine absence (404 or ComfyUI's "200 + empty body" convention) or an unreachable server; a refused status (401/403/5xx) or malformed body surfaces its own honest error and never loads a colliding local file. Absolute paths and the default-dir case are unchanged.

## Tests
Regression tests added for each bug driving the real path:
- `panel-secrets.test.ts` — request-correlation (`requested`/`tabId`) on save, revoke, Settings-save.
- `restart-coalesce.test.ts` — silent restarts preserve a queued per-request nudge.
- `queue-monitor.stall.test.ts` — busy-node no false positive; dark-server real stall; 30-min backstop.
- `panel-load-workflow-userdata.test.ts` — runtime file wins over colliding default-dir file; 404 & empty-200 local fallback; refused/malformed surface honestly.

Full unit suite green (the one unrelated pre-existing `node-dev` ripgrep-vs-builtin failure is environment-dependent and untouched here). `tsc --noEmit` clean. Codex adversarial review: **VERDICT: PASS** (5 rounds; caught and fixed real correlation/clobber and fallback-classification issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)