### PR TITLE
fix(panel): panel_set_widget can clear a widget to empty string (#347)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -131,6 +131,72 @@ describe("panel-tools: copy/paste + subgraph blueprints", () => {
   });
 });
 
+describe("panel-tools: panel_set_widget (empty-string clear, issue #347)", () => {
+  it("forwards a normal non-empty value unchanged", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "text_input", value: "hello" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_set_widget",
+      node_id: 39,
+      widget: "text_input",
+      value: "hello",
+    });
+  });
+
+  it("forwards an explicit empty-string value (present-but-empty is honored)", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "text_input", value: "" },
+      ctx,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_set_widget",
+      node_id: 39,
+      widget: "text_input",
+      value: "",
+    });
+  });
+
+  it("clear:true sets the widget to an empty string even when value is absent", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    // Simulates the client that drops the empty-string value from the payload.
+    await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "text_input", clear: true },
+      ctx,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      cmd: "graph_set_widget",
+      node_id: 39,
+      widget: "text_input",
+      value: "",
+    });
+  });
+
+  it("clear:true overrides any provided value", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "text_input", value: "stale", clear: true },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({ cmd: "graph_set_widget", value: "" });
+  });
+
+  it("errors (does not forward) when neither value nor clear is provided", async () => {
+    const { ctx, calls } = makeFakeCtx();
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "text_input" },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});
+
 describe("panel-tools: panel_set_node_mode (bypass/mute/active)", () => {
   it("is present in the shared def list", () => {
     const names = buildPanelToolDefs().map((d) => d.name);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1788,16 +1788,31 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_widget",
-      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z.",
+      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works).",
       {
         node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
         value: z
           .union([z.string(), z.number(), z.boolean()])
-          .describe("New value. Must match the widget's expected type."),
+          .optional()
+          .describe("New value. Must match the widget's expected type. Optional only when `clear: true` is set (which forces an empty string)."),
+        clear: z
+          .boolean()
+          .optional()
+          .describe("Set true to clear the widget to an empty string (\"\"). Escape hatch for when a client cannot carry an empty-string `value` through tool-arg JSON. Overrides `value`."),
       },
-      async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value: args.value }),
+      async (args: A, ctx) => {
+        // Distinguish "value present but empty" from "value absent" by key
+        // presence, NOT a truthiness check — an empty string is a legitimate
+        // value. `clear: true` is the transport-independent way to set "".
+        const value = args.clear === true ? "" : args.value;
+        if (value === undefined) {
+          return fail(
+            "panel_set_widget needs a `value`. To set an empty string, pass `clear: true` (some clients drop an empty-string `value`).",
+          );
+        }
+        return ctx.call({ cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value });
+      },
     ),
     def(
       "panel_move_node",


### PR DESCRIPTION
## What

`panel_set_widget` could not set a widget to an empty string. Some MCP clients drop an empty-string `value` from the serialized tool-arg JSON (`{"value": }` fails to parse), so `""` never reached the handler. The server-side zod union already accepted `""`, but there was no transport-independent way to express it — clearing a text prompt (e.g. `Florence2Run.text_input`) was impossible without a full save/patch/reload detour.

## Fix

- Add a documented `clear: true` escape hatch that forces `value = ""`. Always survives serialization.
- Make `value` optional so `clear` can stand alone; `clear` overrides `value` when both are given.
- Resolve the value by **key presence**, not truthiness — a present-but-empty `value: ""` is honored, and `absent` is distinguished from `""`. When neither `value` nor `clear` is supplied, the handler returns an error and forwards nothing.
- Normal non-empty sets are unchanged. Both transports (Claude in-process, Codex HTTP) share the single def, so the escape hatch is identical everywhere.

## Tests

5 new cases in `panel-tools.test.ts`: non-empty forward unchanged, explicit `value: ""` honored, `clear:true` sets `""` with value absent, `clear:true` overrides a stale value, and error/no-forward when neither is given. Full suite green (only the pre-existing ripgrep sandbox exception fails); tsc clean.

Adversarial codex self-review: VERDICT: PASS.

Closes #347