### PR TITLE
fix(ui-bridge): proactively gate a bridge command once proven unsupported (#236)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -997,6 +997,97 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
       /too old for "graph_query".*0\.6\.8.*update/is,
     );
   });
+
+  // #236 — the FIRST call to an unsupported command still round-trips to the
+  // panel (there's no way to know in advance), but every LATER call in the same
+  // session must be gated proactively: rejected with the same actionable message
+  // WITHOUT ever reaching the panel again. FAIL-before: the old code always
+  // re-dispatched and re-parsed the panel's raw "Unknown command" string on every
+  // single call.
+  it("gates a REPEAT call to an already-proven-unsupported command without re-dispatching to the panel", async () => {
+    const sock = await connectPanel(undefined);
+    let dispatchCount = 0;
+    sock.send(JSON.stringify({ type: "hello", tab_id: "old-tab-2", title: "wf", panel_version: "0.6.8" }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        dispatchCount += 1;
+        sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // First call: genuinely round-trips (the only way to discover it's unsupported).
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-2" })).rejects.toThrow(
+      /too old for "graph_query"/i,
+    );
+    expect(dispatchCount).toBe(1);
+
+    // Second call: gated proactively — same actionable message, but the panel
+    // must NEVER see a second dispatch of this command.
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-2" })).rejects.toThrow(
+      /too old for "graph_query".*0\.6\.8.*update/is,
+    );
+    expect(dispatchCount).toBe(1);
+  });
+
+  // A command that has NEVER been tried on this connection must never be
+  // pre-emptively blocked by another command's failure (no blanket gate — only
+  // the SPECIFIC cmd that was empirically proven unsupported is gated).
+  it("does NOT gate a different, never-tried command after another command was proven unsupported", async () => {
+    const sock = await connectPanel(undefined);
+    sock.send(JSON.stringify({ type: "hello", tab_id: "old-tab-3", title: "wf", panel_version: "0.6.8" }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (!msg.rid || !msg.cmd) return;
+      if (msg.cmd === "graph_query") {
+        sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }));
+      } else {
+        // Every other command this (otherwise old) panel actually DOES support.
+        sock.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-3" })).rejects.toThrow(
+      /too old for "graph_query"/i,
+    );
+    // graph_add_node must still be dispatched normally and succeed.
+    const res = await bridge.send({ cmd: "graph_add_node" }, { tabId: "old-tab-3" });
+    expect(res).toEqual({ cmd: "graph_add_node" });
+  });
+
+  // A reconnect (fresh hello) may be an updated panel build — a previously
+  // learned "unsupported" verdict must never carry over and permanently block a
+  // command the NEW connection could actually support.
+  it("clears the learned-unsupported set on a fresh hello (reconnect may be an updated panel)", async () => {
+    const sock1 = await connectPanel(undefined);
+    sock1.send(JSON.stringify({ type: "hello", tab_id: "old-tab-4", title: "wf", panel_version: "0.6.8" }));
+    sock1.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        sock1.send(JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-4" })).rejects.toThrow(
+      /too old for "graph_query"/i,
+    );
+
+    // Reconnect under the same tab id with a NEWER panel that now supports it.
+    const sock2 = await connectPanel(undefined);
+    sock2.send(JSON.stringify({ type: "hello", tab_id: "old-tab-4", title: "wf", panel_version: "0.11.4" }));
+    sock2.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        sock2.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-4" });
+    expect(res).toEqual({ cmd: "graph_query" });
+  });
 });
 
 // ── #486: a validated ask_user answer that lands AFTER the reply timeout must be

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -96,11 +96,36 @@ interface Conn {
    *  (see makeUnknownCommandError) — the panel gained these bridge commands in
    *  0.11.4, so older builds reject graph_* / ui_* with a raw dispatch error. */
   panelVersion?: string;
+  /** Commands THIS connection has already proven it doesn't support, via a real
+   *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
+   *  here, every later call is gated proactively — rejected before it ever
+   *  reaches the panel, with the same actionable message — instead of paying a
+   *  full round trip (and re-parsing the panel's raw error) every single time.
+   *  Never pre-populated from panelVersion alone: some graph_ and ui_ commands
+   *  predate 0.11.4 and DO work on older panels, so only an EMPIRICALLY observed
+   *  rejection from this exact connection can prove a command unsupported —
+   *  guaranteeing this never blocks a call that would otherwise have succeeded.
+   *  Reset to empty on every hello (a reconnect may be a freshly updated panel
+   *  build, so a stale unsupported-verdict must never carry over). */
+  unsupportedCmds: Set<string>;
 }
 
 /** Panel build that first implements the full graph_* / ui_* bridge command set.
  *  Reports of "Unknown command <x>" come from panels older than this. */
 export const MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS = "0.11.4";
+
+/** The actionable "update your panel" message for a command a connected panel has
+ *  been discovered NOT to support. Shared by the reactive path (the panel's own
+ *  "Unknown command" reply, mapped by makeUnknownCommandError) and the proactive
+ *  gate (#236 — a command already known-unsupported for THIS connection, from an
+ *  earlier call in the same session) so both produce the identical message. */
+function buildPanelTooOldError(cmd: string, panelVersion?: string): Error {
+  const detected = panelVersion ? ` (detected ${panelVersion})` : "";
+  return new Error(
+    `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
+      `to ≥${MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`,
+  );
+}
 
 /**
  * A panel replies `{ ok: false, error: 'Unknown command "<cmd>"' }` when the
@@ -122,12 +147,7 @@ export function makeUnknownCommandError(
   // exactly this string. Case-insensitive, tolerant of straight or smart quotes.
   const m = /^unknown command\s*["“']?([\w.-]+)["”']?/i.exec(error.trim());
   if (!m) return null;
-  const cmd = m[1];
-  const detected = panelVersion ? ` (detected ${panelVersion})` : "";
-  return new Error(
-    `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
-      `to ≥${MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`,
-  );
+  return buildPanelTooOldError(m[1], panelVersion);
 }
 
 export interface BridgeCommand {
@@ -637,6 +657,8 @@ export class UiBridge {
             typeof (msg as { panel_version?: unknown }).panel_version === "string"
               ? ((msg as { panel_version?: string }).panel_version || undefined)
               : existing?.panelVersion,
+          // Fresh per hello — see the field's doc comment (#236).
+          unsupportedCmds: new Set<string>(),
         });
         if (incomingHeadless) this.headlessSeen.add(tabId);
         this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
@@ -1031,6 +1053,15 @@ export class UiBridge {
       }
       return Promise.reject(err instanceof Error ? err : new Error(String(err)));
     }
+    // #236 — proactively gate a command this exact connection has already proven
+    // unsupported (see Conn.unsupportedCmds), instead of dispatching it again just
+    // to have the panel reject it and re-parse the same "Unknown command" string.
+    // Never a false gate: membership here is only ever set from a REAL rejection
+    // on THIS connection (in dispatch()'s rejectMapped below), never inferred from
+    // panelVersion alone.
+    if (conn.unsupportedCmds.has(cmd.cmd)) {
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
+    }
     if (conn.sock.readyState !== WebSocket.OPEN) {
       if (opts.tabId && UiBridge.isMailboxable(cmd)) {
         this.storeMailbox(opts.tabId, cmd);
@@ -1088,6 +1119,13 @@ export class UiBridge {
     // passed through untouched.
     const rejectMapped = (err: Error) => {
       const friendly = makeUnknownCommandError(err.message, conn.panelVersion);
+      if (friendly) {
+        // Learned, not assumed (#236) — this exact connection just proved it
+        // doesn't support cmd.cmd, so every later call in this session is gated
+        // proactively (see the `send()` preflight above) instead of round-
+        // tripping to the panel again.
+        conn.unsupportedCmds.add(cmd.cmd);
+      }
       ctx.reject(friendly ?? err);
     };
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary

Companion fix for comfyui-mcp-panel issue **#236** ("Old panel protocol exposes graph_query tool then rejects it at runtime"). Investigation found the root cause lives here, not in the panel repo: the panel's `hello` already sends `panel_version`, and `ui-bridge.ts` already rewrites an old panel's raw `Unknown command` reply into an actionable message (`makeUnknownCommandError`) — but only *after* dispatching the command and getting that reply back, every single time, on every call.

- `Conn` gains `unsupportedCmds: Set<string>` — commands THIS connection has empirically proven unsupported via a real `Unknown command` rejection.
- `UiBridge.send()` now checks this set before ever touching the socket, rejecting immediately with the identical actionable message for any later call to an already-proven-unsupported command.
- The set is populated inside `dispatch()`'s `rejectMapped` whenever `makeUnknownCommandError` successfully maps a reply, and reset to empty on every `hello` (a reconnect may be a freshly-updated panel build, so a stale verdict must never carry over).
- **Deliberately not** a blanket per-connection/per-prefix version gate against `MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS`: the issue's own repro shows `graph_add_node`/`graph_connect` working fine on the same old panel that rejected `graph_query`, so gating by a single version floor would risk falsely blocking calls that currently succeed. Only a command *actually proven* unsupported by its own dispatch is ever gated — this can never regress a working call.
- The MCP tool list (`panel-tools.ts`) is built once, statically, not per-connection, so truly hiding a tool from the exposed list per panel version isn't a small/safe change; this fix instead makes every call after the first fail fast and proactively, with the same clear message, instead of round-tripping and re-parsing the same string every time.

## Test plan
- [x] New tests in `src/__tests__/services/ui-bridge.test.ts`: first call round-trips (`dispatchCount===1`), second call gated proactively (`dispatchCount` still `===1`), a different never-tried command is NOT falsely gated, and a fresh hello clears the gate.
- [x] `npx vitest run src/__tests__/services/ui-bridge.test.ts` — 56 pass.
- [x] `npx vitest run` (full suite) — 2478 pass, 1 unrelated pre-existing failure (`node-dev.test.ts`, environment-dependent ripgrep-vs-builtin engine detection; reproduced identically on a clean `main` checkout, unrelated to this change).
- [x] `npx tsc --noEmit` — clean.
- [x] Independent adversarial codex review of the diff — PASS, no findings.

Closes #236