### PR TITLE
fix(orchestrator): strip [object Object] user-turn artifact + consume panel status base_path (#534, #296)

### DIFF
--- a/src/__tests__/services/panel-status-base-path.test.ts
+++ b/src/__tests__/services/panel-status-base-path.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #296: an embedded LOCAL sidebar session with no CLI-configured workspace
+// (COMFYUI_PATH unset, auto-detect empty) used to spawn path-less because the
+// orchestrator never consumed the panel's `/comfyui_mcp_panel/status` route,
+// which exposes the ComfyUI install `base_path` (panel commit f45054e). These
+// tests cover the new orchestrator-side consumer that recovers that base_path.
+//
+// Fail-before: `fetchPanelBasePath` did not exist on main (the route had zero
+// consumers), so importing/calling it failed. Pass-after: it GETs the status
+// route and returns the `base_path`, degrading to undefined on any failure so it
+// can only ADD a path, never break session start.
+
+const OLD_ENV = process.env;
+
+function statusCall(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.find(([u]) =>
+    String(u).includes("/comfyui_mcp_panel/status"),
+  );
+}
+
+describe("fetchPanelBasePath (#296)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    // Pin the target so config.ts's import-time port probe never runs (and can't
+    // pollute the fetch mock).
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+    process.env.COMFYUI_AUTH_TOKEN = "";
+    process.env.COMFYUI_AUTH_HEADER = "";
+    process.env.COMFYUI_AUTH_SCHEME = "";
+    process.env.CF_ACCESS_CLIENT_ID = "";
+    process.env.CF_ACCESS_CLIENT_SECRET = "";
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs the panel status route and returns its base_path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_path: "C:/Users/me/ComfyUI" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    const out = await fetchPanelBasePath("http://127.0.0.1:8188");
+
+    expect(out).toBe("C:/Users/me/ComfyUI");
+    const call = statusCall(fetchMock);
+    expect(call, "status GET should have been made").toBeTruthy();
+    // A GET (no explicit method / no POST body), not a mutation.
+    const init = (call as [string, RequestInit | undefined])[1];
+    expect(init?.method ?? "GET").toBe("GET");
+  });
+
+  it("trims surrounding whitespace on the returned base_path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_path: "  /home/me/ComfyUI  " }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBe("/home/me/ComfyUI");
+  });
+
+  it("tolerates a camelCase basePath alias", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ basePath: "/opt/ComfyUI" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBe("/opt/ComfyUI");
+  });
+
+  it("carries the ComfyUI auth headers so a token-gated panel answers", async () => {
+    process.env.COMFYUI_AUTH_TOKEN = "abc123";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_path: "/x" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    await fetchPanelBasePath("http://127.0.0.1:8188");
+
+    const init = (statusCall(fetchMock) as [string, RequestInit])[1];
+    expect(init.headers).toMatchObject({ Authorization: "Bearer abc123" });
+  });
+
+  it("returns undefined on a non-2xx status (no consumer error)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBeUndefined();
+  });
+
+  it("returns undefined when base_path is missing / blank", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_path: "   " }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBeUndefined();
+  });
+
+  it("never throws when the route is unreachable — degrades to undefined", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    let out: string | undefined = "unset";
+    await expect(
+      (async () => {
+        out = await fetchPanelBasePath("http://127.0.0.1:8188");
+      })(),
+    ).resolves.toBeUndefined();
+    expect(out).toBeUndefined();
+  });
+
+  it("returns undefined for a non-JSON body without throwing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchPanelBasePath } = await import("../../services/secure-bridge.js");
+    expect(await fetchPanelBasePath("http://127.0.0.1:8188")).toBeUndefined();
+  });
+});
+
+// The adoption DECISION (which the orchestrator threads into every spawn env at
+// startup AND on a panel-`hello` retarget). This is the exact logic that decides
+// whether an embedded local session gets a LOCAL ComfyUI base — including the
+// retarget case where the previous version silently stayed path-less.
+describe("resolveComfyuiPathForTarget (#296 adoption decision)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.COMFYUI_URL = "http://127.0.0.1:8188";
+  });
+  afterEach(() => {
+    process.env = OLD_ENV;
+    vi.unstubAllGlobals();
+  });
+
+  const LOOPBACK = "http://127.0.0.1:8188";
+
+  it("prefers a configured/auto-detected local path without fetching the panel", async () => {
+    const fetchBasePath = vi.fn(async () => "/should/not/be/used");
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: LOOPBACK,
+      localPath: "/home/me/ComfyUI",
+      forceRemote: false,
+      isLoopback: true,
+      fetchBasePath,
+      exists: () => true,
+    });
+    expect(out).toBe("/home/me/ComfyUI");
+    expect(fetchBasePath).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the panel status base_path when there is NO local path", async () => {
+    const fetchBasePath = vi.fn(async () => "/panel/ComfyUI");
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: LOOPBACK,
+      localPath: undefined,
+      forceRemote: false,
+      isLoopback: true,
+      fetchBasePath,
+      exists: (p) => p === "/panel/ComfyUI",
+    });
+    expect(out).toBe("/panel/ComfyUI");
+    expect(fetchBasePath).toHaveBeenCalledWith(LOOPBACK);
+  });
+
+  it("REFUSES a panel base_path that does not exist on this machine", async () => {
+    const fetchBasePath = vi.fn(async () => "/remote/only/ComfyUI");
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: LOOPBACK,
+      localPath: undefined,
+      forceRemote: false,
+      isLoopback: true,
+      fetchBasePath,
+      exists: () => false, // path not present locally
+    });
+    expect(out).toBeUndefined();
+  });
+
+  it("never fetches (and never adopts a local path) for a REMOTE target", async () => {
+    const fetchBasePath = vi.fn(async () => "/x");
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: "https://pod-3000.proxy.runpod.net",
+      localPath: "/home/me/ComfyUI",
+      forceRemote: false,
+      isLoopback: false,
+      fetchBasePath,
+      exists: () => true,
+    });
+    expect(out).toBeUndefined();
+    expect(fetchBasePath).not.toHaveBeenCalled();
+  });
+
+  it("never fetches under --force-remote even for a loopback (port-forward to a pod)", async () => {
+    const fetchBasePath = vi.fn(async () => "/x");
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    const out = await resolveComfyuiPathForTarget({
+      target: LOOPBACK,
+      localPath: "/home/me/ComfyUI",
+      forceRemote: true,
+      isLoopback: true,
+      fetchBasePath,
+      exists: () => true,
+    });
+    expect(out).toBeUndefined();
+    expect(fetchBasePath).not.toHaveBeenCalled();
+  });
+
+  it("degrades to undefined (no throw) when the panel fetch itself throws", async () => {
+    const fetchBasePath = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const { resolveComfyuiPathForTarget } = await import("../../services/secure-bridge.js");
+    let out: string | undefined = "unset";
+    await expect(
+      (async () => {
+        out = await resolveComfyuiPathForTarget({
+          target: LOOPBACK,
+          localPath: undefined,
+          forceRemote: false,
+          isLoopback: true,
+          fetchBasePath,
+          exists: () => true,
+        });
+      })(),
+    ).resolves.toBeUndefined();
+    expect(out).toBeUndefined();
+  });
+});

--- a/src/orchestrator/error-text.test.ts
+++ b/src/orchestrator/error-text.test.ts
@@ -140,6 +140,46 @@ describe("promptText (#175)", () => {
   });
 });
 
+describe("promptText — literal [object Object] artifact (#534)", () => {
+  it("maps an exact literal sentinel string to empty", () => {
+    expect(promptText("[object Object]")).toBe("");
+  });
+
+  it("trims a padded exact sentinel to empty", () => {
+    expect(promptText("  [object Object]  ")).toBe("");
+  });
+
+  it("strips a standalone leading sentinel line and keeps the real message", () => {
+    expect(promptText("[object Object]\n\n지금 연결된 니 모델이 뭐야")).toBe(
+      "지금 연결된 니 모델이 뭐야",
+    );
+  });
+
+  it("strips a leading sentinel line with a single newline too", () => {
+    expect(promptText("[object Object]\nhello")).toBe("hello");
+  });
+
+  it("tolerates horizontal whitespace around a leading sentinel line", () => {
+    expect(promptText("  [object Object]  \n\nreal message")).toBe("real message");
+  });
+
+  it("does NOT touch a legitimate mid-prose mention of the phrase", () => {
+    const prose = "my logs printed [object Object] and I want to know why";
+    expect(promptText(prose)).toBe(prose);
+  });
+
+  it("does NOT strip a sentinel that is not on its own leading line", () => {
+    const prose = "here is the value: [object Object]";
+    expect(promptText(prose)).toBe(prose);
+  });
+
+  it("only strips the FIRST leading sentinel line, leaving inline copies intact", () => {
+    expect(promptText("[object Object]\n\nkeep [object Object] here")).toBe(
+      "keep [object Object] here",
+    );
+  });
+});
+
 describe("messageText (#421, #422)", () => {
   it("passes a plain string reply through unchanged", () => {
     expect(messageText("Done — 4 images rendered.")).toBe("Done — 4 images rendered.");

--- a/src/orchestrator/error-text.ts
+++ b/src/orchestrator/error-text.ts
@@ -44,6 +44,28 @@ export function errorText(err: unknown): string {
 }
 
 /**
+ * Strip a leading/whole-value literal "[object Object]" coercion artifact from a
+ * user-turn string (#534) without corrupting legitimate prose.
+ *
+ * Only two shapes are treated as the upstream artifact:
+ *  - the ENTIRE (trimmed) value is the sentinel -> "" (the whole turn was lost)
+ *  - the value STARTS with a sentinel on its own line, followed by one or more
+ *    line breaks -> that leading line is removed, the real message is preserved.
+ * A sentinel appearing mid-prose (e.g. a user quoting "[object Object]") is left
+ * untouched.
+ */
+function stripObjectSentinel(value: string): string {
+  if (value.trim() === "[object Object]") return "";
+  // Leading sentinel line (optional surrounding horizontal whitespace) followed
+  // by at least one newline, then the genuine message body.
+  const withoutLeadingSentinel = value.replace(
+    /^[ \t]*\[object Object\][ \t]*(?:\r?\n)+/,
+    "",
+  );
+  return withoutLeadingSentinel;
+}
+
+/**
  * Coerce a user-turn payload into prompt-safe text.
  *
  * A user turn's `text` is normally a string, but a structured/multi-part chat
@@ -52,9 +74,18 @@ export function errorText(err: unknown): string {
  * `text` field when the value is an object, otherwise JSON-serialize — never
  * rely on implicit object coercion, and never collapse a payload that still
  * carries `parts` to an empty prompt.
+ *
+ * A string value is normally authoritative and passes through unchanged, but an
+ * UPSTREAM boundary may have already coerced the structured object to the literal
+ * "[object Object]" sentinel BEFORE it reaches here — e.g. after a sidebar/Codex
+ * reconnect the turn arrived as `"[object Object]\n\n<real message>"` (#534). Strip
+ * that specific artifact — an exact sentinel becomes "", and a standalone leading
+ * sentinel line is removed — WITHOUT touching a legitimate mention of the phrase
+ * inside normal prose (only a whole-value match or a leading sentinel-on-its-own-line
+ * is treated as the artifact).
  */
 export function promptText(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return stripObjectSentinel(value);
   if (value == null) return "";
   if (typeof value === "object") {
     let text: unknown;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import readline from "node:readline";
 import { startUiBridge, isLoopbackBindHost, type UiBridge } from "../services/ui-bridge.js";
-import { setupSecureBridge, type SecureBridge } from "../services/secure-bridge.js";
+import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } from "../services/secure-bridge.js";
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
@@ -1064,7 +1064,28 @@ export async function runPanelOrchestrator(): Promise<void> {
   // force-remote flag, so a leaked path would silently defeat --force-remote.
   const localPathForTarget = (url: string): string | undefined =>
     !isForceRemoteFlagSet() && isLoopbackUrl(url) ? localComfyuiPath : undefined;
-  let comfyuiPath = localPathForTarget(comfyuiUrl);
+  // #296: an embedded LOCAL sidebar session with NO CLI-configured workspace
+  // (COMFYUI_PATH unset AND auto-detect empty) would otherwise spawn path-less —
+  // its comfyui MCP stuck in a degraded "local but path-less" state (no
+  // download_model/apply_manifest/model-scan LOCAL surface, panel_load_workflow's
+  // local fallback blind). The panel already KNOWS where ComfyUI lives and serves
+  // it at GET /comfyui_mcp_panel/status (base_path). resolveComfyuiPathForTarget
+  // consumes it as a last-resort fallback for a loopback, non-force-remote target
+  // (adopting only a path that actually exists on THIS machine). Awaited here so
+  // the recovered path is in place BEFORE the MCP-env builders / manager below
+  // capture it. Best-effort — a failed/absent status route leaves us path-less.
+  let comfyuiPath = await resolveComfyuiPathForTarget({
+    target: comfyuiUrl,
+    localPath: localComfyuiPath,
+    forceRemote: isForceRemoteFlagSet(),
+    isLoopback: isLoopbackUrl(comfyuiUrl),
+  });
+  if (comfyuiPath && comfyuiPath !== localPathForTarget(comfyuiUrl)) {
+    logger.info(
+      `[panel-orchestrator] no COMFYUI_PATH/default workspace; adopted ComfyUI ` +
+        `base_path from the panel status route: ${comfyuiPath} (#296).`,
+    );
+  }
   // Force the child remote only when opted in (--force-remote) or the target is
   // non-loopback; a default loopback panel user with no COMFYUI_PATH is left to
   // auto-detect its local install (keeps download_model/apply_manifest/scans).
@@ -2029,6 +2050,37 @@ export async function runPanelOrchestrator(): Promise<void> {
     logger.info(
       `[panel-orchestrator] retargeted ComfyUI ${prev} → ${comfyuiUrl} (${isLoopbackUrl(next) ? "local" : "remote"} mode) from panel hello`,
     );
+    // #296: the synchronous `localPathForTarget(next)` above can't see the NEWLY
+    // targeted panel's base_path, so a retarget to a loopback ComfyUI with no
+    // env/auto-detected path lands path-less even though that panel serves it. Kick
+    // off a best-effort recovery from the NEW target's status route (fire-and-forget
+    // so the retarget stays synchronous). On success — and only if a newer retarget
+    // hasn't superseded us mid-fetch — adopt the path and rebuild the comfyui MCP
+    // spawn env so each tab's child respawns in LOCAL mode. Skipped entirely when a
+    // local path is already set (the common case does no I/O).
+    if (!comfyuiPath) {
+      void (async () => {
+        const recovered = await resolveComfyuiPathForTarget({
+          target: next,
+          localPath: localComfyuiPath,
+          forceRemote: isForceRemoteFlagSet(),
+          isLoopback: isLoopbackUrl(next),
+        });
+        if (!recovered) return;
+        // Superseded by a newer retarget while we fetched — do nothing.
+        if (canonTargetUrl(comfyuiUrl) !== canonTargetUrl(next)) return;
+        if (comfyuiPath === recovered) return;
+        comfyuiPath = recovered;
+        logger.info(
+          `[panel-orchestrator] recovered ComfyUI base_path from panel status route ` +
+            `after retarget: ${recovered} (#296).`,
+        );
+        // Rebuild the comfyui MCP spawn env (now carrying COMFYUI_PATH) and respawn
+        // each tab's agent at its next idle so the LIVE child runs in LOCAL mode.
+        manager.setMcpServers(buildMcpServers());
+        manager.restartAllForMcpEnv();
+      })();
+    }
     // Advertising itself happens unconditionally on every hello (see below) —
     // a retarget doesn't need its own advertise call here.
     return true;

--- a/src/services/secure-bridge.ts
+++ b/src/services/secure-bridge.ts
@@ -23,6 +23,7 @@
 // (see UiBridge).
 
 import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
 import { startQuickTunnel, type QuickTunnel } from "./tunnel.js";
 import { RelayClient } from "./relay-client.js";
 import { logger } from "../utils/logger.js";
@@ -84,6 +85,93 @@ export async function advertiseBridge(comfyuiUrl: string, wssUrl: string, should
     await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
   }
   return false;
+}
+
+/**
+ * GET the panel's status route to learn where ComfyUI lives on THIS machine.
+ *
+ * The sidebar panel serves `/comfyui_mcp_panel/status` with a `base_path` — the
+ * ComfyUI install root the panel is running inside (panel commit f45054e). The
+ * orchestrator consumes it as a LAST-RESORT source of the local ComfyUI base for
+ * an embedded loopback session that has no CLI-configured workspace (COMFYUI_PATH
+ * unset AND auto-detect empty), so the path-dependent LOCAL surface still works —
+ * the comfyui MCP runs in LOCAL mode (download_model / apply_manifest / model
+ * scans) and panel_load_workflow's local fallback can resolve names (#296).
+ *
+ * Best-effort and time-bounded: returns undefined on ANY failure (unreachable,
+ * non-2xx, non-JSON, missing/blank field) so it can only ADD a path — it must
+ * NEVER throw or stall session start. Sent with the same auth headers as
+ * advertiseBridge so a token-gated panel answers. Disk validation is the caller's
+ * job (this returns the panel's raw claim).
+ */
+export async function fetchPanelBasePath(
+  comfyuiUrl: string,
+  timeoutMs = 2500,
+): Promise<string | undefined> {
+  let endpoint: string;
+  try {
+    endpoint = new URL("/comfyui_mcp_panel/status", comfyuiUrl).toString();
+  } catch {
+    return undefined;
+  }
+  try {
+    const res = await fetch(endpoint, {
+      headers: { ...getComfyUIAuthHeaders() },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return undefined;
+    const data = (await res.json()) as unknown;
+    if (!data || typeof data !== "object") return undefined;
+    // The route's field is snake_case `base_path`; tolerate a camelCase alias.
+    const raw =
+      (data as { base_path?: unknown }).base_path ??
+      (data as { basePath?: unknown }).basePath;
+    if (typeof raw === "string" && raw.trim()) return raw.trim();
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the effective LOCAL ComfyUI base directory for a session target,
+ * consulting the panel's status route as a LAST-RESORT fallback (#296).
+ *
+ * Decision order — kept in ONE place so startup and the panel-`hello` retarget
+ * path can never disagree about where ComfyUI lives:
+ *   1. A CLI-configured / auto-detected local path (`localPath`) wins, but ONLY
+ *      for a loopback, non-force-remote target (a REMOTE/force-remote target must
+ *      never adopt a local dir — it isn't the remote host).
+ *   2. Remote / force-remote target → undefined (routes through the Manager).
+ *   3. Otherwise (loopback, non-force-remote, but NO local path) → GET the panel's
+ *      `/comfyui_mcp_panel/status` `base_path` and adopt it, but ONLY if that path
+ *      actually EXISTS on this machine (a bogus / remote-looking claim must not
+ *      poison LOCAL mode).
+ *
+ * `fetchBasePath`/`exists` are injectable purely for tests; production uses the
+ * real status fetch + `fs.existsSync`. Best-effort — never throws.
+ */
+export async function resolveComfyuiPathForTarget(opts: {
+  target: string;
+  localPath: string | undefined;
+  forceRemote: boolean;
+  isLoopback: boolean;
+  fetchBasePath?: (url: string) => Promise<string | undefined>;
+  exists?: (p: string) => boolean;
+}): Promise<string | undefined> {
+  const { target, localPath, forceRemote, isLoopback } = opts;
+  if (!forceRemote && isLoopback && localPath) return localPath;
+  if (forceRemote || !isLoopback) return undefined;
+  const fetchBasePath = opts.fetchBasePath ?? fetchPanelBasePath;
+  const exists = opts.exists ?? existsSync;
+  let fromPanel: string | undefined;
+  try {
+    fromPanel = await fetchBasePath(target);
+  } catch {
+    return undefined; // bulletproof — a broken fetch must not break session start
+  }
+  if (fromPanel && exists(fromPanel)) return fromPanel;
+  return undefined;
 }
 
 export interface SetupSecureBridgeOpts {


### PR DESCRIPTION
## Two mcp-side fixes

### #534 — literal `[object Object]` prefix in user-turn text
`promptText()` (src/orchestrator/error-text.ts) passed any string through unchanged. When an upstream boundary had already coerced a structured turn to the literal `[object Object]` sentinel (observed after a sidebar/Codex reconnect as `"[object Object]\n\n<real message>"`), it survived into the model prompt. Now stripped at the chokepoint:
- exact / whitespace-padded sentinel → `""`
- a **standalone leading** sentinel line is removed, preserving the real body
- a legitimate mid-prose mention of the phrase is left untouched

### #296 — orchestrator never consumed the panel's status route
The panel serves `GET /comfyui_mcp_panel/status` exposing `base_path` (panel commit f45054e), but the orchestrator never read it (zero hits in `src/`). An embedded LOCAL session with no CLI-configured workspace (COMFYUI_PATH unset, auto-detect empty) therefore spawned **path-less**, degrading its LOCAL tool surface (download_model / apply_manifest / model scans, panel_load_workflow's local fallback).

Fix:
- `fetchPanelBasePath()` — best-effort, time-bounded, auth-carrying GET of the status route (src/services/secure-bridge.ts).
- `resolveComfyuiPathForTarget()` — one shared adoption decision: a configured/auto-detected local path wins; a remote/force-remote target → `undefined`; otherwise adopt the panel's `base_path` **only if it exists on this machine** (a bogus/remote-looking value can't poison LOCAL mode).
- Wired at **both** startup (awaited, before the MCP-env builders/manager capture `comfyuiPath`) **and** the panel-`hello` retarget path in `applyComfyuiUrl` (fire-and-forget recovery, guarded against a superseding retarget, that re-fires `manager.setMcpServers(buildMcpServers())` + `restartAllForMcpEnv()` so tab children respawn in LOCAL mode).

> Note: this repo's GitHub #296 is a separate, already-merged `restart_comfyui` PR; the `Closes #296` below is per the task's explicit tracking instruction for the described base_path bug.

## Tests
- +8 `promptText` artifact cases (exact/padded/leading-line/mid-prose) — fail-before (string passthrough returned `[object Object]`), pass-after.
- +14 `fetchPanelBasePath` + `resolveComfyuiPathForTarget` cases covering the GET/parse and the full adoption decision (local wins / remote skip / force-remote skip / existsSync refusal / throw→undefined).

## Gates
- `tsc --noEmit` clean.
- Full suite green (2523 passed, 1 skipped) — the single failure is the known **ripgrep sandbox exception** (node-dev.test.ts).
- Embed-diff Codex self-gate (gpt-5.6-terra/high): **PASS** on round 2. Round 1 caught a real P1 — the retarget path lost the adopted base_path — which this diff fixes.

Closes #534
Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
