### PR TITLE
fix(ui-bridge): tolerant default reply timeout for read ops (panel #357)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -6,6 +6,10 @@ import {
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
   markDispatched,
   dispatchOutcomeOf,
+  defaultBridgeTimeoutMs,
+  BRIDGE_DEFAULT_TIMEOUT_MS,
+  BRIDGE_READ_DEFAULT_TIMEOUT_MS,
+  BRIDGE_READONLY_CMDS,
 } from "../../services/ui-bridge.js";
 
 let bridge: UiBridge;
@@ -1019,6 +1023,69 @@ describe("tabServerOrigin (server-observed handshake Origin — #509 spoof gate)
     await vi.waitFor(() => expect(bridge.canReach("tab-origin-3")).toBe(true));
     expect(bridge.tabServerOrigin("tab-origin-3")).toBe("http://127.0.0.1:8188");
     s.close();
+  });
+});
+
+describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
+  it("gives READ (idempotent) ops the tolerant default, mutating ops the tight one", () => {
+    // Every readonly command gets the tolerant bound…
+    for (const readCmd of BRIDGE_READONLY_CMDS) {
+      expect(defaultBridgeTimeoutMs(readCmd)).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+    }
+    // …and anything else (a render/edit) keeps the tight default.
+    for (const mutateCmd of ["graph_run", "graph_add_node", "graph_move_node", "workflow_save"]) {
+      expect(defaultBridgeTimeoutMs(mutateCmd)).toBe(BRIDGE_DEFAULT_TIMEOUT_MS);
+    }
+  });
+
+  it("covers the OTHER main-thread graph reads that share the FBX-busy hazard (#357)", () => {
+    // These run on the same busy panel main thread as graph_query and are
+    // dispatched with no explicit timeout — they must be tolerant too.
+    for (const readCmd of [
+      "graph_view_selected",
+      "graph_view_nodes_in_viewport",
+      "graph_get_state",
+      "graph_get_subgraph",
+      "graph_outline",
+    ]) {
+      expect(BRIDGE_READONLY_CMDS.has(readCmd)).toBe(true);
+      expect(defaultBridgeTimeoutMs(readCmd)).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+    }
+  });
+
+  it("graph_query is tolerant and STRICTLY longer than the old flat 6s default (#357)", () => {
+    // The regression: graph_query used the flat 6000ms default and timed out while
+    // Preview3D loaded a large FBX on a busy-but-alive main thread.
+    expect(defaultBridgeTimeoutMs("graph_query")).toBe(20_000);
+    expect(defaultBridgeTimeoutMs("graph_query")).toBeGreaterThan(6000);
+    expect(defaultBridgeTimeoutMs("graph_query")).toBeGreaterThan(defaultBridgeTimeoutMs("graph_run"));
+  });
+
+  it("a no-timeout READ stays alive PAST the old 6s cutoff (end-to-end) (#357)", async () => {
+    const a = await connectPanel("tab-aaaa-1111"); // never auto-replies
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    let settled = false;
+    // No explicit timeout → send() applies the tolerant read default (20s). Swallow
+    // the eventual late rejection so it never surfaces as an unhandled rejection
+    // (the bridge is torn down in afterEach; the pending read settles then).
+    void bridge.send({ cmd: "graph_query" }).then(
+      () => { settled = true; },
+      () => { settled = true; },
+    );
+    // Wait comfortably past the OLD 6000ms default: before the fix this would have
+    // already rejected (settled === true); after it, the read is still in-flight.
+    await new Promise((r) => setTimeout(r, 6500));
+    expect(settled).toBe(false);
+    a.close();
+  }, 12000);
+
+  it("an explicit timeout always overrides the read default", async () => {
+    const a = await connectPanel("tab-aaaa-1111"); // never replies
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    await expect(bridge.send({ cmd: "graph_query" }, { timeoutMs: 120 })).rejects.toThrow(
+      /did not reply to "graph_query" within 120 ms/,
+    );
+    a.close();
   });
 });
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -170,6 +170,48 @@ export function makeUnknownCommandError(
   return buildPanelTooOldError(m[1], panelVersion);
 }
 
+/**
+ * Bridge commands with NO side effect — safe to re-dispatch after a reconnect and
+ * safe to WAIT ON longer (a read can't be double-applied). Module-level so both
+ * the mutating-vs-read classification and the default-timeout policy share one
+ * authoritative list. Everything not listed is treated as mutating.
+ */
+export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
+  "graph_serialize",
+  "graph_outline",
+  "graph_get_errors",
+  "graph_get_state",
+  "graph_get_subgraph",
+  "graph_view_selected",
+  "graph_view_nodes_in_viewport",
+  "graph_prompt_director_audit",
+  "graph_query",
+  "civitai_results",
+  "get_todo",
+]);
+
+/** Tight default reply timeout for a MUTATING command with no explicit timeout —
+ *  fail fast so the agent isn't blocked on a stuck write. */
+export const BRIDGE_DEFAULT_TIMEOUT_MS = 6000;
+/** More tolerant default for a READ (idempotent) command with no explicit timeout.
+ *  A legitimately busy-but-alive panel main thread — e.g. Preview3D parsing a large
+ *  FBX — can take many seconds to service a graph_query; failing it at the tight
+ *  6s default surfaced a FALSE "tab backgrounded or frozen" timeout even though a
+ *  retry moments later succeeded (#357). Reads have no side effect, so waiting
+ *  longer is safe; a genuinely dead/frozen tab still times out, just at this bound.
+ *  Note: a WebSocket pong is answered by the browser network stack even while JS is
+ *  blocked, so it can't distinguish busy-JS from dead-JS — a tolerant read timeout,
+ *  not pong-liveness, is the correct lever here. */
+export const BRIDGE_READ_DEFAULT_TIMEOUT_MS = 20_000;
+
+/** The default reply timeout to use for `cmd` when the caller passed none. Read
+ *  ops get the tolerant bound; everything else stays tight (#357). */
+export function defaultBridgeTimeoutMs(cmdName: string): number {
+  return BRIDGE_READONLY_CMDS.has(cmdName)
+    ? BRIDGE_READ_DEFAULT_TIMEOUT_MS
+    : BRIDGE_DEFAULT_TIMEOUT_MS;
+}
+
 export interface BridgeCommand {
   cmd: string;
   [key: string]: unknown;
@@ -335,17 +377,10 @@ export class UiBridge {
   private static readonly RECONNECT_GRACE_MS = 4000;
   /** Bridge commands with no side effect — safe to re-dispatch after a reconnect.
    *  Everything else is treated as mutating (no auto-retry) so a render/edit is
-   *  never silently double-applied. */
-  private static readonly READONLY_CMDS = new Set<string>([
-    "graph_serialize",
-    "graph_outline",
-    "graph_get_errors",
-    "graph_get_subgraph",
-    "graph_prompt_director_audit",
-    "graph_query",
-    "civitai_results",
-    "get_todo",
-  ]);
+   *  never silently double-applied. Single source of truth at module scope
+   *  (BRIDGE_READONLY_CMDS) so the mutating flag and the default-timeout policy
+   *  can never drift apart. */
+  private static readonly READONLY_CMDS = BRIDGE_READONLY_CMDS;
   private portInUse = false;
   private bindRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -1183,7 +1218,10 @@ export class UiBridge {
   }
 
   send(cmd: BridgeCommand, opts: { tabId?: string; timeoutMs?: number } = {}): Promise<unknown> {
-    const timeoutMs = opts.timeoutMs ?? 6000;
+    // #357: read (idempotent) ops get a more tolerant default so a busy-but-alive
+    // panel main thread (e.g. Preview3D loading a large FBX) isn't declared frozen;
+    // mutating ops keep the tight default. An explicit opts.timeoutMs always wins.
+    const timeoutMs = opts.timeoutMs ?? defaultBridgeTimeoutMs(cmd.cmd);
     let conn: Conn;
     try {
       conn = this.resolveTarget(opts.tabId);


### PR DESCRIPTION
## ui-bridge: tolerant default reply timeout for read ops (panel #357)

`UiBridge.send()` used a flat 6000ms default reply timeout for every command. A read like `graph_query` therefore timed out while a busy-but-alive panel main thread loaded a large FBX (Preview3D) — a retry moments later succeeded, confirming the tab was alive, not frozen.

A WebSocket pong is answered by the browser's network stack even while JS is blocked, so pong-liveness cannot distinguish busy-JS from dead-JS. The correct lever is a more tolerant default for idempotent reads.

- `src/services/ui-bridge.ts`: hoisted the readonly command set to module scope (`BRIDGE_READONLY_CMDS` — single source of truth for both the mutating-vs-read classification and the timeout policy) and added `graph_get_state` / `graph_view_selected` / `graph_view_nodes_in_viewport` (pure main-thread reads that share the same hazard and are dispatched with no explicit timeout).
- Added `BRIDGE_DEFAULT_TIMEOUT_MS = 6000`, `BRIDGE_READ_DEFAULT_TIMEOUT_MS = 20000`, and `defaultBridgeTimeoutMs(cmd)`. `send()` now uses `opts.timeoutMs ?? defaultBridgeTimeoutMs(cmd.cmd)`: reads get 20s, mutating ops stay tight at 6s, an explicit timeout always wins. A genuinely dead tab still times out (at the read bound). Read ops in this set are also reconnect-resumable, which is safe because they are side-effect-free.

### Tests
- `src/__tests__/services/ui-bridge.test.ts`: read-vs-mutate default policy, `graph_query` strictly greater than the old 6s, coverage of the other main-thread reads, an end-to-end proof a no-timeout read survives past the old 6s cutoff, explicit-timeout override.
- `tsc --noEmit` clean; ui-bridge suite 61/61 (full mcp suite green apart from one pre-existing, unrelated environment-sensitive `node-dev` ripgrep-vs-builtin assertion).

Codex (gpt-5.6-terra, high) embed-diff review: PASS.

Closes Artokun/comfyui-mcp-panel#357

🤖 Generated with [Claude Code](https://claude.com/claude-code)
