### PR TITLE
feat(env-caps): disk fallback for panel version when hello omits it

### DIFF
--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -9,6 +9,7 @@ import {
   resolveComfyuiPython,
   reconcileProbeState,
   resolveBackends,
+  readInstalledPanelVersion,
   type EnvCapabilities,
 } from "../../services/env-capabilities.js";
 
@@ -368,5 +369,74 @@ describe("buildPanelSystemAppend", () => {
 
   it("returns the static prompt unchanged when the env block is empty", () => {
     expect(buildPanelSystemAppend(STATIC, {})).toBe(STATIC);
+  });
+});
+
+describe("readInstalledPanelVersion (disk fallback)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "cmcp-panelver-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // Write a pyproject.toml under a specific custom_nodes subdir.
+  async function writePanel(dirName: string, body: string) {
+    const d = join(dir, "custom_nodes", dirName);
+    await mkdir(d, { recursive: true });
+    await writeFile(join(d, "pyproject.toml"), body, "utf8");
+  }
+
+  it("reads the panel's [project].version (authoritative by [project].name)", async () => {
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.11.20"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.11.20");
+  });
+
+  it("mirrors the shipped parsePyproject reader (single-line description, then version)", async () => {
+    // Shape mirrors the real panel pyproject.toml (long single-line description).
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\n` +
+        `name = "comfyui-agent-panel"\n` +
+        `description = "Autonomous AI agent in the ComfyUI sidebar - drive the canvas, browse CivitAI, generate."\n` +
+        `version = "0.11.20"\n` +
+        `license = { file = "LICENSE" }\n` +
+        `[tool.comfy]\nPublisherId = "artokun"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.11.20");
+  });
+
+  it("finds the panel under the alternate registry dir name", async () => {
+    await writePanel(
+      "comfyui-agent-panel",
+      `[project]\nname = "comfyui-agent-panel"\nversion = "0.12.0"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBe("0.12.0");
+  });
+
+  it("returns undefined for a non-panel pyproject squatting a known dir (wrong project name)", async () => {
+    // Authoritative guard: only [project].name == comfyui-agent-panel is trusted,
+    // so a different node at the same dir name never yields a WRONG version.
+    await writePanel(
+      "comfyui-mcp-panel",
+      `[project]\nname = "some-other-node"\nversion = "9.9.9"\n`,
+    );
+    expect(readInstalledPanelVersion(dir)).toBeUndefined();
+  });
+
+  it("returns undefined when the panel pyproject declares no version", async () => {
+    await writePanel("comfyui-mcp-panel", `[project]\nname = "comfyui-agent-panel"\n`);
+    expect(readInstalledPanelVersion(dir)).toBeUndefined();
+  });
+
+  it("returns undefined when the file/dir is missing or comfyuiPath is undefined", () => {
+    expect(readInstalledPanelVersion(undefined)).toBeUndefined();
+    expect(readInstalledPanelVersion(join(dir, "does-not-exist"))).toBeUndefined();
+    // custom_nodes exists but the panel is not installed.
+    expect(readInstalledPanelVersion(dir)).toBeUndefined();
   });
 });

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -16,10 +16,13 @@
 
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
 import { isForceRemoteFlagSet } from "../config.js";
 import { resolveComfyuiPython } from "./workspace-env.js";
+import { parsePyproject } from "./node-authoring.js";
 
 // The interpreter resolver lives in workspace-env (which owns ComfyUI-base
 // resolution) so get_environment and this panel probe share ONE live-first
@@ -499,12 +502,53 @@ export interface GatherOptions {
   tritonTimeoutMs?: number;
 }
 
+// The panel's known custom_nodes dir names (registry unpack vs repo name), kept
+// in sync with panel-installer's FAST_PATH_DIRS.
+const PANEL_DIR_NAMES = ["comfyui-mcp-panel", "comfyui-agent-panel"] as const;
+// pyproject `[project].name` — the AUTHORITATIVE panel identity (a dir may be
+// squatted; the project name is not). Mirrors panel-installer's PANEL_REGISTRY_ID.
+const PANEL_PROJECT_NAME = "comfyui-agent-panel";
+
+/**
+ * Fallback panel version from DISK. The panel version normally rides the panel's
+ * `hello`, but a stale (browser-cached) panel — one loaded before the panel began
+ * advertising its version — omits it, leaving the agent's ENV line `panel=?` and
+ * bug reports unable to version-match the panel. Read the INSTALLED panel's
+ * version from its `pyproject.toml` under ComfyUI's custom_nodes.
+ *
+ * Parsing is delegated to the shipped `parsePyproject` (the same minimal reader
+ * that gates panel install/reinstall) so there is ONE pyproject convention, not
+ * two. We only accept a version whose `[project].name` is authoritatively the
+ * panel's — a non-panel pyproject squatting a known dir name yields undefined,
+ * never a wrong version. Best-effort: returns undefined on any failure, never
+ * throws.
+ */
+export function readInstalledPanelVersion(comfyuiPath?: string): string | undefined {
+  if (!comfyuiPath) return undefined;
+  for (const name of PANEL_DIR_NAMES) {
+    try {
+      const toml = readFileSync(
+        join(comfyuiPath, "custom_nodes", name, "pyproject.toml"),
+        "utf8",
+      );
+      const parsed = parsePyproject(toml);
+      if (parsed.projectName === PANEL_PROJECT_NAME && parsed.version) return parsed.version;
+    } catch {
+      /* try the next known dir name */
+    }
+  }
+  return undefined;
+}
+
 export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCapabilities> {
   const caps: EnvCapabilities = {};
 
   // --- our own build versions (caller-supplied; panel version rides the hello) ---
   caps.mcpVersion = opts.mcpVersion;
-  caps.panelVersion = opts.panelVersion;
+  // Prefer the live hello's panel version; fall back to the INSTALLED panel's
+  // pyproject version so a stale (cached) panel that omits it from the hello
+  // still gets the agent's ENV line stamped (report_issue can version-match).
+  caps.panelVersion = opts.panelVersion ?? readInstalledPanelVersion(opts.comfyuiPath);
 
   // --- cheap, synchronous local machine facts (node os) ---
   caps.os = friendlyOs();


### PR DESCRIPTION
## Why
The panel version normally rides the panel's `hello` frame. A **stale (browser-cached) panel** — one loaded before the panel began advertising its version (the panelVersion-in-hello feature shipped 0.11.x) — omits it, leaving the agent's ENV line stuck at `panel=?` and `report_issue` unable to version-match the panel against the triage worker's `latest`. (Seen live: a via-panel report came in with `panel=?`.)

## What
- New best-effort `readInstalledPanelVersion(comfyuiPath)` reads the **installed** panel's version from its `pyproject.toml` under `custom_nodes/{comfyui-mcp-panel,comfyui-agent-panel}`.
- Parsing is **delegated to the shipped `parsePyproject`** (`node-authoring.ts`) — the same minimal reader that already gates panel install/reinstall via `detectPanelInstall`. One pyproject convention, not two.
- Only a version whose `[project].name` is authoritatively `comfyui-agent-panel` is accepted, so a non-panel pyproject squatting a known dir name yields `undefined` — **never a wrong version**. Best-effort: returns `undefined` on any failure, never throws.
- Wired as the fallback in `gatherEnvCapabilities`:
  `caps.panelVersion = opts.panelVersion ?? readInstalledPanelVersion(opts.comfyuiPath)`
  — the live hello still wins; a version-omitting hello no longer strands the ENV line at `panel=?`.

## Tests
`env-capabilities.test.ts` — delegation, both dir names, squatter rejection (wrong `[project].name`), missing version, and all best-effort/absent paths. Full `tsc --noEmit` clean; suite green (one unrelated pre-existing `node-dev` failure).

## Review
Independent adversarial codex review: **PASS** (after driving the design from a hand-rolled scanner to delegating the established `parsePyproject` convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)