### PR TITLE
fix(panel-orchestrator): honest bounded restart-confirm + correct ready-banner model

### DIFF
--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -35,7 +35,7 @@ function makeCtx(): { ctx: PanelToolCtx; calls: Forwarded[] } {
       calls.push(cmd);
       return { content: [{ type: "text", text: "ok" }] };
     },
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     bridge: { send: async (cmd: Forwarded) => { calls.push(cmd); return {}; } },
     tabId: "test-tab",
   } as unknown as PanelToolCtx;

--- a/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
+++ b/src/__tests__/orchestrator/panel-reboot-cache-invalidation.test.ts
@@ -27,7 +27,7 @@ function ctxReplying(reply: unknown): PanelToolCtx {
   // asserts cache-reset gating on the reboot CLASSIFICATION, not readiness.
   return {
     call: async () => ({ content: [{ type: "text", text: JSON.stringify(reply) }] }),
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     ensureReachable: () => {},
     bridge: {
       send: async () => reply,

--- a/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-health-readiness.test.ts
@@ -73,7 +73,7 @@ function makeCtx(opts: {
     },
     confirm: async (_q: string, _h: string, timeoutMs?: number) => {
       opts.confirmSeen?.(timeoutMs);
-      return true;
+      return "yes" as const;
     },
     ensureReachable: () => {},
     bridge,

--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -60,7 +60,7 @@ function makeCtx(
     call: async () => {
       throw new Error("ctx.call must not be used for reboot dispatch");
     },
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     ensureReachable: () => {},
     bridge: {
       send: async (cmd: { cmd: string }) => {

--- a/src/__tests__/orchestrator/panel-restart-readiness.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-readiness.test.ts
@@ -31,7 +31,7 @@ function ctxReboot(reply: Record<string, unknown> | null, throwMsg?: string): Pa
     call: async () => {
       throw new Error("ctx.call must not be used for reboot dispatch");
     },
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     ensureReachable: () => {},
     bridge: {
       send: async () => {

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -37,7 +37,7 @@ function makeFakeCtx(
       calls.push(cmd);
       return { content: [{ type: "text", text: JSON.stringify(cmd) }] };
     },
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     // Some tools (panel_civitai_search) go through the raw bridge so they can
     // inspect the panel's reply. Record the forwarded cmd on the same `calls`
     // array and hand back a caller-supplied reply.
@@ -417,7 +417,7 @@ function makeRunCtx(reply: ToolResult): { ctx: PanelToolCtx; calls: Forwarded[] 
       calls.push(cmd);
       return reply;
     },
-    confirm: async () => true,
+    confirm: async () => "yes" as const,
     bridge: {} as unknown as PanelToolCtx["bridge"],
     tabId: "test-tab",
   };
@@ -1552,7 +1552,7 @@ describe("panel-tools: strip/slice read the live canvas by default", () => {
     const send = vi.fn(sendImpl ?? (async () => ({ workflow: CANVAS_GRAPH, node_count: 1 })));
     const ctx: PanelToolCtx = {
       call: async (cmd) => ({ content: [{ type: "text", text: JSON.stringify(cmd) }] }),
-      confirm: async () => true,
+      confirm: async () => "yes" as const,
       bridge: { send } as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     };
@@ -1620,7 +1620,7 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
         }
         return { content: [{ type: "text", text: "{}" }] };
       },
-      confirm: async () => true,
+      confirm: async () => "yes" as const,
       bridge: {} as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     } as PanelToolCtx;
@@ -1683,7 +1683,7 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
         if (cmd.cmd === "workflow_list") listCalls++;
         return { content: [{ type: "text", text: "{}" }] };
       },
-      confirm: async () => true,
+      confirm: async () => "yes" as const,
       bridge: {} as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     } as PanelToolCtx;
@@ -1718,7 +1718,7 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
         if (cmd.cmd === "workflow_list") listCalls++;
         return { content: [{ type: "text", text: JSON.stringify({ active: { path: TARGET } }) }] };
       },
-      confirm: async () => true,
+      confirm: async () => "yes" as const,
       bridge: {} as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     } as PanelToolCtx;
@@ -1745,7 +1745,7 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
         if (cmd.cmd === "workflow_list") listCalls++;
         return { content: [{ type: "text", text: "{}" }] };
       },
-      confirm: async () => true,
+      confirm: async () => "yes" as const,
       bridge: {} as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     } as PanelToolCtx;
@@ -1912,6 +1912,124 @@ describe("panel_ask surface + late-answer resilience (#300/#486) and set_todo bo
     expect(res.isError).toBeFalsy();
     expect(forwardedTimeout).toBeGreaterThanOrEqual(15000);
     expect(sent.at(-1)).toMatchObject({ cmd: "set_todo" });
+  });
+});
+
+describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)", () => {
+  const REPLY_TIMEOUT_ERR = (cmd: string, ms: number) =>
+    new Error(
+      `Panel tab abcd1234 did not reply to "${cmd}" within ${ms} ms — the ComfyUI tab may be backgrounded or frozen`,
+    );
+
+  function toolText(res: ToolResult): string {
+    return (res.content[0] as { text: string }).text;
+  }
+
+  afterEach(() => {
+    __panelAskTestHooks.setAskTiming(null);
+  });
+
+  // FAIL-BEFORE: the old confirm swallowed a card-reply timeout as `false`, so an
+  // unanswered restart card reported "Cancelled — ComfyUI was not restarted." (a
+  // wrong, definitive decline). PASS-AFTER: an unanswered card reports an honest
+  // "timed out waiting for confirmation" AND never dispatches the reboot.
+  it("panel_restart_comfyui reports a timeout honestly and does NOT restart when the card is unanswered", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 20, pollMs: 2 });
+    const dispatched: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+        dispatched.push(cmd);
+        return { rebooting: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const res = await defByName("panel_restart_comfyui").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(toolText(res)).toMatch(/timed out waiting for your confirmation/i);
+    expect(toolText(res)).not.toMatch(/^Cancelled/);
+    // Critically: the reboot was NEVER dispatched.
+    expect(dispatched.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  // The confirm card deadline must be CLAMPED under the ~300s MCP tools/call budget
+  // (the old hardcoded 300000ms had zero margin and blew the transport).
+  it("panel_restart_comfyui clamps the confirm-card deadline under the MCP budget", async () => {
+    let forwardedTimeout = Infinity;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") {
+          forwardedTimeout = opts?.timeoutMs ?? 0;
+          return "No, cancel";
+        }
+        return { rebooting: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    await defByName("panel_restart_comfyui").handler({}, ctx);
+    expect(forwardedTimeout).toBeGreaterThan(0);
+    expect(forwardedTimeout).toBeLessThan(300000);
+  });
+
+  // #360 mirrors #486: a slow-but-valid answer buffered after the card timeout must
+  // be HONORED, not lost — a late "yes" still performs the action. Uses panel_clear
+  // (dispatch-and-return) so the assertion isolates the confirm path.
+  it("confirm honors a late-but-valid 'yes' buffered after the card timeout", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 500, pollMs: 2 });
+    const dispatched: Array<Record<string, unknown>> = [];
+    let takes = 0;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+        dispatched.push(cmd);
+        return {};
+      },
+      takeLateAskReply: (_askId: string) => {
+        takes += 1;
+        return takes >= 2 ? "Yes, go ahead" : undefined;
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const res = await defByName("panel_clear").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(toolText(res)).not.toMatch(/timed out|Cancelled/i);
+    expect(dispatched.some((c) => c.cmd === "graph_clear")).toBe(true);
+  });
+
+  // An explicit decline is still a clean, definitive "Cancelled" (not a timeout).
+  it("panel_clear reports a clean cancel on an explicit decline and a timeout on no answer", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 20, pollMs: 2 });
+    // Decline branch.
+    const declineDispatched: Array<Record<string, unknown>> = [];
+    const declineBridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "ask_user") return "No, cancel";
+        declineDispatched.push(cmd);
+        return {};
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const declineRes = await defByName("panel_clear").handler(
+      {},
+      makePanelToolCtx(declineBridge, "abcd1234"),
+    );
+    expect(toolText(declineRes)).toMatch(/^Cancelled/);
+    expect(declineDispatched.some((c) => c.cmd === "graph_clear")).toBe(false);
+
+    // Timeout branch.
+    const timeoutBridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+        return {};
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const timeoutRes = await defByName("panel_clear").handler(
+      {},
+      makePanelToolCtx(timeoutBridge, "abcd1234"),
+    );
+    expect(toolText(timeoutRes)).toMatch(/timed out waiting for your confirmation/i);
   });
 });
 

--- a/src/__tests__/orchestrator/ready-banner.test.ts
+++ b/src/__tests__/orchestrator/ready-banner.test.ts
@@ -1,0 +1,84 @@
+// #376 — the ready banner must show the ACTUALLY-resolved model, not the pre-init
+// default that was sent at hello time. bannerCorrection is the decision the
+// SDK-init handler uses to re-send a corrected banner.
+
+import { describe, expect, it } from "vitest";
+import { readyBannerText, bannerCorrection } from "../../orchestrator/ready-banner.js";
+
+describe("ready-banner text + correction (#376)", () => {
+  it("readyBannerText substitutes the given model label (Claude/default path)", () => {
+    const text = readyBannerText("claude", "claude-sonnet-4-5");
+    expect(text).toContain("claude-sonnet-4-5");
+    expect(text).toMatch(/on your Claude subscription/);
+    // Must NOT hardcode the pre-init default.
+    expect(text).not.toContain("claude-opus-5");
+  });
+
+  it("readyBannerText renders provider-specific phrasing with the label", () => {
+    expect(readyBannerText("codex", "gpt-5.5")).toMatch(/gpt-5\.5.*Codex/);
+    expect(readyBannerText("custom", "my-model", "http://localhost:8000/v1")).toContain(
+      "http://localhost:8000/v1",
+    );
+  });
+
+  // CORE #376 regression: the banner advertised the pre-init default, but the SDK
+  // resolved a DIFFERENT model → a corrected banner must be produced showing the
+  // real model. FAIL-BEFORE: nothing re-sent, so the wrong "claude-opus-5" stuck.
+  it("bannerCorrection produces a corrected banner when the resolved model differs", () => {
+    const corrected = bannerCorrection({
+      backend: "claude",
+      advertisedLabel: "claude-opus-5",
+      resolvedModel: "claude-sonnet-4-5",
+    });
+    expect(corrected).not.toBeNull();
+    expect(corrected!).toContain("claude-sonnet-4-5");
+    expect(corrected!).not.toContain("claude-opus-5");
+  });
+
+  it("bannerCorrection returns null when the resolved model matches the advertised label (no duplicate)", () => {
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: "claude-opus-5",
+        resolvedModel: "claude-opus-5",
+      }),
+    ).toBeNull();
+  });
+
+  // A resume/reconnect never sent a greeting, so the advertised-label map is empty.
+  // bannerCorrection must NOT treat an absent label as a mismatch (no spurious banner
+  // on resume) — this is P1-a from the codex gate.
+  it("bannerCorrection returns null when no banner was advertised (resume/reconnect)", () => {
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: undefined,
+        resolvedModel: "claude-sonnet-4-5",
+      }),
+    ).toBeNull();
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: "",
+        resolvedModel: "claude-sonnet-4-5",
+      }),
+    ).toBeNull();
+  });
+
+  it("bannerCorrection returns null when no model was resolved (no init model)", () => {
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: "claude-opus-5",
+        resolvedModel: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      bannerCorrection({
+        backend: "claude",
+        advertisedLabel: "claude-opus-5",
+        resolvedModel: "   ",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -79,6 +79,7 @@ import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/pro
 import { allBackendReadiness } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
 import { buildStartFailureNotice } from "./start-failure-notice.js";
+import { readyBannerText, bannerCorrection } from "./ready-banner.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
@@ -1360,6 +1361,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   const defaultBackend = KNOWN_BACKENDS.has(backendId) ? backendId : "claude";
   const AGENT_KEY_SEP = "::";
   const tabBackends = new Map<string, string>(); // panel tabId -> selected backend
+  // #376: the model label advertised in a tab's ready banner (sent at hello, before
+  // the SDK reports the real model). onSession re-sends a corrected banner when the
+  // resolved model differs from what's stored here. A tab with NO entry never got a
+  // greeting (a resume/reconnect), so it must never be "corrected".
+  const advertisedBannerModel = new Map<string, string>();
+  // The SDK-resolved model per tab, learned from the session/init event. Kept so a
+  // greeting emitted AFTER the model is already known (the onSession-before-greeting
+  // race) can label itself correctly instead of showing the pre-init default.
+  const resolvedModelByTab = new Map<string, string>();
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
   const workflowTargets = new WorkflowTargetStore();
   const backendForTab = (panelTabId: string): string =>
@@ -1871,9 +1881,27 @@ export async function runPanelOrchestrator(): Promise<void> {
     // Per-response usage → the panel's context/usage meter (updates live).
     onStatus: (key, status) => pushStatus(panelTabOf(key), status),
     // Report the SDK session id so the panel can persist it and resume on reload.
-    onSession: (key, sessionId) => {
-      bridge.push({ type: "session", session_id: sessionId }, panelTabOf(key));
+    onSession: (key, sessionId, model) => {
+      const panelTab = panelTabOf(key);
+      bridge.push({ type: "session", session_id: sessionId }, panelTab);
       bridge.broadcastTabList(); // a session started/changed → refresh mirror pickers
+      // #376: the ready banner was sent at hello with the PRE-init default model.
+      // Now the SDK reports the ACTUALLY-resolved model — remember it, then re-send
+      // a corrected banner IFF a banner was actually advertised for this tab AND the
+      // resolved model differs (bannerCorrection returns null otherwise, so a resume
+      // with no prior greeting is never "corrected" and a correct banner never
+      // duplicates).
+      if (typeof model === "string" && model.trim()) resolvedModelByTab.set(panelTab, model);
+      const corrected = bannerCorrection({
+        backend: backendForTab(panelTab),
+        advertisedLabel: advertisedBannerModel.get(panelTab),
+        resolvedModel: model,
+        customBaseUrl,
+      });
+      if (corrected) {
+        advertisedBannerModel.set(panelTab, model as string);
+        bridge.push({ type: "say", text: corrected }, panelTab);
+      }
     },
     // Per-turn rewind anchor (assistant UUID) → the panel stores it so a later
     // "rewind conversation to here" can fork the session at that point.
@@ -2633,32 +2661,16 @@ export async function runPanelOrchestrator(): Promise<void> {
             }
             // Greet only on a FRESH session (a resume/reconnect already has the thread).
             if (!resume) {
-              const readyText = reg
-                ? reg.readyMessage(agentLabel)
-                : isCx
-                ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Codex (ChatGPT) account. Ask away.`
-                : isCg
-                  ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your ChatGPT subscription (direct OAuth). Ask away.`
-                : isGm
-                  ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google account (Gemini Code Assist). Ask away.`
-                  : isAg
-                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.`
-                  : isGk
-                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your Grok (xAI) account. Ask away.`
-                  : isOl
-                    ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
-                    : isLs
-                      ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via LM Studio (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
-                      : isLc
-                        ? `🟢 comfyui-mcp agent ready — ${agentLabel} running locally via llama.cpp (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`
-                        : isCu
-                          ? `🟢 comfyui-mcp agent ready — ${agentLabel} via your custom endpoint (${customBaseUrl}). Ask away.`
-                          : isOr
-                      ? `🟢 comfyui-mcp agent ready — ${agentLabel} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`
-                      : isCp
-                        ? `🟢 comfyui-mcp agent ready — ${agentLabel} on your GitHub Copilot subscription (⚠️ experimental, ToS risk — you opted in). Ask away.`
-                      : `🟢 comfyui-mcp agent ready — ${agentLabel} on your Claude subscription. Ask away.`;
-              bridge.push({ type: "say", text: readyText }, panelTab);
+              // Prefer an ALREADY-resolved model if the SDK init raced ahead of this
+              // greeting (#376) — otherwise the pre-init label. Remember what we
+              // advertised so the onSession correction re-sends only on a real
+              // mismatch.
+              const bannerLabel = resolvedModelByTab.get(panelTab) ?? agentLabel;
+              advertisedBannerModel.set(panelTab, bannerLabel);
+              bridge.push(
+                { type: "say", text: readyBannerText(backend, bannerLabel, customBaseUrl) },
+                panelTab,
+              );
             }
             bridge.push({ type: "ack", ok: true, kind: "ready", agent: agentLabel, backend }, panelTab);
             logger.debug(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (${backend}) — agent healthy, ready ack`);

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -145,8 +145,9 @@ export interface PanelAgentDeps {
   onStream?: (tabId: string, ev: StreamDelta) => void;
   /** Report per-turn usage (context meter) for this tab. */
   onStatus?: (tabId: string, status: UsageStatus) => void;
-  /** Report the SDK session id once known, so the panel can persist/resume it. */
-  onSession?: (tabId: string, sessionId: string) => void;
+  /** Report the SDK session id once known, so the panel can persist/resume it.
+   *  `model` is the SDK-resolved model (#376), used to correct the ready banner. */
+  onSession?: (tabId: string, sessionId: string, model?: string) => void;
   /** Report each turn's ending assistant-message UUID — the anchor the panel
    *  stores so a later "rewind conversation to here" can fork the session at that
    *  point (resumeSessionAt + forkSession). */
@@ -900,7 +901,9 @@ export class PanelAgent {
       case "session": {
         this.sessionId = ev.sessionId;
         if (ev.model) this.model = ev.model;
-        this.deps.onSession?.(this.tabId, ev.sessionId);
+        // Pass the SDK-resolved model so the panel can correct a ready banner that
+        // was sent with the pre-init default (#376).
+        this.deps.onSession?.(this.tabId, ev.sessionId, ev.model);
         logger.info(
           `[panel-agent ${this.short()}] init model=${ev.model} session=${ev.sessionId.slice(0, 8)} effort=${this.effort ?? "default"}`,
         );
@@ -1073,7 +1076,7 @@ export interface PanelAgentManagerOptions {
   /** Live incremental thinking/reply deltas (streaming). */
   onStream?: (tabId: string, ev: StreamDelta) => void;
   onStatus?: (tabId: string, status: UsageStatus) => void;
-  onSession?: (tabId: string, sessionId: string) => void;
+  onSession?: (tabId: string, sessionId: string, model?: string) => void;
   onTurnAnchor?: (tabId: string, uuid: string) => void;
   onTurn?: (tabId: string, state: "working" | "done") => void;
   /** Live extended-thinking token count, for a "thinking… (N)" indicator. */
@@ -1214,9 +1217,9 @@ export class PanelAgentManager {
       onStatus: this.opts.onStatus,
       // Persist the session id to our durable store (resume-after-restart) BEFORE
       // forwarding it to the panel — so it's on disk the moment the SDK reports it.
-      onSession: (id, sid) => {
+      onSession: (id, sid, model) => {
         this.opts.sessionStore?.set(id, sid);
-        this.opts.onSession?.(id, sid);
+        this.opts.onSession?.(id, sid, model);
       },
       onTurnAnchor: this.opts.onTurnAnchor,
       // Wrap onTurn so the manager learns when a turn ends — the safe point to

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1354,6 +1354,15 @@ const rect = () =>
   z.array(z.number()).min(4).max(4).describe("[x, y, width, height] (four numbers).");
 
 /**
+ * Outcome of a human-in-the-loop confirm card (#360). A tri-state so callers can
+ * tell a deliberate DECLINE ("no") apart from the user simply not answering in
+ * time ("timeout") — the latter must be reported honestly ("timed out waiting for
+ * confirmation"), never silently treated as a decline. Any non-timeout failure
+ * (no panel, transport error) maps to "no" so the destructive op is SKIPPED.
+ */
+export type ConfirmOutcome = "yes" | "no" | "timeout";
+
+/**
  * The execution context every tool handler receives. Both transports (Anthropic
  * SDK in-process, MCP-SDK over HTTP) build the SAME context bound to a tab, so a
  * handler is transport-agnostic — it only ever talks to the bridge via `call` /
@@ -1362,8 +1371,12 @@ const rect = () =>
 export interface PanelToolCtx {
   /** Forward a command to the panel and wrap the reply as a tool result. */
   call: (cmd: Record<string, unknown>, timeoutMs?: number) => Promise<ToolResult>;
-  /** Human-in-the-loop yes/no confirm card (false on decline/timeout/no-panel). */
-  confirm: (question: string, header: string, timeoutMs?: number) => Promise<boolean>;
+  /** Human-in-the-loop yes/no confirm card. Tri-state (#360): "yes" on an explicit
+   *  affirmative, "no" on a decline / no-panel / transport error, "timeout" when the
+   *  user never answered in time. `timeoutMs` (optional, #536) caps the WHOLE confirm
+   *  wait (card deadline + late-answer grace) for a caller with a tighter
+   *  whole-handler budget (e.g. panel_restart) — always clamped under the ask ceiling. */
+  confirm: (question: string, header: string, timeoutMs?: number) => Promise<ConfirmOutcome>;
   /** The raw bridge + tab id, for the handful of tools that need bespoke wiring
    *  (image screenshots, secret collection). */
   bridge: UiBridge;
@@ -1508,13 +1521,35 @@ export function makePanelToolCtx(
   const confirm = async (
     question: string,
     header: string,
-    timeoutMs = 300000,
-  ): Promise<boolean> => {
+    timeoutMs?: number,
+  ): Promise<ConfirmOutcome> => {
+    // #360: the enclosing MCP `tools/call` is killed at ~300s. A hardcoded 300s
+    // card wait had ZERO margin below that budget — so an unanswered confirm blew
+    // the whole tool call (a transport timeout) instead of returning cleanly, and
+    // any late answer was lost. CLAMP the card deadline under the budget (the same
+    // getAskTiming() ceiling panel_ask uses for #486) and, on a reply-timeout,
+    // poll the bridge's late-reply buffer for a bounded grace so a slow-but-valid
+    // yes/no is still HONORED. A genuine no-answer returns "timeout" (reported
+    // honestly by the caller), never a silent decline.
+    const base = getAskTiming();
+    // A caller may pass a tighter WHOLE-confirm budget (#536: panel_restart bounds
+    // confirm+dispatch+readiness under the outer limit). Treat timeoutMs as the HARD
+    // ceiling on deadline+grace so we never overrun the caller's budget, while still
+    // never exceeding the ask clamp. Absent → the full clamp (deadline+grace).
+    const total =
+      typeof timeoutMs === "number"
+        ? Math.max(1, Math.min(timeoutMs, base.deadlineMs + base.graceMs))
+        : base.deadlineMs + base.graceMs;
+    const deadlineMs = Math.max(1, Math.min(base.deadlineMs, total));
+    const graceMs = Math.max(0, total - deadlineMs);
+    const timing = { deadlineMs, graceMs, pollMs: base.pollMs };
+    const askId = randomUUID();
     try {
       ensureReachable();
       const reply = await bridge.send(
         {
           cmd: "ask_user",
+          ask_id: askId,
           question,
           header,
           options: [
@@ -1522,11 +1557,20 @@ export function makePanelToolCtx(
             { label: "No, cancel", description: "" },
           ],
         } as { cmd: string },
-        { tabId: ctx.tabId, timeoutMs: Math.max(1, timeoutMs) },
+        { tabId: ctx.tabId, timeoutMs: timing.deadlineMs },
       );
-      return isAffirmative(reply);
-    } catch {
-      return false;
+      return isAffirmative(reply) ? "yes" : "no";
+    } catch (err) {
+      // Only a card-reply TIMEOUT is recoverable/honest-as-timeout: poll the late
+      // buffer, then report "timeout" if still unanswered. Any other error (no
+      // panel, transport failure) → "no" so the destructive op is SKIPPED, exactly
+      // as the previous catch-all did.
+      if (isReplyTimeoutError(err)) {
+        const late = await pollLateAskReply(bridge, askId, timing);
+        if (late !== undefined) return isAffirmative(late) ? "yes" : "no";
+        return "timeout";
+      }
+      return "no";
     }
   };
 
@@ -2093,12 +2137,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "Remove EVERY node from the user's open graph — only for an explicit 'clear/reset the canvas'. Just CALL THIS DIRECTLY when they ask to clear: the tool itself pops a confirm card and only wipes on a yes (don't ask separately first). The wipe is a single Ctrl+Z undo. NEVER use this for a 'new workflow' — that's panel_new_workflow (a new tab, leaves this graph intact).",
       {},
       async (_args, ctx) => {
-        if (
-          !(await ctx.confirm(
-            "Clear the canvas? This removes every node from the open workflow. (One Ctrl+Z undoes it.)",
-            "Clear canvas",
-          ))
-        ) {
+        const decision = await ctx.confirm(
+          "Clear the canvas? This removes every node from the open workflow. (One Ctrl+Z undoes it.)",
+          "Clear canvas",
+        );
+        if (decision === "timeout") {
+          return ok(
+            "Timed out waiting for your confirmation, so I left the canvas as-is. " +
+              "Tell me to clear it again when you're ready.",
+          );
+        }
+        if (decision !== "yes") {
           return ok("Cancelled — the canvas was left as-is.");
         }
         return ctx.call({ cmd: "graph_clear" });
@@ -3549,20 +3598,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "Restart the user's ComfyUI server via the built-in Manager — needed to load newly installed/updated custom nodes. CALL THIS DIRECTLY when a restart is needed: it pops a confirm card and only restarts on a yes (don't ask separately first). ComfyUI and this agent go down briefly, then the panel auto-reconnects and you resume. ⚠️ BUSY GUARD: a restart ABORTS any in-progress or queued generation — if ComfyUI is generating, this tool REFUSES and tells you (it does NOT restart). When that happens, tell the user a render is running and WAIT for it (poll panel_node_queue_status), or pass force:true ONLY if the user explicitly confirms they want to kill the running generation. Best practice: before restarting after an install, check the queue is idle first. Only call when a restart is actually needed.",
       { force: z.boolean().optional() },
       async ({ force }, ctx) => {
-        // Whole-handler budget (coordinator): confirm + dispatch + readiness — INCLUDING
+        // Whole-handler budget (#536): confirm + dispatch + readiness — INCLUDING
         // the legacy path's UNPREEMPTIBLE synchronous execSync blocks — must ALL finish
         // under the outer ~300s tools/call limit. 255s + the legacy admission rule below
         // (kill+relaunch starts only with >=130s left, its ~40s of sync work FRONT-LOADED)
-        // means the handler PROVABLY returns well under 300s.
+        // means the handler PROVABLY returns well under 300s. The confirm wait is bound
+        // to the remaining budget (its deadline+grace can't overrun it — see confirm).
         const OVERALL_MAX_MS = 255_000;
         const overallDeadline = Date.now() + OVERALL_MAX_MS;
-        if (
-          !(await ctx.confirm(
-            "Restart ComfyUI now? It (and this agent) will go down briefly, then reconnect and resume automatically.",
-            "Restart ComfyUI",
-            Math.max(1, overallDeadline - Date.now()),
-          ))
-        ) {
+        const decision = await ctx.confirm(
+          "Restart ComfyUI now? It (and this agent) will go down briefly, then reconnect and resume automatically.",
+          "Restart ComfyUI",
+          Math.max(1, overallDeadline - Date.now()),
+        );
+        if (decision === "timeout") {
+          return ok(
+            "Timed out waiting for your confirmation, so I did NOT restart ComfyUI. " +
+              "Tell me to restart it and I'll go ahead.",
+          );
+        }
+        if (decision !== "yes") {
           return ok("Cancelled — ComfyUI was not restarted.");
         }
         // Heal an orphaned session onto the live tab FIRST, then bind the reboot dispatch

--- a/src/orchestrator/ready-banner.ts
+++ b/src/orchestrator/ready-banner.ts
@@ -1,0 +1,73 @@
+// Ready-banner text (#376) — extracted as a PURE builder so the connect handler
+// and the later "real model learned" correction render the SAME phrasing, and so
+// it is unit-testable.
+//
+// The bug (#376): the greeting is sent at HELLO time, before the SDK's init
+// message reports the actually-resolved model — so the Claude/default path's
+// label was the pre-init env default (COMFYUI_MCP_PANEL_MODEL ?? "claude-opus-5"),
+// not the model the agent actually runs. Threading the resolved model through
+// onSession lets us RE-SEND a corrected banner (bannerCorrection below) once the
+// real model is known.
+
+import { openAiKeyProvider } from "../services/openai-provider-registry.js";
+
+/**
+ * The "🟢 comfyui-mcp agent ready — <label> …" greeting for a given backend, with
+ * `label` (the model/agent name) substituted in. `customBaseUrl` is only used by
+ * the custom-endpoint backend. Mirrors the connect-handler's provider phrasing
+ * exactly so an initial banner and a later correction are identical but for the
+ * model name.
+ */
+export function readyBannerText(backend: string, label: string, customBaseUrl = ""): string {
+  const reg = openAiKeyProvider(backend);
+  if (reg) return reg.readyMessage(label);
+  switch (backend) {
+    case "codex":
+      return `🟢 comfyui-mcp agent ready — ${label} on your Codex (ChatGPT) account. Ask away.`;
+    case "chatgpt":
+      return `🟢 comfyui-mcp agent ready — ${label} on your ChatGPT subscription (direct OAuth). Ask away.`;
+    case "gemini":
+      return `🟢 comfyui-mcp agent ready — ${label} on your Google account (Gemini Code Assist). Ask away.`;
+    case "antigravity":
+      return `🟢 comfyui-mcp agent ready — ${label} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.`;
+    case "grok":
+      return `🟢 comfyui-mcp agent ready — ${label} on your Grok (xAI) account. Ask away.`;
+    case "ollama":
+      return `🟢 comfyui-mcp agent ready — ${label} running locally via Ollama (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+    case "lmstudio":
+      return `🟢 comfyui-mcp agent ready — ${label} running locally via LM Studio (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+    case "llamacpp":
+      return `🟢 comfyui-mcp agent ready — ${label} running locally via llama.cpp (no account, no API key). Small local models are slower and simpler than frontier ones — expect fewer frills. Ask away.`;
+    case "custom":
+      return `🟢 comfyui-mcp agent ready — ${label} via your custom endpoint (${customBaseUrl}). Ask away.`;
+    case "openrouter":
+      return `🟢 comfyui-mcp agent ready — ${label} via OpenRouter (hosted API, your OPENROUTER_API_KEY). Ask away.`;
+    case "copilot":
+      return `🟢 comfyui-mcp agent ready — ${label} on your GitHub Copilot subscription (⚠️ experimental, ToS risk — you opted in). Ask away.`;
+    default:
+      return `🟢 comfyui-mcp agent ready — ${label} on your Claude subscription. Ask away.`;
+  }
+}
+
+/**
+ * Decide the CORRECTED ready banner to re-send once the SDK reports the real model
+ * (#376), or `null` when no correction is warranted. Returns a banner ONLY when:
+ *   - a banner WAS actually advertised for this tab (`advertisedLabel` is a
+ *     non-empty string) — a resume/reconnect never greeted, so an EMPTY map must
+ *     NOT be read as a mismatch and produce a spurious banner; and
+ *   - the resolved model is a non-empty string that DIFFERS from that label.
+ * So a correct initial banner never duplicates, and a resumed session with no
+ * prior greeting is never corrected.
+ */
+export function bannerCorrection(opts: {
+  backend: string;
+  advertisedLabel: string | undefined;
+  resolvedModel: string | undefined;
+  customBaseUrl?: string;
+}): string | null {
+  const { backend, advertisedLabel, resolvedModel, customBaseUrl = "" } = opts;
+  if (typeof advertisedLabel !== "string" || !advertisedLabel) return null;
+  if (typeof resolvedModel !== "string" || !resolvedModel.trim()) return null;
+  if (resolvedModel === advertisedLabel) return null;
+  return readyBannerText(backend, resolvedModel, customBaseUrl);
+}


### PR DESCRIPTION
Two panel-orchestrator bugs (issues filed in comfyui-mcp-panel; root cause is orchestrator-side).

## #360 — restart-confirm waits until the MCP call times out
`panel_restart_comfyui` (and `panel_clear`) rendered a confirm card via `ctx.confirm`, which waited a hardcoded `timeoutMs: 300000` — equal to the outer MCP `tools/call` transport budget (~300s) with **zero margin**. If the user hadn't answered, the whole tool call died as a transport timeout, and the catch-all returned `false`, which callers reported as a definitive **"Cancelled"** (a wrong answer, and any late reply was lost).

Fix:
- `ctx.confirm` now returns a tri-state `ConfirmOutcome` (`"yes" | "no" | "timeout"`).
- Clamps the card deadline to `getAskTiming().deadlineMs` (the same <285s ceiling `panel_ask` uses for #486), so it can never blow the transport budget.
- Attaches a stable `ask_id` and polls the bridge late-reply buffer on a reply-timeout, so a slow-but-valid yes/no is still **honored**.
- Returns `"timeout"` only when truly unanswered; both callers now report an honest *"timed out waiting for your confirmation"* and **never** dispatch the restart/clear on a timeout. A non-timeout error still maps to `"no"` (safe skip), preserving prior behavior.

## #376 — ready-banner shows the wrong model
The ready banner was pushed at hello time using the pre-init default (`COMFYUI_MCP_PANEL_MODEL ?? "claude-opus-5"`), **before** the SDK's session/init event reports the actually-resolved model — and nothing re-sent a corrected banner.

Fix:
- Extracted the banner text into a pure `readyBannerText()` (strings unchanged per backend).
- Threaded the SDK-resolved model through `onSession`; `bannerCorrection()` re-sends a corrected banner **iff** a banner was actually advertised for the tab **and** the resolved model differs (returns `null` otherwise → no duplicate, and no spurious banner on a resume/reconnect that never greeted).
- A `resolvedModelByTab` reconcile labels the greeting itself correctly if init races ahead of it.

## Tests
- New `ready-banner.test.ts` (7): label substitution, per-backend phrasing, correction on mismatch, null on match / absent model / **absent advertised label (resume)**.
- New `#360` block in `panel-tools.test.ts` (4): honest timeout + no dispatch, deadline clamped under budget, late-answer honored, explicit decline vs timeout.
- Full orchestrator suite green (372).

## Codex self-gate
gpt-5.6-terra/high adversarial embed-diff review: round 1 flagged 2 P1s (spurious banner on resume; grounding drift-overwrite in the companion panel PR) → both fixed → round 2 **VERDICT: PASS**.

Companion PR (panel repo, #330): grounds unsaved workflows every turn.

Closes artokun/comfyui-mcp-panel#360
Closes artokun/comfyui-mcp-panel#376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
