### PR TITLE
feat(downloads): per-download cancellation + reconnect-adoptable download_status (#515, #529)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**181 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**182 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 
@@ -248,7 +248,7 @@ for the port, the capability matrix, and the per-provider "clink" points, and th
 
 ## MCP Tools
 
-181 tools across workflow execution, generation, iteration, composition, models, and more:
+182 tools across workflow execution, generation, iteration, composition, models, and more:
 
 ### Image Generation (high-level)
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 181 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 182 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 

--- a/src/__tests__/services/download-cache.test.ts
+++ b/src/__tests__/services/download-cache.test.ts
@@ -128,6 +128,98 @@ describe("downloadModel cache", () => {
     await expect(readFile(twoPath, "utf-8")).resolves.toBe("one network body");
   });
 
+  it("#515: a cancelled COALESCED caller never materializes its destination", async () => {
+    // A and B fetch the SAME url (→ one physical download, coalesced) to DIFFERENT
+    // destinations. B is cancelled while awaiting A's shared stream; when A finishes, B
+    // must bail BEFORE materializing — no completed file at B's models path.
+    let resolveFetch!: (r: Response) => void;
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((res) => {
+        resolveFetch = res;
+      }),
+    );
+
+    const ctrlB = new AbortController();
+    // Start A first and let it become the physical-stream OWNER (fetch fired) before B
+    // joins, so B deterministically COALESCES onto A's stream (rather than the reverse).
+    const a = downloadModel(
+      "https://example.com/models/coalesce.safetensors",
+      "checkpoints",
+      "a.safetensors",
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const b = downloadModel(
+      "https://example.com/models/coalesce.safetensors",
+      "loras",
+      "b.safetensors",
+      undefined,
+      undefined,
+      undefined,
+      ctrlB.signal,
+    );
+    // Let B reach the coalesce point (await A's shared inflight promise).
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock).toHaveBeenCalledTimes(1); // B did NOT start its own fetch
+    ctrlB.abort(); // cancel B while it awaits A's shared physical download
+    // Attach B's rejection expectation BEFORE resolving A, so B's rejection is never
+    // momentarily unhandled once A completes.
+    const bRejects = expect(b).rejects.toThrow();
+    resolveFetch(okResponse("real model bytes"));
+
+    const aPath = await a;
+    await bRejects;
+    // A landed; B did NOT (its destination was never materialized).
+    await expect(readFile(aPath, "utf-8")).resolves.toBe("real model bytes");
+    const bTarget = join(comfyDir, "models", "loras", "b.safetensors");
+    await expect(stat(bTarget)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("#515: aborting mid-stream rejects and never finalizes the target (integrity preserved)", async () => {
+    // A body that emits one chunk then STALLS forever, so we can abort it mid-transfer.
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode("partial-bytes-on-disk"));
+      },
+      pull() {
+        return new Promise<void>(() => {}); // never resolves — the stream stalls
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-length": "1000000" }, // far more than we ever send
+      }),
+    );
+
+    const controller = new AbortController();
+    const p = downloadModel(
+      "https://example.com/models/abortme.safetensors",
+      "checkpoints",
+      "abortme.safetensors",
+      undefined,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+    // Let the stream begin, then abort it.
+    await new Promise((r) => setTimeout(r, 25));
+    controller.abort();
+
+    // The transfer rejects (aborted) — it is NOT reported as a successful download.
+    await expect(p).rejects.toThrow();
+    // The web body was cancelled by the aborted pipeline.
+    expect(cancelled).toBe(true);
+    // Integrity: the destination file was NEVER created — no truncated partial was
+    // renamed into place and reported as complete (#515/#343).
+    const target = join(comfyDir, "models", "checkpoints", "abortme.safetensors");
+    await expect(stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("falls back to copying when hardlink materialization fails", async () => {
     const linkSpy = vi
       .spyOn(downloadCacheFs, "link")

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -124,10 +124,17 @@ async function writeForeignJobRecord(
     url: string;
     owner: string;
     dest_key?: string;
+    /** Route-independent request key (for local↔Manager route-flip adoption). */
+    req_key?: string;
     /** Age of the record's `updated` stamp in ms (defaults to fresh). */
     ageMs?: number;
+    /** Terminal status to simulate (defaults to an in-flight "downloading" record). */
+    status?: "downloading" | "done" | "error" | "cancelled";
+    /** Landed path for a "done" record. */
+    path?: string;
   },
 ): Promise<void> {
+  const status = rec.status ?? "downloading";
   const body = {
     id: rec.id,
     trayId: rec.trayId,
@@ -135,8 +142,11 @@ async function writeForeignJobRecord(
     url: rec.url,
     target_subfolder: "loras",
     dest_key: rec.dest_key,
-    status: "downloading",
+    req_key: rec.req_key,
+    status,
+    path: rec.path,
     started_at: Date.now(),
+    finished_at: status === "downloading" ? undefined : Date.now(),
     owner: rec.owner,
     updated: Date.now() - (rec.ageMs ?? 0),
   };
@@ -1043,6 +1053,33 @@ describe("download job registry", () => {
       }
     });
 
+    it("never reads a half-written temp as a record (atomic-write safety → no torn-read missed adoption)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // A valid, complete in-flight record.
+        await writeForeignJobRecord(dir, {
+          id: "validid000000001",
+          trayId: "validtray0000001",
+          progressId: "p",
+          url: URL_A,
+          owner: "sess",
+        });
+        // A half-written atomic-write temp with GARBAGE bytes (what a reader could see if
+        // persist wrote in place). Its name ends in `.tmp`, so no scanner reads it.
+        await writeFile(
+          pathJoin(dir, `control-job-validid000000001-sess.json.99999-0.tmp`),
+          "{ half-written garba",
+        );
+        // Readers see only the complete record — never the torn temp.
+        expect(getDownloadJob("validid000000001")?.status).toBe("downloading");
+        expect(listDownloadJobs().filter((j) => j.id === "validid000000001")).toHaveLength(1);
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
     it("reaps a DEAD (crashed-writer) in-flight record so it is not reported as still streaming", async () => {
       const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
       setProgressDir(dir);
@@ -1080,6 +1117,230 @@ describe("download job registry", () => {
         const adopted = getDownloadJob(id);
         expect(adopted?.status).toBe("done");
         expect(adopted?.path).toBe("/M/checkpoints/big.safetensors");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a reconnect + reissue ADOPTS another session's in-flight download instead of starting a SECOND writer", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // Session A started the download (this test process stands in for it to compute
+        // the real deterministic id), then a DIFFERENT session (owner) owns it in flight.
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        const id = a.job.id;
+        expect(hoisted.calls).toBe(1);
+        // Simulate the OTHER session owning the in-flight download, and this session NOT
+        // having it: rewrite the record under a different owner and drop our own copy +
+        // in-memory registry (a reconnect is a NEW process = NEW owner).
+        await fsRm(pathJoin(dir, `control-job-${id}-${PERSIST_OWNER}.json`), { force: true });
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId: a.job.trayId,
+          progressId: `prog-${URL_A}`,
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-other`,
+          dest_key: a.job.destKey,
+        });
+        resetDownloadJobs();
+
+        // Reissue the SAME url/destination — must ADOPT the foreign in-flight job.
+        const b = await startDownloadJob(URL_A, "checkpoints");
+        expect(b.job.id).toBe(id);
+        expect(b.job.status).toBe("downloading");
+        // Crucially: NO second physical writer was started for the same file.
+        expect(hoisted.calls).toBe(1);
+        // The adopted view is read-only (not registered) — settled resolves immediately.
+        await expect(b.settled).resolves.toBeUndefined();
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("this session's IN-MEMORY cancelled does NOT mask another session's validated DONE (same id)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // This session (A) is cancelled locally — its in-memory record is terminal cancelled.
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        cancelDownloadJob(a.job.id);
+        await a.settled;
+        expect(a.job.status).toBe("cancelled");
+        // Another session (B) landed + VALIDATED the SAME file (done), same id + trayId.
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: a.job.trayId,
+          progressId: `prog-${URL_A}`,
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-other`,
+          status: "done",
+          path: "/M/checkpoints/big.safetensors",
+        });
+
+        // NON-reconnect: A is STILL in this process's in-memory registry as cancelled — but
+        // getDownloadJob and the no-selector list must report B's validated DONE, not A's cancelled.
+        const got = getDownloadJob(a.job.id);
+        expect(got?.status).toBe("done");
+        expect(got?.path).toBe("/M/checkpoints/big.safetensors");
+        const listed = listDownloadJobs().find((j) => j.id === a.job.id && j.trayId === a.job.trayId);
+        expect(listed?.status).toBe("done");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("adopts across a local↔Manager route flip via the route-independent reqKey (not just id)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // This session runs LOCAL → public id = destination hash; capture its reqKey.
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        const reqKey = a.job.reqKey!;
+        const localId = a.job.id;
+        expect(reqKey).toBeTruthy();
+        // The OTHER session ran the SAME request via the MANAGER route → a DIFFERENT public
+        // id (keyed by the request key) but the SAME reqKey + trayId. Remove our own record.
+        await fsRm(pathJoin(dir, `control-job-${localId}-${PERSIST_OWNER}.json`), { force: true });
+        await writeForeignJobRecord(dir, {
+          id: reqKey, // remote route keys the public id by the request key
+          trayId: a.job.trayId,
+          progressId: "foreign-prog",
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-other`,
+          req_key: reqKey,
+        });
+        resetDownloadJobs();
+
+        // Reissue LOCALLY (our id = destination hash ≠ the foreign remote id) — must still
+        // ADOPT the foreign in-flight download via the route-independent reqKey, not
+        // double-write.
+        const b = await startDownloadJob(URL_A, "checkpoints");
+        expect(b.job.id).toBe(reqKey); // adopted the foreign (remote-keyed) record
+        expect(b.job.status).toBe("downloading");
+        expect(hoisted.calls).toBe(1); // NO second physical writer
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("stops a completed job's heartbeat when persistence goes inactive (no forever-retrying interval)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      vi.useFakeTimers();
+      const clearSpy = vi.spyOn(globalThis, "clearInterval");
+      try {
+        const entry = await startDownloadJob(URL_A, "checkpoints");
+        const hb = (entry as { heartbeat?: ReturnType<typeof setInterval> }).heartbeat;
+        expect(hb).toBeDefined();
+        // Persistence goes INACTIVE, then the download completes. The settled finally's
+        // terminal persist no-ops (no dir → not durable), so it does NOT clear the
+        // heartbeat there — the heartbeat itself must stop on its next tick.
+        setProgressDir("");
+        hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+        await entry.settled;
+        clearSpy.mockClear();
+        // One heartbeat tick later, the terminal branch clears the interval (persistence
+        // inactive) — a completed job's interval never does filesystem work forever.
+        await vi.advanceTimersByTimeAsync(15_001);
+        expect(clearSpy).toHaveBeenCalledWith(hb);
+      } finally {
+        vi.useRealTimers();
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("installs a heartbeat only when the persisted store is active (no leak on non-panel downloads)", async () => {
+      // No progress dir → persistence inactive → NO heartbeat interval (would otherwise
+      // leak, retrying a no-op forever since persist never reports durable).
+      const noPanel = await startDownloadJob(URL_A, "checkpoints");
+      expect((noPanel as { heartbeat?: unknown }).heartbeat).toBeUndefined();
+
+      // With a progress dir → a heartbeat is installed (and cleared by resetDownloadJobs).
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const panel = await startDownloadJob(URL_B, "loras");
+        expect((panel as { heartbeat?: unknown }).heartbeat).toBeDefined();
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("does NOT adopt a foreign live download of a DIFFERENT url to the same destination (same id, different trayId)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // Discover the deterministic id for URL_A → checkpoints, then clear everything.
+        const probe = await startDownloadJob(URL_A, "checkpoints");
+        const id = probe.job.id;
+        const destKey = probe.job.destKey;
+        await fsRm(pathJoin(dir, `control-job-${id}-${PERSIST_OWNER}.json`), { force: true });
+        resetDownloadJobs();
+        // A foreign session is live-downloading a DIFFERENT source url (different trayId)
+        // to the SAME destination+auth (same id).
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId: "differenturltray",
+          progressId: "foreign-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-other`,
+          dest_key: destKey,
+        });
+
+        // Reissuing URL_A must NOT adopt the foreign URL_B download — it's a distinct
+        // logical download. We start our OWN writer for URL_A.
+        const b = await startDownloadJob(URL_A, "checkpoints");
+        expect(b.job.trayId).toBe(downloadIdFor(URL_A)); // OUR url, not the foreign one
+        expect(b.job.status).toBe("downloading");
+        expect(hoisted.calls).toBe(2); // our own writer started (probe was call 1)
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a validated DONE record WINS over a LATER same-id cancelled/error record (no cancelled-over-complete)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const sharedId = "sharedid00000001";
+        const sharedTray = "sharedtray000001";
+        // Session B landed + VALIDATED the file (done) — EARLIER.
+        await writeForeignJobRecord(dir, {
+          id: sharedId,
+          trayId: sharedTray,
+          progressId: "shared-prog",
+          url: URL_A,
+          owner: "sessionB",
+          status: "done",
+          path: "/M/checkpoints/m.safetensors",
+          ageMs: 5000, // 5s ago
+        });
+        // Session A cancelled the SAME id LATER — must NOT override the validated file.
+        await writeForeignJobRecord(dir, {
+          id: sharedId,
+          trayId: sharedTray,
+          progressId: "shared-prog",
+          url: URL_A,
+          owner: "sessionA",
+          status: "cancelled",
+          ageMs: 0, // now (newer than the done)
+        });
+
+        // download_status(id) MUST report the validated DONE, not the newer cancelled.
+        const got = getDownloadJob(sharedId);
+        expect(got?.status).toBe("done");
+        expect(got?.path).toBe("/M/checkpoints/m.safetensors");
+        // The no-selector list must also surface the DONE for that (id, trayId), not the cancelled.
+        const listed = listDownloadJobs().find((j) => j.id === sharedId && j.trayId === sharedTray);
+        expect(listed?.status).toBe("done");
       } finally {
         setProgressDir("");
         await fsRm(dir, { recursive: true, force: true });

--- a/src/__tests__/services/download-jobs.test.ts
+++ b/src/__tests__/services/download-jobs.test.ts
@@ -13,6 +13,15 @@ const hoisted = vi.hoisted(() => ({
   dispatchQueue: [] as boolean[],
   dispatchEvals: 0,
   lastDispatchArg: undefined as boolean | undefined,
+  // The per-download AbortSignal threaded into downloadModel (#515) — captured so a
+  // cancel test can prove the abort reached the writer.
+  lastSignal: undefined as AbortSignal | undefined,
+  // The onTrayId callback threaded into downloadModel (#515) — captured so a test can
+  // prove the job's trayId realigns with the actual tray-row id (post-auth/HF rewrite).
+  lastOnTrayId: undefined as ((trayId: string) => void) | undefined,
+  // The onLanded callback threaded into downloadModel (#515) — captured so a test can
+  // prove the job commits done synchronously at the destination rename.
+  lastOnLanded: undefined as ((targetPath: string) => void) | undefined,
 }));
 
 // isRemoteMode gates the identity branch in startDownloadJob. Keep every other
@@ -44,11 +53,32 @@ vi.mock("../../services/model-resolver.js", () => ({
   // Capture the routing decision THREADED IN by startDownloadJob (5th arg) so a
   // test can assert the writer used the job's decision, not a fresh evaluation.
   downloadModel: vi.fn(
-    (url: string, _sub?: string, _fn?: string, _auth?: unknown, dispatchToManager?: boolean) => {
+    (
+      url: string,
+      _sub?: string,
+      _fn?: string,
+      _auth?: unknown,
+      dispatchToManager?: boolean,
+      _onResume?: unknown,
+      signal?: AbortSignal,
+      onTrayId?: (trayId: string) => void,
+      onLanded?: (targetPath: string) => void,
+    ) => {
       hoisted.calls += 1;
       hoisted.lastDispatchArg = dispatchToManager;
+      hoisted.lastSignal = signal;
+      hoisted.lastOnTrayId = onTrayId;
+      hoisted.lastOnLanded = onLanded;
+      // Model the writer reporting the physical tray id (a hash of the post-auth/HF
+      // request URL). Keyed by URL so same-URL jobs to different destinations share one
+      // progressId (they coalesce onto one physical stream/row), as in production.
+      onTrayId?.(`prog-${url}`);
       return new Promise<string>((resolve, reject) => {
         hoisted.resolvers.push({ resolve, reject, url });
+        // Model a real fetch/pipeline: aborting the signal rejects the transfer.
+        if (signal) {
+          signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        }
       });
     },
   ),
@@ -69,14 +99,49 @@ vi.mock("../../services/model-resolver.js", () => ({
 import {
   startDownloadJob,
   getDownloadJob,
+  findDownloadJob,
   listDownloadJobs,
+  cancelDownloadJob,
   resetDownloadJobs,
   downloadIdFor,
 } from "../../services/download-jobs.js";
+import { setProgressDir, PERSIST_OWNER } from "../../services/download-progress.js";
+import * as progressModule from "../../services/download-progress.js";
 import { downloadModel, resolveDownloadTarget } from "../../services/model-resolver.js";
-import { mkdtemp, mkdir, symlink, rm as fsRm } from "node:fs/promises";
+import { mkdtemp, mkdir, symlink, writeFile, rm as fsRm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
+
+/** Simulate ANOTHER MCP session's persisted in-flight record on disk: a distinct
+ *  owner-scoped control-job- file (owner ≠ this process's PERSIST_OWNER). Used to
+ *  exercise cross-session sibling detection without a second process. */
+async function writeForeignJobRecord(
+  dir: string,
+  rec: {
+    id: string;
+    trayId: string;
+    progressId: string;
+    url: string;
+    owner: string;
+    dest_key?: string;
+    /** Age of the record's `updated` stamp in ms (defaults to fresh). */
+    ageMs?: number;
+  },
+): Promise<void> {
+  const body = {
+    id: rec.id,
+    trayId: rec.trayId,
+    progressId: rec.progressId,
+    url: rec.url,
+    target_subfolder: "loras",
+    dest_key: rec.dest_key,
+    status: "downloading",
+    started_at: Date.now(),
+    owner: rec.owner,
+    updated: Date.now() - (rec.ageMs ?? 0),
+  };
+  await writeFile(pathJoin(dir, `control-job-${rec.id}-${rec.owner}.json`), JSON.stringify(body));
+}
 
 const URL_A = "https://huggingface.co/org/repo/resolve/main/big.safetensors";
 const URL_B = "https://huggingface.co/org/repo/resolve/main/other.safetensors";
@@ -90,6 +155,9 @@ describe("download job registry", () => {
     hoisted.dispatchQueue.length = 0;
     hoisted.dispatchEvals = 0;
     hoisted.lastDispatchArg = undefined;
+    hoisted.lastSignal = undefined;
+    hoisted.lastOnTrayId = undefined;
+    hoisted.lastOnLanded = undefined;
     resetDownloadJobs();
   });
 
@@ -470,5 +538,552 @@ describe("download job registry", () => {
     await pub.settled;
     await new Promise((r) => setTimeout(r, 0));
     expect(hoisted.calls).toBe(2);
+  });
+
+  // ── #515: per-download cancellation ────────────────────────────────────────
+  describe("#515 per-download cancellation", () => {
+    it("cancels a running download by id — aborts the stream, no false-complete, and never resurrects to done/error", async () => {
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints");
+      expect(job.status).toBe("downloading");
+      // A signal was threaded into the writer (the abort handle).
+      expect(hoisted.lastSignal).toBeInstanceOf(AbortSignal);
+      expect(hoisted.lastSignal!.aborted).toBe(false);
+
+      const res = cancelDownloadJob(job.id);
+      expect(res.found).toBe(true);
+      expect(res.owned).toBe(true);
+      expect(res.aborted).toBe(true); // abort REQUESTED (best-effort; final state via settled)
+      // The abort reached the writer's signal.
+      expect(hoisted.lastSignal!.aborted).toBe(true);
+
+      // The FINAL state is resolved by the settled closure: the writer's stream rejects
+      // because of the abort (modeled in the mock), so it settles as cancelled — never a
+      // false "error" and never a false-complete (no landed path).
+      await settled;
+      expect(job.status).toBe("cancelled");
+      expect(job.error).toBeUndefined();
+      expect(job.path).toBeUndefined();
+    });
+
+    it("cancel only aborts the targeted download — other in-flight downloads keep running", async () => {
+      const a = await startDownloadJob(URL_A, "checkpoints");
+      const b = await startDownloadJob(URL_B, "loras");
+      expect(hoisted.calls).toBe(2);
+
+      cancelDownloadJob(a.job.id);
+      // B is untouched and still streaming.
+      expect(b.job.status).toBe("downloading");
+      await a.settled; // the abort rejects A's stream → cancelled
+      expect(a.job.status).toBe("cancelled");
+
+      // B still completes normally.
+      const bResolver = hoisted.resolvers.find((r) => r.url === URL_B)!;
+      bResolver.resolve("/M/loras/other.safetensors");
+      await b.settled;
+      expect(b.job.status).toBe("done");
+      expect(b.job.path).toBe("/M/loras/other.safetensors");
+    });
+
+    it("is idempotent — a second cancel, or a cancel of a finished/failed job, is a no-op", async () => {
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints");
+      cancelDownloadJob(job.id);
+      await settled;
+      const again = cancelDownloadJob(job.id);
+      expect(again.aborted).toBe(false);
+      expect(again.status).toBe("cancelled");
+
+      // A completed download can't be cancelled.
+      const done = await startDownloadJob(URL_B, "loras");
+      hoisted.resolvers.find((r) => r.url === URL_B)!.resolve("/M/loras/other.safetensors");
+      await done.settled;
+      const res = cancelDownloadJob(done.job.id);
+      expect(res.aborted).toBe(false);
+      expect(res.status).toBe("done");
+      expect(done.job.status).toBe("done");
+    });
+
+    it("reports a not-found id honestly", () => {
+      const res = cancelDownloadJob("deadbeefdeadbeef");
+      expect(res.found).toBe(false);
+      expect(res.aborted).toBe(false);
+    });
+
+    it("marks a remote Manager-dispatched job viaManager, and a cancel during dispatch reports cancelled (not done)", async () => {
+      hoisted.remote = true; // route to the remote ComfyUI-Manager dispatch
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints");
+      expect(job.viaManager).toBe(true);
+
+      // A cancel while the dispatch is in flight must NOT be converted to "done" by a
+      // dispatch return — the mock rejects on abort exactly as the real remote path
+      // throws on abort, so the job settles as cancelled.
+      cancelDownloadJob(job.id);
+      await settled;
+      expect(job.status).toBe("cancelled");
+      expect(job.path).toBeUndefined();
+    });
+
+    it("declines cancel-by-id (and status-by-id) when a live foreign session shares the id with a different trayId", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // A concurrent foreign session downloads a DIFFERENT url to the SAME dest+auth:
+        // same id, different (fresh) trayId.
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "foreigntrayid000",
+          progressId: "foreign-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-other`,
+        });
+
+        // cancel_download by id must DECLINE (could hit the wrong concurrent download).
+        const res = cancelDownloadJob(a.job.id);
+        expect(res.ambiguous).toBe(true);
+        expect(res.aborted).toBe(false);
+        expect(a.job.status).toBe("downloading"); // not cancelled
+        // status-by-id likewise declines rather than silently reporting the local one.
+        expect(getDownloadJob(a.job.id)).toBeUndefined();
+
+        // A STALE foreign record (dead session) does NOT block the local id — cancel works.
+        await fsRm(pathJoin(dir, `control-job-${a.job.id}-${PERSIST_OWNER}-other.json`), { force: true });
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: "foreigntrayid000",
+          progressId: "foreign-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-dead`,
+          ageMs: 10 * 60 * 1000,
+        });
+        expect(getDownloadJob(a.job.id)?.id).toBe(a.job.id);
+        const res2 = cancelDownloadJob(a.job.id);
+        expect(res2.aborted).toBe(true);
+        await a.settled;
+        expect(a.job.status).toBe("cancelled");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("cancelling a coalesced sibling does NOT clear the active owner's shared progress row (only the last one out clears it)", async () => {
+      const clearSpy = vi.spyOn(progressModule, "clearDownloadProgress");
+      try {
+        // Two DIFFERENT-destination jobs for the same URL coalesce onto one physical
+        // stream and share ONE progress row (progressId). Simulate the writer having
+        // reported that shared id to both.
+        const ja = await startDownloadJob(URL_A, "checkpoints");
+        const jb = await startDownloadJob(URL_A, "loras");
+        ja.job.progressId = "sharedprogressid";
+        jb.job.progressId = "sharedprogressid";
+        clearSpy.mockClear();
+
+        // Cancel the coalesced sibling B while owner A is still in flight — A's live
+        // row MUST survive (B must not clear the shared id). The clean-up runs in B's
+        // settled closure (registry-aware), so await it.
+        const resB = cancelDownloadJob(jb.job.id);
+        expect(resB.aborted).toBe(true);
+        await jb.settled;
+        expect(jb.job.status).toBe("cancelled");
+        expect(clearSpy).not.toHaveBeenCalledWith("sharedprogressid");
+
+        // Now cancel the owner A — no other in-flight job shares the id, so the row is
+        // finally cleared.
+        const resA = cancelDownloadJob(ja.job.id);
+        expect(resA.aborted).toBe(true);
+        await ja.settled;
+        expect(clearSpy).toHaveBeenCalledWith("sharedprogressid");
+      } finally {
+        clearSpy.mockRestore();
+      }
+    });
+
+    it("does NOT clear another SESSION's shared progress row on cancel — even for the SAME job id (owner-scoped sibling check)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      const clearSpy = vi.spyOn(progressModule, "clearDownloadProgress");
+      try {
+        // This session starts A locally; it shares progressId "prog-URL_A" with the row.
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        expect(a.job.progressId).toBe(`prog-${URL_A}`);
+
+        // ANOTHER session is running the SAME logical download — SAME deterministic id
+        // AND the same progressId, but a DIFFERENT owner (distinct persisted file).
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: a.job.trayId,
+          progressId: `prog-${URL_A}`,
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-other`,
+        });
+        clearSpy.mockClear();
+
+        // Cancelling our copy must NOT clear the row — the other session still uses it.
+        // (id-based exclusion would miss the foreign same-id record; owner-based catches it.)
+        const res = cancelDownloadJob(a.job.id);
+        expect(res.aborted).toBe(true);
+        await a.settled;
+        expect(clearSpy).not.toHaveBeenCalledWith(`prog-${URL_A}`);
+      } finally {
+        clearSpy.mockRestore();
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a STALE (crashed-session) foreign record does NOT suppress cleanup of a sole cancelled job", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      const clearSpy = vi.spyOn(progressModule, "clearDownloadProgress");
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // A crashed session left a stale in-flight record (heartbeat stopped long ago).
+        await writeForeignJobRecord(dir, {
+          id: a.job.id,
+          trayId: a.job.trayId,
+          progressId: `prog-${URL_A}`,
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-dead`,
+          ageMs: 10 * 60 * 1000, // 10 min old → well past the staleness threshold
+        });
+        clearSpy.mockClear();
+        const res = cancelDownloadJob(a.job.id);
+        expect(res.aborted).toBe(true);
+        await a.settled;
+        // The dead session's stale record must NOT block our clean-up.
+        expect(clearSpy).toHaveBeenCalledWith(`prog-${URL_A}`);
+      } finally {
+        clearSpy.mockRestore();
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("DOES clear the row on cancel when this session is the only owner", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      const clearSpy = vi.spyOn(progressModule, "clearDownloadProgress");
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        expect(a.job.progressId).toBe(`prog-${URL_A}`);
+        clearSpy.mockClear();
+        const res = cancelDownloadJob(a.job.id);
+        expect(res.aborted).toBe(true);
+        await a.settled;
+        // Sole owner, no sibling in either store → the row IS cleared.
+        expect(clearSpy).toHaveBeenCalledWith(`prog-${URL_A}`);
+      } finally {
+        clearSpy.mockRestore();
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("records the actual tray-row id as progressId WITHOUT disturbing the stable trayId (so cancel cleanup + URL adoption both work)", async () => {
+      const { job } = await startDownloadJob(URL_A, "checkpoints");
+      expect(job.trayId).toBe(downloadIdFor(URL_A));
+      // The writer reports the id the tray rows are ACTUALLY written under (a hash of
+      // the post-auth/HF-rewrite request URL).
+      expect(hoisted.lastOnTrayId).toBeInstanceOf(Function);
+      hoisted.lastOnTrayId!("aaaabbbbccccdddd");
+      // progressId adopts it (used for byte display + cancel cleanup)…
+      expect(job.progressId).toBe("aaaabbbbccccdddd");
+      // …but trayId stays the STABLE original-URL hash so URL adoption still resolves.
+      expect(job.trayId).toBe(downloadIdFor(URL_A));
+      expect(findDownloadJob({ url: URL_A })?.id).toBe(job.id);
+    });
+
+    it("a cancel DURING the onComplete post-download hook reports done — the model file already MATERIALIZED", async () => {
+      // The physical download FINISHED (downloadModel resolved a path ⇒ the model file
+      // materialized + validated to its destination) and THEN onComplete (e.g. the
+      // CivitAI sidecar hook) runs. A cancel arriving in that window is too late: the
+      // real model is on disk, so the honest outcome is DONE (not a false "cancelled,
+      // resumable partial" while a complete file exists at the destination).
+      let releaseOnComplete!: () => void;
+      const gate = new Promise<void>((r) => {
+        releaseOnComplete = r;
+      });
+      let signalOnCompleteStarted!: () => void;
+      const started = new Promise<void>((r) => {
+        signalOnCompleteStarted = r;
+      });
+      const { job, settled } = await startDownloadJob(
+        URL_A,
+        "checkpoints",
+        undefined,
+        undefined,
+        async () => {
+          signalOnCompleteStarted();
+          await gate;
+          return ["sidecar written"];
+        },
+      );
+      // Finish the transfer so the file has landed and onComplete begins.
+      hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+      await started;
+
+      cancelDownloadJob(job.id); // too late — the file already materialized
+
+      releaseOnComplete(); // let the hook finish
+      await settled;
+
+      // The completed, validated file is on disk → honest report is done with its path.
+      expect(job.status).toBe("done");
+      expect(job.path).toBe("/M/checkpoints/big.safetensors");
+    });
+
+    it("commits done at the destination rename (onLanded), so a cancel in the rename→return window is a no-op", async () => {
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints", "big.safetensors");
+      expect(job.status).toBe("downloading");
+      // The writer renames the completed file into place → onLanded fires SYNCHRONOUSLY.
+      expect(hoisted.lastOnLanded).toBeInstanceOf(Function);
+      hoisted.lastOnLanded!("/M/checkpoints/big.safetensors");
+      // Done is committed the instant the file lands — before downloadModel even returns.
+      expect(job.status).toBe("done");
+      expect(job.path).toBe("/M/checkpoints/big.safetensors");
+
+      // A cancel arriving in the window between landing and the return is a NO-OP
+      // (the file is already on disk) — never a false "cancelled" over a complete file.
+      const res = cancelDownloadJob(job.id);
+      expect(res.aborted).toBe(false);
+      expect(res.status).toBe("done");
+
+      hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+      await settled;
+      expect(job.status).toBe("done");
+    });
+
+    it("a cancel that arrives just before the rename's onLanded continuation still lands as done (no cancelled-over-complete race)", async () => {
+      // The exact round-27 race: the destination rename physically completed, but a cancel
+      // arrives before its onLanded promise-continuation runs. cancelDownloadJob must NOT
+      // synchronously mark the job cancelled — otherwise commitDone (which only advances a
+      // "downloading" job) could not correct it and a complete validated file would read
+      // "cancelled".
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints", "big.safetensors");
+      const res = cancelDownloadJob(job.id);
+      expect(res.aborted).toBe(true);
+      // NOT synchronously cancelled — the final state is decided by what happened on disk.
+      expect(job.status).toBe("downloading");
+      // The rename's continuation now fires onLanded → commitDone → done, despite the abort.
+      hoisted.lastOnLanded!("/M/checkpoints/big.safetensors");
+      expect(job.status).toBe("done");
+      expect(job.path).toBe("/M/checkpoints/big.safetensors");
+      hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+      await settled;
+      expect(job.status).toBe("done");
+    });
+
+    it("if the file MATERIALIZES despite a late cancel, the job reports done (a real complete file, not a false 'cancelled')", async () => {
+      // Model the race where materialize/rename completed before the abort took effect:
+      // downloadModel RESOLVES a path even though the signal was aborted.
+      vi.mocked(downloadModel).mockImplementationOnce(
+        async (_url: string, sub: string, fn?: string) => `/M/${sub}/${fn ?? "big.safetensors"}`,
+      );
+      const { job, settled } = await startDownloadJob(URL_A, "checkpoints", "big.safetensors");
+      cancelDownloadJob(job.id); // the download already resolved (file landed)
+      await settled;
+      expect(job.status).toBe("done");
+      expect(job.path).toBe("/M/checkpoints/big.safetensors");
+    });
+  });
+
+  // ── #529: adopt an in-flight download after a session reconnect ─────────────
+  describe("#529 reconnect adoption", () => {
+    it("still resolves an in-flight download by id (and by URL) after a simulated reconnect", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir); // enable the cross-session persisted store (as the panel does)
+      try {
+        const { job } = await startDownloadJob(URL_A, "checkpoints");
+        expect(job.status).toBe("downloading");
+        const id = job.id;
+        // Simulate the writer reporting a DIFFERENT physical progress id (as a
+        // query-auth / HF-rewritten URL would) — URL adoption must still work off the
+        // stable original-URL trayId, not this rewritten progressId.
+        hoisted.lastOnTrayId?.("ffff0000ffff0000");
+
+        // A reconnect respawns the MCP child: the in-memory registry is empty again.
+        resetDownloadJobs();
+        expect(listDownloadJobs().find((j) => j.id === id && j.status === "downloading")).toBeTruthy();
+
+        // Before the fix this returned undefined ("tracked per server session").
+        const adopted = getDownloadJob(id);
+        expect(adopted).toBeTruthy();
+        expect(adopted!.id).toBe(id);
+        expect(adopted!.status).toBe("downloading");
+        expect(adopted!.trayId).toBe(downloadIdFor(URL_A));
+
+        // Adoptable by source URL too (no id needed), without starting a duplicate.
+        const byUrl = findDownloadJob({ url: URL_A });
+        expect(byUrl?.id).toBe(id);
+        expect(hoisted.calls).toBe(1); // no second writer spun up
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("declines an ambiguous URL adoption when the same URL has two in-flight destinations across stores", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // Two same-URL downloads to DIFFERENT destinations — distinct jobs, both in
+        // flight, both persisted.
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        const b = await startDownloadJob(URL_A, "loras");
+        expect(a.job.id).not.toBe(b.job.id);
+
+        // Reconnect, then re-create ONLY A in this session so the ambiguity spans BOTH
+        // stores: in-memory A (URL_A→checkpoints) + persisted-only B (URL_A→loras).
+        resetDownloadJobs();
+        const a2 = await startDownloadJob(URL_A, "checkpoints");
+        expect(a2.job.id).toBe(a.job.id);
+
+        // Adopting by URL alone can't tell A from B — must decline, not guess.
+        expect(findDownloadJob({ url: URL_A })).toBeUndefined();
+        // …but each is still resolvable by its exact id.
+        expect(getDownloadJob(a.job.id)?.id).toBe(a.job.id);
+        expect(getDownloadJob(b.job.id)?.id).toBe(b.job.id);
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("lists BOTH same-id/different-trayId physical downloads and declines the ambiguous id lookup", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // This session runs one download (id X, trayId = downloadIdFor(URL_A)).
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        const id = a.job.id;
+        const trayA = a.job.trayId;
+        // Another session ran a DISTINCT URL that resolved to the SAME dest+auth: same
+        // deterministic id, but a DIFFERENT trayId — a distinct physical download.
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId: "distincttrayid00",
+          progressId: "other-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-other`,
+        });
+        // Reconnect: drop the in-memory copy so resolution goes through the persisted
+        // store where both records (same id, different trayId) coexist.
+        resetDownloadJobs();
+
+        // download_status with no selector must list BOTH, not silently drop one.
+        const all = listDownloadJobs();
+        const mine = all.filter((j) => j.id === id);
+        expect(new Set(mine.map((j) => j.trayId))).toEqual(new Set([trayA, "distincttrayid00"]));
+        // An id lookup can't disambiguate the two → decline rather than guess.
+        expect(getDownloadJob(id)).toBeUndefined();
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("a STALE foreign same-id/different-trayId record does NOT block resolving the fresh valid job after reconnect", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        const id = a.job.id;
+        const trayA = a.job.trayId;
+        // A crashed foreign session left a STALE in-flight record sharing the id with a
+        // different trayId. It must NOT permanently make the id unresolvable.
+        await writeForeignJobRecord(dir, {
+          id,
+          trayId: "staletray0000000",
+          progressId: "stale-prog",
+          url: URL_B,
+          owner: `${PERSIST_OWNER}-dead`,
+          ageMs: 10 * 60 * 1000,
+        });
+        // Reconnect: resolution now goes through the persisted store.
+        resetDownloadJobs();
+
+        // The fresh valid record (A) must still resolve — the stale one is ignored.
+        const got = getDownloadJob(id);
+        expect(got?.id).toBe(id);
+        expect(got?.trayId).toBe(trayA);
+        expect(got?.status).toBe("downloading");
+        // cancel_download reports it as tracked-but-not-owned (another session), NOT "not found".
+        const res = cancelDownloadJob(id);
+        expect(res.found).toBe(true);
+        expect(res.owned).toBe(false);
+        // URL adoption also ignores the stale sibling and resolves the fresh job.
+        expect(findDownloadJob({ url: URL_A })?.id).toBe(id);
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("URL adoption ignores a STALE sibling for the same URL and still resolves the fresh in-flight job", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // Fresh in-flight job for URL_A → checkpoints (this session).
+        const a = await startDownloadJob(URL_A, "checkpoints");
+        // A STALE crashed record for the SAME URL_A → a different destination (loras):
+        // different id AND trayId is the same URL hash, so it matches the URL query too.
+        await writeForeignJobRecord(dir, {
+          id: "otheridxxxxxxxxx",
+          trayId: downloadIdFor(URL_A),
+          progressId: "stale-prog",
+          url: URL_A,
+          owner: `${PERSIST_OWNER}-dead`,
+          ageMs: 10 * 60 * 1000,
+        });
+        // The stale sibling must NOT inflate the ambiguity count → the fresh job resolves.
+        expect(findDownloadJob({ url: URL_A })?.id).toBe(a.job.id);
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("reaps a DEAD (crashed-writer) in-flight record so it is not reported as still streaming", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        // A crashed session left a stale in-flight record (heartbeat stopped long ago).
+        await writeForeignJobRecord(dir, {
+          id: "deadjobxxxxxxxx1",
+          trayId: "deadtrayxxxxxxx1",
+          progressId: "dead-prog",
+          url: URL_A,
+          owner: "crashedsession",
+          ageMs: 10 * 60 * 1000,
+        });
+        // It must NOT be resolvable/listed as a live download (it's dead, not streaming).
+        expect(getDownloadJob("deadjobxxxxxxxx1")).toBeUndefined();
+        expect(listDownloadJobs().some((j) => j.id === "deadjobxxxxxxxx1")).toBe(false);
+        expect(findDownloadJob({ url: URL_A })).toBeUndefined();
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("reflects the terminal outcome across a reconnect (a completed job persists as done)", async () => {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "djobs-persist-"));
+      setProgressDir(dir);
+      try {
+        const { job, settled } = await startDownloadJob(URL_A, "checkpoints");
+        const id = job.id;
+        hoisted.resolvers[0].resolve("/M/checkpoints/big.safetensors");
+        await settled;
+        expect(job.status).toBe("done");
+
+        resetDownloadJobs(); // reconnect
+        const adopted = getDownloadJob(id);
+        expect(adopted?.status).toBe("done");
+        expect(adopted?.path).toBe("/M/checkpoints/big.safetensors");
+      } finally {
+        setProgressDir("");
+        await fsRm(dir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/__tests__/services/download-persist-atomic.test.ts
+++ b/src/__tests__/services/download-persist-atomic.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, readdir, rm as fsRm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Force renameSync failure on demand to exercise persistDownloadJob's atomic-write
+// failure path (#529). node:fs (the SYNC api download-progress uses) is mocked; only
+// renameSync is wrapped — everything else passes through. node:fs/promises (used by this
+// test for setup) is a DIFFERENT module and stays real.
+const h = vi.hoisted(() => ({
+  realRename: undefined as ((from: string, to: string) => void) | undefined,
+  fail: false,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  h.realRename = actual.renameSync as (from: string, to: string) => void;
+  return {
+    ...actual,
+    renameSync: (from: string, to: string) => {
+      if (h.fail) throw new Error("EPERM: forced rename failure");
+      return h.realRename!(from, to);
+    },
+  };
+});
+
+import {
+  persistDownloadJob,
+  readPersistedDownloadJob,
+  setProgressDir,
+  PERSIST_OWNER,
+} from "../../services/download-progress.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "djobs-atomic-"));
+  setProgressDir(dir);
+  h.fail = false;
+});
+
+afterEach(async () => {
+  setProgressDir("");
+  h.fail = false;
+  await fsRm(dir, { recursive: true, force: true });
+});
+
+const rec = (status: "downloading" | "done") => ({
+  id: "atomicid00000001",
+  trayId: "atomictray000001",
+  progressId: "p",
+  url: "https://example.com/model.safetensors",
+  target_subfolder: "checkpoints",
+  status,
+  path: status === "done" ? "/M/checkpoints/x.safetensors" : undefined,
+  started_at: Date.now(),
+});
+
+describe("persistDownloadJob atomic write (#529 torn-write guard)", () => {
+  it("a normal persist writes atomically, reports durable, and leaves no temp behind", async () => {
+    expect(persistDownloadJob(rec("downloading"))).toBe(true); // durably replaced
+    const files = await readdir(dir);
+    expect(files.some((f) => f.endsWith(".tmp"))).toBe(false);
+    expect(readPersistedDownloadJob("atomicid00000001")?.status).toBe("downloading");
+  });
+
+  it("on a rename failure, NEVER rewrites the scanned .json in place (no torn-write) and leaks no temp", async () => {
+    // First persist succeeds atomically → a complete record on disk.
+    persistDownloadJob(rec("downloading"));
+    const filePath = join(dir, `control-job-atomicid00000001-${PERSIST_OWNER}.json`);
+    const rawBefore = await readFile(filePath, "utf8");
+    expect(JSON.parse(rawBefore).status).toBe("downloading");
+
+    // Force EVERY rename attempt to fail on the next persist (a done update).
+    h.fail = true;
+    expect(persistDownloadJob(rec("done"))).toBe(false); // NOT durably replaced
+
+    // The scanned .json is UNCHANGED — the prior COMPLETE record was NOT rewritten in
+    // place (an in-place truncate+write is exactly the torn-read that lets another process
+    // see the record as absent and start a SECOND writer). Still valid + readable.
+    const rawAfter = await readFile(filePath, "utf8");
+    expect(rawAfter).toBe(rawBefore);
+    expect(readPersistedDownloadJob("atomicid00000001")?.status).toBe("downloading");
+    // No temp leaked.
+    expect((await readdir(dir)).some((f) => f.endsWith(".tmp"))).toBe(false);
+
+    // Recovery: once rename works again (next heartbeat), the atomic replace applies.
+    h.fail = false;
+    expect(persistDownloadJob(rec("done"))).toBe(true); // durable this time
+    expect(readPersistedDownloadJob("atomicid00000001")?.status).toBe("done");
+    expect((await readdir(dir)).some((f) => f.endsWith(".tmp"))).toBe(false);
+  });
+});

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -271,6 +271,9 @@ describe("applyManifest", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
   });
 
@@ -434,6 +437,9 @@ describe("applyManifest", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
   });
 
@@ -460,6 +466,9 @@ describe("applyManifest", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
   });
 

--- a/src/__tests__/services/storage-download-integrity.test.ts
+++ b/src/__tests__/services/storage-download-integrity.test.ts
@@ -88,4 +88,42 @@ describe("S3 download integrity (#343)", () => {
     await downloadS3ToFile("s3://bucket/nolen.safetensors", target);
     await expect(readFile(target, "utf-8")).resolves.toBe("no-length-header-body");
   });
+
+  it("#515: threads the AbortSignal into the S3 request AND aborts the write pipeline (cancel actually cancels)", async () => {
+    // A Body that emits one chunk then STALLS forever, so we can abort mid-pipeline —
+    // proving the signal reaches the write pipeline and stops the cloud stream (not a
+    // no-op that runs to completion).
+    const body = new Readable({ read() {} });
+    body.push(Buffer.from("partial-cloud-bytes"));
+    // never push(null) → the stream never ends on its own
+    s3Send.mockResolvedValueOnce({ Body: body, ContentLength: 1_000_000 });
+
+    const controller = new AbortController();
+    const p = downloadS3ToFile("s3://bucket/abort.safetensors", target, undefined, controller.signal);
+    await new Promise((r) => setTimeout(r, 20));
+    controller.abort();
+
+    // The transfer rejects on abort (it does NOT hang or silently complete).
+    await expect(p).rejects.toThrow();
+    // The abort signal was passed to the S3 request itself (request-level cancellation).
+    expect(s3Send).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ abortSignal: controller.signal }),
+    );
+    // Best-effort cleanup: the write stream is destroyed on abort.
+    body.destroy();
+  });
+
+  it("#515: a pre-aborted signal aborts the S3 download before it completes", async () => {
+    const body = new Readable({ read() {} });
+    body.push(Buffer.from("bytes"));
+    s3Send.mockResolvedValueOnce({ Body: body, ContentLength: 1_000_000 });
+
+    const controller = new AbortController();
+    controller.abort(); // already aborted before we start
+    await expect(
+      downloadS3ToFile("s3://bucket/pre-abort.safetensors", target, undefined, controller.signal),
+    ).rejects.toThrow();
+    body.destroy();
+  });
 });

--- a/src/__tests__/tools/model-extras.test.ts
+++ b/src/__tests__/tools/model-extras.test.ts
@@ -236,6 +236,9 @@ describe("download_civitai_model", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("Cool Model");
@@ -261,6 +264,9 @@ describe("download_civitai_model", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
     expect(res.isError).toBeFalsy();
   });
@@ -300,6 +306,9 @@ describe("download_civitai_model", () => {
       undefined,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
   });
 

--- a/src/__tests__/tools/model-management.test.ts
+++ b/src/__tests__/tools/model-management.test.ts
@@ -72,6 +72,9 @@ describe("download_model tool", () => {
       auth,
       false, // routing decision threaded through (local, #420 codex round 1)
       expect.any(Function), // onResume callback — reports the resume decision onto the job (#467)
+      expect.any(AbortSignal), // per-download abort signal threaded from the job's controller (#515)
+      expect.any(Function), // onTrayId callback — aligns the job trayId with the tray row id (#515)
+      expect.any(Function), // onLanded callback — commits done synchronously at the destination rename (#515)
     );
     expect(res.isError).toBeFalsy();
   });

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -653,6 +653,17 @@ export interface DownloadCacheOptions {
    *  misattribute it to another job (#467). Not called on a coalesced/cache-hit
    *  path (no physical resume happened). */
   onResume?: ResumeReporter;
+  /** Per-download abort signal (#515), threaded into the fetch + stream pipeline so
+   *  cancel_download aborts exactly this transfer. On abort the partial is left on
+   *  disk (resumable) and is NEVER renamed to the destination — no false-complete. */
+  signal?: AbortSignal;
+  /** Fired SYNCHRONOUSLY the instant the completed, validated file is renamed into its
+   *  destination (#515). The job commits "done" here — BEFORE any later await (LRU
+   *  eviction, stat) — so there is NO window where the file exists at the destination
+   *  yet the job still reads "downloading" and a cancel could falsely mark it cancelled.
+   *  Not fired for the remote Manager path (no local rename); that commits done when
+   *  downloadModel returns. */
+  onLanded?: (targetPath: string) => void;
 }
 
 export interface DownloadCacheResult {
@@ -821,7 +832,12 @@ async function streamUrlToFile(
    *  than finalized as a corrupt model under a false success (#473). Empty ⇒ no
    *  payload validation (unknown/non-model destination). */
   modelExt = "",
+  /** Per-download abort signal (#515): passed to fetch AND the write pipeline so a
+   *  cancel aborts the in-flight transfer promptly; the partial is left on disk. */
+  signal?: AbortSignal,
 ): Promise<string> {
+  // Fail fast if we were cancelled before any bytes moved — no request, no partial.
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
   if (supportsCloudDownload(url)) {
     // Cloud downloaders (S3/Azure) don't range-resume — they overwrite the target.
     // If a partial exists it's being discarded; surface that (#467) instead of a
@@ -847,7 +863,13 @@ async function streamUrlToFile(
       );
       onResume?.({ outcome: "declined:full-response", discardedBytes: resumeFromBytes, discarded: true });
     }
-    await downloadCloudUrlToFile(url, targetPath, storageAuth);
+    await downloadCloudUrlToFile(url, targetPath, storageAuth, signal);
+    // INTEGRITY BACKSTOP (#515): the S3/Azure SDKs may not honor the abort promptly
+    // (or at all), so a cancel that arrived mid-transfer could let the cloud download
+    // run to completion. If we were cancelled, throw BEFORE the size/payload checks
+    // and the caller's rename/materialize — so a cancelled cloud transfer is NEVER
+    // finalized as a complete file (the partial is left in the cache dir, unrenamed).
+    if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
     // #343 edge: the S3/Azure path bypasses the HTTP size gate below. The cloud
     // downloaders verify their own Content-Length (truncation), but a stream
     // that yielded ZERO bytes can still resolve cleanly — backstop it here so a
@@ -976,7 +998,7 @@ async function streamUrlToFile(
   for (let redirectCount = 0; ; redirectCount += 1) {
     res = await fetchOrThrow(
       currentUrl,
-      { headers: currentHeaders, redirect: "manual" },
+      { headers: currentHeaders, redirect: "manual", signal },
       currentUrl === url ? logUrl : redactUrlForLogs(currentUrl),
     );
     if (res.status < 300 || res.status >= 400) break;
@@ -1414,7 +1436,7 @@ async function streamUrlToFile(
 
   // No progress wanted (internal/cache caller, or not under the panel) → straight pipe.
   if (!progress) {
-    await pipeline(nodeStream, fileStream);
+    await pipeline(nodeStream, fileStream, { signal });
     await assertComplete();
     await assertModelPayload();
     // Complete: the validator sidecar is only needed to guard a resume, so drop it.
@@ -1449,7 +1471,7 @@ async function streamUrlToFile(
     },
   });
   try {
-    await pipeline(nodeStream, counter, fileStream);
+    await pipeline(nodeStream, counter, fileStream, { signal });
     await assertComplete();
     await assertModelPayload();
     if (resumable) await safeRm(validatorSidecar);
@@ -1457,7 +1479,11 @@ async function streamUrlToFile(
     emit("done", true);
     return responseContentType;
   } catch (err) {
-    emit("error", true);
+    // On a user cancel (#515) the abort left a resumable .partial on disk. Do NOT emit
+    // an "error" row for it, and do NOT clear the row here: this cache layer has no
+    // registry context, and a coalesced sibling may share this progress row. The JOB
+    // layer (finalizeCancelled) clears it registry-aware. Only a genuine failure emits.
+    if (!signal?.aborted) emit("error", true);
     throw err;
   }
 }
@@ -1470,6 +1496,7 @@ async function downloadIntoCache(
   progress?: ProgressMeta,
   onResume?: ResumeReporter,
   modelExt = "",
+  signal?: AbortSignal,
 ): Promise<string> {
   // Representation-aware identity (#467): a same-URL download with different HTTP
   // auth headers OR different cloud (S3/Azure) credentials gets its OWN cache file,
@@ -1482,6 +1509,21 @@ async function downloadIntoCache(
   // of its own — the decision is reported to the job that actually runs the
   // stream (#467). This is inherent to the callback model: onResume is not passed
   // to the shared promise, so a coalesced caller simply awaits the same result.
+  //
+  // CANCEL SEMANTICS across coalescing (#515): two DIFFERENT-destination jobs for the
+  // same URL+auth are distinct jobs (distinct AbortControllers) but share ONE physical
+  // stream here (the first caller's, keyed by cache identity). This shared stream binds
+  // the FIRST caller's signal. Integrity is preserved in every case:
+  //  - Cancelling the stream OWNER aborts the shared stream; the other (uncancelled)
+  //    caller's promise rejects, and since ITS signal is not aborted, downloadWithCache
+  //    falls back to a fresh direct download and still completes correctly.
+  //  - Cancelling a COALESCED caller does not abort the shared stream (it keeps running
+  //    for the owner), but that caller's own commit guard (its aborted signal, checked
+  //    in downloadModel before the done row / return) refuses to finalize — so it is
+  //    never reported as complete.
+  // The deliberate trade-off is prompt stream-abort for the common SOLE-caller case at
+  // the cost of a rare redundant re-download when a shared owner is cancelled; no caller
+  // can ever false-complete or be corrupted by another's cancel.
   if (existing) return existing;
 
   const promise = (async () => {
@@ -1597,6 +1639,7 @@ async function downloadIntoCache(
         true, // resumable: cache partials use the .partial + If-Range resume handshake
         onResume,
         modelExt,
+        signal,
       );
       await downloadCacheFs.rename(partial, target);
       await touch(target);
@@ -1682,9 +1725,27 @@ function isHardlinkUnsupported(code: unknown): boolean {
  *  EEXIST — ONLY then do we move the destination ASIDE and swap. Any OTHER rename
  *  error (ENOENT, EIO, EXDEV, …) must NOT touch a valid existing destination (#467):
  *  clean our temp and propagate. */
-async function renameTempOverDestination(tmp: string, targetPath: string): Promise<void> {
+async function renameTempOverDestination(
+  tmp: string,
+  targetPath: string,
+  /** Fired SYNCHRONOUSLY the instant the destination rename succeeds — BEFORE any
+   *  further await (e.g. Windows backup cleanup) — so the job can commit "done" with no
+   *  window where the file is at its destination yet the job still reads "downloading"
+   *  and a cancel could falsely mark it cancelled (#515). */
+  onLanded?: (targetPath: string) => void,
+  /** Abort signal (#515). Checked before the atomic replace AND (Windows path) after the
+   *  destination is moved aside but before the swap — so a cancel that lands during the
+   *  backup move restores the original and bails instead of swapping the temp in. */
+  signal?: AbortSignal,
+): Promise<void> {
+  // Cancelled before the swap — leave the destination untouched (the temp is cleaned up).
+  if (signal?.aborted) {
+    await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+    throw new DOMException("The download was cancelled.", "AbortError");
+  }
   try {
     await downloadCacheFs.rename(tmp, targetPath);
+    onLanded?.(targetPath); // landed (POSIX atomic replace) — commit done before returning
     return;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
@@ -1707,8 +1768,32 @@ async function renameTempOverDestination(tmp: string, targetPath: string): Promi
     } catch {
       /* destination may not exist — nothing to move aside */
     }
+    // A cancel that landed WHILE we moved the old destination aside must NOT swap the
+    // temp in — restore the original and bail, so a cancelled download never lands its
+    // file over the destination (#515). The temp is cleaned up.
+    if (signal?.aborted) {
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      if (backedUp) {
+        const restored = await downloadCacheFs
+          .rename(backup, targetPath)
+          .then(() => true)
+          .catch(() => false);
+        if (!restored) {
+          throw new ModelError(
+            `Download cancelled but the previous file could not be restored — it is PRESERVED at ` +
+              `"${backup}"; move it back to "${targetPath}" manually.`,
+            { url: targetPath },
+          );
+        }
+      }
+      throw new DOMException("The download was cancelled.", "AbortError");
+    }
     try {
       await downloadCacheFs.rename(tmp, targetPath);
+      // Swapped in — the file is at its destination. Commit done NOW, before the backup
+      // cleanup await, so a cancel during that await can't falsely mark a landed file
+      // cancelled (#515).
+      onLanded?.(targetPath);
       if (backedUp) await downloadCacheFs.rm(backup, { force: true }).catch(() => undefined);
     } catch (e) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
@@ -1736,8 +1821,15 @@ const MATERIALIZE_TEMP_ATTEMPTS = 5;
 async function materializeCacheFile(
   cachePath: string,
   targetPath: string,
+  signal?: AbortSignal,
+  onLanded?: (targetPath: string) => void,
 ): Promise<"hardlink" | "copy"> {
-  if (resolve(cachePath) === resolve(targetPath)) return "hardlink";
+  if (resolve(cachePath) === resolve(targetPath)) {
+    // The download streamed directly to the destination (cache === target) — it is
+    // already on disk; commit "done" synchronously (#515).
+    onLanded?.(targetPath);
+    return "hardlink";
+  }
 
   // Materialize ATOMICALLY into an UNGUESSABLE, EXCLUSIVELY-created temp, then
   // rename over targetPath — never write directly at targetPath, and never reuse a
@@ -1773,7 +1865,19 @@ async function materializeCacheFile(
       }
       mode = "copy";
     }
-    await renameTempOverDestination(tmp, targetPath);
+    // FINAL CANCEL GUARD (#515): the temp is built but NOT yet swapped in. If this
+    // caller was cancelled, remove the temp and bail WITHOUT replacing the destination
+    // — so a cancelled download never lands its target even if the abort arrived during
+    // materialization. (The cache entry itself is untouched — the temp was our own.)
+    if (signal?.aborted) {
+      await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
+      throw new DOMException("The download was cancelled.", "AbortError");
+    }
+    // onLanded fires INSIDE renameTempOverDestination the instant the destination rename
+    // succeeds (before any Windows backup cleanup await), closing the landed→return
+    // window entirely; the signal lets it also abort the Windows swap after the backup
+    // move (#515).
+    await renameTempOverDestination(tmp, targetPath, onLanded, signal);
     return mode;
   }
 }
@@ -1819,6 +1923,7 @@ export async function downloadUrlToFile(
   storageAuth: CloudStorageAuth = {},
   progress?: ProgressMeta,
   modelExt = extname(targetPath),
+  signal?: AbortSignal,
 ): Promise<void> {
   await streamUrlToFile(
     url,
@@ -1831,6 +1936,7 @@ export async function downloadUrlToFile(
     false,
     undefined,
     modelExt,
+    signal,
   );
 }
 
@@ -1852,7 +1958,14 @@ export async function downloadWithCache(
       options.progress,
       options.onResume,
       modelExt,
+      options.signal,
     );
+    // CANCEL GUARD (#515): a COALESCED caller (or a CACHE HIT) reaches here without
+    // ever streaming — it awaited another job's shared physical download. If THIS
+    // caller was cancelled meanwhile, it must NOT materialize its destination: bail
+    // BEFORE validation/materialization so a cancelled download never lands a completed
+    // file at its models path (which we'd then misreport as "cancelled, partial left").
+    if (options.signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
     // Validate the CACHE FILE itself before materializing it to this destination —
     // this is the authoritative per-caller gate (#473). It covers four cases the
     // stream-time check can't: (1) a CACHE HIT that skipped streaming entirely,
@@ -1884,7 +1997,12 @@ export async function downloadWithCache(
         if (neutralized) await safeRm(cacheCtSidecar(cachePath));
       },
     });
-    const materializedBy = await materializeCacheFile(cachePath, options.targetPath);
+    const materializedBy = await materializeCacheFile(
+      cachePath,
+      options.targetPath,
+      options.signal,
+      options.onLanded,
+    );
     await evictLruIfNeeded();
     return {
       targetPath: options.targetPath,
@@ -1894,6 +2012,10 @@ export async function downloadWithCache(
     };
   } catch (err) {
     if (err instanceof ModelError) throw err;
+    // A user cancel (#515) aborted the transfer — do NOT fall back to a direct
+    // download (it would immediately re-abort). Propagate so the job records a
+    // clean cancellation; the resumable .partial is left in the cache dir.
+    if (options.signal?.aborted) throw err;
     logger.warn("Download cache unavailable; falling back to direct download", {
       url: logUrl,
       error: err instanceof Error ? err.message : String(err),
@@ -1916,8 +2038,19 @@ export async function downloadWithCache(
         options.storageAuth,
         options.progress,
         modelExt,
+        options.signal,
       );
-      await renameTempOverDestination(tmp, options.targetPath);
+      // PRE-RENAME CANCEL GUARD (#515), mirroring the cache-path materialize guard: a
+      // cancel that arrived during the post-stream validation lets the stream return
+      // normally, but we must NOT swap the temp into the destination — bail so a
+      // cancelled download never lands its target here either. (An abort DURING the
+      // un-interruptible rename lands a complete, validated file → the job reports done,
+      // consistent with the invariant.) The temp is removed by the catch below.
+      if (options.signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+      // onLanded fires inside renameTempOverDestination at the successful rename (before
+      // any backup-cleanup await) — commits "done" with no landed→return window; the
+      // signal also aborts the Windows swap after the backup move (#515).
+      await renameTempOverDestination(tmp, options.targetPath, options.onLanded, options.signal);
     } catch (e) {
       await downloadCacheFs.rm(tmp, { force: true }).catch(() => undefined);
       throw e;

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -31,6 +31,7 @@ import {
   listPersistedDownloadJobs,
   findPersistedDownloadJob,
   clearDownloadProgress,
+  persistedRecordsEnabled,
   PERSIST_OWNER,
   PERSISTED_INFLIGHT_STALE_MS,
   type PersistedDownloadJob,
@@ -75,6 +76,12 @@ export interface DownloadJob {
    *  job serializes/persists under — surfaced so a reconnecting session can adopt
    *  the same in-flight download by destination without starting a duplicate (#529). */
   destKey?: string;
+  /** The ROUTE-INDEPENDENT request key (url+subfolder+filename+auth) — the SAME whether
+   *  the download routed to local disk or the remote Manager (#420). Persisted so
+   *  cross-session adoption matches a reconnect whose route flipped local↔Manager (which
+   *  changes the public `id` from a destination hash to a request hash) — otherwise the
+   *  reissue would miss the in-flight record and start a second writer. */
+  reqKey?: string;
   /** True when this download is DISPATCHED to a remote ComfyUI-Manager (server-side
    *  fetch) rather than streamed to local disk. A "done" viaManager job means the
    *  dispatch was ACCEPTED — NOT that the file has verifiably landed (Manager reports
@@ -109,6 +116,12 @@ interface Entry {
 /** How often an in-flight job re-persists its record (liveness heartbeat). Must stay
  *  comfortably below PERSISTED_INFLIGHT_STALE_MS so a live download is always fresh. */
 const HEARTBEAT_MS = 15_000;
+/** Cap on heartbeat retries of a transiently-failing TERMINAL persist. Chosen so the
+ *  total window (attempts × HEARTBEAT_MS) exceeds PERSISTED_INFLIGHT_STALE_MS — by then
+ *  the last-successful (in-flight) record has already aged out via the stale reap, so
+ *  giving up can't leave a fresh, adoptable record. Prevents a permanently-unwritable
+ *  progress store from keeping a COMPLETED job's interval doing filesystem work forever. */
+const TERMINAL_PERSIST_MAX_ATTEMPTS = 6; // 6 × 15s = 90s > 60s stale window
 
 // The in-flight registry is indexed under MULTIPLE keys per job so dedup is
 // ROUTE-INDEPENDENT: a repeated request finds the in-flight job whether or not the
@@ -388,6 +401,62 @@ export async function startDownloadJob(
     });
     return adopted;
   }
+
+  // #529 double-writer guard: no in-flight job in THIS process, but ANOTHER session may
+  // already be running this EXACT download (same public id) — e.g. a reconnect reissued
+  // the same URL/destination. Adopt its persisted in-flight record instead of starting a
+  // SECOND physical writer for one file. Only a FRESH in-flight record from a DIFFERENT
+  // owner counts (the scan below filters stale via the heartbeat window; and a terminal
+  // record — done/cancelled — is NOT "downloading", so a finished/failed prior download
+  // correctly falls through to a fresh re-download). This
+  // process's own live jobs were already checked above. The adopted view is READ-ONLY (we
+  // hold no handle on the other session's writer): it is NOT registered in this registry,
+  // runs no writer/heartbeat/AbortController, and its `settled` resolves immediately — the
+  // tool then reports it as in-flight and the caller polls download_status (which reads
+  // the live persisted record) for the resolved state.
+  //
+  // SCOPE: this dedup is BEST-EFFORT and covers the reported case — a SEQUENTIAL reconnect
+  // that reissues after another session already published its record. It is a
+  // filesystem-level read-then-start, NOT an atomic cross-process claim, so two DISTINCT
+  // processes reissuing the SAME download at the SAME instant (both reading before either
+  // publishes) can still both start writers. That is not a regression (it is the
+  // pre-existing behavior the adoption improves for the common case) and is NON-CORRUPTING:
+  // the #467 machinery materializes each writer through its OWN O_EXCL temp + atomic rename
+  // (last-writer-wins on the destination only, never a shared cache inode) and validates
+  // the payload (#473), so the only cost of that rare race is a duplicate download — never
+  // a corrupt file. A full distributed lease is deliberately out of scope (its stale-claim
+  // / crash-cleanup failure modes would be worse than a rare duplicate transfer).
+  // Scan ROUTE-INDEPENDENTLY (#420): match a foreign fresh in-flight record by the public
+  // `id` OR the route-independent request key `reqKey`, so a reconnect whose route flipped
+  // local↔Manager (which changes the id from a destination hash to a request hash) still
+  // finds the in-flight record instead of starting a second writer. Require the SAME source
+  // URL (trayId): a foreign live download of a DIFFERENT url to the same dest+auth (same
+  // id, different trayId) is a distinct logical download whose bytes may differ — adopting
+  // it would report the WRONG job, so it is declined (we proceed with our own request). A
+  // reqKey match already implies the same url (reqKey embeds it), so trayId is consistent.
+  const nowForAdopt = Date.now();
+  const foreign = listPersistedDownloadJobs().find(
+    (rec) =>
+      rec.owner !== PERSIST_OWNER &&
+      rec.status === "downloading" &&
+      nowForAdopt - (rec.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS &&
+      rec.trayId === trayId &&
+      (rec.id === id || (rec.req_key !== undefined && rec.req_key === reqKey)),
+  );
+  if (foreign) {
+    logger.info(`Adopting a cross-session in-flight download (no second writer): ${foreign.id}`, {
+      url,
+      target_subfolder: targetSubfolder,
+      filename,
+    });
+    return {
+      job: jobFromPersisted(foreign),
+      settled: Promise.resolve(),
+      keys: [],
+      controller: new AbortController(),
+    };
+  }
+
   // No in-flight match. Retire any superseded (done/error) entries shadowing our keys
   // — entry-scoped, so we only clear rows still pointing at that finished entry and
   // never delete a row now owned by a different, live writer (rule 2).
@@ -409,12 +478,18 @@ export async function startDownloadJob(
     status: "downloading",
     started_at: Date.now(),
     destKey: serializeKey,
+    reqKey,
     viaManager: dispatchToManager,
   };
 
   // Per-download abort handle (#515). The signal is threaded through downloadModel
   // into the fetch + stream pipeline, so cancel_download aborts exactly THIS job.
   const controller = new AbortController();
+
+  // The liveness heartbeat timer (assigned below, after the settled closure). Hoisted
+  // here so the settled closure's finally can clear it once the terminal state is durably
+  // persisted. Runs async — assigned before it ever fires or the finally runs.
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
 
   // Serialize behind any in-flight job writing the SAME destination (#467 P1-C) so
   // this job's download+materialize+onComplete run without a concurrent different-
@@ -513,8 +588,12 @@ export async function startDownloadJob(
       }
     } finally {
       // Persist the terminal state so a reconnecting session sees the resolved
-      // outcome (#529) instead of a forever-"downloading" record.
-      persistJobRecord(job);
+      // outcome (#529) instead of a forever-"downloading" record. If this atomic
+      // replace transiently fails (rare), the heartbeat below KEEPS retrying until the
+      // terminal state is durable — so a done/cancelled job can't linger as a
+      // fresh-and-adoptable "downloading" record (beyond the stale reap that already
+      // bounds it). Only once the terminal record is durable does the heartbeat stop.
+      if (persistJobRecord(job) && heartbeat) clearInterval(heartbeat);
     }
   })();
 
@@ -538,12 +617,35 @@ export async function startDownloadJob(
   // (its heartbeat stops) when deciding whether to preserve a shared tray row. Cheap
   // (a small write every 15s, only under the panel where persistence is active) and
   // unref'd so it never keeps the process alive.
-  const heartbeat = setInterval(() => {
-    if (job.status === "downloading") persistJobRecord(job);
-  }, HEARTBEAT_MS);
-  if (typeof heartbeat.unref === "function") heartbeat.unref();
-  entry.heartbeat = heartbeat;
-  void settled.finally(() => clearInterval(heartbeat));
+  // Only run the heartbeat when the persisted store is actually active (panel). Without a
+  // channel dir there is nothing to persist and no reader to serve — an interval there
+  // would just leak, retrying a no-op forever (persistJobRecord returns false, so the
+  // terminal cleanup below would never clear it). Plain non-panel downloads install none.
+  if (persistedRecordsEnabled()) {
+    let terminalPersistAttempts = 0;
+    heartbeat = setInterval(() => {
+      // In-flight: refresh liveness so another session can tell this live download from a
+      // crashed one. Terminal (only reached when the settled finally's terminal persist
+      // transiently FAILED to atomically replace): keep retrying until it's durable, then
+      // stop — so a done/cancelled job never lingers as a fresh, adoptable "downloading".
+      const durable = persistJobRecord(job);
+      if (job.status !== "downloading") {
+        // Stop the interval once the terminal state is durable, OR the retry budget is
+        // spent (by which point the stale record is already reaped), OR persistence went
+        // inactive — never let a completed job's interval do filesystem work forever.
+        if (
+          (durable ||
+            ++terminalPersistAttempts >= TERMINAL_PERSIST_MAX_ATTEMPTS ||
+            !persistedRecordsEnabled()) &&
+          heartbeat
+        ) {
+          clearInterval(heartbeat);
+        }
+      }
+    }, HEARTBEAT_MS);
+    if (typeof heartbeat.unref === "function") heartbeat.unref();
+    entry.heartbeat = heartbeat;
+  }
   return entry;
 }
 
@@ -593,9 +695,11 @@ function finalizeCancelled(job: DownloadJob): void {
 }
 
 /** Persist a job record to the cross-session store (progress dir), redacting the
- *  URL. No-op outside the panel. Keeps the persisted copy in step with the job. */
-function persistJobRecord(job: DownloadJob): void {
-  persistDownloadJob({
+ *  URL. No-op outside the panel. Keeps the persisted copy in step with the job.
+ *  Returns whether the record was DURABLY replaced (so the heartbeat can retry a
+ *  transiently-failing terminal persist). */
+function persistJobRecord(job: DownloadJob): boolean {
+  return persistDownloadJob({
     id: job.id,
     trayId: job.trayId,
     progressId: job.progressId,
@@ -609,6 +713,7 @@ function persistJobRecord(job: DownloadJob): void {
     finished_at: job.finished_at,
     notes: job.notes,
     dest_key: job.destKey,
+    req_key: job.reqKey,
     via_manager: job.viaManager,
     resume: job.resume,
   });
@@ -633,6 +738,7 @@ function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
     finished_at: rec.finished_at,
     notes: rec.notes,
     destKey: rec.dest_key,
+    reqKey: rec.req_key,
     viaManager: rec.via_manager,
     resume: rec.resume as ResumeDiagnostic | undefined,
   };
@@ -659,17 +765,38 @@ export function getDownloadJob(id: string): DownloadJob | undefined {
   // The registry indexes each job under its request key and (when local) its
   // destination key; the public id is one of those, so a direct get resolves it.
   const live = jobs.get(id)?.job;
-  if (live) {
-    // Cross-session ambiguity: a live foreign download shares this id with a DIFFERENT
-    // trayId. Don't silently report the local one — decline (same as the persisted path).
+  // A LIVE in-flight job in THIS process is authoritative (it's actively writing here) —
+  // but decline if a concurrent live FOREIGN session shares the id with a different trayId.
+  if (live && live.status === "downloading") {
     if (hasAmbiguousForeignSibling(id, live.trayId)) return undefined;
     return live;
   }
-  // #529: after a reconnect the in-memory registry is empty, but the download's
-  // record persists in the progress dir — resolve it there so an id from a prior
-  // session still reports instead of "no download with id …, tracked per session".
-  const persisted = readPersistedDownloadJob(id);
-  return persisted ? jobFromPersisted(persisted) : undefined;
+  // Otherwise resolve across this session's TERMINAL in-memory record AND the persisted
+  // store (#529), honoring the INTEGRITY TRUTH: a validated DONE (file landed) — from
+  // ANY session, in-memory or persisted — must WIN over a cancelled/error record for the
+  // same id. A cancel/error never lands a file, so it must never mask another session's
+  // validated-complete file (cancelled-over-complete), and this holds whether the
+  // cancelled/error record is in-memory or persisted.
+  if (live && live.status === "done") return live;
+  const now = Date.now();
+  const matches = listPersistedDownloadJobs().filter((r) => r.id === id);
+  const persistedDone = matches
+    .filter((r) => r.status === "done")
+    .sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  if (persistedDone) return jobFromPersisted(persistedDone);
+  // No DONE anywhere. Prefer a fresh live foreign in-flight download (it's still running
+  // elsewhere) — declining if ambiguous by trayId — then this session's own terminal
+  // record, then the newest persisted terminal.
+  const foreignLive = matches.filter(
+    (r) => r.status === "downloading" && now - (r.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  if (foreignLive.length > 0) {
+    if (new Set(foreignLive.map((r) => r.trayId)).size > 1) return undefined; // ambiguous live
+    return jobFromPersisted(foreignLive.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0]);
+  }
+  if (live) return live; // this session's terminal (cancelled/error), no DONE to prefer
+  const terminal = matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  return terminal ? jobFromPersisted(terminal) : undefined;
 }
 
 /** Adopt an in-flight download by URL or destination after a reconnect (#529) —
@@ -737,15 +864,26 @@ export function listDownloadJobs(): DownloadJob[] {
   for (const e of jobs.values()) {
     if (seen.has(e)) continue;
     seen.add(e);
-    byKey.set(keyOf(e.job), e.job);
+    const cur = byKey.get(keyOf(e.job));
+    // Among this process's own entries for one key (rare), prefer a DONE.
+    if (!cur || (e.job.status === "done" && cur.status !== "done")) byKey.set(keyOf(e.job), e.job);
   }
   // #529: fold in persisted records for jobs THIS session's registry doesn't hold
   // (started before a reconnect), so download_status still lists in-flight downloads.
-  // A live in-memory job always wins over its persisted snapshot (same id+trayId).
+  // INTEGRITY TRUTH: a validated DONE (file landed) WINS over a cancelled/error record for
+  // the SAME (id, trayId) — whether that other record is a persisted counterpart OR this
+  // session's own in-memory cancelled/error. So a persisted DONE overrides any current
+  // entry that is neither DONE nor a LIVE in-memory download (which stays visible as the
+  // user's active action). The list never shows a cancelled in place of a validated file.
   for (const rec of listPersistedDownloadJobs()) {
     const job = jobFromPersisted(rec);
     const k = keyOf(job);
-    if (!byKey.has(k)) byKey.set(k, job);
+    const cur = byKey.get(k);
+    if (!cur) {
+      byKey.set(k, job);
+    } else if (job.status === "done" && cur.status !== "done" && cur.status !== "downloading") {
+      byKey.set(k, job);
+    }
   }
   return [...byKey.values()].sort((a, b) => b.started_at - a.started_at);
 }

--- a/src/services/download-jobs.ts
+++ b/src/services/download-jobs.ts
@@ -24,6 +24,17 @@ import {
 } from "./model-resolver.js";
 import type { DownloadAuth } from "./download-auth.js";
 import type { ResumeDiagnostic } from "./download-resume-diag.js";
+import { ModelError } from "../utils/errors.js";
+import {
+  persistDownloadJob,
+  readPersistedDownloadJob,
+  listPersistedDownloadJobs,
+  findPersistedDownloadJob,
+  clearDownloadProgress,
+  PERSIST_OWNER,
+  PERSISTED_INFLIGHT_STALE_MS,
+  type PersistedDownloadJob,
+} from "./download-progress.js";
 import { logger } from "../utils/logger.js";
 
 export interface DownloadJob {
@@ -31,11 +42,18 @@ export interface DownloadJob {
    *  fetched to two different targets is two separately-pollable jobs
    *  (download_status(id) resolves each independently). Also the registry key. */
   id: string;
-  /** The panel tray / progress-file id — a hash of the SOURCE URL only, matching
-   *  the row the streaming download writes (readDownloadProgress keys on this).
-   *  Kept separate from `id` so distinct-destination jobs still read their live
-   *  byte progress from the tray. */
+  /** The panel tray / progress-file id — a hash of the ORIGINAL source URL only.
+   *  STABLE for the life of the job and used to ADOPT this download by URL after a
+   *  reconnect (#529): findDownloadJob({url}) hashes the same original URL. Kept
+   *  separate from `id` so distinct-destination jobs still map to their URL. */
   trayId: string;
+  /** The id the PHYSICAL progress rows are actually written under — a hash of the
+   *  POST-auth/post-HF-rewrite request URL, reported by the writer (#515). Differs
+   *  from `trayId` only for query-auth or HF_ENDPOINT-rewritten URLs; equals it for
+   *  the common case. download_status byte display and cancel cleanup key on THIS id
+   *  (falling back to trayId when unset). Never used for URL adoption (that needs the
+   *  stable original-URL trayId). */
+  progressId?: string;
   /** This job's OWN resume decision (#467), reported by its physical download via
    *  a callback and stored here — so download_status surfaces exactly this job's
    *  outcome and never a stale/other job's. Absent when no resumable download ran
@@ -45,12 +63,25 @@ export interface DownloadJob {
   url: string;
   target_subfolder: string;
   filename?: string;
-  status: "downloading" | "done" | "error";
+  /** "cancelled" is a user-requested abort (#515): the stream was aborted, no
+   *  false-complete is reported, and the resumable .partial is left on disk. */
+  status: "downloading" | "done" | "error" | "cancelled";
   /** Absolute path once the file has landed. */
   path?: string;
   error?: string;
   started_at: number;
   finished_at?: number;
+  /** The auth-free destination key (local targetPath or canonical remote id) this
+   *  job serializes/persists under — surfaced so a reconnecting session can adopt
+   *  the same in-flight download by destination without starting a duplicate (#529). */
+  destKey?: string;
+  /** True when this download is DISPATCHED to a remote ComfyUI-Manager (server-side
+   *  fetch) rather than streamed to local disk. A "done" viaManager job means the
+   *  dispatch was ACCEPTED — NOT that the file has verifiably landed (Manager reports
+   *  its queue task done even on failure), and a cancel can't recall the server task.
+   *  download_status renders it as "dispatched (not verified here)" so it isn't
+   *  mistaken for a validated local completion. */
+  viaManager?: boolean;
   /** Lines produced by post-download work (trigger words, sidecar paths,
    *  not-a-model warnings). These used to be returned inline by the tool; once a
    *  download outlives its tool call they have to survive somewhere the agent
@@ -65,7 +96,19 @@ interface Entry {
    *  destination key when locally resolvable). Kept so a superseding job can
    *  unregister ALL of a stale entry's keys — no orphaned index rows. */
   keys: string[];
+  /** Per-download abort handle (#515). Its `signal` is threaded through
+   *  downloadModel → the fetch + stream pipeline, so `cancel_download` can abort
+   *  exactly THIS job's transfer without touching any other in-flight download. */
+  controller: AbortController;
+  /** While in flight, periodically re-persists the record so its `updated` stamp
+   *  acts as a liveness heartbeat — letting ANOTHER session tell a live download from
+   *  a crashed one when deciding whether to preserve a shared tray row (#515/#529). */
+  heartbeat?: ReturnType<typeof setInterval>;
 }
+
+/** How often an in-flight job re-persists its record (liveness heartbeat). Must stay
+ *  comfortably below PERSISTED_INFLIGHT_STALE_MS so a live download is always fresh. */
+const HEARTBEAT_MS = 15_000;
 
 // The in-flight registry is indexed under MULTIPLE keys per job so dedup is
 // ROUTE-INDEPENDENT: a repeated request finds the in-flight job whether or not the
@@ -365,7 +408,13 @@ export async function startDownloadJob(
     filename,
     status: "downloading",
     started_at: Date.now(),
+    destKey: serializeKey,
+    viaManager: dispatchToManager,
   };
+
+  // Per-download abort handle (#515). The signal is threaded through downloadModel
+  // into the fetch + stream pipeline, so cancel_download aborts exactly THIS job.
+  const controller = new AbortController();
 
   // Serialize behind any in-flight job writing the SAME destination (#467 P1-C) so
   // this job's download+materialize+onComplete run without a concurrent different-
@@ -376,15 +425,58 @@ export async function startDownloadJob(
   // would take down the process on a simple 404.
   // The physical download reports its resume decision straight onto THIS job — no
   // shared keyed map, so it can never be misattributed to another job (#467).
+  // Commit the DONE state. Invoked SYNCHRONOUSLY the instant the file is renamed into
+  // its destination (via the onLanded callback below) — before any later await — so
+  // there is NO window where the file exists at the destination yet the job still reads
+  // "downloading" (which a cancel would otherwise flip to "cancelled"). Idempotent and
+  // only advances a still-"downloading" job, so it never overrides a real terminal
+  // state. Reads status as the full union to dodge the closure's "downloading" narrowing.
+  const commitDone = (landedPath: string): void => {
+    if ((job.status as DownloadJob["status"]) !== "downloading") return;
+    job.path = landedPath;
+    job.status = "done";
+    job.finished_at = Date.now();
+    persistJobRecord(job);
+  };
   const settled = (async () => {
     // Wait for the prior same-destination job to fully finish (never fail THIS job
     // because that one errored — swallow its result).
     if (priorSameDest) await priorSameDest.catch(() => undefined);
     try {
-      const path = await downloadModel(url, targetSubfolder, filename, auth, dispatchToManager, (d) => {
-        job.resume = d;
-      });
-      job.path = path;
+      // A cancel that arrived before (or while waiting for) our turn makes downloadModel
+      // throw at its up-front abort guard → the catch records the cancellation. So there
+      // is no separate pre-start branch: the download either runs to a materialized file
+      // (done) or is aborted before the file lands (cancelled).
+      const path = await downloadModel(
+        url,
+        targetSubfolder,
+        filename,
+        auth,
+        dispatchToManager,
+        (d) => {
+          job.resume = d;
+        },
+        controller.signal,
+        (progressId) => {
+          // Record the id the tray rows are ACTUALLY written under (post-auth/HF
+          // rewrite) as job.progressId — WITHOUT touching job.trayId, which must stay
+          // the stable original-URL hash so URL reconnect adoption (#529) still
+          // resolves. download_status byte display and cancel cleanup key on
+          // progressId (falling back to trayId); it only differs for query-auth /
+          // mirror-rewritten URLs. Persist so a reconnecting session reads live bytes.
+          if (progressId && progressId !== job.progressId) {
+            job.progressId = progressId;
+            persistJobRecord(job);
+          }
+        },
+        // onLanded: fires the moment the local file is renamed into place → commit done
+        // synchronously, closing the rename→return window.
+        commitDone,
+      );
+      // Local paths already committed done via onLanded at the rename. The remote Manager
+      // dispatch has no local rename, so commit done here when it returns (dispatch
+      // accepted — the viaManager flag marks it as unverified in the tools). Idempotent.
+      commitDone(path);
       if (onComplete) {
         // Post-processing must not turn a landed file into a failed download —
         // the bytes are on disk either way, and reporting "error" here would
@@ -397,12 +489,32 @@ export async function startDownloadJob(
           ];
         }
       }
-      job.status = "done";
-      job.finished_at = Date.now();
     } catch (err: unknown) {
-      job.status = "error";
-      job.error = err instanceof Error ? err.message : String(err);
-      job.finished_at = Date.now();
+      // If the file ALREADY landed (onLanded committed done) a later throw — e.g. an LRU
+      // eviction hiccup after the rename — must NOT override a real completed download.
+      if ((job.status as DownloadJob["status"]) === "done") {
+        // keep done
+      } else if (controller.signal.aborted) {
+        // An abort that stopped the transfer BEFORE the file landed surfaces here as a
+        // rejected fetch/pipeline (or a guard throw) — a clean cancellation, never an
+        // "error" and never a false success.
+        finalizeCancelled(job);
+        // …but if the cancellation cleanup threw a recovery-critical ModelError (e.g. the
+        // Windows backup of the PREVIOUS destination file could not be restored, so it's
+        // preserved under a random .bak path), surface that message on the job so
+        // download_status shows the recoverable path instead of masking it behind a plain
+        // "cancelled, resumable partial". (Ordinary cancellation throws an AbortError,
+        // which is NOT a ModelError, so it never sets this.)
+        if (err instanceof ModelError) job.error = err.message;
+      } else {
+        job.status = "error";
+        job.error = err instanceof Error ? err.message : String(err);
+        job.finished_at = Date.now();
+      }
+    } finally {
+      // Persist the terminal state so a reconnecting session sees the resolved
+      // outcome (#529) instead of a forever-"downloading" record.
+      persistJobRecord(job);
     }
   })();
 
@@ -416,32 +528,298 @@ export async function startDownloadJob(
   // Index under EVERY key (deduped) so any of them adopts this one writer. Uses the
   // entry-scoped registerKey guard so a fresh registration can never overwrite a row
   // still owned by a different, live writer (rule 3).
-  const entry: Entry = { job, settled, keys: [] };
+  const entry: Entry = { job, settled, keys: [], controller };
   for (const k of new Set(lookupKeys)) registerKey(entry, k);
+  // Persist the (downloading) record so a session that reconnects while this is in
+  // flight can still resolve/adopt it by id or URL/destination (#529).
+  persistJobRecord(job);
+  // Liveness heartbeat: while in flight, refresh the persisted record's `updated`
+  // stamp so ANOTHER session can distinguish this LIVE download from a crashed one
+  // (its heartbeat stops) when deciding whether to preserve a shared tray row. Cheap
+  // (a small write every 15s, only under the panel where persistence is active) and
+  // unref'd so it never keeps the process alive.
+  const heartbeat = setInterval(() => {
+    if (job.status === "downloading") persistJobRecord(job);
+  }, HEARTBEAT_MS);
+  if (typeof heartbeat.unref === "function") heartbeat.unref();
+  entry.heartbeat = heartbeat;
+  void settled.finally(() => clearInterval(heartbeat));
   return entry;
+}
+
+/** Mark a job cancelled: never a false-complete, and drop its tray row. The
+ *  resumable .partial is deliberately LEFT on disk (a later download resumes it). */
+function finalizeCancelled(job: DownloadJob): void {
+  job.status = "cancelled";
+  if (job.finished_at === undefined) job.finished_at = Date.now();
+  // Remove the panel tray row so a cancelled download doesn't linger — but clear it
+  // ONLY when this job exclusively owns that physical row. Two subtleties:
+  //  - A job with no progressId never wrote a row (the writer reports progressId
+  //    BEFORE the first row), so there is nothing to clear.
+  //  - Same-URL siblings can SHARE one physical stream/row: a coalesced consumer (same
+  //    URL+auth, different destination) or a serialized same-auth sibling observes the
+  //    OWNER's progressId. Clearing it while ANOTHER in-flight job still uses it would
+  //    wipe that active job's live display. So skip the clear when any other in-flight
+  //    job shares this progressId; the last one out clears it. (trayId is deliberately
+  //    NOT a fallback — it's the original-URL hash siblings share even more broadly.)
+  if (!job.progressId) return;
+  const sharedByLocal = [...new Set(jobs.values())].some(
+    (e) =>
+      e.job !== job && e.job.status === "downloading" && e.job.progressId === job.progressId,
+  );
+  // Also honor a live sibling in ANOTHER session (#529): a persisted in-flight record
+  // written by a DIFFERENT session (owner ≠ this process's PERSIST_OWNER) that shares
+  // this progressId is another session's active download of the same URL — its tray row
+  // must not be wiped. Comparing by OWNER (not id) catches the case two sessions run the
+  // SAME logical download (identical deterministic id): they persist distinct
+  // owner-scoped files, so the other session's record is still seen here. This process's
+  // OWN persisted records (same owner) are excluded — they always correspond to an
+  // in-memory job already covered by the local scan above. If any live sibling exists in
+  // either store, leave the row for the last one out (or the orchestrator's dead-writer
+  // prune) to clear.
+  const now = Date.now();
+  const sharedByPersisted = listPersistedDownloadJobs().some(
+    (rec) =>
+      rec.owner !== PERSIST_OWNER &&
+      rec.status === "downloading" &&
+      rec.progressId === job.progressId &&
+      // Only a FRESH record counts as a live sibling — a crashed session's heartbeat
+      // stops, so its record goes stale and must NOT permanently suppress this sole
+      // job's cleanup (its tray row would otherwise linger). Bounded by the heartbeat
+      // interval so a genuinely-live foreign download is always seen as fresh.
+      now - (rec.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  if (!sharedByLocal && !sharedByPersisted) clearDownloadProgress(job.progressId);
+}
+
+/** Persist a job record to the cross-session store (progress dir), redacting the
+ *  URL. No-op outside the panel. Keeps the persisted copy in step with the job. */
+function persistJobRecord(job: DownloadJob): void {
+  persistDownloadJob({
+    id: job.id,
+    trayId: job.trayId,
+    progressId: job.progressId,
+    url: job.url,
+    target_subfolder: job.target_subfolder,
+    filename: job.filename,
+    status: job.status,
+    path: job.path,
+    error: job.error,
+    started_at: job.started_at,
+    finished_at: job.finished_at,
+    notes: job.notes,
+    dest_key: job.destKey,
+    via_manager: job.viaManager,
+    resume: job.resume,
+  });
+}
+
+/** Rebuild an in-memory DownloadJob view from a persisted record (#529 adoption
+ *  after a reconnect). It is a read-only snapshot — there is no live AbortController
+ *  in THIS process for a job another/previous session started, so it can be polled
+ *  by download_status but not cancelled from here. */
+function jobFromPersisted(rec: PersistedDownloadJob): DownloadJob {
+  return {
+    id: rec.id,
+    trayId: rec.trayId,
+    progressId: rec.progressId,
+    url: rec.url,
+    target_subfolder: rec.target_subfolder,
+    filename: rec.filename,
+    status: rec.status,
+    path: rec.path,
+    error: rec.error,
+    started_at: rec.started_at,
+    finished_at: rec.finished_at,
+    notes: rec.notes,
+    destKey: rec.dest_key,
+    viaManager: rec.via_manager,
+    resume: rec.resume as ResumeDiagnostic | undefined,
+  };
+}
+
+/** True when a FRESH foreign in-flight persisted record shares `id` but carries a
+ *  DIFFERENT trayId — a distinct concurrent physical download in ANOTHER session (two
+ *  distinct URLs resolving to the same dest+auth). The id alone can't disambiguate, so
+ *  a by-id lookup/cancel must decline rather than silently act on the local one.
+ *  Excludes this process's own records (same owner) and stale/dead ones (heartbeat). */
+function hasAmbiguousForeignSibling(id: string, localTrayId: string): boolean {
+  const now = Date.now();
+  return listPersistedDownloadJobs().some(
+    (rec) =>
+      rec.id === id &&
+      rec.trayId !== localTrayId &&
+      rec.owner !== PERSIST_OWNER &&
+      rec.status === "downloading" &&
+      now - (rec.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
 }
 
 export function getDownloadJob(id: string): DownloadJob | undefined {
   // The registry indexes each job under its request key and (when local) its
   // destination key; the public id is one of those, so a direct get resolves it.
-  return jobs.get(id)?.job;
+  const live = jobs.get(id)?.job;
+  if (live) {
+    // Cross-session ambiguity: a live foreign download shares this id with a DIFFERENT
+    // trayId. Don't silently report the local one — decline (same as the persisted path).
+    if (hasAmbiguousForeignSibling(id, live.trayId)) return undefined;
+    return live;
+  }
+  // #529: after a reconnect the in-memory registry is empty, but the download's
+  // record persists in the progress dir — resolve it there so an id from a prior
+  // session still reports instead of "no download with id …, tracked per session".
+  const persisted = readPersistedDownloadJob(id);
+  return persisted ? jobFromPersisted(persisted) : undefined;
+}
+
+/** Adopt an in-flight download by URL or destination after a reconnect (#529) —
+ *  so a caller can confirm a download is still running (and not start a duplicate)
+ *  even without the id. Prefers a LIVE in-memory job, then the persisted store.
+ *
+ *  URL matching is EXACT (query included): in-memory by raw url, persisted by the
+ *  trayId hash of the full url — so two distinct signed/versioned URLs are never
+ *  conflated (the persisted url is credential-redacted and can't be compared safely). */
+export function findDownloadJob(query: { url?: string; destKey?: string }): DownloadJob | undefined {
+  const trayId = query.url ? downloadIdFor(query.url) : undefined;
+  const destKey = query.destKey;
+  if (!trayId && !destKey) return undefined;
+
+  // Gather candidate IN-FLIGHT jobs from BOTH this process's registry AND the cross-
+  // session persisted store, deduped by id (a live in-memory copy wins over its
+  // persisted snapshot). The ambiguity guard must span BOTH stores: one session's live
+  // job for URL→destA plus another session's persisted in-flight job for URL→destB are
+  // two DISTINCT jobs for the same URL, and adopting either by URL alone would be a
+  // guess — so decline (the caller must use the exact id).
+  // Key candidates by (id, trayId): two distinct URLs to one dest+auth share an id but
+  // differ in trayId (distinct physical downloads), so id alone would wrongly collapse
+  // them and mask the ambiguity. A live in-memory copy wins over its persisted snapshot
+  // (same id+trayId key).
+  const keyOf = (id: string, tray: string): string => `${id}\n${tray}`;
+  const now = Date.now();
+  const inflightByKey = new Map<string, DownloadJob>();
+  for (const e of new Set(jobs.values())) {
+    if (e.job.status !== "downloading") continue;
+    if ((query.url && e.job.url === query.url) || (destKey && e.job.destKey === destKey)) {
+      inflightByKey.set(keyOf(e.job.id, e.job.trayId), e.job);
+    }
+  }
+  for (const rec of listPersistedDownloadJobs()) {
+    // Only FRESH in-flight records count as live candidates — a stale/dead record
+    // (crashed session, never reaped) must not inflate the ambiguity count and force a
+    // false "no download" (matching the persisted helpers' fresh-in-flight rule).
+    if (rec.status !== "downloading" || now - (rec.updated ?? 0) >= PERSISTED_INFLIGHT_STALE_MS) {
+      continue;
+    }
+    const key = keyOf(rec.id, rec.trayId);
+    if (inflightByKey.has(key)) continue;
+    if ((trayId && rec.trayId === trayId) || (destKey && rec.dest_key === destKey)) {
+      inflightByKey.set(key, jobFromPersisted(rec));
+    }
+  }
+  if (inflightByKey.size > 1) return undefined; // ambiguous across both stores
+  if (inflightByKey.size === 1) return [...inflightByKey.values()][0];
+
+  // No in-flight match anywhere — fall back to a single unambiguous SETTLED persisted
+  // record (for status reporting); findPersistedDownloadJob declines if ambiguous.
+  const persisted = findPersistedDownloadJob({ trayId, destKey });
+  return persisted ? jobFromPersisted(persisted) : undefined;
 }
 
 export function listDownloadJobs(): DownloadJob[] {
-  // One Entry is indexed under multiple keys — dedup by identity so a job appears
-  // once regardless of how many keys point at it.
+  // One Entry is indexed under multiple keys — dedup by identity so a job appears once
+  // regardless of how many keys point at it. Identity is (id, trayId), NOT id alone:
+  // two distinct URLs to one dest+auth share an id but are distinct physical downloads
+  // (different trayId), and both must be listed — download_status with no selector
+  // promises EVERY tracked download.
   const seen = new Set<Entry>();
-  const out: DownloadJob[] = [];
+  const keyOf = (j: DownloadJob): string => `${j.id}\n${j.trayId}`;
+  const byKey = new Map<string, DownloadJob>();
   for (const e of jobs.values()) {
     if (seen.has(e)) continue;
     seen.add(e);
-    out.push(e.job);
+    byKey.set(keyOf(e.job), e.job);
   }
-  return out.sort((a, b) => b.started_at - a.started_at);
+  // #529: fold in persisted records for jobs THIS session's registry doesn't hold
+  // (started before a reconnect), so download_status still lists in-flight downloads.
+  // A live in-memory job always wins over its persisted snapshot (same id+trayId).
+  for (const rec of listPersistedDownloadJobs()) {
+    const job = jobFromPersisted(rec);
+    const k = keyOf(job);
+    if (!byKey.has(k)) byKey.set(k, job);
+  }
+  return [...byKey.values()].sort((a, b) => b.started_at - a.started_at);
+}
+
+/**
+ * Cancel an in-flight download by id (#515): abort its stream and mark it
+ * cancelled. The abort unwinds the fetch + pipeline; the .partial is left on disk
+ * (resumable) and NEVER renamed to the destination, so nothing is reported as
+ * complete. Idempotent — cancelling an already-settled job just reports its state.
+ * Returns the resulting status plus whether this call performed the abort.
+ *
+ * Only a download owned by THIS process can be aborted (its AbortController lives
+ * here). A job resolvable only via the persisted store (started by another/previous
+ * session after a reconnect) cannot be aborted from here — reported as not-owned.
+ */
+export function cancelDownloadJob(id: string): {
+  found: boolean;
+  owned: boolean;
+  aborted: boolean;
+  /** The id denotes MORE than one concurrent physical download (a live foreign
+   *  session shares it with a different trayId) — declined, nothing was aborted. */
+  ambiguous?: boolean;
+  status?: DownloadJob["status"];
+  job?: DownloadJob;
+} {
+  const entry = jobs.get(id);
+  if (entry) {
+    const { job, controller } = entry;
+    // Cross-session ambiguity: a live foreign download shares this id with a DIFFERENT
+    // trayId. Aborting by id could act on the wrong logical download — decline so a
+    // cancel-by-id can never hit an unintended concurrent download (a #515 invariant).
+    if (job.status === "downloading" && hasAmbiguousForeignSibling(id, job.trayId)) {
+      return { found: true, owned: true, aborted: false, ambiguous: true, status: job.status, job };
+    }
+    if (job.status !== "downloading") {
+      // Already settled (done/error/cancelled) — idempotent no-op.
+      return { found: true, owned: true, aborted: false, status: job.status, job };
+    }
+    // Request the abort ONLY — do NOT set a synchronous terminal state here. The FINAL
+    // state is decided by the settled closure based on what actually happened on disk:
+    //   - the file already landed (its destination rename completed, so onLanded →
+    //     commitDone marks it DONE) — a validated complete file must never read
+    //     "cancelled"; OR
+    //   - the transfer was stopped before the file landed (downloadModel THROWS via the
+    //     stream abort / pre-materialize / pre-rename guards → the catch marks it
+    //     CANCELLED and cleans up the tray row + resumable partial).
+    // Setting "cancelled" synchronously here would LOSE the race where a rename has
+    // physically completed but its promise continuation (→ onLanded) hasn't run yet:
+    // commitDone only advances a still-"downloading" job, so a synchronous "cancelled"
+    // would strand a landed file as cancelled (#515 codex). The tool reports this as a
+    // best-effort request and points the caller at download_status for the resolved state.
+    if (!controller.signal.aborted) controller.abort();
+    return { found: true, owned: true, aborted: true, status: "downloading", job };
+  }
+  // Not in THIS process's registry. It may still exist in the persisted store
+  // (another/previous session owns the AbortController), which we can't abort here.
+  const persisted = readPersistedDownloadJob(id);
+  if (persisted) {
+    return {
+      found: true,
+      owned: false,
+      aborted: false,
+      status: persisted.status,
+      job: jobFromPersisted(persisted),
+    };
+  }
+  return { found: false, owned: false, aborted: false };
 }
 
 /** Test seam — the registry is process-global otherwise. */
 export function resetDownloadJobs(): void {
+  for (const e of new Set(jobs.values())) {
+    if (e.heartbeat) clearInterval(e.heartbeat);
+  }
   jobs.clear();
   destChains.clear();
 }

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -10,8 +10,21 @@
 // normal (non-panel) use of the MCP — so it costs nothing outside the panel.
 
 import { mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { basename, dirname, join } from "node:path";
+
+/** Per-PROCESS owner nonce (#515/#529). Distinguishes THIS session's persisted job
+ *  records from another concurrent session's — even when both run the SAME logical
+ *  download (identical deterministic job id from the same URL/dest/auth). Each session
+ *  writes its OWN record file (…-<owner>.json) instead of clobbering a shared one, so a
+ *  cross-session sibling check can tell two live sessions apart by owner rather than id. */
+export const PERSIST_OWNER = randomBytes(8).toString("hex");
+
+/** A persisted in-flight record whose `updated` is older than this is treated as a
+ *  crashed/dead session (its liveness heartbeat stopped). Such records neither block
+ *  resolution/adoption nor count as a live sibling — only FRESH in-flight records do.
+ *  Must exceed the writer's heartbeat interval by a generous margin. */
+export const PERSISTED_INFLIGHT_STALE_MS = 60_000;
 
 export interface DownloadProgress {
   /** Stable id for this download (a hash of the source URL). */
@@ -334,4 +347,207 @@ export function consumeTargetChange(file: string): void {
   } catch {
     // ignore
   }
+}
+
+// ── Persisted download-job records (cross-session adoption, #529) ─────────────
+// The in-memory download-job registry (download-jobs.ts) is process-global, so a
+// sidebar/tool-session RECONNECT — which respawns the MCP child — starts with an
+// EMPTY registry and `download_status(id)` can no longer resolve an id returned by
+// a previous session ("Downloads are tracked per server session"). The live download
+// itself keeps running and keeps writing its progress row, so the STATE exists on
+// disk; it just isn't discoverable by the new session's registry.
+//
+// This persists a small per-job record into the SAME progress dir the tray already
+// uses, so any session can rediscover (adopt) an in-flight job by its public id — or
+// by URL/destination — after a reconnect. The record is prefixed with CONTROL_PREFIX
+// so the orchestrator's tray poll (pollDownloads skips CONTROL_PREFIX) and its
+// control-request reader (listTargetChangeRequests only reads REQUEST_PREFIX) both
+// ignore it. No-ops entirely without a progress dir, exactly like reportDownloadProgress.
+const JOB_PREFIX = `${CONTROL_PREFIX}job-`;
+
+export interface PersistedDownloadJob {
+  id: string;
+  trayId: string;
+  /** The id the physical progress rows are written under (post-auth/HF-rewrite);
+   *  differs from trayId only for query-auth / mirror URLs. Optional/back-compat. */
+  progressId?: string;
+  url: string;
+  target_subfolder: string;
+  filename?: string;
+  status: "downloading" | "done" | "error" | "cancelled";
+  path?: string;
+  error?: string;
+  started_at: number;
+  finished_at?: number;
+  notes?: string[];
+  /** The auth-free destination key (local targetPath or canonical remote id) — lets
+   *  a caller adopt by DESTINATION as well as by URL, without a duplicate download. */
+  dest_key?: string;
+  /** True when dispatched to a remote ComfyUI-Manager (server-side fetch), not streamed
+   *  to local disk — a "done" record then means dispatch-accepted, not verified landed. */
+  via_manager?: boolean;
+  /** The writing session's per-process owner nonce (PERSIST_OWNER). Two sessions
+   *  running the same logical download share an `id` but differ here, so a sibling
+   *  check can distinguish them. Absent on pre-fix records. */
+  owner?: string;
+  resume?: unknown;
+  /** Epoch ms of this snapshot (set on write). */
+  updated: number;
+}
+
+function sanitizeIdPart(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_.-]/g, "_");
+}
+
+/** THIS session's record file for a job id — owner-scoped, so a second session running
+ *  the same id writes a DIFFERENT file rather than clobbering ours. */
+function jobFileFor(id: string): string {
+  return join(channelDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${PERSIST_OWNER}.json`);
+}
+
+/** Persist (or update) a job record so another session can adopt it after a
+ *  reconnect (#529). URL is redacted before it touches disk (it can carry query
+ *  auth), matching the rest of this channel. Best-effort — a persistence failure
+ *  never fails a download. No-op without a progress dir. */
+export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): void {
+  const dir = channelDir();
+  if (!dir) return;
+  try {
+    mkdirSync(dir, { recursive: true });
+    const safe: PersistedDownloadJob = {
+      ...job,
+      owner: PERSIST_OWNER,
+      url: job.url ? redactUrl(job.url) : job.url,
+      updated: Date.now(),
+    };
+    writeFileSync(jobFileFor(job.id), JSON.stringify(safe));
+  } catch {
+    // best-effort — adoption is a convenience, never fail a download over it
+  }
+}
+
+/** Remove a persisted job record (e.g. once it's fully retired). Best-effort. */
+export function removePersistedDownloadJob(id: string): void {
+  const dir = channelDir();
+  if (!dir) return;
+  try {
+    rmSync(jobFileFor(id), { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+/** How long a TERMINAL (done/error/cancelled) persisted record is kept for late
+ *  adoption before it's reaped on the next scan. A slow multi-GB in-flight download
+ *  stays adoptable because its owner heartbeats the record within
+ *  PERSISTED_INFLIGHT_STALE_MS — so only a DEAD (crashed) writer's in-flight record
+ *  goes stale and gets reaped (below). */
+const PERSISTED_JOB_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+
+function parseJobFile(dir: string, f: string): PersistedDownloadJob | null {
+  try {
+    const raw = JSON.parse(readFileSync(join(dir, f), "utf8")) as PersistedDownloadJob;
+    if (!raw || typeof raw !== "object" || typeof raw.id !== "string") return null;
+    const age = typeof raw.updated === "number" ? Date.now() - raw.updated : 0;
+    // Reap a record that is either a long-settled terminal one OR a DEAD in-flight one.
+    // In-flight records are heartbeated every ~15s by their live owner, so an in-flight
+    // record older than PERSISTED_INFLIGHT_STALE_MS (60s) means the writer crashed —
+    // reap it so download_status / cancel_download never report a dead download as
+    // "still streaming". A genuinely-live (even stalled) download keeps heartbeating and
+    // is never stale; a falsely-reaped one reappears on the owner's next heartbeat.
+    const terminalExpired = raw.status !== "downloading" && age > PERSISTED_JOB_TTL_MS;
+    const inflightDead = raw.status === "downloading" && age > PERSISTED_INFLIGHT_STALE_MS;
+    if (terminalExpired || inflightDead) {
+      try {
+        rmSync(join(dir, f), { force: true });
+      } catch {
+        /* ignore */
+      }
+      return null;
+    }
+    return raw;
+  } catch {
+    return null; // absent / mid-write / corrupt — skip
+  }
+}
+
+/** Read the best persisted record for a public id, or null when absent/expired. More
+ *  than one record can exist for one id — one per session that ran it (owner-scoped
+ *  files) — so scan all matches and prefer an in-flight one, then the most recent. */
+export function readPersistedDownloadJob(id: string): PersistedDownloadJob | null {
+  const matches = listPersistedDownloadJobs().filter((j) => j.id === id);
+  if (matches.length === 0) return null;
+  const now = Date.now();
+  // A LIVE download is a FRESH in-flight record (heartbeat recent). Ambiguity that
+  // matters is >1 distinct trayId among LIVE records — two distinct URLs resolving to
+  // the same dest+auth are distinct concurrent physical downloads the id can't
+  // disambiguate. Dead in-flight records are already reaped in parseJobFile, so
+  // `matches` holds only fresh in-flight and terminal records; the freshness filter
+  // here is defense-in-depth against a record that aged out between scan and use.
+  const live = matches.filter(
+    (j) => j.status === "downloading" && now - (j.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  if (live.length > 0) {
+    if (new Set(live.map((j) => j.trayId)).size > 1) return null; // ambiguous live download
+    return live.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  }
+  // No live download — report the most recent record (terminal, or a stale in-flight)
+  // for status. No live ambiguity to guard against here.
+  return matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+}
+
+/** Every persisted job record (freshest not guaranteed; caller sorts). Used to
+ *  list in-flight downloads after a reconnect and to look one up by URL/destination. */
+export function listPersistedDownloadJobs(): PersistedDownloadJob[] {
+  const dir = channelDir();
+  if (!dir) return [];
+  const out: PersistedDownloadJob[] = [];
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir).filter((f) => f.startsWith(JOB_PREFIX) && f.endsWith(".json"));
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    const rec = parseJobFile(dir, f);
+    if (rec) out.push(rec);
+  }
+  return out;
+}
+
+/** Find a persisted job by TRAY id or by destination key — so a caller can adopt an
+ *  in-flight download after a reconnect WITHOUT starting a duplicate (#529).
+ *
+ *  Matching is on `trayId` (a hash of the FULL raw source URL, query included — the
+ *  caller derives it via downloadIdFor), NOT the persisted `url` string: the persisted
+ *  url is credential-redacted (query stripped), so comparing it would conflate two
+ *  distinct signed/versioned URLs that differ only by query. Hashing the raw url keeps
+ *  the match exact AND credential-free. Prefers an in-flight ("downloading") match,
+ *  then the most recently updated (a niche same-exact-URL-two-destinations case is
+ *  inherently ambiguous from a URL alone — the id selector disambiguates it). */
+export function findPersistedDownloadJob(query: { trayId?: string; destKey?: string }): PersistedDownloadJob | null {
+  const { trayId, destKey } = query;
+  if (!trayId && !destKey) return null;
+  const matches = listPersistedDownloadJobs().filter(
+    (j) => (trayId && j.trayId === trayId) || (destKey && j.dest_key === destKey),
+  );
+  if (matches.length === 0) return null;
+  // AMBIGUITY GUARD: one URL can legitimately drive TWO jobs to different destinations
+  // (they share a trayId), and one auth-free destination can back two different-auth
+  // jobs (they share a dest_key). Adopting by URL/destination alone then can't tell them
+  // apart — so REFUSE to guess when more than one DISTINCT LIVE job matches; the caller
+  // must use the exact id. Distinctness is (id, trayId). Ambiguity is judged over LIVE
+  // (fresh in-flight) records ONLY: a stale/dead record (crashed session, explicitly
+  // never reaped) must not block adoption or force a false decline.
+  const distinctKey = (j: PersistedDownloadJob): string => `${j.id}\n${j.trayId}`;
+  const now = Date.now();
+  const live = matches.filter(
+    (j) => j.status === "downloading" && now - (j.updated ?? 0) < PERSISTED_INFLIGHT_STALE_MS,
+  );
+  if (live.length > 0) {
+    if (new Set(live.map(distinctKey)).size > 1) return null; // ambiguous live download
+    return live.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  }
+  // No live download — report the most recent record (terminal/stale) for status.
+  return matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
 }

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -9,7 +9,7 @@
 // This no-ops entirely when COMFYUI_MCP_PROGRESS_DIR is unset — i.e. for every
 // normal (non-panel) use of the MCP — so it costs nothing outside the panel.
 
-import { mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync, renameSync, rmSync } from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 
@@ -65,6 +65,15 @@ const lastWriteAt = new Map<string, number>();
 /** True when running under the panel orchestrator (progress channel is active). */
 export function progressEnabled(): boolean {
   return !!PROGRESS_DIR;
+}
+
+/** True when the cross-session persisted job store is active (a channel dir exists,
+ *  from the env var OR the orchestrator's late binding). Unlike progressEnabled(), this
+ *  honors the late-bound dir — so the job registry only runs its persistence heartbeat
+ *  when there is actually somewhere to persist/adopt (avoids a leaked no-op interval on
+ *  plain non-panel downloads). */
+export function persistedRecordsEnabled(): boolean {
+  return !!channelDir();
 }
 
 function fileFor(id: string, target?: string): string {
@@ -383,6 +392,10 @@ export interface PersistedDownloadJob {
   /** The auth-free destination key (local targetPath or canonical remote id) — lets
    *  a caller adopt by DESTINATION as well as by URL, without a duplicate download. */
   dest_key?: string;
+  /** The route-independent request key (url+subfolder+filename+auth) — the SAME across a
+   *  local↔Manager route flip, so cross-session adoption matches a reconnect even when
+   *  the route (and thus the public id) changed. */
+  req_key?: string;
   /** True when dispatched to a remote ComfyUI-Manager (server-side fetch), not streamed
    *  to local disk — a "done" record then means dispatch-accepted, not verified landed. */
   via_manager?: boolean;
@@ -405,13 +418,28 @@ function jobFileFor(id: string): string {
   return join(channelDir(), `${JOB_PREFIX}${sanitizeIdPart(id)}-${PERSIST_OWNER}.json`);
 }
 
+let persistSeq = 0;
+
 /** Persist (or update) a job record so another session can adopt it after a
  *  reconnect (#529). URL is redacted before it touches disk (it can carry query
  *  auth), matching the rest of this channel. Best-effort — a persistence failure
- *  never fails a download. No-op without a progress dir. */
-export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): void {
+ *  never fails a download. No-op without a progress dir.
+ *
+ *  ATOMIC: writes to a unique temp then renames it over the target, so a concurrent
+ *  reader (another session polling for adoption, or this session's heartbeat) NEVER sees
+ *  a half-written/truncated record and treats a live download as absent — which would let
+ *  a reconnect-reissue start a SECOND writer (torn-write double-writer race). fs.rename
+ *  atomically replaces on POSIX and on Windows (libuv MoveFileEx REPLACE_EXISTING). The
+ *  `.tmp` name ends in `.tmp` (not `.json`) so no scanner ever picks up a temp.
+ *
+ *  Returns TRUE iff the record was DURABLY replaced (the atomic rename succeeded), so the
+ *  caller (the heartbeat) can keep retrying a transiently-failing TERMINAL persist until
+ *  the terminal state is durable — otherwise a done/cancelled job could linger as a fresh
+ *  "downloading" record (bounded by the stale reap, but this recovers it sooner). Returns
+ *  false when there is no channel dir (nothing to persist) or the replace didn't happen. */
+export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): boolean {
   const dir = channelDir();
-  if (!dir) return;
+  if (!dir) return false;
   try {
     mkdirSync(dir, { recursive: true });
     const safe: PersistedDownloadJob = {
@@ -420,9 +448,38 @@ export function persistDownloadJob(job: Omit<PersistedDownloadJob, "updated">): 
       url: job.url ? redactUrl(job.url) : job.url,
       updated: Date.now(),
     };
-    writeFileSync(jobFileFor(job.id), JSON.stringify(safe));
+    const body = JSON.stringify(safe);
+    const finalPath = jobFileFor(job.id);
+    const tmpPath = `${finalPath}.${process.pid}-${persistSeq++}.tmp`;
+    writeFileSync(tmpPath, body);
+    // Atomic replace, retried a few times for a TRANSIENT Windows sharing violation (a
+    // reader briefly holding the target open during its own readFileSync). We must NEVER
+    // fall back to an in-place writeFileSync(finalPath): that truncate+rewrite is exactly
+    // the torn-read that lets another process see the record as absent and start a SECOND
+    // writer. On persistent failure we KEEP the prior COMPLETE record untouched and drop
+    // the temp; the next ~15s heartbeat retries the atomic replace (self-healing). A
+    // terminal persist that can't replace ages out via the stale-in-flight reap instead
+    // of ever corrupting the scanned .json.
+    let renamed = false;
+    for (let attempt = 0; attempt < 5 && !renamed; attempt++) {
+      try {
+        renameSync(tmpPath, finalPath); // readers see old or new complete record, never torn
+        renamed = true;
+      } catch {
+        /* transient (e.g. Windows sharing violation) — retry */
+      }
+    }
+    if (!renamed) {
+      try {
+        rmSync(tmpPath, { force: true });
+      } catch {
+        /* ignore — a stray temp is never scanned (ends in .tmp) */
+      }
+    }
+    return renamed;
   } catch {
     // best-effort — adoption is a convenience, never fail a download over it
+    return false;
   }
 }
 
@@ -491,9 +548,14 @@ export function readPersistedDownloadJob(id: string): PersistedDownloadJob | nul
     if (new Set(live.map((j) => j.trayId)).size > 1) return null; // ambiguous live download
     return live.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
   }
-  // No live download — report the most recent record (terminal, or a stale in-flight)
-  // for status. No live ambiguity to guard against here.
-  return matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  // No live download. INTEGRITY TRUTH (cross-session): a terminal DONE means a validated
+  // file landed at the destination. It must WIN over a later cancelled/error record for
+  // the SAME id — a cancel/error never lands a file, so it must NEVER override another
+  // session's validated-complete file (cancelled-over-complete). Prefer the most-recent
+  // DONE; only if there is none do we report the most-recent terminal record.
+  const done = matches.filter((j) => j.status === "done");
+  const pool = done.length > 0 ? done : matches;
+  return pool.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
 }
 
 /** Every persisted job record (freshest not guaranteed; caller sorts). Used to
@@ -548,6 +610,10 @@ export function findPersistedDownloadJob(query: { trayId?: string; destKey?: str
     if (new Set(live.map(distinctKey)).size > 1) return null; // ambiguous live download
     return live.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
   }
-  // No live download — report the most recent record (terminal/stale) for status.
-  return matches.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
+  // No live download. INTEGRITY TRUTH: a terminal DONE (validated file landed) must WIN
+  // over a later cancelled/error record for the same destination — never override a
+  // validated-complete file. Prefer the most-recent DONE, else the most-recent terminal.
+  const done = matches.filter((j) => j.status === "done");
+  const pool = done.length > 0 ? done : matches;
+  return pool.sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))[0];
 }

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -803,7 +803,10 @@ async function downloadModelViaManagerRemote(
   targetSubfolder: string,
   filename?: string,
   auth?: DownloadAuth,
+  signal?: AbortSignal,
 ): Promise<string> {
+  // Cancelled before we dispatched — do not hand the fetch to the remote Manager at all.
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
   const raw = (targetSubfolder ?? "").trim();
   if (!raw) {
     throw new ModelError("target_subfolder is required (e.g. 'loras', 'checkpoints').");
@@ -887,6 +890,12 @@ async function downloadModelViaManagerRemote(
     trayCategory: modelType,
   });
 
+  // Cancelled while the dispatch was in flight (#515): the local job is cancelled.
+  // We CAN'T recall a Manager queue task, so the host may keep fetching — but this
+  // must NOT be reported as a completed local download. Throw so the job records
+  // "cancelled" (the tool message notes the server may still be fetching).
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+
   return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authWarning}`;
 }
 
@@ -963,7 +972,25 @@ export async function downloadModel(
   /** Sink for the resume decision, threaded from the job so the outcome is stored
    *  on that job (#467). Omitted by direct callers (no job to report to). */
   onResume?: ResumeReporter,
+  /** Per-download abort signal, threaded from the job's AbortController into the
+   *  fetch + stream pipeline so cancel_download aborts exactly this transfer (#515).
+   *  Omitted by direct callers (no cancellation handle). */
+  signal?: AbortSignal,
+  /** Reports the ACTUAL progress-tray id (a hash of the post-auth/post-HF-rewrite
+   *  request URL) back to the job, so the job's trayId matches the id the streaming
+   *  and done rows are written under. Without it a query-auth or HF_ENDPOINT-rewritten
+   *  download's tray row is keyed differently from the job's original-URL trayId — so
+   *  download_status byte display AND cancel cleanup would target the wrong id. Called
+   *  only on the LOCAL streaming path (the Manager path writes no streaming rows). */
+  onTrayId?: (trayId: string) => void,
+  /** Fired the instant the completed, validated file is renamed into its destination
+   *  (#515) — so the job can commit "done" with NO window where the file exists but the
+   *  job still reads "downloading". Local paths only (the remote Manager dispatch has no
+   *  local rename; the caller commits done when this function returns). */
+  onLanded?: (targetPath: string) => void,
 ): Promise<string> {
+  // Cancelled before we did anything — never start a transfer (local OR server-side).
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
   // Region flags (issue #127) applied at THE choke point every download path
   // funnels through (local disk AND the remote Manager dispatch below).
   const wasHfUrl = /^https?:\/\/huggingface\.co([/?#]|$)/i.test(url);
@@ -987,7 +1014,7 @@ export async function downloadModel(
   const routeToManager =
     dispatchToManager ?? (await shouldDispatchDownloadToManager());
   if (routeToManager) {
-    return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth);
+    return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal);
   }
 
   // Root the destination at the LIVE server's models dir (its --base-directory),
@@ -1023,6 +1050,9 @@ export async function downloadModel(
   // retries map to the same row. Name is the friendly file name.
   const progressId = createHash("sha256").update(request.url).digest("hex").slice(0, 16);
   const progress = { id: progressId, name: resolvedFilename };
+  // Tell the job the id the tray rows actually use, so status display + cancel
+  // cleanup key on the SAME id even when auth/HF-endpoint rewrote the request URL.
+  onTrayId?.(progressId);
 
   try {
     await downloadWithCache({
@@ -1033,14 +1063,29 @@ export async function downloadModel(
       storageAuth: auth?.type === "s3" ? { s3: auth } : undefined,
       progress,
       onResume,
+      signal,
+      onLanded,
     });
   } catch (err) {
-    // Surface a failed row in the tray, then rethrow for the tool to report.
-    reportDownloadProgress({ ...progress, downloaded: 0, total: 0, bytes_per_sec: 0, status: "error" }, true);
+    // On a user cancel (#515) the transfer was aborted, not a real failure — do NOT
+    // emit an "error" row (the job reports "cancelled"). The tray row is cleared by the
+    // JOB layer (finalizeCancelled), which is registry-aware so it can't wipe a
+    // coalesced sibling's live row; clearing here would clear that shared row blindly.
+    // For a genuine error, surface a failed row, then rethrow.
+    if (!signal?.aborted) {
+      reportDownloadProgress({ ...progress, downloaded: 0, total: 0, bytes_per_sec: 0, status: "error" }, true);
+    }
     throw err;
   }
 
   const info = await stat(targetPath);
+  // The file has MATERIALIZED to its destination and passed model-payload/size
+  // validation. We deliberately do NOT abort here on a late cancel: the file on disk is
+  // a complete, valid model, so the honest outcome is a completed download (the job
+  // reports "done"). A cancel that arrived BEFORE the file landed already made this
+  // function THROW — via the stream abort, or the cache-layer pre-materialize /
+  // pre-rename guards — so it never reaches this point. (Rolling a validated landed file
+  // back would be unsafe.) Result: file present ⟺ done; file absent ⟺ cancelled.
   logger.info(`Download complete: ${resolvedFilename} (${(info.size / 1024 / 1024).toFixed(1)} MB)`);
   // Ensure a terminal "done" row even on a cache hit (no streaming happened).
   reportDownloadProgress(

--- a/src/services/storage/azure-blob.ts
+++ b/src/services/storage/azure-blob.ts
@@ -137,15 +137,24 @@ async function blobServiceClientForUpload(): Promise<BlobServiceClient> {
   return envClient.client;
 }
 
-export async function downloadAzureBlobToFile(url: string, targetPath: string): Promise<void> {
+export async function downloadAzureBlobToFile(
+  url: string,
+  targetPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
   try {
-    const response = await (await blobClientForDownload(url)).download();
+    // Thread the abort signal into BOTH the SDK download and the write pipeline so a
+    // cancel_download (#515) aborts the Azure transfer; the streamUrlToFile cloud
+    // branch also guards before/after so a cancelled transfer is never finalized.
+    const response = await (await blobClientForDownload(url)).download(undefined, undefined, {
+      abortSignal: signal,
+    });
     if (!response.readableStreamBody) {
       throw new ModelError("Azure Blob download response has no body", {
         url: redactUrlForLogs(url),
       });
     }
-    await pipeline(response.readableStreamBody, createWriteStream(targetPath));
+    await pipeline(response.readableStreamBody, createWriteStream(targetPath), { signal });
     // #343 edge: verify the written size against the blob's authoritative
     // contentLength so an early-ending stream can't be reported as a complete
     // download (silent truncation).

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -97,13 +97,14 @@ export async function downloadCloudUrlToFile(
   url: string,
   targetPath: string,
   auth: CloudStorageAuth = {},
+  signal?: AbortSignal,
 ): Promise<void> {
   if (isS3Url(url)) {
-    await downloadS3ToFile(url, targetPath, auth.s3);
+    await downloadS3ToFile(url, targetPath, auth.s3, signal);
     return;
   }
   if (isAzureBlobUrl(url)) {
-    await downloadAzureBlobToFile(url, targetPath);
+    await downloadAzureBlobToFile(url, targetPath, signal);
     return;
   }
   throw new ValidationError(

--- a/src/services/storage/s3.ts
+++ b/src/services/storage/s3.ts
@@ -62,16 +62,23 @@ export async function downloadS3ToFile(
   url: string,
   targetPath: string,
   auth?: S3Auth,
+  signal?: AbortSignal,
 ): Promise<void> {
   const { bucket, key } = parseS3Url(url);
   const { GetObjectCommand } = await loadAwsS3();
   const client = await makeS3Client(auth);
   try {
-    const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    // Thread the abort signal into BOTH the SDK request and the write pipeline so a
+    // cancel_download (#515) aborts the S3 transfer promptly instead of running to
+    // completion. The streamUrlToFile cloud branch also guards before/after as a
+    // backstop, so a cancelled transfer is never finalized even if the SDK ignores it.
+    const response = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }), {
+      abortSignal: signal,
+    });
     if (!response.Body) {
       throw new ModelError("S3 download response has no body", { url: redactUrlForLogs(url) });
     }
-    await pipeline(bodyToReadable(response.Body), createWriteStream(targetPath));
+    await pipeline(bodyToReadable(response.Body), createWriteStream(targetPath), { signal });
     // #343 edge: the S3 stream can end early (dropped connection) and pipeline()
     // still resolves, leaving a truncated file. S3 tells us the authoritative
     // object size in ContentLength — verify the bytes on disk match before this

--- a/src/tools/model-extras.ts
+++ b/src/tools/model-extras.ts
@@ -498,12 +498,32 @@ export function registerModelExtrasTools(server: McpServer): void {
             ],
           };
         }
+        if (job.status === "cancelled") {
+          // A concurrent cancel_download landed during this grace window — do NOT fall
+          // through to the success renderer (which would dereference an unset job.path).
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: job.viaManager
+                  ? `CivitAI download \`${job.id}\` was cancelled. It was a remote ComfyUI-Manager dispatch, so there is no local partial to resume; the host MAY still be fetching server-side. Check list_local_models to see if it landed; re-issuing starts a NEW dispatch, not a resume.`
+                  : `CivitAI download \`${job.id}\` was cancelled. A resumable partial may remain on disk — re-issue the same download to resume it.`,
+              },
+            ],
+          };
+        }
 
         const savedPath = job.path!;
-        const lines = [
-          "CivitAI model downloaded successfully:",
-          `  ${savedPath}`,
-        ];
+        const lines = job.viaManager
+          ? [
+              "CivitAI model DISPATCHED to the remote ComfyUI via ComfyUI-Manager (server-side fetch):",
+              `  ${savedPath}`,
+              "  NOTE: the dispatch was ACCEPTED, NOT verified as landed — ComfyUI-Manager reports its queue task 'done' even on failure. Confirm with list_local_models before relying on it.",
+            ]
+          : [
+              "CivitAI model downloaded successfully:",
+              `  ${savedPath}`,
+            ];
         if (resolved.modelName) lines.push(`  Model: ${resolved.modelName}`);
         lines.push(`  Version id: ${resolved.versionId}`);
         lines.push(...(job.notes ?? []));

--- a/src/tools/model-management.ts
+++ b/src/tools/model-management.ts
@@ -8,7 +8,9 @@ import {
 import {
   startDownloadJob,
   getDownloadJob,
+  findDownloadJob,
   listDownloadJobs,
+  cancelDownloadJob,
   type DownloadJob,
 } from "../services/download-jobs.js";
 import { readDownloadProgress } from "../services/download-progress.js";
@@ -154,15 +156,33 @@ export function registerModelManagementTools(server: McpServer): void {
         if (timer) clearTimeout(timer);
 
         if (job.status === "done") {
+          const text = job.viaManager
+            ? `Download DISPATCHED to the remote ComfyUI via ComfyUI-Manager (server-side fetch):\n${job.path}\n\n` +
+              `NOTE: the dispatch was ACCEPTED, NOT verified as landed — ComfyUI-Manager reports its queue task 'done' even on failure, so this does not guarantee the file is present. Confirm with list_local_models before relying on it.`
+            : `Model downloaded successfully to:\n${job.path}`;
           return {
-            content: [{ type: "text", text: `Model downloaded successfully to:\n${job.path}` }],
+            content: [{ type: "text", text }],
           };
         }
         if (job.status === "error") {
           return errorToToolResult(new ModelError(job.error ?? "Download failed", { url: args.url }));
         }
+        if (job.status === "cancelled") {
+          // A concurrent cancel_download landed during this grace window (e.g. a reissue
+          // adopted a running job, then that id was cancelled).
+          return {
+            content: [
+              {
+                type: "text",
+                text: job.viaManager
+                  ? `Download \`${job.id}\` was cancelled. It was a remote ComfyUI-Manager dispatch, so there is no local partial to resume; the host MAY still be fetching server-side (no Manager recall API). Check list_local_models to see if it landed; re-issuing starts a NEW dispatch, not a resume.`
+                  : `Download \`${job.id}\` was cancelled. A resumable partial may remain on disk — re-issue the same download to resume it (it picks up where it left off).`,
+              },
+            ],
+          };
+        }
 
-        const p = readDownloadProgress(job.trayId);
+        const p = readDownloadProgress(job.progressId ?? job.trayId);
         const pct =
           p && p.total > 0 ? ` (${Math.floor((p.downloaded / p.total) * 100)}%)` : "";
         return {
@@ -188,35 +208,49 @@ export function registerModelManagementTools(server: McpServer): void {
 
   server.tool(
     "download_status",
-    "Check on model downloads started by download_model. Reports each download's state (downloading / done / error), its destination path once it lands, and byte progress when the panel progress channel is enabled. " +
-      "Use this after download_model reports a download is still running — that means the transfer is in flight, NOT that it failed. Read-only.",
+    "Check on model downloads started by download_model. Reports each download's state (downloading / done / error / cancelled), its destination path once it lands, and byte progress when the panel progress channel is enabled. " +
+      "Use this after download_model reports a download is still running — that means the transfer is in flight, NOT that it failed. " +
+      "Survives a sidebar/tool-session reconnect: an in-flight download started in a previous session is still resolvable by its id (or by `url`), so you can confirm it's still running instead of starting a duplicate. Read-only.",
     {
       id: z
         .string()
         .optional()
-        .describe("Download id from download_model. Omit to list every download this session."),
+        .describe("Download id from download_model. Omit to list every tracked download (incl. in-flight ones from before a reconnect)."),
+      url: z
+        .string()
+        .url()
+        .optional()
+        .describe("Adopt an in-flight download by its source URL when you don't have the id (e.g. after a reconnect) — reports the matching job without starting a duplicate."),
     },
     async (args) => {
       try {
-        const list = args.id
-          ? [getDownloadJob(args.id)].filter((j): j is DownloadJob => !!j)
-          : listDownloadJobs();
+        const byId = args.id ? getDownloadJob(args.id) : undefined;
+        const byUrl = !byId && args.url ? findDownloadJob({ url: args.url }) : undefined;
+        const list =
+          args.id || args.url
+            ? [byId ?? byUrl].filter((j): j is DownloadJob => !!j)
+            : listDownloadJobs();
 
         if (list.length === 0) {
+          const selector = args.id
+            ? `id \`${args.id}\``
+            : args.url
+              ? `url \`${args.url}\``
+              : "";
           return {
             content: [
               {
                 type: "text",
-                text: args.id
-                  ? `No download with id \`${args.id}\`. Downloads are tracked per server session, so an id from a previous session won't resolve — check the panel download tray instead.`
-                  : "No downloads have been started this session.",
+                text: (args.id || args.url)
+                  ? `No download matching ${selector}. It has either finished long ago (settled records are pruned after a while) or never started — check the panel download tray before re-downloading. Within the SAME session, re-issuing an identical in-flight download adopts it rather than duplicating; across a reconnect, confirm via the tray first.`
+                  : "No downloads are being tracked.",
               },
             ],
           };
         }
 
         const lines = list.map((j) => {
-          const p = readDownloadProgress(j.trayId);
+          const p = readDownloadProgress(j.progressId ?? j.trayId);
           const bytes =
             p && p.total > 0
               ? `  ${(p.downloaded / 1024 ** 3).toFixed(2)}/${(p.total / 1024 ** 3).toFixed(2)} GB (${Math.floor((p.downloaded / p.total) * 100)}%)`
@@ -226,10 +260,20 @@ export function registerModelManagementTools(server: McpServer): void {
           const head = `- \`${j.id}\` **${j.status}**${bytes}`;
           const detail =
             j.status === "done"
-              ? `\n    landed at: ${j.path}`
+              ? j.viaManager
+                ? `\n    dispatched to the remote ComfyUI via ComfyUI-Manager (server-side fetch): ${j.path}\n    NOTE: this means the dispatch was accepted, NOT that the file has verifiably landed — Manager reports its task done even on failure. Confirm with list_local_models.`
+                : `\n    landed at: ${j.path}`
               : j.status === "error"
                 ? `\n    failed: ${j.error}`
-                : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
+                : j.status === "cancelled"
+                  ? (j.viaManager
+                      ? `\n    cancelled — this was a remote ComfyUI-Manager dispatch, so there is NO local partial to resume, and the host MAY still be fetching server-side (there's no Manager recall API). Re-issuing starts a NEW server-side dispatch (a duplicate, not a resume). Check list_local_models to see whether the file landed before deciding.`
+                      : `\n    cancelled — the partial was left on disk and can be resumed by re-issuing the download (it picks up where it left off)`) +
+                    // A recovery-critical note from cancellation cleanup (e.g. a previous
+                    // destination file preserved under a .bak path because it couldn't be
+                    // restored) — surface it so the user can recover, not mask it.
+                    (j.error ? `\n    IMPORTANT: ${j.error}` : "")
+                  : `\n    still streaming — started ${Math.round((Date.now() - j.started_at) / 1000)}s ago`;
           // Surface a declined resume so the agent/user knows a pre-existing
           // .partial was discarded and why — instead of it being silent (#467).
           // The decision is stored on THIS job by its own physical download, so it
@@ -264,6 +308,83 @@ export function registerModelManagementTools(server: McpServer): void {
         });
 
         return { content: [{ type: "text", text: `## Downloads\n\n${lines.join("\n")}` }] };
+      } catch (err) {
+        return errorToToolResult(err);
+      }
+    },
+  );
+
+  server.tool(
+    "cancel_download",
+    "Cancel ONE in-flight model download started by download_model / download_civitai_model, by its id (from download_status or the tool that started it). Aborts only that download's transfer — other downloads keep running. The partially-downloaded bytes are left on disk as a resumable .partial and are NEVER reported as a completed file, so nothing corrupt lands in your models directory; re-issuing the same download later resumes where it left off. Idempotent: cancelling an already-finished, failed, or already-cancelled download just reports its current state. Only downloads owned by the current server session can be aborted — a download started before a reconnect is reported but must be stopped from the panel download tray. NOTE: for a download dispatched to a REMOTE ComfyUI via ComfyUI-Manager (server-side fetch), the local job is marked cancelled but the host may keep fetching — there is no Manager API to stop it.",
+    {
+      id: z
+        .string()
+        .min(1)
+        .describe("The download id to cancel (from download_model / download_civitai_model / download_status)."),
+    },
+    async (args) => {
+      try {
+        const res = cancelDownloadJob(args.id);
+        if (!res.found) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `No download with id \`${args.id}\` to cancel. It may have already finished and been pruned, or the id is wrong — check download_status.`,
+              },
+            ],
+          };
+        }
+        if (res.ambiguous) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Refusing to cancel \`${args.id}\`: that id currently denotes MORE than one concurrent download ` +
+                  `(another session is downloading a different source to the same destination). Cancelling by id ` +
+                  `could stop the wrong one. Stop the specific download from the panel download tray instead.`,
+              },
+            ],
+          };
+        }
+        if (res.aborted) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Cancellation requested for \`${args.id}\` — the transfer is being aborted. ` +
+                  `If it hadn't finished, it stops with a resumable partial and nothing corrupt lands (re-issue the same download later to resume). ` +
+                  `If it had ALREADY completed at the moment you cancelled, the finished file is present and the download reports as done — that's expected (cancel lost the race), not a bug. ` +
+                  `Check \`download_status\` with this id to see the final state. ` +
+                  `(If this was a remote/ComfyUI-Manager server-side download, the host may keep fetching — there's no Manager API to stop it.)`,
+              },
+            ],
+          };
+        }
+        if (!res.owned) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  `Download \`${args.id}\` is tracked (status: ${res.status}) but was started by a different/previous server session, so it can't be aborted from here. ` +
+                  `Stop it from the panel download tray instead.`,
+              },
+            ],
+          };
+        }
+        // Found + owned but already settled — idempotent no-op.
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Download \`${args.id}\` is already **${res.status}** — nothing to cancel.`,
+            },
+          ],
+        };
       } catch (err) {
         return errorToToolResult(err);
       }


### PR DESCRIPTION
Fixes the download-management cluster **#515 + #529** (same job-registry subsystem).

## #515 — per-download cancellation
- Each download job now owns an `AbortController`; its signal threads through `downloadModel` → `downloadWithCache` → the `fetch` + stream `pipeline`, the S3/Azure cloud downloaders, and the remote ComfyUI-Manager dispatch.
- New **`cancel_download`** MCP tool aborts one job by id — other downloads keep running.
- **Async-resolved, race-free semantics:** cancel merely *requests* the abort; the settled closure decides the final state from what actually landed on disk. The job commits `done` synchronously the instant the validated file is renamed into place (an `onLanded` callback fired before any further await, on every land path — HTTP, cloud, cache-hit/coalesced, direct-download fallback, and the Windows backup-swap). Invariant: **validated file present ⟺ done; file absent ⟺ cancelled** (resumable `.partial` left; a pre-existing destination is preserved/restored). Never a corrupt false-complete and never a cancelled-over-complete. Builds on the existing #343/#467/#473 integrity gates.

## #529 — `download_status` survives a sidebar/tool-session reconnect
- Each job is persisted to the progress dir as an owner-scoped `control-job-<id>-<owner>` record (ignored by the orchestrator tray poll + control reader), refreshed by a ~15s liveness heartbeat.
- `download_status` / `getDownloadJob` / `findDownloadJob` / `listDownloadJobs` fall back to the persisted store, so an id (or URL) returned by a previous session still resolves an **in-flight** download after a reconnect.
- A stable original-URL `trayId` drives URL adoption; a separate `progressId` keys the physical tray rows. Dead in-flight records (stale heartbeat) are reaped; ambiguous same-id/different-trayId or concurrent cross-session matches are **declined** rather than guessed.

## Notes
- Remote Manager dispatches are throw-on-abort and distinctly labeled **"dispatched, not verified"** (`viaManager`) across `download_model`, `download_civitai_model`, and `download_status` — a server-side handoff is never reported as a validated local completion.
- Adversarial self-review (codex, embedded-diff) looped to **PASS**.
- Full suite green except the pre-existing ripgrep-exception test; `tsc` clean.

Closes #515
Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)