### PR TITLE
0.48.22 — async AI-triage client (#544), report-bug upstream (#548), panel-version disk fallback (#575)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.22] - 2026-07-31
+
+### MCP
+
+#### Added
+- per-download cancellation + reconnect-adoptable download_status (#515, #529) (#577)
+- disk fallback for panel version when hello omits it (#575)
+- async AI-triage client — versions, upgrade advice, no double-file (#544)
+
+#### Fixed
+- honest bounded restart-confirm + correct ready-banner model (#360, #376) (#576)
+- tolerant default reply timeout for read ops (panel #357) (#574)
+- certify reboot readiness via a concurrent, post-write-gated boot-endpoint observer (#509) (#536)
+- strip [object Object] user-turn artifact + consume panel status base_path (#534, #296) (#573)
+- graph-capture fallback + correct dynamic-widget/Get-Set link mapping (#384, #361) (#522)
+- proactively gate a bridge command once proven unsupported (#236) (#564)
+- allow panel_set_widget to clear a widget to "" (#347) (#561)
+- list_local_models omits .gguf models via REST path (#526) (#549)
+- stale-bug cluster — secret-notice correlation, stall false-positive, load_workflow custom user-dir (#550)
+- TTL-bounded cache so out-of-band ComfyUI restart/install self-heals (#528) (#542)
+- report actual backend in ENVIRONMENT (#358); accurate list_workflow_templates description (#359) (#533)
+- ACE Step 1.5 fields (#501); lock native VAE/UNET loaders (#482); bundled-pack runtime (#464) (#519)
+- never silently substitute comboOpts[0] for a user-staged value + refresh stale loader dropdowns (#504, #499) (#517)
+- fail-fast when no interactive surface (#300); don't drop a late-but-valid answer (#486); saner set_todo deadline (#322) (#525)
+- live-first download target + poll Manager queue instead of 300s false timeout (#490, #463, #489) (#524)
+
+
 ## [0.48.21] - 2026-07-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.21",
+  "version": "0.48.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.21",
+      "version": "0.48.22",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.21",
+  "version": "0.48.22",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Release **0.48.22**. Bundles 20 merged PRs since v0.48.21.

### Headline
- **`report_issue` async AI-triage client (#544)** — the client that sends `X-Triage-Async`, so the terra triage agent runs (version-match, upgrade advice, no double-file) instead of the worker's legacy dumb-file sync path. Shipping this is the prerequisite for auto-update to start delivering intelligent triage to users.
- **report-bug files upstream on a user-confirmed fix (#548)**.
- **panel-version disk fallback (#575)** — fills the ENV line `panel=?` when a stale cached panel omits its version from the hello.
- **per-download cancellation + reconnect-adoptable `download_status` (#515/#529/#577)**.

### Fix batch
object-info TTL self-heal (#528/#542) · `[object Object]` user-turn strip (#534/#296) · panel restart-confirm + reboot certification (#360/#376/#509) · `list_local_models` .gguf via REST (#526) · `set_widget` clear-to-"" (#347) · apply-manifest live-first + Manager-queue poll (#490/#463/#489) · combo substitution guard (#504/#499) · panel-ask fail-fast (#300/#486/#322) · bridge-cmd gating (#236) · ACE Step / loader-lock / bundled-pack runtime (#501/#482/#464) · backend-in-ENV (#358). Full list in CHANGELOG.

### Process
- Build clean, `asset-counts --check` in sync (README tool counts match).
- **Merge with a MERGE commit (not squash)** so the version commit `e9924f2` lands on `main`; I then tag `v0.48.22` at it to trigger the publish workflow (`npm publish --provenance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)