### PR TITLE
fix: emit download-completion agent_event (#547) + get_history media type & well-formed get_image (#554)

### DIFF
--- a/src/__tests__/orchestrator/download-done-event.test.ts
+++ b/src/__tests__/orchestrator/download-done-event.test.ts
@@ -1,0 +1,130 @@
+// #547: a finished download must wake the agent, mirroring the render-finished
+// path (manager.injectEvent kind:"executed"). This locks the manager+agent side
+// of the wiring: injectEvent(kind:"download_done") enqueues a NON-urgent turn
+// whose text names the settled downloads and points at download_status, and a
+// coalesced batch of several files produces ONE turn (not N). liveKeys() exposes
+// the single-live-agent fallback the orchestrator uses for un-stamped rows.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** Records the text of every turn the agent runs, and auto-completes each. */
+class TurnRecordingBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-dl" };
+    for await (const turn of opts.channel) {
+      this.turns.push((turn as { text?: string }).text ?? "");
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeManager(backend: AgentBackend) {
+  return new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+    makeBackend: () => backend,
+  } as never);
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("download-completion agent event (#547)", () => {
+  it("injectEvent(download_done) wakes the agent with a turn naming the download and download_status", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-dl";
+
+    manager.send(tab, "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    const delivered = manager.injectEvent(tab, {
+      kind: "download_done",
+      downloads: [{ name: "z_image_turbo_bf16.safetensors", status: "done" }],
+    });
+    expect(delivered).toBe(true);
+
+    await waitFor(() => backend.turns.length >= 2);
+    const evText = backend.turns[1];
+    expect(evText).toContain("z_image_turbo_bf16.safetensors");
+    expect(evText).toContain("finished");
+    expect(evText).toContain("download_status");
+  });
+
+  it("a coalesced batch (many files) produces ONE turn listing all of them", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    const tab = "tab-batch";
+
+    manager.send(tab, "hi");
+    await waitFor(() => backend.turns.length >= 1);
+
+    manager.injectEvent(tab, {
+      kind: "download_done",
+      downloads: [
+        { name: "a.safetensors", status: "done" },
+        { name: "b.safetensors", status: "done" },
+        { name: "c.safetensors", status: "error" },
+      ],
+    });
+
+    await waitFor(() => backend.turns.length >= 2);
+    // Only ONE new turn for the whole batch.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(backend.turns.length).toBe(2);
+    const evText = backend.turns[1];
+    expect(evText).toContain("a.safetensors");
+    expect(evText).toContain("b.safetensors");
+    expect(evText).toContain("c.safetensors");
+    expect(evText).toContain("FAILED");
+  });
+
+  it("liveKeys() reports the single live agent (the un-stamped-row fallback)", async () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    expect(manager.liveKeys()).toEqual([]);
+    manager.send("only-tab", "hi");
+    await waitFor(() => backend.turns.length >= 1);
+    expect(manager.liveKeys()).toEqual(["only-tab"]);
+  });
+
+  it("injectEvent into a nonexistent agent is a no-op returning false", () => {
+    const backend = new TurnRecordingBackend();
+    const manager = makeManager(backend);
+    const delivered = manager.injectEvent("ghost", {
+      kind: "download_done",
+      downloads: [{ name: "x", status: "done" }],
+    });
+    expect(delivered).toBe(false);
+  });
+});

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -36,6 +36,30 @@ describe("download target stamping (#269)", () => {
   });
 });
 
+describe("download tab stamping (#547)", () => {
+  it("stamps the row with the writer's COMFYUI_MCP_TAB so the orchestrator can wake that tab's agent", () => {
+    process.env.COMFYUI_MCP_TAB = "tab-abc123";
+    mod.reportDownloadProgress({ id: "t1", name: "m.safetensors", downloaded: 1, total: 2, bytes_per_sec: 1, status: "done" }, true);
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("t1-"))!), "utf-8"));
+    expect(row.tab).toBe("tab-abc123");
+    expect(row.status).toBe("done");
+  });
+
+  it("omits tab when no COMFYUI_MCP_TAB is set (non-panel / in-process caller)", () => {
+    delete process.env.COMFYUI_MCP_TAB;
+    mod.reportDownloadProgress({ id: "t2", name: "m.safetensors", downloaded: 1, total: 2, bytes_per_sec: 1, status: "done" }, true);
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("t2-"))!), "utf-8"));
+    expect(row.tab).toBeUndefined();
+  });
+
+  it("an explicit p.tab overrides the env stamp", () => {
+    process.env.COMFYUI_MCP_TAB = "env-tab";
+    mod.reportDownloadProgress({ id: "t3", name: "m", downloaded: 1, total: 2, bytes_per_sec: 1, status: "downloading", tab: "explicit-tab" }, true);
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("t3-"))!), "utf-8"));
+    expect(row.tab).toBe("explicit-tab");
+  });
+});
+
 describe("readDownloadProgress (target-scoped read, #290)", () => {
   it("reads back a row written under a remote COMFYUI_URL (target-scoped filename)", () => {
     // The writer scopes the filename by target; readDownloadProgress must find it

--- a/src/__tests__/tools/get-history-media-type.test.ts
+++ b/src/__tests__/tools/get-history-media-type.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #554: get_history summarized media filenames but DROPPED each ref's ComfyUI
+// directory type. A PixaromaCompare (and other preview/compare) node writes its
+// outputs to temp/, not output/ — so following the documented
+// get_image(type:"output") call 404'd, while type:"temp" succeeded. The summary
+// must carry the type so the caller fetches the media reliably in one shot.
+
+const getHistoryMock = vi.fn();
+vi.mock("../../comfyui/client.js", () => ({
+  getLogs: vi.fn(),
+  getHistory: (...a: unknown[]) => getHistoryMock(...a),
+}));
+
+import { registerDiagnosticsTools } from "../../tools/diagnostics.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}>;
+
+function getHandler(name: string): ToolHandler {
+  let handler: ToolHandler | undefined;
+  const server = {
+    tool: (n: string, _d: string, _s: unknown, h: ToolHandler) => {
+      if (n === name) handler = h;
+    },
+  };
+  registerDiagnosticsTools(server as never);
+  if (!handler) throw new Error(`tool ${name} not registered`);
+  return handler;
+}
+
+beforeEach(() => getHistoryMock.mockReset());
+
+describe("get_history media type (#554)", () => {
+  it("includes each media ref's ComfyUI directory type (temp) so get_image gets the right type", async () => {
+    getHistoryMock.mockResolvedValue({
+      "p-temp": {
+        prompt: [1, "p-temp", {}, {}, []],
+        status: { status_str: "success", completed: true, messages: [] },
+        outputs: {
+          "7091": {
+            images: [
+              { filename: "pixaroma_compare_00001_.png", subfolder: "", type: "temp" },
+            ],
+          },
+        },
+      },
+    });
+
+    const out = await getHandler("get_history")({ prompt_id: "p-temp" });
+    const text = out.content.map((c) => c.text).join("\n");
+    expect(text).toContain("pixaroma_compare_00001_.png");
+    // The actionable bit: the type must be present so the caller does NOT default
+    // to type:"output" and 404.
+    expect(text).toContain("type=temp");
+    expect(text).not.toContain("type=output");
+  });
+
+  it("defaults an unspecified type to output and preserves the subfolder", async () => {
+    getHistoryMock.mockResolvedValue({
+      "p-out": {
+        prompt: [2, "p-out", {}, {}, []],
+        status: { status_str: "success", completed: true, messages: [] },
+        outputs: {
+          "9": {
+            images: [{ filename: "ComfyUI_00007_.png", subfolder: "renders" }],
+            videos: [{ filename: "clip.mp4", subfolder: "", type: "output" }],
+          },
+        },
+      },
+    });
+
+    const out = await getHandler("get_history")({ prompt_id: "p-out" });
+    const text = out.content.map((c) => c.text).join("\n");
+    expect(text).toContain("renders/ComfyUI_00007_.png (type=output)");
+    expect(text).toContain("clip.mp4 (type=output)");
+  });
+});

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -73,5 +73,9 @@ describe("get_image — binary-safe (#483)", () => {
     const text = out.content.map((c) => c.text ?? "").join("");
     expect(text).toContain("IMAGE_NOT_FOUND");
     expect(text).not.toContain("Unexpected end of JSON input");
+    // #554: the failure envelope must itself be WELL-FORMED JSON (a clean
+    // structured error), not free-form prose the caller then fails to parse.
+    const parsed = JSON.parse(text) as { error?: string };
+    expect(parsed.error).toBe("IMAGE_NOT_FOUND");
   });
 });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1836,6 +1836,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         COMFYUI_URL: comfyuiUrl,
         // Where download_model writes live progress for the panel tray.
         COMFYUI_MCP_PROGRESS_DIR: progressDir,
+        // Self-scope this tab's downloads so the orchestrator can wake EXACTLY
+        // this tab's agent when a download settles (#547) — the child stamps its
+        // own COMFYUI_MCP_TAB into each progress row, mirroring COMFYUI_MCP_BLIND.
+        ...(panelTab ? { COMFYUI_MCP_TAB: panelTab } : {}),
         // Local mode → enables download_model, apply_manifest (installer packs),
         // and model scans so the agent installs the right way instead of curl.
         ...(comfyuiPath ? { COMFYUI_PATH: comfyuiPath } : forceRemoteEnv()),
@@ -3537,6 +3541,39 @@ export async function runPanelOrchestrator(): Promise<void> {
   // a downloading row that stops updating for 60s is treated as a dead writer.
   const DOWNLOAD_LINGER_MS = 8000;
   const downloadRemoveAt = new Map<string, number>();
+  // Download-completion agent events (#547). A finished render already wakes the
+  // agent (manager.injectEvent kind:"executed"); a finished DOWNLOAD had no
+  // equivalent, so a "download then use the model" task stalled until the user
+  // poked it. We observe the SAME first-terminal transition the tray-prune timer
+  // uses and inject a completion event to the tab's agent — but COALESCED: an
+  // apply_manifest that pulls many files would otherwise fire one turn per file,
+  // so completions accumulate per agent for a short window and flush as ONE event.
+  const DOWNLOAD_DONE_DEBOUNCE_MS = 1500;
+  // agentKey → { download identity → {name, terminal status} } accumulated since
+  // the last flush, plus the epoch-ms deadline (extended by each new completion)
+  // at which we emit. Keyed by download IDENTITY (row.id), not display name, so
+  // two distinct downloads sharing a filename in one batch don't overwrite each
+  // other and hide a failure (codex).
+  const downloadDonePending = new Map<
+    string,
+    { downloads: Map<string, { name: string; status: string }>; flushAt: number }
+  >();
+  // Resolve which agent to wake for a settled download row: the stamped tab's
+  // agent when it's still live; else the SINGLE live agent (pre-fix/in-process
+  // rows carry no tab, AND a tab-id migration/backend change can leave the
+  // stamped tab's key no longer resolving to the live agent — codex); else none —
+  // never fan out to unrelated tabs (#547).
+  const resolveDownloadAgentKey = (row: Record<string, unknown>): string | null => {
+    const tab = typeof row.tab === "string" ? row.tab.trim() : "";
+    if (tab) {
+      const key = agentKeyFor(tab);
+      if (manager.hasLiveAgent(key)) return key;
+      // Stamped tab's agent is gone (migration/backend switch) — fall through to
+      // the single-live-agent fallback rather than silently dropping the event.
+    }
+    const live = manager.liveKeys();
+    return live.length === 1 ? live[0] : null;
+  };
   /** Boolean URL probe with a timeout — readiness checks for pending pod connects. */
   const probeOk = async (url: string, timeoutMs = 8_000): Promise<boolean> => {
     const ctl = new AbortController();
@@ -3635,6 +3672,20 @@ export async function runPanelOrchestrator(): Promise<void> {
         const due = downloadRemoveAt.get(full);
         if (due == null) {
           downloadRemoveAt.set(full, now + DOWNLOAD_LINGER_MS); // start the linger
+          // FIRST terminal observation of this download (due was unset) — the
+          // exact once-per-download moment. Wake the tab's agent with the result
+          // (#547), coalesced via downloadDonePending so a many-file manifest is
+          // one turn, not N.
+          const key = resolveDownloadAgentKey(row);
+          if (key && manager.hasLiveAgent(key)) {
+            const bucket =
+              downloadDonePending.get(key) ??
+              { downloads: new Map<string, { name: string; status: string }>(), flushAt: 0 };
+            const idKey = String(row.id ?? full);
+            bucket.downloads.set(idKey, { name: String(row.name ?? row.id ?? "model"), status: String(status) });
+            bucket.flushAt = now + DOWNLOAD_DONE_DEBOUNCE_MS;
+            downloadDonePending.set(key, bucket);
+          }
         } else if (now >= due) {
           try { unlinkSync(full); } catch { /* already gone */ }
           downloadRemoveAt.delete(full);
@@ -3659,6 +3710,15 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (snapshot !== lastDownloadSnapshot) {
       lastDownloadSnapshot = snapshot;
       bridge.push({ type: "download_progress", downloads }); // broadcast to all tabs
+    }
+    // Flush any download-completion buckets whose debounce window has elapsed —
+    // ONE agent event per tab per batch of settled downloads (#547). Runs every
+    // tick (700ms) so a flush always fires shortly after the last file settles.
+    for (const [key, bucket] of [...downloadDonePending]) {
+      if (now < bucket.flushAt) continue;
+      downloadDonePending.delete(key);
+      const settled = [...bucket.downloads.values()];
+      manager.injectEvent(key, { kind: "download_done", downloads: settled });
     }
     // MCP-child control channel (#269): runpod_* tools that ran in spawned
     // agent children ask the orchestrator to retarget / watch / unwatch /

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -359,7 +359,13 @@ export class PanelAgent {
    * reached the agent." Only meaningful when a session is live (the manager only
    * calls this for an existing agent, so we never spawn one just for an event).
    */
-  injectEvent(ev: { kind?: string; images?: ImageRef[]; error?: string; note?: string }): void {
+  injectEvent(ev: {
+    kind?: string;
+    images?: ImageRef[];
+    error?: string;
+    note?: string;
+    downloads?: Array<{ name: string; status: string }>;
+  }): void {
     let text: string | null = null;
     let images: ImageRef[] | undefined;
     if (ev.kind === "executed") {
@@ -392,6 +398,27 @@ export class PanelAgent {
       text =
         `[panel event] The user's workflow run just ERRORED: ${ev.error ?? "unknown error"}. ` +
         `If it relates to what you were doing, diagnose it (panel_get_errors has the details) and offer a fix.`;
+    } else if (ev.kind === "download_done") {
+      // A model download the agent kicked off (download_model / apply_manifest)
+      // just settled. Mirror the render-finished path so the agent is WOKEN with
+      // the result instead of having to poll download_status in sleep loops
+      // (#547). NON-urgent: queued like `executed`, not front-inserted — a landed
+      // download never interrupts a live turn. Coalesced upstream (one event per
+      // batch of settled downloads for this tab), so a multi-file pack install
+      // wakes the agent ONCE, not per file.
+      const dl = (ev.downloads ?? []).filter((d) => d && d.name);
+      if (dl.length === 0) return;
+      const done = dl.filter((d) => d.status === "done").map((d) => d.name);
+      const failed = dl.filter((d) => d.status !== "done").map((d) => d.name);
+      const parts: string[] = [];
+      if (done.length) parts.push(`finished: ${done.join(", ")}`);
+      if (failed.length) parts.push(`FAILED: ${failed.join(", ")}`);
+      const plural = dl.length > 1 ? "these downloads" : "it";
+      text =
+        `[panel event] Model download ${parts.join("; ")}. ` +
+        `If you were waiting on ${plural} to continue a task, proceed now — ` +
+        `call download_status for the exact landed path(s)${failed.length ? " or the error detail" : ""}. ` +
+        `Otherwise reply with ONE short sentence acknowledging it and no tool calls.`;
     }
     if (!text) return;
     this.busy = true;
@@ -1271,6 +1298,15 @@ export class PanelAgentManager {
     return this.agents.has(key);
   }
 
+  /** Composite keys of every live agent. Used to deliver a download-completion
+   *  event to the SINGLE live agent when a settled download row carries no tab
+   *  stamp (a pre-fix row, or an in-process/mobile caller) — the orchestrator
+   *  wakes it only when there is exactly one, never fanning out to unrelated
+   *  tabs (#547). */
+  liveKeys(): string[] {
+    return [...this.agents.keys()];
+  }
+
   /** Respawn every active tab's agent (resume + carry-over) so the live comfyui
    *  MCP subprocess is recreated with the updated env. Deferred to each tab's
    *  next idle so the turn that SAVED the secret finishes first (we never
@@ -1400,7 +1436,16 @@ export class PanelAgentManager {
 
   /** Feed a ComfyUI execution event to an EXISTING agent (no-op if none — we
    *  never spawn an agent just to react to an event). Returns whether delivered. */
-  injectEvent(tabId: string, ev: { kind?: string; images?: ImageRef[]; error?: string; note?: string }): boolean {
+  injectEvent(
+    tabId: string,
+    ev: {
+      kind?: string;
+      images?: ImageRef[];
+      error?: string;
+      note?: string;
+      downloads?: Array<{ name: string; status: string }>;
+    },
+  ): boolean {
     const agent = this.agents.get(tabId);
     if (!agent || agent.isStopped) return false; // best-effort; don't enqueue into a closed agent
     agent.injectEvent(ev);

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -46,6 +46,12 @@ export interface DownloadProgress {
    *  veto counts ONLY rows for the watched pod: a local download must not
    *  disable a pod's auto-stop, nor vice versa (#269). Absent on pre-fix rows. */
   target?: string;
+  /** The panel tab whose agent started this download (the writer's own
+   *  COMFYUI_MCP_TAB at write time — self-scoping, exactly like `target`), so the
+   *  orchestrator notifies EXACTLY that tab's agent when the download settles
+   *  instead of waking every tab (#547). Absent for non-panel/in-process callers
+   *  and pre-fix rows — the orchestrator then falls back to the single live agent. */
+  tab?: string;
 }
 
 const PROGRESS_DIR = process.env.COMFYUI_MCP_PROGRESS_DIR || "";
@@ -130,7 +136,11 @@ export function reportDownloadProgress(
     // Redacted — target URLs can carry userinfo (codex finding).
     const rawTarget = p.target ?? (process.env.COMFYUI_URL?.trim() || undefined);
     const target = rawTarget ? redactUrl(rawTarget) : undefined;
-    writeFileSync(fileFor(p.id, target), JSON.stringify({ ...p, target, updated: now }));
+    // Stamp the panel tab that started this download (the spawned MCP child's own
+    // COMFYUI_MCP_TAB) so the orchestrator can wake EXACTLY that tab's agent when
+    // the download settles (#547), the same self-scoping trick `target` uses.
+    const tab = p.tab ?? (process.env.COMFYUI_MCP_TAB?.trim() || undefined);
+    writeFileSync(fileFor(p.id, target), JSON.stringify({ ...p, target, tab, updated: now }));
   } catch {
     // best-effort — progress is cosmetic, never fail a download over it
   }

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -184,9 +184,18 @@ function formatHistoryEntry(
         const items = output[key];
         if (!Array.isArray(items)) continue;
         const fileList = (
-          items as Array<{ filename: string; subfolder?: string }>
+          items as Array<{ filename: string; subfolder?: string; type?: string }>
         )
-          .map((m) => (m.subfolder ? `${m.subfolder}/${m.filename}` : m.filename))
+          .map((m) => {
+            const path = m.subfolder ? `${m.subfolder}/${m.filename}` : m.filename;
+            // Carry each ref's ComfyUI directory TYPE (output/temp/input) so the
+            // caller passes the RIGHT `type` to get_image (#554): preview/compare
+            // nodes (e.g. PixaromaCompare) write to temp/, not output/, and
+            // get_image defaults to output — the old summary dropped the type, so
+            // the documented get_image(type:"output") call 404'd on a temp file.
+            const type = typeof m.type === "string" && m.type ? m.type : "output";
+            return `${path} (type=${type})`;
+          })
           .join(", ");
         if (fileList) expanded.push(`${key} → **${fileList}**`);
       }


### PR DESCRIPTION
## What & why

Two response/event-completeness bugs.

### #547 — `download_model` completion now wakes the agent
A finished **render** already injects an agent turn (`PanelAgentManager.injectEvent` `kind:"executed"`), but a finished **download** had no equivalent — the agent had to poll `download_status` in `sleep` loops to learn a model landed, so "download then use the model" tasks stalled until the user poked them.

The terminal transition was *already observed* in `pollDownloads()` (it starts the tray-prune linger at the first `done`/`error` sighting); it just wasn't wired to the agent channel. This PR wires it, mirroring the render path:

- **`download-progress.ts`** — `DownloadProgress` gains an optional `tab?`, self-stamped from the writer child's own `COMFYUI_MCP_TAB` (exactly how `target` self-stamps from `COMFYUI_URL`), so a completion notifies **exactly that tab's** agent.
- **`orchestrator/index.ts` `buildMcpServers`** — injects `COMFYUI_MCP_TAB=<panelTab>` into the comfyui MCP child env (mirrors `COMFYUI_MCP_BLIND`).
- **`orchestrator/index.ts` `pollDownloads`** — at the first terminal observation, resolves the target agent (`row.tab` -> `agentKeyFor`; if that agent isn't live, or the row carries no tab, the **single** live agent; else none — never fans out) and injects `kind:"download_done"`. Completions are **coalesced** (`DOWNLOAD_DONE_DEBOUNCE_MS=1500`, keyed by download identity) so a many-file `apply_manifest` wakes the agent **once**, not per file.
- **`panel-agent.ts`** — `injectEvent` handles `download_done` as a **non-urgent** turn (queued like `executed`, not front-inserted like `injectRunError`): names the settled/failed downloads and points at `download_status` for the landed path/error. Adds `liveKeys()` for the single-live-agent fallback.

### #554 — `get_history` media type + well-formed `get_image`
- **`get_history` omitted the media TYPE**: a `PixaromaCompare` output written to `temp/` looked identical to an `output/` ref, so the documented `get_image(type:"output")` 404'd. `formatHistoryEntry` now appends `(type=<output|temp|input>)` per media ref (defaulting to `output` when absent), so the caller fetches with the right `type` first try.
- **Malformed `get_image` error ("Unexpected end of JSON input")** was already fixed by #483/#435 (shipped 0.48.21; the issue was filed on 0.48.7): `getOutputImage` throws a structured `IMAGE_NOT_FOUND` for empty/non-image `/view` bodies and `fetchImage` throws structured on 404, both rendering as a clean JSON envelope. This PR adds a regression assertion that the failure envelope is **parseable JSON**.

Auto-resolving `type` when a filename is unique across dirs (the issue's *optional* item) was intentionally skipped — the type in `get_history` makes `get_image` reliable at the source without an extra multi-fetch.

## Tests
- `orchestrator/download-done-event.test.ts` — `download_done` wakes the agent with a turn naming the download + `download_status`; a coalesced batch produces one turn; `liveKeys()` fallback; no-op into a dead agent.
- `services/download-progress.test.ts` — `tab` stamped from `COMFYUI_MCP_TAB`, omitted for non-panel callers, explicit `p.tab` wins.
- `tools/get-history-media-type.test.ts` — type surfaced for `temp`; defaults to `output`, preserves subfolder.
- `tools/get-image-binary-safe.test.ts` — failure envelope is well-formed JSON.

`npm run build` clean; `npm test` green except the known environment-dependent `node-dev.test.ts` ripgrep-sandbox flake (pre-existing, unrelated).

## Codex self-gate
`gpt-5.6-terra`/high, two rounds. Round 1 found 1xP1 (tab-migration could drop a completion) + 1xP2 (debounce dedupe by display name) — both fixed (live-agent fallback for a migrated/dead stamped tab; bucket keyed by download identity). A third P2 (same URL+target re-download inside the 8s linger) is intentional dedup — the progress-file path is keyed by URL-hash+target, so it's the same logical model landing at the same destination. Round 2: **PASS**, no remaining P0/P1.

Closes #547
Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
