### PR TITLE
chore: drop bundled Civitai MCP default (#539), graceful civitai-meta degrade (#541), flux Klein CLIPLoader (#545), skill doc refs (#552, #546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**182 MCP tools** | **35 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**182 MCP tools** | **36 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 35 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 182 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 36 AI skills, 11 slash commands, 4 autonomous agents, and 4 hooks on top of the 182 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 35 AI skills — and growing
+## 36 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,
@@ -25,6 +25,7 @@ and failure-mode guidance:
 |---|---|
 | `flux-txt2img` | Flux.1 Dev/Schnell + Flux 2 Klein — BF16 vs FP8 pitfalls, dual-CLIP wiring, VAE selection |
 | `wan-t2v-video` / `wan-flf-video` | WAN 2.x text-to-video and first-last-frame workflows |
+| `wan-scail-replacement` | SCAIL-2 in-video character replacement — reference-framing→scale rule, tuning and compositing pitfalls |
 | `ltxv2-video` | LTX-2.3 (and LTX-2 19B) — GGUF UNet, distilled model, camera-control LoRAs, two-stage upscaling, kornia fix |
 | `qwen-txt2img` / `qwen-image-edit` | Qwen-Image generation and instruction-based editing |
 | `z-image-txt2img` | Z-Image Turbo workflows |
@@ -36,7 +37,7 @@ and failure-mode guidance:
 | `installer-packs` | Use, build, and derive one-command installer packs — and invite users to contribute new packs upstream |
 | `model-compatibility` | Which VAE/CLIP/text-encoder pairs with which architecture — the #1 source of broken workflows |
 | `model-registry` | Curated download URLs + target dirs for every model the skills reference — grows each release |
-| `civitai` | Pair the official [Civitai MCP](https://mcp.civitai.com/mcp) for discovery, hand version ids to the local download/wire/generate loop |
+| `civitai` | Native Civitai discovery → local download/wire/generate loop via built-in `search_civitai_models` (no key, no extra server); the official [Civitai MCP](https://mcp.civitai.com/mcp) is an optional community-surface add-on, not bundled |
 | `comfyui-core` | Queue, history, and API semantics |
 | `comfyui-node-registry` | Authoring + publishing custom node packs to the Comfy Registry |
 | `comfyui-frontend-extensions` | v1/v2 frontend extension authoring (sidebar tabs, widgets) |

--- a/plugin/skills/flux-txt2img/SKILL.md
+++ b/plugin/skills/flux-txt2img/SKILL.md
@@ -30,7 +30,7 @@ Flux is a guidance-distilled diffusion model family from Black Forest Labs. It u
 | Component | Node | Model | Notes |
 |-----------|------|-------|-------|
 | **UNET** | `UNETLoader` | `bigLove_klein1.safetensors` | 17.3GB, Klein 9B variant |
-| **CLIP** | `CLIPLoader` (type=`flux`) | `qwen_3_8b_fp8mixed.safetensors` | Qwen3-8B in text_encoders/ (8.3GB) |
+| **CLIP** | `CLIPLoader` (type=`flux2`) | `qwen_3_8b_fp8mixed.safetensors` | Qwen3-8B in text_encoders/ (8.3GB). Use `flux2`, NOT `flux` — both exist in the enum and `flux` fails at the sampler |
 | **VAE** | `VAELoader` | `flux2-vae.safetensors` | Flux 2 specific VAE (321MB) |
 
 **Klein 9B vs Flux.1 Dev**: Klein uses Qwen3-8B text encoder (not T5XXL + CLIP-L). It has a different VAE (`flux2-vae.safetensors`). 9B distilled runs in 4 steps; 9B base needs ~50 steps at CFG 5.0. Fits in ~20GB VRAM with FP8.
@@ -195,11 +195,11 @@ Bad: "masterpiece, best quality, 1girl, cafe, paris"
 ```json
 {
   "1": { "class_type": "UNETLoader", "inputs": { "unet_name": "bigLove_klein1.safetensors", "weight_dtype": "default" }},
-  "2": { "class_type": "CLIPLoader", "inputs": { "clip_name": "qwen_3_8b_fp8mixed.safetensors", "type": "flux" }},
+  "2": { "class_type": "CLIPLoader", "inputs": { "clip_name": "qwen_3_8b_fp8mixed.safetensors", "type": "flux2" }},
   "3": { "class_type": "VAELoader", "inputs": { "vae_name": "flux2-vae.safetensors" }},
   "4": { "class_type": "CLIPTextEncode", "inputs": { "clip": ["2", 0], "text": "<prompt>" }},
   "5": { "class_type": "ConditioningZeroOut", "inputs": { "conditioning": ["4", 0] }},
-  "6": { "class_type": "EmptyLatentImage", "inputs": { "width": 1024, "height": 1024, "batch_size": 1 }},
+  "6": { "class_type": "EmptyFlux2LatentImage", "inputs": { "width": 1024, "height": 1024, "batch_size": 1 }},
   "7": { "class_type": "KSampler", "inputs": {
     "model": ["1", 0],
     "positive": ["4", 0],
@@ -212,7 +212,12 @@ Bad: "masterpiece, best quality, 1girl, cafe, paris"
 }
 ```
 
-**Klein note**: Uses single `CLIPLoader` (not DualCLIPLoader) with `type: "flux"` and the Qwen3-8B text encoder from `text_encoders/`. The CLIP loader path resolves from `models/text_encoders/`.
+**Klein note**: Uses single `CLIPLoader` (not DualCLIPLoader) with `type: "flux2"` and the Qwen3-8B text encoder from `text_encoders/`. The CLIP loader path resolves from `models/text_encoders/`.
+
+**Two Flux-2-specific gotchas** (both fail at the KSampler, not at the loader, so the error points at the wrong node):
+- `type` must be **`flux2`**, not `flux`. Both values exist in the CLIPLoader enum, so `flux` loads without complaint and then dies during sampling.
+- Use **`EmptyFlux2LatentImage`**, not `EmptyLatentImage` — Flux 2 uses a different latent channel count.
+- Klein **9B** pairs with the **Qwen3-8B** encoder (`qwen_3_8b*` from `Comfy-Org/vae-text-encorder-for-flux-klein-9b`). The similarly-named `qwen_3_4b` ships in the klein-**4b** repo and is for the 4B model. Mismatching them raises `mat1 and mat2 shapes cannot be multiplied (512x7680 and 12288x4096)` — 7680 = 2560x3 (4B hidden size) vs 12288 = 4096x3 (8B) — which reads as a confusing CLIP error rather than a wrong-file error.
 
 ## Complete Workflow: Flux.1 Dev + Turbo LoRA (4-Step)
 

--- a/plugin/skills/wan-scail-replacement/SKILL.md
+++ b/plugin/skills/wan-scail-replacement/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: wan-scail-replacement
+description: SCAIL-2 in-video character replacement on WAN 2.1 — WanSCAILToVideo + SCAIL2ColoredMask + SAM3, the reference-image framing→scale rule, and the tuning/compositing pitfalls
+globs:
+  - "**/*.json"
+---
+
+# SCAIL-2 In-Video Character Replacement (WAN 2.1)
+
+SCAIL-2 (zai-org, on WAN 2.1 14B) replaces the person in a driving video with a
+character you supply as a reference image — end-to-end, with no pose maps, and
+with multi-character support. It is the successor to WAN Animate / motion
+transfer for the "swap the subject, keep the motion" job. The official ComfyUI
+template is **`video_wan21_scail2_character_replacement_int8`**, built around
+`WanSCAILToVideo` (+ `SCAIL2ColoredMask`) with a SAM3 mask driving *where* the
+character goes.
+
+This skill documents the non-obvious behaviours that cost a full multi-minute
+render to discover. It is not a from-scratch graph — start from the official
+template and apply the guidance below.
+
+## The one rule that costs a re-render: reference framing controls SCALE
+
+**In `replacement_mode: true`, the reference image's FRAMING controls the output
+character's SIZE — not just its appearance.** The SAM3 mask controls *where* the
+character is placed; the reference image controls *how large*.
+
+Measured on a 720x1280 driving clip where the subject occupied ~30% of frame
+height (subject bbox 363 px):
+
+| Reference framing | Person bbox in output | vs driving subject |
+|---|---|---|
+| Full-bleed portrait (person ~93% of frame) | 621 px | **1.71x oversized** |
+| Reframed (person ~34% of frame) | 364 px | **1.003x — correct** |
+
+After reframing, top/bottom registration matched the driving subject within 1 px
+(the character stands on the same ground plane at the same height). Pose transfer
+was correct in *both* cases — only the scale was wrong, which makes it easy to
+misread as "the model works" until you A/B against the source.
+
+**Guidance — pad/reframe the reference before you render:**
+
+> Pad/reframe the reference image onto a canvas at the working resolution so the
+> person occupies roughly the same fraction of frame height as the subject in the
+> driving video. A full-bleed portrait reference against a wide-shot driving clip
+> renders the character oversized in proportion to the framing mismatch.
+
+Why it's a trap: this isn't stated in the template's on-canvas notes, and it does
+not surface in the popular Civitai motion-transfer workflows — those run
+*animation* mode, where the reference legitimately fills the frame.
+
+## Tuning trade-off: distill LoRA strength / shift leaks driving-subject detail
+
+Running the `lightx2v` distill LoRA at `0.8` with `ModelSamplingSD3 shift 5` (the
+settings the popular Civitai workflow uses) improves colour and detail versus
+`1.0` / `shift 8` — but it also increases adherence to the driving video enough
+that **original-subject details bleed onto the replacement character.** In one
+run the original golfer's neon-yellow shoe appeared on a replacement character
+who wears white shoes in the reference (same seed, same reference, only those two
+params changed). If you see source details you didn't ask for, raise the LoRA
+strength / shift back toward `1.0` / `shift 8`.
+
+## Don't "fix" colour with post-hoc compositing — it's a regression
+
+The raw SCAIL-2 output shows a measurable colour error (background ~-5 per channel
+from the VAE round-trip; the character loses red ~2.4x faster than green, which
+reads as a slight green cast). It is tempting to composite the generated character
+back over the original plate through the SAM3 mask to "correct" it. **Don't** —
+it measures better but looks worse:
+
+- The mask boundary produces an obvious halo.
+- Layering the original plate's props (e.g. a golf club) over generated hands
+  severs the grip relationship the model had solved coherently.
+
+SCAIL-2 resolves colour, edges, grip and occlusion *jointly*; correcting any one
+of them in isolation breaks the others. Leave the raw output alone.
+
+## Models (reference set)
+
+The template's int8 build was exercised with:
+
+- `wan2.1_14B_SCAIL_2_int8_convrot` — SCAIL-2 model
+- `wan2.1_SCAIL_2_DPO_lora_bf16` — DPO LoRA
+- `lightx2v_I2V_14B_480p_cfg_step_distill_rank64_bf16` — distill LoRA (see tuning note)
+- `Wan2_1_VAE_bf16`
+- `umt5_xxl_fp8_e4m3fn_scaled` — text encoder
+- `clip_vision_h`
+- `sam3.1_multiplex_fp16` — SAM3 mask model
+
+VRAM: ~22.2 GB peak at 576x1024 / 81-frame chunks on a 24 GB card.
+
+## See also
+
+- `wan-t2v-video`, `wan-flf-video` — other WAN 2.x video pipelines
+- `director` — multi-shot scene direction for video pipelines

--- a/scripts/sync-agents.mjs
+++ b/scripts/sync-agents.mjs
@@ -57,9 +57,25 @@ ${body.trim()}`;
 const skillsDir = path.join(PLUGIN_DIR, 'skills');
 if (fs.existsSync(skillsDir)) {
   for (const skillName of fs.readdirSync(skillsDir)) {
-    const srcPath = path.join(skillsDir, skillName, 'SKILL.md');
-    const destPath = path.join(AGENTS_DIR, 'skills', skillName, 'SKILL.md');
+    const skillSrcDir = path.join(skillsDir, skillName);
+    if (!fs.statSync(skillSrcDir).isDirectory()) continue;
+    const srcPath = path.join(skillSrcDir, 'SKILL.md');
+    const destSkillDir = path.join(AGENTS_DIR, 'skills', skillName);
+    const destPath = path.join(destSkillDir, 'SKILL.md');
     processSkillOrAgent(srcPath, destPath, skillName, false);
+
+    // Also copy sibling asset folders the SKILL.md links to (references/, docs/).
+    // Without this the synced bundle keeps the SKILL.md but drops the docs it
+    // points at, leaving dangling relative-doc links in .agents/skills/<name>/
+    // (the class of breakage reported in #552).
+    for (const sub of ['references', 'docs']) {
+      const subSrc = path.join(skillSrcDir, sub);
+      if (fs.existsSync(subSrc) && fs.statSync(subSrc).isDirectory()) {
+        const subDest = path.join(destSkillDir, sub);
+        fs.cpSync(subSrc, subDest, { recursive: true });
+        console.log(`Synced ${subSrc} -> ${subDest}`);
+      }
+    }
   }
 }
 
@@ -127,12 +143,6 @@ const mcpConfig = {
       args: ["-y", "comfyui-mcp"],
       env: {
         CIVITAI_API_TOKEN: ""
-      }
-    },
-    civitai: {
-      url: "https://mcp.civitai.com/mcp",
-      headers: {
-        Authorization: "Bearer ${CIVITAI_API_TOKEN:-}"
       }
     },
     huggingface: {

--- a/src/__tests__/tools/model-explorer.test.ts
+++ b/src/__tests__/tools/model-explorer.test.ts
@@ -69,14 +69,65 @@ describe("model_metadata_read / fetch_civitai 404 handling", () => {
     expect(text).not.toContain("detail HTTP 404 (is ComfyUI running");
   });
 
-  it("model_metadata_fetch_civitai: 404 → same actionable message", async () => {
+  it("model_metadata_fetch_civitai: 404 (no version_id) → optional-feature-unavailable message, points at version_id path", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 404, text: async () => "" });
     const { fetchCivitai } = makeServer();
     const res = await fetchCivitai({ category: "loras", name: "x.safetensors" });
 
     expect(res.isError).toBe(true);
-    expect(res.content[0].text).toContain("comfyui-model-explorer");
-    expect(res.content[0].text).not.toContain("civitai HTTP 404");
+    const text = res.content[0].text;
+    expect(text).toContain("comfyui-model-explorer");
+    expect(text).toContain("OPTIONAL");
+    // Tells the caller how to recover without the node.
+    expect(text).toContain("version_id");
+    expect(text).not.toContain("civitai HTTP 404");
+  });
+
+  it("model_metadata_fetch_civitai: 404 WITH version_id → degrades to CivitAI public API (no error)", async () => {
+    fetchMock
+      // node route 404s (node absent)
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => "" })
+      // direct CivitAI public API succeeds
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 1567118,
+          modelId: 900,
+          name: "v2",
+          baseModel: "Flux.1 D",
+          model: { name: "Dark Fantasy", type: "LORA", nsfw: false },
+          trainedWords: ["dark fantasy"],
+          description: "desc",
+          downloadUrl: "https://civitai.com/api/download/models/1567118",
+          images: [{ url: "u", meta: { prompt: "a dark fantasy castle" } }],
+        }),
+      });
+    const { fetchCivitai } = makeServer();
+    const res = await fetchCivitai({ category: "loras", name: "x.safetensors", version_id: 1567118 });
+
+    expect(res.isError).toBeFalsy();
+    const text = res.content[0].text;
+    expect(text).toContain("civitai-public-api");
+    expect(text).toContain("dark fantasy");
+    expect(text).toContain("a dark fantasy castle"); // mined example prompt
+    expect(text).toContain("1567118");
+    // The public API URL was used for the fallback.
+    const calledUrls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes("civitai.com/api/v1/model-versions/1567118"))).toBe(true);
+  });
+
+  it("model_metadata_fetch_civitai: 404 WITH version_id but public API also fails → clear error noting the version lookup failed", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => "" })
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => "" });
+    const { fetchCivitai } = makeServer();
+    const res = await fetchCivitai({ category: "loras", name: "x.safetensors", version_id: 999999999 });
+
+    expect(res.isError).toBe(true);
+    const text = res.content[0].text;
+    expect(text).toContain("comfyui-model-explorer");
+    expect(text).toContain("version_id was supplied");
   });
 
   it("model_metadata_read: still succeeds when the node is present", async () => {

--- a/src/tools/model-explorer.ts
+++ b/src/tools/model-explorer.ts
@@ -42,6 +42,70 @@ export function explorerHttpError(route: string, status: number, body?: string):
   return new Error(`model_explorer ${route} HTTP ${status}`);
 }
 
+// #541: `model_metadata_fetch_civitai` proxies the OPTIONAL `comfyui-model-explorer`
+// node, which does a local SHA256 → CivitAI by-hash lookup. When that node isn't
+// installed the route 404s. Rather than hard-failing, degrade: if the caller gave a
+// `version_id` we can fetch the SAME data straight from CivitAI's public REST API
+// (no auth, no custom node, no hash) and return a normalized shape.
+export async function fetchCivitaiVersionDirect(
+  versionId: number,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await fetch(`https://civitai.com/api/v1/model-versions/${versionId}`);
+    if (!res || !res.ok) return null;
+    const v = (await res.json()) as any;
+    const modelId = v?.modelId ?? null;
+    const examplePrompts = Array.isArray(v?.images)
+      ? v.images
+          .map((im: any) => im?.meta?.prompt)
+          .filter((p: any) => typeof p === "string" && p.trim().length > 0)
+          .slice(0, 20)
+      : [];
+    return {
+      _source: "civitai-public-api",
+      _note: "Fetched directly from civitai.com (the optional comfyui-model-explorer node was unavailable). Version-endpoint fields only.",
+      source_url: modelId
+        ? `https://civitai.com/models/${modelId}?modelVersionId=${versionId}`
+        : `https://civitai.com/api/v1/model-versions/${versionId}`,
+      model_version_id: versionId,
+      model_id: modelId,
+      version_name: v?.name ?? null,
+      model_name: v?.model?.name ?? null,
+      model_type: v?.model?.type ?? null,
+      base_model: v?.baseModel ?? null,
+      nsfw: v?.model?.nsfw ?? null,
+      trainedWords: Array.isArray(v?.trainedWords) ? v.trainedWords : [],
+      description: v?.description ?? null,
+      example_prompts: examplePrompts,
+      download_url: v?.downloadUrl ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Graceful "optional feature unavailable" message for the CivitAI enrichment tool
+// when the node route 404s (node absent OR node present but model not found). Points
+// at the dependency-free `version_id` path so the caller can recover without the node.
+export function civitaiFetchUnavailableError(body?: string, hadVersionId?: boolean): Error {
+  const hint = body && body.trim() ? ` Upstream detail: ${body.trim().slice(0, 200)}.` : "";
+  const recover = hadVersionId
+    ? `A version_id was supplied, but the direct fallback to CivitAI's public API ` +
+      `(https://civitai.com/api/v1/model-versions/<id>) also failed — that version may ` +
+      `not exist, or civitai.com was unreachable.`
+    : `To fetch metadata WITHOUT the node, pass 'version_id' (the CivitAI modelVersionId) — ` +
+      `this tool then reads it straight from CivitAI's public API (no node, no auth).`;
+  return new Error(
+    `model_metadata_fetch_civitai: CivitAI enrichment is unavailable. This is an OPTIONAL ` +
+      `feature that proxies the optional 'comfyui-model-explorer' custom node (its ` +
+      `/model_explorer/civitai route returned 404). Most likely the node is not installed — ` +
+      `install it via ComfyUI-Manager or install_custom_node and restart to enable automatic ` +
+      `by-hash lookup. If that node IS installed, the 404 instead means it could not find the ` +
+      `requested model file — check 'category' (model folder) and 'name' (filename incl. ` +
+      `.safetensors). ${recover}${hint}`,
+  );
+}
+
 async function readBodyText(res: { text?: () => Promise<string> }): Promise<string | undefined> {
   try {
     return res.text ? await res.text() : undefined;
@@ -137,7 +201,11 @@ export function registerModelExplorerTools(server: McpServer): void {
       "result as RAW input: distill the (often marketing-heavy) description, and MINE THE EXAMPLE PROMPTS for " +
       "the real trigger — the trigger is frequently ONLY in the sample prompts even when trainedWords is EMPTY " +
       "(e.g. every prompt starting with 'photo in the style of X' means X is the trigger). Adult models (civitai.red) " +
-      "resolve through this same API. Then clean it up and call model_metadata_propose.",
+      "resolve through this same API. Then clean it up and call model_metadata_propose. " +
+      "DEPENDENCY: automatic by-hash lookup uses the OPTIONAL 'comfyui-model-explorer' custom node. If that node " +
+      "isn't installed, pass 'version_id' (the CivitAI modelVersionId) and this tool degrades to CivitAI's public " +
+      "REST API directly — no node, no auth. Without both the node AND a version_id it returns a clear " +
+      "'optional feature unavailable' message rather than enriching.",
     {
       category: z.string().describe("ComfyUI model folder, e.g. 'loras'"),
       name: z.string().describe("model filename incl. .safetensors"),
@@ -146,12 +214,27 @@ export function registerModelExplorerTools(server: McpServer): void {
     async (args) => {
       try {
         const COMFY = comfyBase();
+        // A CivitAI modelVersionId is always a positive integer; treat anything
+        // else (incl. 0) as "not supplied" so the node query and the fallback
+        // agree on when we actually have an id.
+        const hasVersionId = typeof args.version_id === "number" && args.version_id > 0;
         const q =
           `category=${encodeURIComponent(args.category)}&name=${encodeURIComponent(args.name)}` +
-          (args.version_id ? `&version_id=${args.version_id}` : "");
+          (hasVersionId ? `&version_id=${args.version_id}` : "");
         const r = await fetch(`${COMFY}/model_explorer/civitai?${q}`);
-        if (!r.ok) return errorToToolResult(explorerHttpError("civitai", r.status, await readBodyText(r)));
-        return okText(await r.json());
+        if (r.ok) return okText(await r.json());
+        const body = await readBodyText(r);
+        // #541: the node route is unavailable. Degrade instead of hard-failing.
+        // With a version_id we can satisfy the request straight from CivitAI's
+        // public API (no node, no auth, no hash).
+        if (r.status === 404 && hasVersionId) {
+          const direct = await fetchCivitaiVersionDirect(args.version_id as number);
+          if (direct) return okText(direct);
+        }
+        if (r.status === 404) {
+          return errorToToolResult(civitaiFetchUnavailableError(body, hasVersionId));
+        }
+        return errorToToolResult(explorerHttpError("civitai", r.status, body));
       } catch (err) {
         return errorToToolResult(err);
       }


### PR DESCRIPTION
Low-risk config/skill/docs cleanup batch. `npm run build` green, full suite green except one pre-existing environment-dependent failure unrelated to this diff (see below). Codex self-gate (gpt-5.6-terra/high, read-only, embed-diff) **PASS** after fixing its two findings.

## What changed, per issue

**#539 — drop bundled Civitai MCP from the default config**
- `scripts/sync-agents.mjs`: removed the `civitai` remote server from the default generated `mcpServers`. Native `search_civitai_models` + `download_civitai_model` already cover the measured-used surface; `CIVITAI_API_TOKEN` stays on the `comfyui` server for gated downloads.
- `docs/plugin.mdx`: reworded the skills-table `civitai` row to built-in-first (was "Pair the official Civitai MCP for discovery").
- The `civitai` SKILL.md already documents "no longer auto-bundled, add it once" with the `claude mcp add` one-liner, so it needed no change. The `panel_add_mcp` on-demand flow (the "users add it themselves" path) is untouched. The `user-mcp-config.test.ts` fixture still uses civitai as an arbitrary add/remove fixture — left as-is per the issue.

**#541 — `model_metadata_fetch_civitai` graceful degrade**
- `src/tools/model-explorer.ts`: on a node-route 404, if a positive `version_id` was supplied, fall back to CivitAI's public REST API (`fetchCivitaiVersionDirect`) — no node, no auth, no hash — returning a normalized shape. Otherwise return a clearly-framed "optional feature unavailable" message (`civitaiFetchUnavailableError`) that points at the `version_id` path. Tool description now states the optional dependency up front. Tests added for both fallback paths.
- Scope note: the hash-based auto-fallback for the *no-version_id* case (compute SHA256 locally without the node) is deliberately NOT included — it needs local file access and would break for remote ComfyUI, i.e. bigger/riskier than this cleanup. The graceful-degradation ask is fully delivered via the version_id path + clear messaging.

**#545 — flux-txt2img Flux 2 Klein recipe**
- `plugin/skills/flux-txt2img/SKILL.md`: `CLIPLoader` `type` `flux` → `flux2`, and `EmptyLatentImage` → `EmptyFlux2LatentImage`, in the component table, the workflow JSON, and the Klein note (added the two-gotcha explainer + the qwen_3_8b vs qwen_3_4b mismatch note). This is the reporter's exact, live-verified diff (enqueues to `status:success`). The unverified Flux.1 `EmptyLatentImage` at the Turbo-LoRA recipe was left untouched, matching the reporter's decision.

**#552 — skill references a missing doc**
- Investigation: the reported `~/.agents/skills/comfyui/SKILL.md` referencing `docs/BUILDING_NODES.md` is **not produced by this repo** — `BUILDING_NODES` appears in zero commits across all refs, no plugin cache contains it, and the sync never emits a bare `comfyui` skill dir (we ship `comfyui-core`). It is an external/hand-authored skill.
- But the **same failure mode is real here**: `scripts/sync-agents.mjs` copied only each skill's `SKILL.md` and dropped its `references/` folder, so two synced skills had dangling relative-doc links in the `.agents` bundle (`comfyui-frontend-extensions` → `references/migrate-v1-to-v2.md`, `comfyui-node-registry` → `references/pyproject.toml`). Fix: the sync now also copies `references/` and `docs/` subfolders. (Maintainer: if you want #552 tracked separately since its literal skill is external, downgrade this to "relates to".)

**#546 — SCAIL-2 character replacement docs gap**
- Added `plugin/skills/wan-scail-replacement/SKILL.md` documenting the reporter's verified findings: reference-image framing controls output character *scale* (with the measured table), the distill-LoRA strength/shift tuning trade-off that leaks driving-subject detail, and why post-hoc mask compositing is a regression. Scoped to verified facts + the official template name rather than reproducing an unverified full graph.
- Skill count 35 → 36: bumped `README.md` and both `docs/plugin.mdx` count claims; added a plugin.mdx table row. `node scripts/asset-counts.mjs --check` passes.

## Test / gate status
- `npm run build`: clean.
- `npm test`: 2631 passed, 1 skipped, **1 pre-existing env-dependent failure** in `node-dev.test.ts > searchNodePacks > builtin fallback` (asserts the `builtin` search engine but this machine has ripgrep on PATH, so it used `ripgrep`). Untouched by this diff.
- `asset-counts --check`: green.
- Codex self-gate: PASS (its P1 stale plugin.mdx skill counts and P2 `version_id=0` edge case were fixed, then re-reviewed clean).

Closes #539
Closes #541
Closes #545
Closes #552
Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
