### PR TITLE
docs(save): panel_save_workflow description states Save-As COPY semantics, drops "rename" (#579)

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3106,8 +3106,8 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_save_workflow",
-      "Save the user's open workflow PROGRAMMATICALLY — no Save/Rename dialog ever pops. A never-saved workflow is auto-named and persisted; pass `name` to give it (or rename it to) a specific name. Use this freely (e.g. after building a graph) — it won't interrupt the user.",
-      { name: z.string().optional().describe("Name to save/rename to (no .json needed). Omit to save in place / auto-name an unsaved workflow.") },
+      "Save the user's open workflow PROGRAMMATICALLY — no Save/Rename dialog ever pops. With no `name`: saves in place (or auto-names + persists a never-saved workflow). With `name`: if the workflow is ALREADY saved under a different name this is a SAVE-AS — it writes a NEW file and leaves the original untouched on disk (it NEVER renames/moves/destroys the original); for a never-saved workflow it is simply the first save. The result reports what happened: `saved_as`+`copied_from`+`original_on_disk` (a disk-verified check that the original file still exists) for a Save-As copy, or `first_save` for a brand-new workflow. Use this freely (e.g. after building a graph) — it won't interrupt the user.",
+      { name: z.string().optional().describe("Name for the workflow (no .json needed). If the workflow is already saved under a different name, this writes a NEW file (Save-As COPY) and leaves the original in place — it never renames/moves/destroys it. Omit to save in place / auto-name an unsaved workflow.") },
       async (args: A, ctx) =>
         args.name
           ? ctx.call({ cmd: "workflow_save_as", name: args.name }, 15000)


### PR DESCRIPTION
Refs #579 (closed by the panel PR artokun/comfyui-mcp-panel#440)

## What
The `panel_save_workflow` tool description said **"Name to save/rename to"**, which invited the exact destructive mental model behind #579 — an agent reads *save* as a Save-As while the wording implies a *rename/move*. This rewords it to state explicitly that giving a name to an already-saved workflow **writes a NEW file (Save-As COPY) and never renames/moves/destroys the original**, and documents the new result fields (`saved_as` / `copied_from` / `original_on_disk` for a copy; `first_save` for a brand-new workflow).

## Why this is docs-only
The save **behaviour** was already copy-not-move on `main` — `panel_save_workflow(name)` bridges to the panel's `saveActiveWorkflow`, which writes a new file via the atomic `overwrite:false` copy trio and refuses to move a persisted source (#226 / #268 / #285 / #309). The substantive proof (regression tests for the exact #579/#363 scenarios) and the result-payload transparency live in the companion panel PR **artokun/comfyui-mcp-panel#440**. This change is the misleading-wording half.

`tsc --noEmit` clean. Self-gated with the panel change via codex (3 rounds, final PASS). Not merging — independent adversarial codex runs before merge.