### PR TITLE
fix(restart): relaunch with an absolute launch command/path (#535)

### DIFF
--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -32,6 +32,9 @@ const mockSpawn = vi.hoisted(() => vi.fn());
 const mockGetSystemStats = vi.hoisted(() => vi.fn());
 const mockResetClient = vi.hoisted(() => vi.fn());
 const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+// statSync backs isRegularFile (#535 regular-file validation). By default any path
+// that "exists" is a regular file; individual tests override to model a directory.
+const mockIsFile = vi.hoisted(() => vi.fn((_p: string) => true));
 const mockFindComfyuiPython = vi.hoisted(() => vi.fn());
 const mockResolveBase = vi.hoisted(() => vi.fn<[], string | undefined>());
 const mockLiveRootFromArgv = vi.hoisted(() =>
@@ -52,6 +55,17 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
+  // The live-cwd /proc reader is injected via setLiveCwdResolver in these tests;
+  // keep a throwing stub so any un-mocked call path stays refuse-safe (#535).
+  readlinkSync: vi.fn(() => {
+    throw new Error("no /proc in test");
+  }),
+  // isRegularFile(#535) calls statSync().isFile(); throw for non-existent paths so
+  // it returns false, mirroring existsSync, and honor per-test isFile overrides.
+  statSync: vi.fn((p: string) => {
+    if (!mockExistsSync(String(p))) throw new Error("ENOENT");
+    return { isFile: () => mockIsFile(String(p)) };
+  }),
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -135,6 +149,8 @@ beforeEach(() => {
     const s = String(p);
     return s === ABS_MAIN || s === ABS_PYTHON;
   });
+  // Default: everything that exists is a regular file (tests override to model dirs).
+  mockIsFile.mockImplementation((_p: string) => true);
   // Running server exposes the RELATIVE portable-launcher script path.
   mockGetSystemStats.mockResolvedValue({
     system: { argv: ["ComfyUI\\main.py", "--port", "8188"] },
@@ -192,6 +208,190 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
       system: { argv: ["main.py", "--port", "8188"] },
     });
     mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("RESTARTS a bare relative `main.py` by anchoring to the LIVE process cwd when no canonical base exists (#535)", async () => {
+    // #535: `python main.py …` with an unset/stale COMFYUI_PATH → no canonical
+    // base, no argv-derived live root — but the reachable process's cwd points at
+    // a valid install containing main.py. Resolve the relative script against that
+    // live cwd instead of refusing.
+    const LIVE_CWD = resolve("proc", "live_comfy");
+    const LIVE_MAIN = join(LIVE_CWD, "main.py");
+    mockResolveBase.mockReturnValue(undefined); // no canonical base
+    mockLiveRootFromArgv.mockReturnValue(undefined); // no argv root
+    mockGetSystemStats.mockResolvedValue({
+      system: {
+        argv: ["main.py", "--cache-none", "--output-directory", "/data/out"],
+      },
+    });
+    // The interpreter and the LIVE-cwd main.py exist; the bare "main.py" does not.
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === ABS_PYTHON || s === LIVE_MAIN;
+    });
+    // The running process's cwd (captured live, survives the kill).
+    __processControlTestHooks.setLiveCwdResolver(() => LIVE_CWD);
+    mockLivePortThenFree();
+    const children: FakeChild[] = [];
+    mockSpawn.mockImplementation(() => {
+      const child = new FakeChild();
+      children.push(child);
+      return child;
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    // It restarted (did NOT refuse), anchoring the relative script to the live cwd.
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args, opts] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(ABS_PYTHON);
+    expect(args[0]).toBe(LIVE_MAIN);
+    // Spawn FROM the live cwd, not a stale/undefined config.comfyuiPath (#535 P1).
+    expect((opts as { cwd?: string }).cwd).toBe(LIVE_CWD);
+
+    killSpy.mockRestore();
+  });
+
+  it("pairs the live-cwd script with the live-cwd's OWN python, NOT a stale-but-existing COMFYUI_PATH python (#535)", async () => {
+    // Stale COMFYUI_PATH points at an OLD install that still exists on disk (its
+    // python resolves). The live server runs `python main.py` from a DIFFERENT
+    // cwd. The relaunch must use the LIVE cwd's script AND its OWN interpreter —
+    // never the old install's python (which would relaunch under the wrong env).
+    const LIVE_CWD = resolve("proc", "live_comfy");
+    const LIVE_MAIN = join(LIVE_CWD, "main.py");
+    const LIVE_PY = join(LIVE_CWD, "venv", "bin", "python");
+    const STALE_BASE = resolve("old_install");
+    const STALE_PY = join(STALE_BASE, "venv", "bin", "python");
+    mockConfig.comfyuiPath = STALE_BASE;
+    mockResolveBase.mockReturnValue(STALE_BASE);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    // Interpreter resolution is root-aware: live cwd -> live python; else stale.
+    mockFindComfyuiPython.mockImplementation((root?: string) =>
+      root === LIVE_CWD ? LIVE_PY : STALE_PY,
+    );
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === LIVE_MAIN || s === LIVE_PY || s === STALE_PY;
+    });
+    __processControlTestHooks.setLiveCwdResolver(() => LIVE_CWD);
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args, opts] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(LIVE_PY); // live cwd's python, NOT STALE_PY
+    expect(args[0]).toBe(LIVE_MAIN);
+    expect((opts as { cwd?: string }).cwd).toBe(LIVE_CWD);
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES when the live-cwd `main.py` is a DIRECTORY, not a regular file (#535 atomic invariant)", async () => {
+    // existsSync alone would accept a directory named main.py; the regular-file
+    // guard must reject it so the reachable server is not killed for an unrunnable
+    // relaunch. No canonical base, so it falls through to refuse-safe.
+    const LIVE_CWD = resolve("proc", "live_comfy");
+    const LIVE_MAIN = join(LIVE_CWD, "main.py");
+    const LIVE_PY = join(LIVE_CWD, "venv", "bin", "python");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockFindComfyuiPython.mockReturnValue(LIVE_PY);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === LIVE_MAIN || s === LIVE_PY;
+    });
+    // main.py exists but is a DIRECTORY; the interpreter is a real file.
+    mockIsFile.mockImplementation((p: string) => String(p) !== LIVE_MAIN);
+    __processControlTestHooks.setLiveCwdResolver(() => LIVE_CWD);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES a live-cwd relative script when the interpreter is only a BARE PATH fallback (never kill without a validated interpreter, #535/#368)", async () => {
+    // The live cwd holds main.py, but no venv/embedded python resolves — so the
+    // interpreter is a bare `python3`. Killing then spawning that could ENOENT or
+    // run the wrong environment; the refuse-safe gate must leave the server up.
+    const LIVE_CWD = resolve("proc", "live_comfy");
+    const LIVE_MAIN = join(LIVE_CWD, "main.py");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockFindComfyuiPython.mockReturnValue("python3"); // bare, unvalidated
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    // main.py exists under the live cwd; no absolute interpreter exists on disk.
+    mockExistsSync.mockImplementation((p: string) => String(p) === LIVE_MAIN);
+    __processControlTestHooks.setLiveCwdResolver(() => LIVE_CWD);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
+
+    killSpy.mockRestore();
+  });
+
+  it("still REFUSES when the live cwd does NOT contain the relative script (guard falls through to refuse-safe)", async () => {
+    // A live cwd that does not hold main.py must NOT produce a bogus absolute
+    // path — the on-disk guard rejects it and, with no canonical base, we refuse.
+    const WRONG_CWD = resolve("proc", "not_comfy");
+    mockResolveBase.mockReturnValue(undefined);
+    mockLiveRootFromArgv.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    // Only the interpreter exists; join(WRONG_CWD, "main.py") does not.
+    mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    __processControlTestHooks.setLiveCwdResolver(() => WRONG_CWD);
     mockLivePortThenFree();
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readlinkSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { getSystemStats, resetClient, resetObjectInfoCache } from "../comfyui/client.js";
@@ -20,6 +20,14 @@ interface ProcessInfo {
   argv: string[];
   isDesktopApp: boolean;
   desktopExePath?: string;
+  /**
+   * The live ComfyUI process's working directory, captured at gather-time while
+   * the process is still ALIVE (a known-good moment). Used to resolve a RELATIVE
+   * launch script (`python main.py`) to an absolute path so relaunch works
+   * regardless of the orchestrator's own cwd — and, crucially, still resolves
+   * after the stop kills the pid (when `/proc/<pid>/cwd` is gone) (#535).
+   */
+  liveCwd?: string;
 }
 
 interface StopResult {
@@ -549,7 +557,10 @@ function spawnFromProcessInfo(info: ProcessInfo): ChildProcess | null {
   return spawn(cmd.exe, cmd.args, {
     detached: true,
     stdio: "ignore",
-    cwd: config.comfyuiPath ?? undefined,
+    // Prefer the cwd the command resolved against (the live process cwd for a
+    // relative-script relaunch, #535); only then the configured install dir. A
+    // stale/nonexistent config.comfyuiPath as cwd would ENOENT the spawn.
+    cwd: cmd.cwd ?? config.comfyuiPath ?? undefined,
     shell: false,
     windowsHide: true,
   });
@@ -592,9 +603,33 @@ function resolveScriptAnchor(argv: string[]): string | undefined {
   return undefined;
 }
 
+/**
+ * The live process's own working directory — the most authoritative anchor for a
+ * RELATIVE launch script. A ComfyUI launched as `python main.py …` has argv[0] =
+ * `main.py` with no path root, an unset/stale COMFYUI_PATH gives no canonical base,
+ * and no absolute argv root exists — so every anchor in resolveScriptAnchor comes
+ * up empty and restart refuses, even though the reachable process's cwd points at a
+ * valid install containing main.py (#535). On Linux we read `/proc/<pid>/cwd`. This
+ * MUST be captured while the process is still alive (gatherProcessInfo) because the
+ * symlink vanishes the instant the pid is killed; other OSes have no cheap /proc
+ * equivalent and return undefined (the existing refuse-safe fallback still applies).
+ */
+let liveCwdResolverOverride: ((pid: number) => string | undefined) | null = null;
+
+function resolveLiveProcessCwd(pid: number): string | undefined {
+  if (liveCwdResolverOverride) return liveCwdResolverOverride(pid);
+  if (!pid || IS_WIN) return undefined;
+  try {
+    const cwd = readlinkSync(`/proc/${pid}/cwd`);
+    return cwd && isAbsolute(cwd) ? cwd : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveLaunchCommand(
   info: ProcessInfo,
-): { exe: string; args: string[] } | null {
+): { exe: string; args: string[]; cwd?: string } | null {
   if (info.argv.length === 0) return null;
   const [first, ...rest] = info.argv;
   // Strip surrounding quotes a launcher may leave on the script path BEFORE the
@@ -630,13 +665,53 @@ function resolveLaunchCommand(
     // exists we keep the raw (possibly relative) script and let assessRelaunch's
     // refuse-safe preflight catch a truly unresolvable install.
     const anchor = resolveScriptAnchor(info.argv);
-    const script =
-      isAbsolute(firstUnquoted) || isWindowsAbsolute
-        ? firstUnquoted
+    const scriptIsAbsolute = isAbsolute(firstUnquoted) || isWindowsAbsolute;
+    // LIVE-CWD anchor (#535): before falling back to the canonical base, resolve a
+    // RELATIVE script against the running process's OWN cwd (captured live, so it
+    // survives the stop that kills the pid). Two hard requirements keep the stop
+    // refuse-safe and env-consistent:
+    //   1. Both the script AND the interpreter must be resolved from the SAME live
+    //      cwd — never pair a live-cwd script with a stale COMFYUI_PATH's python,
+    //      which would relaunch the live server under the wrong environment (codex
+    //      round-2 P1). So the interpreter is re-resolved with the live cwd as its
+    //      search root (finds that install's own venv/embedded python).
+    //   2. Both must be validated as REGULAR FILES (not just existsSync): a dir
+    //      named `main.py`, or a dir at the interpreter path, must NOT unlock a kill
+    //      we can't actually exec afterward (codex round-2 P1).
+    // Split into segments + re-join so a Windows `ComfyUI\main.py` normalizes to
+    // host-native separators on a POSIX host instead of a literal one-segment name.
+    const relSegments = firstUnquoted.split(/[\\/]/).filter(Boolean);
+    let liveCwdScript: string | undefined;
+    let liveCwdPython: string | undefined;
+    if (!scriptIsAbsolute && info.liveCwd && relSegments.length > 0) {
+      const candidateScript = join(info.liveCwd, ...relSegments);
+      const candidatePython = findComfyuiPython(info.liveCwd, info.argv);
+      const pythonIsAbsolute =
+        !!candidatePython &&
+        (isAbsolute(candidatePython) || /^[a-zA-Z]:[\\/]/.test(candidatePython));
+      if (
+        isRegularFile(candidateScript) &&
+        pythonIsAbsolute &&
+        isRegularFile(candidatePython)
+      ) {
+        liveCwdScript = candidateScript;
+        liveCwdPython = candidatePython;
+      }
+    }
+    const script = scriptIsAbsolute
+      ? firstUnquoted
+      : liveCwdScript
+        ? liveCwdScript
         : anchor
           ? join(anchor, scriptBasename)
           : firstUnquoted;
-    return { exe: python, args: [script, ...rest] };
+    // When the script was anchored to the LIVE cwd, use that install's OWN python
+    // and spawn FROM that cwd — never a stale/nonexistent config.comfyuiPath, which
+    // would ENOENT the spawn after the server was already killed (#535). Otherwise
+    // keep the existing interpreter + let the caller default cwd to comfyuiPath.
+    const exe = liveCwdScript ? liveCwdPython! : python;
+    const cwd = liveCwdScript ? info.liveCwd : undefined;
+    return { exe, args: [script, ...rest], cwd };
   }
   return { exe: first, args: rest };
 }
@@ -645,6 +720,22 @@ function fileExists(p: string | undefined): boolean {
   if (!p) return false;
   try {
     return existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stricter than fileExists: the path must be a REGULAR FILE, not a directory.
+ * Used to unlock the atomic live-cwd relaunch (#535) — a directory named
+ * `main.py`, or a directory at the interpreter path, exists per existsSync yet
+ * cannot be exec'd, so validating it as a file keeps the stop refuse-safe. NOT a
+ * drop-in for fileExists elsewhere: a macOS `.app` bundle is a directory.
+ */
+function isRegularFile(p: string | undefined): boolean {
+  if (!p) return false;
+  try {
+    return statSync(p).isFile();
   } catch {
     return false;
   }
@@ -889,8 +980,18 @@ async function gatherProcessInfo(): Promise<ProcessInfo> {
 
   const desktop = isDesktopApp(argv);
   const desktopExe = desktop ? findDesktopExePath(argv) : undefined;
+  // Capture the live process cwd NOW, while the pid is guaranteed alive — the
+  // `/proc/<pid>/cwd` symlink is gone the instant a later stop kills it (#535).
+  const liveCwd = desktop ? undefined : resolveLiveProcessCwd(pid);
 
-  return { pid, port, argv, isDesktopApp: desktop, desktopExePath: desktopExe };
+  return {
+    pid,
+    port,
+    argv,
+    isDesktopApp: desktop,
+    desktopExePath: desktopExe,
+    liveCwd,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1400,6 +1501,12 @@ export const __processControlTestHooks = {
     supervisorWindowStartedAt = 0;
     supervisorGaveUp = false;
     remoteRebootTimingOverride = null;
+    liveCwdResolverOverride = null;
+  },
+  /** Inject a fake live-process-cwd resolver (#535) so tests can drive the
+   *  `/proc/<pid>/cwd` relative-script anchor without a real process/filesystem. */
+  setLiveCwdResolver(fn: ((pid: number) => string | undefined) | null): void {
+    liveCwdResolverOverride = fn;
   },
   setLastProcessInfo(info: ProcessInfo): void {
     lastProcessInfo = info;


### PR DESCRIPTION
## Summary

`panel_restart_comfyui` refused to relaunch a live, reachable ComfyUI launched as `python main.py …` when `COMFYUI_PATH` was stale/unset (legacy Manager 3.x → managed kill+relaunch fallback). The relaunch preflight validated the RELATIVE script `main.py`, but every anchor it tried — absolute argv root, canonical `COMFYUI_PATH`/workspace base, `config.comfyuiPath` — came up empty, so it refused even though the running process's own cwd pointed at a valid install containing `main.py`.

## Fix

Resolve the launch command + path to an ABSOLUTE form captured at a known-good time:

- **Capture the live process cwd** (`/proc/<pid>/cwd` on Linux) in `gatherProcessInfo()` while the pid is still ALIVE, stored on `ProcessInfo`. This is essential because the symlink vanishes the instant a later stop kills the pid, and the relaunch command is re-derived AFTER the kill in `spawnFromProcessInfo()`.
- **Anchor a relative script to that live cwd** (full path, segment-joined so a Windows `ComfyUI\main.py` normalizes host-native), and **re-resolve the interpreter from the SAME live cwd**, so the script and its venv/embedded python always come from one install — never a stale-but-existing `COMFYUI_PATH`'s python (mismatched env).
- **Preserve the refuse-safe / atomic invariant** (#368/#370): the anchor only unlocks a stop when BOTH the script AND the interpreter validate as absolute REGULAR FILES (`isRegularFile`, not bare `existsSync`). A directory named `main.py`, a dir at the interpreter path, or a bare `python3` fallback all refuse instead of killing a reachable server we cannot provably relaunch.
- **Spawn FROM the captured live cwd** (never a stale/nonexistent config `COMFYUI_PATH`, which would `ENOENT` the spawn after the kill).

Reuses the existing `findComfyuiPython` / `interpreterCandidates` resolution (prior COMFYUI_PATH work: #420/#476/#426/#510); the desktop-app path is unaffected (`liveCwd` is never resolved for it).

## Tests

`src/__tests__/services/restart-live-first.test.ts` adds:
- restart succeeds by anchoring a bare relative `main.py` to the live cwd (asserts spawn exe, script, and cwd);
- interpreter is paired to the live cwd's own python, NOT a stale-but-existing `COMFYUI_PATH` python;
- refuse when `main.py` is a directory (regular-file guard);
- refuse when the interpreter is only a bare PATH fallback;
- refuse when the live cwd does not contain the script.

`npm run build` + `npm test` green (one pre-existing, unrelated `node-dev` ripgrep-vs-builtin env test fails identically on clean `main`). Codex self-gate (gpt-5.6-terra/high) PASS with no findings after addressing two review rounds (interpreter/env pairing + regular-file validation).

## Related

panel#347 (restart hangs to the 300s tool timeout) was verified ALREADY FIXED in 0.48.22 via #536/#509 and closed separately with a version cross-check + reopen clause — no code change here for it.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)
