### PR TITLE
fix(panel-target): pinned workflow target actually binds reads+edits, fails at pin time if unbindable (#556, #571)

### DIFF
--- a/docs/design/workflow-target.md
+++ b/docs/design/workflow-target.md
@@ -11,7 +11,19 @@ The orchestrator keeps a per-`tab_id` **workflow target**:
 | mode | behavior |
 |------|----------|
 | `current` | Graph tools follow the user's active workflow tab (default) |
-| `pinned` | Graph tools include `workflow_path` on scoped commands |
+| `pinned` | Graph tools include `workflow_path` on scoped commands. The pin **must target the active canvas at pin time** — see the constraint below |
+
+### Active-canvas constraint (#556/#571)
+
+The panel has **no way to read or mutate a non-active workflow's graph**: every graph executor runs against `app.canvas.graph`, and the panel's pinned-target guard (#349/#186) **fails closed** with a "workflow mismatch" error whenever an injected `workflow_path` is not the workflow currently in view. Background editing of a non-active tab is therefore **not supported**.
+
+Consequently a pin is only honorable when its target is the active canvas. `panel_set_workflow_target` (and the panel-driven `set_workflow_target` event) **validate at pin time** via `resolvePinTarget` and:
+
+- **fail closed** if the workflow isn't open (#259),
+- **fail at pin time** if it is open but not the active canvas (#556/#571) — never accept-then-defer,
+- canonicalize an honorable pin to the workflow's stable `key`.
+
+The injected `workflow_path` then acts as a **guard**: if the user later switches away, the next graph command fails loudly instead of silently editing the wrong graph.
 
 ### Orchestrator API
 
@@ -31,14 +43,13 @@ Never injected on: `workflow_list`, `workflow_new`, `workflow_open`.
 
 ### Panel implementation (comfyui-mcp-panel)
 
-Each graph executor should:
+Graph executors run against the **active canvas** (`app.canvas.graph`); the panel cannot address a non-active workflow document. So each executor:
 
-1. Read optional `workflow_path` on the incoming `{ rid, cmd, … }` frame.
-2. Resolve the workflow document for that path (not only the active tab).
-3. Apply the mutation on that document's graph store.
-4. Optionally refresh UI if that workflow is visible; **do not** switch the user's active tab unless `workflow_open` is called.
+1. Reads optional `workflow_path` on the incoming `{ rid, cmd, … }` frame.
+2. Treats it as a **guard**: if `workflow_path` does not identify the active canvas, it **fails closed** with a retryable "workflow mismatch" error (#349/#186) — it never blindly mutates the active graph under a mismatched pin.
+3. Otherwise applies the mutation on the active canvas.
 
-Background edits on a non-active workflow should still persist and mark that tab modified.
+Because background editing is not possible, the orchestrator rejects a background pin **at pin time** (see the active-canvas constraint above) so the mismatch guard is only ever a last line of defense (e.g. the user switches tabs after a valid pin), not the normal failure path.
 
 ## Files
 

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -853,6 +853,107 @@ describe("panel-tools: single authoritative pin resolution (#259 wrong-tab)", ()
     expect(store.get("test-tab")).toMatchObject({ mode: "current" });
   });
 
+  it("FAILS AT PIN TIME when the target is open but NOT the active canvas (#556) — no deferred mismatch", async () => {
+    const store = new WorkflowTargetStore();
+    // Two open tabs; the ACTIVE one is the Unsaved tab (workflows[1]). Pinning to the
+    // BACKGROUND WAN workflow must be rejected up front — the panel can only edit the
+    // in-view canvas, so accepting the pin would only defer a "workflow mismatch".
+    const wan = { path: "workflows/Wan/WAN 2.2 SVI I2V.json", filename: "WAN 2.2 SVI I2V.json", key: "wf-wan", active: false };
+    const unsaved = { path: null, filename: null, title: "Unsaved Workflow (2)", key: "tmp:uuid-active", active: true };
+    const { bridge } = listBridge([wan, unsaved], unsaved);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/Wan/WAN 2.2 SVI I2V.json" },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).toMatch(/not the active canvas/i);
+    expect(text).toMatch(/Unsaved Workflow \(2\)/); // names the workflow actually in view
+    expect(text).toMatch(/panel_open_workflow/); // actionable: switch to it first
+    // Nothing was pinned — the session stays on "current" (never a silent background pin).
+    expect(store.get("test-tab")).toMatchObject({ mode: "current" });
+  });
+
+  it("FAILS AT PIN TIME for an UNSAVED (persisted:false) background workflow (#571)", async () => {
+    const store = new WorkflowTargetStore();
+    // Workflow B is open but unsaved (persisted:false) and NOT active; A is active.
+    const a = { path: "workflows/A.json", filename: "A.json", key: "wf-a", active: true, persisted: true };
+    const b = { path: null, filename: null, title: "Unsaved Workflow", key: "tmp:uuid-b", active: false, persisted: false };
+    const { bridge } = listBridge([a, b], a);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "tmp:uuid-b" },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toMatch(/not the active canvas/i);
+    expect(store.get("test-tab")).toMatchObject({ mode: "current" });
+  });
+
+  it("PINS SUCCESSFULLY when the target IS the active canvas (positive control)", async () => {
+    const store = new WorkflowTargetStore();
+    const a = { path: "workflows/A.json", filename: "A.json", key: "wf-a", active: true };
+    const b = { path: "workflows/B.json", filename: "B.json", key: "wf-b", active: false };
+    const { bridge } = listBridge([a, b], a);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/A.json" },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(store.get("test-tab")).toMatchObject({ mode: "pinned", path: "wf-a" });
+  });
+
+  it("stays LENIENT (pins) when the list carries NO active signal — indeterminate, not background (#556 P1b)", async () => {
+    const store = new WorkflowTargetStore();
+    // Enumerable list but neither a usable active object NOR per-record `active` flags:
+    // active-ness is INDETERMINATE, so a valid pin must NOT be rejected (older/partial panel).
+    const x = { path: "workflows/x.json", filename: "x.json", key: "kx" };
+    const { bridge } = listBridge([x], {} as Record<string, unknown>);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/x.json" },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(store.get("test-tab")).toMatchObject({ mode: "pinned", path: "kx" });
+  });
+
+  it("stays LENIENT when record and active object share NO comparable identity field (indeterminate, not background)", async () => {
+    const store = new WorkflowTargetStore();
+    // Record exposes only path/filename (no key); active object exposes only a key.
+    // There is no comparable dimension, so active-ness is INDETERMINATE — a valid pin
+    // must NOT be rejected as "background" (would regress older/partial-panel compat).
+    const rec = { path: "workflows/y.json", filename: "y.json" };
+    const { bridge } = listBridge([rec], { key: "k-something-else" } as Record<string, unknown>);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "workflows/y.json" },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    // No key to canonicalize to → pins the raw path (lenient).
+    expect(store.get("test-tab")).toMatchObject({ mode: "pinned", path: "workflows/y.json" });
+  });
+
+  it("duplicate filename across tabs: pins the ACTIVE same-name tab, not a background one (#556 P1a)", async () => {
+    const store = new WorkflowTargetStore();
+    // Two tabs share filename "dup.json" (different dirs). The ACTIVE one is dir2.
+    const bg = { path: "workflows/dir1/dup.json", filename: "dup.json", key: "k-bg", active: false };
+    const live = { path: "workflows/dir2/dup.json", filename: "dup.json", key: "k-live", active: true };
+    const { bridge } = listBridge([bg, live], live);
+    const ctx = makePanelToolCtx(bridge, "test-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler(
+      { mode: "pinned", path: "dup.json" },
+      ctx,
+    );
+    // A filename-only token matches BOTH; the resolver disambiguates to the active
+    // record and pins it — never silently binds the background same-name tab.
+    expect(res.isError).toBeFalsy();
+    expect(store.get("test-tab")).toMatchObject({ mode: "pinned", path: "k-live" });
+  });
+
   it("live-canvas capture (graph_serialize) carries the pinned workflow_path, not the visible tab", async () => {
     const store = new WorkflowTargetStore();
     store.set("test-tab", { mode: "pinned", path: "wf-pinned-key" });

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -36,7 +36,7 @@ import {
   type UsageStatus,
 } from "./panel-agent.js";
 import { promptText } from "./error-text.js";
-import { createPanelMcpServer } from "./panel-tools.js";
+import { createPanelMcpServer, makePanelToolCtx, resolvePinTarget } from "./panel-tools.js";
 import {
   optionsAckFrame,
   optionsErrorAckFrame,
@@ -129,7 +129,7 @@ REPORT OUR OWN BUGS (we're in beta — bias HARD toward filing) — distinct fro
 
 WEDGED RENDER / OOM / VRAM PINNED — when a generation is stuck or hits CUDA out-of-memory, or a cancel didn't actually free GPU memory (models still resident, VRAM pinned, the next run still OOMs), call panel_free_vram to UNLOAD all models and free VRAM before retrying — it does NOT restart ComfyUI, so it's the cheap first move. Escalation ladder: cancel the run → panel_free_vram (unload + free) → retry; only as a LAST RESORT panel_restart_comfyui (which refuses mid-render and guards the running generation). Reach for panel_free_vram before a restart whenever a cancel left memory pinned.
 
-WORKFLOW TARGETING — by default your panel_* graph edits follow whichever workflow tab the user is currently viewing. If the user wants you to work on a DIFFERENT open workflow while they browse another tab, call panel_set_workflow_target(mode:"pinned", path:<from panel_list_workflows>) to pin edits to that workflow; panel_get_workflow_target shows the current binding. Set mode:"current" to follow the user's active tab again. Pinning does NOT switch what the user sees — it only routes your graph tools. When pinned, still use panel_open_workflow only when you intentionally want to switch the user's view.
+WORKFLOW TARGETING — by default your panel_* graph edits follow whichever workflow tab the user is currently viewing. The panel can only read or edit the workflow currently IN VIEW, so to work on a specific open workflow, make it the active canvas first with panel_open_workflow, then call panel_set_workflow_target(mode:"pinned", path:<from panel_list_workflows>) to bind your edits to it; panel_get_workflow_target shows the current binding. Pinning to a background (open but not active) workflow is REJECTED at pin time — it cannot route edits to a tab that isn't in view. A pin does NOT switch what the user sees; it binds your edits to that workflow so that if the user later switches away, your next graph call fails loudly instead of silently editing the wrong graph. Set mode:"current" to follow the user's active tab again.
 
 CRITICAL — never destroy the user's work. When they ask for a "new workflow", a "fresh canvas", or to "start over for a new project", call panel_new_workflow (it opens a NEW TAB and leaves their current workflow intact). NEVER use panel_clear for that — panel_clear wipes the CURRENTLY OPEN graph and is ONLY for an explicit "clear/reset this canvas". You can manage tabs with panel_list_workflows / panel_open_workflow / panel_rename_workflow / panel_close_workflow, and group nodes with panel_select_nodes / panel_create_subgraph. To label a node by its purpose, use panel_set_node_title. To read or edit nodes INSIDE a subgraph, call panel_enter_subgraph(node_id) first — then panel_query_graph / panel_graph_outline and the panel_* edit tools operate on the subgraph's inner nodes — and panel_exit_subgraph when you're done.
 
@@ -1372,6 +1372,13 @@ export async function runPanelOrchestrator(): Promise<void> {
   const resolvedModelByTab = new Map<string, string>();
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
   const workflowTargets = new WorkflowTargetStore();
+  // Monotonic per-tab sequence for set_workflow_target events. A pinned target is
+  // validated asynchronously (resolvePinTarget queries workflow_list), so a later event
+  // (another pin, or a synchronous mode:"current") can arrive before the async pin
+  // commits. Each event bumps the tab's sequence; a pinned resolution only commits/acks if
+  // its captured sequence is still the latest — otherwise a stale pin would clobber the
+  // user's newer selection (codex race).
+  const workflowTargetSeq = new Map<string, number>();
   const backendForTab = (panelTabId: string): string =>
     tabBackends.get(panelTabId) ?? defaultBackend;
   const agentKeyFor = (panelTabId: string): string =>
@@ -2475,6 +2482,11 @@ export async function runPanelOrchestrator(): Promise<void> {
         tabBackends.delete(migratedFrom);
         headlessTabs.delete(migratedFrom);
         workflowTargets.clear(migratedFrom);
+        // Invalidate any in-flight set_workflow_target(pinned) resolution captured under
+        // the retired id: dropping its sequence makes isCurrent() false, so a late async
+        // pin can no longer write a stale target / emit a late ack that the bridge's
+        // migration map would deliver to the new tab (codex race, tab-id migration edge).
+        workflowTargetSeq.delete(migratedFrom);
       }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live
@@ -2775,12 +2787,56 @@ export async function runPanelOrchestrator(): Promise<void> {
         );
         return;
       }
-      const target = workflowTargets.set(panelTab, { mode, path, filename });
-      bridge.push({ type: "ack", ok: true, kind: "workflow_target", target }, panelTab);
-      bridge.push({ type: "workflow_target", target }, panelTab);
-      logger.info(
-        `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow target → ${target.mode}${target.path ? ` (${target.path})` : ""}`,
-      );
+      // Every target event bumps the tab's sequence so a later selection always wins over
+      // an in-flight (async) pin resolution.
+      const seq = (workflowTargetSeq.get(panelTab) ?? 0) + 1;
+      workflowTargetSeq.set(panelTab, seq);
+      const isCurrent = () => workflowTargetSeq.get(panelTab) === seq;
+      const ackTarget = (t: ReturnType<typeof workflowTargets.set>) => {
+        bridge.push({ type: "ack", ok: true, kind: "workflow_target", target: t }, panelTab);
+        bridge.push({ type: "workflow_target", target: t }, panelTab);
+        logger.info(
+          `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow target → ${t.mode}${t.path ? ` (${t.path})` : ""}`,
+        );
+      };
+      // A PINNED target must clear the SAME validation as the MCP tool
+      // (panel_set_workflow_target) — otherwise this panel-driven event path would be a
+      // bypass that re-admits #556/#571 (background pin) and #259 (not-open pin). Resolve
+      // async through the shared helper, failing at pin time before the store is written.
+      if (mode === "pinned") {
+        void (async () => {
+          const ctx = makePanelToolCtx(bridge, panelTab, workflowTargets);
+          const res = await resolvePinTarget(ctx, String(path), filename);
+          // Superseded by a newer target event while we were validating — drop silently
+          // (no write, no late ack) so the newer selection is never clobbered.
+          if (!isCurrent()) return;
+          if (!res.ok) {
+            bridge.push(
+              { type: "ack", ok: false, kind: "workflow_target", message: res.error },
+              panelTab,
+            );
+            return;
+          }
+          ackTarget(
+            workflowTargets.set(panelTab, { mode: "pinned", path: res.pinPath, filename: res.pinFilename }),
+          );
+        })().catch((err) => {
+          if (!isCurrent()) return;
+          bridge.push(
+            {
+              type: "ack",
+              ok: false,
+              kind: "workflow_target",
+              message: `Could not pin workflow: ${err instanceof Error ? err.message : String(err)}`,
+            },
+            panelTab,
+          );
+        });
+        return;
+      }
+      // mode === "current" — no target to validate; follow the active tab. Writes
+      // synchronously and is the latest sequence, so it wins over any in-flight pin.
+      ackTarget(workflowTargets.set(panelTab, { mode, path, filename }));
       return;
     }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1026,14 +1026,42 @@ interface OpenWorkflowRecord {
   path?: string;
   filename?: string;
   key?: string;
+  /** Per-instance routing id ("wf:<path>" saved / "tmp:<uuid>" unsaved). */
+  routing_key?: string;
+  /** Per-record authoritative "is the active canvas" flag from workflow_list. */
+  active?: boolean;
+}
+
+/**
+ * The matched open-workflow record PLUS whether it is the ACTIVE canvas. The panel
+ * has no way to read/mutate a NON-active workflow's graph (every graph executor runs
+ * against app.canvas.graph and fails closed on a workflow_path mismatch — panel
+ * #349/#186), so a pin can only be honored when its target is the workflow currently
+ * in view. `isActive` lets the caller reject an open-but-background pin AT PIN TIME
+ * instead of accepting it and surfacing a deferred "workflow mismatch" on the next
+ * graph call (#556/#571).
+ */
+interface ResolvedOpenWorkflow {
+  record: OpenWorkflowRecord;
+  /**
+   * TRI-STATE. `true` = the target IS the active canvas (pin honorable). `false` =
+   * the target is POSITIVELY KNOWN to be a background tab (reject at pin time). `undefined`
+   * = INDETERMINATE (the list carried no active signal — older/partial panel); the caller
+   * must stay LENIENT and pin anyway rather than fail closed (#556/#571 vs older-panel compat).
+   */
+  isActive?: boolean;
+  /** Human label for the workflow currently active (for a clear pin-time error). */
+  activeLabel?: string;
 }
 
 /**
  * Resolve a caller-supplied pin `path` (path / filename / key, any form) to the
  * AUTHORITATIVE open-workflow record from a fresh `workflow_list` — the single
- * source of truth for which tabs exist and their canonical `key` (#259). Returns:
- *  - the matched record when the workflow IS open (so the pin can be canonicalized
- *    to its stable key and bound to the exact frontend tab identity);
+ * source of truth for which tabs exist, their canonical `key`, and which one is
+ * ACTIVE (#259). Returns:
+ *  - a {record, isActive} pair when the workflow IS open (so the caller can
+ *    canonicalize the pin to its stable key AND reject a background target that the
+ *    panel could never route to — #556/#571);
  *  - `null` when workflow_list is unreachable/empty or carries no `workflows`
  *    array (indeterminate — caller should fall back to the raw path, NOT fail);
  *  - the sentinel `NOT_OPEN` when the list IS known but the target is absent, so
@@ -1044,7 +1072,7 @@ const NOT_OPEN = Symbol("workflow-not-open");
 async function resolveOpenWorkflow(
   ctx: PanelToolCtx,
   path: string,
-): Promise<OpenWorkflowRecord | null | typeof NOT_OPEN> {
+): Promise<ResolvedOpenWorkflow | null | typeof NOT_OPEN> {
   let parsed: Record<string, unknown> | null = null;
   try {
     parsed = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
@@ -1057,14 +1085,152 @@ async function resolveOpenWorkflow(
     // No enumerable tab list (older panel / stub) — can't verify, don't fail closed.
     return null;
   }
-  for (const wf of rawList) {
-    if (activeMatchesTarget(wf, path)) return wf as OpenWorkflowRecord;
+  const activeObj = (parsed as { active?: unknown }).active;
+  const activeLabel = workflowRecordLabel(activeObj);
+
+  // A caller token (path / filename / key) can match MORE THAN ONE open record —
+  // e.g. two tabs share the filename "A.json" from different dirs, or two never-saved
+  // tabs. Selecting the wrong same-token record and then reading its `active` flag would
+  // misjudge active-ness (codex P1). So gather ALL matches and disambiguate toward the
+  // one that is actually the live canvas before deciding.
+  const matches = rawList.filter((wf) => activeMatchesTarget(wf, path)) as OpenWorkflowRecord[];
+  let rec: OpenWorkflowRecord | undefined;
+  if (matches.length === 1) {
+    rec = matches[0];
+  } else if (matches.length > 1) {
+    // Prefer an EXACT stable-identity (key/path) match to the caller token; then prefer
+    // the record that is the active canvas; otherwise leave it unresolved and let the
+    // active-object branch / NOT_OPEN handle it (never guess among ambiguous tabs).
+    const exact = matches.filter((m) => m.key === path || m.path === path);
+    const activePreferred = matches.filter((m) => m.active === true || recMatchesActive(m, activeObj));
+    rec = exact.length === 1 ? exact[0] : activePreferred.length === 1 ? activePreferred[0] : undefined;
+  }
+
+  if (rec) {
+    return { record: rec, isActive: computeIsActive(rec, activeObj), activeLabel };
   }
   // The active object is authoritative too, in case it isn't mirrored in the array.
-  if (activeMatchesTarget((parsed as { active?: unknown }).active, path)) {
-    return (parsed as { active: OpenWorkflowRecord }).active;
+  if (activeMatchesTarget(activeObj, path)) {
+    return { record: activeObj as OpenWorkflowRecord, isActive: true, activeLabel };
   }
   return NOT_OPEN;
+}
+
+/**
+ * Is `rec` the active canvas? TRI-STATE (#556/#571):
+ *  - the record's OWN `active` boolean is authoritative and immune to filename aliasing;
+ *  - else compare `rec` to the `active` object by STABLE identity (key/path/routing_key —
+ *    never filename alone, which can collide across tabs). This yields `true`/`false`
+ *    ONLY when the two share a COMPARABLE identity dimension;
+ *  - else (no per-record flag AND nothing comparable) → `undefined` (indeterminate): the
+ *    caller must stay lenient rather than fail a valid pin on an older/partial panel.
+ */
+function computeIsActive(rec: OpenWorkflowRecord, activeObj: unknown): boolean | undefined {
+  if (typeof rec.active === "boolean") return rec.active;
+  return identityVerdict(rec, activeObj);
+}
+
+/**
+ * Stable-identity (key/path/routing_key) verdict between a record and the active object.
+ * Returns `true` on a positive match, `false` only when the two expose a COMPARABLE field
+ * (both non-empty) that DISAGREES, and `undefined` when they share no comparable field at
+ * all (so the caller cannot conclude "background" — stay lenient). Filename is never used
+ * (it collides across tabs).
+ */
+function identityVerdict(rec: OpenWorkflowRecord, activeObj: unknown): boolean | undefined {
+  if (!activeObj || typeof activeObj !== "object") return undefined;
+  const a = activeObj as { path?: unknown; key?: unknown; routing_key?: unknown };
+  const r = rec as { path?: unknown; key?: unknown; routing_key?: unknown };
+  const nonEmpty = (v: unknown): v is string => typeof v === "string" && v.trim() !== "";
+  const pairs: Array<[unknown, unknown]> = [
+    [r.key, a.key],
+    [r.path, a.path],
+    [r.routing_key, a.routing_key],
+    [r.key, a.routing_key],
+    [r.routing_key, a.key],
+  ];
+  let comparable = false;
+  for (const [x, y] of pairs) {
+    if (nonEmpty(x) && nonEmpty(y)) {
+      comparable = true;
+      if (x === y) return true;
+    }
+  }
+  return comparable ? false : undefined;
+}
+
+/** Stable-identity match (positive only) — used to prefer the active record among matches. */
+function recMatchesActive(rec: OpenWorkflowRecord, activeObj: unknown): boolean {
+  return identityVerdict(rec, activeObj) === true;
+}
+
+/** Best-effort human label for a workflow_list record/active object. */
+function workflowRecordLabel(rec: unknown): string | undefined {
+  if (!rec || typeof rec !== "object") return undefined;
+  const r = rec as { filename?: unknown; title?: unknown; path?: unknown; key?: unknown };
+  for (const v of [r.filename, r.title, r.path, r.key]) {
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  return undefined;
+}
+
+/** Outcome of validating + canonicalizing a pin target. */
+export type PinTargetResolution =
+  | { ok: true; pinPath: string; pinFilename?: string }
+  | { ok: false; error: string };
+
+/**
+ * Validate and canonicalize a pin `path` to a routable target, SHARED by every entry
+ * point that writes a pinned workflow target (the MCP tool AND the panel-driven
+ * set_workflow_target event) so none can bypass the guarantees:
+ *  - FAIL CLOSED when the workflow isn't open (#259) — never route the pin to another tab;
+ *  - FAIL AT PIN TIME when it is open but NOT the active canvas (#556/#571) — the panel can
+ *    only read/edit the in-view workflow (panel #349/#186), so a background pin would only
+ *    defer a "workflow mismatch"; reject it honestly and immediately;
+ *  - otherwise canonicalize to the stable `key` (survives rename/reconnect);
+ *  - INDETERMINATE lists (older/partial panel — no `workflows` array, or no comparable
+ *    active identity) stay LENIENT: pin the raw path rather than fail a valid pin.
+ */
+export async function resolvePinTarget(
+  ctx: PanelToolCtx,
+  path: string,
+  filename: string | undefined,
+): Promise<PinTargetResolution> {
+  const resolved = await resolveOpenWorkflow(ctx, path);
+  if (resolved === NOT_OPEN) {
+    return {
+      ok: false,
+      error:
+        `Cannot pin to "${path}" — it is not open in ComfyUI. Open it first ` +
+        `(panel_open_workflow) or pick an open workflow from panel_list_workflows, ` +
+        `then pin. (Refusing to pin to a workflow that isn't open so graph edits ` +
+        `never land on the wrong tab.)`,
+    };
+  }
+  if (resolved && resolved.isActive === false) {
+    const activeName = resolved.activeLabel ? ` (currently "${resolved.activeLabel}")` : "";
+    return {
+      ok: false,
+      error:
+        `Cannot pin to "${filename ?? path}" — it is open but not the active canvas${activeName}. ` +
+        `The panel can only read or edit the workflow that is currently in view, so a background ` +
+        `pin would fail on your next panel_* graph call. To work on it, switch to it first with ` +
+        `panel_open_workflow (that makes it the active canvas), then pin — or, if you meant to ` +
+        `edit the workflow already in view, pin that one instead. (Pinning does not switch the ` +
+        `user's view and cannot route edits to a background tab.)`,
+    };
+  }
+  if (resolved) {
+    // Canonicalize to the stable key so routing survives rename/reconnect.
+    const rec = resolved.record;
+    return {
+      ok: true,
+      pinPath: rec.key ?? rec.path ?? path,
+      pinFilename: filename ?? rec.filename ?? rec.path,
+    };
+  }
+  // Indeterminate list — stay lenient (older/partial panel).
+  return { ok: true, pinPath: path, pinFilename: filename };
 }
 
 export const __openWorkflowTestHooks = {
@@ -3121,7 +3287,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_get_workflow_target",
-      "Read which workflow this agent is bound to edit. mode 'current' means graph tools follow whatever tab the user is viewing; mode 'pinned' means edits go to the pinned workflow even if the user switched to another tab. Call this when unsure which workflow your panel_* edits will affect.",
+      "Read which workflow this agent is bound to edit. mode 'current' means graph tools follow whatever tab the user is viewing; mode 'pinned' means edits are bound to the pinned workflow (which was the active canvas at pin time) — if the user later switches to another tab, your next graph call FAILS LOUDLY rather than silently editing the wrong graph. Call this when unsure which workflow your panel_* edits will affect.",
       {},
       async (_args, ctx) => {
         const target = ctx.workflowTarget?.get(ctx.tabId) ?? { mode: "current" as const };
@@ -3130,7 +3296,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_workflow_target",
-      "Pin the agent to a specific open workflow tab, or release the pin to follow the user's current tab. Use pinned when the user asks you to work on workflow A while they browse workflow B — set mode:'pinned' and path from panel_list_workflows. Set mode:'current' (or omit path) to follow the active tab again. Does NOT switch what the user sees; it only routes your panel_* graph edits. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab` after ComfyUI reconnected, the panel reloaded, or the user switched to a different workflow FILE, call this with mode:'current' to rebind this session onto the tab that's live now.",
+      "Pin the agent to a specific open workflow tab (it must be the ACTIVE/in-view workflow at pin time), or release the pin to follow the user's current tab. The panel can only read or edit the workflow currently in view, so pinning to a background tab is REJECTED at pin time — to work on a different open workflow, switch to it first with panel_open_workflow (that makes it active), then pin. Pinning does NOT change the user's view; it binds your panel_* graph edits to that workflow and makes a later mismatch (e.g. the user switches away) fail loudly instead of silently editing the wrong graph. Set mode:'pinned' with path from panel_list_workflows; set mode:'current' (or omit path) to follow the active tab again. mode:'current' is ALSO the explicit RECOVERY signal: if your panel_* calls started failing with `no connected tab` after ComfyUI reconnected, the panel reloaded, or the user switched to a different workflow FILE, call this with mode:'current' to rebind this session onto the tab that's live now.",
       {
         mode: z
           .enum(["current", "pinned"])
@@ -3168,27 +3334,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           }
         }
         // PIN: bind to the EXACT open-workflow identity from the authoritative
-        // workflow_list, canonicalizing to its stable `key` and FAILING CLOSED when
-        // the requested workflow isn't actually open — instead of letting the panel
-        // silently route the pin to another tab (#259). Indeterminate lists (older
-        // panel / no `workflows` array) fall back to the raw path (unchanged).
+        // workflow_list, canonicalizing to its stable `key`, FAILING CLOSED when the
+        // requested workflow isn't open (#259), and FAILING AT PIN TIME when it is open
+        // but not the active canvas (#556/#571). Shared with the panel-driven event path
+        // so both entry points validate identically.
         let pinPath = path;
         let pinFilename = filename;
         if (mode === "pinned" && path) {
-          const resolved = await resolveOpenWorkflow(ctx, path);
-          if (resolved === NOT_OPEN) {
-            return fail(
-              `Cannot pin to "${path}" — it is not open in ComfyUI. Open it first ` +
-                `(panel_open_workflow) or pick an open workflow from panel_list_workflows, ` +
-                `then pin. (Refusing to pin to a workflow that isn't open so graph edits ` +
-                `never land on the wrong tab.)`,
-            );
-          }
-          if (resolved) {
-            // Canonicalize to the stable key so routing survives rename/reconnect.
-            pinPath = resolved.key ?? resolved.path ?? path;
-            pinFilename = filename ?? resolved.filename ?? resolved.path;
-          }
+          const res = await resolvePinTarget(ctx, path, filename);
+          if (!res.ok) return fail(res.error);
+          pinPath = res.pinPath;
+          pinFilename = res.pinFilename;
         }
         const target = ctx.workflowTarget.set(ctx.tabId, {
           mode,

--- a/src/services/workflow-target-store.ts
+++ b/src/services/workflow-target-store.ts
@@ -2,9 +2,13 @@
 // should edit. Without pinning, graph_* commands hit whatever workflow the user
 // is currently viewing — browsing another tab mid-conversation redirects edits.
 //
-// Pinning injects `workflow_path` on workflow-scoped bridge commands so the
-// panel can operate on a background workflow without switching the user's view.
-// The comfyui-mcp-panel pack must honor `workflow_path` on graph executors.
+// Pinning injects `workflow_path` on workflow-scoped bridge commands. The panel can
+// only read/edit the workflow currently IN VIEW (its graph executors run against the
+// active canvas and fail closed on a workflow_path mismatch — panel #349/#186), so a
+// pin must target the active canvas at pin time (enforced in panel_set_workflow_target)
+// and the injected `workflow_path` acts as a GUARD: if the user later switches away, the
+// next graph command fails loudly instead of silently editing the wrong graph. It does
+// NOT enable background editing of a non-active tab.
 
 export type WorkflowTargetMode = "current" | "pinned";
 


### PR DESCRIPTION
## Root cause

The comfyui-mcp panel can only read or edit the workflow **currently in view**: every graph executor runs against `app.canvas.graph`, and the panel's pinned-target guard (#349/#186) **fails closed** with `workflow mismatch` whenever an injected `workflow_path` is not the active canvas. Background editing of a non-active tab is therefore architecturally impossible panel-side.

`panel_set_workflow_target(mode:"pinned")` ignored this: it accepted a pin to an **open-but-background** workflow and returned a success note promising background routing. The result was a DEFERRED failure — the pin call succeeded, then every subsequent `panel_*` graph call broke with `workflow mismatch` (#556), or reads silently addressed the active canvas instead (#571). Pinning only ever "worked" when the target was already active — the one case where pinning is unnecessary.

## Fix (orchestrator-side)

Make a pin bind honestly, and fail at pin time when it cannot:

- **`resolveOpenWorkflow`** now reports **tri-state** active-ness: authoritative per-record `active` flag, else a **stable-identity** (key/path/routing_key — never filename-only, which collides across tabs) match against the active object, else `undefined` (indeterminate → stay lenient). Multiple same-token matches disambiguate to the active record.
- New shared **`resolvePinTarget`**: FAIL CLOSED if not open (#259), **FAIL AT PIN TIME** if open-but-not-active (#556/#571), canonicalize an honorable pin to its stable key, and stay lenient on an indeterminate/older-panel list.
- Both entry points — the MCP tool **and** the panel-driven `set_workflow_target` event (index.ts) — route through `resolvePinTarget`, so neither can bypass the guarantees. The event path validates asynchronously behind a **per-tab sequence guard** (a newer selection always wins over an in-flight pin; the sequence is invalidated on tab-id migration).
- Corrected the over-promising tool description, `panel_get_workflow_target`, the store header, the orchestrator system prompt, and `docs/design/workflow-target.md` (background editing marked unsupported).

The injected `workflow_path` remains as a **guard**: if the user switches away after a valid pin, the next graph command fails loudly instead of silently editing the wrong graph — the prior active-target routing fix is not regressed.

## Tests

`src/__tests__/orchestrator/panel-tools.test.ts`: background-reject (persisted + unsaved `persisted:false`), active-canvas positive control, indeterminate-lenient (including the no-comparable-identity edge), and duplicate-filename disambiguation.

`npm run build` clean; full suite green (the single `node-dev` ripgrep-vs-builtin failure is a pre-existing environment artifact, unrelated to this change).

## Review

Codex self-gate (gpt-5.6-terra/high, embed-diff): PASS after 5 rounds — each round caught a distinct real issue (filename-aliasing false-positive, indeterminate-vs-background tri-state, the panel event-path bypass, an async write race, and a tab-id-migration edge of that race), all fixed and re-verified.

Closes #556
Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)