### PR TITLE
fix(manager): authoritative v3/v4 detection + GET/POST method negotiation + v3→v4 recovery (#551, #553, #555)

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1277,4 +1277,261 @@ describe("node-management service", () => {
       expect(calls.some((c) => c.url.endsWith("/manager/queue/status"))).toBe(true);
     });
   });
+
+  // ── Manager version-dialect cluster (#551 GET-only start, #553 v3→v4 recovery,
+  //    #555 authoritative v4 detection — a 405 is a method/route signal, never a
+  //    version signal) ─────────────────────────────────────────────────────────
+  describe("Manager 405 dialect cluster (#551 / #553 / #555)", () => {
+    const pathOf = (calls: Call[], p: string) =>
+      calls.filter((c) => new URL(c.url).pathname === p);
+
+    // ---- #551: legacy /manager/queue/start exposed GET-only ------------------
+    it("negotiates POST→GET when legacy /manager/queue/start is GET-only (#551)", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/")) return new Response("405: Method Not Allowed", { status: 405 });
+        if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+        if (path === "/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        if (path === "/manager/queue/start") {
+          // GET-only build: 405 to POST, 200 to GET (the #551 quirk).
+          return method === "POST"
+            ? new Response("405: Method Not Allowed", { status: 405 })
+            : new Response("", { status: 200 });
+        }
+        if (path === "/customnode/installed") {
+          return jsonResponse({ "comfyui-impact-pack": { ver: "1.0.0", cnr_id: "comfyui-impact-pack", enabled: true } });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      // Must SUCCEED (the install must not fail on the method mismatch).
+      const res = await installCustomNode({ id: "comfyui-impact-pack" });
+      expect(res.mechanism).toBe("manager-http");
+      const startCalls = pathOf(calls, "/manager/queue/start");
+      // POST was tried first, then re-negotiated as GET.
+      expect(startCalls.some((c) => c.method === "POST")).toBe(true);
+      expect(startCalls.some((c) => c.method === "GET")).toBe(true);
+    });
+
+    it("re-throws a non-405 error from queue/start unchanged (no blind GET retry)", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        calls.push({ url, method, body: undefined });
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/")) return new Response("405", { status: 405 });
+        if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+        if (path === "/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        if (path === "/manager/queue/start") return new Response("boom", { status: 500 });
+        if (path === "/customnode/installed") {
+          return jsonResponse({ "p": { ver: "1", cnr_id: "p", enabled: true } });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await expect(installCustomNode({ id: "p" })).rejects.toBeInstanceOf(NodeManagementError);
+      // A 500 must NOT be retried as GET (only a 405 method-mismatch is).
+      const startGets = pathOf(calls, "/manager/queue/start").filter((c) => c.method === "GET");
+      expect(startGets.length).toBe(0);
+    });
+
+    it("does NOT treat an HTML catchall GET as a successful queue start (codex P2)", async () => {
+      // The start path is UNREGISTERED for both methods: POST 405s, GET 200s with
+      // ComfyUI's SPA HTML page (the frontend catchall). That HTML must NOT be
+      // read as a real GET-only start — the original method error must surface.
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/")) return new Response("405", { status: 405 });
+        if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+        if (path === "/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        if (path === "/manager/queue/start") {
+          return method === "POST"
+            ? new Response("405: Method Not Allowed", { status: 405 })
+            : new Response("<!doctype html><html>frontend</html>", { status: 200, headers: { "Content-Type": "text/html" } });
+        }
+        if (path === "/customnode/installed") {
+          return jsonResponse({ "comfyui-impact-pack": { ver: "1.0.0", cnr_id: "comfyui-impact-pack", enabled: true } });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      // The install must FAIL rather than silently "succeed" on a catchall page.
+      await expect(installCustomNode({ id: "comfyui-impact-pack" })).rejects.toBeInstanceOf(NodeManagementError);
+    });
+
+    // ---- #555: authoritative v4 detection ------------------------------------
+    it("rescues a v4 host to v2 when /manager/queue/status also answers AND the v4 surface re-validates (#555)", async () => {
+      // A hybrid/transient shape: the FIRST /v2 queue-status probe missed (HTML
+      // catchall) and a bare /manager/queue/status answered — which alone made
+      // 0.48.21 conclude "legacy 3.x". The authoritative /v2/manager/version
+      // ("V4.x") overrides that, but ONLY after re-confirming the v4 queue surface
+      // actually validates (so we never route to a dead surface — codex P1).
+      const calls: Call[] = [];
+      let v2StatusHits = 0;
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        calls.push({ url, method, body: undefined });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") {
+          v2StatusHits++;
+          // First probe misses (catchall); the re-probe after the version check
+          // validates → safe to speak v4.
+          return v2StatusHits === 1
+            ? new Response("<!doctype html>", { status: 200, headers: { "Content-Type": "text/html" } })
+            : jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, pending_count: 0, is_processing: false });
+        }
+        if (path === "/manager/queue/status") return jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false });
+        if (path === "/v2/manager/version") return new Response("V4.2.2", { status: 200 });
+        if (path === "/v2/manager/is_legacy_manager_ui") return jsonResponse({ is_legacy_manager_ui: false });
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse({});
+        if (path === "/customnode/installed") return jsonResponse({});
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await listInstalledNodes();
+      // Detected v2 → listed from the /v2 route, NOT the unprefixed legacy route.
+      expect(pathOf(calls, "/v2/customnode/installed").length).toBeGreaterThan(0);
+      expect(pathOf(calls, "/customnode/installed").length).toBe(0);
+    });
+
+    it("does NOT route to v2 when the version says v4 but the v4 queue surface never validates (codex P1)", async () => {
+      // version=V4 but /v2/manager/queue/status is persistently unreachable (HTML
+      // catchall). Routing to v2 would enqueue work we then can't poll → a false
+      // timeout and duplicate on retry. Must keep the WORKING legacy endpoint and
+      // NEVER post a v4 task/queue mutation.
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") return new Response("<!doctype html>", { status: 200, headers: { "Content-Type": "text/html" } });
+        if (path === "/manager/queue/status") return jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false });
+        if (path === "/v2/manager/version") return new Response("V4.2.2", { status: 200 });
+        if (path === "/customnode/installed") return jsonResponse({});
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await listInstalledNodes();
+      // Stayed legacy → listed from the unprefixed route; NEVER touched the v4 task
+      // route (no mutation posted to a dead surface).
+      expect(pathOf(calls, "/customnode/installed").length).toBeGreaterThan(0);
+      expect(pathOf(calls, "/v2/manager/queue/task").length).toBe(0);
+    });
+
+    it("recognizes a v4 queue-status shape carrying pending_count (#555)", async () => {
+      // A status payload with pending_count (v4-style) but the classic counters
+      // too must be accepted by the v2 probe rather than falling through.
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        calls.push({ url, method: init?.method ?? "GET", body: undefined });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") return jsonResponse({ done_count: 0, pending_count: 0, in_progress_count: 0 });
+        if (path === "/v2/manager/is_legacy_manager_ui") return jsonResponse({ is_legacy_manager_ui: false });
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse({});
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await listInstalledNodes();
+      expect(pathOf(calls, "/v2/customnode/installed").length).toBeGreaterThan(0);
+      // never fell through to the legacy probe
+      expect(pathOf(calls, "/manager/queue/status").length).toBe(0);
+    });
+
+    it("still classifies a genuine 3.x host as legacy (version endpoint reports V3)", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        calls.push({ url, method: init?.method ?? "GET", body: undefined });
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/")) return new Response("<!doctype html>", { status: 200, headers: { "Content-Type": "text/html" } });
+        if (path === "/manager/queue/status") return jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false });
+        if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+        if (path === "/customnode/installed") return jsonResponse({});
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await listInstalledNodes();
+      // Legacy → listed from the UNPREFIXED route.
+      expect(pathOf(calls, "/customnode/installed").length).toBeGreaterThan(0);
+      expect(pathOf(calls, "/v2/customnode/installed").length).toBe(0);
+    });
+
+    it("routes install-model on a genuine v4 host to the /v2 task envelope, never the bare legacy route, with no 'legacy 3.x' message (#555)", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, pending_count: 0, is_processing: false });
+        if (path === "/v2/manager/is_legacy_manager_ui") return jsonResponse({ is_legacy_manager_ui: false });
+        if (path === "/v2/manager/queue/task") return new Response("", { status: 200 });
+        if (path === "/v2/manager/queue/start") return new Response("", { status: 200 });
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const res = await installModelViaManager({
+        name: "m.safetensors",
+        url: "https://example.com/m.safetensors",
+        filename: "m.safetensors",
+        type: "checkpoints",
+      });
+      // Correct v4 route: the unified task envelope with kind=install-model.
+      const task = calls.find((c) => new URL(c.url).pathname === "/v2/manager/queue/task");
+      expect(task).toBeDefined();
+      expect((task!.body as { kind?: string }).kind).toBe("install-model");
+      // NEVER the bare legacy per-op route (the #555 symptom).
+      expect(pathOf(calls, "/manager/queue/install_model").length).toBe(0);
+      // and NO false "legacy 3.x" / upgrade nag on a v4 host.
+      expect(res.message).not.toMatch(/legacy/i);
+      expect(res.message).not.toMatch(/pip install -U comfyui_manager/i);
+    });
+
+    // ---- #553: actionable v3→v4 recovery on a legacy install-model failure ----
+    it("surfaces a precise v3→v4 migration recovery when a legacy 3.x model install fails (#553)", async () => {
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const path = new URL(url).pathname;
+        if (path.startsWith("/v2/")) return new Response("405", { status: 405 });
+        if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+        if (path === "/manager/queue/status") {
+          return jsonResponse({ total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false });
+        }
+        // Arbitrary-URL model install is whitelist-gated on 3.x → 500.
+        if (path === "/manager/queue/install_model" && method === "POST") {
+          return new Response("500: Internal Server Error", { status: 500 });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const err = await installModelViaManager({
+        name: "m.safetensors",
+        url: "https://example.com/m.safetensors",
+        filename: "m.safetensors",
+        type: "checkpoints",
+      }).catch((e) => e as Error);
+
+      expect(err).toBeInstanceOf(NodeManagementError);
+      const msg = (err as Error).message;
+      // Precise diagnosis …
+      expect(msg).toMatch(/REQUIRE Manager v4\+/i);
+      // … plus the actionable, numbered recovery path.
+      expect(msg).toMatch(/pip install -U comfyui_manager/i);
+      expect(msg).toMatch(/disable the old custom_nodes\/ComfyUI-Manager clone/i);
+      expect(msg).toMatch(/--enable-manager/i);
+    });
+  });
 });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -184,6 +184,58 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** The HTTP status carried on a NodeManagementError from a non-2xx Manager
+ *  response (managerFetch stores { url, status, body } in `details`). */
+function errorStatus(err: unknown): number | undefined {
+  if (err instanceof NodeManagementError && err.details && typeof err.details === "object") {
+    const s = (err.details as { status?: unknown }).status;
+    return typeof s === "number" ? s : undefined;
+  }
+  return undefined;
+}
+
+/** Does a fetched body look like ComfyUI's SPA catchall page (an HTML document)
+ *  rather than a real Manager response? The frontend catchall answers an
+ *  UNREGISTERED GET path with 200 + a page of HTML, so a 200 alone is not proof a
+ *  route exists. A genuine queue-control GET returns an empty (or small non-HTML)
+ *  body. */
+function looksLikeHtml(body: unknown): boolean {
+  return typeof body === "string" && /^\s*<(?:!doctype\b|html\b|!--)/i.test(body);
+}
+
+/**
+ * POST to a Manager queue CONTROL route (e.g. `${prefix}/start`), negotiating the
+ * HTTP method on a 405.
+ *
+ * Some legacy Manager 3.x builds register `/manager/queue/start` (and peers) as
+ * GET-only, so our POST comes back HTTP 405 Method Not Allowed (#551). On a
+ * Manager route a 405 means "wrong method for THIS endpoint on THIS build" — NOT
+ * "the Manager is unreachable" and NOT "this is a different Manager generation".
+ * So retry the SAME path once with GET before giving up; a GET-only build then
+ * starts its queue instead of failing the whole install.
+ *
+ * The GET retry is itself guarded against ComfyUI's frontend catchall: an
+ * UNREGISTERED start path 405s the POST but 200s the GET with a page of HTML, and
+ * that HTML must NOT be mistaken for a successful queue start (codex review). If
+ * the GET yields a catchall HTML page, the route genuinely doesn't accept our
+ * request — surface the original method error. Any non-405 error, or a
+ * non-2xx GET, propagates unchanged.
+ */
+async function managerQueueControl(path: string): Promise<void> {
+  try {
+    await managerFetch(path, { method: "POST" });
+  } catch (err) {
+    if (errorStatus(err) === 405) {
+      // GET-only legacy build — negotiate the method rather than declare failure.
+      logger.debug("Manager queue control 405 on POST; retrying as GET", { path });
+      const body = await managerFetch<unknown>(path); // throws on a non-2xx GET
+      if (looksLikeHtml(body)) throw err; // catchall page — not a real GET-only start
+      return;
+    }
+    throw err;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Manager API generation detection (issue #116)
 //
@@ -217,14 +269,70 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
 }
 
 /** A real queue/status payload — guards detection against servers that answer
- *  200 with HTML/junk for unknown GETs (SPA fallbacks, index catchalls). */
+ *  200 with HTML/junk for unknown GETs (SPA fallbacks, index catchalls). Accepts
+ *  any of the queue-count fields the Manager reports: `total_count`/`is_processing`
+ *  (both generations) plus `pending_count` (the v4-style field, issue #555) — so a
+ *  v4 status shape is recognized authoritatively rather than falling through to a
+ *  legacy conclusion. HTML/SPA bodies carry none of these, so they still fail. */
 function looksLikeQueueStatus(s: unknown): boolean {
+  if (!s || typeof s !== "object") return false;
+  const q = s as QueueStatus;
   return (
-    !!s &&
-    typeof s === "object" &&
-    (typeof (s as QueueStatus).total_count === "number" ||
-      typeof (s as QueueStatus).is_processing === "boolean")
+    typeof q.total_count === "number" ||
+    typeof q.is_processing === "boolean" ||
+    typeof q.pending_count === "number" ||
+    typeof q.done_count === "number"
   );
+}
+
+/**
+ * Authoritative Manager MAJOR-version probe (issue #555). The two Manager
+ * generations expose their version string on DISJOINT paths and nowhere else:
+ *   • v4 (pip comfyui-manager) → GET /v2/manager/version   → text "V4.2.2"
+ *   • released 3.x             → GET /manager/version      → text "V3.41"
+ * (v4 registers NO bare /manager/version; 3.x registers NO /v2/* — verified
+ * against both upstream sources.) Both return a BARE version string, so this is
+ * an authoritative version signal that a 405/route-shape is NOT: a 405 means
+ * "wrong method for THIS endpoint", never "old Manager". Returns the major int,
+ * or undefined when neither answers with a plausible version string.
+ *
+ * The parse is deliberately strict (short, `V?<digits>.<digits>…`) so ComfyUI's
+ * SPA catchall — which 200s unknown GETs with a page of HTML — can never be
+ * mistaken for a version string.
+ */
+function parseManagerMajor(raw: unknown): number | undefined {
+  if (typeof raw !== "string") return undefined;
+  const t = raw.trim();
+  if (t.length === 0 || t.length > 16) return undefined; // reject HTML/SPA bodies
+  const m = t.match(/^v?(\d+)(?:\.\d+)*$/i);
+  return m ? Number(m[1]) : undefined;
+}
+
+async function probeManagerMajor(): Promise<number | undefined> {
+  // v4's /v2/manager/version is the strongest signal; check it first.
+  const v4 = parseManagerMajor(
+    await managerFetch<string>("/v2/manager/version", { soft: true }),
+  );
+  if (v4 !== undefined) return v4;
+  return parseManagerMajor(
+    await managerFetch<string>("/manager/version", { soft: true }),
+  );
+}
+
+/**
+ * Given that the /v2 queue surface answered, decide between the two pip-Manager
+ * (v4) dialects. Both normal-v4 and legacy-UI mode register
+ * GET /v2/manager/is_legacy_manager_ui and answer truthfully; a missing route
+ * (older pip) means the normal v4 server → unified task dialect.
+ */
+async function resolveV2SubDialect(): Promise<ManagerApi> {
+  const legacyUi = await managerFetch<{ is_legacy_manager_ui?: boolean }>(
+    "/v2/manager/is_legacy_manager_ui",
+    { soft: true },
+  );
+  return legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
+    ? "v2-batch"
+    : "v2";
 }
 
 async function detectManagerApi(): Promise<ManagerApi> {
@@ -232,23 +340,36 @@ async function detectManagerApi(): Promise<ManagerApi> {
   if (managerApiCache?.base === base) return managerApiCache.api;
   const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { soft: true });
   if (looksLikeQueueStatus(v2)) {
-    // Same /v2 surface, two servers: the pip package in legacy-UI mode swaps
-    // in its bundled 3.x server (no task route). Both register
-    // GET /v2/manager/is_legacy_manager_ui and answer truthfully; a missing
-    // route (older pip) means the normal v4 server → task dialect.
-    const legacyUi = await managerFetch<{ is_legacy_manager_ui?: boolean }>(
-      "/v2/manager/is_legacy_manager_ui",
-      { soft: true },
-    );
-    const api: ManagerApi =
-      legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
-        ? "v2-batch"
-        : "v2";
+    const api = await resolveV2SubDialect();
     managerApiCache = { base, api };
     return api;
   }
   const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { soft: true });
   if (looksLikeQueueStatus(legacy)) {
+    // /manager/queue/status answering ALMOST always means the released 3.x
+    // custom-node Manager — but do NOT brand it "legacy 3.x" (and speak 3.x
+    // grammar, and tell the user to upgrade) on the route shape alone (#555). A
+    // v4 host reached only through a proxy/back-compat shim could also answer
+    // here; CONFIRM the generation with the authoritative version string first.
+    // A 405/route-shape is NEVER the version signal — /v2/manager/version ("V4.x")
+    // vs /manager/version ("V3.x") is.
+    const major = await probeManagerMajor();
+    if (major !== undefined && major >= 4) {
+      // Version says v4 — but only speak v4 if its queue surface ACTUALLY
+      // validates now (re-probe): routing to v2 when /v2/manager/queue/status is
+      // unreachable would enqueue work we then can't poll → a false timeout and a
+      // duplicate on retry (codex review). If the v4 surface still doesn't answer,
+      // keep the proven, WORKING legacy classification (we hold a validated
+      // /manager queue endpoint) rather than route to a dead v4 surface.
+      const v2Retry = await managerFetch<QueueStatus>("/v2/manager/queue/status", {
+        soft: true,
+      });
+      if (looksLikeQueueStatus(v2Retry)) {
+        const api = await resolveV2SubDialect();
+        managerApiCache = { base, api };
+        return api;
+      }
+    }
     managerApiCache = { base, api: "legacy" };
     return "legacy";
   }
@@ -271,9 +392,12 @@ async function managerQueuePrefix(): Promise<string> {
 const MANAGER_UPGRADE_HINT =
   "NOTE: this ComfyUI runs the LEGACY ComfyUI-Manager 3.x. comfyui-mcp is optimized " +
   "for Manager v4+ — on 3.x some operations degrade or are unavailable (notably " +
-  "arbitrary-URL model downloads, which 3.x whitelist-gates). Recommend upgrading: " +
-  "`pip install -U comfyui_manager` in the ComfyUI python env, then disable the old " +
-  "custom_nodes/ComfyUI-Manager clone and restart. " +
+  "arbitrary-URL model downloads, which 3.x whitelist-gates). RECOVERY — migrate to " +
+  "Manager v4 (one time, on the ComfyUI host): " +
+  "1) in ComfyUI's python env run `pip install -U comfyui_manager`; " +
+  "2) disable the old custom_nodes/ComfyUI-Manager clone so it no longer shadows the " +
+  "pip package (rename it to ComfyUI-Manager.disabled, or delete it); " +
+  "3) restart ComfyUI with --enable-manager, then retry the operation. " +
   "See https://comfyui-mcp.artokun.io/docs/troubleshooting";
 
 /** Appended to v2-batch (pip Manager in legacy-UI mode) failures. */
@@ -405,8 +529,10 @@ export function setQueueTimingForTests(
 async function runManagerQueue(): Promise<QueueStatus> {
   const prefix = await managerQueuePrefix();
   // queue/start returns 200 (worker started) or 201 (already running) — both
-  // are 2xx, so managerFetch accepts either. Same on both generations.
-  await managerFetch(`${prefix}/start`, { method: "POST" });
+  // are 2xx, so managerFetch accepts either. Same on both generations. Some
+  // legacy 3.x builds expose start as GET-only, so negotiate POST→GET on a 405
+  // (#551) rather than failing the queue on a method mismatch.
+  await managerQueueControl(`${prefix}/start`);
 
   const start = Date.now();
   let lastStatus: QueueStatus | undefined;

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -195,7 +195,24 @@ export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
       await managerFetch("/manager/queue/reset", { method: "POST" });
     },
     startQueue: async () => {
-      await managerFetch("/manager/queue/start", { method: "POST" });
+      // Some legacy Manager 3.x builds expose /manager/queue/start as GET-only,
+      // returning HTTP 405 to our POST (#551). A 405 on a Manager route is a
+      // METHOD mismatch for this endpoint, not an unreachable Manager — retry the
+      // same path with GET before failing so GET-only builds still start. Guard
+      // the GET against ComfyUI's frontend catchall, which 200s an UNREGISTERED
+      // GET with a page of HTML: that HTML is NOT a real queue start (codex
+      // review), so treat it as the route not accepting our request.
+      try {
+        await managerFetch("/manager/queue/start", { method: "POST" });
+      } catch (err) {
+        if (err instanceof ComfyUIError && (err.details as { status?: number } | undefined)?.status === 405) {
+          const res = await managerFetch("/manager/queue/start", { method: "GET" });
+          const body = await res.text().catch(() => "");
+          if (/^\s*<(?:!doctype\b|html\b|!--)/i.test(body)) throw err;
+          return;
+        }
+        throw err;
+      }
     },
     queueStatus: async () => {
       const res = await managerFetch("/manager/queue/status");


### PR DESCRIPTION
## Summary

The ComfyUI-Manager HTTP dialect handling used a **405 as a version signal** and assumed queue-control routes are always POST. That produced three field bugs across `download_model` / `apply_manifest` against different Manager versions.

Authoritative Manager route facts were re-verified against ComfyUI-Manager source (released tags `4.0.3` & `4.2.2`, `manager-v4` HEAD, and legacy 3.x `main`): v4 is strictly `/v2/manager/*` (no bare aliases); v4 `/v2/manager/queue/status` carries `total_count/done_count/in_progress_count/pending_count/is_processing`; the version string lives only at `/v2/manager/version` (`"V4.x"`) vs `/manager/version` (`"V3.x"`); v4 model install works via **both** `POST /v2/manager/queue/task {kind:"install-model"}` and the `/v2/manager/queue/install_model` alias; and ComfyUI's frontend catchall makes any unregistered GET → 200 HTML and any unregistered POST → 405. **So a 405 on a Manager route means "wrong method/route for THIS server", never "older Manager".**

## Bugs fixed

- **#551** — some legacy Manager 3.x builds expose `/manager/queue/start` as **GET-only**, so our POST got HTTP 405 and the queue never started (`apply_manifest`/node installs failed at start; `panel_search_nodes` then reported Manager unreachable).
- **#555** — a Manager v4 host could be branded "legacy 3.x" from a `/manager/queue/status` hit alone, then POST the bare per-op model route and read the resulting 405 as "you're on 3.x".
- **#553** — on genuine 3.x, arbitrary-URL model installs are whitelist-gated and failed with an opaque wall instead of an actionable v3→v4 recovery.

## Changes (`src/services/node-management.ts`, `src/services/workflow-deps.ts`)

- **Method negotiation (#551):** `managerQueueControl()` POSTs `queue/start` and, *only* on a 405, retries the SAME path with GET — guarded so the SPA catchall (unregistered GET → 200 HTML) is never mistaken for a real GET-only start. `workflow-deps` `startQueue()` gets the same negotiation. Non-405 errors and non-2xx GETs propagate unchanged.
- **Authoritative detection (#555):** `looksLikeQueueStatus()` now recognizes the v4-style queue-status shape (`pending_count`/`done_count`). Before concluding "legacy 3.x" from a `/manager/queue/status` hit, detection consults the authoritative version string (`/v2/manager/version` vs `/manager/version`) — a 405/route shape is never the version signal. The version guard only reclassifies to v4 after **re-confirming the v4 queue surface validates**, so it never routes a mutation to an unreachable `/v2` surface. The correct v4 model route (`kind="install-model"` on `/v2/manager/queue/task`) is unchanged.
- **Actionable recovery (#553):** `MANAGER_UPGRADE_HINT` is now a precise, numbered v3→v4 migration (`pip install -U comfyui_manager` → disable the old `custom_nodes/ComfyUI-Manager` clone → restart with `--enable-manager` → retry).

## Tests

9 new cases in `src/__tests__/services/node-management.test.ts`: GET-only start negotiation, non-405 pass-through, the HTML-catchall guard, v4 shape/version detection + the v4-surface-revalidate guard, genuine-3.x classification, the correct v4 model route with no false "legacy" message, and the numbered v3→v4 recovery text. Full suite green except one pre-existing, environment-dependent `node-dev` search-engine test (ripgrep present on the runner), unrelated to this change.

Reviewed via an independent adversarial codex pass (gpt-5.6-terra/high): two findings (a version-only fallback that could enqueue-then-timeout; the GET retry accepting a catchall page) were fixed and the re-review returned **PASS**.

Closes #551
Closes #553
Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)
