### PR TITLE
fix(session): repair tab-id migration staleness + interrupt-storm wedge (#568) + stable resume key for unsaved workflows (#570)

### DIFF
--- a/src/__tests__/orchestrator/interrupt-storm.test.ts
+++ b/src/__tests__/orchestrator/interrupt-storm.test.ts
@@ -1,0 +1,137 @@
+// #568 Defect 2 — an interrupt STORM must not starve the turn-gate release
+// fallback. When the SDK is wedged (an interrupt produces NO terminal result), the
+// gate is held by the aborted turn and only the bounded fallback can force it open.
+// The OLD fallback did clearTimeout + re-arm on EVERY interrupt, so a stream of
+// "send now" landing closer together than the window kept cancelling the pending
+// net before it could fire — the gate stayed shut and NO turn ever started again
+// ("Interrupted." with PENDING messages nothing flushes). The fix coalesces
+// (keeps the earliest deadline) so the net set by the FIRST interrupt of a burst is
+// an absolute ceiling, and fires on the live gate condition.
+
+// Shrink the window so the test is fast. Read at module import, so set it BEFORE
+// the dynamic import below.
+process.env.COMFYUI_MCP_INTERRUPT_RELEASE_MS = "150";
+
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A WEDGED backend: each turn hangs, and an interrupt breaks the hang (so the
+ *  for-await returns to pull the next batch) but emits NO terminal result — exactly
+ *  the wedge in the report, where completeTurn never fires and only the release
+ *  fallback can reopen the gate. */
+class WedgedBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: string[] = [];
+  interrupted = 0;
+  private breakTurn: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-wedge" };
+    for await (const turn of opts.channel) {
+      this.turns.push(turn.text);
+      await new Promise<void>((resolve) => {
+        this.breakTurn = resolve;
+      });
+      this.breakTurn = null;
+      // Deliberately NO result event — the SDK is wedged. The gate can only be
+      // reopened by the interrupt release fallback.
+    }
+  }
+
+  async interrupt(): Promise<void> {
+    this.interrupted += 1;
+    const brk = this.breakTurn;
+    this.breakTurn = null;
+    brk?.();
+  }
+
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+function makeDeps() {
+  return {
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-test",
+    onSay: () => {},
+    onTurn: () => {},
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("interrupt storm does not starve the release fallback (#568 Defect 2)", () => {
+  it("a turn still starts even under CONTINUOUS send-now interrupts spaced under the window", async () => {
+    const backend = new WedgedBackend();
+    const agent = new PanelAgent("tab-storm", makeDeps() as never, backend);
+    void agent.start();
+
+    // Turn 1 is in flight (hung — no result will ever come from this wedged turn).
+    agent.send("first (the wedged turn)");
+    await waitFor(() => backend.turns.length === 1);
+
+    // A queued follow-up that the user is trying to get answered.
+    agent.send("second (must eventually run)");
+
+    // The storm: hammer "send now" every 50ms — FASTER than the 150ms window. With
+    // the old cancel-and-re-arm, this stream keeps postponing the net indefinitely;
+    // it must NOT here. The interval keeps running across the assertion window on
+    // purpose — the release must fire WHILE interrupts are still arriving.
+    const storm = setInterval(() => {
+      void agent.interrupt({ requeueInFlight: true });
+    }, 50);
+
+    try {
+      // Despite the ongoing storm, a NEW turn must start within a bounded time
+      // (window + margin). With the old code this never happens while the interval
+      // runs, so this waitFor would time out.
+      await waitFor(() => backend.turns.length >= 2, 1200);
+    } finally {
+      clearInterval(storm);
+    }
+
+    expect(backend.turns.length).toBeGreaterThanOrEqual(2);
+    // The queued follow-up was addressed (not stranded as a PENDING message).
+    expect(backend.turns.join("\n\n")).toContain("second (must eventually run)");
+
+    await agent.stop();
+  });
+
+  it("a single interrupt whose result never arrives still releases the gate (baseline)", async () => {
+    const backend = new WedgedBackend();
+    const agent = new PanelAgent("tab-single", makeDeps() as never, backend);
+    void agent.start();
+
+    agent.send("wedged first");
+    await waitFor(() => backend.turns.length === 1);
+    agent.send("the follow-up");
+
+    // One interrupt, no further storm — the fallback fires ~window later.
+    await agent.interrupt({ requeueInFlight: true });
+    await waitFor(() => backend.turns.length >= 2, 1000);
+    expect(backend.turns.join("\n\n")).toContain("the follow-up");
+
+    await agent.stop();
+  });
+});

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -6,7 +6,7 @@
 // brand-new orchestrator process reading what the previous one persisted.
 
 import { describe, expect, it, afterEach } from "vitest";
-import { rmSync, writeFileSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../../orchestrator/session-store.js";
@@ -78,5 +78,127 @@ describe("SessionStore", () => {
         /* ignore */
       }
     }
+  });
+
+  it("reads a LEGACY flat file (Record<string,string>) and keeps resuming (#570 migration)", () => {
+    // A pre-#570 store on disk is a flat {tabId: sessionId} map. The new reader must
+    // migrate it in place so an upgrade never forgets a live session.
+    writeFileSync(FILE, JSON.stringify({ "wf:x::claude": "sess-legacy" }));
+    const store = new SessionStore(PORT);
+    expect(store.get("wf:x::claude")).toBe("sess-legacy");
+    // And a subsequent write persists the v2 structured format without losing it.
+    store.set("wf:y::claude", "sess-new");
+    const restarted = new SessionStore(PORT);
+    expect(restarted.get("wf:x::claude")).toBe("sess-legacy");
+    expect(restarted.get("wf:y::claude")).toBe("sess-new");
+  });
+
+  describe("stable resume key — unsaved workflows survive a reload (#570)", () => {
+    it("resumes by stable key when the ephemeral tab id changed", () => {
+      const first = new SessionStore(PORT);
+      // The unsaved tab's session, recorded under BOTH the (ephemeral) tab id and a
+      // STABLE key (origin+title+backend).
+      first.set("tmp:old-uuid::claude", "sess-unsaved");
+      first.setStable("tmp::http://127.0.0.1:8188::Unsaved Workflow (6)::claude", "sess-unsaved");
+
+      // Orchestrator restart + panel reload: the tab returns under a NEW tmp id, so
+      // the exact-tab lookup misses — but the stable key still hits.
+      const restarted = new SessionStore(PORT);
+      expect(restarted.get("tmp:new-uuid::claude")).toBeUndefined();
+      expect(
+        restarted.getStable("tmp::http://127.0.0.1:8188::Unsaved Workflow (6)::claude"),
+      ).toBe("sess-unsaved");
+    });
+
+    it("clearStable forgets the stable session (a deliberate NEW chat)", () => {
+      const store = new SessionStore(PORT);
+      store.setStable("skey", "sess-1");
+      store.clearStable("skey");
+      expect(store.getStable("skey")).toBeUndefined();
+      expect(new SessionStore(PORT).getStable("skey")).toBeUndefined();
+    });
+
+    it("SAME owner writing a new session (rewind/fork) is not a collision", () => {
+      const store = new SessionStore(PORT);
+      store.setStable("skey", "sess-1", "tmp:tabA");
+      store.setStable("skey", "sess-2", "tmp:tabA"); // same tab, forked session
+      expect(store.getStable("skey")).toBe("sess-2");
+    });
+
+    it("a reloaded tab writing the SAME session under a new owner just refreshes", () => {
+      const store = new SessionStore(PORT);
+      store.setStable("skey", "sess-1", "tmp:tabA");
+      store.setStable("skey", "sess-1", "tmp:tabA-reloaded"); // new tmp id, resumed session
+      expect(store.getStable("skey")).toBe("sess-1");
+    });
+
+    it("POISONS a title-collision so a sibling can't resume the wrong conversation", () => {
+      const store = new SessionStore(PORT);
+      // Two different unsaved tabs, same title -> same stable key, distinct sessions.
+      store.setStable("skey", "sess-A", "tmp:tabA");
+      store.setStable("skey", "sess-B", "tmp:tabB"); // collision
+      // Neither may resume it now — degrade to fresh, never resume the wrong one.
+      expect(store.getStable("skey")).toBeUndefined();
+      // Poison is durable and sticky (a later write doesn't un-poison it).
+      store.setStable("skey", "sess-C", "tmp:tabC");
+      expect(store.getStable("skey")).toBeUndefined();
+      expect(new SessionStore(PORT).getStable("skey")).toBeUndefined();
+      // Only an explicit NEW chat (clearStable) revives the key.
+      store.clearStable("skey");
+      store.setStable("skey", "sess-D", "tmp:tabD");
+      expect(store.getStable("skey")).toBe("sess-D");
+    });
+  });
+
+  it("clamps a corrupt FUTURE timestamp AND persists the clamp so it can't be immortal (#570 P3)", () => {
+    writeFileSync(
+      FILE,
+      JSON.stringify({
+        v: 2,
+        sessions: { "wf:x::claude": { s: "sess-future", t: 1e100 } },
+        stable: {},
+      }),
+    );
+    // Load clamps 1e100 → now AND re-flushes, so disk no longer holds the immortal
+    // value (otherwise every reload just re-clamps it and it never ages out).
+    const store = new SessionStore(PORT);
+    expect(store.get("wf:x::claude")).toBe("sess-future");
+    const onDisk = JSON.parse(readFileSync(FILE, "utf8")) as {
+      sessions: Record<string, { t: number }>;
+    };
+    const t = onDisk.sessions["wf:x::claude"].t;
+    expect(Number.isFinite(t)).toBe(true);
+    expect(t).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("garbage-collects entries older than the TTL on load (#570 unbounded growth)", () => {
+    // Hand-craft a v2 file with one FRESH and one ANCIENT entry in each index.
+    const old = Date.now() - (SessionStore.GC_TTL_MS + 60_000);
+    const fresh = Date.now();
+    writeFileSync(
+      FILE,
+      JSON.stringify({
+        v: 2,
+        sessions: {
+          "e2e-stale::claude": { s: "sess-old", t: old },
+          "wf:live::claude": { s: "sess-live", t: fresh },
+        },
+        stable: {
+          "spike-stale": { s: "sess-old2", t: old },
+          "tmp::o::T::claude": { s: "sess-live2", t: fresh },
+        },
+      }),
+    );
+    const store = new SessionStore(PORT);
+    // Stale keys pruned; live keys kept.
+    expect(store.get("e2e-stale::claude")).toBeUndefined();
+    expect(store.get("wf:live::claude")).toBe("sess-live");
+    expect(store.getStable("spike-stale")).toBeUndefined();
+    expect(store.getStable("tmp::o::T::claude")).toBe("sess-live2");
+    // The prune is durable — a re-read of the just-written file has dropped them.
+    store.set("wf:another::claude", "x"); // forces a flush
+    const restarted = new SessionStore(PORT);
+    expect(restarted.get("e2e-stale::claude")).toBeUndefined();
+    expect(restarted.getStable("spike-stale")).toBeUndefined();
   });
 });

--- a/src/__tests__/orchestrator/tab-id-migration-staleness.test.ts
+++ b/src/__tests__/orchestrator/tab-id-migration-staleness.test.ts
@@ -1,0 +1,162 @@
+// #568 Defect 1 — a panel tab-id migration must move the agent's OWN identity, not
+// just re-file it under a new manager-map key. rebindAgent() re-keys this.agents,
+// but the PanelAgent also carries its own `tabId`: every callback (onTurn/onSay/
+// onSeen/onSession → sessionStore) fires with it, and the bound panel MCP server
+// resolves panel_* against it. Left stale, the agent keeps addressing the DEAD
+// pre-migration tab — the log shows the old id forever, panel_* throws "no connected
+// tab", and the session persists under an orphaned key. These pin that the field
+// (and the panel-server binding) move with the tab.
+
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import { SessionStore } from "../../orchestrator/session-store.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgentManager, PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+const PORT = 59231;
+const FILE = join(tmpdir(), `comfyui-mcp-panel-sessions-${PORT}.json`);
+afterEach(() => {
+  try {
+    rmSync(FILE);
+  } catch {
+    /* already gone */
+  }
+});
+
+/** Emits a fresh session at the START of every turn (like a real resume/restart),
+ *  so onSession fires again after a rebind — the proof that persistence follows the
+ *  new key. Records the turns and the mids it dequeued. */
+class SessioningBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turnTexts: string[] = [];
+  sessionId = "sess-migrate";
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    for await (const turn of opts.channel) {
+      yield { type: "session", sessionId: this.sessionId };
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("tab-id migration moves the agent's own identity (#568 Defect 1)", () => {
+  it("after rebind, callbacks fire under the NEW key and the session persists under it", async () => {
+    const backend = new SessioningBackend();
+    const store = new SessionStore(PORT);
+    const seen: Array<{ tab: string; mid: string }> = [];
+    const sessions: Array<{ tab: string; sid: string }> = [];
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSeen: (tab: string, mid: string) => seen.push({ tab, mid }),
+      onSession: (tab: string, sid: string) => sessions.push({ tab, sid }),
+      sessionStore: store,
+      makeBackend: () => backend,
+    } as never);
+
+    const oldKey = "tmp:69c6-old::claude";
+    const newKey = "tmp:7ca3-new::claude";
+
+    // A turn under the OLD key — callbacks + persistence land under it.
+    manager.send(oldKey, "before migration", { mid: "mid-1" });
+    await waitFor(() => backend.turnTexts.length === 1);
+    expect(seen.find((s) => s.mid === "mid-1")?.tab).toBe(oldKey);
+    expect(store.get(oldKey)).toBe("sess-migrate");
+
+    // Panel tab-id migration.
+    expect(manager.rebindAgent(oldKey, newKey)).toBe(true);
+    expect(manager.hasLiveAgent(newKey)).toBe(true);
+    // The durable session moved with the tab (rebindAgent's moveDurable).
+    expect(store.get(newKey)).toBe("sess-migrate");
+    expect(store.get(oldKey)).toBeUndefined();
+
+    // A turn under the NEW key: the live agent (same instance) must now report the
+    // NEW key. Before the fix this.tabId was still oldKey, so onSeen/onSession fired
+    // with the pre-migration id and the session re-persisted under a dead key.
+    manager.send(newKey, "after migration", { mid: "mid-2" });
+    await waitFor(() => backend.turnTexts.length === 2);
+    expect(seen.find((s) => s.mid === "mid-2")?.tab).toBe(newKey);
+    // onSession (new session frame this turn) reported the NEW key…
+    expect(sessions.some((s) => s.tab === newKey)).toBe(true);
+    // …and NOT re-created a stale entry under the old key.
+    expect(store.get(oldKey)).toBeUndefined();
+    expect(store.get(newKey)).toBe("sess-migrate");
+
+    await manager.stopAll();
+  });
+
+  it("rebind re-points the bound panel MCP server so panel_* stops addressing the dead id", async () => {
+    const backend = new SessioningBackend();
+    const rebinds: string[] = [];
+    // A stand-in panel server exposing the rebindTab hook createPanelMcpServer adds.
+    const panelServer = {
+      type: "sdk",
+      name: "comfyui-panel",
+      instance: {},
+      rebindTab: (t: string) => rebinds.push(t),
+    };
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      makeBackend: () => backend,
+      makePanelServer: () => panelServer,
+    } as never);
+
+    const oldKey = "tmp:aaaa-old::claude";
+    const newKey = "wf:bbbb-new::claude";
+    manager.send(oldKey, "spawn under old");
+    await waitFor(() => backend.turnTexts.length === 1);
+
+    expect(manager.rebindAgent(oldKey, newKey)).toBe(true);
+    // The panel server was re-pointed at the BARE panel tab id (no ::backend).
+    expect(rebinds).toEqual(["wf:bbbb-new"]);
+
+    await manager.stopAll();
+  });
+
+  it("PanelAgent.rebindTabId updates the field even with no panel server bound", () => {
+    const agent = new PanelAgent(
+      "tmp:x::claude",
+      { mcpServers: {}, systemAppend: "", model: "m", onSay: () => {}, onTurn: () => {} } as never,
+      { id: "claude", capabilities: CLAUDE_CAPABILITIES } as never,
+    );
+    expect(agent.tabId).toBe("tmp:x::claude");
+    agent.rebindTabId("tmp:y::claude", "tmp:y");
+    expect(agent.tabId).toBe("tmp:y::claude");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1371,6 +1371,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // race) can label itself correctly instead of showing the pre-init default.
   const resolvedModelByTab = new Map<string, string>();
   const headlessTabs = new Set<string>(); // tabs with no ComfyUI canvas (mobile/remote) — deliver renders in-turn
+  // #570: for an UNSAVED workflow the panel tab id is an ephemeral tmp:<uuid>,
+  // regenerated on every reload, so the tab-keyed session store can't survive an
+  // orchestrator restart that also reloads the panel. Map each such tab to a STABLE
+  // resume key (origin + title + backend) computed at hello, so onSession can also
+  // persist under it and a reloaded tab can resume it. tmp: tabs only.
+  const tabStableKey = new Map<string, string>();
   const workflowTargets = new WorkflowTargetStore();
   // Monotonic per-tab sequence for set_workflow_target events. A pinned target is
   // validated asynchronously (resolvePinTarget queries workflow_list), so a later event
@@ -1894,6 +1900,11 @@ export async function runPanelOrchestrator(): Promise<void> {
     // Report the SDK session id so the panel can persist it and resume on reload.
     onSession: (key, sessionId, model) => {
       const panelTab = panelTabOf(key);
+      // #570: also persist under the tab's STABLE resume key (unsaved workflows),
+      // so a panel reload that regenerates the tmp:<uuid> can still resume this
+      // conversation. The manager already persisted under the exact tab key.
+      const skey = tabStableKey.get(panelTab);
+      if (skey) sessionStore.setStable(skey, sessionId, panelTab);
       bridge.push({ type: "session", session_id: sessionId }, panelTab);
       bridge.broadcastTabList(); // a session started/changed → refresh mirror pickers
       // #376: the ready banner was sent at hello with the PRE-init default model.
@@ -2491,6 +2502,7 @@ export async function runPanelOrchestrator(): Promise<void> {
         // pin can no longer write a stale target / emit a late ack that the bridge's
         // migration map would deliver to the new tab (codex race, tab-id migration edge).
         workflowTargetSeq.delete(migratedFrom);
+        tabStableKey.delete(migratedFrom); // recomputed for the new id below (#570)
       }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live
@@ -2534,6 +2546,53 @@ export async function runPanelOrchestrator(): Promise<void> {
       // orchestrator's own store stays authoritative on the actual spawn.
       const resume = typeof event.resume === "string" ? event.resume : undefined;
       if (resume && (!prev || prev === backend)) manager.setResume(key, resume);
+
+      // #570: an UNSAVED workflow's tab id is an ephemeral tmp:<uuid>, regenerated
+      // on every panel reload — so on an orchestrator restart that also reloads the
+      // panel, the tab returns under a never-stored id and forgets everything
+      // (neither our tab-keyed store nor the panel's tab-keyed hello.resume can hit).
+      // Anchor a STABLE resume key on what DOES survive that tab's reload — the
+      // ComfyUI origin + workflow title + backend — and seed it as a fallback.
+      // Saved workflows (wf:<path>) already key stably, so this is tmp:-only.
+      if (panelTab.startsWith("tmp:")) {
+        const origin =
+          (typeof helloUrl === "string" && helloUrl.trim() ? helloUrl.trim() : undefined) ??
+          bridge.tabOrigin(panelTab) ??
+          "";
+        const title = typeof event.title === "string" ? event.title : "";
+        const skey = `tmp::${origin}::${title}::${backend}`;
+        tabStableKey.set(panelTab, skey);
+        // Seed the resume fallback ONLY when the panel supplied none and no live
+        // agent owns the key. spawn() prefers the exact-tab store hit over this
+        // pendingResume, so the precise path is never overridden — this only
+        // rescues the churned tmp: id. setResume() no-ops if a live agent exists.
+        //
+        // COLLISION GUARD: origin+title+backend is NOT unique — two unsaved tabs
+        // with the same (default) title collide. Seed only when THIS tab is the sole
+        // connected holder of the key, so a fresh sibling tab can never resume
+        // another CONCURRENTLY-live unsaved tab's conversation (the cross-tab hijack
+        // the migration path also refuses; setStable poisons a key the moment two
+        // live tabs write distinct sessions to it). When ambiguous we surface fresh —
+        // a lost resume is a mild miss; resuming the WRONG conversation is not.
+        //
+        // The SEQUENTIAL same-title case (tab A closed, a later tab B opens with the
+        // same origin+title+backend) intentionally resumes A: by the only identity
+        // that survives a reload — the workflow identity the issue itself names as the
+        // key — B *is* the same workspace. This is bounded by the GC TTL (an abandoned
+        // session ages out) and always yields to the exact-tab store and the panel's
+        // own hello.resume. A truly-unique panel per-instance id (referenced in #568/
+        // #570's thread) would let us tighten even this — a clean future upgrade.
+        if (!resume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
+          let sameKeyTabs = 0;
+          for (const t of bridge.tabs()) {
+            if (tabStableKey.get(t.tab_id) === skey) sameKeyTabs += 1;
+          }
+          if (sameKeyTabs <= 1) {
+            const stableSid = sessionStore.getStable(skey);
+            if (stableSid) manager.setResume(key, stableSid);
+          }
+        }
+      }
 
       // Live model list for the picker; SDK slash commands are Claude-only.
       pushModels(panelTab);
@@ -3318,6 +3377,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // reset() is synchronous (map cleared now), so no concurrent send() can
       // spawn an agent before we report the cleared session.
       manager.reset(agentKeyFor(tabId));
+      // reset() clears the exact-tab store; the stable resume index (#570) is the
+      // manager's blind spot, so drop it here too — a deliberate NEW chat must not
+      // be resurrected by the unsaved-workflow fallback on the next reload.
+      const sk = tabStableKey.get(tabId);
+      if (sk) sessionStore.clearStable(sk);
       bridge.push({ type: "session", session_id: null }, tabId);
       bridge.push({ type: "ack", ok: true, kind: "new_session" }, tabId);
       bridge.broadcastTabList(); // session cleared → mirror pickers' green dot off

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -179,7 +179,12 @@ export interface PanelAgentDeps {
  * as user turns; the session never closes until `stop()`.
  */
 export class PanelAgent {
-  readonly tabId: string;
+  /** This agent's own (composite `tabId::backend`) key. MUTABLE only via
+   *  {@link rebindTabId}: a panel tab-id migration re-keys the manager's map, and
+   *  the agent must move WITH it or every `this.tabId` read (callbacks, bridge
+   *  pushes, sessionStore persistence, the bound panel MCP server) keeps addressing
+   *  the DEAD pre-migration tab (#568 Defect 1). */
+  tabId: string;
   private deps: PanelAgentDeps;
   /** The injected provider adapter (Claude today). PanelAgent owns the queue,
    *  turn-gate, rewind tracking and self-restart; the backend owns the SDK call,
@@ -251,6 +256,11 @@ export class PanelAgent {
    *  short fallback that opens the gate anyway if no result ever arrives, so an
    *  interrupt can never stop cold. */
   private interruptReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+  /** The turn number the pending interrupt-release fallback is guarding — the turn
+   *  an interrupt aborted. The fallback force-releases only while THIS turn is still
+   *  the one parked on the gate, so a stale timer can't cut a later, legit turn
+   *  short. Refreshed on every interrupt(). See armInterruptReleaseFallback(). */
+  private interruptGuardTurn = 0;
   /** Mutable so the model/effort picker can change them at runtime. */
   private model: string;
   private effort?: Effort;
@@ -300,6 +310,22 @@ export class PanelAgent {
 
   private short(): string {
     return this.tabId.slice(0, 8);
+  }
+
+  /** Re-point this agent onto a migrated tab id (#568 Defect 1). The manager's
+   *  rebindAgent() re-keys its map, but the agent ALSO carries its own tabId —
+   *  every callback (onTurn/onSay/onSession → sessionStore) fires with it, bridge
+   *  pushes route by it, and the bound panel MCP server resolves `panel_*` against
+   *  it. Left stale, the agent keeps addressing the DEAD pre-migration tab
+   *  (panel_* → "no connected tab"; pushes/persists land under an orphaned id).
+   *  Update the field AND the panel server's bound tab so nothing drifts.
+   *  `panelTabId` is the bare panel id (no ::backend) the panel server binds to. */
+  rebindTabId(newKey: string, panelTabId: string): void {
+    this.tabId = newKey;
+    const server = this.deps.panelServer as
+      | (McpSdkServerConfigWithInstance & { rebindTab?: (t: string) => void })
+      | undefined;
+    server?.rebindTab?.(panelTabId);
   }
 
   /** Queue a panel message and wake the streaming generator (the "channel in").
@@ -529,11 +555,6 @@ export class PanelAgent {
     // The aborted turn's result is EXPECTED (and error-subtyped on the Claude
     // SDK) — don't let the result case report it as a turn failure.
     this.interruptRequested = true;
-    // The turn that's in flight RIGHT NOW — the one we're aborting. Captured
-    // before the await so the release fallback below targets exactly this turn's
-    // gate (not a later one the channel may legitimately advance to if the
-    // aborted turn's result lands during the await).
-    const interruptedTurn = this.yieldedTurns;
     // Re-queue the interrupted turn ONLY for "send now" (requeueInFlight) — there
     // the user wants BOTH the interrupted message and the new one answered. A plain
     // Stop / Ctrl+C / Esc (requeueInFlight=false) must NOT re-queue, or it would
@@ -543,39 +564,57 @@ export class PanelAgent {
       // user sends next (which is appended after this interrupt is handled).
       this.queue.unshift({ text: interrupted.text, images: interrupted.images });
     }
+    // Track the turn this interrupt is aborting (the one holding the gate). The
+    // fallback only force-releases while THIS turn is still the one parked on the
+    // gate, so a stale timer left by an idle/settled interrupt can't cut a LATER,
+    // legit turn short. Updated on every interrupt (a storm keeps it pointed at the
+    // still-stuck turn); the coalesced timer keeps the earliest deadline.
+    this.interruptGuardTurn = this.yieldedTurns;
+    // Arm the fallback BEFORE the await, not in a `finally` after it: if
+    // backend.interrupt() itself hangs, a `finally`-armed net would never start and
+    // the gate would stay parked forever. Armed here, the timer runs regardless;
+    // a result that lands first calls completeTurn → clears it (no premature fire).
+    // Do NOT force the gate open synchronously — that fed the next batch (the
+    // re-queued turn + the "send now" message) into the backend before the aborted
+    // turn had settled, so the SDK took the message but started no turn on it (wedged
+    // until the idle watchdog). Let the aborted turn's `result` drive completeTurn()
+    // at the right moment; the fallback only fires if no result ever arrives.
+    this.armInterruptReleaseFallback();
     try {
       await this.backend.interrupt();
     } catch (err) {
       logger.debug(`[panel-agent ${this.short()}] interrupt: ${msgOf(err)}`);
-    } finally {
-      // Do NOT force the gate open here. Synchronously releasing it fed the next
-      // batch (the re-queued turn + the "send now" message) into Claude before the
-      // aborted turn had settled — the SDK took the message into the session but
-      // started no turn on it, so it sat wedged until the slow idle watchdog (or
-      // the user's next message) nudged it. Instead let the aborted turn's
-      // `result` event drive completeTurn() — that fires once the SDK has finished
-      // tearing the turn down and is ready for the next prompt, so the re-queued
-      // batch is fed at the right moment and answered immediately. The fallback
-      // guarantees we still advance if no result ever arrives.
-      this.armInterruptReleaseFallback(interruptedTurn);
     }
   }
 
   /** Bounded safety net for interrupt(): if the aborted turn's `result` (which
    *  opens the gate via completeTurn) hasn't arrived shortly, force the gate so an
-   *  interrupt can't stop cold. `guardTurn` is the interrupted turn's number —
-   *  we only force-release while THAT turn is still the one the gate waits on, so
-   *  a result that lands during the await (advancing the channel to a new, legit
-   *  in-flight turn) can't be wrongly cut short. Cancelled by completeTurn(). */
-  private armInterruptReleaseFallback(guardTurn: number): void {
-    if (this.interruptReleaseTimer) clearTimeout(this.interruptReleaseTimer);
+   *  interrupt can't stop cold. Cancelled by completeTurn()/releaseTurns().
+   *
+   *  ROBUST TO AN INTERRUPT STORM (#568 Defect 2). The old version did
+   *  `clearTimeout` + re-arm on EVERY interrupt, so a burst of "send now" landing
+   *  closer together than the window kept cancelling the pending net before it
+   *  could ever fire — the gate stayed shut and NO turn started again ("Interrupted."
+   *  with PENDING messages that no send-now flushes). The fix:
+   *   1. COALESCE — if a timer is already armed, keep it. The net set by the FIRST
+   *      interrupt of an unsettled burst is an ABSOLUTE ceiling that later interrupts
+   *      cannot postpone. completeTurn/releaseTurns clear it, so a burst that DOES
+   *      settle (a result lands) re-arms a fresh ceiling on the next interrupt.
+   *   2. GUARD by the tracked interrupted turn (`interruptGuardTurn`), NOT the bare
+   *      live gate. A stale timer left by an idle or already-settled interrupt must
+   *      not fire against a LATER legit turn that merely happens to be parked — only
+   *      release while the turn this interrupt aborted is still the one stuck. The
+   *      guard is refreshed on every interrupt, so a storm keeps it pointed at the
+   *      still-stuck turn while the coalesced deadline holds. */
+  private armInterruptReleaseFallback(): void {
+    if (this.interruptReleaseTimer) return; // coalesce — keep the earliest deadline
     this.interruptReleaseTimer = setTimeout(() => {
       this.interruptReleaseTimer = null;
       if (this.closed) return;
-      // Fire only if the SAME interrupted turn still hasn't completed (no result
-      // arrived). If a result landed, completedTurns has reached guardTurn (and
-      // completeTurn already cleared this timer), so this is a no-op.
-      if (this.completedTurns < guardTurn) {
+      // Fire only if the tracked interrupted turn still hasn't completed. A result
+      // would have called completeTurn → advanced completedTurns AND cleared this
+      // timer, so surviving to fire here means the gate is genuinely stuck on it.
+      if (this.completedTurns < this.interruptGuardTurn) {
         logger.debug(
           `[panel-agent ${this.short()}] interrupt: no result within ${INTERRUPT_RELEASE_FALLBACK_MS}ms — releasing the gate`,
         );
@@ -1624,6 +1663,12 @@ export class PanelAgentManager {
     }
     this.agents.delete(oldKey);
     this.agents.set(newKey, agent);
+    // The live agent must ADOPT the new id, not just be re-filed under it (#568
+    // Defect 1). A panel tab id never contains the "::" backend separator, so the
+    // segment before the LAST "::" is the bare panel tab the panel server binds to.
+    const sep = newKey.lastIndexOf("::");
+    const panelTabId = sep >= 0 ? newKey.slice(0, sep) : newKey;
+    agent.rebindTabId(newKey, panelTabId);
     // has()-based moves throughout (codex review): truthy checks dropped
     // legitimate null/undefined sentinels (e.g. restart-without-nudge, an
     // explicit effort-override clear).

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -4243,11 +4243,19 @@ export function createPanelMcpServer(
   const tools = defs.map((d) =>
     tool(d.name, d.description, d.schema, (args: Record<string, unknown>) => d.handler(args, ctx)),
   ) as unknown as SdkTool[];
-  return createSdkMcpServer({
+  const server = createSdkMcpServer({
     name: "comfyui-panel",
     version: "1.0.0",
     tools,
-  });
+  }) as McpSdkServerConfigWithInstance & { rebindTab?: (newTabId: string) => void };
+  // Re-point this server's bound tab after a panel tab-id migration (#568 Defect
+  // 1). ctx.tabId is read LIVE by every handler (and by call/confirm), so updating
+  // it in place moves ALL panel_* routing onto the migrated tab — no stale id that
+  // makes the tools throw `no connected tab`. PanelAgent.rebindTabId() calls this.
+  server.rebindTab = (newTabId: string) => {
+    ctx.tabId = newTabId;
+  };
+  return server;
 }
 
 /**

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -15,58 +15,236 @@ import { logger } from "../utils/logger.js";
  * the orchestrator's own belt-and-suspenders copy: written when the agent reports
  * its session id, read as the resume fallback when a tab first spawns. Keyed by the
  * bridge port so two ComfyUI instances on one machine never cross-resume.
+ *
+ * TWO indexes (#570):
+ *  - `sessions` — keyed by the exact (composite `tabId::backend`) key. Authoritative
+ *    when the tab id is STABLE across a reload (a SAVED workflow: `wf:<path>`).
+ *  - `stable` — keyed by a caller-supplied identity that survives a panel reload
+ *    even for an UNSAVED workflow, whose tab id is an ephemeral `tmp:<uuid>` that is
+ *    REGENERATED every reload. Without this, an orchestrator restart that also
+ *    reloads the panel brings the tab back under a never-stored `tmp:` id → store
+ *    miss → fresh session → conversation gone. The stable index is the resume
+ *    FALLBACK: `sessions` (exact tab id) always wins when present, so this never
+ *    weakens the precise path — it only rescues the ephemeral one.
+ *
+ * Both indexes carry a write timestamp and are GC'd on load (entries older than
+ * {@link SessionStore.GC_TTL_MS} are dropped), so the file can't grow unbounded with
+ * dead `tmp:`/`e2e-*`/`spike-*` keys from prior runs.
  */
+
+interface Entry {
+  /** SDK session id to resume. */
+  s: string;
+  /** Epoch ms of the last write — for GC. */
+  t: number;
+  /** STABLE index only: the panel tab (owner) that last wrote this key. Used to
+   *  distinguish "the SAME tab's session evolved (rewind/fork)" from "a DIFFERENT
+   *  same-title tab contends for this non-unique key". */
+  o?: string;
+  /** STABLE index only: POISONED — two different tabs wrote two different sessions
+   *  under this (title-collision) key, so it can no longer be trusted to resume
+   *  either. getStable refuses it; only clearStable (a NEW chat) revives the key. */
+  p?: boolean;
+}
+
+interface StoreFileV2 {
+  v: 2;
+  sessions: Record<string, Entry>;
+  stable: Record<string, Entry>;
+}
+
 export class SessionStore {
+  /** Entries untouched for longer than this are pruned on load. Resumes are
+   *  same-day / few-days in practice; three weeks is a generous ceiling that still
+   *  bounds growth (stale test + reloaded-`tmp:` keys never accumulate forever). */
+  static readonly GC_TTL_MS = 21 * 24 * 60 * 60 * 1000;
+
   private readonly path: string;
-  private map: Record<string, string>;
+  private sessions: Record<string, Entry>;
+  private stable: Record<string, Entry>;
 
   constructor(port: number) {
     this.path = join(tmpdir(), `comfyui-mcp-panel-sessions-${port}.json`);
-    this.map = this.read();
+    const loaded = this.read();
+    this.sessions = loaded.sessions;
+    this.stable = loaded.stable;
+    // If load had to SANITIZE the file (migrate the legacy format, GC an expired
+    // entry, clamp a corrupt future timestamp), persist the cleaned version NOW.
+    // Otherwise a clamped-in-memory-only future timestamp survives on disk and is
+    // re-clamped to "now" on every load — immortal, never aging out (#570 P3).
+    if (loaded.dirty) this.flush();
   }
 
-  private read(): Record<string, string> {
+  private now(): number {
+    return Date.now();
+  }
+
+  private read(): { sessions: Record<string, Entry>; stable: Record<string, Entry>; dirty: boolean } {
+    const empty = { sessions: {}, stable: {}, dirty: false };
     try {
       const parsed: unknown = JSON.parse(readFileSync(this.path, "utf8"));
-      if (parsed && typeof parsed === "object") {
-        // Keep only string→string entries — never trust the file blindly.
-        const out: Record<string, string> = {};
-        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-          if (typeof v === "string") out[k] = v;
+      if (!parsed || typeof parsed !== "object") return empty;
+      const obj = parsed as Record<string, unknown>;
+      const cutoff = this.now() - SessionStore.GC_TTL_MS;
+      // `dirty` = the on-disk bytes no longer match what we hold, so the constructor
+      // must re-flush (drop GC'd/malformed rows, persist a clamped timestamp, migrate).
+      let dirty = false;
+      // Coerce an untrusted map into {key -> Entry}, dropping malformed/expired rows.
+      const coerce = (raw: unknown): Record<string, Entry> => {
+        const out: Record<string, Entry> = {};
+        if (raw === undefined) return out; // absent field — canonicalized on next write
+        if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+          dirty = true; // malformed container → rewrite as a canonical {} on load
+          return out;
+        }
+        const nowMs = this.now();
+        for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+          if (!v || typeof v !== "object") {
+            dirty = true;
+            continue;
+          }
+          const e = v as { s?: unknown; t?: unknown; o?: unknown; p?: unknown };
+          if (typeof e.s !== "string") {
+            dirty = true;
+            continue;
+          }
+          // Sanitize the timestamp. A corrupt `1e999` parses as Infinity and would
+          // slip past `t < cutoff` forever (never GC'd, never refreshed); a finite
+          // FUTURE value (e.g. 1e100) likewise never ages out and makes touch() a
+          // no-op. Non-finite → epoch 0 (pruned as too old); future → clamped to now
+          // so the TTL is measured from load like any other entry.
+          const rawT = typeof e.t === "number" && Number.isFinite(e.t) ? e.t : 0;
+          let t = rawT;
+          if (t > nowMs) t = nowMs;
+          if (t !== rawT) dirty = true; // clamp/coerce must be persisted (P3)
+          if (t < cutoff) {
+            dirty = true; // GC drop must be persisted
+            continue;
+          }
+          const entry: Entry = { s: e.s, t };
+          if (typeof e.o === "string") entry.o = e.o;
+          if (e.p === true) entry.p = true;
+          out[k] = entry;
         }
         return out;
+      };
+      if (obj.v === 2) {
+        const sessions = coerce(obj.sessions);
+        const stable = coerce(obj.stable);
+        return { sessions, stable, dirty };
       }
+      // LEGACY flat format (Record<string,string>) — migrate. Stamp `now` so the
+      // migration itself never trips GC (a live install's keys stay resumable).
+      const sessions: Record<string, Entry> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (typeof v === "string") sessions[k] = { s: v, t: this.now() };
+      }
+      return { sessions, stable: {}, dirty: true }; // format upgrade → re-flush as v2
     } catch {
       // Missing or corrupt — start empty. Resume falls back to a fresh session.
     }
-    return {};
+    return empty;
   }
 
   private flush(): void {
     try {
-      writeFileSync(this.path, JSON.stringify(this.map));
+      const payload: StoreFileV2 = { v: 2, sessions: this.sessions, stable: this.stable };
+      writeFileSync(this.path, JSON.stringify(payload));
     } catch (err) {
       logger.debug(`[session-store] write failed: ${String(err)}`);
     }
   }
 
+  /** Touch an entry's timestamp on a resume hit so an actively-used session never
+   *  ages out of the store. GC only ever reclaims a key that hasn't been RESUMED
+   *  (spawned) within the TTL — i.e. a genuinely idle tab. Debounced (1h) so the
+   *  per-spawn read doesn't churn the disk. */
+  private touch(map: Record<string, Entry>, key: string): void {
+    const e = map[key];
+    if (!e) return;
+    const now = this.now();
+    if (now - e.t < 60 * 60 * 1000) return;
+    e.t = now;
+    this.flush();
+  }
+
   /** The persisted session id to resume for a tab, if any. */
   get(tabId: string): string | undefined {
-    return this.map[tabId];
+    const s = this.sessions[tabId]?.s;
+    if (s !== undefined) this.touch(this.sessions, tabId);
+    return s;
   }
 
   /** Record (and persist) a tab's current session id. No-op if unchanged. */
   set(tabId: string, sessionId: string): void {
-    if (this.map[tabId] === sessionId) return;
-    this.map[tabId] = sessionId;
+    if (this.sessions[tabId]?.s === sessionId) {
+      // Same id — refresh the timestamp so an actively-used session never GCs out,
+      // but skip the disk write when the timestamp is already recent.
+      const existing = this.sessions[tabId];
+      if (existing && this.now() - existing.t < 60 * 60 * 1000) return;
+    }
+    this.sessions[tabId] = { s: sessionId, t: this.now() };
     this.flush();
   }
 
   /** Forget a tab's session — called when the panel starts a NEW chat, so the
    *  disk fallback never resurrects a deliberately-reset conversation. */
   clear(tabId: string): void {
-    if (!(tabId in this.map)) return;
-    delete this.map[tabId];
+    if (!(tabId in this.sessions)) return;
+    delete this.sessions[tabId];
+    this.flush();
+  }
+
+  /** The resume session id for a STABLE identity (survives a panel reload for an
+   *  unsaved workflow), if any. A POISONED key (two tabs contended — see setStable)
+   *  returns undefined, so a collision degrades to a fresh session, never a resume of
+   *  the WRONG conversation. See the class docstring. */
+  getStable(stableKey: string): string | undefined {
+    const e = this.stable[stableKey];
+    if (!e || e.p) return undefined;
+    this.touch(this.stable, stableKey);
+    return e.s;
+  }
+
+  /** Record (and persist) the session id under a STABLE identity, so a reloaded
+   *  unsaved-workflow tab (new `tmp:` id) can still resume it. `owner` is the panel
+   *  tab writing it — the collision discriminator.
+   *
+   *  The stable key (origin+title+backend) is NOT unique: two unsaved tabs with the
+   *  same default title collide. If a DIFFERENT owner writes a DIFFERENT session
+   *  under an existing key, that key is POISONED — neither tab may resume it, so a
+   *  fresh sibling can never inherit the other's conversation. The SAME owner writing
+   *  a new session (a rewind/fork) is NOT a collision; a reloaded tab writing the
+   *  SAME (resumed) session under a new owner just refreshes it. */
+  setStable(stableKey: string, sessionId: string, owner?: string): void {
+    const existing = this.stable[stableKey];
+    if (existing?.p) return; // already poisoned — stays refused until clearStable
+    if (
+      existing &&
+      existing.s !== sessionId &&
+      existing.o !== undefined &&
+      owner !== undefined &&
+      existing.o !== owner
+    ) {
+      // Two different tabs, two different sessions, one non-unique key → poison it.
+      this.stable[stableKey] = { s: "", t: this.now(), p: true };
+      this.flush();
+      return;
+    }
+    if (existing && existing.s === sessionId && existing.o === owner) {
+      // Unchanged — refresh the timestamp (debounced) so an active session doesn't GC.
+      if (this.now() - existing.t < 60 * 60 * 1000) return;
+    }
+    const entry: Entry = { s: sessionId, t: this.now() };
+    if (owner !== undefined) entry.o = owner;
+    this.stable[stableKey] = entry;
+    this.flush();
+  }
+
+  /** Forget a stable identity's session (a deliberate NEW chat on that tab). */
+  clearStable(stableKey: string): void {
+    if (!(stableKey in this.stable)) return;
+    delete this.stable[stableKey];
     this.flush();
   }
 }


### PR DESCRIPTION
## What

A tab-identity/session-continuity cluster: an ephemeral or migrated tab id breaks the binding between a live tab and its persisted session.

### #568 Defect 1 — tab-id migration left `PanelAgent.tabId` stale
`rebindAgent()` re-keyed the manager's `agents` map on a migration but never updated the agent's **own** `tabId`, which every callback (`onTurn`/`onSay`/`onSeen`/`onSession`→`sessionStore`), bridge push, and the bound panel MCP server read. The agent kept addressing the dead pre-migration tab → `panel_*` threw `no connected tab`, and sessions persisted under an orphaned key.

**Fix:** `tabId` is now mutable via `PanelAgent.rebindTabId(newKey, panelTabId)`, called from `rebindAgent`. It updates the field **and** re-points the in-process panel MCP server's `ctx.tabId` (`createPanelMcpServer` now exposes a `rebindTab` hook). Non-Claude backends route the HTTP MCP through the bridge's maintained migration-alias chain (unchanged, not regressed).

### #568 Defect 2 — interrupt storm starved the release fallback → permanent wedge
`armInterruptReleaseFallback` did `clearTimeout` + re-arm on **every** interrupt, so "send now" hammered faster than the 1500ms window kept cancelling the safety net and **no turn ever restarted** (panel stuck on "Interrupted." with PENDING messages).

**Fix:** the fallback now **coalesces** (keeps the earliest deadline — an absolute ceiling from the first interrupt of an unsettled burst), is **armed before** the `backend.interrupt()` await (a hanging RPC still gets a release), and fires guarded by `interruptGuardTurn` (the tracked aborted turn) so a stale timer from an idle/settled interrupt can never cut a later legit turn short.

### #570 — resume keyed by the ephemeral `tmp:<uuid>` → unsaved workflows lost memory on restart
`SessionStore` is keyed by the tab id. For an unsaved workflow that is a `tmp:<uuid>` regenerated on reload, so an orchestrator restart that also reloaded the panel came back under a never-stored id → fresh session, conversation gone.

**Fix:** a **stable secondary index** keyed on `origin + title + backend` (the workflow identity, which survives the reload). `onSession` persists under it; the hello handler seeds it as a resume **fallback** that always yields to the exact-tab store and the panel's own `hello.resume`. Safety:
- A **concurrent** same-title collision is **poisoned** — never resumes the wrong conversation. A same-tab session evolution (rewind/fork) and a reloaded tab writing the same resumed session are correctly *not* collisions.
- The **sequential** same-title case (tab A closed, later tab B same identity) intentionally resumes — by the only identity that survives a reload, B *is* the same workspace; this is documented and bounded by GC + precedence. A unique panel-supplied per-instance id would tighten even this (future upgrade).
- Store file upgraded to a timestamped **v2 format** with **GC** (TTL prune on load, sanitized writes re-flushed, `Infinity`/future-timestamp hardened) + legacy-flat migration — fixing the unbounded-growth defect. Preserves #278/#334/#349 (exact-tab resume still wins).

## Tests
- `tab-id-migration-staleness.test.ts` — after rebind, callbacks/persistence report the NEW key; the bound panel server is re-pointed.
- `interrupt-storm.test.ts` — a turn still starts under continuous send-now interrupts spaced under the window; single-interrupt baseline.
- `session-store.test.ts` (extended) — stable resume across a churned tmp id, poison on collision, GC, legacy migration, future-timestamp clamp persisted.

`npm run build` + `npm test` green (2642 passing; the one unrelated `node-dev` failure is environmental — it expects the `builtin` search engine but ripgrep is installed on the runner).

## Codex self-gate
gpt-5.6-terra / high, 4 rounds — **PASS**. Each round's findings were addressed and re-verified: interrupt fixes hold, tab-id fix confirmed, the idle/hang interrupt regressions and the timestamp-immortality bug fixed, the poison sentinel is correct and sticky; the sequential same-title resume is an accepted, documented tradeoff with no cheaper no-panel-change fix.

Closes #568
Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
