### PR TITLE
fix(panel): context-meter denominator (#543), self-queued backlog warning (#559), DOM-overlay screenshot note (#567)

### DIFF
--- a/src/__tests__/orchestrator/context-window-denominator.test.ts
+++ b/src/__tests__/orchestrator/context-window-denominator.test.ts
@@ -1,0 +1,244 @@
+// Regression tests for the context-meter denominator (#543).
+//
+// BUG: the panel's context-usage ring scored `used / contextWindow`, but
+// contextWindow only ever RATCHETED UP (`ev.contextWindow > this.contextWindow`).
+// Because the model can change mid-session (setModel is live — no restart),
+// switching DOWN to a smaller-window model kept the larger denominator forever,
+// so the meter silently under-reported fill (100k used shown as 10% of a stale
+// 1M window when the true figure was 50% of the current 200k window).
+//
+// FIX: track the LATEST reported window (drop the `>` guard), and CLEAR the cache
+// on a model switch so the outgoing model's window can't score the next turn —
+// reportStatus omits contextPct while the cache is 0 (the panel holds its prior
+// reading) and the next result refreshes it for the incoming model. `used` is
+// still reported throughout.
+//
+// Harness mirrors effort-carry.test.ts: a fake AgentBackend that emits scripted
+// assistant/result events + a PanelAgentManager wired to capture onStatus.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+interface TurnSpec {
+  /** Prompt usage for the assistant event (used = input + cache reads/creates). */
+  usage?: Record<string, number>;
+  /** Window the result event reports; omit to report NO window that turn. */
+  contextWindow?: number;
+}
+
+/** Emits one scripted assistant (+usage) then one result (+contextWindow) per
+ *  incoming turn, in order from `turns`. Records the models setModel() was asked
+ *  to apply. */
+class ScriptedContextBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: TurnSpec[] = [];
+  modelCalls: string[] = [];
+  private i = 0;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-ctx" };
+    for await (const turn of opts.channel) {
+      void turn;
+      const spec = this.turns[this.i++] ?? {};
+      if (spec.usage) yield { type: "assistant", text: "", usage: spec.usage };
+      yield {
+        type: "result",
+        ok: true,
+        subtype: "success",
+        ...(spec.contextWindow != null ? { contextWindow: spec.contextWindow } : {}),
+      };
+    }
+  }
+
+  async interrupt(): Promise<void> {}
+  async setModel(model: string): Promise<void> {
+    this.modelCalls.push(model);
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+/** Like ScriptedContextBackend but HOLDS each turn after the assistant event,
+ *  before the result — so a test can switch models MID-TURN and then release the
+ *  outgoing turn's (old-model) result. */
+class GatedContextBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turns: TurnSpec[] = [];
+  modelCalls: string[] = [];
+  private i = 0;
+  private releaseResult: (() => void) | null = null;
+
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    yield { type: "session", sessionId: "sess-gated" };
+    for await (const turn of opts.channel) {
+      void turn;
+      const spec = this.turns[this.i++] ?? {};
+      if (spec.usage) yield { type: "assistant", text: "", usage: spec.usage };
+      await new Promise<void>((resolve) => {
+        this.releaseResult = resolve;
+      });
+      this.releaseResult = null;
+      yield {
+        type: "result",
+        ok: true,
+        subtype: "success",
+        ...(spec.contextWindow != null ? { contextWindow: spec.contextWindow } : {}),
+      };
+    }
+  }
+
+  releaseTurn(): void {
+    const r = this.releaseResult;
+    this.releaseResult = null;
+    r?.();
+  }
+  async interrupt(): Promise<void> {
+    this.releaseTurn();
+  }
+  async setModel(model: string): Promise<void> {
+    this.modelCalls.push(model);
+  }
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+interface CapturedStatus {
+  used?: number;
+  contextWindow?: number;
+  contextPct?: number;
+  model?: string;
+}
+
+function makeManager(backend: AgentBackend, statuses: CapturedStatus[]) {
+  return new PanelAgentManager({
+    mcpServers: {},
+    systemAppend: "",
+    model: "claude-big", // starting model
+    onSay: () => {},
+    onTurn: () => {},
+    onStatus: (_tab: string, status: CapturedStatus) => {
+      statuses.push({ ...status });
+    },
+    makeBackend: () => backend,
+  } as never);
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("context-meter denominator tracks the CURRENT model's window (#543)", () => {
+  it("a SMALLER window reported later replaces the larger one (no max-ratchet)", async () => {
+    const backend = new ScriptedContextBackend();
+    // Turn 1: a 1M-window model. Turn 2: a 200k-window model, same 100k used.
+    backend.turns = [
+      { usage: { input_tokens: 100_000 }, contextWindow: 1_000_000 },
+      { usage: { input_tokens: 100_000 }, contextWindow: 200_000 },
+    ];
+    const statuses: CapturedStatus[] = [];
+    const manager = makeManager(backend, statuses);
+    const tab = "tab-ratchet";
+
+    manager.send(tab, "turn 1");
+    await waitFor(() => statuses.some((s) => s.contextWindow === 1_000_000));
+
+    manager.send(tab, "turn 2");
+    await waitFor(() => statuses.some((s) => s.contextWindow === 200_000));
+
+    const last = statuses[statuses.length - 1];
+    // The denominator SHRANK with the model — 100k / 200k = 0.5, NOT the stale
+    // 100k / 1M = 0.1 the old max-ratchet would have kept.
+    expect(last.contextWindow).toBe(200_000);
+    expect(last.contextPct).toBeCloseTo(0.5, 6);
+    // The old max-ratchet would have pinned the denominator at 1M forever; the
+    // final reading must reflect the CURRENT (smaller) model, not the largest seen.
+    expect(last.contextWindow).not.toBe(1_000_000);
+  });
+
+  it("a model switch DROPS the outgoing model's window rather than reusing it", async () => {
+    const backend = new ScriptedContextBackend();
+    // Turn 1 establishes a 1M window. Turn 2 (after the switch) reports NO window,
+    // so any denominator that survives can only be the stale cache.
+    backend.turns = [
+      { usage: { input_tokens: 100_000 }, contextWindow: 1_000_000 },
+      { usage: { input_tokens: 100_000 } }, // no window this turn
+    ];
+    const statuses: CapturedStatus[] = [];
+    const manager = makeManager(backend, statuses);
+    const tab = "tab-switch";
+
+    manager.send(tab, "turn 1");
+    await waitFor(() => statuses.some((s) => s.contextWindow === 1_000_000));
+
+    // Switch models live — this must clear the cached window.
+    await manager.setOptions(tab, { model: "claude-small" });
+    expect(backend.modelCalls).toContain("claude-small");
+
+    // Only inspect statuses emitted AFTER the switch.
+    statuses.length = 0;
+    manager.send(tab, "turn 2");
+    await waitFor(() => statuses.some((s) => s.used === 100_000));
+    // Give the result event a beat to also land.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Every post-switch status still reports `used`, but NONE reports a denominator
+    // (the stale 1M is gone and the new model reported none yet).
+    expect(statuses.length).toBeGreaterThan(0);
+    for (const s of statuses) {
+      expect(s.used).toBe(100_000);
+      expect(s.contextWindow).toBeUndefined();
+      expect(s.contextPct).toBeUndefined();
+    }
+  });
+
+  it("a model switched DURING a turn: the outgoing turn's late result does NOT restore the old window", async () => {
+    const backend = new GatedContextBackend();
+    // Turn 1 (on the big model) will report a 1M window — but only AFTER we've
+    // switched to the small model mid-turn. That stale window must be dropped.
+    backend.turns = [{ usage: { input_tokens: 100_000 }, contextWindow: 1_000_000 }];
+    const statuses: CapturedStatus[] = [];
+    const manager = makeManager(backend, statuses);
+    const tab = "tab-midturn";
+
+    manager.send(tab, "turn 1");
+    // Wait until the assistant event has reported usage (turn is now HELD before result).
+    await waitFor(() => statuses.some((s) => s.used === 100_000));
+
+    // Switch models while the (big-model) turn is still in flight.
+    await manager.setOptions(tab, { model: "claude-small" });
+    expect(backend.modelCalls).toContain("claude-small");
+
+    // Only look at what happens AFTER the switch releases the old-model result.
+    statuses.length = 0;
+    backend.releaseTurn();
+    await waitFor(() => statuses.some((s) => s.used === 100_000));
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The late 1M window belonged to the outgoing model — it must NOT become the
+    // small model's denominator.
+    for (const s of statuses) {
+      expect(s.contextWindow).not.toBe(1_000_000);
+      expect(s.contextWindow).toBeUndefined();
+    }
+  });
+});

--- a/src/__tests__/orchestrator/panel-run-backpressure.test.ts
+++ b/src/__tests__/orchestrator/panel-run-backpressure.test.ts
@@ -1,0 +1,208 @@
+// panel_run backpressure note (#559) + panel_screenshot DOM-overlay note (#567).
+//
+// #559: queuing a batch is normal. A queue made of the agent's OWN recent jobs must
+//       be reported NEUTRALLY, never as a "[QUEUE WARNING] … cancel_job
+//       clear_pending:true" that would wipe the whole batch. A job we did NOT queue
+//       still drives a (softened) warning.
+// #567: a canvas screenshot cannot show DOM-overlay widget content (MarkdownNote
+//       renders as an empty body). panel_screenshot must FLAG such nodes so the
+//       agent doesn't read the blank body as missing content.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  domOverlayScreenshotNote,
+  type PanelToolCtx,
+} from "../../orchestrator/panel-tools.js";
+import { QueueMonitor } from "../../services/queue-monitor.js";
+
+type QMPriv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const qm = QueueMonitor as unknown as QMPriv;
+
+function defByName(name: string) {
+  const def = buildPanelToolDefs().find((d) => d.name === name);
+  if (!def) throw new Error(`tool ${name} not found`);
+  return def;
+}
+
+/** A ctx whose graph_run reply is the given JSON object (as text), and whose raw
+ *  bridge.send returns `bridgeReply`. */
+function makeCtx(runReply: Record<string, unknown>, bridgeReply?: unknown): PanelToolCtx {
+  const bridge = {
+    send: async () => bridgeReply ?? {},
+    push: () => 1,
+    canReach: () => true,
+  } as unknown as PanelToolCtx["bridge"];
+  const ctx = makePanelToolCtx(bridge, "test-tab");
+  // Override `call` so panel_run's graph_run gets our scripted reply.
+  (ctx as { call: PanelToolCtx["call"] }).call = async () => ({
+    content: [{ type: "text", text: JSON.stringify(runReply) }],
+  });
+  return ctx;
+}
+
+function firstText(res: { content?: Array<{ type: string; text?: string }> }): string {
+  return res.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+beforeEach(() => {
+  qm.url = "http://127.0.0.1:9999";
+  qm.stopped = false;
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.state.connected = true;
+  qm.state.runningPromptId = null;
+  qm.state.pendingPromptIds = [];
+  qm.state.queueRemaining = 0;
+  qm.state.lastServerAliveTs = Date.now();
+  qm.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  qm.selfQueuedIds.clear();
+  qm.lastSelfQueueTs = null;
+  qm.stopped = true;
+  qm.url = null;
+});
+
+describe("panel_run backpressure note (#559)", () => {
+  it("a batch queued behind the agent's OWN running job → NEUTRAL note, no destructive headline", async () => {
+    // Simulate a prior batch item already running + pending, all ours.
+    QueueMonitor.markSelfQueued("p-batch-1");
+    QueueMonitor.markSelfQueued("p-batch-a");
+    QueueMonitor.markSelfQueued("p-batch-b");
+    qm.state.runningPromptId = "p-batch-1";
+    qm.state.pendingPromptIds = ["p-batch-a", "p-batch-b"];
+    qm.state.queueRemaining = 3; // 1 running + 2 pending, all ours
+
+    const ctx = makeCtx({ queued: true, prompt_id: "p-batch-2" });
+    const res = await defByName("panel_run").handler({}, ctx);
+    const text = firstText(res);
+
+    expect(text).toContain("[QUEUE]");
+    expect(text).toContain("your own");
+    // Must NOT be the old destructive warning, and must NOT lead with clear_pending.
+    expect(text).not.toContain("[QUEUE WARNING]");
+    expect(text).not.toContain("ALREADY RUNNING");
+    // clear_pending is only mentioned as a conditional last resort, never the headline.
+    expect(text).toContain("Only use cancel_job with clear_pending:true if a render is ACTUALLY wedged");
+    // The successful queue registered p-batch-2 for the NEXT run's attribution.
+    expect(qm.selfQueuedIds.has("p-batch-2")).toBe(true);
+  });
+
+  it("a job we did NOT queue running ahead → softened warning that leads with inspection", async () => {
+    qm.state.runningPromptId = "p-foreign";
+    qm.state.queueRemaining = 1; // just the foreign running job
+
+    const ctx = makeCtx({ queued: true, prompt_id: "p-mine" });
+    const res = await defByName("panel_run").handler({}, ctx);
+    const text = firstText(res);
+
+    expect(text).toContain("[QUEUE]");
+    expect(text).toContain("didn't queue");
+    expect(text).toContain("get_queue"); // lead with inspection
+    expect(text).not.toContain("your own");
+  });
+
+  it("nothing running → no backpressure note at all", async () => {
+    qm.state.runningPromptId = null;
+    qm.state.queueRemaining = 0;
+
+    const ctx = makeCtx({ queued: true, prompt_id: "p-solo" });
+    const res = await defByName("panel_run").handler({}, ctx);
+    const text = firstText(res);
+
+    expect(text).not.toContain("[QUEUE]");
+    expect(text).toContain("notified automatically"); // the anti-poll note still appended
+  });
+});
+
+describe("panel_screenshot DOM-overlay note (#567)", () => {
+  it("flags a MarkdownNote in view as content the capture cannot show", async () => {
+    const bridgeReply = (cmd: unknown): unknown => {
+      const c = cmd as { cmd?: string };
+      if (c.cmd === "graph_screenshot") return { image: "iVBORw0KGgo=", mimeType: "image/png" };
+      if (c.cmd === "graph_serialize") {
+        return { nodes: [{ id: 1, type: "MarkdownNote" }, { id: 2, type: "KSampler" }] };
+      }
+      return {};
+    };
+    const bridge = {
+      send: async (cmd: unknown) => bridgeReply(cmd),
+      push: () => 1,
+      canReach: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "test-tab");
+
+    const res = await defByName("panel_screenshot").handler({}, ctx);
+    // The image still comes back…
+    expect(res.content?.[0]?.type).toBe("image");
+    // …plus a text note naming the DOM-overlay node.
+    const note = res.content?.find((c: { type: string }) => c.type === "text")?.text ?? "";
+    expect(note).toContain("MarkdownNote #1");
+    expect(note).toContain("panel_query_graph");
+    expect(note).toContain("EMPTY");
+  });
+
+  it("no DOM-overlay node in view → image only, no note", async () => {
+    const bridge = {
+      send: async (cmd: unknown) => {
+        const c = cmd as { cmd?: string };
+        if (c.cmd === "graph_screenshot") return { image: "iVBORw0KGgo=", mimeType: "image/png" };
+        if (c.cmd === "graph_serialize") return { nodes: [{ id: 1, type: "KSampler" }] };
+        return {};
+      },
+      push: () => 1,
+      canReach: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "test-tab");
+
+    const res = await defByName("panel_screenshot").handler({}, ctx);
+    expect(res.content).toHaveLength(1);
+    expect(res.content?.[0]?.type).toBe("image");
+  });
+
+  it("a failed graph_serialize never breaks the screenshot (note simply omitted)", async () => {
+    const bridge = {
+      send: async (cmd: unknown) => {
+        const c = cmd as { cmd?: string };
+        if (c.cmd === "graph_screenshot") return { image: "iVBORw0KGgo=", mimeType: "image/png" };
+        throw new Error("serialize boom");
+      },
+      push: () => 1,
+      canReach: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "test-tab");
+
+    const res = await defByName("panel_screenshot").handler({}, ctx);
+    expect(res.content?.[0]?.type).toBe("image");
+  });
+});
+
+describe("domOverlayScreenshotNote (pure)", () => {
+  it("is empty when no overlay nodes are present", () => {
+    expect(domOverlayScreenshotNote([])).toBe("");
+  });
+  it("lists every overlay node and gives an id-scoped read hint", () => {
+    const note = domOverlayScreenshotNote([
+      { id: 1, type: "MarkdownNote" },
+      { id: 5, type: "MarkdownNote" },
+    ]);
+    expect(note).toContain("MarkdownNote #1");
+    expect(note).toContain("MarkdownNote #5");
+    expect(note).toContain("ids:[1, 5]");
+  });
+});

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -270,12 +270,17 @@ function formatQueueNote(rep: StallReport): string | null {
       `Do NOT queue another run on top.`
     );
   }
-  if (rep.backlog) {
+  // A plain backlog (depth > 1) is NOT evidence of a wedge — deliberately queuing
+  // a batch is a normal workflow. Suppress the note entirely when the in-flight
+  // work is this session's own recent jobs, and when it isn't, report it NEUTRALLY
+  // (no false "you likely queued behind a stuck job" diagnosis, no destructive
+  // clear_pending as the headline). A genuinely stalled job is handled above (#559).
+  if (rep.backlog && !rep.selfAttributed) {
     const pending = Math.max(0, rep.queueDepth - 1);
     return (
-      `⚠️ ComfyUI queue backlog: ${rep.queueDepth} tasks in flight (1 running + ${pending} pending). ` +
-      `You likely queued behind a slow/stuck job. Check get_queue; use cancel_job with clear_pending:true to ` +
-      `reset before re-queuing rather than stacking another run.`
+      `ℹ️ ComfyUI queue: ${rep.queueDepth} tasks in flight (1 running + ${pending} pending) that this session ` +
+      `didn't queue. This is only a problem if the running one is stuck — inspect with get_queue. ` +
+      `cancel_queued_job drops a single pending item; cancel_job with clear_pending:true resets everything.`
     );
   }
   return null;

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -282,6 +282,12 @@ export class PanelAgent {
   private lastUsage: Record<string, number> | null = null;
   /** Context window for the active model, cached from result.modelUsage. */
   private contextWindow = 0;
+  /** The model the IN-FLIGHT turn was dispatched with. A live setModel can change
+   *  this.model mid-turn (the outgoing turn still runs on the old model), so the
+   *  result event's contextWindow must only be cached when the turn's model still
+   *  matches the current one — otherwise a late old-model result would restore the
+   *  wrong denominator after a switch (#543). */
+  private turnModel: string | null = null;
   /** Last status pushed — re-sent on reconnect so the meter isn't blank. */
   lastStatus: UsageStatus | null = null;
   /** Set true when start()'s bounded self-restart loop GAVE UP (the session kept
@@ -484,6 +490,12 @@ export class PanelAgent {
   async setModel(model: string): Promise<void> {
     if (model === this.model) return;
     this.model = model;
+    // Drop the outgoing model's cached context window (#543). The new model may
+    // have a different (smaller) window; scoring the next turn against the old
+    // denominator would under-report fill. reportStatus omits contextPct while
+    // the cache is 0, so the panel holds its last reading until the next result
+    // event refreshes the window for the incoming model. `used` is still reported.
+    this.contextWindow = 0;
     try {
       // setModel is live: no session restart, the next turn uses it.
       await this.backend.setModel?.(model);
@@ -737,6 +749,9 @@ export class PanelAgent {
       this.errorSurfaced = false; // fresh turn → its failure (if any) is unreported
       this.interruptRequested = false; // a stale interrupt can't mute THIS turn's failure
       this.busy = true;
+      // Snapshot the model this turn runs on, so a live setModel mid-turn can't let
+      // the outgoing turn's result restore the wrong context window (#543).
+      this.turnModel = this.model;
       this.deps.onTurn?.(this.tabId, "working");
       // Arm the freeze watchdog AT DISPATCH: a turn that produces NO events at all
       // (the exact ROOT CAUSE B freeze — turn/start sent, no notifications ever
@@ -1062,8 +1077,14 @@ export class PanelAgent {
       }
       case "result": {
         // Cache the context window + cost from the result, then re-report using
-        // the last assistant usage (the true current context).
-        if (ev.contextWindow && ev.contextWindow > this.contextWindow) {
+        // the last assistant usage (the true current context). Track the LATEST
+        // reported window, not the max ever seen: the model can change mid-session
+        // (setModel is live) and a smaller-window model must shrink the denominator,
+        // otherwise the meter under-reports fill against a stale larger window (#543).
+        // Only cache when the turn's model still matches the current one — a result
+        // from a turn whose model was switched away mid-flight carries the OUTGOING
+        // model's window, which must NOT restore the denominator setModel cleared.
+        if (ev.contextWindow && this.turnModel === this.model) {
           this.contextWindow = ev.contextWindow;
         }
         if (this.lastUsage) this.reportStatus(this.lastUsage, ev.costUsd);

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1860,6 +1860,74 @@ function reconstructUiFromState(reply: unknown): Record<string, unknown> | null 
   return { nodes: uiNodes, links } as unknown as Record<string, unknown>;
 }
 
+/**
+ * Core ComfyUI node types whose PRIMARY content is drawn by a DOM OVERLAY widget
+ * positioned over the LiteGraph canvas — NOT painted onto the canvas itself. A
+ * canvas capture (panel_screenshot / graph_screenshot) therefore shows their body
+ * EMPTY even though the content is present in the graph. Flagging them in the tool
+ * result stops an agent from concluding the node is blank and "fixing" a
+ * non-existent problem (#567).
+ *
+ * Kept deliberately narrow (the confirmed reproducer) to avoid false positives.
+ * Custom DOM widgets contributed by node packs (preview/image/video/HTML widgets)
+ * are NOT enumerable from the orchestrator, and the faithful fix — compositing the
+ * live DOM overlay into the capture — is a browser/panel-side change. This
+ * annotation is the cheap, always-correct half that protects the agent's reasoning.
+ */
+const DOM_OVERLAY_NODE_TYPES = new Set<string>(["MarkdownNote"]);
+
+/** Best-effort: serialize the live graph and return the nodes whose content a
+ *  canvas capture misses (DOM-overlay widgets, per DOM_OVERLAY_NODE_TYPES). Never
+ *  throws and never rejects — returns [] on any failure so panel_screenshot still
+ *  returns its image; the note is a bonus, not a dependency. */
+async function domOverlayNodesInView(
+  ctx: PanelToolCtx,
+): Promise<Array<{ id: unknown; type: string }>> {
+  try {
+    const target = ctx.workflowTarget?.get(ctx.tabId);
+    const cmd = target
+      ? withWorkflowTarget({ cmd: "graph_serialize" }, target)
+      : { cmd: "graph_serialize" };
+    const reply = (await ctx.bridge.send(cmd as { cmd: string }, {
+      tabId: ctx.tabId,
+      timeoutMs: 5000,
+    })) as { nodes?: unknown[] } | null;
+    const nodes = reply?.nodes;
+    if (!Array.isArray(nodes)) return [];
+    const hits: Array<{ id: unknown; type: string }> = [];
+    for (const raw of nodes) {
+      const n = raw as { id?: unknown; type?: unknown };
+      if (typeof n?.type === "string" && DOM_OVERLAY_NODE_TYPES.has(n.type)) {
+        hits.push({ id: n.id, type: n.type });
+      }
+    }
+    return hits;
+  } catch {
+    return [];
+  }
+}
+
+/** Compose the "these nodes appear empty in the capture" note (#567), or "" when
+ *  no DOM-overlay nodes are in view. Exported for tests. */
+export function domOverlayScreenshotNote(nodes: Array<{ id: unknown; type: string }>): string {
+  if (!nodes.length) return "";
+  const list = nodes
+    .map((n) => `${n.type}${n.id != null ? ` #${n.id}` : ""}`)
+    .join(", ");
+  const ids = nodes
+    .map((n) => n.id)
+    .filter((id): id is number => typeof id === "number");
+  const readHint = ids.length
+    ? ` Read their text with panel_query_graph {ids:[${ids.join(", ")}], fields:'detail'}.`
+    : " Read their text with panel_query_graph (fields:'detail').";
+  return (
+    `note: this workflow contains ${nodes.length} node(s) (${list}) whose content is drawn by a ` +
+    `DOM overlay widget that a canvas capture like this screenshot cannot render — such a node shows ` +
+    `an EMPTY body in the PNG even though its content IS present in the graph.${readHint} If a node ` +
+    `looks blank here, do NOT treat it as missing content or "fix" it.`
+  );
+}
+
 async function resolveWorkflowInput(
   args: Record<string, unknown>,
   ctx: PanelToolCtx,
@@ -2688,17 +2756,43 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // gets the anti-poll note below.
         const rejection = detectRunRejection(res);
         if (rejection) return rejection;
+        // Attribute this genuine queue to ourselves so a later panel_run in the
+        // same batch recognizes the in-flight job as our own and doesn't false-warn
+        // (#559). The panel forwards ComfyUI's /prompt reply, which carries the
+        // prompt_id; when it doesn't, the timestamp still marks a recent self-queue.
+        const queuedId = ((): string | null => {
+          const parsed = parseToolResultJson(res);
+          const pid = parsed?.prompt_id;
+          return typeof pid === "string" && pid ? pid : null;
+        })();
+        QueueMonitor.markSelfQueued(queuedId);
         // Append anti-poll guidance: the agent should go idle after queuing so the
         // executed event auto-injects the output image, rather than busy-polling.
         const note =
           "\n\n[IMPORTANT] You will be notified automatically with the output image(s)/video when the render finishes — do NOT poll get_queue, get_history, or list_output_images. Just end your turn now and wait for the result to be delivered to you.";
+        // Backpressure note. A backlog is only alarming when it's a job we did NOT
+        // queue (possibly foreign/stuck). Deliberately batching renders — a sweep,
+        // a multi-variant comparison — is a NORMAL workflow, so a queue made of our
+        // own recent jobs is reported NEUTRALLY, never paired with the destructive
+        // clear_pending remedy that would wipe the user's whole batch (#559). A
+        // genuinely stalled render is caught by the turn-start stall notice, which
+        // does the staleness gating and keeps the interrupt guidance.
         let warn = "";
         if (pre.connected && pre.running) {
-          const morePending = pre.queueDepth > 1 ? ` plus ${pre.queueDepth - 1} already pending` : "";
-          warn =
-            `\n\n[QUEUE WARNING] A render is ALREADY RUNNING${pre.runningPromptId ? ` (prompt ${pre.runningPromptId})` : ""}${morePending} — ` +
-            `this new run is QUEUED BEHIND it and will not start until that finishes. If the running one looks stuck, do NOT keep queuing: ` +
-            `call cancel_job with clear_pending:true (it interrupts the running job AND drops pending), then escalate to restart_comfyui if it reports the job wedged.`;
+          const pending = Math.max(0, pre.queueDepth - 1);
+          const pendingTxt = pending > 0 ? ` + ${pending} pending` : "";
+          if (pre.selfAttributed) {
+            warn =
+              `\n\n[QUEUE] Queued behind your own in-flight render(s) (1 running${pendingTxt}). ` +
+              `This is normal when batching a sweep or comparison — they drain in order and nothing is stuck; ` +
+              `each result is delivered to you as it finishes. To drop a single pending item, use cancel_queued_job. ` +
+              `Only use cancel_job with clear_pending:true if a render is ACTUALLY wedged — it kills the running job AND your entire queue.`;
+          } else {
+            warn =
+              `\n\n[QUEUE] A render is already running${pre.runningPromptId ? ` (prompt ${pre.runningPromptId})` : ""}${pendingTxt}, ` +
+              `and the queue includes work this session didn't queue — your run is queued behind it. Inspect with get_queue before acting. ` +
+              `If the running job is genuinely stuck, cancel_job with clear_pending:true interrupts it AND drops pending, then escalate to restart_comfyui if it reports the job wedged.`;
+          }
         }
         if (res.content?.[0]?.type === "text") {
           return {
@@ -3616,7 +3710,18 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             mimeType?: string;
           };
           if (!res?.image) return fail("screenshot returned no image");
-          return { content: [{ type: "image", data: res.image, mimeType: res.mimeType ?? "image/png" }] };
+          const content: Array<
+            | { type: "image"; data: string; mimeType: string }
+            | { type: "text"; text: string }
+          > = [{ type: "image", data: res.image, mimeType: res.mimeType ?? "image/png" }];
+          // A canvas capture cannot show DOM-overlay widget content (MarkdownNote
+          // text renders as an empty body) — flag any such node in view so the
+          // agent doesn't read the blank body as missing content (#567). Best-effort:
+          // the note is skipped silently if the graph can't be serialized.
+          const overlayNodes = await domOverlayNodesInView(ctx);
+          const overlayNote = domOverlayScreenshotNote(overlayNodes);
+          if (overlayNote) content.push({ type: "text", text: overlayNote });
+          return { content };
         } catch (err) {
           return fail(err);
         }

--- a/src/services/queue-monitor.self-attribution.test.ts
+++ b/src/services/queue-monitor.self-attribution.test.ts
@@ -1,0 +1,154 @@
+// queue-monitor.self-attribution.test.ts — the backlog warning must tell the
+// agent's OWN deliberate batch from a foreign or stuck job (#559).
+//
+// BUG: panel_run's "[QUEUE WARNING] … cancel_job clear_pending:true" fired on ANY
+// running job — so batching 11 renders (the normal way to run a comparison) made
+// every run after the first warn about a "backlog" it created, and recommended the
+// single most destructive action (kill the running render AND drop the queue).
+//
+// FIX: the orchestrator records the prompt ids it queued (markSelfQueued). A queue
+// made of our own recent jobs is `selfAttributed` and is reported neutrally; only a
+// job we did NOT queue drives the warning. Here we drive the singleton's state and
+// assert snapshot()/report() attribution.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { QueueMonitor } from "./queue-monitor.js";
+
+type Priv = {
+  url: string | null;
+  stopped: boolean;
+  selfQueuedIds: Set<string>;
+  lastSelfQueueTs: number | null;
+  state: {
+    connected: boolean;
+    runningPromptId: string | null;
+    pendingPromptIds: string[];
+    queueRemaining: number;
+    lastActivityTs: number | null;
+    lastServerAliveTs: number | null;
+    lastFrameTs: number | null;
+  };
+};
+const priv = QueueMonitor as unknown as Priv;
+
+beforeEach(() => {
+  priv.url = "http://127.0.0.1:9999";
+  priv.stopped = false;
+  priv.selfQueuedIds.clear();
+  priv.lastSelfQueueTs = null;
+  priv.state.connected = true;
+  priv.state.runningPromptId = null;
+  priv.state.pendingPromptIds = [];
+  priv.state.queueRemaining = 0;
+  priv.state.lastActivityTs = null;
+  // Keep the server "alive" so report() never flags a stall on its own.
+  priv.state.lastServerAliveTs = Date.now();
+  priv.state.lastFrameTs = Date.now();
+});
+
+afterEach(() => {
+  priv.selfQueuedIds.clear();
+  priv.lastSelfQueueTs = null;
+  priv.stopped = true;
+  priv.url = null;
+});
+
+const STALL_MS = 180_000;
+
+describe("self-attribution of the in-flight queue (#559)", () => {
+  it("a batch of OUR prompts (running + pending, all matched by id) is self-attributed", () => {
+    QueueMonitor.markSelfQueued("p-mine-1");
+    QueueMonitor.markSelfQueued("p-mine-2");
+    QueueMonitor.markSelfQueued("p-mine-3");
+    priv.state.runningPromptId = "p-mine-1";
+    priv.state.pendingPromptIds = ["p-mine-2", "p-mine-3"];
+    priv.state.queueRemaining = 3;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(true);
+    const rep = QueueMonitor.report(STALL_MS);
+    expect(rep.selfAttributed).toBe(true);
+    expect(rep.backlog).toBe(true); // depth > 1 — but it's OUR batch, so callers suppress the warning
+    expect(rep.stalled).toBe(false);
+  });
+
+  it("a recent self-queue with NO recorded id attributes the in-flight work to us (timestamp fallback)", () => {
+    // The panel reply carried no prompt_id — markSelfQueued(null) only marks the time.
+    QueueMonitor.markSelfQueued(null);
+    priv.state.runningPromptId = "p-unknown"; // id we never recorded
+    priv.state.queueRemaining = 1;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(true);
+    expect(QueueMonitor.report(STALL_MS).selfAttributed).toBe(true);
+  });
+
+  it("a foreign running job (no self-queue at all) is NOT self-attributed → backlog warning stands", () => {
+    priv.state.runningPromptId = "p-foreign";
+    priv.state.queueRemaining = 2;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+    const rep = QueueMonitor.report(STALL_MS);
+    expect(rep.selfAttributed).toBe(false);
+    expect(rep.backlog).toBe(true);
+  });
+
+  it("P1-a: a foreign RUNNING id is NOT masked by a recent self-queue (explicit id mismatch)", () => {
+    // We queued p-mine recently, but the job actually running is one we can SEE is
+    // not ours. The time window must NOT override that.
+    QueueMonitor.markSelfQueued("p-mine"); // recent, and gives us an id set
+    priv.state.runningPromptId = "p-foreign"; // running job we did NOT queue
+    priv.state.pendingPromptIds = [];
+    priv.state.queueRemaining = 1;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+  });
+
+  it("P1-b: our own running job does NOT cover a FOREIGN pending job", () => {
+    QueueMonitor.markSelfQueued("p-mine");
+    priv.state.runningPromptId = "p-mine"; // ours, running
+    priv.state.pendingPromptIds = ["p-foreign"]; // someone else's job queued behind us
+    priv.state.queueRemaining = 2;
+
+    // Not the whole queue is ours → the agent should still be told.
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+  });
+
+  it("rapid own batch: queueRemaining outruns the poll's captured pending ids → still ours (recent self-queue)", () => {
+    // The reported scenario: queuing a batch faster than the 1 Hz poll. Status
+    // frames bumped queueRemaining to 3, but the poll has only captured the running
+    // id so far. We queued them all seconds ago → still our batch.
+    QueueMonitor.markSelfQueued("p-mine");
+    priv.state.runningPromptId = "p-mine";
+    priv.state.pendingPromptIds = []; // poll hasn't captured the 2 pending yet
+    priv.state.queueRemaining = 3;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(true);
+  });
+
+  it("incomplete accounting with NO recent self-queue → NOT ours (an unseen item may be foreign)", () => {
+    QueueMonitor.markSelfQueued("p-mine");
+    priv.lastSelfQueueTs = Date.now() - 11 * 60 * 1000; // aged past the window
+    priv.state.runningPromptId = "p-mine"; // the one job we can see is ours…
+    priv.state.pendingPromptIds = [];
+    priv.state.queueRemaining = 3; // …but 2 more are in flight, unaccounted
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+  });
+
+  it("attribution expires after the window (a stale self-queue no longer covers a new foreign job)", () => {
+    QueueMonitor.markSelfQueued("p-old");
+    // Age our last self-queue past the 10-minute window and drop the id.
+    priv.lastSelfQueueTs = Date.now() - 11 * 60 * 1000;
+    priv.selfQueuedIds.clear();
+    priv.state.runningPromptId = "p-foreign-new";
+    priv.state.queueRemaining = 2;
+
+    expect(QueueMonitor.snapshot().selfAttributed).toBe(false);
+  });
+
+  it("markSelfQueued bounds its id set (no unbounded growth)", () => {
+    for (let i = 0; i < 250; i++) QueueMonitor.markSelfQueued(`p-${i}`);
+    expect(priv.selfQueuedIds.size).toBeLessThanOrEqual(200);
+    // The most recent ids survive; the oldest are evicted FIFO.
+    expect(priv.selfQueuedIds.has("p-249")).toBe(true);
+    expect(priv.selfQueuedIds.has("p-0")).toBe(false);
+  });
+});

--- a/src/services/queue-monitor.ts
+++ b/src/services/queue-monitor.ts
@@ -36,6 +36,11 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 interface MonitorState {
   connected: boolean;
   runningPromptId: string | null;
+  // Prompt ids of the PENDING (queued, not yet running) tasks, from GET /queue's
+  // queue_pending. Enables per-item self-attribution: a backlog is only the agent's
+  // own batch when the running job AND every pending job are ids we queued (#559).
+  // Best-effort (poll-derived); empty when the poll hasn't populated it.
+  pendingPromptIds: string[];
   currentNode: string | null;
   progressValue: number | null;
   progressMax: number | null;
@@ -78,6 +83,10 @@ export interface StallReport {
   /** More than one task in flight (running + pending) — a backlog the agent may
    *  not realize it created by re-queuing behind a slow job. */
   backlog: boolean;
+  /** True when the in-flight work is attributable to THIS session (a prompt id we
+   *  queued, or a very recent self-queue) — a deliberate batch, not a foreign or
+   *  stuck job. The backlog warning is suppressed in that case (#559). */
+  selfAttributed: boolean;
   runningPromptId: string | null;
   currentNode: string | null;
   /** running + pending, from ComfyUI's own queue_remaining. */
@@ -100,9 +109,18 @@ export interface QueueSnapshot {
   progressMax: number | null;
   /** The most recent completed run (sticky; null until one completes). */
   lastCompleted: CompletionEvent | null;
+  /** True when the in-flight work is attributable to THIS session (#559). */
+  selfAttributed: boolean;
 }
 
 const RECONNECT_MS = 5000;
+// How long after a self-queue (panel_run) the in-flight work is still treated as
+// this session's own batch when the running prompt id can't be matched directly
+// (e.g. the panel reply carried no prompt_id). A sweep of a dozen renders at tens
+// of seconds each drains well inside this, so a deliberate batch never trips the
+// backlog warning; a genuinely foreign job appearing long after our last queue
+// still surfaces (#559).
+const SELF_QUEUE_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 // /history tail entries fetched per poll. Wide enough that a realistic burst
 // of sub-second runs between 1 Hz polls stays inside the window; when a diff
 // still saturates it (every entry new), we log the potential gap instead of
@@ -130,6 +148,7 @@ class QueueMonitorImpl {
   private state: MonitorState = {
     connected: false,
     runningPromptId: null,
+    pendingPromptIds: [],
     currentNode: null,
     progressValue: null,
     progressMax: null,
@@ -158,6 +177,13 @@ class QueueMonitorImpl {
   private completedReported = new Set<string>();
   // Completions not yet drained by the broadcaster. Bounded.
   private pendingCompletions: CompletionEvent[] = [];
+  // ---- self-attribution for the backlog warning (#559) ----
+  // Prompt ids THIS orchestrator queued via panel_run, plus the ms timestamp of
+  // the most recent self-queue. A backlog made entirely of the agent's own recent
+  // jobs is an EXPECTED batch (a sweep/comparison), not evidence of a wedge, so it
+  // must not trigger the destructive "cancel_job clear_pending" remedy.
+  private selfQueuedIds = new Set<string>();
+  private lastSelfQueueTs: number | null = null;
 
   /** Open the watchdog WS to ComfyUI. Idempotent per-URL; best-effort (never
    *  throws). A retarget (new URL) or a prior stop() must re-open the socket:
@@ -180,6 +206,10 @@ class QueueMonitorImpl {
     this.completedReported.clear();
     this.pendingCompletions.length = 0;
     this.state.lastCompleted = null;
+    // Self-queued prompt ids belong to the OLD target — a fresh ComfyUI's jobs are
+    // foreign to us until we queue them, so drop the attribution (#559).
+    this.selfQueuedIds.clear();
+    this.lastSelfQueueTs = null;
     // Liveness heartbeats belong to the OLD target — reset so a fresh target's
     // stall clock doesn't inherit a stale "alive" (or a stale "dark") reading.
     this.state.lastFrameTs = null;
@@ -222,6 +252,62 @@ class QueueMonitorImpl {
   /** Is a generation currently in flight (edge-tracked)? */
   isBusy(): boolean {
     return this.busy;
+  }
+
+  /** Record a prompt THIS orchestrator just queued (panel_run), so the backlog
+   *  warning can tell the agent's own deliberate batch from a foreign or stuck
+   *  job (#559). `promptId` may be null when the panel reply carried none — the
+   *  timestamp alone still marks a recent self-queue. Never throws. */
+  markSelfQueued(promptId?: string | null): void {
+    this.lastSelfQueueTs = Date.now();
+    if (typeof promptId === "string" && promptId) {
+      this.selfQueuedIds.add(promptId);
+      // Bounded FIFO — Set iterates in insertion order, so drop the oldest.
+      while (this.selfQueuedIds.size > 200) {
+        const oldest = this.selfQueuedIds.values().next().value;
+        if (oldest === undefined) break;
+        this.selfQueuedIds.delete(oldest);
+      }
+    }
+  }
+
+  /** True when the ENTIRE in-flight queue is attributable to this session — i.e.
+   *  every visible prompt (the running one plus every pending one) is an id we
+   *  queued. That is the only safe basis for suppressing the backlog warning: a
+   *  single foreign job (running OR pending) means the queue is NOT purely our own
+   *  batch and the agent should still be told (#559).
+   *
+   *  Precise id-matching is used whenever we have ANY recorded self-queued id AND
+   *  there is at least one identifiable in-flight prompt. Only when we have no ids
+   *  to match against (the panel reply never carried a prompt_id) OR nothing is yet
+   *  identifiable do we fall back to the coarse "did we self-queue very recently"
+   *  heuristic — so a recent self-queue can NOT mask a job whose id we can see is
+   *  not ours. */
+  private isSelfAttributed(): boolean {
+    const inFlight: string[] = [];
+    if (this.state.runningPromptId) inFlight.push(this.state.runningPromptId);
+    inFlight.push(...this.state.pendingPromptIds);
+    const recentSelfQueue =
+      this.lastSelfQueueTs != null && Date.now() - this.lastSelfQueueTs < SELF_QUEUE_WINDOW_MS;
+
+    if (this.selfQueuedIds.size > 0 && inFlight.length > 0) {
+      // We receive a prompt id for every job we queue, so any VISIBLE in-flight id
+      // that isn't one of ours is definitively a foreign job → not our batch.
+      if (inFlight.some((id) => !this.selfQueuedIds.has(id))) return false;
+      // Every VISIBLE in-flight job is ours. The pending ids are poll-derived and can
+      // lag a rapid burst of queues, so queueRemaining (updated live by status frames)
+      // may exceed what we've captured. If the poll has fully accounted for the depth,
+      // the whole queue is provably ours; if some items aren't captured yet, only
+      // treat them as ours when we self-queued recently (the reported case — queuing a
+      // batch faster than the 1 Hz poll). A stale unseen item with NO recent self-queue
+      // is treated as possibly-foreign so the warning still fires.
+      const depth = Math.max(inFlight.length, Math.max(0, this.state.queueRemaining));
+      if (inFlight.length >= depth) return true;
+      return recentSelfQueue;
+    }
+    // No ids to match against (the panel never surfaced one) or nothing identifiable
+    // in flight yet → fall back to the coarse recent-self-queue timestamp.
+    return recentSelfQueue;
   }
 
   stop(): void {
@@ -354,6 +440,7 @@ class QueueMonitorImpl {
           // progress frames would otherwise never clear — drain it here.
           if (qr === 0) {
             if (this.state.runningPromptId !== null) this.clearRunning();
+            this.state.pendingPromptIds = []; // fully idle — no pending work
             this.emitEndIfIdle();
           }
         }
@@ -531,6 +618,11 @@ class QueueMonitorImpl {
     const running = Array.isArray(q.queue_running) ? q.queue_running : [];
     const pending = Array.isArray(q.queue_pending) ? q.queue_pending : [];
     this.state.queueRemaining = running.length + pending.length;
+    // queue_pending entries are [number, prompt_id, prompt, extra, outputs] too —
+    // record their ids for per-item self-attribution (#559).
+    this.state.pendingPromptIds = pending
+      .map((entry) => (Array.isArray(entry) && typeof entry[1] === "string" ? entry[1] : null))
+      .filter((id): id is string => id !== null);
     // queue_running entries are [number, prompt_id, prompt, extra, outputs] —
     // the ONLY place a passive observer learns WHICH prompt runs on 0.28.
     const first = running[0];
@@ -633,6 +725,7 @@ class QueueMonitorImpl {
       progressValue: this.state.progressValue,
       progressMax: this.state.progressMax,
       lastCompleted: this.state.lastCompleted,
+      selfAttributed: this.isSelfAttributed(),
     };
   }
 
@@ -671,6 +764,7 @@ class QueueMonitorImpl {
     return {
       stalled,
       backlog: queueDepth > 1,
+      selfAttributed: this.isSelfAttributed(),
       runningPromptId: this.state.runningPromptId,
       currentNode: this.state.currentNode,
       queueDepth,

--- a/src/services/queue-status-broadcast.test.ts
+++ b/src/services/queue-status-broadcast.test.ts
@@ -23,6 +23,7 @@ const idle = (): QueueSnapshot => ({
   progressValue: null,
   progressMax: null,
   lastCompleted: null,
+  selfAttributed: false,
 });
 
 const running = (progress: number): QueueSnapshot => ({
@@ -34,6 +35,7 @@ const running = (progress: number): QueueSnapshot => ({
   progressValue: progress,
   progressMax: 20,
   lastCompleted: null,
+  selfAttributed: false,
 });
 
 describe("buildQueueStatusFrame", () => {


### PR DESCRIPTION
Three independent `panel_*` MCP tool bug fixes. Each is isolated; tests added for all three.

## #543 — context-meter denominator ratchets up
`Closes #543`

**Root cause:** the `result` handler kept the MAX `contextWindow` ever seen (`ev.contextWindow > this.contextWindow`). `setModel` is live (no restart), so switching to a smaller-window model left the denominator pinned at the largest window any model reported — 100k used shown as 10% of a stale 1M window instead of the true 50% of 200k.

**Fix:**
- Track the LATEST reported window (drop the `>` guard).
- Clear the cache on `setModel` (reportStatus already omits `contextPct` while the cache is 0, so the panel holds its previous reading and `used` is still reported).
- Gate the result-event caching on a per-turn model snapshot (`turnModel`) so a late result from a turn whose model was switched away mid-flight can't restore the outgoing model's window (closes the mid-turn-switch race).

## #559 — queue-backlog warning false-positives on self-queued jobs
`Closes #559`

**Root cause:** `panel_run`'s backlog warning fired on ANY running job and led with the destructive `cancel_job clear_pending:true`. Deliberately batching renders (the normal way to run a sweep/comparison) made every run after the first warn about a backlog it created and recommend wiping the whole queue.

**Fix:** the orchestrator records the prompt ids it queues (`QueueMonitor.markSelfQueued`) and captures pending ids from `/queue`. A queue is "self-attributed" only when every visible in-flight job is one we queued (a visible foreign running OR pending id disqualifies it); poll-lagging unaccounted items count as ours only with a recent self-queue (so a rapid batch outrunning the 1 Hz poll isn't mis-flagged). Self-attributed batches get a NEUTRAL note; foreign/unknown queues get a softened, inspect-first note; the destructive `clear_pending` remedy is only the headline for a genuinely stalled job (unchanged staleness detection).

## #567 — panel_screenshot omits DOM-overlay widget content
`Closes #567`

**Root cause:** `panel_screenshot` captures the LiteGraph canvas; DOM-overlay widgets (MarkdownNote text) render as an empty node body. **The faithful fix — compositing the live DOM overlay into the capture — is browser/panel-side (the separate comfyui-mcp-panel repo) and is split out.** This repo only forwards `graph_screenshot` to the panel.

**Fix (the cheap, always-correct half the issue explicitly recommends):** after capturing, best-effort `graph_serialize` and append a note naming any DOM-overlay node (MarkdownNote) so the agent doesn't read the blank body as missing content. Never breaks the screenshot (serialization failure → note simply omitted).

## Verification
- `npm run build` clean; `npm test` green (the one failing `node-dev` test is a pre-existing environment artifact — it expects the builtin search fallback but this box has ripgrep installed; untouched by this PR).
- New tests: `context-window-denominator.test.ts` (ratchet, idle switch, mid-turn-switch race), `queue-monitor.self-attribution.test.ts` (id match, foreign running/pending, rapid-batch poll lag, window expiry, bounds), `panel-run-backpressure.test.ts` (neutral vs foreign vs none + the DOM-overlay note). Regression guards verified by reverting each fix.
- Codex self-gate (gpt-5.6-terra / high, embedded diff): **PASS** after three rounds — it caught 4 real P1s (foreign-job masking, foreign-pending under a self running job, the mid-turn context-window race, and incomplete-poll accounting), all fixed.

Closes #543
Closes #559
Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
