### PR TITLE
fix(download): warn when a remote ComfyUI-Manager dispatch is authentication-gated (#473)

### DIFF
--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -620,6 +620,72 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
     expect(out).not.toMatch(/AUTHENTICATION-GATED/i);
   });
 
+  it("does NOT leak the HF token to an attacker host whose URL merely CONTAINS 'huggingface.co' (#590 P0)", async () => {
+    config.huggingfaceToken = "hf-secret";
+    // unauth → auth page (would drive a flip IF a credential were derived); but the PARSED
+    // host is attacker.example, so no HF token is derived and no request carries it.
+    fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
+      Promise.resolve(opts?.headers?.Authorization ? binaryProbeResponse() : htmlProbeResponse()),
+    );
+    await downloadModel(
+      "https://attacker.example/m.safetensors?ref=huggingface.co",
+      "checkpoints",
+      "m.safetensors",
+    );
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1); // never blocked
+    const leaked = fetchMock.mock.calls.some((c) =>
+      String((c[1] as { headers?: Record<string, string> } | undefined)?.headers?.Authorization ?? "").includes("hf-secret"),
+    );
+    expect(leaked).toBe(false);
+  });
+
+  it("attaches the HF token by PARSED host for a genuine huggingface.co gated URL and warns on the flip", async () => {
+    config.huggingfaceToken = "hf-secret";
+    fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
+      Promise.resolve(opts?.headers?.Authorization ? binaryProbeResponse() : htmlProbeResponse()),
+    );
+    const out = await downloadModel(
+      "https://huggingface.co/org/repo/resolve/main/m.safetensors",
+      "checkpoints",
+      "m.safetensors",
+    );
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(out).toMatch(/AUTHENTICATION-GATED/i);
+    const sentHf = fetchMock.mock.calls.some(
+      (c) => (c[1] as { headers?: Record<string, string> } | undefined)?.headers?.Authorization === "Bearer hf-secret",
+    );
+    expect(sentHf).toBe(true);
+  });
+
+  it("keeps the HF token flowing to an HF_ENDPOINT mirror (pre-rewrite wasHfUrl threaded) — #590 P1", async () => {
+    const prev = process.env.HF_ENDPOINT;
+    process.env.HF_ENDPOINT = "https://hf-mirror.example";
+    try {
+      config.huggingfaceToken = "hf-secret";
+      fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
+        Promise.resolve(opts?.headers?.Authorization ? binaryProbeResponse() : htmlProbeResponse()),
+      );
+      const out = await downloadModel(
+        "https://huggingface.co/org/repo/resolve/main/m.safetensors",
+        "checkpoints",
+        "m.safetensors",
+      );
+      expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+      // The URL was rewritten to the mirror, yet the HF token still applies (threaded
+      // wasHfUrl) → the flip is detected and the auth-gated warning fires.
+      expect(out).toMatch(/AUTHENTICATION-GATED/i);
+      const sentToMirror = fetchMock.mock.calls.some(
+        (c) =>
+          String(c[0]).startsWith("https://hf-mirror.example") &&
+          (c[1] as { headers?: Record<string, string> } | undefined)?.headers?.Authorization === "Bearer hf-secret",
+      );
+      expect(sentToMirror).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.HF_ENDPOINT;
+      else process.env.HF_ENDPOINT = prev;
+    }
+  });
+
   it("does NOT probe a NON-model-binary destination (.zip) — dispatch proceeds, no warning", async () => {
     // A .zip is not a model-binary ext, so the probe short-circuits to inconclusive WITHOUT
     // fetching and the dispatch proceeds unchanged.

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -61,6 +61,40 @@ function headersOf(callIndex = 0): Record<string, string> {
   return opts.headers;
 }
 
+// #473 remote residual: the remote (Manager) dispatch path now PROBES the exact URL
+// Manager will fetch (unauthenticated) before dispatching, and refuses on a definitive
+// auth/error payload. These build the probe responses the mocked fetch returns.
+/** Non-text first bytes + octet-stream → classifier "binary" → probe verdict "model". */
+function binaryProbeResponse(): Response {
+  return new Response(new Uint8Array([0, 1, 2, 3, 0xff, 0x80, 0x12, 0x34]), {
+    status: 200,
+    headers: { "content-type": "application/octet-stream" },
+  });
+}
+/** An HTML login page (200) — the exact #473 poison shape → probe verdict "non-model". */
+function htmlProbeResponse(): Response {
+  return new Response("<!doctype html><html><body>Please log in</body></html>", {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+/** A JSON auth error (401). */
+function jsonAuthProbeResponse(): Response {
+  return new Response(JSON.stringify({ error: "unauthorized" }), {
+    status: 401,
+    headers: { "content-type": "application/json" },
+  });
+}
+/** Flip-aware fetch: an UNAUTHENTICATED probe (no Authorization) gets `pageResp` (an
+ *  auth/error page — what Manager would land), a CREDENTIALED probe gets a real model.
+ *  This is the auth-gated shape the #473 gate must refuse. */
+function flipFetch(pageResp: () => Response): void {
+  fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) => {
+    const authed = !!opts?.headers?.Authorization;
+    return Promise.resolve(authed ? binaryProbeResponse() : pageResp());
+  });
+}
+
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   fetchMock.mockReset();
@@ -353,6 +387,10 @@ describe("downloadModel — auth headers (token never in URL)", () => {
 describe("downloadModel — remote mode (Manager install-model dispatch)", () => {
   beforeEach(() => {
     config.comfyuiPath = undefined; // remote mode
+    // #473: the remote dispatch probes the URL Manager will fetch first. Default to a
+    // benign binary payload → verdict "model" → dispatch proceeds, so the existing
+    // dispatch assertions hold; refusal tests below override to an auth/error payload.
+    fetchMock.mockResolvedValue(binaryProbeResponse());
   });
 
   it("dispatches a top-level download via installModelViaManager (no save_path) and never touches disk", async () => {
@@ -373,8 +411,10 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       save_path: "default",
       trayCategory: "checkpoints",
     });
-    // No local-disk work in remote mode.
-    expect(fetchMock).not.toHaveBeenCalled();
+    // The pre-dispatch probe fetched the URL Manager will fetch (#473), but NO local
+    // disk work happened — the probe is a network read, never a file write.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe("https://example.com/model.safetensors");
     expect(mkdirMock).not.toHaveBeenCalled();
     expect(out).toContain("checkpoints/model.safetensors");
     expect(out).toContain("ComfyUI-Manager");
@@ -507,6 +547,88 @@ describe("downloadModel — remote mode (Manager install-model dispatch)", () =>
       expect(out).toContain(auth.type);
     }
   });
+
+  // ── #473 remote residual: WARN LOUDLY (never block) when a credential flip proves the
+  //    URL is AUTH-GATED — so a dispatched auth page isn't mistaken for a real model, while
+  //    a legitimate download is NEVER refused (the host's fetch vantage may differ). ──
+  it("WARNS but still dispatches when the URL is auth-gated — an HTML page that flips with the token", async () => {
+    config.civitaiApiToken = "tok"; // the local token that Manager can't receive
+    flipFetch(htmlProbeResponse); // unauth → login HTML; with the token → real model
+    const out = await downloadModel(
+      "https://civitai.com/api/download/models/627113",
+      "loras",
+      "KNP.safetensors",
+    );
+    // NEVER blocks — the dispatch still happens (the host may succeed from its own vantage)…
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    // …but a loud, specific warning is surfaced so the auth page isn't trusted as a model.
+    expect(out).toMatch(/AUTHENTICATION-GATED/i);
+    expect(out).toMatch(/CORRUPT model/i);
+  });
+
+  it("WARNS when an auth-gated URL returns a JSON error unauthenticated but flips with the token", async () => {
+    config.civitaiApiToken = "tok";
+    flipFetch(jsonAuthProbeResponse);
+    const out = await downloadModel(
+      "https://civitai.com/api/download/models/9",
+      "checkpoints",
+      "gated.safetensors",
+    );
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(out).toMatch(/AUTHENTICATION-GATED/i);
+  });
+
+  it("names the CivitAI host-token remediation in the auth-gated warning", async () => {
+    config.civitaiApiToken = "tok";
+    flipFetch(htmlProbeResponse);
+    const out = await downloadModel(
+      "https://civitai.com/api/download/models/1",
+      "loras",
+      "x.safetensors",
+    );
+    expect(out).toMatch(/CIVITAI_API_TOKEN on the ComfyUI HOST/i);
+  });
+
+  it("does NOT warn (no false alarm) on a location interstitial that does NOT flip with the token", async () => {
+    // The Codex vantage P0: a WAF/geo interstitial can reach the MCP as 200 HTML while the
+    // host gets a real model. It ignores the bearer, so BOTH probes return HTML → no flip →
+    // no auth-gated warning, and (as always) the dispatch proceeds.
+    config.civitaiApiToken = "tok";
+    fetchMock.mockResolvedValue(htmlProbeResponse()); // same page with or without auth
+    const out = await downloadModel("https://civitai.com/api/download/models/1", "loras", "x.safetensors");
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(out).not.toMatch(/AUTHENTICATION-GATED/i);
+  });
+
+  it("does NOT warn when an HTML page appears but NO credential is configured (can't prove auth-gating)", async () => {
+    config.civitaiApiToken = undefined;
+    fetchMock.mockResolvedValue(htmlProbeResponse());
+    const out = await downloadModel("https://civitai.com/api/download/models/1", "loras", "x.safetensors");
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(out).not.toMatch(/AUTHENTICATION-GATED/i);
+  });
+
+  it("dispatches normally (no warning) when the probe is INCONCLUSIVE (network error)", async () => {
+    fetchMock.mockRejectedValue(new Error("connreset"));
+    const out = await downloadModel(
+      "https://example.com/m.safetensors",
+      "checkpoints",
+      "m.safetensors",
+    );
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(out).toContain("ComfyUI-Manager");
+    expect(out).not.toMatch(/AUTHENTICATION-GATED/i);
+  });
+
+  it("does NOT probe a NON-model-binary destination (.zip) — dispatch proceeds, no warning", async () => {
+    // A .zip is not a model-binary ext, so the probe short-circuits to inconclusive WITHOUT
+    // fetching and the dispatch proceeds unchanged.
+    fetchMock.mockResolvedValue(htmlProbeResponse());
+    const out = await downloadModel("https://example.com/pack.zip", "loras", "pack.zip");
+    expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(out).not.toMatch(/AUTHENTICATION-GATED/i);
+  });
 });
 
 describe("downloadModel — threaded routing decision (#420 split-brain guard)", () => {
@@ -515,6 +637,7 @@ describe("downloadModel — threaded routing decision (#420 split-brain guard)",
     // disk. Passing the job's already-decided route must WIN — the writer follows
     // the decision the job id was keyed on, never a fresh evaluation.
     config.comfyuiPath = "/comfy";
+    fetchMock.mockResolvedValue(binaryProbeResponse()); // #473 pre-dispatch probe
     const out = await downloadModel(
       "https://example.com/model.safetensors",
       "checkpoints",
@@ -523,7 +646,10 @@ describe("downloadModel — threaded routing decision (#420 split-brain guard)",
       true, // dispatchToManager — decided upstream by startDownloadJob
     );
     expect(installModelViaManagerMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).not.toHaveBeenCalled(); // no local streaming
+    // The one fetch is the pre-dispatch probe (a network read), NOT local streaming —
+    // no disk work happened in the Manager route.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mkdirMock).not.toHaveBeenCalled();
     expect(out).toContain("ComfyUI-Manager");
   });
 

--- a/src/__tests__/services/model-resolver.test.ts
+++ b/src/__tests__/services/model-resolver.test.ts
@@ -272,6 +272,29 @@ describe("downloadModel — auth headers (token never in URL)", () => {
     expect(headersOf().Authorization).toBeUndefined();
   });
 
+  it("does NOT leak the HF token on the LOCAL path to an attacker host whose URL merely CONTAINS 'huggingface.co' (#590 P0)", async () => {
+    config.huggingfaceToken = "hf";
+    failingFetch();
+
+    await expect(
+      downloadModel("https://evil.example/m.safetensors?ref=huggingface.co", "checkpoints", "m.safetensors"),
+    ).rejects.toBeInstanceOf(ModelError);
+
+    // Parsed host is evil.example → NO token. A substring `includes` would have leaked it.
+    expect(headersOf().Authorization).toBeUndefined();
+  });
+
+  it("does NOT leak the HF token on the LOCAL path to a look-alike subdomain (huggingface.co.evil.com)", async () => {
+    config.huggingfaceToken = "hf";
+    failingFetch();
+
+    await expect(
+      downloadModel("https://huggingface.co.evil.com/m.safetensors", "checkpoints", "m.safetensors"),
+    ).rejects.toBeInstanceOf(ModelError);
+
+    expect(headersOf().Authorization).toBeUndefined();
+  });
+
   it("attaches a HuggingFace bearer header for huggingface.co", async () => {
     config.huggingfaceToken = "hf";
     failingFetch();

--- a/src/__tests__/services/remote-payload-probe.test.ts
+++ b/src/__tests__/services/remote-payload-probe.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { probeRemoteModelPayload } from "../../services/download-cache.js";
+
+// The #473 remote gate refuses a Manager dispatch ONLY when a credential FLIP proves the
+// URL is authentication-gated: an unauthenticated fetch (what Manager does) returns a
+// non-model auth/error page, but the SAME url fetched WITH the local credential (which
+// Manager can never receive) returns a real model. A location-specific WAF/geo interstitial
+// affects both fetches equally → no flip → never blocked (no false positive across the
+// MCP-vs-host vantage gap).
+
+const fetchMock = vi.fn();
+const AUTH = { Authorization: "Bearer secret" };
+
+function response(body: BodyInit, status: number, contentType?: string): Response {
+  const headers: Record<string, string> = {};
+  if (contentType) headers["content-type"] = contentType;
+  return new Response(body, { status, headers });
+}
+function htmlPage(status = 200): Response {
+  return response("<!doctype html><html><body>Please log in</body></html>", status, "text/html; charset=utf-8");
+}
+function jsonErr(status = 401): Response {
+  return response(JSON.stringify({ error: "unauthorized" }), status, "application/json");
+}
+function modelBinary(status = 200): Response {
+  // Leading bytes that are NOT `<`/`{`/`[` and not valid text → classifier "binary".
+  return response(new Uint8Array([0x8c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7b]), status, "application/octet-stream");
+}
+/** unauth fetch (no Authorization) → `unauthResp`; credentialed fetch → `authedResp`. */
+function flipMock(unauthResp: () => Response, authedResp: () => Response): void {
+  fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) => {
+    const authed = !!opts?.headers?.Authorization;
+    return Promise.resolve(authed ? authedResp() : unauthResp());
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("probeRemoteModelPayload — #473 credential-flip gate", () => {
+  it("verdict MODEL for a public url (unauthenticated fetch already returns binary) — one probe only", async () => {
+    fetchMock.mockResolvedValue(modelBinary());
+    const p = await probeRemoteModelPayload("https://x/pub.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("model");
+    // No need for the credentialed flip probe once the unauthenticated fetch is a model.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("verdict NON-MODEL when an HTML page flips to a real model with the credential (auth-gated)", async () => {
+    flipMock(() => htmlPage(200), () => modelBinary());
+    const p = await probeRemoteModelPayload("https://civitai.com/api/download/models/1", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("non-model");
+    expect(p.kind).toBe("html");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // unauth + credentialed flip
+  });
+
+  it("verdict NON-MODEL when a 401 JSON flips to a real model with the credential", async () => {
+    flipMock(() => jsonErr(401), () => modelBinary());
+    const p = await probeRemoteModelPayload("https://x/gated.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("non-model");
+    expect(p.kind).toBe("json");
+  });
+
+  it("verdict NON-MODEL when a bare 401 (no classifiable body) flips to a real model", async () => {
+    flipMock(() => response(new Uint8Array([0x00, 0x11, 0x22]), 401, "application/octet-stream"), () => modelBinary());
+    const p = await probeRemoteModelPayload("https://x/gated.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("non-model");
+    expect(p.kind).toBeUndefined();
+  });
+
+  it("verdict INCONCLUSIVE for a location interstitial that does NOT flip (WAF ignores the bearer)", async () => {
+    // Both the unauth AND the credentialed fetch return the same HTML → NOT auth-gating →
+    // must NOT block (the host could still get a real model). This is the Codex vantage P0.
+    flipMock(() => htmlPage(200), () => htmlPage(200));
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("verdict INCONCLUSIVE when an HTML page appears but NO credential is available to flip", async () => {
+    fetchMock.mockResolvedValue(htmlPage(200));
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: {} });
+    expect(p.verdict).toBe("inconclusive");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no credential → no second probe
+  });
+
+  it("verdict INCONCLUSIVE when the credential is present but does not flip (invalid token → still 401)", async () => {
+    flipMock(() => jsonErr(401), () => jsonErr(401));
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("verdict INCONCLUSIVE when the credentialed flip fetch itself errors (network)", async () => {
+    fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
+      opts?.headers?.Authorization ? Promise.reject(new Error("connreset")) : Promise.resolve(htmlPage(200)),
+    );
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("verdict INCONCLUSIVE on a network error on the first (unauthenticated) probe — never blocks", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("verdict INCONCLUSIVE on a transient non-2xx that does not flip (403/429/5xx)", async () => {
+    // A 403/5xx that returns the same non-model on both probes → cannot prove auth-gating.
+    flipMock(() => response("<!doctype html><html>Just a moment…</html>", 403, "text/html"), () => response("upstream down", 503, "text/plain"));
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("does NOT fetch or gate a non-model-binary extension (.zip)", async () => {
+    const p = await probeRemoteModelPayload("https://x/pack.zip", ".zip", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fetch when the extension is missing", async () => {
+    const p = await probeRemoteModelPayload("https://x/model", undefined, undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Range-limits the request and follows redirects (does not drain a large body)", async () => {
+    const big = new Uint8Array(10 * 1024 * 1024);
+    big[0] = 0x8c; // non-text lead → binary
+    fetchMock.mockResolvedValue(response(big, 200, "application/octet-stream"));
+    const p = await probeRemoteModelPayload("https://x/big.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("model");
+    const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string>; redirect?: string };
+    expect(opts.headers.Range).toMatch(/^bytes=0-\d+$/);
+    expect(opts.redirect).toBe("follow");
+  });
+
+  it("TIMES OUT to inconclusive when the fetch stalls, even with a caller signal present (both signals apply)", async () => {
+    // Regression for the compat-path P1: the manual timeout must fire independently of the
+    // caller signal (never `signal ?? timeout`), so a stalled probe can't hang the dispatch.
+    vi.useFakeTimers();
+    fetchMock.mockImplementation(
+      (_url: string, opts?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+        }),
+    );
+    const callerSignal = new AbortController().signal; // present, but never aborts on its own
+    const p = probeRemoteModelPayload("https://x/m.safetensors", ".safetensors", callerSignal, { authHeaders: AUTH });
+    await vi.advanceTimersByTimeAsync(13_000); // past the 12s probe ceiling
+    await expect(p).resolves.toMatchObject({ verdict: "inconclusive" });
+    vi.useRealTimers();
+  });
+
+  it("treats a form-feed-prefixed HTML login page as html when it flips (matches the #473 classifier)", async () => {
+    flipMock(() => response("\f<!doctype html><html>gated</html>", 200, "application/octet-stream"), () => modelBinary());
+    const p = await probeRemoteModelPayload("https://x/model.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("non-model");
+    expect(p.kind).toBe("html");
+  });
+});

--- a/src/__tests__/services/remote-payload-probe.test.ts
+++ b/src/__tests__/services/remote-payload-probe.test.ts
@@ -66,11 +66,68 @@ describe("probeRemoteModelPayload — #473 credential-flip gate", () => {
     expect(p.kind).toBe("json");
   });
 
-  it("verdict NON-MODEL when a bare 401 (no classifiable body) flips to a real model", async () => {
+  it("verdict INCONCLUSIVE for a bare 401 with NO html/json body (not a clear auth page — no cry wolf)", async () => {
+    // A bare status with no HTML/JSON body is not a CLEAR auth page, so even if the
+    // credentialed retry is a model we stay inconclusive (P2 — only warn on a clear page).
     flipMock(() => response(new Uint8Array([0x00, 0x11, 0x22]), 401, "application/octet-stream"), () => modelBinary());
     const p = await probeRemoteModelPayload("https://x/gated.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
-    expect(p.verdict).toBe("non-model");
-    expect(p.kind).toBeUndefined();
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("verdict INCONCLUSIVE on a TRANSIENT 503 even if the credentialed retry is a model (no cry wolf)", async () => {
+    // P2: a public URL that momentarily 503s (even with an HTML maintenance page) then serves
+    // the model on retry must NOT fire the auth-gated warning. A 5xx is never a clear auth page.
+    let calls = 0;
+    fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) => {
+      calls += 1;
+      return Promise.resolve(
+        opts?.headers?.Authorization ? modelBinary() : response("<!doctype html>maintenance</html>", 503, "text/html"),
+      );
+    });
+    const p = await probeRemoteModelPayload("https://x/m.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+    expect(calls).toBe(1); // transient unauth → NOT a clear auth page → no credentialed probe
+  });
+
+  it("verdict INCONCLUSIVE on a TRANSIENT 429 (rate limit) even if the credentialed retry is a model", async () => {
+    fetchMock.mockImplementation((_url: string, opts?: { headers?: Record<string, string> }) =>
+      Promise.resolve(opts?.headers?.Authorization ? modelBinary() : jsonErr(429)),
+    );
+    const p = await probeRemoteModelPayload("https://x/m.safetensors", ".safetensors", undefined, { authHeaders: AUTH });
+    expect(p.verdict).toBe("inconclusive");
+  });
+
+  it("CREDENTIAL SAFETY: strips ALL auth (Authorization + custom headers) on a cross-origin redirect", async () => {
+    // The credentialed flip probe must send auth ONLY to the original target host. When the
+    // origin 302s cross-origin, Authorization AND any custom header (e.g. X-API-Key) are
+    // dropped for the rest of the chain — only Range survives. Regression for a P0 leak.
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    fetchMock.mockImplementation((u: string, opts?: { headers?: Record<string, string> }) => {
+      const headers = opts?.headers ?? {};
+      calls.push({ url: u, headers });
+      const authed = !!headers.Authorization || !!headers["X-API-Key"];
+      if (u === "https://origin.example/m.safetensors") {
+        // Unauthenticated → a clear auth page (drives the flip); authenticated → redirect off-origin.
+        return Promise.resolve(
+          authed
+            ? new Response("", { status: 302, headers: { location: "https://cdn.other.example/signed/m.safetensors" } })
+            : htmlPage(200),
+        );
+      }
+      return Promise.resolve(modelBinary()); // the cross-origin CDN serves the model
+    });
+    const authHeaders = { Authorization: "Bearer secret", "X-API-Key": "custom-key" };
+    const p = await probeRemoteModelPayload("https://origin.example/m.safetensors", ".safetensors", undefined, { authHeaders });
+    expect(p.verdict).toBe("non-model"); // flip confirmed via the authed redirect→model chain
+    // The cross-origin CDN hop must carry NO credential — only Range.
+    const cdnCall = calls.find((c) => c.url.startsWith("https://cdn.other.example/"));
+    expect(cdnCall).toBeDefined();
+    expect(cdnCall!.headers.Authorization).toBeUndefined();
+    expect(cdnCall!.headers["X-API-Key"]).toBeUndefined();
+    expect(cdnCall!.headers.Range).toMatch(/^bytes=0-\d+$/);
+    // …while the original-origin authed hop DID carry both.
+    const originAuthed = calls.find((c) => c.url === "https://origin.example/m.safetensors" && !!c.headers.Authorization);
+    expect(originAuthed!.headers["X-API-Key"]).toBe("custom-key");
   });
 
   it("verdict INCONCLUSIVE for a location interstitial that does NOT flip (WAF ignores the bearer)", async () => {
@@ -136,7 +193,7 @@ describe("probeRemoteModelPayload — #473 credential-flip gate", () => {
     expect(p.verdict).toBe("model");
     const opts = fetchMock.mock.calls[0][1] as { headers: Record<string, string>; redirect?: string };
     expect(opts.headers.Range).toMatch(/^bytes=0-\d+$/);
-    expect(opts.redirect).toBe("follow");
+    expect(opts.redirect).toBe("manual"); // manual redirects — never "follow" (credential safety)
   });
 
   it("TIMES OUT to inconclusive when the fetch stalls, even with a caller signal present (both signals apply)", async () => {

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -600,8 +600,11 @@ async function readResponseHead(res: Response, n: number): Promise<Buffer | unde
       const { done, value } = await reader.read();
       if (done) break;
       if (value && value.length) {
-        chunks.push(Buffer.from(value));
-        total += value.length;
+        // Cap what we buffer to the sniff window: a server that ignores Range and streams
+        // a large first chunk must not make us hold it all in memory (we only need n bytes).
+        const take = value.length > n - total ? value.subarray(0, n - total) : value;
+        chunks.push(Buffer.from(take));
+        total += take.length;
       }
     }
   } catch {
@@ -624,43 +627,80 @@ interface PayloadSniff {
   isModelBinary: boolean;
 }
 
-/** One bounded, redirect-following, Range-limited probe fetch of `url`, classified with
- *  the SAME #473 classifier the local finalize gate uses. Never throws — a network
- *  error/timeout/abort yields `{ ok: false }`. */
+const PROBE_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Parse an origin, or null when the URL is unparseable (treated as a DIFFERENT origin —
+ *  i.e. auth is stripped, the safe default). */
+function safeOrigin(u: string): string | null {
+  try {
+    return new URL(u).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One bounded, Range-limited probe of `url`, classified with the SAME #473 classifier the
+ * local finalize gate uses. Never throws — a network error/timeout/abort yields
+ * `{ ok: false }`. `signal` is the caller-composed abort+timeout (owned by the caller so a
+ * single budget bounds BOTH probes).
+ *
+ * CREDENTIAL SAFETY (do not regress): redirects are followed MANUALLY (never
+ * `redirect: "follow"`, which re-sends arbitrary custom auth headers like `X-API-Key`
+ * across origins). `authHeaders` — which can include ANY caller header — are sent ONLY to
+ * the ORIGINAL target origin; the FIRST time a redirect leaves that origin, ALL auth
+ * headers are dropped for the rest of the chain (only `Range` is retained), mirroring the
+ * local downloader. A caller credential is therefore never sent to any host but the one the
+ * caller addressed.
+ */
 async function sniffPayloadShape(
   url: string,
   modelExt: string,
   authHeaders: Record<string, string> | undefined,
-  signal?: AbortSignal,
+  signal: AbortSignal,
 ): Promise<PayloadSniff> {
-  // Compose the caller's abort AND a hard timeout MANUALLY (never rely on AbortSignal.any,
-  // which is unavailable on older runtimes): both must always apply, or a stalled probe
-  // could hang the dispatch. The timer is unref'd so it never keeps the process alive, and
-  // it is cleared in `finally` — it bounds the WHOLE probe (fetch + body head read), since
-  // an abort here cancels the response stream and unblocks a hung `reader.read()`.
-  const controller = new AbortController();
-  const onCallerAbort = (): void => controller.abort();
-  const timer = setTimeout(() => controller.abort(), REMOTE_PROBE_TIMEOUT_MS);
-  if (typeof (timer as { unref?: unknown }).unref === "function") timer.unref();
-  if (signal) {
-    if (signal.aborted) controller.abort();
-    else signal.addEventListener("abort", onCallerAbort, { once: true });
-  }
-  try {
+  const rangeHeader = { Range: `bytes=0-${PAYLOAD_SNIFF_BYTES - 1}` };
+  const hasAuth = !!authHeaders && Object.keys(authHeaders).length > 0;
+  const originalOrigin = safeOrigin(url);
+  let currentUrl = url;
+  let authStripped = false; // once we leave the original origin, never re-send auth
+  for (let hop = 0; hop <= MAX_HTTP_REDIRECTS; hop++) {
+    const sendAuth = hasAuth && !authStripped;
     let res: Response;
     try {
-      res = await fetch(url, {
-        // Mirror Manager's server-side fetch: follow redirects (CivitAI 302s to a signed
-        // CDN URL for a PUBLIC model). Range-limit to the sniff window so a multi-GB model
-        // is never pulled. The credentialed pass adds the auth headers the LOCAL path uses.
-        redirect: "follow",
-        headers: { Range: `bytes=0-${PAYLOAD_SNIFF_BYTES - 1}`, ...(authHeaders ?? {}) },
-        signal: controller.signal,
+      res = await fetch(currentUrl, {
+        // Manual redirects (see CREDENTIAL SAFETY above) — never "follow". Range-limit to
+        // the sniff window so a multi-GB model is never pulled.
+        redirect: "manual",
+        headers: sendAuth ? { ...rangeHeader, ...authHeaders } : rangeHeader,
+        signal,
       });
     } catch {
       return { ok: false, kind: null, isModelBinary: false };
     }
     if (!res || typeof res.status !== "number") return { ok: false, kind: null, isModelBinary: false };
+    const location =
+      typeof res.headers?.get === "function" ? res.headers.get("location") : null;
+    if (PROBE_REDIRECT_STATUSES.has(res.status) && location) {
+      // Drain the (usually empty) redirect body so the socket is released.
+      try {
+        await (res.body as ReadableStream | null | undefined)?.cancel?.();
+      } catch {
+        /* ignore */
+      }
+      let nextUrl: string;
+      try {
+        nextUrl = new URL(location, currentUrl).toString();
+      } catch {
+        return { ok: false, kind: null, isModelBinary: false };
+      }
+      // Cross-origin relative to the ORIGINAL target (or an unparseable next URL) → strip
+      // ALL auth for the remainder of the chain. Never send a caller credential elsewhere.
+      if (safeOrigin(nextUrl) !== originalOrigin) authStripped = true;
+      currentUrl = nextUrl;
+      continue;
+    }
+    // Terminal (non-redirect) response → classify its first bytes.
     const status = res.status;
     const contentType =
       (typeof res.headers?.get === "function" ? res.headers.get("content-type") : "") ?? "";
@@ -674,10 +714,9 @@ async function sniffPayloadShape(
     const isSuccess = status === 200 || status === 206;
     const isModelBinary = isSuccess && !kind && !!head && head.length > 0;
     return { ok: true, status, kind, isModelBinary };
-  } finally {
-    clearTimeout(timer);
-    if (signal) signal.removeEventListener("abort", onCallerAbort);
   }
+  // Redirect limit exceeded — treat as unresolvable (inconclusive).
+  return { ok: false, kind: null, isModelBinary: false };
 }
 
 /**
@@ -726,28 +765,52 @@ export async function probeRemoteModelPayload(
   if (!modelExt || !MODEL_BINARY_EXTS.has(modelExt.toLowerCase())) {
     return { verdict: "inconclusive" };
   }
-  // (1) Unauthenticated probe — what Manager will actually do.
-  const unauth = await sniffPayloadShape(url, modelExt, undefined, signal);
-  if (!unauth.ok) return { verdict: "inconclusive" };
-  if (unauth.isModelBinary) return { verdict: "model", status: unauth.status };
-
-  // (2) The unauthenticated fetch did NOT yield a clean model (auth page / 401 / non-2xx /
-  // empty). Only a credential FLIP proves this is auth-gating (IP-independent) rather than
-  // a location-specific interstitial. Try the same url WITH the local credential.
-  const authHeaders = opts?.authHeaders;
-  if (authHeaders && Object.keys(authHeaders).length > 0) {
-    const authed = await sniffPayloadShape(url, modelExt, authHeaders, signal);
-    if (authed.ok && authed.isModelBinary) {
-      // The credential turns the SAME url from non-model into a real model → AUTH-GATED,
-      // and the credential is what unlocks it. Manager, which can't carry it, will land the
-      // auth/error page. Block, reporting the UNAUTHENTICATED body shape (what Manager sees).
-      return { verdict: "non-model", kind: unauth.kind ?? undefined, status: unauth.status };
-    }
+  // ONE shared abort budget for BOTH probes (they run sequentially): compose the caller's
+  // abort with a single hard timeout MANUALLY (never AbortSignal.any — unavailable on older
+  // runtimes), so the TOTAL probe time is bounded by REMOTE_PROBE_TIMEOUT_MS, not 2x, and a
+  // stalled probe can never hang the dispatch. Unref'd (never keeps the process alive),
+  // cleared in `finally`.
+  const controller = new AbortController();
+  const onCallerAbort = (): void => controller.abort();
+  const timer = setTimeout(() => controller.abort(), REMOTE_PROBE_TIMEOUT_MS);
+  if (typeof (timer as { unref?: unknown }).unref === "function") timer.unref();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onCallerAbort, { once: true });
   }
-  // (3) No credential, the credential didn't flip it, or a network error — we cannot prove
-  // auth-gating (could be a location interstitial, an invalid token, or a transient error),
-  // so NEVER hard-block. Dispatch proceeds under the existing "dispatched, not verified" note.
-  return { verdict: "inconclusive", status: unauth.status };
+  try {
+    // (1) Unauthenticated probe — what Manager will actually do.
+    const unauth = await sniffPayloadShape(url, modelExt, undefined, controller.signal);
+    if (!unauth.ok) return { verdict: "inconclusive" };
+    if (unauth.isModelBinary) return { verdict: "model", status: unauth.status };
+
+    // (2) The unauthenticated fetch did NOT yield a clean model. Only warn on a credential
+    // FLIP, and ONLY when the unauth response is a CLEAR auth page — an HTML/JSON body
+    // (`kind` set) on a NON-transient status. A transient 429/5xx (or an ambiguous empty /
+    // bare-status response) is NOT proof of gating: a public URL that momentarily 503s and
+    // then serves the model on the credentialed retry must NOT cry wolf. Those stay
+    // inconclusive.
+    const status = unauth.status ?? 0;
+    const transient = status === 429 || (status >= 500 && status <= 599);
+    const clearAuthPage = (unauth.kind === "html" || unauth.kind === "json") && !transient;
+    const authHeaders = opts?.authHeaders;
+    if (clearAuthPage && authHeaders && Object.keys(authHeaders).length > 0) {
+      const authed = await sniffPayloadShape(url, modelExt, authHeaders, controller.signal);
+      if (authed.ok && authed.isModelBinary) {
+        // The credential turns the SAME url from a clear auth page into a real model →
+        // AUTH-GATED, and the credential is what unlocks it. Manager, which can't carry it,
+        // will land the auth/error page. Report the UNAUTHENTICATED body shape (what Manager
+        // sees). This is a WARNING signal for the caller — never a refusal.
+        return { verdict: "non-model", kind: unauth.kind ?? undefined, status: unauth.status };
+      }
+    }
+    // (3) No clear auth page, no credential, no flip, or a network/transient outcome — we
+    // cannot prove auth-gating, so stay inconclusive (never warn, never block).
+    return { verdict: "inconclusive", status: unauth.status };
+  } finally {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 /** POSITIVELY true only when `path` is confirmed discarded — it no longer exists

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -556,6 +556,200 @@ async function assertModelPayloadOrThrow(opts: {
   throw nonModelPayloadError(kind, url, logUrl);
 }
 
+/** Verdict from a pre-dispatch probe of what a server-side (ComfyUI-Manager) fetch
+ *  will land — see {@link probeRemoteModelPayload}. */
+export interface RemotePayloadProbe {
+  /** "non-model": a DEFINITIVE auth/error payload — the caller MUST refuse to dispatch.
+   *  "model": the first bytes look like real model binary — safe to dispatch.
+   *  "inconclusive": ANY uncertainty (network error/timeout, a non-auth error status,
+   *  an unsniffable body, or a non-model-binary destination) — the caller must NOT
+   *  refuse, so the probe can never block a download that might be legitimate. */
+  verdict: "non-model" | "model" | "inconclusive";
+  /** The offending shape when a body/Content-Type signal drove a "non-model" verdict.
+   *  Absent for a bare 401 with no classifiable body. */
+  kind?: "html" | "json";
+  /** The probe response status, when a response was received. */
+  status?: number;
+}
+
+/** Ceiling on the pre-dispatch probe. Kept short: it reads only the sniff window and a
+ *  hung probe must never wedge a download — on timeout it returns "inconclusive" and
+ *  the dispatch proceeds exactly as it does today. */
+const REMOTE_PROBE_TIMEOUT_MS = 12_000;
+
+/** Read up to `n` bytes from a fetch Response body, then cancel the stream so a
+ *  multi-GB file is NEVER drained by the probe. Returns the bytes read (may be shorter
+ *  than `n`), or undefined when there is no readable body. */
+async function readResponseHead(res: Response, n: number): Promise<Buffer | undefined> {
+  const body = res.body as ReadableStream<Uint8Array> | null | undefined;
+  if (!body || typeof body.getReader !== "function") {
+    // No stream (e.g. a minimal stubbed Response) — fall back to a bounded buffer read.
+    try {
+      const ab = await res.arrayBuffer();
+      const buf = Buffer.from(ab);
+      return buf.length ? buf.subarray(0, n) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    while (total < n) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value && value.length) {
+        chunks.push(Buffer.from(value));
+        total += value.length;
+      }
+    }
+  } catch {
+    // A partial read is fine — classification runs on whatever prefix we got.
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return total === 0 ? undefined : Buffer.concat(chunks).subarray(0, n);
+}
+
+/** The raw shape of one probe fetch — used to compare an unauthenticated fetch against
+ *  a credentialed one (the flip test). */
+interface PayloadSniff {
+  /** A response was received (the fetch itself did not throw/timeout). */
+  ok: boolean;
+  status?: number;
+  /** Body/Content-Type classification via the #473 classifier: an auth/error page shape. */
+  kind: "html" | "json" | null;
+  /** A SUCCESS (2xx) response whose first bytes are real model binary (not html/json). */
+  isModelBinary: boolean;
+}
+
+/** One bounded, redirect-following, Range-limited probe fetch of `url`, classified with
+ *  the SAME #473 classifier the local finalize gate uses. Never throws — a network
+ *  error/timeout/abort yields `{ ok: false }`. */
+async function sniffPayloadShape(
+  url: string,
+  modelExt: string,
+  authHeaders: Record<string, string> | undefined,
+  signal?: AbortSignal,
+): Promise<PayloadSniff> {
+  // Compose the caller's abort AND a hard timeout MANUALLY (never rely on AbortSignal.any,
+  // which is unavailable on older runtimes): both must always apply, or a stalled probe
+  // could hang the dispatch. The timer is unref'd so it never keeps the process alive, and
+  // it is cleared in `finally` — it bounds the WHOLE probe (fetch + body head read), since
+  // an abort here cancels the response stream and unblocks a hung `reader.read()`.
+  const controller = new AbortController();
+  const onCallerAbort = (): void => controller.abort();
+  const timer = setTimeout(() => controller.abort(), REMOTE_PROBE_TIMEOUT_MS);
+  if (typeof (timer as { unref?: unknown }).unref === "function") timer.unref();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener("abort", onCallerAbort, { once: true });
+  }
+  try {
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        // Mirror Manager's server-side fetch: follow redirects (CivitAI 302s to a signed
+        // CDN URL for a PUBLIC model). Range-limit to the sniff window so a multi-GB model
+        // is never pulled. The credentialed pass adds the auth headers the LOCAL path uses.
+        redirect: "follow",
+        headers: { Range: `bytes=0-${PAYLOAD_SNIFF_BYTES - 1}`, ...(authHeaders ?? {}) },
+        signal: controller.signal,
+      });
+    } catch {
+      return { ok: false, kind: null, isModelBinary: false };
+    }
+    if (!res || typeof res.status !== "number") return { ok: false, kind: null, isModelBinary: false };
+    const status = res.status;
+    const contentType =
+      (typeof res.headers?.get === "function" ? res.headers.get("content-type") : "") ?? "";
+    let head: Buffer | undefined;
+    try {
+      head = await readResponseHead(res, PAYLOAD_SNIFF_BYTES);
+    } catch {
+      head = undefined;
+    }
+    const kind = detectNonModelPayload(head, contentType, modelExt);
+    const isSuccess = status === 200 || status === 206;
+    const isModelBinary = isSuccess && !kind && !!head && head.length > 0;
+    return { ok: true, status, kind, isModelBinary };
+  } finally {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener("abort", onCallerAbort);
+  }
+}
+
+/**
+ * PREDICT what a server-side ComfyUI-Manager fetch of `url` will land, WITHOUT
+ * downloading the whole file, so a REMOTE dispatch can fail loudly BEFORE Manager
+ * saves an auth/login/error page under a `.safetensors` name and reports success
+ * (#473 remote residual — the local finalize gate above can't run on the remote path,
+ * where the MCP never sees the bytes and has no way to sniff or delete the landed file).
+ *
+ * The MCP probes from a DIFFERENT network vantage than the ComfyUI host, so a raw
+ * "unauthenticated fetch returned HTML" is NOT proof the host would land HTML — a
+ * location-specific WAF/geo interstitial could hit the MCP while the host gets a real
+ * model. To avoid ever blocking a download that could succeed, this gate refuses ONLY on
+ * a signal that is provably AUTH-based and therefore IP-INDEPENDENT: a credential FLIP.
+ *
+ *   1. Probe UNAUTHENTICATED — exactly what Manager's server-side fetch does. If that
+ *      already returns real model binary, the URL is public → dispatch (verdict "model").
+ *   2. Otherwise (auth page / 401 / non-2xx / empty), fetch the SAME url WITH the
+ *      credential the LOCAL path would apply (`opts.authHeaders` — the CivitAI/HF token or
+ *      explicit auth that Manager can NEVER receive). If THAT returns real model binary,
+ *      the credential — not the vantage point — is what unlocks it: the URL is
+ *      AUTHENTICATION-GATED and Manager (tokenless) WILL land the auth/error page →
+ *      verdict "non-model" (block). This is exactly the reported bug (a local token that
+ *      is not forwarded to a remote Manager).
+ *   3. Any other outcome — no credential to test, the credential did not flip it (an
+ *      invalid token, or a location interstitial that ignores the header), or a network
+ *      error — is "inconclusive": we cannot PROVE auth-gating, so we never hard-block.
+ *
+ * Because a block requires the credential to flip the SAME url from non-model to model,
+ * it can never refuse a download that would have succeeded via Manager (a public model
+ * returns binary on the first, unauthenticated probe; a location interstitial does not
+ * flip on a bearer header). Not applicable to a non-model-binary destination (returns
+ * "inconclusive"), matching the local gate.
+ */
+export async function probeRemoteModelPayload(
+  url: string,
+  modelExt: string | undefined,
+  signal?: AbortSignal,
+  opts?: {
+    /** The auth HEADERS the LOCAL download path would apply for this url (explicit auth,
+     *  or the auto HF/CivitAI host-token). The flip test uses them to prove auth-gating;
+     *  Manager itself can never receive them. */
+    authHeaders?: Record<string, string>;
+  },
+): Promise<RemotePayloadProbe> {
+  if (!modelExt || !MODEL_BINARY_EXTS.has(modelExt.toLowerCase())) {
+    return { verdict: "inconclusive" };
+  }
+  // (1) Unauthenticated probe — what Manager will actually do.
+  const unauth = await sniffPayloadShape(url, modelExt, undefined, signal);
+  if (!unauth.ok) return { verdict: "inconclusive" };
+  if (unauth.isModelBinary) return { verdict: "model", status: unauth.status };
+
+  // (2) The unauthenticated fetch did NOT yield a clean model (auth page / 401 / non-2xx /
+  // empty). Only a credential FLIP proves this is auth-gating (IP-independent) rather than
+  // a location-specific interstitial. Try the same url WITH the local credential.
+  const authHeaders = opts?.authHeaders;
+  if (authHeaders && Object.keys(authHeaders).length > 0) {
+    const authed = await sniffPayloadShape(url, modelExt, authHeaders, signal);
+    if (authed.ok && authed.isModelBinary) {
+      // The credential turns the SAME url from non-model into a real model → AUTH-GATED,
+      // and the credential is what unlocks it. Manager, which can't carry it, will land the
+      // auth/error page. Block, reporting the UNAUTHENTICATED body shape (what Manager sees).
+      return { verdict: "non-model", kind: unauth.kind ?? undefined, status: unauth.status };
+    }
+  }
+  // (3) No credential, the credential didn't flip it, or a network error — we cannot prove
+  // auth-gating (could be a location interstitial, an invalid token, or a transient error),
+  // so NEVER hard-block. Dispatch proceeds under the existing "dispatched, not verified" note.
+  return { verdict: "inconclusive", status: unauth.status };
+}
+
 /** POSITIVELY true only when `path` is confirmed discarded — it no longer exists
  *  (stat throws ENOENT) or exists but is empty (size 0). A non-ENOENT stat error
  *  (a transient fs hiccup) or a still-present non-empty file returns false, so a

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -800,11 +800,30 @@ export async function resolveExistingModelFile(
  * model proves the URL is authentication-gated (the exact bug — a local token Manager can
  * never receive). Returns `{}` when no credential applies (a public/anonymous URL).
  */
-function localAuthHeadersFor(url: string, auth?: DownloadAuth): Record<string, string> {
+function localAuthHeadersFor(
+  url: string,
+  auth: DownloadAuth | undefined,
+  /** Whether the ORIGINAL (pre-HF_ENDPOINT-rewrite) url was a huggingface.co url — threaded
+   *  from downloadModel so an HF_ENDPOINT mirror still gets the token (mirrors the local
+   *  streaming path; without it a rewritten url would parse to the mirror host and drop the
+   *  token → a false-negative). */
+  wasHfUrl: boolean,
+): Record<string, string> {
   const request = applyDownloadAuth(url, auth);
   const headers: Record<string, string> = { ...request.headers };
-  const wasHfUrl = /^https?:\/\/huggingface\.co([/?#]|$)/i.test(url);
-  if (!auth && config.huggingfaceToken && (wasHfUrl || url.includes("huggingface.co"))) {
+  // HF token: attach ONLY when the url's PARSED hostname is huggingface.co (or a subdomain),
+  // or the ORIGINAL url was a HF url that HF_ENDPOINT rewrote to a trusted mirror. NEVER a
+  // substring match — `https://attacker.example/x?ref=huggingface.co` must NOT receive the
+  // token (a credential-leak; the parsed host is attacker.example). isCivitaiUrl is already
+  // hostname-parsed, so the CivitAI branch is safe by construction.
+  let host = "";
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    /* unparseable url → no host-token injection */
+  }
+  const isHfHost = host === "huggingface.co" || host.endsWith(".huggingface.co");
+  if (!auth && config.huggingfaceToken && (wasHfUrl || isHfHost)) {
     headers["Authorization"] = `Bearer ${config.huggingfaceToken}`;
   } else if (!auth && config.civitaiApiToken && isCivitaiUrl(url)) {
     headers["Authorization"] = `Bearer ${config.civitaiApiToken}`;
@@ -824,6 +843,10 @@ async function downloadModelViaManagerRemote(
   filename?: string,
   auth?: DownloadAuth,
   signal?: AbortSignal,
+  /** Whether the ORIGINAL url (before any HF_ENDPOINT rewrite the caller applied) was a
+   *  huggingface.co url — threaded to the #473 flip probe's credential derivation so an
+   *  HF_ENDPOINT mirror still gets the HF token (matches the local streaming path). */
+  wasHfUrl = false,
 ): Promise<string> {
   // Cancelled before we dispatched — do not hand the fetch to the remote Manager at all.
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
@@ -915,8 +938,9 @@ async function downloadModelViaManagerRemote(
   const probe = await probeRemoteModelPayload(dispatchUrl, modelExt, signal, {
     // The auth the LOCAL path would apply — used ONLY to prove auth-gating via a credential
     // flip; Manager can never receive these headers. Derived from `url` (pre-query-fold) so
-    // host detection (civitai/hf) matches the local streaming path.
-    authHeaders: localAuthHeadersFor(url, auth),
+    // host detection (civitai/hf) matches the local streaming path. `wasHfUrl` preserves the
+    // pre-HF_ENDPOINT-rewrite HF identity so a mirror still gets the token.
+    authHeaders: localAuthHeadersFor(url, auth, wasHfUrl),
   });
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
   let authGateWarning = "";
@@ -1097,7 +1121,9 @@ export async function downloadModel(
   const routeToManager =
     dispatchToManager ?? (await shouldDispatchDownloadToManager());
   if (routeToManager) {
-    return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal);
+    // Thread the PRE-rewrite HF identity so the flip probe's credential derivation keeps the
+    // HF token flowing to an HF_ENDPOINT mirror (matches the local path below).
+    return downloadModelViaManagerRemote(url, targetSubfolder, filename, auth, signal, wasHfUrl);
   }
 
   // Root the destination at the LIVE server's models dir (its --base-directory),

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -467,6 +467,24 @@ function isCivitaiUrl(url: string): boolean {
   }
 }
 
+/**
+ * True when `url`'s PARSED hostname is huggingface.co (or a subdomain). The single
+ * authority for the "is this a Hugging Face host?" credential decision — used by BOTH the
+ * local streaming download and the #473 remote flip probe. NEVER a substring match:
+ * `https://attacker.example/m.safetensors?ref=huggingface.co` and
+ * `https://huggingface.co.evil.com/...` both parse to a non-HF host and get NO token
+ * (a substring `url.includes("huggingface.co")` would leak HF_TOKEN to them). An
+ * unparseable url is not HF (no token).
+ */
+function isHuggingFaceHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "huggingface.co" || host.endsWith(".huggingface.co");
+  } catch {
+    return false;
+  }
+}
+
 /** Network-restricted regions (issue #127): honor the de-facto HF_ENDPOINT
  *  mirror var (e.g. https://hf-mirror.com) by rewriting huggingface.co URLs at
  *  the API/download boundary. Only http(s) endpoints are accepted; anything
@@ -813,17 +831,9 @@ function localAuthHeadersFor(
   const headers: Record<string, string> = { ...request.headers };
   // HF token: attach ONLY when the url's PARSED hostname is huggingface.co (or a subdomain),
   // or the ORIGINAL url was a HF url that HF_ENDPOINT rewrote to a trusted mirror. NEVER a
-  // substring match — `https://attacker.example/x?ref=huggingface.co` must NOT receive the
-  // token (a credential-leak; the parsed host is attacker.example). isCivitaiUrl is already
-  // hostname-parsed, so the CivitAI branch is safe by construction.
-  let host = "";
-  try {
-    host = new URL(url).hostname.toLowerCase();
-  } catch {
-    /* unparseable url → no host-token injection */
-  }
-  const isHfHost = host === "huggingface.co" || host.endsWith(".huggingface.co");
-  if (!auth && config.huggingfaceToken && (wasHfUrl || isHfHost)) {
+  // substring match (see isHuggingFaceHost). isCivitaiUrl is likewise hostname-parsed, so
+  // the CivitAI branch is safe by construction.
+  if (!auth && config.huggingfaceToken && (wasHfUrl || isHuggingFaceHost(url))) {
     headers["Authorization"] = `Bearer ${config.huggingfaceToken}`;
   } else if (!auth && config.civitaiApiToken && isCivitaiUrl(url)) {
     headers["Authorization"] = `Bearer ${config.civitaiApiToken}`;
@@ -1139,9 +1149,12 @@ export async function downloadModel(
 
   const request = applyDownloadAuth(url, auth);
   const headers: Record<string, string> = { ...request.headers };
-  // wasHfUrl keeps the token flowing when HF_ENDPOINT rewrote the host to a
-  // mirror (mirrors proxy gated repos and accept the same Bearer token).
-  if (!auth && config.huggingfaceToken && (wasHfUrl || url.includes("huggingface.co"))) {
+  // HF token: attach ONLY when the url's PARSED hostname is huggingface.co (or a subdomain),
+  // or the ORIGINAL url was a HF url that HF_ENDPOINT rewrote to a trusted mirror (wasHfUrl).
+  // NEVER a substring match — `https://evil.example/m.safetensors?ref=huggingface.co` parses
+  // to evil.example and must get NO token (a credential-leak; the same parsed-host authority
+  // the remote flip probe uses).
+  if (!auth && config.huggingfaceToken && (wasHfUrl || isHuggingFaceHost(url))) {
     headers["Authorization"] = `Bearer ${config.huggingfaceToken}`;
   } else if (!auth && config.civitaiApiToken && isCivitaiUrl(url)) {
     // CivitAI auth travels as a request header (never in the URL/query) so the

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, type Stats } from "node:fs";
 import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
-import { dirname, join, basename, resolve, relative, sep, isAbsolute } from "node:path";
+import { dirname, join, basename, resolve, relative, sep, isAbsolute, extname } from "node:path";
 import { config, isRemoteMode } from "../config.js";
 import { getClient, getSystemStats } from "../comfyui/client.js";
 import { getExtraModelRoots } from "./extra-paths.js";
@@ -9,7 +9,7 @@ import { resolveEffectiveComfyUIBase, liveRootFromArgv } from "./workspace-env.j
 import { installModelViaManager } from "./node-management.js";
 import { ModelError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { downloadWithCache } from "./download-cache.js";
+import { downloadWithCache, probeRemoteModelPayload } from "./download-cache.js";
 import { reportDownloadProgress } from "./download-progress.js";
 import type { ResumeReporter } from "./download-resume-diag.js";
 import { resolveModelsDir, parseModelsDirFromArgv } from "./output-dir.js";
@@ -793,6 +793,26 @@ export async function resolveExistingModelFile(
 }
 
 /**
+ * The auth HEADERS the LOCAL download path would apply for `url` — explicit auth first,
+ * else the auto HuggingFace/CivitAI host-token injection. MIRRORS the header build in
+ * `downloadModel`'s local streaming path (kept in sync with it) and is used ONLY by the
+ * #473 remote flip probe: a credentialed fetch that turns a non-model response into a real
+ * model proves the URL is authentication-gated (the exact bug — a local token Manager can
+ * never receive). Returns `{}` when no credential applies (a public/anonymous URL).
+ */
+function localAuthHeadersFor(url: string, auth?: DownloadAuth): Record<string, string> {
+  const request = applyDownloadAuth(url, auth);
+  const headers: Record<string, string> = { ...request.headers };
+  const wasHfUrl = /^https?:\/\/huggingface\.co([/?#]|$)/i.test(url);
+  if (!auth && config.huggingfaceToken && (wasHfUrl || url.includes("huggingface.co"))) {
+    headers["Authorization"] = `Bearer ${config.huggingfaceToken}`;
+  } else if (!auth && config.civitaiApiToken && isCivitaiUrl(url)) {
+    headers["Authorization"] = `Bearer ${config.civitaiApiToken}`;
+  }
+  return headers;
+}
+
+/**
  * Remote-mode download: hand the file off to the connected ComfyUI host via
  * ComfyUI-Manager's `install-model` task. Validates the subfolder/filename with
  * the same guards as the local path (no traversal, bare filename) before
@@ -871,6 +891,69 @@ async function downloadModelViaManagerRemote(
   );
 
   const sensitiveParams = auth?.type === "query" ? [auth.query_param] : undefined;
+
+  // #473 remote residual. The MCP cannot fully close this on the remote path: a server-side
+  // Manager fetch can't carry our auth headers, the MCP never sees the landed bytes, and
+  // there is no remote primitive to sniff, size, or delete the file afterward — so a
+  // login-gated URL makes Manager save an HTML/JSON auth page under the `.safetensors` name
+  // and report its queue task "done", a corrupt "model" under a false success. (The
+  // authoritative fix is a host-side authenticated transport — the MCP-to-panel streamed
+  // upload the issue scopes — tracked separately.)
+  //
+  // What the MCP CAN do here WITHOUT ever wrongly blocking a legitimate download: detect,
+  // with HIGH CONFIDENCE, that the URL is AUTHENTICATION-GATED and warn LOUDLY, so a
+  // dispatched auth/login page is never silently mistaken for a real model. Proof is a
+  // credential FLIP: an unauthenticated fetch (what Manager does) returns a non-model
+  // auth/error page, but the SAME url fetched WITH the credential the local path would
+  // apply (which Manager can NEVER receive) returns a real model — IP-independent evidence
+  // of token gating, the exact reported bug. We deliberately DO NOT refuse the dispatch:
+  // the ComfyUI host fetches from a DIFFERENT network vantage and could still succeed
+  // (e.g. an IP allowlist the MCP isn't on), so a hard refusal from the MCP's vantage
+  // could block a download that would actually work. A prominent warning that never blocks
+  // is the safe ceiling of what the MCP can assert remotely.
+  const modelExt = extname(resolvedFilename).toLowerCase();
+  const probe = await probeRemoteModelPayload(dispatchUrl, modelExt, signal, {
+    // The auth the LOCAL path would apply — used ONLY to prove auth-gating via a credential
+    // flip; Manager can never receive these headers. Derived from `url` (pre-query-fold) so
+    // host detection (civitai/hf) matches the local streaming path.
+    authHeaders: localAuthHeadersFor(url, auth),
+  });
+  if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
+  let authGateWarning = "";
+  if (probe.verdict === "non-model") {
+    const what =
+      probe.kind === "html"
+        ? "an HTML page (a login/authentication or error page)"
+        : probe.kind === "json"
+          ? "a JSON document (an API error or auth challenge)"
+          : "an authentication/error response";
+    let host = "";
+    try {
+      host = new URL(dispatchUrl).hostname;
+    } catch {
+      /* host is only used to tailor the remediation hint */
+    }
+    const isCivitai = /(^|\.)civitai\.com$/i.test(host);
+    const remediation = isCivitai
+      ? `set CIVITAI_API_TOKEN on the ComfyUI HOST (the MCP's locally-configured token is ` +
+        `NOT forwarded to a remote ComfyUI-Manager), or download to a LOCAL ComfyUI where the ` +
+        `token is applied and the payload is validated on disk`
+      : `configure the credential on the ComfyUI host, or download to a LOCAL ComfyUI where the ` +
+        `credential is applied and the payload is validated on disk`;
+    authGateWarning =
+      ` WARNING: this URL is AUTHENTICATION-GATED — an unauthenticated fetch (exactly what ` +
+      `ComfyUI-Manager performs server-side, since it cannot carry the MCP's auth headers) ` +
+      `returns ${what}, while the SAME URL fetched WITH the configured credential returns a ` +
+      `real model. ComfyUI-Manager will therefore almost certainly save that auth/error page ` +
+      `under "${resolvedFilename}" as a CORRUPT model (it fails at load time, e.g. "header too ` +
+      `large" / "Expecting value") — do NOT treat it as a real model until verified. To ` +
+      `download it, ${remediation}.`;
+    logger.warn(
+      "Remote model dispatch is authentication-gated; ComfyUI-Manager will fetch it unauthenticated",
+      { url: redactUrlForLogs(dispatchUrl, sensitiveParams), filename: resolvedFilename },
+    );
+  }
+
   logger.info("Dispatching model install to remote ComfyUI via ComfyUI-Manager", {
     url: redactUrlForLogs(dispatchUrl, sensitiveParams),
     type: managerType,
@@ -896,7 +979,7 @@ async function downloadModelViaManagerRemote(
   // "cancelled" (the tool message notes the server may still be fetching).
   if (signal?.aborted) throw new DOMException("The download was cancelled.", "AbortError");
 
-  return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authWarning}`;
+  return `${normalizedSubfolder}/${resolvedFilename} (dispatched to the remote ComfyUI via ComfyUI-Manager — download continues server-side; the file lists under /models when complete)${authGateWarning}${authWarning}`;
 }
 
 /**


### PR DESCRIPTION
Closes #473

## The residual (verified on current `main`, 0.48.23)

`#511`/0.48.21 added the magic-byte/Content-Type gate (`assertModelPayloadOrThrow` + `classifyPayload`/`detectNonModelPayload`), but it lives entirely in `download-cache.ts` and runs **only when the MCP process materializes bytes locally** (HTTP stream, cache-hit, cloud). The **remote ComfyUI‑Manager dispatch** (`downloadModelViaManagerRemote` → `installModelViaManager` → `queueManagerTask("install-model")`) hands the raw URL to Manager, which fetches it **server-side and unauthenticated** (it can't carry the MCP's auth headers). A login-gated CivitAI version therefore makes Manager save a `200` HTML login page under the `.safetensors` name and report its queue task `done` — exactly the recurrence reported on **0.48.22** (a 10,036-byte `<!doctype html>` login page saved as `KNP_000003000.safetensors`). The `#577`/0.48.22 "dispatched, not verified" message shipped, yet the poisoned file still landed and `list_local_models` trusted it.

Crucially, for a generic remote host the MCP has **no primitive to sniff, size, or delete** the landed file: `/models/<dir>` returns filenames only (remote `listLocalModels` hardcodes `size:0`), there is no model-byte/header read endpoint, and `remove_model` hard-refuses in remote mode. So the local "validate-before-commit + atomic rename" cannot be reproduced on the remote path.

## The fix — a non-blocking, credential-FLIP warning

Before the remote dispatch, `probeRemoteModelPayload` predicts what Manager will land:

1. Probe **unauthenticated** (exactly what Manager does). Real model binary → `model` (public → dispatch).
2. Otherwise fetch the **same URL with the credential the local path would apply** (`localAuthHeadersFor` — explicit auth, else the auto HF/CivitAI host token). If **that** returns real model binary, the credential — not the network vantage — is what unlocks it: the URL is **authentication-gated** (IP-independent proof, the exact reported bug: a local token Manager never receives) → `non-model`.
3. Any other outcome (no credential, no flip, network error/timeout, or a location interstitial that ignores the bearer) → `inconclusive`.

On a confirmed flip the dispatch **is not refused** — it surfaces a loud, specific `WARNING` (auth-gated; Manager will save an auth/login page; remediation = set the token on the **host**, or download locally) and still dispatches.

### Why warn, not block
No MCP-side probe can prove what the differently-vantaged host receives (an IP-allowlisted host could succeed unauthenticated where the MCP fails), so a hard refusal from the MCP's vantage could block a legitimate download. The probe is designed so it **can never block or fail a legitimate dispatch**: every uncertainty path proceeds unchanged, and the probe is bounded by a manually-composed abort (caller signal + 12 s unref'd timeout) so it can't hang.

**Authoritative prevention still requires the host-side authenticated transport the issue scopes** (an MCP-to-panel streamed upload into a validated destination). This PR is the safe MCP-only hardening in the meantime — it converts a silent false success into a high-confidence, actionable warning for the exact reported scenario.

## Tests
`npm run build` + `npm test` green (only a pre-existing, unrelated `node-dev` ripgrep-vs-builtin environment failure). 22 new tests cover: flip → warn; no-flip interstitial → no warn (the MCP-vs-host vantage case); no credential → no warn; public → single probe; inconclusive → dispatch; and the timeout firing with a caller signal present.

## Codex self-gate
5 adversarial rounds (`gpt-5.6-terra`, high). Round 1 caught a transient-status false-positive (fixed → status-gated). Rounds 2–3 drove the design from a status heuristic to credential-flip and finally to warn-not-block (eliminating the MCP-vs-host vantage false-positive). Round 4 flagged a compat-path timeout P1 (fixed → manual signal composition + regression test). **Round 5: `VERDICT: PASS`, no remaining P0/P1.**

> Draft — please run your own independent adversarial review before merge.
