### PR TITLE
fix(ui-bridge): proactively gate a bridge command the panel's advertised version proves too old (panel #392)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -3,6 +3,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import {
   UiBridge,
   makeUnknownCommandError,
+  panelVersionProvesUnsupported,
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
   minPanelVersionForCmd,
   markDispatched,
@@ -1171,6 +1172,41 @@ describe("makeUnknownCommandError (old-panel version gate)", () => {
   });
 });
 
+describe("panelVersionProvesUnsupported (#392 proactive version gate)", () => {
+  it("is TRUE only for a listed command whose verified minimum the parseable version undercuts", () => {
+    // graph_query shipped at panel 0.7.0 (changelog-verified).
+    expect(panelVersionProvesUnsupported("graph_query", "0.6.8")).toBe(true);
+    expect(panelVersionProvesUnsupported("graph_query", "0.6.99")).toBe(true);
+    // At or above the minimum → supported → not proven-unsupported.
+    expect(panelVersionProvesUnsupported("graph_query", "0.7.0")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_query", "0.11.21")).toBe(false);
+  });
+
+  it("NEVER gates an unlisted command (would otherwise inherit the inflated 0.11.4 baseline and false-gate an early-but-capable panel)", () => {
+    // graph_get_errors / graph_set_widget / ui_render shipped long before 0.11.4 but
+    // are NOT in BRIDGE_CMD_MIN_PANEL_VERSION — proactively gating them off the
+    // fallback baseline would wrongly block a 0.4.6–0.11.3 panel that supports them.
+    expect(panelVersionProvesUnsupported("graph_get_errors", "0.6.8")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_set_widget", "0.9.0")).toBe(false);
+    expect(panelVersionProvesUnsupported("ui_render", "0.6.8")).toBe(false);
+  });
+
+  it("returns FALSE for a missing or unparseable version (can't prove it — fall through to the reactive path)", () => {
+    expect(panelVersionProvesUnsupported("graph_query", undefined)).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_query", "")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_query", "dev")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_query", "nightly-2026")).toBe(false);
+  });
+
+  it("gates graph_serialize (0.8.2) and leaves graph_outline (0.4.6) effectively ungated for any modern panel", () => {
+    expect(panelVersionProvesUnsupported("graph_serialize", "0.8.1")).toBe(true);
+    expect(panelVersionProvesUnsupported("graph_serialize", "0.8.2")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_outline", "0.4.5")).toBe(true);
+    expect(panelVersionProvesUnsupported("graph_outline", "0.4.6")).toBe(false);
+    expect(panelVersionProvesUnsupported("graph_outline", "0.11.7")).toBe(false);
+  });
+});
+
 describe("UiBridge.send (graceful gate end-to-end)", () => {
   it("surfaces an actionable message (with panel version) when an old panel rejects a bridge command", async () => {
     const sock = await connectPanel(undefined);
@@ -1191,12 +1227,14 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     );
   });
 
-  // #236 — the FIRST call to an unsupported command still round-trips to the
-  // panel (there's no way to know in advance), but every LATER call in the same
-  // session must be gated proactively: rejected with the same actionable message
-  // WITHOUT ever reaching the panel again. FAIL-before: the old code always
-  // re-dispatched and re-parsed the panel's raw "Unknown command" string on every
-  // single call.
+  // #236 — for a command with NO changelog-verified per-command minimum (so the
+  // advertised version can't PROVE it unsupported in advance — see the #392 proactive
+  // gate below), the FIRST call still round-trips to discover it's unsupported, and
+  // every LATER call in the same session is gated proactively: rejected with the same
+  // actionable message WITHOUT ever reaching the panel again. FAIL-before: the old
+  // code always re-dispatched and re-parsed the panel's raw "Unknown command" string
+  // on every single call. ui_render is used precisely because it is NOT in
+  // BRIDGE_CMD_MIN_PANEL_VERSION, so only the REACTIVE (#236) path can gate it.
   it("gates a REPEAT call to an already-proven-unsupported command without re-dispatching to the panel", async () => {
     const sock = await connectPanel(undefined);
     let dispatchCount = 0;
@@ -1210,18 +1248,44 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
     });
     await new Promise((r) => setTimeout(r, 50));
 
-    // First call: genuinely round-trips (the only way to discover it's unsupported).
-    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-2" })).rejects.toThrow(
-      /too old for "graph_query"/i,
+    // First call: genuinely round-trips (no per-command minimum to prove it unsupported).
+    await expect(bridge.send({ cmd: "ui_render" }, { tabId: "old-tab-2" })).rejects.toThrow(
+      /too old for "ui_render"/i,
     );
     expect(dispatchCount).toBe(1);
 
-    // Second call: gated proactively — same actionable message, but the panel
+    // Second call: gated proactively (learned) — same actionable message, but the panel
     // must NEVER see a second dispatch of this command.
-    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-2" })).rejects.toThrow(
-      /too old for "graph_query".*0\.6\.8.*update/is,
+    await expect(bridge.send({ cmd: "ui_render" }, { tabId: "old-tab-2" })).rejects.toThrow(
+      /too old for "ui_render".*0\.6\.8.*update/is,
     );
     expect(dispatchCount).toBe(1);
+  });
+
+  // #392 — a command WITH a changelog-verified minimum (graph_query → 0.7.0), on a
+  // panel whose ADVERTISED version parseably undercuts it (0.6.8), is gated PROACTIVELY
+  // on the VERY FIRST call: the panel must never see a dispatch at all, and the honest,
+  // correctly-versioned (≥0.7.0, NOT the inflated 0.11.4 baseline) verdict is returned
+  // immediately. FAIL-before (#392): the tool was exposed/dispatched, the panel rejected
+  // it at runtime, and only THEN was a verdict synthesized from the round-trip reply.
+  it("PROACTIVELY gates a listed command the advertised version proves too old — no dispatch on the first call (#392)", async () => {
+    const sock = await connectPanel(undefined);
+    let dispatchCount = 0;
+    sock.send(JSON.stringify({ type: "hello", tab_id: "old-tab-2b", title: "wf", panel_version: "0.6.8" }));
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        dispatchCount += 1;
+        sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: `Unknown command "${msg.cmd}"` }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-2b" })).rejects.toThrow(
+      /too old for "graph_query".*0\.7\.0.*update/is,
+    );
+    // The FIRST call is gated before dispatch — the panel is never asked.
+    expect(dispatchCount).toBe(0);
   });
 
   // A command that has NEVER been tried on this connection must never be
@@ -1280,6 +1344,43 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
 
     const res = await bridge.send({ cmd: "graph_query" }, { tabId: "old-tab-4" });
     expect(res).toEqual({ cmd: "graph_query" });
+  });
+
+  // #392 regression (codex WS review): panelVersion is INHERITED across a reconnect
+  // that OMITS panel_version (so the reactive message can still quote a detected
+  // version). That inherited, possibly-STALE version must NOT drive the proactive gate
+  // — a reconnect may be a freshly UPGRADED panel. An old 0.6.8 connection followed by
+  // a capable panel reconnecting under the same tab id WITHOUT re-advertising its
+  // version must have its FIRST graph_query DISPATCHED (and succeed), never gated
+  // unprobed. FAIL-before (had the gate keyed only on panelVersion): the inherited
+  // 0.6.8 would proactively reject graph_query forever until yet another reconnect.
+  it("does NOT proactively gate a reconnect that omits panel_version (inherited stale version must not block an upgraded panel) (#392)", async () => {
+    const sock1 = await connectPanel(undefined);
+    sock1.send(JSON.stringify({ type: "hello", tab_id: "reconn-tab", title: "wf", panel_version: "0.6.8" }));
+    await new Promise((r) => setTimeout(r, 50));
+    // First connection: advertised 0.6.8 → graph_query is proactively gated.
+    await expect(bridge.send({ cmd: "graph_query" }, { tabId: "reconn-tab" })).rejects.toThrow(
+      /too old for "graph_query"/i,
+    );
+
+    // Reconnect under the SAME tab id, this time WITHOUT panel_version, on a panel that
+    // DOES support graph_query. The version is inherited (0.6.8) for messaging only.
+    let dispatched = false;
+    const sock2 = await connectPanel(undefined);
+    sock2.send(JSON.stringify({ type: "hello", tab_id: "reconn-tab", title: "wf" }));
+    sock2.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) {
+        dispatched = true;
+        sock2.send(JSON.stringify({ rid: msg.rid, ok: true, result: { cmd: msg.cmd } }));
+      }
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await bridge.send({ cmd: "graph_query" }, { tabId: "reconn-tab" });
+    expect(res).toEqual({ cmd: "graph_query" });
+    // Proof it was actually PROBED, not answered from a stale proactive gate.
+    expect(dispatched).toBe(true);
   });
 
   // #352 FALSE NEGATIVE end-to-end: a NEW-ENOUGH panel (advertises 0.11.21, well

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -97,6 +97,18 @@ interface Conn {
    *  (see makeUnknownCommandError) — the panel gained these bridge commands in
    *  0.11.4, so older builds reject graph_* / ui_* with a raw dispatch error. */
   panelVersion?: string;
+  /** True only when THIS hello actually CARRIED a `panel_version` (not inherited from
+   *  a prior connection under the same tab id). `panelVersion` is deliberately
+   *  inherited across a reconnect that omits the field (line ~849) so the reactive
+   *  "update your panel" message can still quote a detected version — but that stale,
+   *  inherited value must NOT drive the PROACTIVE gate (#392): a reconnect may be a
+   *  freshly UPGRADED panel, so proactively blocking it on the old version — without
+   *  ever probing it — would strand a now-capable panel until yet another reconnect
+   *  (codex WS review). So proactive gating fires ONLY when the current connection
+   *  advertised its own version; an omitted-version reconnect falls through to normal
+   *  dispatch + the reactive #236 path (which learns from a REAL rejection). Mirrors
+   *  the unsupportedCmds "reset on every hello" philosophy for the version dimension. */
+  panelVersionAdvertised: boolean;
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
    *  here, every later call is gated proactively — rejected before it ever
@@ -174,6 +186,27 @@ function panelSupportsCmd(cmd: string, panelVersion?: string): boolean {
   return compareSemver(panelVersion, minPanelVersionForCmd(cmd)) >= 0;
 }
 
+/** True when the panel's ADVERTISED version PARSEABLY PROVES it is too old to
+ *  support `cmd` — the mirror image of panelSupportsCmd, used to PROACTIVELY gate a
+ *  call BEFORE dispatch (#392) so the honest "update your panel" verdict fires on
+ *  the FIRST call, with no wasted round-trip to collect an "Unknown command" reply
+ *  (and even when a frozen old panel wouldn't cleanly reply at all).
+ *
+ *  Deliberately gates ONLY commands with an EXPLICIT, changelog-verified entry in
+ *  BRIDGE_CMD_MIN_PANEL_VERSION. A command NOT listed there falls back to the
+ *  inflated full-set baseline (0.11.4) which is WRONG as a proactive minimum for the
+ *  many bridge commands that shipped much earlier — using it here would FALSE-GATE a
+ *  capable 0.4.6–0.11.3 panel out of e.g. graph_get_errors. So an unlisted command is
+ *  NEVER proactively gated; it still learns unsupported reactively from a real
+ *  rejection (#236). Missing/unparseable version also returns false (can't prove it —
+ *  fall through to the reactive path, preserving fail-open). */
+export function panelVersionProvesUnsupported(cmd: string, panelVersion?: string): boolean {
+  const min = BRIDGE_CMD_MIN_PANEL_VERSION[cmd];
+  if (!min) return false;
+  if (!panelVersion || !SEMVER_RE.test(panelVersion.trim())) return false;
+  return compareSemver(panelVersion, min) < 0;
+}
+
 /** The actionable "update your panel" message for a command a connected panel has
  *  been discovered NOT to support. Shared by the reactive path (the panel's own
  *  "Unknown command" reply, mapped by makeUnknownCommandError) and the proactive
@@ -191,8 +224,10 @@ function buildPanelTooOldError(cmd: string, panelVersion?: string): Error {
 /**
  * A panel replies `{ ok: false, error: 'Unknown command "<cmd>"' }` when the
  * orchestrator dispatches a bridge command the (older) panel doesn't register —
- * graph_query, ui_render, graph_serialize, graph_view_nodes_in_viewport, etc. all
- * shipped in the panel at 0.11.4. Detect that raw dispatch error and rewrite it
+ * graph_query, ui_render, graph_serialize, graph_view_nodes_in_viewport, etc. are
+ * registered only from the panel version each was introduced in (see
+ * BRIDGE_CMD_MIN_PANEL_VERSION — NOT a blanket 0.11.4; graph_query shipped at 0.7.0,
+ * graph_outline at 0.4.6). Detect that raw dispatch error and rewrite it
  * into an actionable "update your panel" message instead of surfacing the opaque
  * internal command name to the agent/user. Returns null when `error` is anything
  * else (a genuine command failure), so the happy/normal-error path is untouched.
@@ -824,6 +859,12 @@ export class UiBridge {
             typeof (msg as { panel_version?: unknown }).panel_version === "string"
               ? ((msg as { panel_version?: string }).panel_version || undefined)
               : existing?.panelVersion,
+          // Did THIS hello carry its own version? Only then may proactive gating trust
+          // it (#392) — an omitted-version reconnect inherits panelVersion for messaging
+          // but must not be proactively blocked on it (see the field's doc comment).
+          panelVersionAdvertised:
+            typeof (msg as { panel_version?: unknown }).panel_version === "string" &&
+            !!(msg as { panel_version?: string }).panel_version,
           // Fresh per hello — see the field's doc comment (#236).
           unsupportedCmds: new Set<string>(),
           // window.location the browser was served from — the ComfyUI instance THIS
@@ -1290,6 +1331,20 @@ export class UiBridge {
     // on THIS connection (in dispatch()'s rejectMapped below), never inferred from
     // panelVersion alone.
     if (conn.unsupportedCmds.has(cmd.cmd)) {
+      return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
+    }
+    // #392 — PROACTIVELY gate a command whose changelog-verified minimum the panel's
+    // ADVERTISED version parseably undercuts (e.g. graph_query on a <0.7.0 panel), so
+    // the honest, correctly-versioned "update your panel" verdict fires on the FIRST
+    // call — no round-trip to collect an "Unknown command" reply, and it still works
+    // if a frozen old panel wouldn't reply. Conservative (panelVersionProvesUnsupported
+    // gates ONLY explicitly-listed commands against their true minimum, never the
+    // inflated fallback), so a capable panel is never falsely gated. Intentionally does
+    // NOT add to conn.unsupportedCmds — that learned set stays reserved for REAL
+    // rejections (#236), so nothing is permanently poisoned from version alone.
+    // Gated on panelVersionAdvertised so a stale version INHERITED across an
+    // omitted-version reconnect never blocks a possibly-upgraded panel unprobed.
+    if (conn.panelVersionAdvertised && panelVersionProvesUnsupported(cmd.cmd, conn.panelVersion)) {
       return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {


### PR DESCRIPTION
## Issue
Fixes **panel#392** — the orchestrator exposed and dispatched `panel_query_graph` (bridge command `graph_query`, panel ≥0.7.0) even when the connected panel was too old to register it. The agent was told to use the tool, then hit a runtime rejection; capability/version negotiation never gated it up front.

## Root cause (verify-first)
The `#352`/`#557` fix already made the *reactive* "Unknown command" round-trip produce the honest, command-specific minimum (`graph_query` → 0.7.0, not the old blanket 0.11.4). But the gate was purely reactive-learned (`Conn.unsupportedCmds`, set only after a real rejection), so the **first** call to an old panel still round-tripped, and an opaque failure surfaced before the honest verdict.

## Fix (`src/services/ui-bridge.ts`)
- New `panelVersionProvesUnsupported(cmd, panelVersion)` — the parseable-and-below mirror of `panelSupportsCmd`. Gates **only** commands with an explicit, changelog-verified entry in `BRIDGE_CMD_MIN_PANEL_VERSION`, never the inflated 0.11.4 full-set fallback, so an early-but-capable 0.4.6–0.11.3 panel is never false-gated out of commands that shipped earlier (e.g. `graph_get_errors`).
- `UiBridge.send()` now proactively rejects with the honest `buildPanelTooOldError` message **before** dispatch when the advertised version proves the command too old — no wasted round-trip, works even if a frozen old panel wouldn't reply. Does **not** touch the learned `unsupportedCmds` set (`#236` stays reserved for real rejections).
- New `Conn.panelVersionAdvertised`: proactive gating fires only on a version **this** hello carried, so a stale version inherited across an omitted-version reconnect never blocks a freshly-upgraded panel unprobed (caught by codex adversarial review).
- Corrected a stale comment claiming `graph_query` shipped at 0.11.4.

Hiding an MCP tool per live connection isn't feasible (the tool list is session-static and the panel version changes across reconnects), so the correct "gated-when-too-old" behavior is this honest, first-call proactive gate.

## Tests
`src/__tests__/services/ui-bridge.test.ts` — new `panelVersionProvesUnsupported` unit block + end-to-end: first-call proactive gate (no dispatch), omitted-version reconnect not blocked, reactive-learning path retargeted to an unlisted command. **78 passing**; `tsc` build green.

## Codex self-gate
`gpt-5.6-terra` adversarial review (embed-diff, working-tree): **APPROVE — no material findings** (an earlier medium re: stale-version inheritance across reconnect was found and fixed via `panelVersionAdvertised`, then re-reviewed clean).

Closes artokun/comfyui-mcp-panel#392

🤖 Generated with [Claude Code](https://claude.com/claude-code)