### PR TITLE
release: 0.48.24 — proactive panel version-gate (#392), context-meter (#543), self-queued backlog (#559), screenshot note (#567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.24] - 2026-08-01
+
+### MCP
+
+#### Fixed
+- **Proactively gate a panel bridge command when the panel's advertised version proves it too old (panel #392).** `panel_query_graph`/`graph_query` (etc.) are refused before dispatch with an honest, correctly-versioned message instead of being exposed and then failing at runtime — gated only on explicitly-listed commands and only when the connected panel actually advertised a too-old version (an omitted-version reconnect never blocks an upgraded panel).
+- **Context-meter denominator tracks the current model's window (#543)** — switching to a smaller-context model no longer leaves the denominator pinned to a stale larger window.
+- **`panel_run`'s queue-backlog warning no longer false-positives on self-queued jobs (#559)** — deliberately batching your own renders no longer warns about (and recommends destructively clearing) a backlog it created; the warning + destructive `clear_pending` recommendation are suppressed for your own in-flight batch.
+- **`panel_screenshot` annotates DOM-overlay nodes (#567)** — a MarkdownNote that renders empty on the LiteGraph canvas is now named in a result note (the faithful DOM composite is a separate panel-side change).
+
+
 ## [0.48.23] - 2026-08-01
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.23",
+  "version": "0.48.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.23",
+      "version": "0.48.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.23",
+  "version": "0.48.24",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Version bump + changelog. Tag v0.48.24 publishes via release.yml. Two codex-gated clusters since 0.48.23: #591 (proactive version-gate for panel #392) + #589 (#543/#559/#567). Composed main: build clean, 2704 tests pass (only the known ripgrep env-flake). Companion to panel 0.11.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)