### PR TITLE
fix(orchestrator): expose panel_* tools to Codex by spawning comfyui compact (#291)

### DIFF
--- a/src/__tests__/orchestrator/http-backend-tools.test.ts
+++ b/src/__tests__/orchestrator/http-backend-tools.test.ts
@@ -1,0 +1,30 @@
+// #291: the non-Claude HTTP backends (Codex/Gemini/Grok/…) reach panel_* over a
+// loopback HTTP MCP. The full ~250-tool comfyui surface saturates codex's tool
+// budget and makes it SILENTLY DROP the panel_* tools, so the live-canvas graph
+// tools vanished for a Codex session. resolveHttpLaneComfyToolMode defaults these
+// backends' comfyui server to COMPACT (3 meta-tools) so panel_* survives, while
+// an explicit COMFYUI_MCP_TOOL_MODE=full opts back into the full surface.
+
+import { describe, expect, it } from "vitest";
+import { resolveHttpLaneComfyToolMode } from "../../orchestrator/http-backend-tools.js";
+
+describe("resolveHttpLaneComfyToolMode (#291)", () => {
+  it("defaults to compact so comfyui never crowds panel_* out of codex", () => {
+    expect(resolveHttpLaneComfyToolMode({})).toBe("compact");
+  });
+
+  it("stays compact when the env var is unset/unrelated", () => {
+    expect(resolveHttpLaneComfyToolMode({ SOMETHING: "else" })).toBe("compact");
+    expect(resolveHttpLaneComfyToolMode({ COMFYUI_MCP_TOOL_MODE: "" })).toBe("compact");
+    expect(resolveHttpLaneComfyToolMode({ COMFYUI_MCP_TOOL_MODE: "compact" })).toBe("compact");
+  });
+
+  it("honors an explicit COMFYUI_MCP_TOOL_MODE=full override", () => {
+    expect(resolveHttpLaneComfyToolMode({ COMFYUI_MCP_TOOL_MODE: "full" })).toBe("full");
+  });
+
+  it("treats any non-'full' value as compact (fail safe toward exposing panel_*)", () => {
+    expect(resolveHttpLaneComfyToolMode({ COMFYUI_MCP_TOOL_MODE: "FULL" })).toBe("compact");
+    expect(resolveHttpLaneComfyToolMode({ COMFYUI_MCP_TOOL_MODE: "verbose" })).toBe("compact");
+  });
+});

--- a/src/orchestrator/http-backend-tools.ts
+++ b/src/orchestrator/http-backend-tools.ts
@@ -1,0 +1,29 @@
+import type { ToolMode } from "../transport/cli.js";
+
+/**
+ * The comfyui tool-server TOOL MODE to spawn for the NON-Claude HTTP backends
+ * (Codex / Gemini / Grok / Copilot / …), which reach panel_* over the loopback
+ * HTTP MCP.
+ *
+ * #291: the headless comfyui MCP exposes ~250 tools. A Codex session adds those
+ * on top of its OWN large built-in + user-configured tool surface, and once the
+ * total tool budget is saturated codex SILENTLY DROPS the panel HTTP-MCP server's
+ * tools — so the live-canvas `panel_*` graph tools became invisible to a Codex
+ * session even though the HTTP MCP was wired correctly. (Verified live: with the
+ * comfyui surface trimmed, `panel_*` reappears and is callable; with it full,
+ * `panel_*` is dropped.)
+ *
+ * So default these backends' comfyui server to COMPACT mode — the 3 meta-tools
+ * (list_tools / describe_tool / call_tool, issue #97) — instead of the full
+ * ~250-schema surface. That leaves ample tool budget for `panel_*` while keeping
+ * every comfyui tool reachable via `call_tool`. Claude is unaffected: it hosts
+ * panel_* via an in-process SDK server, not this HTTP path.
+ *
+ * An explicit `COMFYUI_MCP_TOOL_MODE=full` in the orchestrator env opts back into
+ * the full surface (accepting the panel_* crowd-out) for a user who wants it.
+ */
+export function resolveHttpLaneComfyToolMode(
+  env: NodeJS.ProcessEnv = process.env,
+): ToolMode {
+  return env.COMFYUI_MCP_TOOL_MODE === "full" ? "full" : "compact";
+}

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -82,6 +82,7 @@ import { buildStartFailureNotice } from "./start-failure-notice.js";
 import { readyBannerText, bannerCorrection } from "./ready-banner.js";
 import { OAUTH_PROVIDERS } from "../services/oauth-flow.js";
 import { startPanelMcpHttpServer, type PanelMcpHttpServer } from "./panel-mcp-http.js";
+import { resolveHttpLaneComfyToolMode } from "./http-backend-tools.js";
 import { startPanelConsoleHttpServer, type PanelConsoleHttpServer } from "./panel-console-http.js";
 import type { AgentBackend } from "./agent-backend.js";
 import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
@@ -1573,6 +1574,10 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Shared MCP server config for BOTH the Codex and Gemini backends — they take an
   // identical { transport } spec (the headless comfyui stdio MCP + the panel HTTP
   // MCP for this tab). Claude keeps its own in-process server set unchanged.
+  // #291: spawn comfyui COMPACT for these non-Claude HTTP backends so its ~250
+  // tools don't saturate the backend's tool budget and make codex silently drop
+  // the panel_* HTTP-MCP tools (overridable via COMFYUI_MCP_TOOL_MODE=full).
+  const httpLaneComfyToolMode = resolveHttpLaneComfyToolMode();
   const makeHttpBackendMcpServers = (tabId: string) => ({
     // Headless comfyui MCP (this build) over stdio — same as Claude.
     comfyui: {
@@ -1585,6 +1590,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       // withholds image pixels from the model.
       env: buildComfyuiMcpEnv({
         ...comfyuiBaseEnv(),
+        COMFYUI_MCP_TOOL_MODE: httpLaneComfyToolMode,
         ...(blindTabs.has(tabId) ? { COMFYUI_MCP_BLIND: "1" } : {}),
       }),
     },


### PR DESCRIPTION
## #291 — Codex sidebar session did not expose live `panel_*` graph tools

Closes artokun/comfyui-mcp#291

### Root cause (verified LIVE against codex 0.144.1, not assumed)
The panel_* live-graph tools ARE wired correctly to the non-Claude HTTP backends (Codex/Gemini/Grok/…) over the loopback HTTP MCP — codex connects, negotiates capabilities, and calls `tools/list` successfully. The failure is **tool-budget saturation**: the headless comfyui MCP exposes ~250 tools, and once codex's total tool surface (its own built-ins + the user's `~/.codex` plugins/apps + comfyui's 250) is saturated, codex **silently drops the panel HTTP-MCP server's tools** — so `panel_*` never reaches the model even though the wiring is sound.

Reproduced deterministically with a faithful copy of `panel-mcp-http.ts` + a real `codex exec`:
- Full comfyui present → `panel_*` absent from the model's toolset.
- comfyui neutralized (~0 tools) → `panel_ping` exposed **and callable** (`mcp__panel__panel_ping` → returned `pong`).
- comfyui forced **compact** → **both** `panel_*` and comfyui (via compact meta-tools) present.

This also disproves the earlier hypothesis that codex needs an `experimental_use_rmcp_client` flag — codex 0.144.1's own `codex mcp add --url` writes only `url=`, and the rmcp/StreamableHttp client is built-in.

### Fix
Spawn the comfyui tool server in **COMPACT** mode (3 meta-tools — `list_tools`/`describe_tool`/`call_tool`, issue #97) for the non-Claude HTTP backends via `COMFYUI_MCP_TOOL_MODE=compact`, freeing tool budget for `panel_*`. Every comfyui tool stays reachable through `call_tool`. New pure helper `resolveHttpLaneComfyToolMode(env)` (default compact; only an explicit `COMFYUI_MCP_TOOL_MODE=full` opts back into the full surface and accepts the crowd-out). Claude is unaffected — it hosts panel_* via an in-process SDK server, a separate path.

### Note — this is a real UX change for non-Claude backends
comfyui tools become `call_tool`-gated (meta-tools) instead of ~250 direct tools; `panel_*` (the primary sidebar value) is restored. Overridable with `COMFYUI_MCP_TOOL_MODE=full`.

### Tests / verification
- New `src/__tests__/orchestrator/http-backend-tools.test.ts` (resolver semantics: default compact, unset/unrelated → compact, explicit `full` → full, any non-`full` → compact).
- `tsc --noEmit` clean; full unit suite green (one pre-existing, unrelated ripgrep-env flake in `node-dev.test.ts`).
- Live end-to-end validation on the rig as described above.
- Adversarial codex review (gpt-5.6-terra/high): **PASS**.

### Related
#236 (advertised-but-rejected version gate) was verified **already resolved** on `main` by the reactive actionable-message gate + learned-repeat gate + command-specific minimums (#342/#352/#392/#591) — no code change here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)