### PR TITLE
feat(panel-tools): add panel_resize_node + document LTXDirector timeline set_widget (#530, #314)

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2559,7 +2559,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_set_widget",
-      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works).",
+      "Set a widget value on a node in the user's open graph (steps, cfg, seed, ckpt_name, text prompts, …). Returns the previous and new value. Undoable with Ctrl+Z. To CLEAR a text widget to an empty string, pass `clear: true` (some MCP clients drop an empty-string `value` from the serialized payload, so `value: \"\"` may not arrive — `clear: true` always works). For the LTXDirector timeline node (WhatDreamsCost CSGlide), set `timeline_data` with the FULL timeline JSON (segments + global_prompt) to drive its custom timeline UI — this re-syncs the editor and regenerates its derived `local_prompts`/`segment_lengths`/`guide_strength` widgets; setting those derived widgets directly is refused (they are silently reverted).",
       {
         node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
         widget: z.string().describe("Widget name (e.g. 'steps', 'cfg', 'text')."),
@@ -2593,6 +2593,19 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         pos: xy().describe("New canvas [x, y] (two numbers)."),
       },
       async (args: A, ctx) => ctx.call({ cmd: "graph_move_node", node_id: args.node_id, pos: args.pos }),
+    ),
+    def(
+      "panel_resize_node",
+      "Resize a node to [width, height] (canvas px) on the user's open graph. Essential for Note / MarkdownNote nodes, which are created tiny (140×60) and are unreadable until enlarged — panel_move_node only repositions, it cannot resize. Uses the node's own setSize so DOM-widget nodes (MarkdownNote) and nodes that clamp to a computed minimum reflow correctly. Undoable with Ctrl+Z.",
+      {
+        node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
+        size: z
+          .array(z.number())
+          .min(2)
+          .max(2)
+          .describe("New [width, height] in canvas px (both > 0)."),
+      },
+      async (args: A, ctx) => ctx.call({ cmd: "graph_resize_node", node_id: args.node_id, size: args.size }),
     ),
     def(
       "panel_auto_layout",


### PR DESCRIPTION
Node-UI-manipulation cluster. Paired with artokun/comfyui-mcp-panel#461 (same branch name) — the panel-side executors live there; merge together.

## #530 — `panel_resize_node`
Registers `panel_resize_node` (node_id + `size: [w, h]`), which calls `graph_resize_node` on the panel. Fixes the gap where an agent can create `MarkdownNote`/`Note` nodes (LiteGraph default 140×60, unreadable) but has no way to enlarge them — `panel_move_node` only repositions and `panel_auto_layout` doesn't resize. Mirrors `panel_move_node`; the panel executor prefers `node.setSize()` so DOM-widget/min-clamping nodes reflow.

`panel_resize_node` is a **panel** tool (`buildPanelToolDefs`), so the `asset-counts --check` gate (which validates `mcp_tools` from `collectToolCatalog`) is unaffected — verified: `asset counts match the source of truth` (mcp_tools 182 unchanged, panel_tools 87→88).

## #314 — `panel_set_widget` note
Documents in `panel_set_widget`'s description that the LTXDirector (CSGlide) timeline is driven by setting `timeline_data` with the full timeline JSON — which re-syncs the custom UI and regenerates the derived `local_prompts`/`segment_lengths`/`guide_strength` widgets — and that setting those derived widgets directly is refused. The behavior itself is implemented in the paired panel PR (feasibility analysis there).

### Verification
`tsc` build clean; full mcp suite passes except one pre-existing, unrelated `searchNodePacks` jail-root test that fails identically on pristine `origin/main` (HEAD 8c435fe). Codex self-gate **PASS** (gpt-5.6-terra/high).

Closes artokun/comfyui-mcp#530

🤖 Generated with [Claude Code](https://claude.com/claude-code)