### PR TITLE
fix: strip_workflow fallback on rewritten too-old error + workflows/ path normalization (panel #413/#414)

### DIFF
--- a/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
+++ b/src/__tests__/orchestrator/panel-load-workflow-userdata.test.ts
@@ -238,3 +238,144 @@ describe("panel_load_workflow: userdata fallback for a custom --user-directory (
     }
   });
 });
+
+// #414 — panel_list_workflows reports each workflow's userdata STORE KEY, which
+// already carries the "workflows/" prefix (e.g. "workflows/Daily Anime.json").
+// Feeding that exact value back to a path-taking tool (panel_strip_workflow /
+// panel_load_workflow share readWorkflowFromPath) double-prefixed the userdata
+// key → 404 → local miss → "No workflow file at …". The resolver must normalize
+// a leading "workflows/" so the list key resolves to the SAME single-prefixed key.
+describe("readWorkflowFromPath: a list-style 'workflows/…' path is not double-prefixed (#414)", () => {
+  it("resolves the userdata key WITHOUT nesting a second workflows/ segment", async () => {
+    const graph = { nodes: [{ id: 1, type: "KSampler" }], links: [] };
+    fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(graph) });
+
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler(
+      { path: "workflows/Daily Anime Portrait - Fast Preview.json" },
+      ctx,
+    );
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/Daily Anime Portrait - Fast Preview.json")}`,
+    );
+    // The pre-fix DOUBLED key must NEVER be requested.
+    expect(fetchApi).not.toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/workflows/Daily Anime Portrait - Fast Preview.json")}`,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].graph).toMatchObject(graph);
+  });
+
+  it("a bare name (no prefix) still resolves to the same single-prefixed key", async () => {
+    const graph = { nodes: [{ id: 2, type: "VAEDecode" }], links: [] };
+    fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(graph) });
+
+    const { ctx } = makeCtx();
+    await loadWorkflow().handler({ path: "Daily Anime Portrait - Fast Preview.json" }, ctx);
+    expect(fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/Daily Anime Portrait - Fast Preview.json")}`,
+    );
+  });
+
+  it("a 'workflows/'-prefixed path falls back to local disk WITHOUT nesting workflows/", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      const staged = { nodes: [{ id: 7, type: "PrefixedLocalNode" }], links: [] };
+      writeFileSync(join(defaultDir, "Foo.json"), JSON.stringify(staged), "utf8");
+      process.env.COMFYUI_PATH = root;
+
+      // Server 404s the name → local fallback. rel ("Foo.json") must join the
+      // workflows dir directly, not as workflows/workflows/Foo.json.
+      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "workflows/Foo.json" }, ctx);
+
+      expect(res.isError).toBeUndefined();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].graph).toMatchObject(staged);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// #414 hardening (codex) — normalizing the "workflows/" prefix must not let a
+// ".." segment escape the workflows root (e.g. "workflows/../secret.json" would
+// otherwise strip to "../secret.json"). Such a path is refused outright.
+describe("readWorkflowFromPath: refuses a '..' traversal segment (#414 hardening)", () => {
+  it("rejects a workflows/.. path without fetching or loading anything", async () => {
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "workflows/../secret.json" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(fetchApi).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/not a valid workflow name|\.\.|traversal/i);
+  });
+
+  it("still accepts a colon in a workflow NAME (legal POSIX filename, not a drive letter)", async () => {
+    // Regression guard: the drive-relative check must not reject a normal colon in
+    // a listed name like "workflows/style:anime.json".
+    const graph = { nodes: [{ id: 3, type: "SaveImage" }], links: [] };
+    fetchApi.mockResolvedValue({ ok: true, status: 200, text: async () => JSON.stringify(graph) });
+    const { ctx } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "workflows/style:anime.json" }, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(fetchApi).toHaveBeenCalledWith(
+      `/api/userdata/${encodeURIComponent("workflows/style:anime.json")}`,
+    );
+  });
+
+  it("rejects a Windows drive-relative traversal after the prefix is stripped", async () => {
+    // "workflows/C:../secret.json" strips to "C:../secret.json" — no exact ".."
+    // segment, but resolve() would canonicalize the embedded ".." and escape. The
+    // ":" (drive-letter) guard blocks it before any fetch/local read.
+    const { ctx, calls } = makeCtx();
+    const res = await loadWorkflow().handler({ path: "workflows/C:../secret.json" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(fetchApi).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
+    expect(JSON.stringify(res)).toMatch(/not a valid workflow name/i);
+  });
+
+  it("does NOT read a file via a symlink under the workflows dir that escapes the root", async () => {
+    // A lexically-clean name ("linked/secret.json") where `linked` is a symlink to
+    // an EXTERNAL dir would, without realpath containment, be read on the local
+    // fallback. The realpath check rejects it. (Skipped where the OS denies
+    // unprivileged symlink creation, e.g. stock Windows.)
+    const { symlinkSync } = await import("node:fs");
+    const root = mkdtempSync(join(tmpdir(), "cmcp-userdir-"));
+    const external = mkdtempSync(join(tmpdir(), "cmcp-external-"));
+    try {
+      const defaultDir = join(root, "user", "default", "workflows");
+      mkdirSync(defaultDir, { recursive: true });
+      writeFileSync(
+        join(external, "secret.json"),
+        JSON.stringify({ nodes: [{ id: 1, type: "SecretNode" }], links: [] }),
+        "utf8",
+      );
+      try {
+        symlinkSync(external, join(defaultDir, "linked"), "junction");
+      } catch {
+        return; // unprivileged symlink creation — skip on this platform
+      }
+      process.env.COMFYUI_PATH = root;
+      fetchApi.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+      const { ctx, calls } = makeCtx();
+      const res = await loadWorkflow().handler({ path: "linked/secret.json" }, ctx);
+
+      // The escaping file must NOT be loaded — surfaces the honest not-found error.
+      expect(calls).toHaveLength(0);
+      expect(res.isError).toBe(true);
+      expect(JSON.stringify(res)).toMatch(/No workflow file at|userdata/i);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2277,4 +2277,72 @@ describe("panel_strip_workflow live-canvas fallback (issue #384)", () => {
     // never attempted the state fallback for a non-unknown-command failure
     expect(sent).not.toContain("graph_get_state");
   });
+
+  // #413 — the REAL bridge does NOT surface the raw "Unknown command" text: the
+  // reactive rewrite (makeUnknownCommandError) and the #236 proactive gate both
+  // throw a "too old for graph_serialize" error instead. The old
+  // /unknown command/ test here never matched that, so the graph_get_state
+  // fallback was silently SKIPPED and the actionable error surfaced even though
+  // the back-compat path would have worked. These assert the fallback now fires.
+  it("falls back to graph_get_state on the bridge's REWRITTEN 'too old' error (message-only)", async () => {
+    const sent: string[] = [];
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          if (cmd.cmd === "graph_serialize") {
+            // The bridge-rewritten message — note it no longer says "unknown command".
+            throw new Error(
+              'This ComfyUI-MCP panel is too old for "graph_serialize" (detected 0.7.0) — update the ComfyUI-MCP panel to ≥0.8.2, then reconnect.',
+            );
+          }
+          if (cmd.cmd === "graph_get_state") {
+            return {
+              nodes: [
+                { id: 1, type: "SaveImage", widgets: { filename_prefix: "out" }, inputs: [], outputs: [] },
+              ],
+            };
+          }
+          return {};
+        },
+      },
+    } as unknown as PanelToolCtx;
+    const wf = (await __panelToolsTestHooks.resolveWorkflowInput({}, ctx)) as {
+      nodes: Array<{ type: string }>;
+    };
+    expect(sent).toContain("graph_serialize");
+    expect(sent).toContain("graph_get_state");
+    expect(wf.nodes[0].type).toBe("SaveImage");
+  });
+
+  it("falls back on the STRUCTURED unsupported-command tag (the #236 proactive gate throws this)", async () => {
+    const sent: string[] = [];
+    const tagged = Object.assign(
+      new Error('This ComfyUI-MCP panel is too old for "graph_serialize" — update…'),
+      { panelCmdUnsupported: "graph_serialize" },
+    );
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          if (cmd.cmd === "graph_serialize") throw tagged;
+          if (cmd.cmd === "graph_get_state") {
+            return {
+              nodes: [{ id: 9, type: "PreviewImage", widgets: {}, inputs: [], outputs: [] }],
+            };
+          }
+          return {};
+        },
+      },
+    } as unknown as PanelToolCtx;
+    const wf = (await __panelToolsTestHooks.resolveWorkflowInput({}, ctx)) as {
+      nodes: Array<{ type: string }>;
+    };
+    expect(sent).toContain("graph_get_state");
+    expect(wf.nodes[0].type).toBe("PreviewImage");
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   UiBridge,
   makeUnknownCommandError,
   panelVersionProvesUnsupported,
+  isPanelCmdUnsupportedError,
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
   minPanelVersionForCmd,
   markDispatched,
@@ -1204,6 +1205,51 @@ describe("panelVersionProvesUnsupported (#392 proactive version gate)", () => {
     expect(panelVersionProvesUnsupported("graph_outline", "0.4.5")).toBe(true);
     expect(panelVersionProvesUnsupported("graph_outline", "0.4.6")).toBe(false);
     expect(panelVersionProvesUnsupported("graph_outline", "0.11.7")).toBe(false);
+  });
+});
+
+// #413 — the bridge REWRITES a panel's raw "Unknown command graph_serialize" into
+// a "too old for graph_serialize" message (and throws the same, tagged, from the
+// #236 proactive gate). A caller with a back-compat fallback (panel_strip_workflow
+// → graph_get_state) needs to detect that condition WITHOUT string-matching the
+// literal "unknown command" text that was rewritten away. isPanelCmdUnsupportedError
+// reads the STRUCTURED tag buildPanelTooOldError attaches, with a message-regex
+// fallback for errors that never passed through the rewrite.
+describe("isPanelCmdUnsupportedError (#413 structured unsupported-command detection)", () => {
+  it("detects the STRUCTURED tag on a rewritten 'too old' error (the reactive path)", () => {
+    // makeUnknownCommandError funnels through buildPanelTooOldError, which tags
+    // the error with panelCmdUnsupported — even though the message no longer says
+    // "unknown command".
+    const e = makeUnknownCommandError('Unknown command "graph_serialize"');
+    expect(e).not.toBeNull();
+    expect(e?.message.toLowerCase()).not.toContain("unknown command");
+    expect(isPanelCmdUnsupportedError(e)).toBe(true);
+    expect(isPanelCmdUnsupportedError(e, "graph_serialize")).toBe(true);
+    // A tag for a DIFFERENT command must not match a specific query.
+    expect(isPanelCmdUnsupportedError(e, "graph_outline")).toBe(false);
+  });
+
+  it("matches the raw panel 'Unknown command' text (untagged fallback)", () => {
+    expect(isPanelCmdUnsupportedError(new Error('Unknown command "graph_serialize"'))).toBe(true);
+    expect(
+      isPanelCmdUnsupportedError(new Error('Unknown command "graph_serialize"'), "graph_serialize"),
+    ).toBe(true);
+    expect(
+      isPanelCmdUnsupportedError(new Error('Unknown command "graph_serialize"'), "graph_outline"),
+    ).toBe(false);
+  });
+
+  it("matches the rewritten 'too old for' text even without the tag", () => {
+    const raw = new Error('This ComfyUI-MCP panel is too old for "graph_serialize" — update…');
+    expect(isPanelCmdUnsupportedError(raw)).toBe(true);
+    expect(isPanelCmdUnsupportedError(raw, "graph_serialize")).toBe(true);
+  });
+
+  it("does NOT match a genuine transport/timeout error (fallback must not fire)", () => {
+    expect(isPanelCmdUnsupportedError(new Error("bridge ack timed out after 30000ms"))).toBe(false);
+    expect(isPanelCmdUnsupportedError(new Error("panel not reachable"))).toBe(false);
+    expect(isPanelCmdUnsupportedError(undefined)).toBe(false);
+    expect(isPanelCmdUnsupportedError(null)).toBe(false);
   });
 });
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -25,8 +25,8 @@
 
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { extname, isAbsolute, join, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
@@ -34,7 +34,7 @@ import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UiBridge } from "../services/ui-bridge.js";
-import { dispatchOutcomeOf } from "../services/ui-bridge.js";
+import { dispatchOutcomeOf, isPanelCmdUnsupportedError } from "../services/ui-bridge.js";
 import {
   type WorkflowTargetStore,
   withWorkflowTarget,
@@ -1507,10 +1507,37 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
     | { kind: "refused"; detail: string } // non-404 HTTP error → error, no fallback
     | { kind: "absent"; detail: string } // 404 → local fallback allowed
     | { kind: "unreachable"; detail: string }; // transport failure → local fallback allowed
+  // #414: panel_list_workflows reports each workflow's userdata STORE KEY, which
+  // already carries the "workflows/" prefix (e.g. "workflows/Daily Anime.json").
+  // Feeding that exact value back here double-prefixed it to
+  // "workflows/workflows/Daily Anime.json" → a 404 → the local fallback missed too
+  // → "No workflow file at …", even though it is the documented list output. Strip
+  // one leading "workflows/" segment so the list key, a bare name, and a subfolder
+  // path all normalize to the same store-relative name. (A genuinely absolute path
+  // — including a Windows leading-slash path — was already handled and returned
+  // above, so it never reaches this relative-name normalization.)
+  const rel = p.replace(/^[\\/]+/, "").replace(/^workflows[\\/]+/i, "");
+  // Refuse traversal / drive-relative escapes (codex): a real workflow name is a
+  // plain relative path whose segments are filenames/subfolders. Stripping the
+  // "workflows/" prefix must never turn the input into something that ESCAPES the
+  // workflows root — both in the userdata key sent to the server and in the local
+  // resolve(dir, rel) fallback. Reject a ".." segment ("workflows/../secret.json")
+  // and a Windows DRIVE-RELATIVE segment ("C:..", "C:foo", which resolve()
+  // canonicalizes with drive semantics past a plain ".."-segment check). A colon
+  // ELSEWHERE is a legal POSIX filename char (e.g. "style:anime.json"), so match
+  // only a leading drive-letter form — not every colon. The realpath containment
+  // check below is the authoritative backstop for the local read regardless.
+  const relSegs = rel.split(/[\\/]+/);
+  if (relSegs.includes("..") || relSegs.some((s) => /^[A-Za-z]:/.test(s))) {
+    throw new Error(
+      `"${p}" is not a valid workflow name — pass a name relative to the ComfyUI ` +
+        `workflows folder (no "..", drive letters, or absolute paths), or an absolute path.`,
+    );
+  }
   let outcome: Outcome;
   try {
     const client = getClient();
-    const encoded = encodeURIComponent(`workflows/${p.replace(/^[\\/]+/, "")}`);
+    const encoded = encodeURIComponent(`workflows/${rel}`);
     const res = await client.fetchApi(`/api/userdata/${encoded}`);
     if (res.ok) {
       // Read the body as TEXT and classify HERE so a malformed 2xx surfaces its
@@ -1559,11 +1586,29 @@ async function readWorkflowFromPath(rawPath: string): Promise<Record<string, unk
   // orchestrator's guessed local workflows dirs (best-effort; only meaningful on
   // a same-machine ComfyUI whose user-dir matches the default layout, or a file
   // staged straight to disk).
-  const localCandidates = [
-    ...comfyWorkflowsDirs().map((dir) => resolve(dir, p)),
-    resolve(process.cwd(), p), // orchestrator CWD as a last local resort
-  ];
-  const local = localCandidates.find((c) => existsSync(c) && statSync(c).isFile());
+  // Each candidate is the store-relative name resolved UNDER a base dir. Only the
+  // NORMALIZED `rel` is used (never the raw `workflows/…` key), so nothing nests a
+  // second workflows/ (codex P1/P2). Belt-and-suspenders containment: an existing
+  // candidate is only accepted if its REAL path (symlinks/junctions resolved)
+  // stays beneath the base's REAL path — so a link under the workflows dir that
+  // targets an external directory can't be read on the 404/unreachable fallback
+  // (codex). Canonicalizing BOTH sides keeps a legitimately-symlinked workflows
+  // dir working (its base resolves too), while blocking a per-file escape.
+  const realBaseUnder = (base: string, candidate: string): boolean => {
+    try {
+      const rb = realpathSync(base);
+      const rc = realpathSync(candidate);
+      return rc === rb || rc.startsWith(rb + sep);
+    } catch {
+      return false;
+    }
+  };
+  const localBases = [...comfyWorkflowsDirs(), process.cwd()];
+  const local = localBases
+    .map((dir) => ({ dir, path: resolve(dir, rel) }))
+    .filter(({ path }) => existsSync(path) && statSync(path).isFile())
+    .filter(({ dir, path }) => realBaseUnder(dir, path))
+    .map(({ path }) => path)[0];
   if (local) return readLocal(local);
 
   throw new Error(
@@ -2127,13 +2172,19 @@ async function resolveWorkflowInput(
       timeoutMs: 30000,
     });
   } catch (err) {
-    // #384: a panel too old to register graph_serialize (added at 0.11.4) still
-    // answers the back-compat `graph_get_state`. On an "Unknown command" rejection
-    // ONLY (a genuine transport/timeout error must surface as-is), fall back to it
-    // and reconstruct the graph so "strip the live canvas" works without a
-    // save-to-disk round trip.
+    // #384: a panel too old to register graph_serialize (added at 0.8.2) still
+    // answers the back-compat `graph_get_state`. On an unsupported-command
+    // rejection ONLY (a genuine transport/timeout error must surface as-is), fall
+    // back to it and reconstruct the graph so "strip the live canvas" works
+    // without a save-to-disk round trip.
+    // #413: the bridge REWRITES the panel's raw "Unknown command" into a "too old
+    // for graph_serialize" message (reactive) or throws it proactively (#236) —
+    // both stripped the literal "unknown command" text, so the old
+    // /unknown command/ regex here NEVER matched and the fallback was silently
+    // skipped, surfacing the actionable error even though graph_get_state would
+    // have worked. Detect the condition structurally instead.
     const msg = err instanceof Error ? err.message : String(err);
-    if (allowStateFallback && /unknown command/i.test(msg)) {
+    if (allowStateFallback && isPanelCmdUnsupportedError(err, "graph_serialize")) {
       try {
         const target = ctx.workflowTarget?.get(ctx.tabId);
         const stateCmd = target

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -215,9 +215,43 @@ export function panelVersionProvesUnsupported(cmd: string, panelVersion?: string
  *  quoted minimum is COMMAND-SPECIFIC (#352) — not a blanket 0.11.4. */
 function buildPanelTooOldError(cmd: string, panelVersion?: string): Error {
   const detected = panelVersion ? ` (detected ${panelVersion})` : "";
-  return new Error(
+  const e = new Error(
     `This ComfyUI-MCP panel is too old for "${cmd}"${detected} — update the ComfyUI-MCP panel ` +
       `to ≥${minPanelVersionForCmd(cmd)} (ComfyUI Manager → update comfyui-mcp panel), then reconnect.`,
+  );
+  // STRUCTURED discriminator (#413): both the reactive rewrite and the #236
+  // proactive gate funnel through here, so tagging the error object lets callers
+  // detect an unsupported-command rejection WITHOUT string-matching a message
+  // that was already rewritten away from the panel's raw "Unknown command" text.
+  // panel_strip_workflow relies on this to still take its graph_get_state
+  // back-compat fallback (which was skipped when the message no longer contained
+  // "unknown command").
+  (e as PanelCmdUnsupportedError).panelCmdUnsupported = cmd;
+  return e;
+}
+
+/** An Error carrying the bridge command a connected panel was proven NOT to
+ *  support (too old / unknown command). Produced by buildPanelTooOldError. */
+export interface PanelCmdUnsupportedError extends Error {
+  panelCmdUnsupported: string;
+}
+
+/** True when `err` is (or plausibly is) an unsupported-command rejection for
+ *  `cmd` — either the STRUCTURED tag set by buildPanelTooOldError (authoritative),
+ *  or, as a belt-and-suspenders fallback for errors that never passed through the
+ *  rewrite, the raw panel "Unknown command" text or the rewritten "too old for"
+ *  message. Callers that carry a graceful fallback (e.g. panel_strip_workflow's
+ *  graph_get_state reconstruction, #384/#413) use this to decide whether to try
+ *  it. When `cmd` is given, a structured tag must match it. */
+export function isPanelCmdUnsupportedError(err: unknown, cmd?: string): boolean {
+  const tag = (err as Partial<PanelCmdUnsupportedError> | null | undefined)
+    ?.panelCmdUnsupported;
+  if (typeof tag === "string") return cmd == null || tag === cmd;
+  const msg = err instanceof Error ? err.message : String(err ?? "");
+  const cmdPat = cmd ? cmd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[\\w.-]+";
+  return (
+    new RegExp(`unknown command\\s*["“']?${cmdPat}`, "i").test(msg) ||
+    new RegExp(`too old for\\s*["“']?${cmdPat}`, "i").test(msg)
   );
 }
 


### PR DESCRIPTION
Fixes two panel-tooling bugs that live in the orchestrator (the `panel_*` MCP tools), filed against the panel repo. Verified against `origin/main` (0.48.23) — both reproduce on current main.

## panel#413 — strip_workflow live capture fails on graph_serialize version skew
The `#384` graph_get_state back-compat fallback only fired on a raw `Unknown command` message — but `bridge.send` **rewrites** that into `too old for "graph_serialize"` (reactive `makeUnknownCommandError`) or throws it proactively (`#236` gate). Neither contains "unknown command", so the fallback was silently skipped and the actionable error surfaced even though `graph_get_state` would have worked.

**Fix:** `buildPanelTooOldError` now tags the error with `panelCmdUnsupported`; a new exported `isPanelCmdUnsupportedError(err, cmd?)` detects it structurally (both the reactive and proactive paths funnel through `buildPanelTooOldError`), with a message-regex fallback for untagged errors. `resolveWorkflowInput` uses it so the fallback fires on the real, rewritten error.

## panel#414 — strip_workflow rejects a path returned by panel_list_workflows
`panel_list_workflows` reports the userdata **store key**, already prefixed `workflows/…`. `readWorkflowFromPath` prepended another `workflows/` → doubled key → 404 → local miss → "No workflow file at". **Fix:** strip one leading `workflows/` segment before building the userdata key and local candidates. Hardened (per adversarial review): reject `..` and Windows drive-letter segments, realpath-containment-check each local candidate stays beneath its base (blocks symlink escapes), while still accepting legal POSIX colons like `style:anime.json`.

## Verification
- Affected suites green: `ui-bridge.test.ts`, `panel-tools.test.ts`, `panel-load-workflow-userdata.test.ts` (228 tests). Full build clean. (One pre-existing unrelated failure in `node-dev.test.ts` — a ripgrep-vs-builtin environmental assertion, outside this diff.)
- Codex self-gate (gpt-5.6-terra, high): **PASS** after 6 review rounds (each caught a real path-safety edge: local double-nest, `..` traversal, Windows drive-relative `C:..`, symlink escape, and a colon over-rejection regression — all fixed).

Do not merge — draft for review.

Closes artokun/comfyui-mcp-panel#413
Closes artokun/comfyui-mcp-panel#414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
