### PR TITLE
release: 0.48.26 — strip_workflow fallback + path load (#413/#414), panel_* tools for Codex (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.26] - 2026-08-01
+
+### Fixed
+- **`panel_strip_workflow` live-capture fallback fires against a version-skewed panel, and `panel_list_workflows` paths load (panel #413, #414).** The #384 `graph_get_state` fallback was skipped because the bridge rewrites `unknown command` → `too old for "graph_serialize"`; it's now detected structurally via a typed `panelCmdUnsupported` tag (which also covers the new #392 proactive version-gate). And a `panel_list_workflows` key already prefixed `workflows/` was double-prefixed → 404; it now strips one leading prefix, with path-traversal / drive-letter / symlink-escape hardening.
+- **Codex (and other non-Claude backends) get the live `panel_*` graph tools again (panel #291).** ComfyUI's ~250 tools saturated Codex's tool budget and it silently dropped the `panel_*` tools; the non-Claude HTTP lane now spawns the comfyui MCP in **compact** mode (freeing budget), so `panel_*` are advertised and callable. Claude is unaffected; `COMFYUI_MCP_TOOL_MODE=full` opts out (comfyui tools then become `call_tool`-gated for those backends).
+
 ## [0.48.25] - 2026-08-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.25",
+  "version": "0.48.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.25",
+      "version": "0.48.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.25",
+  "version": "0.48.26",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
Two codex-gated clusters since 0.48.25 (#597, #594). Tag v0.48.26 publishes via release.yml. Companion to panel 0.11.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)