### PR TITLE
fix(panel-tools): name the rebind recovery on a no-route panel refusal (panel #442 defect 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+### Fixed
+- **A mutating panel command names the rebind recovery when it can't reach a tab (panel #442, defect 4).** `panel_set_widget` (and every other mutating `panel_*` edit deliberately excluded from the retry-safe set) surfaced the bare bridge error — `no connected tab … Connected: none` — with no recovery path, whereas a retry-safe read like `panel_get_errors` already names the rebind. That asymmetry made a brief post-reconnect read/edit-channel disagreement (a user hit it ~6× in a long multi-tab session, while `panel_list_workflows` kept answering) look like a dead agent. The bridge now tags a pre-dispatch routing refusal with its authoritative typed `dispatched:false` flag, so the tool layer wraps it — without retrying (no double-apply) — to state nothing was applied and name `panel_set_workflow_target({mode:"current"})`, preserving the raw cause. Keying on the typed flag (not error text) means a post-dispatch executor failure that merely quotes "no connected tab" is never mis-classified. The strict-single silent auto-heal still recovers the ordinary single-tab case untouched.
+
 ## [0.48.26] - 2026-08-01
 
 ### Fixed

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -27,6 +27,7 @@ const { buildPanelToolDefs, makePanelToolCtx, __panelToolsTestHooks, __openWorkf
   await import("../../orchestrator/panel-tools.js");
 import { getBootLocalComfyUIBaseUrl } from "../../config.js";
 import { WorkflowTargetStore } from "../../services/workflow-target-store.js";
+import { markDispatched } from "../../services/ui-bridge.js";
 import type { PanelToolCtx, ToolResult } from "../../orchestrator/panel-tools.js";
 
 const BOOT_BASE = (getBootLocalComfyUIBaseUrl() ?? "http://127.0.0.1:8188").replace(/\/+$/, "");
@@ -52,7 +53,13 @@ function reconnectingBridge(initial: string[] = []) {
   const bridge = {
     send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
       const id = opts?.tabId;
-      if (id && !live.has(id)) throw new Error(`no connected tab with id "${id}". Connected: none`);
+      if (id && !live.has(id)) {
+        // Mirror the REAL UiBridge.resolveTarget refusal: it rejects BEFORE any socket
+        // write, LISTS the actually-connected tabs (not "none" when others are live), and
+        // carries the authoritative typed dispatched:false flag the tool layer keys on.
+        const connected = [...live].map((t) => `${t.slice(0, 8)} ("${t}")`).join(", ") || "none";
+        throw markDispatched(new Error(`no connected tab with id "${id}". Connected: ${connected}`), false);
+      }
       sent.push({ cmd, tabId: id });
       // workflow_list answers the open-verify probe with `active` = the routed tab.
       if (cmd.cmd === "workflow_list") {
@@ -327,6 +334,82 @@ describe("headless-aware reconnect recovery (#400/#402)", () => {
     // ambiguous — it rebinds onto the sole canvas tab and dispatches.
     expect(textOf(res)).not.toMatch(/multiple tabs/i);
     expect(ctx.tabId).toBe("desktop-canvas");
+  });
+});
+
+describe("#442 defect 4: a MUTATING panel command names the rebind on a no-route refusal", () => {
+  it("panel_set_widget surfaces an actionable rebind hint (not the bare bridge error) when its tab is gone and the session is multi-tab", async () => {
+    // Two interactive tabs are live but NEITHER is this session's — the strict-single
+    // silent auto-heal (ensureReachable) refuses to guess, so the send fires into a dead
+    // binding and the bridge REFUSES BEFORE dispatch (typed dispatched:false). This is the
+    // exact condition a user hit ~6× with panel_set_widget while panel_list_workflows still
+    // answered (the two channels briefly disagree after a reconnect).
+    const { bridge, sent } = reconnectingBridge(["a-tab", "b-tab"]);
+    const ctx = makePanelToolCtx(bridge, "dead-tab", new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 7, widget: "steps", value: 20 },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    const text = textOf(res);
+    // Names the documented recovery call (parity with the retry-safe graph_get_errors path).
+    expect(text).toContain('panel_set_workflow_target({mode:"current"})');
+    // A pre-dispatch no-route refusal provably applied nothing — say so, and never retry it.
+    expect(text).toMatch(/Nothing was applied/i);
+    // The raw bridge cause is preserved (and, faithfully, lists the live tabs — not "none").
+    expect(text).toMatch(/no connected tab with id "dead-tab"/);
+    expect(sent.length).toBe(0); // the mutating write was NEVER dispatched (no double-apply)
+  });
+
+  it("does NOT mis-wrap a POST-dispatch executor failure that merely quotes 'no connected tab' as 'nothing applied'", async () => {
+    // A LIVE tab that ACCEPTS the command (it IS dispatched, pushed to `sent`) but whose
+    // executor rejects with a message quoting the routing phrase. Because the typed flag is
+    // absent (dispatchOutcomeOf === undefined, not false), the wrapper must NOT fire — the
+    // raw executor error surfaces and we never falsely claim nothing applied.
+    const live = new Set(["live-tab"]);
+    const sent: Array<{ cmd: Record<string, unknown> }> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (opts?.tabId && !live.has(opts.tabId)) throw new Error("unexpected route");
+        sent.push({ cmd }); // the command WAS dispatched
+        // Executor reply ok:false becomes a plain Error (no dispatched symbol), text quotes
+        // the routing phrase to prove the wrapper keys on the TYPED flag, not the text.
+        throw new Error('graph_set_widget failed: internal reference to "no connected tab" in a stale cache');
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => [...live][0],
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "live-tab", new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 7, widget: "steps", value: 20 },
+      ctx,
+    );
+    expect(res.isError).toBe(true);
+    expect(sent.length).toBe(1); // it really was dispatched
+    const text = textOf(res);
+    expect(text).not.toMatch(/Nothing was applied/i); // never a false "nothing applied"
+    expect(text).toContain("stale cache"); // the raw executor error is surfaced as-is
+  });
+
+  it("still self-heals the common SINGLE-tab case (a sole reconnected tab) — set_widget succeeds silently", async () => {
+    // Only ONE interactive tab is live (under a new id after a reconnect). The strict-single
+    // auto-heal rebinds onto it BEFORE the send, so the ordinary case never even sees the
+    // error — the improved message is reserved for the genuinely ambiguous multi-tab case.
+    const { bridge, sent } = reconnectingBridge(["sole-tab"]);
+    const ctx = makePanelToolCtx(bridge, "dead-tab", new WorkflowTargetStore());
+
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 7, widget: "steps", value: 20 },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(ctx.tabId).toBe("sole-tab"); // rebound onto the sole live tab
+    expect(sent.at(-1)?.cmd).toMatchObject({ cmd: "graph_set_widget" });
+    expect(sent.at(-1)?.tabId).toBe("sole-tab");
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -226,6 +226,74 @@ describe("UiBridge (mailbox — offline render delivery)", () => {
   });
 });
 
+describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
+  // Reply to any command with an executor FAILURE (ok:false). Mirrors a panel-side
+  // graph executor rejecting — the bridge turns it into a plain Error with NO typed
+  // dispatch flag, so a caller must NOT treat it as a pre-dispatch "nothing applied".
+  function replyError(sock: WebSocket, errorText: string): void {
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) sock.send(JSON.stringify({ rid: msg.rid, ok: false, error: errorText }));
+    });
+  }
+
+  it("a resolveTarget refusal (no connected tab) rejects with dispatched:false", async () => {
+    // No panel connected; a non-mailboxable (interactive) command can't be routed.
+    let caught: unknown;
+    await bridge.send({ cmd: "graph_set_widget" }, { tabId: "ghost-tab" }).catch((e) => (caught = e));
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/no connected tab with id "ghost-tab"/);
+    // THE contract the #442 wrapper keys on: this is provably pre-dispatch (nothing sent).
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+  });
+
+  it("lists the actually-connected tabs (not 'none') when OTHER tabs are live — still dispatched:false", async () => {
+    const a = await connectPanel("tab-live-1111", "flux-workflow");
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    let caught: unknown;
+    await bridge.send({ cmd: "graph_set_widget" }, { tabId: "gone-tab" }).catch((e) => (caught = e));
+    // Faithful message: the routing error names the live tab, proving the multi-tab
+    // read/edit-channel disagreement (#442) — panel_list_workflows would still answer.
+    expect((caught as Error).message).toMatch(/Connected:.*flux-workflow/);
+    expect(dispatchOutcomeOf(caught)).toBe(false);
+    a.close();
+  });
+
+  it("a real executor ok:false failure carries NO typed flag (dispatchOutcomeOf === undefined)", async () => {
+    // The tab IS connected and DID receive the command — its executor merely failed, with
+    // an error string that even QUOTES the routing phrase. The wrapper must never treat
+    // this as "nothing applied": the flag is absent, not false.
+    const a = await connectPanel("tab-exec-1111");
+    replyError(a, 'graph_set_widget failed: stale ref to "no connected tab" in cache');
+    await vi.waitFor(() => expect(bridge.connected()).toBe(true));
+    let caught: unknown;
+    await bridge.send({ cmd: "graph_set_widget" }, { tabId: "tab-exec-1111" }).catch((e) => (caught = e));
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("stale ref");
+    expect(dispatchOutcomeOf(caught)).toBeUndefined(); // NOT false — it WAS dispatched
+    a.close();
+  });
+
+  it("a mailboxable delivery to an offline tab RESOLVES (never a dispatched:false rejection)", async () => {
+    // The offline-render mailbox path returns a resolved value, so it never acquires a
+    // dispatch flag — the #442 wrapper only ever sees genuine rejections.
+    const res = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "a.png" }] },
+      { tabId: "offline-phone-1" },
+    );
+    expect(res).toMatchObject({ ok: true, mailboxed: true });
+  });
+
+  it("a successfully-acked command resolves (no dispatch flag involved)", async () => {
+    const a = await connectPanel("tab-ok-1111");
+    autoReply(a, "A");
+    await vi.waitFor(() => expect(bridge.connected()).toBe(true));
+    const result = await bridge.send({ cmd: "graph_set_widget" }, { tabId: "tab-ok-1111" });
+    expect(result).toMatchObject({ from: "A" });
+    a.close();
+  });
+});
+
 describe("UiBridge (multi-tab)", () => {
   it("routes to the single connected tab without tab_id", async () => {
     const a = await connectPanel("tab-aaaa-1111");

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1865,6 +1865,35 @@ export function makePanelToolCtx(
           return fail(err2);
         }
       }
+      // #442 defect 4: a MUTATING command (deliberately excluded from RETRY_SAFE_CMDS)
+      // that the bridge refused BEFORE any socket write surfaced the bare routing error
+      // ("no connected tab … Connected: none") with no recovery path — whereas a
+      // retry-safe read like graph_get_errors, via the branch above, names the rebind.
+      // That asymmetry made a brief post-reconnect read/edit-channel disagreement look
+      // like a dead agent (panel_list_workflows kept answering while panel_set_widget
+      // failed, in a multi-tab session the strict-single silent auto-heal won't touch).
+      // We must NOT retry the mutating command (double-apply risk), but the bridge's
+      // AUTHORITATIVE typed flag proves nothing was dispatched (dispatchOutcomeOf ===
+      // false) — so it is safe to state nothing was applied and name the rebind recovery,
+      // preserving the raw cause. Keying on the TYPED flag (not error text) means a
+      // POST-dispatch executor ok:false reply that merely quotes "no connected tab" is
+      // never mis-wrapped as "nothing applied".
+      if (dispatchOutcomeOf(err) === false) {
+        const name = typeof cmd.cmd === "string" ? cmd.cmd : "panel command";
+        // Neutral wording: a dispatched:false flag proves only that the command was NOT
+        // dispatched — it can be a routing refusal (the bound tab is gone / reconnecting),
+        // an ambiguous-or-multiple-tab resolver refusal (other tabs DO exist), or a socket
+        // write failure. All share the same TRUE facts (nothing applied) and the same
+        // recovery (rebind onto the tab that's live now); the raw cause carries the
+        // specifics. Do NOT overstate "disconnected", which is false for the ambiguity case.
+        return fail(
+          `${name} could not be dispatched to this session's panel tab — nothing was applied. ` +
+            `The tab may be disconnected, still reconnecting after a restart/reload, or the ` +
+            `session's binding is stale (e.g. another workflow tab is now active). Retry in a ` +
+            `moment, or rebind with panel_set_workflow_target({mode:"current"}) to follow the ` +
+            `tab that's live now. (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
       return fail(err);
     }
   };

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1356,7 +1356,13 @@ export class UiBridge {
         this.storeMailbox(opts.tabId, cmd);
         return Promise.resolve({ ok: true, mailboxed: true });
       }
-      return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+      // resolveTarget threw BEFORE any socket write — no tab could be routed to (no
+      // connected tab / ambiguous / multiple / not reachable), so nothing was
+      // transmitted. Tag the rejection with the AUTHORITATIVE typed flag
+      // dispatched:false so a caller classifies "nothing applied" categorically (reboot
+      // readiness; the mutating-command rebind hint, panel #442) — never by
+      // string-matching a message whose text a post-dispatch executor error could quote.
+      return Promise.reject(markDispatched(err instanceof Error ? err : new Error(String(err)), false));
     }
     // #236 — proactively gate a command this exact connection has already proven
     // unsupported (see Conn.unsupportedCmds), instead of dispatching it again just
@@ -1386,7 +1392,11 @@ export class UiBridge {
         this.storeMailbox(opts.tabId, cmd);
         return Promise.resolve({ ok: true, mailboxed: true });
       }
-      return Promise.reject(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`));
+      // The resolved socket is not OPEN — the command cannot be written, so nothing is
+      // dispatched. Typed dispatched:false, same as the resolveTarget refusal above.
+      return Promise.reject(
+        markDispatched(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`), false),
+      );
     }
     return new Promise((resolve, reject) => {
       const ctx: SendCtx = {


### PR DESCRIPTION
## Triage of panel#442 — "Five panel defects from a long graph-editing session"

Bundled report of 5 distinct defects observed in one ~2h, 319-node session on **comfyui-mcp 0.48.22 / panel 0.11.0**. Verified each against current `origin/main` (post-0.11.25 / 0.48.25). Most were already fixed by the 0.11.11–0.11.25 batch; this PR fixes the one genuine residual. `Refs artokun/comfyui-mcp-panel#442` (not `Closes` — defects 2 & 5 remain as scoped follow-ups; see below).

| # | Defect | Outcome |
|---|--------|---------|
| 1 | No node-resize tool exists (patch attached: `graph_set_node_size`) | **Already fixed** — shipped as `panel_resize_node` / `graph_resize_node` (#530, panel 0.11.25 / mcp 0.48.25), functionally identical to the proposed patch (prefers `setSize()`, undo-enveloped). Covered by `graph-resize-node.test.mjs`. |
| 2 | `panel_open_workflow` serves a stale cached tab | **Split out** — reproduces *by design* (switching to an already-open tab paints its in-memory buffer, preserving unsaved edits — #65/#63/#64). A full fix (re-read when on-disk mtime is newer, or a `stale`/`reloaded:false` flag) needs product input on the unsaved-edit-vs-disk-freshness tradeoff, and the primary driver (out-of-band JSON editing to work around the missing resize tool, defect 1) is now gone. Workaround `panel_load_workflow(path:…)` forces a fresh read. |
| 3 | `panel_save_workflow` 409s when saving over the workflow's own name | **Already fixed** — the in-place (same-name / no-name) save path calls `saveWorkflow` (overwrite in place, no 409); the 0.11.0 409 came from the drifted-`isTemporary` misclassification since fixed by the #226/#309/#375 cluster. Covered by `workflow-save.test.mjs` ("save-in-place (same name) overwrites the same file, no copy"; "workflow_save with no name saves the current persisted file in place"). |
| 4 | Edit channel disconnects (`no connected tab … Connected: none`) while the read channel still works | **Fixed here.** |
| 5 | A ComfyUI restart closes every workflow tab | **Split out** — this is ComfyUI-frontend tab-persistence behavior (unsaved tabs can't survive a page reload; restoring all saved tabs is a frontend/core concern). The shipped #400/#402/#474 work already rebinds the *active* tab across a restart; restoring all 13 tabs is a separate effort. |

### Defect 4 — the fix (this PR)

**Root cause.** In the orchestrator's `makePanelToolCtx.call()`, a retry-safe read (e.g. `graph_get_errors`) that hits a post-reconnect `no connected tab … Connected: none` goes through the retry-once branch and, if it still fails, returns a message that *names* the rebind call. A **mutating** command (`graph_set_widget` et al.) is deliberately excluded from `RETRY_SAFE_CMDS` (no double-apply), so it skipped that branch and returned the **bare bridge error with no recovery path**. In a long multi-tab session — where the strict-single silent auto-heal won't guess among tabs — a brief read/edit-channel disagreement (`panel_list_workflows` kept answering while `panel_set_widget` failed) therefore looked like a dead agent. The reporter hit it ~6× and asked four times "are you stuck?".

**Fix.** The bridge already carries an **authoritative typed** `dispatched` flag (`markDispatched`/`dispatchOutcomeOf`). This PR tags the two remaining pre-dispatch refusal paths in `UiBridge.send()` — the `resolveTarget` catch (no connected tab / ambiguous / multiple / not reachable) and the socket-not-`OPEN` reject — with `dispatched:false` (the socket-write-failure path was already tagged). The tool layer then wraps a failure **iff `dispatchOutcomeOf(err) === false`** (typed, *not* error text) — without retrying (no double-apply) — to state nothing was applied and name `panel_set_workflow_target({mode:"current"})`, preserving the raw cause. A **post-dispatch executor `ok:false`** reply carries no flag, so a command that merely *quotes* "no connected tab" is never mis-classified as "nothing applied". The strict-single silent auto-heal still recovers the ordinary single-tab case untouched. Marking `resolveTarget` `dispatched:false` also sharpens the reboot-readiness classifier (an unresolved tab now categorically aborts certification).

### Tests
- `panel-session-rebind-residuals.test.ts` — multi-tab dead session names the rebind (and never dispatches); a post-dispatch executor error quoting the phrase is **not** mis-wrapped; single-tab self-heal still succeeds silently.
- `ui-bridge.test.ts` — direct real-`UiBridge.send()` contract: `resolveTarget` refusal → `dispatched:false` (and lists live tabs, not "none", when others exist); real `ok:false` → `dispatchOutcomeOf` **undefined**; mailboxable offline delivery resolves; a successful ack resolves.

`tsc` build green, `npm test` green (the one failing `node-dev` "builtin fallback" test is pre-existing/environmental — ripgrep is on PATH — and unrelated to this diff). Panel `workflow-save` + `graph-resize` suites green (citations for defects 1 & 3).

Verified by a 3-round independent adversarial codex review (gpt-5.6-terra/high): round 1 caught a text-classifier false-positive (fixed via the typed flag), round 2 asked to neutralize the wrapper wording and add direct bridge-contract tests (both done), round 3 **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
