### PR TITLE
fix(manager): negotiate v2 task 405 → v2-batch so panel_update_node stops 405ing on legacy Manager (panel #464)

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -1254,6 +1254,148 @@ describe("node-management service", () => {
     });
   });
 
+  // ── issue #464: unified /v2 task route 405s → negotiate to v2-batch ───────
+  // A build serves the bundled 3.x server under /v2 (queue/status answers), but
+  // its `is_legacy_manager_ui` probe does NOT identify it, so detection defaults
+  // to the "v2" unified dialect. A POST to /v2/manager/queue/task then 405s (the
+  // frontend catchall — the task route is unregistered), which used to surface
+  // as a raw "Manager …/queue/task: HTTP 405" from panel_update_node. The fix
+  // treats that 405 as a method/route signal (like the queue/start POST→GET
+  // negotiation) and downgrades to the v2-batch dialect, retrying via batch.
+  describe("v2 task 405 → v2-batch negotiation (issue #464)", () => {
+    /** Stub a build whose /v2 queue surface answers status but 405s the unified
+     *  task route, with `is_legacy_manager_ui` absent (catchall HTML). */
+    function stub464Fetch(opts: { failed?: unknown[] } = {}) {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        // The `is_legacy_manager_ui` route is unregistered → catchall HTML, so
+        // resolveV2SubDialect can't detect legacy-UI and defaults to "v2".
+        if (path === "/v2/manager/is_legacy_manager_ui") {
+          return new Response("<!doctype html><html>frontend</html>", {
+            status: 200, headers: { "Content-Type": "text/html" },
+          });
+        }
+        if (path === "/v2/manager/queue/task") {
+          // The #464 signature: unified task route unregistered → catchall 405.
+          return new Response("405: Method Not Allowed", { status: 405 });
+        }
+        if (path === "/v2/manager/queue/batch" && method === "POST") {
+          return jsonResponse({ failed: opts.failed ?? [] });
+        }
+        if (path === "/v2/manager/queue/start" && method === "POST") {
+          return new Response("", { status: 200 });
+        }
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return { calls };
+    }
+
+    it("panel_update_node succeeds via batch when /v2 task 405s (no raw 405 surfaced)", async () => {
+      const { calls } = stub464Fetch();
+      const res = await updateCustomNode({ id: "my-pack" });
+      expect(res.mechanism).toBe("manager-http");
+      // Downgraded to the batch envelope with the 3.x update body …
+      const batch = calls.find((c) => c.url.includes("/v2/manager/queue/batch"));
+      expect(batch).toBeDefined();
+      const payload = batch!.body as Record<string, Array<Record<string, unknown>>>;
+      expect(Object.keys(payload)).toEqual(["update"]);
+      // … after first attempting the unified task route (proving the 405 path ran).
+      expect(calls.some((c) => new URL(c.url).pathname === "/v2/manager/queue/task")).toBe(true);
+      // and still drains the queue.
+      expect(calls.some((c) => c.url.endsWith("/v2/manager/queue/start"))).toBe(true);
+    });
+
+    it("caches the corrected v2-batch dialect (second op skips the dead task route)", async () => {
+      const { calls } = stub464Fetch();
+      await updateCustomNode({ id: "pack-a" });
+      const taskHitsAfterFirst = calls.filter(
+        (c) => new URL(c.url).pathname === "/v2/manager/queue/task",
+      ).length;
+      await updateCustomNode({ id: "pack-b" });
+      const taskHitsTotal = calls.filter(
+        (c) => new URL(c.url).pathname === "/v2/manager/queue/task",
+      ).length;
+      // The second update must NOT re-probe the 405 task route — the dialect is pinned.
+      expect(taskHitsTotal).toBe(taskHitsAfterFirst);
+      expect(calls.filter((c) => c.url.includes("/v2/manager/queue/batch")).length).toBe(2);
+    });
+
+    it("does NOT poison the cache when task 405s but batch also fails — next op re-probes /task", async () => {
+      // A proxy/WAF (or an unusual v4) could 405 /task while /v2 status works but
+      // /batch does not. The failed downgrade must NOT pin "v2-batch" for later
+      // ops. Here batch fails on the first attempt (500) then succeeds on the
+      // second: the second op must still hit /task first (proving the cache was
+      // never poisoned) before succeeding via batch.
+      const calls: Call[] = [];
+      let batchHits = 0;
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
+        }
+        if (path === "/v2/manager/is_legacy_manager_ui") {
+          return new Response("<!doctype html>", { status: 200, headers: { "Content-Type": "text/html" } });
+        }
+        if (path === "/v2/manager/queue/task") {
+          return new Response("405: Method Not Allowed", { status: 405 });
+        }
+        if (path === "/v2/manager/queue/batch" && method === "POST") {
+          batchHits++;
+          return batchHits === 1
+            ? new Response("500: Internal Server Error", { status: 500 })
+            : jsonResponse({ failed: [] });
+        }
+        if (path === "/v2/manager/queue/start" && method === "POST") return new Response("", { status: 200 });
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      // First op: task 405 → batch 500 → throws; cache must stay "v2".
+      await expect(updateCustomNode({ id: "pack-a" })).rejects.toBeInstanceOf(NodeManagementError);
+      const taskAfterFirst = calls.filter((c) => new URL(c.url).pathname === "/v2/manager/queue/task").length;
+      expect(taskAfterFirst).toBeGreaterThan(0);
+      // Second op: because the cache was NOT poisoned, it re-probes /task before batch.
+      const res = await updateCustomNode({ id: "pack-b" });
+      expect(res.mechanism).toBe("manager-http");
+      const taskTotal = calls.filter((c) => new URL(c.url).pathname === "/v2/manager/queue/task").length;
+      expect(taskTotal).toBe(taskAfterFirst + 1);
+    });
+
+    it("leaves a genuine v4 host on the unified task route (405 fallback not triggered)", async () => {
+      const calls: Call[] = [];
+      const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ url, method, body });
+        const path = new URL(url).pathname;
+        if (path === "/v2/manager/queue/status") {
+          return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, pending_count: 0, is_processing: false });
+        }
+        if (path === "/v2/manager/is_legacy_manager_ui") return jsonResponse({ is_legacy_manager_ui: false });
+        if (path === "/v2/manager/queue/task") return new Response("", { status: 200 });
+        if (path === "/v2/manager/queue/start") return new Response("", { status: 200 });
+        return new Response("", { status: 200 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await updateCustomNode({ id: "my-pack" });
+      const task = calls.find((c) => new URL(c.url).pathname === "/v2/manager/queue/task");
+      expect(task).toBeDefined();
+      expect((task!.body as { kind?: string }).kind).toBe("update");
+      // Never downgraded to batch on a healthy v4 host.
+      expect(calls.some((c) => c.url.includes("/v2/manager/queue/batch"))).toBe(false);
+    });
+  });
+
   describe("Manager detection hardening (issue #235)", () => {
     it("a 200-HTML SPA fallback on the v2 status probe does NOT detect v2", async () => {
       const calls: Call[] = [];

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -268,6 +268,19 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
   managerApiCache = api ? { base: managerBaseUrl(), api } : null;
 }
 
+/**
+ * Re-classify the cached Manager dialect to "v2-batch" after the unified
+ * /v2/manager/queue/task route answered 405 AND a batch retry then SUCCEEDED.
+ * The /v2 queue surface is real (it answered a status during detection), so the
+ * build is the bundled 3.x server under /v2 whose `is_legacy_manager_ui` probe
+ * didn't identify it (#464). Pin the corrected dialect so subsequent operations
+ * skip the dead task route. Caller must only invoke this once the batch enqueue
+ * has actually succeeded, so a transient/proxy 405 can't poison the cache.
+ */
+function demoteManagerApiToV2Batch(): void {
+  managerApiCache = { base: managerBaseUrl(), api: "v2-batch" };
+}
+
 /** A real queue/status payload — guards detection against servers that answer
  *  200 with HTML/junk for unknown GETs (SPA fallbacks, index catchalls). Accepts
  *  any of the queue-count fields the Manager reports: `total_count`/`is_processing`
@@ -573,59 +586,105 @@ async function queueManagerTask(
 ): Promise<QueueStatus> {
   const uiId = randomUUID();
   const api = await detectManagerApi();
-  if (api === "legacy") {
-    // Released Manager 3.x: per-operation routes + different body shapes
-    // (issue #116 — the unified /v2 task route 405s there).
-    const { path, body } = legacyTaskRequest(kind, params, uiId);
-    try {
-      await managerFetch(path, { method: "POST", body });
-    } catch (err) {
-      throw annotateLegacyError(err, kind);
+  if (api === "legacy") return runLegacyTask(kind, params, uiId);
+  if (api === "v2-batch") return runV2BatchTask(kind, params, uiId);
+  // v2 unified task envelope (normal-mode pip Manager v4).
+  try {
+    await managerFetch("/v2/manager/queue/task", {
+      method: "POST",
+      body: {
+        ui_id: uiId,
+        client_id: MANAGER_CLIENT_ID,
+        kind,
+        params: { ...params, ui_id: uiId },
+      },
+    });
+  } catch (err) {
+    if (errorStatus(err) === 405) {
+      // Detection chose the unified /v2 task dialect (the /v2 queue surface
+      // answered a real status during detectManagerApi), yet THIS build 405s a
+      // POST to /v2/manager/queue/task. That is the bundled 3.x server served
+      // under /v2 — a legacy-UI pip Manager whose `is_legacy_manager_ui` probe
+      // did NOT answer truthfully, so resolveV2SubDialect defaulted to "v2"
+      // (#464: panel_update_node → "Manager …/queue/task: HTTP 405" on a
+      // legacy-dialect Manager). A 405 on a Manager route is a method/route
+      // signal, never "unreachable" — mirror the queue/start POST→GET
+      // negotiation (#551/#586) by retrying via the v2-batch envelope instead
+      // of surfacing the raw 405.
+      logger.debug(
+        "Manager /v2/manager/queue/task 405 — retrying via the v2-batch envelope",
+        { kind },
+      );
+      const status = await runV2BatchTask(kind, params, uiId);
+      // Pin the corrected dialect ONLY after the batch enqueue actually
+      // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
+      // batch also unavailable) never poisons the cache: runV2BatchTask throws
+      // on a batch failure, leaving the cache as "v2" so the next op re-probes
+      // the unified task route (codex review).
+      demoteManagerApiToV2Batch();
+      return status;
     }
-    return runManagerQueue();
+    throw err;
   }
-  if (api === "v2-batch") {
-    // pip Manager in legacy-UI mode (issue #235): the /v2 prefix serves the
-    // BUNDLED 3.x server — no task route (POST there 405s via the frontend
-    // catchall). Mutations take 3.x body shapes, wrapped in the batch
-    // envelope {<op>: [body, ...]}; the batch runs its items synchronously
-    // and reports failures as {failed: [id, ...]}. install-model keeps its
-    // dedicated route (same path as v4, 3.x whitelist semantics).
-    const { path, body } = legacyTaskRequest(kind, params, uiId);
-    try {
-      if (kind === "install-model") {
-        await managerFetch("/v2/manager/queue/install_model", { method: "POST", body });
-      } else {
-        // legacyTaskRequest's path is "/manager/queue/<op>"; the batch key is
-        // that trailing op ("enable" maps to an install body → key "install").
-        const op = path.split("/").pop() as string;
-        const res = await managerFetch<{ failed?: unknown[] }>("/v2/manager/queue/batch", {
-          method: "POST",
-          body: { [op]: [body] },
-        });
-        const failed = Array.isArray(res?.failed) ? res.failed : [];
-        if (failed.length && (body.id === undefined || failed.includes(body.id))) {
-          throw new NodeManagementError(
-            `ComfyUI-Manager batch reported the ${op} of "${String(body.id ?? "?")}" as failed ` +
-              "(check the ComfyUI server log for the underlying error — security_level " +
-              "gating is a common cause).",
-          );
-        }
+  return runManagerQueue();
+}
+
+/**
+ * Enqueue one operation on the released Manager 3.x per-operation routes
+ * (issue #116 — the unified /v2 task route 405s there) and drain the queue.
+ */
+async function runLegacyTask(
+  kind: ManagerTaskKind,
+  params: Record<string, unknown>,
+  uiId: string,
+): Promise<QueueStatus> {
+  const { path, body } = legacyTaskRequest(kind, params, uiId);
+  try {
+    await managerFetch(path, { method: "POST", body });
+  } catch (err) {
+    throw annotateLegacyError(err, kind);
+  }
+  return runManagerQueue();
+}
+
+/**
+ * Enqueue one operation on the v2-batch dialect — pip Manager in legacy-UI mode
+ * (issue #235): the /v2 prefix serves the BUNDLED 3.x server, which has no
+ * unified task route (a POST there 405s via the frontend catchall). Mutations
+ * take 3.x body shapes wrapped in the batch envelope {<op>: [body, ...]}; the
+ * batch runs its items synchronously and reports failures as {failed: [id, ...]}.
+ * install-model keeps its dedicated route (same path as v4, 3.x whitelist
+ * semantics).
+ */
+async function runV2BatchTask(
+  kind: ManagerTaskKind,
+  params: Record<string, unknown>,
+  uiId: string,
+): Promise<QueueStatus> {
+  const { path, body } = legacyTaskRequest(kind, params, uiId);
+  try {
+    if (kind === "install-model") {
+      await managerFetch("/v2/manager/queue/install_model", { method: "POST", body });
+    } else {
+      // legacyTaskRequest's path is "/manager/queue/<op>"; the batch key is
+      // that trailing op ("enable" maps to an install body → key "install").
+      const op = path.split("/").pop() as string;
+      const res = await managerFetch<{ failed?: unknown[] }>("/v2/manager/queue/batch", {
+        method: "POST",
+        body: { [op]: [body] },
+      });
+      const failed = Array.isArray(res?.failed) ? res.failed : [];
+      if (failed.length && (body.id === undefined || failed.includes(body.id))) {
+        throw new NodeManagementError(
+          `ComfyUI-Manager batch reported the ${op} of "${String(body.id ?? "?")}" as failed ` +
+            "(check the ComfyUI server log for the underlying error — security_level " +
+            "gating is a common cause).",
+        );
       }
-    } catch (err) {
-      throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
     }
-    return runManagerQueue();
+  } catch (err) {
+    throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
   }
-  await managerFetch("/v2/manager/queue/task", {
-    method: "POST",
-    body: {
-      ui_id: uiId,
-      client_id: MANAGER_CLIENT_ID,
-      kind,
-      params: { ...params, ui_id: uiId },
-    },
-  });
   return runManagerQueue();
 }
 


### PR DESCRIPTION
## Problem

`panel_update_node` surfaced a raw `Manager …/queue/task: HTTP 405` against a legacy-dialect ComfyUI-Manager (panel #464; related #364).

## Root cause

`queueManagerTask` posts to the unified `/v2/manager/queue/task` whenever `detectManagerApi()` returns `"v2"` — which it does whenever `/v2/manager/queue/status` answers a queue shape **and** `is_legacy_manager_ui` is not truthy. On a build that serves the **bundled 3.x server under `/v2`** but whose `is_legacy_manager_ui` probe is absent (ComfyUI's frontend catchall returns HTML), `resolveV2SubDialect` defaults to `"v2"`, yet the unified task route is unregistered → the catchall answers **405**.

The shipped v3/v4 work (#551/#553/#555, PR #586) added POST→GET negotiation for `queue/start`, but the **task POST had no fallback**, so the raw 405 propagated up through `panel_update_node` (single-pack update calls `queueManagerTask("update", …)`).

## Fix

Treat a 405 on the unified `/v2/manager/queue/task` POST as a method/route signal (mirroring the `queue/start` negotiation): retry via the v2-batch `/v2/manager/queue/batch` envelope, and **pin the corrected dialect only after the batch enqueue actually succeeds**. `runV2BatchTask` throws on any batch failure, leaving the cache as `"v2"` so a transient/proxy 405 on a genuine v4 host re-probes `/task` next time — no cache poisoning. Genuine v4 (task 200s) is unaffected. The legacy and v2-batch branches were extracted into `runLegacyTask` / `runV2BatchTask` helpers (bodies verbatim).

This is an orchestrator-only fix — `panel_update_node` and the Manager HTTP call live in the orchestrator; the panel is a passthrough that displays the tool result, so no panel-side change is required.

## Tests (`node-management.test.ts`)

- v2 task-405 → succeeds via `/queue/batch` (no raw 405 surfaced)
- corrected `v2-batch` dialect is cached (second op skips the dead task route)
- **cache-poisoning guard**: task 405 + batch failure → op throws and the cache stays `"v2"`; the next op re-probes `/task`
- genuine v4 host stays on the unified task route (fallback not triggered)

`npm run build` + `npm test` green (the one unrelated failure is the pre-existing `node-dev` ripgrep-vs-builtin environment test, untouched here).

## Codex self-gate

`gpt-5.6-terra` / high, read-only — first pass raised one [H] (cache pinned before the batch retry proved out); addressed by pinning only after a successful batch enqueue + a new poisoning-guard test. Re-review: **VERDICT: PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
