### PR TITLE
fix(panel): await tab reconnect before a mutating graph edit — no post-restart flap (#436)

### DIFF
--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -420,3 +420,92 @@ describe("#400 panel_restart_comfyui awaits the tab reconnect before returning",
     expect(String(out.note)).toMatch(/has NOT reconnected|rebind/i);
   });
 });
+
+// #436 — the flap: after a restart a READ (panel_graph_outline) succeeds while the
+// very next WRITE (panel_add_node) fails "no connected tab … Connected: none". Root
+// cause: reads survive the "Connected: none" window (parked mid-command + retry-once)
+// but the live graph MUTATION tools dispatched via ctx.call with NO pre-send wait, so
+// they fired straight into the momentarily-empty tab registry. The fix gates every
+// mutating graph edit behind the same bounded awaitReachable() that open/save use —
+// centralized in ctx.call so no mutating tool can miss it — while leaving the read
+// path untouched.
+describe("#436 a MUTATING graph edit awaits the reconnect before dispatch", () => {
+  it("waits out the post-restart 0-tab window, then dispatches to the reconnected tab (no flap)", async () => {
+    const { bridge, live, sent } = reconnectingBridge([]); // Connected: none
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    setTimeout(() => live.add("reconnected-tab"), 40); // the browser re-hellos
+    const res = await defByName("panel_add_node").handler({ class_type: "KSampler" }, ctx);
+    expect(res.isError).toBeFalsy();
+    // The mutating edit was dispatched — and to the RECONNECTED tab, never fired into
+    // the dead "Connected: none" binding that produced the flap.
+    expect(sent.at(-1)?.cmd).toMatchObject({ cmd: "graph_add_node", class_type: "KSampler" });
+    expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+    expect(ctx.tabId).toBe("reconnected-tab"); // rebound onto the live tab
+  });
+
+  it("REFUSES with ZERO dispatch when nothing reconnects — never fires into the dead binding", async () => {
+    const { bridge, sent } = reconnectingBridge([]); // stays Connected: none
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    const res = await defByName("panel_add_node").handler({ class_type: "KSampler" }, ctx);
+    expect(res.isError).toBe(true);
+    expect(sent.length).toBe(0); // the mutating edit was NEVER dispatched
+  });
+
+  it("a HEALTHY session dispatches the edit immediately — no added latency", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 5000, intervalMs: 50 });
+    const { bridge, sent } = reconnectingBridge(["live-tab"]);
+    const ctx = makePanelToolCtx(bridge, "live-tab", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_add_node").handler({ class_type: "KSampler" }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(Date.now() - t0).toBeLessThan(1000); // did NOT wait the 5s budget
+    expect(sent.at(-1)?.tabId).toBe("live-tab");
+  });
+
+  it("panel_set_widget (also mutating) is gated too — waits then dispatches to the reconnected tab", async () => {
+    const { bridge, live, sent } = reconnectingBridge([]);
+    const ctx = makePanelToolCtx(bridge, "wf:workflows/x.json", new WorkflowTargetStore());
+    setTimeout(() => live.add("reconnected-tab"), 40);
+    const res = await defByName("panel_set_widget").handler(
+      { node_id: 3, widget: "seed", value: 42 },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(sent.at(-1)?.tabId).toBe("reconnected-tab");
+  });
+
+  it("does NOT gate an idempotent READ — graph_outline keeps its existing (non-waiting) path", async () => {
+    // A read is NOT a mutating graph edit, so the pre-wait must not apply; with a live
+    // tab it simply dispatches through its normal path.
+    const { bridge, sent } = reconnectingBridge(["live-tab"]);
+    const ctx = makePanelToolCtx(bridge, "live-tab", new WorkflowTargetStore());
+    const res = await defByName("panel_graph_outline").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(sent.at(-1)?.cmd).toMatchObject({ cmd: "graph_outline" });
+  });
+
+  // Codex-flagged: reads that are NOT in BRIDGE_READONLY_CMDS (so an exclusion rule
+  // would have wrongly gated them) must NOT wait out the reconnect budget. With a
+  // reconnect that never happens, a gated command would spin the whole budget; these
+  // reads must return promptly instead (their existing non-waiting behavior).
+  it("does NOT gate graph_list_subgraphs (a read absent from BRIDGE_READONLY_CMDS)", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 5000, intervalMs: 50 });
+    const { bridge } = reconnectingBridge([]); // Connected: none, nothing reconnects
+    const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_list_subgraphs").handler({}, ctx);
+    // It fails (no tab) — but it must FAIL FAST, never spend the 5s budget waiting.
+    expect(res.isError).toBe(true);
+    expect(Date.now() - t0).toBeLessThan(1000);
+  });
+
+  it("does NOT gate training_get_state (a read absent from BRIDGE_READONLY_CMDS)", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 5000, intervalMs: 50 });
+    const { bridge } = reconnectingBridge([]);
+    const ctx = makePanelToolCtx(bridge, "stale-tab", new WorkflowTargetStore());
+    const t0 = Date.now();
+    const res = await defByName("panel_training_get_state").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    expect(Date.now() - t0).toBeLessThan(1000);
+  });
+});

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -312,6 +312,59 @@ function isRetrySafeCmd(cmd: Record<string, unknown>): boolean {
   return RETRY_SAFE_CMDS.has(name);
 }
 
+// Graph-EDIT mutations that CHANGE the user's canvas (undoable edits). These are
+// the #436 bug surface: a real side effect the bridge will NOT auto-retry, so —
+// unlike a read — such a command can be neither parked mid-command nor retried
+// once, and firing it into the post-restart "Connected: none" window fails with
+// "no connected tab". It must await a stable binding BEFORE dispatch.
+//
+// This is an EXPLICIT ALLOWLIST, deliberately NOT "everything not read-only":
+// several genuine reads/probes/views that flow through ctx.call are absent from
+// BRIDGE_READONLY_CMDS (e.g. graph_list_subgraphs, training_get_state,
+// graph_canvas, graph_screenshot), so an exclusion rule would wrongly make THOSE
+// wait out the reconnect budget. Under-inclusion here is at worst an unfixed edge
+// (a command keeps today's behavior); over-inclusion would regress a read — so we
+// list only commands that unambiguously mutate the graph. Keep in sync when new
+// graph-edit tools are added (mirrors the RETRY_SAFE_CMDS maintenance model).
+const MUTATING_GRAPH_EDIT_CMDS = new Set<string>([
+  "graph_add_node",
+  "graph_remove_node",
+  "graph_clear",
+  "graph_connect",
+  "graph_disconnect",
+  "graph_set_widget",
+  "graph_move_node",
+  "graph_resize_node",
+  "graph_set_title",
+  "graph_set_node_mode",
+  "graph_set_node_color",
+  "graph_set_node_collapsed",
+  "graph_update_node",
+  "graph_create_group",
+  "graph_edit_group",
+  "graph_remove_group",
+  "graph_move_group",
+  "graph_create_subgraph",
+  "graph_add_subgraph",
+  "graph_save_subgraph",
+  "graph_unpack_subgraph",
+  "graph_subgraph_group",
+  "graph_expose_subgraph_input",
+  "graph_expose_subgraph_output",
+  "graph_promote_widget",
+  "graph_move_rail",
+  "graph_paste_nodes",
+  "graph_auto_layout",
+  "graph_load",
+]);
+
+/** A MUTATING graph edit that must await a stable tab binding before dispatch so
+ *  it never fires into the post-restart "Connected: none" window (#436). */
+function isMutatingGraphCmd(cmd: Record<string, unknown>): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  return MUTATING_GRAPH_EDIT_CMDS.has(name);
+}
+
 /** True when an error is a TRANSIENT transport/reconnect drop (the tab went away
  *  or was replaced), NOT a genuine command error or a live-but-frozen reply
  *  timeout. Deliberately EXCLUDES "did not reply within N ms" (a backgrounded/
@@ -1838,6 +1891,21 @@ export function makePanelToolCtx(
 
   const call = async (cmd: Record<string, unknown>, timeoutMs?: number): Promise<ToolResult> => {
     try {
+      // #436: a MUTATING graph edit must not fire into the "Connected: none"
+      // window a ComfyUI restart/reload opens. A read survives that window (it is
+      // parked mid-command and is retry-safe), but a mutating edit is NEITHER — so
+      // panel_graph_outline succeeds while the very next panel_add_node hits
+      // resolveTarget's momentarily-empty registry and fails with
+      // "no connected tab … Connected: none" (the flap). Await a stable binding
+      // BEFORE dispatch — nothing is sent during the wait, so there is no
+      // double-apply risk — exactly as workflow_open/save already do. This returns
+      // INSTANTLY for a healthy session and only waits in the zero-tab window; the
+      // read path (parking + retry-once below) is left exactly as-is. A wait that
+      // times out unreached still falls through to sendRouted, whose authoritative
+      // dispatched:false surfaces the actionable "nothing applied — rebind" message.
+      if (isMutatingGraphCmd(cmd)) {
+        await awaitReachable();
+      }
       ensureReachable();
       return ok(await sendRouted(cmd, timeoutMs));
     } catch (err) {


### PR DESCRIPTION
## Problem (comfyui-mcp-panel#436)

After `restart_comfyui`, the panel binding comes back half-connected: a **read** (`panel_graph_outline`) succeeds while the **very next write** (`panel_add_node` / `panel_set_widget`) fails with `no connected tab with id "wf:…". Connected: none`, and the documented recovery then reports no panel at all. Only a manual F5 restored it.

## Root cause

Both paths route through the same tab registry, but reads have two survival layers writes lack: an idempotent read is **parked mid-command** and re-dispatched on re-hello, and is **retry-safe** (retried once after a rebind). The live graph-**edit** tools, however, dispatched via `ctx.call` with **no pre-send reachability wait** — so a write fired straight into the momentarily-empty registry the "Connected: none" restart window opens, while the preceding read had already returned. That made the read a false positive: "the outline succeeded" told the agent it was safely reconnected when it was not.

The pre-send reconnect wait `#400/#402/#474` shipped (0.48.25) was wired into `workflow_open` / save / `set_workflow_target` — **but not** the live graph-edit tools.

## Fix

`ctx.call` now gates a **mutating graph edit** behind the existing bounded `awaitReachable()` primitive (the same one open/save use):
- returns **instantly** for a healthy session (`canReach(ctx.tabId)` true) — zero added latency;
- only waits out the **zero-tab** window, and **dispatches nothing during the wait** → no double-apply;
- on reconnect it rebinds onto the reconnected canvas tab and dispatches there;
- a wait that never reconnects falls through to the authoritative `dispatched:false` path (`#442`), which states nothing was applied and names the rebind — a mutating edit is **never** fired into a dead binding.

"Mutating" is an **explicit allowlist** (`MUTATING_GRAPH_EDIT_CMDS`), deliberately **not** "everything not read-only": several genuine reads/probes/views flow through `ctx.call` but are absent from `BRIDGE_READONLY_CMDS` (`graph_list_subgraphs`, `training_get_state`, `graph_canvas`, `graph_screenshot`), so an exclusion rule would wrongly make those wait the reconnect budget. Under-inclusion is at worst a benign unfixed edge; over-inclusion would regress a read — so only unambiguous graph mutations are listed. The read path is left exactly as-is.

## Tests

Extends `panel-session-rebind-residuals.test.ts` (#436 block):
- `panel_add_node` / `panel_set_widget` wait out the 0-tab window then dispatch to the **reconnected** tab (never "Connected: none")
- **zero dispatch** when nothing reconnects
- a **healthy** session dispatches immediately (does not spin the budget)
- `graph_outline`, and the two flagged reads `graph_list_subgraphs` / `training_get_state`, are **not** gated (fail fast, never spin the budget)

Verification: `tsc --noEmit` clean; the three tab-binding suites (`panel-session-rebind-residuals`, `panel-tools`, `ui-bridge`) 247 pass; full suite 2743 pass / 1 skipped (one pre-existing environmental `node-dev` ripgrep-vs-builtin failure, unrelated, reproduces on untouched `main`). Codex adversarial self-gate (gpt-5.6-terra/high): **PASS** — no double-apply, no read over-inclusion, complete graph-edit coverage, healthy/multi-tab/pinned sessions unaffected.

Closes artokun/comfyui-mcp-panel#436

🤖 Generated with [Claude Code](https://claude.com/claude-code)