### PR TITLE
test(ui-bridge): de-flake the #486 late-ask_user-reply test (ECONNREFUSED port race)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -41,10 +41,14 @@ function autoReply(sock: WebSocket, tag: string): void {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   port = 20000 + Math.floor(Math.random() * 20000);
   bridge = new UiBridge(port);
   bridge.start();
+  // Await the actual bound `listening` event before any test connects a client.
+  // start() binds asynchronously; without this, connectPanel() can race the bind
+  // and fail with ECONNREFUSED on loaded CI (ubuntu-latest) — the #486 flake.
+  expect(await bridge.whenReady()).toBe(true);
 });
 
 afterEach(async () => {


### PR DESCRIPTION
## Root cause

The flaky test `UiBridge (late ask_user answer buffer — #486)` → `"buffers a valid ask_user reply that arrives after the reply timeout"` intermittently failed on CI (especially `ubuntu-latest`) with `Error: connect ECONNREFUSED 127.0.0.1:<port>`. This flake failed a release publish and blocked ~4 PR merges.

The shared `beforeEach` in `src/__tests__/services/ui-bridge.test.ts` called `bridge.start()` **without awaiting readiness**:

```js
beforeEach(() => {
  port = 20000 + Math.floor(Math.random() * 20000);
  bridge = new UiBridge(port);
  bridge.start();   // binds the WS server ASYNCHRONOUSLY
});
```

`UiBridge.start()` binds the WebSocket server asynchronously — `wss.on("listening")` resolves `readyPromise` only later (`src/services/ui-bridge.ts` ~L576-631). So a test body's immediate `connectPanel()` client could open a socket **before the port was bound** → `ECONNREFUSED`. On loaded CI runners the bind lags far enough behind that the race loses. Note the file's standalone bridges (token-gate, LAN bind) already `await tbridge.whenReady()` before connecting — the shared harness was the only one missing that guard.

## Fix

Make `beforeEach` async and await the bridge's real bound signal before any test connects:

```js
beforeEach(async () => {
  port = 20000 + Math.floor(Math.random() * 20000);
  bridge = new UiBridge(port);
  bridge.start();
  expect(await bridge.whenReady()).toBe(true);
});
```

`whenReady()` resolves `true` only once the `listening` event fires. This is a **shared-harness fix** — it removes the connect/bind race for **every sibling test** using this `beforeEach`, not just #486. No real-network timing dependency remains; the readiness comes from the bridge's actual ready signal, not a sleep.

The #486 assertion is **unchanged**: a late-but-valid `ask_user` reply arriving after the send's reply timeout is still buffered and retrievable via `takeLateAskReply`, then drained once. Only the connection race was removed.

## Verification

- Loop-proof: the #486 test passed **20/20** in a tight loop (`vitest run -t "buffers a valid ask_user reply"`).
- `npm run build` — clean (`tsc`).
- `npm test` — 208/209 test files pass, entire ui-bridge suite green. The single failure is the pre-existing `node-dev` ripgrep-env flake (`expected 'ripgrep' to be 'builtin'`, depends on whether `rg` is on PATH), unrelated to this change.
- Codex self-gate (gpt-5.6-terra, high) — **PASS**: confirmed the fix removes the race for all sibling tests and does not weaken the #486 assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)