### PR TITLE
fix(panel): fresh-/object_info usability — set_widget false-timeout + panel_refresh_nodes (#599 #608)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -30,11 +30,15 @@ type Forwarded = Record<string, unknown>;
 
 function makeFakeCtx(
   bridgeReply?: unknown,
-): { ctx: PanelToolCtx; calls: Forwarded[] } {
+): { ctx: PanelToolCtx; calls: Forwarded[]; timeouts: (number | undefined)[] } {
   const calls: Forwarded[] = [];
+  // Per-call ack timeout (ctx.call's 2nd arg), index-aligned with `calls`, so a
+  // test can assert the #599 refresh-ack budget the tool forwarded.
+  const timeouts: (number | undefined)[] = [];
   const ctx: PanelToolCtx = {
-    call: async (cmd) => {
+    call: async (cmd, timeoutMs) => {
       calls.push(cmd);
+      timeouts.push(timeoutMs);
       return { content: [{ type: "text", text: JSON.stringify(cmd) }] };
     },
     confirm: async () => "yes" as const,
@@ -49,7 +53,7 @@ function makeFakeCtx(
     } as unknown as PanelToolCtx["bridge"],
     tabId: "test-tab",
   };
-  return { ctx, calls };
+  return { ctx, calls, timeouts };
 }
 
 function defByName(name: string) {
@@ -194,6 +198,56 @@ describe("panel-tools: panel_set_widget (empty-string clear, issue #347)", () =>
     );
     expect(res.isError).toBe(true);
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe("panel-tools: fresh /object_info ack timeout (#599)", () => {
+  // The refresh-before-validate FRONTEND handlers (graph_set_widget #338/#458,
+  // graph_add_node #289/#458) await an authoritative /object_info fetch before
+  // replying; on a large install that can outlast the bridge's 6000 ms default
+  // ack, returning a FALSE "tab did not reply" timeout. The tools must forward a
+  // larger BOUNDED ack budget so a slow-but-valid refresh isn't a false timeout.
+  const REFRESH_ACK_MS = 30_000;
+
+  it("panel_set_widget forwards graph_set_widget with the 30s refresh ack timeout, not the 6s default", async () => {
+    const { ctx, calls, timeouts } = makeFakeCtx();
+    await defByName("panel_set_widget").handler(
+      { node_id: 39, widget: "image", value: "staged_00001_.png" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({ cmd: "graph_set_widget" });
+    expect(timeouts[0]).toBe(REFRESH_ACK_MS);
+  });
+
+  it("panel_add_node forwards graph_add_node with the 30s refresh ack timeout", async () => {
+    const { ctx, calls, timeouts } = makeFakeCtx();
+    await defByName("panel_add_node").handler(
+      { class_type: "LoadImage", pos: [0, 0] },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({ cmd: "graph_add_node", class_type: "LoadImage" });
+    expect(timeouts[0]).toBe(REFRESH_ACK_MS);
+  });
+
+  it("keeps the ack bounded (never Infinity) so a genuinely dead tab still fails", () => {
+    expect(Number.isFinite(REFRESH_ACK_MS)).toBe(true);
+    expect(REFRESH_ACK_MS).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe("panel-tools: panel_refresh_nodes (#608 — force a combo/object_info refresh)", () => {
+  it("forwards a bare refresh_nodes command (no graph mutation) with the refresh ack budget", async () => {
+    const { ctx, calls, timeouts } = makeFakeCtx();
+    await defByName("panel_refresh_nodes").handler({}, ctx);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ cmd: "refresh_nodes" });
+    // Same 30s budget as the refresh-before-validate writes — this command's whole
+    // purpose is to await a fresh /object_info fetch.
+    expect(timeouts[0]).toBe(30_000);
+  });
+
+  it("takes no arguments (empty schema)", () => {
+    expect(Object.keys(defByName("panel_refresh_nodes").schema)).toEqual([]);
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1128,6 +1128,15 @@ describe("defaultBridgeTimeoutMs — tolerant read timeout (#357)", () => {
     }
   });
 
+  it("classifies refresh_nodes as a READ so it is parked/resumed on reconnect and gets the tolerant default (#608)", () => {
+    // refresh_nodes only re-registers node defs + rebuilds combos (idempotent, no
+    // graph mutation). It MUST be a read so a mid-command socket drop parks and
+    // resumes it (not OUTCOME-UNKNOWN, which the orchestrator won't retry) and so a
+    // slow /object_info fetch on a large install isn't cut off at the tight 6s.
+    expect(BRIDGE_READONLY_CMDS.has("refresh_nodes")).toBe(true);
+    expect(defaultBridgeTimeoutMs("refresh_nodes")).toBe(BRIDGE_READ_DEFAULT_TIMEOUT_MS);
+  });
+
   it("graph_query is tolerant and STRICTLY longer than the old flat 6s default (#357)", () => {
     // The regression: graph_query used the flat 6000ms default and timed out while
     // Preview3D loaded a large FBX on a busy-but-alive main thread.

--- a/src/__tests__/services/workflow-target-store.test.ts
+++ b/src/__tests__/services/workflow-target-store.test.ts
@@ -64,6 +64,18 @@ describe("withWorkflowTarget", () => {
     const out = withWorkflowTarget({ cmd: "graph_run" }, { mode: "current" });
     expect(out).toEqual({ cmd: "graph_run" });
   });
+
+  it("does NOT inject workflow_path on refresh_nodes even when pinned (#608 global refresh)", () => {
+    // panel_refresh_nodes forces a GLOBAL /object_info re-register that is not tied
+    // to any one graph; it is deliberately named `refresh_nodes` (not `graph_*`) so
+    // shouldInjectWorkflowPath excludes it — no workflow_path is added, so the
+    // frontend's pinned-target guard is skipped and the refresh runs regardless of
+    // which workflow the pinned session points at. This LOCKS that design: renaming
+    // it to a graph_* command (which WOULD inject a pin and trip the guard) must
+    // fail this test.
+    expect(shouldInjectWorkflowPath("refresh_nodes", {})).toBe(false);
+    expect(withWorkflowTarget({ cmd: "refresh_nodes" }, pinned)).toEqual({ cmd: "refresh_nodes" });
+  });
 });
 
 describe("shouldInjectWorkflowPath", () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -288,6 +288,18 @@ function sleep(ms: number): Promise<void> {
 // settle. Mutating graph edits (add_node/connect/set_widget/…) are deliberately
 // EXCLUDED — re-issuing them could double-apply — so they keep surfacing the
 // bridge's honest OUTCOME-UNKNOWN error.
+// #599: commands whose FRONTEND handler intentionally awaits a fresh /object_info
+// re-register before it can reply — the refresh-before-validate path in
+// graph_set_widget (#338/#458) and graph_add_node (#289/#458), and the explicit
+// forced node-def refresh in refresh_nodes (#608). On a large install with many
+// custom-node packs a legitimate /object_info fetch can take longer than the
+// bridge's 6000 ms DEFAULT ack window, so the panel replies late and the tool
+// returns a FALSE "tab did not reply" timeout even though the write is valid and
+// in progress. Give these a larger BOUNDED ack budget so a slow-but-valid refresh
+// is not mistaken for a dead tab — still capped (never Infinity) so a genuinely
+// frozen/backgrounded tab fails in bounded time instead of hanging forever.
+const OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000;
+
 const RETRY_SAFE_CMDS = new Set<string>([
   // Idempotent reads (mirror UiBridge.READONLY_CMDS + list/status probes).
   "graph_serialize",
@@ -303,6 +315,10 @@ const RETRY_SAFE_CMDS = new Set<string>([
   "node_queue_status",
   // Idempotent full-replace UI state — re-sending the same list is a no-op (#481).
   "set_todo",
+  // #608: a forced /object_info re-register + combo refresh. Non-destructive and
+  // idempotent (re-running just re-fetches the current defs), so a dropped
+  // transport can safely re-issue it once.
+  "refresh_nodes",
 ]);
 
 /** A command whose result is unchanged by being re-issued after a reconnect —
@@ -2670,7 +2686,14 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         title: z.string().optional().describe("Optional custom node title."),
       },
       async (args: A, ctx) =>
-        ctx.call({ cmd: "graph_add_node", class_type: args.class_type, pos: args.pos, title: args.title }),
+        // #599: the frontend gates the add on a FRESH /object_info (assertAddNode-
+        // ResolvableRefreshing) so an uninstalled class can't be added as a
+        // placeholder — that fetch can outlast the 6000 ms default on a large
+        // install. Give it the bounded refresh ack budget.
+        ctx.call(
+          { cmd: "graph_add_node", class_type: args.class_type, pos: args.pos, title: args.title },
+          OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+        ),
     ),
     def(
       "panel_remove_node",
@@ -2962,7 +2985,15 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             "panel_set_widget needs a `value`. To set an empty string, pass `clear: true` (some clients drop an empty-string `value`).",
           );
         }
-        return ctx.call({ cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value });
+        // #599: the frontend runs refresh-before-validate here (pulls a fresh
+        // /object_info so a just-staged/-downloaded/-installed value is accepted on
+        // a single revalidation, #338/#458) — that authoritative fetch can outlast
+        // the 6000 ms default ack on a large install and return a FALSE timeout.
+        // Give the guarded write the bounded refresh ack budget.
+        return ctx.call(
+          { cmd: "graph_set_widget", node_id: args.node_id, widget: args.widget, value },
+          OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
+        );
       },
     ),
     def(
@@ -3133,6 +3164,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       "WHY IS THAT NODE RED / WHY DID THE RUN FAIL? The single error surface for the user's open tab: every errored node JOINED TO ITS CAUSE, which ComfyUI itself does not show — LiteGraph only paints a red outline and stores no reason, which is why users report \"red node, no error message\". Call this whenever the user mentions a red/highlighted/erroring node, a failed run, or \"required models are missing\" — instead of guessing from widget values. Each entry in `nodes[]` is the node's full detail summary plus `red_outline` and `reasons[]`, drawn from every source: `missing_model` (exact file, its models directory, the widget holding it, and a download URL when known), `missing_media` (a referenced input image/video that isn't on disk — the usual cause of a red LoadImage), `validation` (per-input errors from the last queue attempt: message, details, offending input), and `execution` (runtime failure with `exception_type`, e.g. PIL.UnidentifiedImageError). TWO THINGS THAT MAKE THIS ESSENTIAL: (1) missing model/media assets paint nodes red AS SOON AS THE WORKFLOW LOADS, long before any queue attempt — so the raw validation map is still EMPTY while the user is staring at red nodes; (2) a node that throws AT RUNTIME is never painted red at all, so it can't be spotted on the canvas — it appears here with red_outline:false. Also returns graph-level `missing_models`, `missing_media`, `missing_node_types` (or `missing_node_count`), plus the raw `node_errors` map and `last_execution_error` for reference. A ⚠️ GRAPH VALIDATION block is auto-injected at your turn start when this state changes; call this to re-check on demand (e.g. after you edit widgets/links). Read-only.",
       {},
       async (_args, ctx) => ctx.call({ cmd: "graph_get_errors" }),
+    ),
+    def(
+      "panel_refresh_nodes",
+      "Re-pull the live ComfyUI server's /object_info and rebuild every combo/loader option list in the user's open tab, so an asset that appeared server-side AFTER the tab loaded becomes SELECTABLE without a manual reload (the 'press R' step) or a restart. Use this right after stage_output_as_input (chaining a stage's output into a LoadImage / VHS_LoadVideo / LoadAudio loader — the returned filename won't be in the loader's dropdown until you refresh), after downloading a model / LoRA / VAE (a freshly downloaded file is otherwise 'not a valid option' in its loader), or after installing a node pack. Then panel_set_widget / panel_add_node will accept the new value. Non-destructive: it only re-registers node defs and refreshes combo option lists — it does NOT change your graph and is undo-neutral. Idempotent (safe to call repeatedly). Returns whether the refresh authoritatively fetched fresh defs.",
+      {},
+      async (_args, ctx) =>
+        // Same bounded ack budget as the refresh-before-validate writes (#599): a
+        // fresh /object_info on a large install routinely exceeds the 6000 ms
+        // default, and this command's WHOLE purpose is to await that fetch.
+        ctx.call({ cmd: "refresh_nodes" }, OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS),
     ),
     def(
       "panel_reload",

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -332,6 +332,14 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "graph_query",
   "civitai_results",
   "get_todo",
+  // #608: a forced /object_info re-register + combo refresh. It has NO effect on
+  // graph content — it only re-registers node defs and rebuilds combo option lists
+  // (idempotent, undo-neutral) — so it is classified with the READS: it earns the
+  // tolerant read default timeout (a fresh /object_info on a large install can run
+  // many seconds), and on a mid-command socket drop it is PARKED and resumed on the
+  // tab's re-hello rather than surfacing a scary OUTCOME-UNKNOWN the orchestrator
+  // won't retry. Re-running it is always safe.
+  "refresh_nodes",
 ]);
 
 /** Tight default reply timeout for a MUTATING command with no explicit timeout —

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -234,7 +234,13 @@ export function registerImageManagementTools(server: McpServer): void {
                 `Input filename: ${staged.filename}\n` +
                 `subfolder: ${staged.subfolder || "(none)"}\n` +
                 `type: ${staged.type}\n\n` +
-                `Use "${staged.filename}" as ${loaderHint}.`,
+                `Use "${staged.filename}" as ${loaderHint}.\n\n` +
+                `NOTE: the open ComfyUI tab's loader dropdown was populated at page-load, ` +
+                `so this just-registered input is not in it yet — call panel_refresh_nodes ` +
+                `first (it re-pulls /object_info so the new file becomes selectable), THEN ` +
+                `panel_set_widget the loader's widget to "${staged.filename}". ` +
+                `(panel_set_widget also self-refreshes on a rejected value, so a single ` +
+                `retry after panel_refresh_nodes will always accept it.)`,
             },
           ],
         };


### PR DESCRIPTION
Fixes a fresh-`/object_info` usability cluster surfaced via the panel.

## #599 — panel_set_widget false timeout when a fresh `/object_info` exceeds 6 s
The frontend `graph_set_widget` / `graph_add_node` handlers run refresh-before-validate — they await a fresh `/object_info` fetch (#338/#458/#289) so a just-staged/-downloaded/-installed value is accepted on a single revalidation. On a large install that fetch outlasts the bridge's **6000 ms default** ack window, so the orchestrator returned a FALSE `tab did not reply within 6000 ms` timeout on a valid, in-progress write.

**Fix:** give those two `ctx.call` sites a bounded **30 s** ack budget (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`) — enough for a slow-but-valid refresh, still capped so a genuinely dead/backgrounded tab fails in bounded time. `graph_get_errors` was already safe (it self-caps its refresh at 4000 ms and resolves-not-rejects); `graph_paste_nodes` already used 15000.

## #608 — stage_output_as_input succeeds but LoadImage can't see the file
`stage_output_as_input` registers the input server-side, but the frontend's loader combos were populated from `/object_info` at page-load and there was **no tool to force a refresh** — so the documented Krea2→LTX/WAN chaining flow dead-ended (only manual **R** worked). `stage_output_as_input` is a core tool in a separate process from the panel bridge, so it can't signal the frontend directly.

**Fix:** add **`panel_refresh_nodes`** → bridge cmd `refresh_nodes` → frontend forced `refreshComfyNodeDefs(force)`, reusing the shipped #396 forced re-register, and point `stage_output_as_input`'s returned guidance at it. Also fixes the frequent "I just downloaded a model and the loader can't see it" case.

### Design notes
- The command is named `refresh_nodes` (not `graph_*`) so `shouldInjectWorkflowPath` excludes it — a global `/object_info` refresh isn't tied to one graph, so no `workflow_path` is injected and the frontend pinned-target guard is correctly skipped (locked by a `workflow-target-store` test).
- Classified read-only in the bridge (`BRIDGE_READONLY_CMDS`) so it earns the tolerant timeout and is **parked/resumed** on a mid-command socket drop instead of OUTCOME-UNKNOWN; retry-safe in the orchestrator (`RETRY_SAFE_CMDS`).

### Companion PR
Frontend `refresh_nodes` executor: artokun/comfyui-mcp-panel#476 (branch `fix/refresh-nodes-608`).

### Tests
- `panel-tools`: ack-timeout forwarding for `panel_set_widget` / `panel_add_node` / `panel_refresh_nodes`; `refresh_nodes` forwarded as a bare command; empty schema.
- `ui-bridge`: `refresh_nodes` classified read-only + tolerant default.
- `workflow-target-store`: no `workflow_path` injected on `refresh_nodes` when pinned.
- Full suite green (one pre-existing, environmental `node-dev` ripgrep-vs-builtin failure, unrelated).

### Codex self-gate
gpt-5.6-terra / high, read-only: **PASS** (round 1 raised a legitimate P2 — now fixed by the `BRIDGE_READONLY_CMDS` classification — plus a false-positive P1 about `workflow_path` injection, refuted and locked with a test; round 2 PASS).

Closes #599
Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

