### PR TITLE
fix(panel-reload): call bridge.isHeadless bound so panel_reload stops crashing on this.conns (panel #478)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1185,6 +1185,83 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
     expect((res.content[0] as { text: string }).text).toMatch(/multiple tabs/i);
   });
 
+  // Regression (panel #478): panel_reload's ambiguity guard must invoke isHeadless
+  // THROUGH the bridge, not via a detached `const headless = ctx.bridge.isHeadless`.
+  // The real UiBridge.isHeadless is a plain method that reads `this.conns`; called
+  // unbound its `this` is undefined and it threw "Cannot read properties of undefined
+  // (reading 'conns')", so panel_reload failed outright instead of reloading. The fake
+  // bridges above never set `isHeadless`, so they skipped the filter and never caught
+  // this — this bridge mirrors the real one (method-form isHeadless over `this.conns`).
+  function methodIsHeadlessBridge(liveTabs: string[]) {
+    const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+    const live = new Set(liveTabs);
+    const bridge = {
+      // `conns` + method-form isHeadless: extracting the method and calling it
+      // unbound (the #478 bug) throws on `this.conns`; calling it bound works.
+      conns: new Map<string, { headless?: boolean }>(liveTabs.map((t) => [t, {}])),
+      isHeadless(id: string): boolean {
+        return this.conns.get(id)?.headless === true;
+      },
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        const id = opts?.tabId;
+        if (id && !live.has(id)) throw new Error(`no connected tab with id "${id}". Connected: none`);
+        sent.push({ cmd, tabId: id });
+        return { ok: true, routedTo: id };
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => liveTabs.map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      // Mirror the real UiBridge: a sole tab resolves; 2+ throw the ambiguity error
+      // (so a rebind attempt lands in the recovery catch that also filters isHeadless).
+      resolveActiveTabId: () => {
+        if (liveTabs.length === 1) return liveTabs[0];
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    return { bridge, sent };
+  }
+
+  it("panel_reload does not crash on a method-form isHeadless bridge (#478 unbound `this.conns`)", async () => {
+    const store = new WorkflowTargetStore();
+    // Two live non-headless tabs + an orphaned session → the ambiguity guard runs the
+    // interactive-tab filter, which is exactly where the unbound isHeadless call sat.
+    const { bridge } = methodIsHeadlessBridge(["a-tab", "b-tab"]);
+    const ctx = makePanelToolCtx(bridge, "dead-session-tab", store);
+    const res = await defByName("panel_reload").handler({}, ctx);
+    // Must reach the clear multi-tab error, NOT throw "reading 'conns'".
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).toMatch(/multiple tabs/i);
+    expect((res.content[0] as { text: string }).text).not.toMatch(/conns/i);
+  });
+
+  it("panel_reload rebinds+forwards on a method-form isHeadless bridge with one live tab (#478)", async () => {
+    const store = new WorkflowTargetStore();
+    // Single live tab: the filter still calls isHeadless (must not crash), the session
+    // rebinds onto it, and soft_reload is forwarded there.
+    const { bridge, sent } = methodIsHeadlessBridge(["only-live-tab"]);
+    const ctx = makePanelToolCtx(bridge, "orphaned-tab", store);
+    const res = await defByName("panel_reload").handler({}, ctx);
+    expect(res.isError).toBeUndefined();
+    expect(ctx.tabId).toBe("only-live-tab");
+    expect(sent.at(-1)).toMatchObject({
+      cmd: { cmd: "soft_reload", scope: "orchestrator" },
+      tabId: "only-live-tab",
+    });
+  });
+
+  it("panel_set_workflow_target recovery filters isHeadless bound, not detached (#478 sibling site)", async () => {
+    const store = new WorkflowTargetStore();
+    // Dead session + 2 ambiguous live non-headless tabs → rebindToActiveTab throws, and
+    // the catch's interactive-tab filter runs isHeadless. Detached, it threw "reading
+    // 'conns'"; bound, it counts 2 interactive tabs and returns the clear ambiguity error.
+    const { bridge } = methodIsHeadlessBridge(["a-tab", "b-tab"]);
+    const ctx = makePanelToolCtx(bridge, "dead-session-tab", store);
+    const res = await defByName("panel_set_workflow_target").handler({ mode: "current" }, ctx);
+    expect(res.isError).toBe(true);
+    expect((res.content[0] as { text: string }).text).not.toMatch(/conns/i);
+    expect((res.content[0] as { text: string }).text).toMatch(/multiple|last active|pass tab_id/i);
+  });
+
   it("a genuinely-gone tab (no reconnect) still fails clearly after the single retry", async () => {
     const store = new WorkflowTargetStore();
     // Nothing ever becomes live — retry can't rebind, so it must surface an error.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3202,11 +3202,16 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // Count only INTERACTIVE (canvas-owning) tabs for the ambiguity guard: one
           // desktop canvas alongside headless viewers is NOT ambiguous — rebindToActiveTab
           // binds the sole desktop tab. Only 2+ real canvas tabs are unpickable here.
-          const headless = ctx.bridge.isHeadless;
-          const interactive =
-            Array.isArray(live) && typeof headless === "function"
-              ? live.filter((t) => !headless(t.tab_id))
-              : live;
+          // Call isHeadless THROUGH the bridge (not an extracted reference): it is a
+          // plain method that reads `this.conns` — invoking a detached `const headless
+          // = ctx.bridge.isHeadless` loses `this`, so `this.conns` throws "Cannot read
+          // properties of undefined (reading 'conns')" and panel_reload fails outright
+          // (panel #478). Mirror the bound `isHeadlessTab` helper used elsewhere here.
+          const isHeadlessTab = (id: string): boolean =>
+            typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
+          const interactive = Array.isArray(live)
+            ? live.filter((t) => !isHeadlessTab(t.tab_id))
+            : live;
           if (orphaned && Array.isArray(interactive) && interactive.length > 1) {
             return fail(
               "This session's ComfyUI tab was replaced and multiple tabs are now open — " +
@@ -3823,10 +3828,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             if (Array.isArray(live)) {
               // Count only INTERACTIVE (canvas-owning) tabs: a headless-only reconnect is
               // NOT a usable graph binding, so it defers (binds once a real canvas tab
-              // connects) rather than failing as if a tab were pickable.
-              const headless = ctx.bridge.isHeadless;
-              const interactive =
-                typeof headless === "function" ? live.filter((t) => !headless(t.tab_id)) : live;
+              // connects) rather than failing as if a tab were pickable. Call isHeadless
+              // THROUGH the bridge (it reads `this.conns`) — a detached reference would
+              // lose `this` and throw "reading 'conns'" (the same #478 unbound-method bug).
+              const isHeadlessTab = (id: string): boolean =>
+                typeof ctx.bridge.isHeadless === "function" && ctx.bridge.isHeadless(id);
+              const interactive = live.filter((t) => !isHeadlessTab(t.tab_id));
               noTabsConnected = interactive.length === 0;
             } else {
               // No tab enumeration — classify by the resolve error: only "nothing


### PR DESCRIPTION
## Root cause (repo note: fix is orchestrator-side, not the panel)

`comfyui-mcp-panel#478` reports `panel_reload` (scope `frontend`) crashing with
**`Cannot read properties of undefined (reading 'conns')`** and returning an error
instead of reloading. The issue was filed against the panel repo, but the `conns`
token does not exist anywhere in the panel frontend — the crash originates **here,
in the orchestrator** (`comfyui-mcp` owns the `panel_reload` tool).

`panel_reload`'s multi-tab ambiguity guard extracted the bridge method as a bare
reference and called it **unbound**:

```ts
const headless = ctx.bridge.isHeadless;               // detached from receiver
const interactive = ... live.filter((t) => !headless(t.tab_id)); // this === undefined
```

`UiBridge.isHeadless` (`src/services/ui-bridge.ts:1252`) is a plain (non-arrow)
method whose body reads `this.conns` / `this.headlessSeen`. Called unbound, `this`
is `undefined`, so `this.conns` throws — killing **every** `panel_reload` that had
at least one connected tab (introduced in `1ef0db0`, #400/#402/#474).

`panel_set_workflow_target`'s rebind-recovery path had the **identical** detached
call (caught during self-review) — same crash, so it is fixed too.

## Fix

Call `isHeadless` **through the bridge receiver** via a `typeof`-guarded
`isHeadlessTab` helper at both sites, mirroring the safe helper already used at
`panel-tools.ts:1821`. Interactive-tab counting (the ambiguity/defer decision) is
unchanged; when `isHeadless` is absent the helper returns `false`, so all tabs stay
counted — identical to the prior fallback.

## Tests

The prior fake bridges never set `isHeadless`, so they skipped the filter and never
caught this. Added 3 regression tests with a fake bridge whose `isHeadless` is a
method over `this.conns` (the real `UiBridge` shape). Each **fails with exactly
`reading 'conns'` without the fix** and passes with it.

- `tsc --noEmit` clean
- `vitest` panel-tools file: 145 passed
- full suite green (one unrelated pre-existing env-dependent `node-dev` failure:
  expects search engine `builtin`, gets `ripgrep` because rg is installed on the rig)

Codex adversarial review (gpt-5.6-terra, high): **PASS**, no P0/P1/P2.

Closes artokun/comfyui-mcp-panel#478

🤖 Generated with [Claude Code](https://claude.com/claude-code)