### PR TITLE
fix(session): key unsaved-workflow resume on a durable per-instance uuid (#570)

### DIFF
--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -149,4 +149,48 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     expect(manager.hasLiveAgent(key)).toBe(false);
     await manager.stopAll();
   });
+
+  it("P0: failed-start held mail counts as state (torn down on an identity transition)", async () => {
+    // A backend prepare() failure DROPS the agent but PARKS the queued user message in
+    // heldMessages (#256) — no live agent, no session. hasAnyState must still see it, so an
+    // in-place replacement resets it instead of re-delivering the prior workflow's message.
+    class RejectingBackend implements AgentBackend {
+      readonly id = "claude" as const;
+      readonly capabilities = CLAUDE_CAPABILITIES;
+      async prepare(): Promise<void> {
+        throw new Error("prepare rejected (bad key)");
+      }
+      async *run(): AsyncGenerator<AgentEvent> {
+        throw new Error("run must not be reached");
+      }
+      async interrupt(): Promise<void> {}
+      async listModels(): Promise<ModelChoice[]> {
+        return [];
+      }
+    }
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onStartFailure: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => new RejectingBackend(),
+      identityForKey: () => IDENTITY_A,
+    } as never);
+    const key = "wf:foo.json::claude";
+    manager.send(key, "A's private message queued behind a failed start");
+    // The start fails: no live agent, no durable session — but the message is PARKED.
+    await waitFor(() => manager.hasAnyState(key) && !manager.hasLiveAgent(key));
+    expect(store.get(key)).toBeUndefined();
+    expect(manager.hasAnyState(key)).toBe(true); // held mail is state
+    // The identity boundary (gated on hasAnyState) resets — the parked message is dropped,
+    // never re-delivered into the replacement workflow.
+    manager.reset(key);
+    expect(manager.hasAnyState(key)).toBe(false);
+    await manager.stopAll();
+  });
 });

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -137,11 +137,11 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     await manager.stopAll();
   });
 
-  it("#570: a tab-id migration COLLISION (destination already live) retires the source agent — no cross-tab leak", async () => {
-    // The same workflow open in TWO tabs; one migrates onto the other's id. rebindAgent refuses
-    // (destination already has a live agent) WITHOUT moving/stopping the source, which stays live
-    // under the old id and would leak its callbacks into the destination tab via the proven
-    // old→new alias. The orchestrator's collision handling retires the orphaned source agent.
+  it("#570: a tab-id migration COLLISION resets the superseded destination then rebinds the source (no cross-tab leak)", async () => {
+    // The same workflow open in TWO tabs; the incoming socket migrates onto the other's id. The
+    // bridge has already SUPERSEDED the destination's socket, so its still-mapped agent would
+    // render into the incoming tab. Reset the superseded destination, THEN rebind the source into
+    // the freed id so the incoming tab keeps its OWN conversation.
     const store = new SessionStore(PORT);
     const manager = new PanelAgentManager({
       mcpServers: {},
@@ -155,20 +155,23 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
       identityForKey: () => IDENTITY_A,
     } as never);
 
-    const oldKey = "tmp:A::claude"; // source tab
+    const oldKey = "tmp:A::claude"; // incoming/source tab
     const newKey = "wf:foo.json::claude"; // destination tab (already open, same workflow)
-    manager.send(newKey, "destination tab conversation");
-    manager.send(oldKey, "source tab conversation");
+    manager.send(newKey, "destination tab (B) conversation");
+    manager.send(oldKey, "incoming tab (A) conversation");
     await waitFor(() => manager.hasLiveAgent(oldKey) && manager.hasLiveAgent(newKey));
 
-    // The migration loop: rebind collides (destination live) → false; source still live.
-    const rebound = manager.rebindAgent(oldKey, newKey);
-    expect(rebound).toBe(false); // collision — destination occupied
-    expect(manager.hasLiveAgent(oldKey)).toBe(true); // source NOT moved
-    // Orchestrator collision handling: retire the orphaned source so it stops emitting.
-    if (!rebound && manager.hasLiveAgent(oldKey)) manager.retire(oldKey);
-    expect(manager.hasLiveAgent(oldKey)).toBe(false); // source retired → no cross-tab leak
-    expect(manager.hasLiveAgent(newKey)).toBe(true); // destination conversation preserved
+    // Without handling, rebind REFUSES (destination occupied) and the source stays stranded live
+    // under the old id — the leak precondition.
+    expect(manager.rebindAgent(oldKey, newKey)).toBe(false);
+    expect(manager.hasLiveAgent(oldKey)).toBe(true);
+
+    // Collision handling: reset the superseded destination (its agent is removed → it can no
+    // longer render into the incoming socket), THEN rebind the incoming source into the freed id.
+    manager.reset(newKey);
+    expect(manager.rebindAgent(oldKey, newKey)).toBe(true); // source takes the id
+    expect(manager.hasLiveAgent(newKey)).toBe(true); // incoming tab keeps its OWN (source) conversation
+    expect(manager.hasLiveAgent(oldKey)).toBe(false); // nothing stranded under the old id
 
     await manager.stopAll();
   });

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -98,6 +98,45 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     await manager.stopAll();
   });
 
+  it("#570: a proven tab-id migration rebinds EVERY backend, so a dormant provider's session survives", async () => {
+    // Saved workflow A: Claude conversed (dormant after a switch to Codex), Codex is current, then
+    // a save/rename changes the wf: tab id. The migration must move the dormant Claude session to
+    // the new id too — not only the current (Codex) one — or switching back to Claude starts fresh.
+    const backend = new SessioningBackend();
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => backend,
+      identityForKey: () => IDENTITY_A,
+    } as never);
+
+    // Dormant Claude session + live-then-retired: model both providers having durable sessions
+    // under the OLD tab id (Claude dormant, Codex current) — bound to the same workflow identity.
+    store.set("wf:old.json::claude", "sess-claude", IDENTITY_A);
+    store.set("wf:old.json::codex", "sess-codex", IDENTITY_A);
+
+    // The proven migration loops over KNOWN_BACKENDS calling rebindAgent(old::b → new::b).
+    for (const b of ["claude", "codex"]) {
+      manager.rebindAgent(`wf:old.json::${b}`, `wf:new.json::${b}`);
+    }
+
+    // BOTH providers' sessions moved to the new id (dormant Claude included), old keys cleared.
+    expect(store.get("wf:new.json::claude")).toBe("sess-claude");
+    expect(store.get("wf:new.json::codex")).toBe("sess-codex");
+    expect(store.get("wf:old.json::claude")).toBeUndefined();
+    expect(store.get("wf:old.json::codex")).toBeUndefined();
+    // …and durably: switching back to Claude on the new id resumes its original conversation.
+    expect(new SessionStore(PORT).get("wf:new.json::claude")).toBe("sess-claude");
+
+    await manager.stopAll();
+  });
+
   it("#570: a backend switch RETIRES the prior provider (preserves its session) so switching back resumes", async () => {
     // BOTH provider-switch protocols on the SAME workflow — the explicit set_backend event AND
     // a re-hello that selects a different backend — now funnel to manager.retire(prevKey). They

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -98,6 +98,43 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     await manager.stopAll();
   });
 
+  it("#570: a backend switch RETIRES the prior provider (preserves its session) so switching back resumes", async () => {
+    // set_backend on the SAME workflow must NOT reset the old provider — that would clear its
+    // durable exact record, and a SAVED wf: workflow has no stable-key fallback, so switching
+    // back could never resume. retire() stops the live agent but keeps the identity-bound
+    // session, so a later switch-back continues the original conversation (codex round-trip).
+    const backend = new SessioningBackend();
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => backend,
+      identityForKey: () => IDENTITY_A,
+    } as never);
+
+    const claudeKey = "wf:foo.json::claude"; // a SAVED workflow (no stable-key fallback)
+    manager.send(claudeKey, "hi from claude on workflow A");
+    await waitFor(() => backend.turnTexts.length === 1);
+    expect(store.get(claudeKey)).toBe("sess-A");
+    expect(manager.hasLiveAgent(claudeKey)).toBe(true);
+
+    // Provider switch A(claude) → B(codex): set_backend now RETIRES claude, not resets it.
+    manager.retire(claudeKey);
+    expect(manager.hasLiveAgent(claudeKey)).toBe(false); // live agent stopped (no double-run)
+    // …but the durable session is PRESERVED — this is what makes the switch-BACK resumable.
+    expect(store.get(claudeKey)).toBe("sess-A");
+    expect(store.identityOf(claudeKey)).toBe(IDENTITY_A);
+    // Durable across a fresh process too (a restart between switches).
+    expect(new SessionStore(PORT).get(claudeKey)).toBe("sess-A");
+
+    await manager.stopAll();
+  });
+
   it("P0a: a live agent in the spawn→first-session window (no durable record) is still torn down", async () => {
     // The prior workflow can have a LIVE agent BEFORE its first `session` event — so no
     // durable exact record exists yet. The identity-boundary reset gates on STATE

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -176,6 +176,42 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     await manager.stopAll();
   });
 
+  it("#570: a tab-id migration COLLISION resets a DORMANT destination session too — incoming tab can't inherit it", async () => {
+    // The destination id previously left a DORMANT provider session (no live agent). If the
+    // incoming source has no state on that provider, rebindAgent's moveDurable would PRESERVE the
+    // destination's session → the incoming tab resumes the OTHER tab's conversation on a later
+    // switch. The collision handling must reset the destination for ANY state (incl. a dormant
+    // durable session / held mail), not just a live agent.
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => new SessioningBackend(),
+      identityForKey: () => IDENTITY_A,
+    } as never);
+
+    const newKey = "wf:foo.json::claude"; // destination id, DORMANT Claude session (no live agent)
+    const srcKey = "tmp:A::claude"; // incoming tab, on Codex → NO Claude state
+    store.set(newKey, "sess-B-claude", IDENTITY_A);
+    expect(manager.hasLiveAgent(newKey)).toBe(false); // dormant — a live-agent-only check misses it
+
+    // The orchestrator's any-state collision reset (dormant durable session present) fires…
+    if (manager.hasAnyState(newKey) || store.get(newKey) !== undefined) manager.reset(newKey);
+    // …then rebinds the source (which has nothing on this provider — moveDurable moves nothing).
+    manager.rebindAgent(srcKey, newKey);
+
+    // B's dormant session is GONE — the incoming tab starts fresh on Claude, never inherits it.
+    expect(store.get(newKey)).toBeUndefined();
+    expect(new SessionStore(PORT).get(newKey)).toBeUndefined(); // durable
+
+    await manager.stopAll();
+  });
+
   it("#570: a backend switch RETIRES the prior provider (preserves its session) so switching back resumes", async () => {
     // BOTH provider-switch protocols on the SAME workflow — the explicit set_backend event AND
     // a re-hello that selects a different backend — now funnel to manager.retire(prevKey). They

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -137,6 +137,42 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     await manager.stopAll();
   });
 
+  it("#570: a tab-id migration COLLISION (destination already live) retires the source agent — no cross-tab leak", async () => {
+    // The same workflow open in TWO tabs; one migrates onto the other's id. rebindAgent refuses
+    // (destination already has a live agent) WITHOUT moving/stopping the source, which stays live
+    // under the old id and would leak its callbacks into the destination tab via the proven
+    // old→new alias. The orchestrator's collision handling retires the orphaned source agent.
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => new SessioningBackend(),
+      identityForKey: () => IDENTITY_A,
+    } as never);
+
+    const oldKey = "tmp:A::claude"; // source tab
+    const newKey = "wf:foo.json::claude"; // destination tab (already open, same workflow)
+    manager.send(newKey, "destination tab conversation");
+    manager.send(oldKey, "source tab conversation");
+    await waitFor(() => manager.hasLiveAgent(oldKey) && manager.hasLiveAgent(newKey));
+
+    // The migration loop: rebind collides (destination live) → false; source still live.
+    const rebound = manager.rebindAgent(oldKey, newKey);
+    expect(rebound).toBe(false); // collision — destination occupied
+    expect(manager.hasLiveAgent(oldKey)).toBe(true); // source NOT moved
+    // Orchestrator collision handling: retire the orphaned source so it stops emitting.
+    if (!rebound && manager.hasLiveAgent(oldKey)) manager.retire(oldKey);
+    expect(manager.hasLiveAgent(oldKey)).toBe(false); // source retired → no cross-tab leak
+    expect(manager.hasLiveAgent(newKey)).toBe(true); // destination conversation preserved
+
+    await manager.stopAll();
+  });
+
   it("#570: a backend switch RETIRES the prior provider (preserves its session) so switching back resumes", async () => {
     // BOTH provider-switch protocols on the SAME workflow — the explicit set_backend event AND
     // a re-hello that selects a different backend — now funnel to manager.retire(prevKey). They

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -99,10 +99,12 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
   });
 
   it("#570: a backend switch RETIRES the prior provider (preserves its session) so switching back resumes", async () => {
-    // set_backend on the SAME workflow must NOT reset the old provider — that would clear its
-    // durable exact record, and a SAVED wf: workflow has no stable-key fallback, so switching
-    // back could never resume. retire() stops the live agent but keeps the identity-bound
-    // session, so a later switch-back continues the original conversation (codex round-trip).
+    // BOTH provider-switch protocols on the SAME workflow — the explicit set_backend event AND
+    // a re-hello that selects a different backend — now funnel to manager.retire(prevKey). They
+    // must NOT reset the old provider: that would clear its durable exact record, and a SAVED
+    // wf: workflow has no stable-key fallback, so switching back could never resume. retire()
+    // stops the live agent but keeps the identity-bound session, so a later switch-back
+    // continues the original conversation (codex round-trip). This pins that shared operation.
     const backend = new SessioningBackend();
     const store = new SessionStore(PORT);
     const manager = new PanelAgentManager({

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -97,4 +97,56 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
 
     await manager.stopAll();
   });
+
+  it("P0a: a live agent in the spawn→first-session window (no durable record) is still torn down", async () => {
+    // The prior workflow can have a LIVE agent BEFORE its first `session` event — so no
+    // durable exact record exists yet. The identity-boundary reset gates on STATE
+    // (hasLiveAgent), not on a durable record, so this window is covered. Here we prove the
+    // precondition (live agent, no durable session) and that manager.reset tears it down.
+    class NoSessionBackend implements AgentBackend {
+      readonly id = "claude" as const;
+      readonly capabilities = CLAUDE_CAPABILITIES;
+      started = false;
+      release: (() => void) | null = null;
+      async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+        for await (const _turn of opts.channel) {
+          this.started = true;
+          // Hang the turn WITHOUT ever yielding a `session` event — the spawn→first-session
+          // window. (No `yield { type: "session" }`.)
+          await new Promise<void>((r) => {
+            this.release = r;
+          });
+        }
+      }
+      async interrupt(): Promise<void> {
+        this.release?.();
+      }
+      async listModels(): Promise<ModelChoice[]> {
+        return [];
+      }
+    }
+    const backend = new NoSessionBackend();
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => backend,
+      identityForKey: () => IDENTITY_A,
+    } as never);
+    const key = "wf:foo.json::claude";
+    manager.send(key, "hang without a session");
+    await waitFor(() => backend.started);
+    // The window: a LIVE agent, but NO durable session record yet.
+    expect(manager.hasLiveAgent(key)).toBe(true);
+    expect(store.get(key)).toBeUndefined();
+    // The identity-boundary branch (gated on hasLiveAgent, not the durable record) resets it.
+    manager.reset(key);
+    expect(manager.hasLiveAgent(key)).toBe(false);
+    await manager.stopAll();
+  });
 });

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -1,0 +1,99 @@
+// #570 P0 — a SAVED workflow overwritten IN PLACE (same wf:<path> tab id, new uuid) must
+// start FRESH. The hello handler detects the durable identity mismatch and calls
+// manager.reset(key) — a FULL session boundary. This pins the manager-lifecycle half:
+// (1) the exact session is BOUND to the identity uuid (identityForKey → SessionStore.u),
+// and (2) reset() stops the LIVE agent AND clears the durable session + pending resume, so
+// the next message can't continue the replaced workflow's conversation.
+
+import { describe, expect, it, beforeAll, afterEach } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+import { SessionStore } from "../../orchestrator/session-store.js";
+
+let PanelAgentManager: typeof import("../../orchestrator/panel-agent.js").PanelAgentManager;
+beforeAll(async () => {
+  ({ PanelAgentManager } = await import("../../orchestrator/panel-agent.js"));
+});
+
+const PORT = 59244;
+const FILE = join(tmpdir(), `comfyui-mcp-panel-sessions-${PORT}.json`);
+afterEach(() => {
+  try {
+    rmSync(FILE);
+  } catch {
+    /* already gone */
+  }
+});
+
+class SessioningBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  turnTexts: string[] = [];
+  sessionId = "sess-A";
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    for await (const turn of opts.channel) {
+      yield { type: "session", sessionId: this.sessionId };
+      this.turnTexts.push(turn.text);
+      yield { type: "result", ok: true, subtype: "success" } as AgentEvent;
+    }
+  }
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+
+describe("in-place workflow replacement resets the live session (#570 P0)", () => {
+  it("binds the exact session to its identity uuid and reset() clears the live agent + session", async () => {
+    const backend = new SessioningBackend();
+    const store = new SessionStore(PORT);
+    const manager = new PanelAgentManager({
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSay: () => {},
+      onTurn: () => {},
+      onSession: () => {},
+      sessionStore: store,
+      makeBackend: () => backend,
+      // Mirrors index.ts: the tab's trusted workflow uuid for a composite key.
+      identityForKey: () => UUID_A,
+    } as never);
+
+    const key = "wf:foo.json::claude";
+    // Workflow A converses — the session persists BOUND to A's uuid.
+    manager.send(key, "hello from workflow A");
+    await waitFor(() => backend.turnTexts.length === 1);
+    expect(store.get(key)).toBe("sess-A");
+    expect(store.identityOf(key)).toBe(UUID_A); // durable identity binding
+    expect(manager.hasLiveAgent(key)).toBe(true);
+
+    // The hello handler, on detecting boundUuid (UUID_A) !== the new hello's uuid, calls
+    // manager.reset(key). That must stop the LIVE agent AND clear the durable session —
+    // not just the disk record — so the replaced workflow can't be continued.
+    manager.reset(key);
+    expect(manager.hasLiveAgent(key)).toBe(false); // live agent stopped
+    expect(store.get(key)).toBeUndefined(); // durable session cleared
+    expect(store.identityOf(key)).toBeUndefined();
+
+    await manager.stopAll();
+  });
+});

--- a/src/__tests__/orchestrator/in-place-replace-reset.test.ts
+++ b/src/__tests__/orchestrator/in-place-replace-reset.test.ts
@@ -60,6 +60,7 @@ async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
 }
 
 const UUID_A = "11111111-1111-4111-8111-111111111111";
+const IDENTITY_A = `http://127.0.0.1:8188::${UUID_A}`;
 
 describe("in-place workflow replacement resets the live session (#570 P0)", () => {
   it("binds the exact session to its identity uuid and reset() clears the live agent + session", async () => {
@@ -74,8 +75,8 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
       onSession: () => {},
       sessionStore: store,
       makeBackend: () => backend,
-      // Mirrors index.ts: the tab's trusted workflow uuid for a composite key.
-      identityForKey: () => UUID_A,
+      // Mirrors index.ts: the tab's FULL trusted workflow identity (origin::uuid).
+      identityForKey: () => IDENTITY_A,
     } as never);
 
     const key = "wf:foo.json::claude";
@@ -83,7 +84,7 @@ describe("in-place workflow replacement resets the live session (#570 P0)", () =
     manager.send(key, "hello from workflow A");
     await waitFor(() => backend.turnTexts.length === 1);
     expect(store.get(key)).toBe("sess-A");
-    expect(store.identityOf(key)).toBe(UUID_A); // durable identity binding
+    expect(store.identityOf(key)).toBe(IDENTITY_A); // durable full-identity binding
     expect(manager.hasLiveAgent(key)).toBe(true);
 
     // The hello handler, on detecting boundUuid (UUID_A) !== the new hello's uuid, calls

--- a/src/__tests__/orchestrator/retire-no-leak.test.ts
+++ b/src/__tests__/orchestrator/retire-no-leak.test.ts
@@ -1,0 +1,83 @@
+// #570 P0a — a RETIRED agent must not leak a buffered event into the workflow it was
+// retired in favor of. PanelAgentManager.retire()/stop() set `closed` fire-and-forget,
+// but the backend's `for await` loop can still yield ONE more event before it observes
+// the flag. The bridge's same-socket migration alias routes frames addressed to the
+// retired tab to the newly-targeted one, so if that buffered event still fired
+// onSession/onSay/onStream the OLD workflow's reply or session id would surface in the
+// SWITCHED-TO workflow. handleEvent() now drops every event once closed.
+
+import { describe, expect, it, beforeAll } from "vitest";
+import type {
+  AgentBackend,
+  AgentEvent,
+  BackendStartOptions,
+  ModelChoice,
+} from "../../orchestrator/agent-backend.js";
+import { CLAUDE_CAPABILITIES } from "../../orchestrator/agent-backend.js";
+
+let PanelAgent: typeof import("../../orchestrator/panel-agent.js").PanelAgent;
+
+beforeAll(async () => {
+  ({ PanelAgent } = await import("../../orchestrator/panel-agent.js"));
+});
+
+/** A backend that, once its turn is unblocked, emits a session + a say event. The test
+ *  unblocks it only AFTER the agent is stopped, so those events arrive post-close. */
+class LateEventBackend implements AgentBackend {
+  readonly id = "claude" as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
+  private release: (() => void) | null = null;
+  gate = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+
+  async *run(_opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    // Hold before emitting anything so the test can stop() the agent first.
+    await this.gate;
+    yield { type: "session", sessionId: "sess-late-LEAK" };
+    yield { type: "say", text: "the OLD workflow's leaked reply", id: "m1" };
+    yield { type: "result", subtype: "success" } as AgentEvent;
+  }
+  fire(): void {
+    this.release?.();
+  }
+  async interrupt(): Promise<void> {}
+  async listModels(): Promise<ModelChoice[]> {
+    return [];
+  }
+}
+
+async function tick(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 20));
+}
+
+describe("a retired/stopped agent leaks no buffered event (#570 P0a)", () => {
+  it("drops a session/say yielded after stop() — no callback fires", async () => {
+    const backend = new LateEventBackend();
+    const sessions: string[] = [];
+    const says: string[] = [];
+    const deps = {
+      mcpServers: {},
+      systemAppend: "",
+      model: "claude-test",
+      onSession: (_tab: string, sid: string) => sessions.push(sid),
+      onSay: (_tab: string, text: string) => says.push(text),
+      onTurn: () => {},
+    };
+    const agent = new PanelAgent("tab-retire", deps as never, backend);
+    void agent.start();
+    agent.send("go");
+
+    // Retire the agent BEFORE the backend emits (mirrors retire() on a workflow switch).
+    await agent.stop();
+    expect(agent.isStopped).toBe(true);
+
+    // Now let the buffered session/say events flow. handleEvent must drop them.
+    backend.fire();
+    await tick();
+
+    expect(sessions).toEqual([]); // no session id surfaced into the switched-to tab
+    expect(says).toEqual([]); // no old reply leaked
+  });
+});

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -9,10 +9,13 @@ import { describe, expect, it, afterEach } from "vitest";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SessionStore } from "../../orchestrator/session-store.js";
+import { SessionStore, deriveStableKey } from "../../orchestrator/session-store.js";
 
 // A port unlikely to collide with a real run or another test.
 const PORT = 59187;
+// Two valid crypto.randomUUID()-shaped ids (deriveStableKey validates the format).
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
 const FILE = join(tmpdir(), `comfyui-mcp-panel-sessions-${PORT}.json`);
 
 afterEach(() => {
@@ -147,6 +150,128 @@ describe("SessionStore", () => {
       store.clearStable("skey");
       store.setStable("skey", "sess-D", "tmp:tabD");
       expect(store.getStable("skey")).toBe("sess-D");
+    });
+  });
+
+  // #570 REOPEN: #587 keyed the stable resume index on origin+title+backend. An
+  // unsaved workflow's title is the DEFAULT "Unsaved Workflow", so two DIFFERENT
+  // unsaved workflows collided on one key and a reset resumed an unrelated earlier
+  // on-disk session (the WRONG conversation) for a turn. deriveStableKey keys on the
+  // panel's durable, globally-unique per-instance uuid when advertised, so the two
+  // can never share a key — and the uuid survives the reload that churns the tmp: id.
+  describe("deriveStableKey — durable per-instance uuid retires the same-title collision (#570 reopen)", () => {
+    it("two DIFFERENT unsaved workflows sharing the default title get DIFFERENT keys", () => {
+      // The exact reopened scenario: same origin, same "Unsaved Workflow" title
+      // (title is no longer part of the key at all) — but distinct per-instance uuids.
+      const a = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188", backend: "claude" });
+      const b = deriveStableKey({ workflowUuid: UUID_B, origin: "http://127.0.0.1:8188", backend: "claude" });
+      expect(a).not.toBe(b);
+    });
+
+    it("the SAME instance keeps ONE key across a reload (churned tmp id / title suffix)", () => {
+      // Post-reload the tmp:<uuid> tab id and even the title's "(N)" suffix can
+      // change; only the embedded per-instance uuid is stable — and since the key no
+      // longer includes the title, the SAME uuid always yields the SAME resume key.
+      const before = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188", backend: "claude" });
+      const after = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188", backend: "claude" });
+      expect(after).toBe(before);
+    });
+
+    it("the uuid key partitions by backend (per-provider sessions)", () => {
+      const claude = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" });
+      const codex = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "codex" });
+      expect(claude).not.toBe(codex);
+    });
+
+    it("the SAME uuid from a DIFFERENT origin can't cross-resume (copied graph metadata)", () => {
+      // The uuid is embedded in graph JSON that can be copied to another instance;
+      // folding the origin into the key stops a replayed uuid from bridging them.
+      const a = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188", backend: "claude" });
+      const b = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8199", backend: "claude" });
+      expect(a).not.toBe(b);
+    });
+
+    it("FAIL CLOSED: no uuid (old panel) → undefined, never the collision-prone legacy key", () => {
+      // The whole reopen was the origin+title key; an un-upgraded panel that sends no
+      // uuid must NOT fall back to it. undefined = the orchestrator forgoes the disk
+      // fallback and starts fresh (a lost resume, never a wrong one).
+      expect(deriveStableKey({ origin: "http://127.0.0.1:8188", backend: "claude" })).toBeUndefined();
+      // Blank/whitespace and malformed identifiers are treated as absent too — a junk
+      // value never becomes an arbitrary session handle.
+      expect(deriveStableKey({ workflowUuid: "  ", origin: "o", backend: "claude" })).toBeUndefined();
+      expect(deriveStableKey({ workflowUuid: "not-a-uuid", origin: "o", backend: "claude" })).toBeUndefined();
+    });
+
+    it("FAIL CLOSED: a missing/blank origin (no trusted handshake origin) → undefined", () => {
+      // The origin must be the server-observed handshake origin; when the bridge can't
+      // supply one (relay/headless) we key on nothing rather than an untrusted value.
+      expect(deriveStableKey({ workflowUuid: UUID_A, backend: "claude" })).toBeUndefined();
+      expect(deriveStableKey({ workflowUuid: UUID_A, origin: "   ", backend: "claude" })).toBeUndefined();
+    });
+
+    it("canonicalizes the origin (case + trailing slash) so trivial variants share one key", () => {
+      const a = deriveStableKey({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188/", backend: "claude" });
+      const b = deriveStableKey({ workflowUuid: UUID_A, origin: "HTTP://127.0.0.1:8188", backend: "claude" });
+      expect(a).toBe(b);
+    });
+
+    it("END-TO-END: two same-title workflows no longer cross-resume through the store", () => {
+      const store = new SessionStore(PORT);
+      // Workflow A converses (session sess-A), stored under its uuid key.
+      const keyA = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      store.setStable(keyA, "sess-A", "tmp:tabA");
+      // A DIFFERENT unsaved workflow B, same default title, opens after a restart.
+      const keyB = deriveStableKey({ workflowUuid: UUID_B, origin: "o", backend: "claude" })!;
+      // Under #587 (origin+title) keyA === keyB and B would resume A's sess-A. Now:
+      expect(store.getStable(keyB)).toBeUndefined(); // B never inherits A's chat
+      // And A itself still resumes across a fresh process (durable).
+      expect(new SessionStore(PORT).getStable(keyA)).toBe("sess-A");
+    });
+
+    it("IDENTITY REGRESSION: a fail-closed hello retires the prior session so a reset can't resurrect it", () => {
+      // Models the index.ts fail-closed branch (both the direct re-hello path AND the
+      // tab-id-migration carry-over path, which funnel to the same clearStable). A tab
+      // connected with a valid uuid and persisted session S under its key. It then
+      // re-hellos from an old/malformed panel (no uuid) → identity regression: the
+      // orchestrator clears S (via the carried-over prior key on a migration). This is
+      // what stops a later `new_session` (which can no longer resolve the key) from
+      // leaving S on disk for a subsequent valid-uuid hello to getStable() back —
+      // resurrecting a conversation the user reset. After the clear, even recomputing
+      // the SAME uuid key misses, so nothing is resurrected.
+      const store = new SessionStore(PORT);
+      const key = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      store.setStable(key, "sess-S", "tmp:tabA");
+      expect(store.getStable(key)).toBe("sess-S");
+
+      // Fail-closed hello: deriveStableKey returns undefined; the branch clears `key`.
+      expect(deriveStableKey({ origin: "o", backend: "claude" })).toBeUndefined();
+      store.clearStable(key);
+
+      // Later valid-uuid hello recomputes the identical key — but it now misses, so the
+      // reset conversation is NOT resurrected. Durable across a fresh process too.
+      const recomputed = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      expect(recomputed).toBe(key);
+      expect(store.getStable(recomputed)).toBeUndefined();
+      expect(new SessionStore(PORT).getStable(recomputed)).toBeUndefined();
+    });
+
+    it("BACKEND SWITCH: each provider's session stays under its OWN recomputed key (no cross-provider resume)", () => {
+      // Models the set_backend recompute. Same tab/workflow (one origin+uuid), used on
+      // backend A then switched to B without a reconnect. Because set_backend recomputes
+      // tabStableKey for the new backend, B's onSession persists under the B key — NOT
+      // the A key — so a later reconnect on A resumes A's session and a reconnect on B
+      // resumes B's, never each other's (the backend-isolation guarantee).
+      const store = new SessionStore(PORT);
+      const keyClaude = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      const keyCodex = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "codex" })!;
+      expect(keyClaude).not.toBe(keyCodex);
+      store.setStable(keyClaude, "sess-claude", "tmp:tabA"); // on claude
+      // switch to codex → key recomputed → codex onSession writes under the codex key.
+      store.setStable(keyCodex, "sess-codex", "tmp:tabA");
+      // Neither leaked into the other; both resume correctly across a fresh process.
+      const restarted = new SessionStore(PORT);
+      expect(restarted.getStable(keyClaude)).toBe("sess-claude");
+      expect(restarted.getStable(keyCodex)).toBe("sess-codex");
     });
   });
 

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -14,10 +14,36 @@ import {
   armableResume,
   deriveStableKey,
   deriveWorkflowIdentity,
+  destinationHasCollisionState,
   keepsBackendState,
   siblingOwnsStableKey,
   workflowIdentityParts,
 } from "../../orchestrator/session-store.js";
+
+// #570 — a tab-id migration destination collides when it holds ANY per-backend state, INCLUDING a
+// render-held (heldDuringGen) queue. Previously held-only destinations were missed → the source
+// re-key appended to the destination's held array → the superseded tab's message flushed into the
+// incoming tab on render completion. The predicate must treat a render-held queue as a collision.
+describe("destinationHasCollisionState (#570 render-held included)", () => {
+  it("treats a RENDER-HELD queue as collision state (the previously-missed case)", () => {
+    expect(
+      destinationHasCollisionState({ hasManagerState: false, hasDurableSession: false, renderHeldCount: 1 }),
+    ).toBe(true);
+  });
+  it("treats manager state or a durable session as collision state", () => {
+    expect(
+      destinationHasCollisionState({ hasManagerState: true, hasDurableSession: false, renderHeldCount: 0 }),
+    ).toBe(true);
+    expect(
+      destinationHasCollisionState({ hasManagerState: false, hasDurableSession: true, renderHeldCount: 0 }),
+    ).toBe(true);
+  });
+  it("no state of any kind ⇒ not a collision (a fresh destination id)", () => {
+    expect(
+      destinationHasCollisionState({ hasManagerState: false, hasDurableSession: false, renderHeldCount: 0 }),
+    ).toBe(false);
+  });
+});
 
 // #570 — a tab OWNS every backend key whose session it RETAINS (a provider switch preserves the
 // old provider's session), so a second honest tab must not resume a key a connected sibling still

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -306,6 +306,29 @@ describe("SessionStore", () => {
       expect(new SessionStore(PORT).get("wf:foo.json::claude")).toBeUndefined();
     });
 
+    it("PRE-UPGRADE: an exact record with no identity binding reads back unbound (drives fail-closed reset)", () => {
+      // A record written before the `u` field existed (a v2 {s,t} entry, or a migrated
+      // legacy flat record) has a session but NO identity. identityOf() is undefined, so
+      // the hello handler treats it as untrusted (can't prove it's this workflow's) and
+      // resets — a one-time lost resume, never a wrong resume.
+      writeFileSync(
+        FILE,
+        JSON.stringify({
+          v: 2,
+          sessions: { "wf:foo.json::claude": { s: "sess-pre-upgrade", t: Date.now() } },
+          stable: {},
+        }),
+      );
+      const store = new SessionStore(PORT);
+      expect(store.get("wf:foo.json::claude")).toBe("sess-pre-upgrade"); // session present
+      expect(store.identityOf("wf:foo.json::claude")).toBeUndefined(); // but NOT identity-bound
+      // Legacy flat format (Record<string,string>) migrates likewise — no identity.
+      writeFileSync(FILE, JSON.stringify({ "wf:bar.json::claude": "sess-legacy" }));
+      const legacy = new SessionStore(PORT);
+      expect(legacy.get("wf:bar.json::claude")).toBe("sess-legacy");
+      expect(legacy.identityOf("wf:bar.json::claude")).toBeUndefined();
+    });
+
     it("WORKFLOW IDENTITY: distinguishes a same-workflow migration from a workflow switch (#570 P0a)", () => {
       // deriveWorkflowIdentity is the backend-independent discriminator the hello
       // handler uses to decide whether a same-socket re-hello under a new tab id is a

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -260,6 +260,31 @@ describe("SessionStore", () => {
       expect(new SessionStore(PORT).getStable(recomputed)).toBeUndefined();
     });
 
+    it("RESUME OWNERSHIP: a session owned by workflow A's identity is NOT owned by workflow B (#570 P0)", () => {
+      // Models the hello-handler's untrusted-hello.resume guard. The panel's default
+      // panel-scoped chat keeps ONE global session id S and re-sends it as hello.resume
+      // for EVERY workflow. The orchestrator honors it ONLY when S is owned by the tab's
+      // trusted identity — its exact-tab store entry OR its trusted stable key. Workflow A
+      // owns S; a fresh/copied workflow B (a different uuid) does NOT, so B's hello.resume=S
+      // is rejected → no cross-workflow chat resume.
+      const store = new SessionStore(PORT);
+      const keyA = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      store.setStable(keyA, "sess-S", "tmp:tabA"); // A converses; onSession persisted S
+      store.set("tmp:tabA::claude", "sess-S"); // and under A's exact key
+      const resume = "sess-S";
+
+      // A (same identity, e.g. a reload): OWNED via the stable key → honor.
+      const keyAReload = deriveStableKey({ workflowUuid: UUID_A, origin: "o", backend: "claude" })!;
+      expect(store.getStable(keyAReload) === resume).toBe(true);
+
+      // B (a different workflow that the panel re-hello'd with the same global S): the
+      // exact key differs (new tmp id) AND B's stable key doesn't hold S → NOT owned.
+      const keyB = deriveStableKey({ workflowUuid: UUID_B, origin: "o", backend: "claude" })!;
+      const bOwnsResume =
+        store.get("tmp:tabB::claude") === resume || store.getStable(keyB) === resume;
+      expect(bOwnsResume).toBe(false); // B's hello.resume=S is dropped, never cross-resumes A
+    });
+
     it("WORKFLOW IDENTITY: distinguishes a same-workflow migration from a workflow switch (#570 P0a)", () => {
       // deriveWorkflowIdentity is the backend-independent discriminator the hello
       // handler uses to decide whether a same-socket re-hello under a new tab id is a

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -9,7 +9,12 @@ import { describe, expect, it, afterEach } from "vitest";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { SessionStore, deriveStableKey } from "../../orchestrator/session-store.js";
+import {
+  SessionStore,
+  deriveStableKey,
+  deriveWorkflowIdentity,
+  workflowIdentityParts,
+} from "../../orchestrator/session-store.js";
 
 // A port unlikely to collide with a real run or another test.
 const PORT = 59187;
@@ -253,6 +258,30 @@ describe("SessionStore", () => {
       expect(recomputed).toBe(key);
       expect(store.getStable(recomputed)).toBeUndefined();
       expect(new SessionStore(PORT).getStable(recomputed)).toBeUndefined();
+    });
+
+    it("WORKFLOW IDENTITY: distinguishes a same-workflow migration from a workflow switch (#570 P0a)", () => {
+      // deriveWorkflowIdentity is the backend-independent discriminator the hello
+      // handler uses to decide whether a same-socket re-hello under a new tab id is a
+      // tab-id MIGRATION of one workflow (identity UNCHANGED → rebind the agent) or a
+      // SWITCH to a different workflow (identity CHANGED → retire, never rebind).
+      const a = deriveWorkflowIdentity({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188" });
+      const aAgain = deriveWorkflowIdentity({ workflowUuid: UUID_A, origin: "http://127.0.0.1:8188" });
+      const b = deriveWorkflowIdentity({ workflowUuid: UUID_B, origin: "http://127.0.0.1:8188" });
+      expect(a).toBeDefined();
+      expect(aAgain).toBe(a); // same workflow → migration (rebind is safe)
+      expect(b).not.toBe(a); // different workflow → switch (must NOT rebind)
+      // Backend-independent (a provider switch is not a workflow switch).
+      // Fails closed (undefined) without a valid uuid or trusted origin — so the
+      // migration decision treats "no proof of continuity" as "do not rebind".
+      expect(deriveWorkflowIdentity({ origin: "http://127.0.0.1:8188" })).toBeUndefined();
+      expect(deriveWorkflowIdentity({ workflowUuid: UUID_A })).toBeUndefined();
+      expect(deriveWorkflowIdentity({ workflowUuid: "not-a-uuid", origin: "o" })).toBeUndefined();
+      // Canonicalized parts match deriveStableKey's (case + trailing slash).
+      expect(workflowIdentityParts({ workflowUuid: UUID_A, origin: "HTTP://Host:8188/" })).toEqual({
+        origin: "http://host:8188",
+        uuid: UUID_A,
+      });
     });
 
     it("BACKEND SWITCH: each provider's session stays under its OWN recomputed key (no cross-provider resume)", () => {

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -504,6 +504,32 @@ describe("SessionStore", () => {
       ).toBe(false);
     });
 
+    it("PROVEN tab-id migration spawn window: a just-rebound agent with NO durable record is KEPT via the carried source identity", () => {
+      // A tmp:→wf: save/rename migration rebinds the agent to the new tab id. The new id has no
+      // prior identity and, in the spawn→first-session window, no durable record. The hello
+      // handler carries the PROVEN source identity (prevIdentity === newIdentity) forward as the
+      // tab's prior identity, so the ownership gate recognizes the rebound backend as owned and
+      // does NOT reset it (which would cancel its in-flight turn / drop its queued message).
+      expect(
+        keepsBackendState({
+          storedIdentity: undefined, // spawn window — no SessionStore entry yet
+          priorIdentity: HELLO, // carried proven source identity (prevIdentity === newIdentity)
+          isCurrentBackend: true, // migration keeps the same backend (tab-id-only change)
+          helloIdentity: HELLO,
+        }),
+      ).toBe(true);
+      // Without the carried identity (the bug: prior derived from the empty new tab id) it WOULD
+      // reset — proving the carry is load-bearing.
+      expect(
+        keepsBackendState({
+          storedIdentity: undefined,
+          priorIdentity: undefined,
+          isCurrentBackend: true,
+          helloIdentity: HELLO,
+        }),
+      ).toBe(false);
+    });
+
     it("END-TO-END: a persisted Claude session survives a restart + hello on Codex for the same workflow", () => {
       const store = new SessionStore(PORT);
       // Claude conversed on workflow A before the restart — persisted, bound to A's identity.

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -13,6 +13,7 @@ import {
   SessionStore,
   deriveStableKey,
   deriveWorkflowIdentity,
+  keepsBackendState,
   workflowIdentityParts,
 } from "../../orchestrator/session-store.js";
 
@@ -439,5 +440,98 @@ describe("SessionStore", () => {
     const restarted = new SessionStore(PORT);
     expect(restarted.get("e2e-stale::claude")).toBeUndefined();
     expect(restarted.getStable("spike-stale")).toBeUndefined();
+  });
+
+  // #570 — per-backend teardown at the identity boundary. A cold-start hello on ONE provider
+  // must NOT erase a DIFFERENT provider's still-valid same-workflow session.
+  describe("keepsBackendState — provider-switch continuity survives a cold start (#570)", () => {
+    const HELLO = `http://127.0.0.1:8188::${UUID_A}`;
+
+    it("KEEPS a dormant provider whose DURABLE identity matches the hello workflow", () => {
+      // Claude has a persisted session bound to workflow A; this hello selected Codex after a
+      // restart (tabStableIdentity empty). Claude's session belongs to the SAME workflow → keep.
+      expect(
+        keepsBackendState({
+          storedIdentity: HELLO, // Claude's Entry.u
+          priorIdentity: undefined, // cold start
+          isCurrentBackend: false, // Claude is the DORMANT provider here
+          helloIdentity: HELLO,
+        }),
+      ).toBe(true);
+    });
+
+    it("RESETS a provider bound to a DIFFERENT workflow (in-place replacement)", () => {
+      const OTHER = `http://127.0.0.1:8188::${UUID_B}`;
+      expect(
+        keepsBackendState({
+          storedIdentity: OTHER,
+          priorIdentity: undefined,
+          isCurrentBackend: false,
+          helloIdentity: HELLO,
+        }),
+      ).toBe(false);
+    });
+
+    it("RESETS a provider with NO durable record unless it is the CURRENT backend with a matching prior identity", () => {
+      // Dormant, no session → reset (nothing proven).
+      expect(
+        keepsBackendState({ storedIdentity: undefined, isCurrentBackend: false, helloIdentity: HELLO }),
+      ).toBe(false);
+      // Current backend, spawn-window live agent (no durable record): the tab's prior-hello
+      // identity certifies it.
+      expect(
+        keepsBackendState({
+          storedIdentity: undefined,
+          priorIdentity: HELLO,
+          isCurrentBackend: true,
+          helloIdentity: HELLO,
+        }),
+      ).toBe(true);
+      // …but a dormant provider must NOT borrow the tab's prior identity.
+      expect(
+        keepsBackendState({
+          storedIdentity: undefined,
+          priorIdentity: HELLO,
+          isCurrentBackend: false,
+          helloIdentity: HELLO,
+        }),
+      ).toBe(false);
+    });
+
+    it("FAILS CLOSED when the hello carries no identity (identity-less client)", () => {
+      expect(
+        keepsBackendState({ storedIdentity: HELLO, isCurrentBackend: true, helloIdentity: undefined }),
+      ).toBe(false);
+    });
+
+    it("END-TO-END: a persisted Claude session survives a restart + hello on Codex for the same workflow", () => {
+      const store = new SessionStore(PORT);
+      // Claude conversed on workflow A before the restart — persisted, bound to A's identity.
+      store.set("tmp:tabW::claude", "sess-claude-A", HELLO);
+      // Cold start: tabStableIdentity empty; the first hello selects Codex for the SAME workflow.
+      // The per-backend loop keeps Claude (matching) and resets Codex (no record).
+      const backends = ["claude", "codex"] as const;
+      const helloBackend = "codex";
+      const kept: string[] = [];
+      for (const b of backends) {
+        const bKey = `tmp:tabW::${b}`;
+        if (
+          keepsBackendState({
+            storedIdentity: store.identityOf(bKey),
+            priorIdentity: undefined,
+            isCurrentBackend: b === helloBackend,
+            helloIdentity: HELLO,
+          })
+        ) {
+          kept.push(b);
+          continue;
+        }
+        store.clear(bKey); // models manager.reset()'s durable-session clear
+      }
+      expect(kept).toEqual(["claude"]);
+      // Switching back to Claude still resumes the pre-restart conversation.
+      expect(store.get("tmp:tabW::claude")).toBe("sess-claude-A");
+      expect(new SessionStore(PORT).get("tmp:tabW::claude")).toBe("sess-claude-A"); // durable
+    });
   });
 });

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -15,8 +15,71 @@ import {
   deriveStableKey,
   deriveWorkflowIdentity,
   keepsBackendState,
+  siblingOwnsStableKey,
   workflowIdentityParts,
 } from "../../orchestrator/session-store.js";
+
+// #570 — a tab OWNS every backend key whose session it RETAINS (a provider switch preserves the
+// old provider's session), so a second honest tab must not resume a key a connected sibling still
+// owns — even after that sibling switched to a different provider. Ownership derives from the
+// retained-session state, NOT the sibling's current-backend mapping.
+describe("siblingOwnsStableKey (#570 owned-SET, not current-backend)", () => {
+  const ORIGIN = "http://127.0.0.1:8188";
+  const identity = { origin: ORIGIN, uuid: UUID_A };
+  const claudeKey = deriveStableKey({ workflowUuid: UUID_A, origin: ORIGIN, backend: "claude" })!;
+
+  it("A switched Claude→Codex but RETAINS its Claude session ⇒ still owns the Claude key (B must not resume it)", () => {
+    // Model A's retained state exactly as the handler derives it: the durable exact session
+    // survives the provider-switch retire.
+    const store = new SessionStore(PORT);
+    store.set("tmp:A::claude", "sess-A-claude", deriveWorkflowIdentity(identity));
+    store.setStable(claudeKey, "sess-A-claude", "tmp:A");
+    const retains = store.get("tmp:A::claude") !== undefined; // true — A retains Claude
+    expect(
+      siblingOwnsStableKey({
+        siblingIdentity: identity, // A's identity (its CURRENT backend is Codex — irrelevant)
+        candidateKey: claudeKey,
+        candidateBackend: "claude",
+        siblingRetainsSession: retains,
+      }),
+    ).toBe(true);
+  });
+
+  it("once A's Claude session is genuinely CLEARED, it no longer owns the key (B CAN resume)", () => {
+    const store = new SessionStore(PORT);
+    store.set("tmp:A::claude", "sess-A-claude", deriveWorkflowIdentity(identity));
+    store.clear("tmp:A::claude"); // genuine clear (new_session / real teardown)
+    const retains = store.get("tmp:A::claude") !== undefined; // false
+    expect(
+      siblingOwnsStableKey({
+        siblingIdentity: identity,
+        candidateKey: claudeKey,
+        candidateBackend: "claude",
+        siblingRetainsSession: retains,
+      }),
+    ).toBe(false);
+  });
+
+  it("a sibling with a DIFFERENT workflow identity never owns the key", () => {
+    expect(
+      siblingOwnsStableKey({
+        siblingIdentity: { origin: ORIGIN, uuid: UUID_B },
+        candidateKey: claudeKey,
+        candidateBackend: "claude",
+        siblingRetainsSession: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("no identity / no retained session ⇒ not owned (fail open to a fresh resume)", () => {
+    expect(
+      siblingOwnsStableKey({ siblingIdentity: undefined, candidateKey: claudeKey, candidateBackend: "claude", siblingRetainsSession: true }),
+    ).toBe(false);
+    expect(
+      siblingOwnsStableKey({ siblingIdentity: identity, candidateKey: claudeKey, candidateBackend: "claude", siblingRetainsSession: false }),
+    ).toBe(false);
+  });
+});
 
 // #570 — a panel-scoped hello.resume may arm from the SHARED stable key only when no OTHER live
 // tab holds it, so a concurrent sibling can't attach to the first tab's live conversation.

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -11,11 +11,32 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   SessionStore,
+  armableResume,
   deriveStableKey,
   deriveWorkflowIdentity,
   keepsBackendState,
   workflowIdentityParts,
 } from "../../orchestrator/session-store.js";
+
+// #570 — a panel-scoped hello.resume may arm from the SHARED stable key only when no OTHER live
+// tab holds it, so a concurrent sibling can't attach to the first tab's live conversation.
+describe("armableResume (#570 concurrent-tab guard)", () => {
+  it("arms an EXACT tab-id match unconditionally (unique to this tab)", () => {
+    expect(armableResume({ exactOwned: true, stableOwned: false, otherTabHoldsStableKey: false })).toBe(true);
+    // Exact ownership wins even if a sibling holds the stable key.
+    expect(armableResume({ exactOwned: true, stableOwned: true, otherTabHoldsStableKey: true })).toBe(true);
+  });
+
+  it("arms a STABLE-key match ONLY when no other live tab holds it", () => {
+    expect(armableResume({ exactOwned: false, stableOwned: true, otherTabHoldsStableKey: false })).toBe(true);
+    // The codex leak: a second live tab of the same identity sends the shared session id → DROP.
+    expect(armableResume({ exactOwned: false, stableOwned: true, otherTabHoldsStableKey: true })).toBe(false);
+  });
+
+  it("does NOT arm an unowned hint", () => {
+    expect(armableResume({ exactOwned: false, stableOwned: false, otherTabHoldsStableKey: false })).toBe(false);
+  });
+});
 
 // A port unlikely to collide with a real run or another test.
 const PORT = 59187;

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -306,6 +306,22 @@ describe("SessionStore", () => {
       expect(new SessionStore(PORT).get("wf:foo.json::claude")).toBeUndefined();
     });
 
+    it("CROSS-ORIGIN: the exact identity binding includes the origin (same uuid, different origin ≠ owned)", () => {
+      // The exact record binds the FULL canonical identity (origin::uuid), not just the
+      // uuid — so a copied/replayed uuid arriving from a DIFFERENT ComfyUI origin on the
+      // same bridge port under the same wf:<path> key does NOT prove ownership → reset.
+      const store = new SessionStore(PORT);
+      const boundA = `http://127.0.0.1:8188::${UUID_A}`;
+      store.set("wf:foo.json::claude", "sess-A", boundA);
+      expect(store.identityOf("wf:foo.json::claude")).toBe(boundA);
+      // Same uuid, DIFFERENT origin → the handler's `provenOwn` (boundIdentity ===
+      // helloIdentity) is false → the stale session is reset, not resumed.
+      const helloFromOtherOrigin = `http://127.0.0.1:8199::${UUID_A}`;
+      expect(store.identityOf("wf:foo.json::claude") === helloFromOtherOrigin).toBe(false);
+      // Same origin + same uuid → owned.
+      expect(store.identityOf("wf:foo.json::claude") === boundA).toBe(true);
+    });
+
     it("PRE-UPGRADE: an exact record with no identity binding reads back unbound (drives fail-closed reset)", () => {
       // A record written before the `u` field existed (a v2 {s,t} entry, or a migrated
       // legacy flat record) has a session but NO identity. identityOf() is undefined, so

--- a/src/__tests__/orchestrator/session-store.test.ts
+++ b/src/__tests__/orchestrator/session-store.test.ts
@@ -285,6 +285,27 @@ describe("SessionStore", () => {
       expect(bOwnsResume).toBe(false); // B's hello.resume=S is dropped, never cross-resumes A
     });
 
+    it("IN-PLACE REPLACE: the exact session is bound to a durable identity uuid (#570 P0)", () => {
+      // A SAVED workflow keeps its wf:<path> tab id when its file is overwritten with a
+      // DIFFERENT workflow. The exact record carries the trusted uuid it belongs to, so the
+      // hello handler can detect the change (boundUuid !== hello uuid) and clear the stale
+      // session — durable, so it survives an orchestrator restart.
+      const first = new SessionStore(PORT);
+      first.set("wf:foo.json::claude", "sess-A", UUID_A);
+      expect(first.get("wf:foo.json::claude")).toBe("sess-A");
+      expect(first.identityOf("wf:foo.json::claude")).toBe(UUID_A);
+
+      // Fresh process (restart): the binding is durable.
+      const restarted = new SessionStore(PORT);
+      expect(restarted.identityOf("wf:foo.json::claude")).toBe(UUID_A);
+      // The overwritten workflow B has a DIFFERENT uuid → the handler detects the mismatch
+      // (modeled here) and clears the stale session so B can't inherit A's chat.
+      expect(restarted.identityOf("wf:foo.json::claude") !== UUID_B).toBe(true);
+      restarted.clear("wf:foo.json::claude");
+      expect(restarted.get("wf:foo.json::claude")).toBeUndefined();
+      expect(new SessionStore(PORT).get("wf:foo.json::claude")).toBeUndefined();
+    });
+
     it("WORKFLOW IDENTITY: distinguishes a same-workflow migration from a workflow switch (#570 P0a)", () => {
       // deriveWorkflowIdentity is the backend-independent discriminator the hello
       // handler uses to decide whether a same-socket re-hello under a new tab id is a

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1193,6 +1193,47 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await onPhone; // resolves, or the test times out (fan-out broke)
   });
 
+  it("DETACHES a mirror viewer on an UNPROVEN same-socket workflow switch (#570 P0)", async () => {
+    // A phone mirrors workflow A (old-id). The desktop switches to a DIFFERENT workflow on
+    // the SAME socket (new-id) — the hello handler optimistically moves the phone's
+    // subscription onto new-id BEFORE continuity is known. When the orchestrator classifies
+    // the switch as UNPROVEN it resets the tab via dropQueuedDeliveries (with the retired id
+    // AND the surviving id) — the phone must then receive NONE of workflow B's frames and its
+    // input must NOT target B: it silently followed A→B without ever attaching to B.
+    const desktop = await connectPanel("old-id", "G");
+    const phone = await connectHeadless("phone-7");
+    await settle();
+    const seen: Array<{ type?: string; tab_id?: string; text?: string }> = [];
+    bridge.onPanelMessage = (e) => seen.push(e as { type?: string; tab_id?: string; text?: string });
+    phone.send(JSON.stringify({ type: "attach_tab", cid: "a", target_tab_id: "old-id" }));
+    await nextFrame(phone, (m) => m.type === "tab_attached");
+
+    // Same-socket switch to a DIFFERENT workflow (subscription moves to new-id at hello).
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "new-id", title: "B" }));
+    await settle();
+
+    // Orchestrator's unproven-transition reset: retired id then surviving id.
+    bridge.dropQueuedDeliveries("old-id");
+    bridge.dropQueuedDeliveries("new-id");
+
+    // Workflow B's activity must NOT reach the phone anymore.
+    let leaked = false;
+    phone.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.type === "say" && m.text === "workflow-B-secret") leaked = true;
+    });
+    bridge.push({ type: "say", text: "workflow-B-secret" }, "new-id");
+    bridge.push({ type: "say", text: "workflow-B-secret" }, "old-id"); // via migration alias too
+    await settle();
+    expect(leaked).toBe(false);
+
+    // The phone's input reverts to its OWN tab — it no longer drives workflow B.
+    phone.send(JSON.stringify({ type: "user_message", text: "still mine", context: {} }));
+    await settle();
+    const drove = seen.find((e) => e.type === "user_message" && e.text === "still mine");
+    expect(drove?.tab_id).toBe("phone-7");
+  });
+
   it("refuses a headless hello takeover of a desktop tab id (no drive-path hijack)", async () => {
     const desktop = await connectPanel("desktop-h", "G");
     autoReply(desktop, "desktop");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -573,6 +573,30 @@ describe("UiBridge (multi-tab)", () => {
     a2.close();
   });
 
+  it("dropQueuedDeliveries CANCELS a parked read so it is NOT re-dispatched onto a replacement (#570 P0)", async () => {
+    const a1 = await connectPanel("wf:foo.json");
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    // Workflow A has an idempotent read in flight (no autoReply → un-acked).
+    const promise = bridge.send({ cmd: "graph_get_errors" }, { tabId: "wf:foo.json", timeoutMs: 5000 });
+    await new Promise((r) => setTimeout(r, 50));
+    a1.close(); // socket drops mid-command → parked in awaitingReconnect
+    await new Promise((r) => setTimeout(r, 20));
+    // The workflow at that path is overwritten in place → the orchestrator's identity reset
+    // cancels the tab's queued work, incl. the parked read (so it can't run against B).
+    bridge.dropQueuedDeliveries("wf:foo.json");
+    // The parked read is REJECTED (cancelled), not left to resume.
+    await expect(promise).rejects.toThrow(/replaced by a different workflow|cancelled/);
+    // The replacement B reconnects under the SAME tab id and answers nothing for A: the
+    // resume must NOT re-dispatch A's old read onto B.
+    const b = await connectPanel();
+    const seen: Array<Record<string, unknown>> = [];
+    b.on("message", (buf) => seen.push(JSON.parse(buf.toString())));
+    b.send(JSON.stringify({ type: "hello", tab_id: "wf:foo.json", title: "workflow-b" }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(seen.find((m) => m.cmd === "graph_get_errors")).toBeUndefined();
+    b.close();
+  });
+
   it("resumes a read addressed by tab-id PREFIX after reconnect (canonical key) (#450)", async () => {
     const a1 = await connectPanel("tab-aaaa-1111");
     await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -14,7 +14,48 @@ import {
   BRIDGE_DEFAULT_TIMEOUT_MS,
   BRIDGE_READ_DEFAULT_TIMEOUT_MS,
   BRIDGE_READONLY_CMDS,
+  isMutatingGraphCommand,
+  requiresWorkflowStampEnforcement,
 } from "../../services/ui-bridge.js";
+
+// #570 P0c — classifier that decides which commands must pass the enforcement+stamp gate.
+describe("requiresWorkflowStampEnforcement (#570 P0c)", () => {
+  it("gates every graph_* mutator, never a read", () => {
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_add_node" })).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_set_widget" })).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_clear" })).toBe(true);
+    expect(isMutatingGraphCommand("graph_get_state")).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_get_state" })).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd: "graph_query" })).toBe(false);
+  });
+
+  it("gates workflow_save / workflow_save_as UNCONDITIONALLY (executors ignore path)", () => {
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save" })).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save", path: "workflows/x.json" })).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save_as" })).toBe(true);
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save_as", path: "x" })).toBe(true);
+  });
+
+  it("gates workflow_rename / workflow_close when the path is ABSENT, EMPTY, or WHITESPACE (all ⇒ active)", () => {
+    for (const cmd of ["workflow_rename", "workflow_close"]) {
+      expect(requiresWorkflowStampEnforcement({ cmd })).toBe(true); // absent
+      expect(requiresWorkflowStampEnforcement({ cmd, path: "" })).toBe(true); // empty ⇒ active (the bypass)
+      expect(requiresWorkflowStampEnforcement({ cmd, path: "   " })).toBe(true); // whitespace ⇒ active
+      expect(requiresWorkflowStampEnforcement({ cmd, path: 0 as never })).toBe(true); // non-string ⇒ active
+    }
+  });
+
+  it("does NOT gate workflow_rename / workflow_close with an EXPLICIT non-empty path (deterministic target)", () => {
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_close", path: "workflows/other.json" })).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_rename", path: "workflows/a.json" })).toBe(false);
+  });
+
+  it("does NOT gate navigation/creation or unrelated commands", () => {
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_open", path: "x" })).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_new" })).toBe(false);
+    expect(requiresWorkflowStampEnforcement({ cmd: "show_media" })).toBe(false);
+  });
+});
 
 let bridge: UiBridge;
 let port: number;
@@ -1360,6 +1401,20 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await expect(
       bridge.send({ cmd: "workflow_close", force: true } as never, { tabId: "tmp:old" }),
     ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
+
+    // EMPTY / whitespace path is treated by the panel executor as the ACTIVE workflow, so it must
+    // ALSO be refused — a `path !== undefined` check would have waved these past the gate (the
+    // empty-path bypass). Covers close/rename (path:"") and save/save_as (ignore path entirely).
+    for (const cmd of [
+      { cmd: "workflow_close", path: "", force: true },
+      { cmd: "workflow_rename", path: "  ", name: "x" },
+      { cmd: "workflow_save" },
+      { cmd: "workflow_save_as", name: "y" },
+    ]) {
+      await expect(bridge.send(cmd as never, { tabId: "tmp:old" })).rejects.toThrow(
+        /enforces per-command workflow targeting|update the ComfyUI-MCP panel/i,
+      );
+    }
 
     // …but an EXPLICIT-path workflow op names a deterministic target (not a switch-race
     // victim) and stays allowed even on an old panel.

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -255,6 +255,27 @@ describe("UiBridge (mailbox — offline render delivery)", () => {
     phone.close();
   });
 
+  it("dropQueuedDeliveries discards buffered frames so a replaced workflow gets nothing (#570 P0)", async () => {
+    // A prior workflow buffered a finished render for an offline tab.
+    const res = await bridge.send(
+      { cmd: "show_media", items: [{ filename: "A-private.png" }] },
+      { tabId: "wf:foo.json" },
+    );
+    expect(res).toMatchObject({ ok: true, mailboxed: true });
+    // The workflow at that path was overwritten in place → the orchestrator's identity
+    // reset drops the buffered deliveries (they belong to the PRIOR workflow).
+    bridge.dropQueuedDeliveries("wf:foo.json");
+    // The replacement reconnects under the SAME tab id → it must receive NOTHING buffered.
+    const got: Array<Record<string, unknown>> = [];
+    const tab = await connectPanel();
+    tab.on("message", (buf) => got.push(JSON.parse(buf.toString())));
+    tab.send(JSON.stringify({ type: "hello", tab_id: "wf:foo.json", title: "workflow-b" }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:foo.json")).toBe(true));
+    expect(got.find((m) => m.cmd === "show_media")).toBeUndefined();
+    expect(got.find((m) => m.type === "mailbox_flush")).toBeUndefined();
+    tab.close();
+  });
+
   it("does not mailbox interactive commands (only show_media)", async () => {
     await expect(
       bridge.send({ cmd: "graph_get_state" }, { tabId: "nobody" }),

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1234,6 +1234,60 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(drove?.tab_id).toBe("phone-7");
   });
 
+  it("STAMPS a dispatched command with the ORIGIN workflow uuid so the panel can fence a post-switch apply (#570 P0)", async () => {
+    // The orchestrator maps each tab to its trusted per-instance workflow uuid.
+    const uuidByTab: Record<string, string> = { "tmp:A": "uuid-A", "tmp:B": "uuid-B" };
+    bridge.setTabWorkflowUuidResolver((tabId) => uuidByTab[tabId]);
+
+    const desktop = await connectPanel("tmp:A", "A");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        // Reply so send() resolves.
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:A")).toBe(true));
+
+    // A command issued for workflow A carries A's uuid.
+    await bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:A" });
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
+    expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
+
+    // Same socket switches to workflow B (migration alias tmp:A → tmp:B).
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B" }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:B")).toBe(true));
+
+    // A late command still ISSUED FOR A (its agent's tab id) must stamp A's uuid — even though
+    // it now resolves onto B's socket — so the panel (showing B) declines to apply it. Stamping
+    // B's uuid would let it cross-apply. The resolver reads the ORIGIN tab, so it stays uuid-A.
+    frames.length = 0;
+    await bridge.send({ cmd: "graph_add_node", node: "y" } as never, { tabId: "tmp:A" });
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
+    expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
+    desktop.close();
+  });
+
+  it("does NOT stamp a workflow uuid when the tab has no established identity (fail-open for old panels) (#570)", async () => {
+    bridge.setTabWorkflowUuidResolver(() => undefined);
+    const desktop = await connectPanel("tmp:none", "N");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:none")).toBe(true));
+    await bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:none" });
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
+    expect("workflow_uuid" in (frames.find((f) => f.cmd === "graph_add_node") as object)).toBe(false);
+    desktop.close();
+  });
+
   it("refuses a headless hello takeover of a desktop tab id (no drive-path hijack)", async () => {
     const desktop = await connectPanel("desktop-h", "G");
     autoReply(desktop, "desktop");

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -597,6 +597,19 @@ describe("UiBridge (multi-tab)", () => {
     b.close();
   });
 
+  it("dropQueuedDeliveries REJECTS an in-flight command so its late reply can't resolve the prior call (#570 P0)", async () => {
+    const a = await connectPanel("wf:foo.json");
+    await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+    // A command is in flight on the live socket (no autoReply → pending, un-acked).
+    const promise = bridge.send({ cmd: "graph_get_state" }, { tabId: "wf:foo.json", timeoutMs: 5000 });
+    await new Promise((r) => setTimeout(r, 50));
+    // The workflow is replaced in place → the identity reset cancels in-flight work so a late
+    // reply can't resolve the PRIOR workflow's tool call.
+    bridge.dropQueuedDeliveries("wf:foo.json");
+    await expect(promise).rejects.toThrow(/replaced by a different workflow|cancelled/);
+    a.close();
+  });
+
   it("resumes a read addressed by tab-id PREFIX after reconnect (canonical key) (#450)", async () => {
     const a1 = await connectPanel("tab-aaaa-1111");
     await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -270,6 +270,33 @@ describe("UiBridge (mailbox — offline render delivery)", () => {
   });
 });
 
+describe("UiBridge — revokeTabMigration fences a switched-away workflow's route (#570 P0a)", () => {
+  it("stops a stale panel_* call to the old id from resolving onto the new workflow", async () => {
+    // One socket hellos as workflow A, then re-hellos as a DIFFERENT workflow B (a
+    // same-socket switch) — the bridge installs the A→B migration alias.
+    const sock = await connectPanel("wf:A", "workflow-a");
+    autoReply(sock, "the-live-canvas");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:A")).toBe(true));
+    sock.send(JSON.stringify({ type: "hello", tab_id: "wf:B", title: "workflow-b" }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:B")).toBe(true));
+
+    // BEFORE the fence: a stale call addressed to the OLD id resolves THROUGH the alias
+    // to the live socket (now showing B) — the exact wrong-canvas mutation path.
+    const leaked = await bridge.send({ cmd: "graph_get_state" }, { tabId: "wf:A" });
+    expect(leaked).toMatchObject({ from: "the-live-canvas" });
+
+    // Fence it (what the orchestrator does on an unproven same-socket switch).
+    bridge.revokeTabMigration("wf:A");
+
+    // AFTER: the same stale call no longer routes to B — it fails to resolve instead of
+    // mutating the newly-selected canvas. B's own id still routes fine.
+    await expect(bridge.send({ cmd: "graph_get_state" }, { tabId: "wf:A" })).rejects.toThrow();
+    const direct = await bridge.send({ cmd: "graph_get_state" }, { tabId: "wf:B" });
+    expect(direct).toMatchObject({ from: "the-live-canvas" });
+    sock.close();
+  });
+});
+
 describe("UiBridge (typed dispatch outcome — panel #442 defect 4)", () => {
   // Reply to any command with an executor FAILURE (ok:false). Mirrors a panel-side
   // graph executor rejecting — the bridge turns it into a plain Error with NO typed

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -93,6 +93,10 @@ beforeEach(async () => {
   // a parallel test file on loaded CI, leaving whenReady() false (the #486/#619
   // Windows bind flake). startBridgeOnFreePort awaits `listening` internally.
   ({ bridge, port } = await startBridgeOnFreePort());
+  // #570 P0c — by default a tab has a trusted workflow identity (current panels always send a
+  // valid workflow_uuid), so mutating graph/workflow commands carry a stamp and pass the gate.
+  // Tests that exercise the NO-stamp / cross-workflow-switch cases override this resolver.
+  bridge.setTabWorkflowUuidResolver(() => "11111111-1111-4111-8111-111111111111");
 });
 
 afterEach(async () => {
@@ -1277,9 +1281,12 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.close();
   });
 
-  it("does NOT stamp a workflow uuid when the tab has no established identity (fail-open for old panels) (#570)", async () => {
+  it("REFUSES a mutation when the tab has no trusted workflow identity, even if the panel advertises enforcement (#570 P0c)", async () => {
+    // A panel that CLAIMS enforcement but has no resolvable workflow uuid: the frame would ship
+    // UNSTAMPED, so the panel's fence has nothing to compare and a stale mutation after a switch
+    // would run unfenced. No stamp ⇒ nothing to fence ⇒ refuse the mutation (codex). Reads pass.
     bridge.setTabWorkflowUuidResolver(() => undefined);
-    const desktop = await connectPanel("tmp:none", "N");
+    const desktop = await connectPanel("tmp:none", "N"); // connectPanel advertises enforcement
     const frames: Array<Record<string, unknown>> = [];
     desktop.on("message", (buf) => {
       const m = JSON.parse(buf.toString());
@@ -1289,9 +1296,34 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       }
     });
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:none")).toBe(true));
-    await bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:none" });
-    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
-    expect("workflow_uuid" in (frames.find((f) => f.cmd === "graph_add_node") as object)).toBe(false);
+    await expect(
+      bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:none" }),
+    ).rejects.toThrow(/no trusted identity|cannot be safely targeted/i);
+    // A READ still dispatches (unstamped is fine — reads have no side effect).
+    await bridge.send({ cmd: "graph_get_state" } as never, { tabId: "tmp:none" });
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_get_state")).toBeTruthy());
+    desktop.close();
+  });
+
+  it("REFUSES a mutation on a same-socket switch when the tab has no trusted uuid (no unstamped write to the replacement) (#570 P0c)", async () => {
+    // Codex regression: an enforcement-advertising panel with NO valid workflow uuid, then a
+    // same-socket workflow switch — a mutating command must NOT be dispatched (it would arrive at
+    // the replacement canvas UNSTAMPED, unfenceable).
+    bridge.setTabWorkflowUuidResolver(() => undefined);
+    const desktop = await connectPanel("tmp:sA", "A");
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:sA")).toBe(true));
+    // Same-socket switch to a different workflow.
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:sB", title: "B", enforces_workflow_stamp: true }));
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:sB")).toBe(true));
+    // A late command issued for A resolves onto B's socket — with no trusted uuid it is refused,
+    // never written unstamped to B.
+    await expect(
+      bridge.send({ cmd: "graph_add_node", node: "y" } as never, { tabId: "tmp:sA" }),
+    ).rejects.toThrow(/no trusted identity|cannot be safely targeted/i);
     desktop.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1424,13 +1424,21 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     old.close();
   });
 
-  it("ALLOWS a mutating graph command for a panel that DOES enforce the stamp (#570 P0c)", async () => {
-    const modern = await connectPanel("tmp:modern", "M"); // connectPanel advertises enforcement
+  it("ALLOWS active-workflow mutations (graph AND workflow_*) for a panel that DOES enforce the stamp (#570 P0c)", async () => {
+    const modern = await connectPanel("tmp:modern", "M"); // connectPanel advertises enforcement + has a resolver stamp
     autoReply(modern, "modern");
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:modern")).toBe(true));
-    await expect(
-      bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:modern" }),
-    ).resolves.toMatchObject({ from: "modern" });
+    // A graph mutator AND each workflow mutator all dispatch (enforcement + trusted stamp present).
+    for (const cmd of [
+      { cmd: "graph_add_node", node: "x" },
+      { cmd: "workflow_save" },
+      { cmd: "workflow_save_as", name: "y" },
+      { cmd: "workflow_close", force: true }, // path-less ⇒ active ⇒ gated, but enforcing panel passes
+    ]) {
+      await expect(bridge.send(cmd as never, { tabId: "tmp:modern" })).resolves.toMatchObject({
+        from: "modern",
+      });
+    }
     modern.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -29,25 +29,18 @@ describe("requiresWorkflowStampEnforcement (#570 P0c)", () => {
     expect(requiresWorkflowStampEnforcement({ cmd: "graph_query" })).toBe(false);
   });
 
-  it("gates workflow_save / workflow_save_as UNCONDITIONALLY (executors ignore path)", () => {
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save" })).toBe(true);
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save", path: "workflows/x.json" })).toBe(true);
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save_as" })).toBe(true);
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_save_as", path: "x" })).toBe(true);
-  });
-
-  it("gates workflow_rename / workflow_close when the path is ABSENT, EMPTY, or WHITESPACE (all ⇒ active)", () => {
-    for (const cmd of ["workflow_rename", "workflow_close"]) {
+  it("gates ALL FOUR workflow mutators UNCONDITIONALLY (the server can't resolve a path selector)", () => {
+    // save/save_as ignore path; rename/close resolve a path against OPEN workflows, which the
+    // server can't evaluate — and an in-place replacement can make a once-non-active path resolve
+    // to the active workflow. So raw path can never prove non-active-ness: gate all four always.
+    for (const cmd of ["workflow_save", "workflow_save_as", "workflow_rename", "workflow_close"]) {
       expect(requiresWorkflowStampEnforcement({ cmd })).toBe(true); // absent
-      expect(requiresWorkflowStampEnforcement({ cmd, path: "" })).toBe(true); // empty ⇒ active (the bypass)
-      expect(requiresWorkflowStampEnforcement({ cmd, path: "   " })).toBe(true); // whitespace ⇒ active
-      expect(requiresWorkflowStampEnforcement({ cmd, path: 0 as never })).toBe(true); // non-string ⇒ active
+      expect(requiresWorkflowStampEnforcement({ cmd, path: "" } as never)).toBe(true); // empty
+      expect(requiresWorkflowStampEnforcement({ cmd, path: "   " } as never)).toBe(true); // whitespace
+      // Even a non-empty explicit path is gated on the server — the ENFORCING panel resolves the
+      // target precisely and exempts a genuinely non-active one client-side.
+      expect(requiresWorkflowStampEnforcement({ cmd, path: "workflows/other.json" } as never)).toBe(true);
     }
-  });
-
-  it("does NOT gate workflow_rename / workflow_close with an EXPLICIT non-empty path (deterministic target)", () => {
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_close", path: "workflows/other.json" })).toBe(false);
-    expect(requiresWorkflowStampEnforcement({ cmd: "workflow_rename", path: "workflows/a.json" })).toBe(false);
   });
 
   it("does NOT gate navigation/creation or unrelated commands", () => {
@@ -1427,25 +1420,21 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       bridge.send({ cmd: "workflow_close", force: true } as never, { tabId: "tmp:old" }),
     ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
 
-    // EMPTY / whitespace path is treated by the panel executor as the ACTIVE workflow, so it must
-    // ALSO be refused — a `path !== undefined` check would have waved these past the gate (the
-    // empty-path bypass). Covers close/rename (path:"") and save/save_as (ignore path entirely).
+    // ALL FOUR workflow mutators are refused on a non-enforcing panel — regardless of path,
+    // including an EXPLICIT non-empty path. The server can't resolve the selector or prove it
+    // stays non-active (an in-place replacement can make a once-non-active path resolve to the
+    // active workflow), so it fails closed; an ENFORCING panel resolves the target client-side.
     for (const cmd of [
       { cmd: "workflow_close", path: "", force: true },
       { cmd: "workflow_rename", path: "  ", name: "x" },
       { cmd: "workflow_save" },
       { cmd: "workflow_save_as", name: "y" },
+      { cmd: "workflow_close", path: "workflows/other.json", force: true }, // explicit path — still gated
     ]) {
       await expect(bridge.send(cmd as never, { tabId: "tmp:old" })).rejects.toThrow(
         /enforces per-command workflow targeting|update the ComfyUI-MCP panel/i,
       );
     }
-
-    // …but an EXPLICIT-path workflow op names a deterministic target (not a switch-race
-    // victim) and stays allowed even on an old panel.
-    await expect(
-      bridge.send({ cmd: "workflow_close", path: "workflows/other.json" } as never, { tabId: "tmp:old" }),
-    ).resolves.toBeTruthy();
     old.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -64,7 +64,11 @@ function connectPanel(tabId?: string, title = "workflow-a"): Promise<WebSocket> 
     const sock = new WebSocket(`ws://127.0.0.1:${port}`);
     sock.on("open", () => {
       if (tabId) {
-        sock.send(JSON.stringify({ type: "hello", tab_id: tabId, title }));
+        // Current panels advertise stamp enforcement, so a mutating graph command is not gated
+        // (#570 P0c). Tests exercising the OLD-panel gate hello WITHOUT this flag explicitly.
+        sock.send(
+          JSON.stringify({ type: "hello", tab_id: tabId, title, enforces_workflow_stamp: true }),
+        );
       }
       resolve(sock);
     });
@@ -1212,9 +1216,12 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.send(JSON.stringify({ type: "hello", tab_id: "new-id", title: "B" }));
     await settle();
 
-    // Orchestrator's unproven-transition reset: retired id then surviving id.
-    bridge.dropQueuedDeliveries("old-id");
-    bridge.dropQueuedDeliveries("new-id");
+    // The orchestrator classified the switch as UNPROVEN and revokes the migration. This is
+    // the retire branch's SOLE call for the OLD id — it does NOT also sweep new-id (when B
+    // owns its own session, provenOwn is true and the destination sweep is skipped). The
+    // mirror detach must therefore ride revokeTabMigration itself (#570 P0a), NOT a manual
+    // destination sweep.
+    bridge.revokeTabMigration("old-id");
 
     // Workflow B's activity must NOT reach the phone anymore.
     let leaked = false;
@@ -1257,7 +1264,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
 
     // Same socket switches to workflow B (migration alias tmp:A → tmp:B).
-    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B" }));
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B", enforces_workflow_stamp: true }));
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:B")).toBe(true));
 
     // A late command still ISSUED FOR A (its agent's tab id) must stamp A's uuid — even though
@@ -1286,6 +1293,46 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
     expect("workflow_uuid" in (frames.find((f) => f.cmd === "graph_add_node") as object)).toBe(false);
     desktop.close();
+  });
+
+  it("FAILS CLOSED: a MUTATING graph command is refused for an OLD panel that doesn't enforce the stamp; reads still work (#570 P0c)", async () => {
+    // An OLD panel hellos WITHOUT enforces_workflow_stamp — it would silently ignore the
+    // per-command workflow stamp and could apply a stale write to the wrong canvas.
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(JSON.stringify({ type: "hello", tab_id: "tmp:old", title: "old" })); // no flag
+        res();
+      });
+      old.on("error", rej);
+    });
+    // Auto-reply so a NON-gated command could resolve (proving the gate, not a hang).
+    old.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) old.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:old")).toBe(true));
+
+    // A mutating graph command is refused BEFORE dispatch (never written to the socket).
+    await expect(
+      bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:old" }),
+    ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
+
+    // …but a READ-ONLY graph command still works (read-only graph access retained).
+    await expect(
+      bridge.send({ cmd: "graph_get_state" } as never, { tabId: "tmp:old" }),
+    ).resolves.toBeTruthy();
+    old.close();
+  });
+
+  it("ALLOWS a mutating graph command for a panel that DOES enforce the stamp (#570 P0c)", async () => {
+    const modern = await connectPanel("tmp:modern", "M"); // connectPanel advertises enforcement
+    autoReply(modern, "modern");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:modern")).toBe(true));
+    await expect(
+      bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:modern" }),
+    ).resolves.toMatchObject({ from: "modern" });
+    modern.close();
   });
 
   it("refuses a headless hello takeover of a desktop tab id (no drive-path hijack)", async () => {
@@ -1823,7 +1870,17 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
   // the SPECIFIC cmd that was empirically proven unsupported is gated).
   it("does NOT gate a different, never-tried command after another command was proven unsupported", async () => {
     const sock = await connectPanel(undefined);
-    sock.send(JSON.stringify({ type: "hello", tab_id: "old-tab-3", title: "wf", panel_version: "0.6.8" }));
+    // Old VERSION (for the #236 too-old graph_query check) but a stamp-enforcing build, so the
+    // orthogonal P0c mutating-graph gate doesn't mask what this test asserts.
+    sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "old-tab-3",
+        title: "wf",
+        panel_version: "0.6.8",
+        enforces_workflow_stamp: true,
+      }),
+    );
     sock.on("message", (buf) => {
       const msg = JSON.parse(buf.toString());
       if (!msg.rid || !msg.cmd) return;

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1322,6 +1322,31 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.close();
   });
 
+  it("workflow_uuid is BRIDGE-OWNED: a caller-supplied stamp is OVERRIDDEN by the trusted resolver value (#570 P0c)", async () => {
+    // A caller must not be able to forge the stamp to the destination workflow to sail past the
+    // panel fence after a switch. dispatch always overwrites workflow_uuid with the resolver value.
+    bridge.setTabWorkflowUuidResolver((tabId) => (tabId === "tmp:A" ? "uuid-A" : undefined));
+    const desktop = await connectPanel("tmp:A", "A");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:A")).toBe(true));
+    // Caller tries to smuggle a conflicting workflow_uuid (the would-be destination) in the cmd.
+    await bridge.send(
+      { cmd: "graph_add_node", node: "x", workflow_uuid: "uuid-FORGED-DESTINATION" } as never,
+      { tabId: "tmp:A" },
+    );
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
+    // The emitted frame carries the TRUSTED origin uuid, not the caller's forged value.
+    expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
+    desktop.close();
+  });
+
   it("REFUSES a mutation when the tab has no trusted workflow identity, even if the panel advertises enforcement (#570 P0c)", async () => {
     // A panel that CLAIMS enforcement but has no resolvable workflow uuid: the frame would ship
     // UNSTAMPED, so the panel's fence has nothing to compare and a stale mutation after a switch

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1322,6 +1322,18 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await expect(
       bridge.send({ cmd: "graph_get_state" } as never, { tabId: "tmp:old" }),
     ).resolves.toBeTruthy();
+
+    // A path-less ACTIVE-workflow mutator (workflow_close discards unsaved work) is ALSO
+    // refused — the class the graph_-only gate previously missed (#570 P0c, codex cycle 8).
+    await expect(
+      bridge.send({ cmd: "workflow_close", force: true } as never, { tabId: "tmp:old" }),
+    ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
+
+    // …but an EXPLICIT-path workflow op names a deterministic target (not a switch-race
+    // victim) and stays allowed even on an old panel.
+    await expect(
+      bridge.send({ cmd: "workflow_close", path: "workflows/other.json" } as never, { tabId: "tmp:old" }),
+    ).resolves.toBeTruthy();
     old.close();
   });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2027,6 +2027,12 @@ export async function runPanelOrchestrator(): Promise<void> {
 
   // Flag the mobile mirror picker's "session attached" (green) dot from live agents.
   bridge.setHasSessionPredicate((tabId) => manager.hasLiveAgent(agentKeyFor(tabId)));
+  // #570 — stamp each dispatched command with the tab's trusted per-instance workflow uuid so
+  // the panel declines to APPLY a command it receives after switching to a different workflow
+  // (the generation-bound-command leak). Resolved from the CALLER's tab id: during the switch
+  // race the retiring tab still maps to its own uuid, so a late command stamps the ORIGIN
+  // workflow's uuid and the panel (now showing the new one) fails it closed.
+  bridge.setTabWorkflowUuidResolver((tabId) => tabStableIdentity.get(panelTabOf(tabId))?.uuid);
 
   // ── Local-agent VRAM pause during generation ────────────────────────────
   // On a single-GPU box the local Ollama chat model and ComfyUI fight for VRAM:

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2529,8 +2529,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // block / post-block overwrite of tabStableIdentity. For an IN-PLACE workflow
       // replacement (same tab id, new uuid) this is the identity the tab's still-LIVE agent
       // and queued work belong to — needed to reset them even before any durable session
-      // record exists (the spawn→first-session window).
-      const priorTabIdentity = tabStableIdentity.get(panelTab);
+      // record exists (the spawn→first-session window). For a PROVEN same-workflow tab-id
+      // migration (tmp:→wf: save/rename) it is REASSIGNED below to the proven source identity:
+      // the migrated tab id is brand new (no prior identity) and the rebound agent may still be
+      // in its spawn→first-session window (no durable record), so without this the ownership
+      // gate would reset the just-rebound agent and drop its queued turn (codex).
+      let priorTabIdentity = tabStableIdentity.get(panelTab);
 
       if (migratedFrom && migratedFrom !== panelTab) {
         const prevBackend = tabBackends.get(migratedFrom) ?? backend;
@@ -2617,6 +2621,13 @@ export async function runPanelOrchestrator(): Promise<void> {
               `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — agent rebound, conversation preserved`,
             );
           }
+          // #570 — carry the PROVEN source identity forward as the tab's prior identity. The
+          // rebound agent belongs to it (prevIdentity === newIdentity by sameWorkflow), but the
+          // new tab id has no prior identity and the agent may have no durable record yet
+          // (spawn→first-session window), so the ownership gate below would otherwise treat it as
+          // unproven and reset the just-rebound agent, cancelling its in-flight turn and dropping
+          // its queued message. prevIdentity is guaranteed defined here (sameWorkflow requires it).
+          priorTabIdentity = prevIdentity;
           // Carry the old tab's runtime prefs to the new id regardless of whether
           // an agent was live (backend pick, headless flag, pinned workflow
           // target, held-during-render queue), then retire the old id.

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2681,32 +2681,40 @@ export async function runPanelOrchestrator(): Promise<void> {
       // hello's, the workflow was replaced — clear the stale exact session (and any stale
       // stable entry) so the new workflow starts fresh. Durable, so it holds across an
       // orchestrator restart too.
-      if (newIdentity) {
+      {
+        // FAIL CLOSED at the identity boundary (#570 P0): an existing EXACT session record
+        // is trusted (kept + resumable) ONLY when PROVEN to belong to THIS workflow — the
+        // record carries a durable identity uuid (Entry.u) AND this hello carries a valid
+        // trusted identity AND they MATCH. Anything else is reset:
+        //   • DIFFERENT bound uuid → a SAVED workflow OVERWRITTEN in place (same wf:<path>
+        //     tab id, new uuid);
+        //   • record with NO binding → a pre-`u` v2 {s,t} or migrated legacy record — can't
+        //     tell whether an in-place replacement already happened;
+        //   • no trusted identity on this hello (old/degraded panel, no server origin) →
+        //     unprovable, and the path-keyed record + an unowned global hello.resume would
+        //     otherwise cross-resume a replaced workflow.
+        // Resetting costs at most a lost resume (one-time on upgrade for a bound record;
+        // per-reload for an identity-less client's SAVED workflow — unsaved tabs churn their
+        // tmp: id so nothing is stored under the reloaded key). A wrong-resume is worse.
+        // onSession re-stamps `u`, so a bound modern client's saved workflow proves out and
+        // is never reset. Runs BEFORE the resume-ownership check and spawn, so neither an
+        // unowned hello.resume nor spawn's exact-store hit can resume a stale session.
         const boundUuid = sessionStore.identityOf(key);
         const hasExact = sessionStore.get(key) !== undefined;
-        // FAIL CLOSED at the identity boundary: reset the tab's session when the exact
-        // record can't be PROVEN to belong to THIS workflow —
-        //   • a DIFFERENT bound uuid → a saved workflow OVERWRITTEN in place; or
-        //   • an existing record with NO binding (a pre-`u` v2 {s,t} entry, or a migrated
-        //     legacy flat record) → untrusted, so we can't tell whether an in-place
-        //     replacement already happened. Resetting it costs at most a one-time
-        //     lost resume for a pre-upgrade SAVED-workflow chat; NOT resetting risks a
-        //     wrong-resume (the durable exact record and an unowned hello.resume both
-        //     point at it), which is strictly worse.
-        // onSession re-stamps `u` for the fresh session, so this fires at most once.
-        if (boundUuid ? boundUuid !== newIdentity.uuid : hasExact) {
+        const provenOwn =
+          hasExact && boundUuid !== undefined && newIdentity !== undefined && boundUuid === newIdentity.uuid;
+        if (hasExact && !provenOwn) {
           // FULL session boundary — reset the LIVE agent too, not just the disk record.
           // manager.reset() stops the mapped agent (whose backend still holds the PRIOR
-          // workflow's session), clears its pendingResume + held mail, AND clears the
-          // durable exact session. Without this, manager.send would reuse that live agent
-          // and answer with — or act on — the replaced workflow's context.
+          // workflow's session), clears its pendingResume + held mail, AND the durable
+          // exact session. Without this, manager.send would reuse that live agent.
           manager.reset(key);
-          if (boundUuid) {
+          if (boundUuid && newIdentity) {
             const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
             if (staleStable) sessionStore.clearStable(staleStable);
           }
           logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} exact session not provably this workflow's (${boundUuid ? "identity uuid changed" : "no durable identity binding"}) — reset the live agent and cleared the stale session`,
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} exact session not provably this workflow's identity — reset the live agent and cleared the stale session`,
           );
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2610,14 +2610,18 @@ export async function runPanelOrchestrator(): Promise<void> {
           // MOVE the pinned workflow target, don't discard it (codex review).
           const pinned = workflowTargets.get(migratedFrom);
           if (pinned.mode === "pinned") workflowTargets.set(panelTab, pinned);
-          // Re-key messages held during a render so the flush reaches the
-          // REBOUND agent instead of respawning one under the retired key.
-          const prevBackendForHeld = tabBackends.get(migratedFrom) ?? backend;
-          const heldOld = heldDuringGen.get(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
-          if (heldOld?.length) {
-            const heldNewKey = panelTab + AGENT_KEY_SEP + prevBackendForHeld;
+          // Re-key messages held during a render so the flush reaches the REBOUND agent
+          // instead of respawning one under the retired key — for EVERY provider, not just
+          // the current one: a message queued while a LOCAL provider was active, then a
+          // provider switch, then this (proven same-workflow) migration, would otherwise
+          // stay under `migratedFrom::<old provider>` and onRunEnd would `manager.send` it
+          // on that retired tab/provider key (a deferred delivery under the wrong key).
+          for (const hk of [...heldDuringGen.keys()]) {
+            if (panelTabOf(hk) !== migratedFrom) continue;
+            const heldOld = heldDuringGen.get(hk)!;
+            const heldNewKey = panelTab + AGENT_KEY_SEP + backendOf(hk);
             heldDuringGen.set(heldNewKey, [...(heldDuringGen.get(heldNewKey) ?? []), ...heldOld]);
-            heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
+            heldDuringGen.delete(hk);
           }
           tabBackends.delete(migratedFrom);
           headlessTabs.delete(migratedFrom);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2713,12 +2713,15 @@ export async function runPanelOrchestrator(): Promise<void> {
         // else the tab's identity from its PRIOR hello (captured before we overwrote it) —
         // which is how the no-durable-record live-agent window is covered.
         //
-        // "Both sides have NO identity" counts as PROVEN (no transition): an identity-less
-        // client (no trusted server origin — never had the uuid boundary) is not torn down
-        // on every hello, which would break its ongoing conversation. Closing the in-place
-        // overwrite for such clients is impossible without that breakage — a client-capability
-        // limitation, disclosed. A MODERN client whose record is unbound (pre-`u`/legacy) still
-        // resets: its hello carries an identity, so identity(state)=undefined ≠ identity(hello).
+        // FAIL CLOSED — state is kept ONLY when POSITIVELY PROVEN: BOTH the state's
+        // identity AND this hello's identity exist AND are equal. An IDENTITY-LESS re-hello
+        // (no trusted server origin / no valid uuid — a relay/old/non-browser client) can NOT
+        // prove continuity, so its state is torn down rather than risk continuing a replaced
+        // workflow's private conversation. A browser panel ALWAYS carries a trusted handshake
+        // origin, so it proves out and is never reset for lack of identity — only genuinely
+        // identity-less (non-browser) or pre-`u`/legacy clients pay the reset. (Disclosed
+        // trade-off: such a client loses conversation continuity across a reload/reconnect —
+        // a lost resume, never a cross-workflow leak.)
         const helloIdentity = newIdentity ? `${newIdentity.origin}::${newIdentity.uuid}` : undefined;
         const stateIdentity =
           sessionStore.identityOf(key) ??
@@ -2729,7 +2732,9 @@ export async function runPanelOrchestrator(): Promise<void> {
         // fires even in the spawn→first-session window or after a prepare failure.
         const hasState =
           manager.hasAnyState(key) || sessionStore.get(key) !== undefined || heldGenKeys.length > 0;
-        if (hasState && stateIdentity !== helloIdentity) {
+        const provenOwn =
+          stateIdentity !== undefined && helloIdentity !== undefined && stateIdentity === helloIdentity;
+        if (hasState && !provenOwn) {
           // FULL session boundary. manager.reset() stops the mapped agent (whose backend
           // still holds the PRIOR workflow's session), clears its pending resume + held
           // mail, AND the durable exact session. Then cancel the render-held queue for

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2011,9 +2011,15 @@ export async function runPanelOrchestrator(): Promise<void> {
       requestSelfExit(`tab ${tabId.slice(0, 8)} ${reason}`);
     },
     sessionStore,
-    // #570 P0 — bind each persisted exact session to its tab's trusted workflow uuid,
-    // so a saved workflow overwritten in place (same tab id, new uuid) is detectable.
-    identityForKey: (k: string) => tabStableIdentity.get(panelTabOf(k))?.uuid,
+    // #570 P0 — bind each persisted exact session to its tab's FULL trusted workflow
+    // identity (server-observed origin + per-instance uuid), so a saved workflow
+    // overwritten in place (same tab id, new uuid) OR a copied uuid replayed from a
+    // DIFFERENT origin on the same bridge port is detectable. Canonical `origin::uuid`
+    // (equality-compared only, so the IPv6-`::` ambiguity is harmless).
+    identityForKey: (k: string) => {
+      const id = tabStableIdentity.get(panelTabOf(k));
+      return id ? `${id.origin}::${id.uuid}` : undefined;
+    },
   });
   // Let refreshEnvCapabilities() feed a freshly-gathered env block into agents
   // spawned after a ComfyUI restart/reconnect.
@@ -2699,20 +2705,22 @@ export async function runPanelOrchestrator(): Promise<void> {
         // onSession re-stamps `u`, so a bound modern client's saved workflow proves out and
         // is never reset. Runs BEFORE the resume-ownership check and spawn, so neither an
         // unowned hello.resume nor spawn's exact-store hit can resume a stale session.
-        const boundUuid = sessionStore.identityOf(key);
+        const boundIdentity = sessionStore.identityOf(key);
+        // The FULL canonical identity (origin+uuid) this hello proves — must equal the
+        // record's bound identity to keep it. Includes origin, so a copied uuid from a
+        // DIFFERENT origin on the same bridge port can't pass (codex).
+        const helloIdentity = newIdentity ? `${newIdentity.origin}::${newIdentity.uuid}` : undefined;
         const hasExact = sessionStore.get(key) !== undefined;
         const provenOwn =
-          hasExact && boundUuid !== undefined && newIdentity !== undefined && boundUuid === newIdentity.uuid;
+          hasExact && boundIdentity !== undefined && helloIdentity !== undefined && boundIdentity === helloIdentity;
         if (hasExact && !provenOwn) {
           // FULL session boundary — reset the LIVE agent too, not just the disk record.
           // manager.reset() stops the mapped agent (whose backend still holds the PRIOR
           // workflow's session), clears its pendingResume + held mail, AND the durable
-          // exact session. Without this, manager.send would reuse that live agent.
+          // exact session. Without this, manager.send would reuse that live agent. (The
+          // overwritten workflow's own stable entry, if any, is keyed by ITS uuid and
+          // stays valid should that workflow ever be restored — nothing to clear here.)
           manager.reset(key);
-          if (boundUuid && newIdentity) {
-            const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
-            if (staleStable) sessionStore.clearStable(staleStable);
-          }
           logger.info(
             `[panel-orchestrator] tab ${panelTab.slice(0, 8)} exact session not provably this workflow's identity — reset the live agent and cleared the stale session`,
           );

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2623,13 +2623,28 @@ export async function runPanelOrchestrator(): Promise<void> {
           // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
           // live-agent move; the rest are durable-only.
           for (const b of KNOWN_BACKENDS) {
-            const reboundLive = manager.rebindAgent(
-              migratedFrom + AGENT_KEY_SEP + b,
-              panelTab + AGENT_KEY_SEP + b,
-            );
+            const srcKey = migratedFrom + AGENT_KEY_SEP + b;
+            const reboundLive = manager.rebindAgent(srcKey, panelTab + AGENT_KEY_SEP + b);
             if (reboundLive) {
               logger.info(
                 `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}) — agent rebound, conversation preserved`,
+              );
+              continue;
+            }
+            // rebindAgent returned false. Two cases: (a) no live source agent — moveDurable ran,
+            // the durable session already followed the tab-id change; nothing more to do. (b)
+            // COLLISION — the destination key ALREADY has a live agent (the same workflow open in
+            // TWO tabs, one migrating onto the other's id), so rebind refused WITHOUT moving or
+            // stopping the source, which is STILL LIVE under the old id. Its callbacks/bridge
+            // frames would route through the proven old→new alias into the destination tab,
+            // leaking one tab's private chat/session into the other (codex). RETIRE the orphaned
+            // source agent so it stops emitting; its durable session stays under the old key (a
+            // lost resume — the destination tab's live conversation wins — never a leak).
+            if (manager.hasLiveAgent(srcKey)) {
+              manager.retire(srcKey);
+              bridge.dropQueuedDeliveries(srcKey); // cancel its in-flight commands / parked reads
+              logger.warn(
+                `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination already had a live agent — retired the colliding source agent (its conversation is orphaned; no cross-tab leak)`,
               );
             }
           }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2626,19 +2626,22 @@ export async function runPanelOrchestrator(): Promise<void> {
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
             const newKey = panelTab + AGENT_KEY_SEP + b;
-            // COLLISION: the destination id ALREADY has a LIVE agent — the same workflow was open
-            // in TWO tabs and the bridge just SUPERSEDED the destination tab's socket with THIS
-            // incoming one (same-kind takeover). The destination agent is now orphaned onto the
-            // incoming socket: its private chat/session frames route by newKey to the socket the
-            // incoming tab holds, rendering INTO the incoming tab (codex). Reset the superseded
-            // destination agent FIRST — its socket is already gone, so its conversation is a lost
-            // resume, never a leak — then rebind the incoming source into the freed id so the
-            // INCOMING tab keeps its OWN conversation (and its held mail follows correctly below).
-            if (manager.hasLiveAgent(newKey)) {
+            // COLLISION: the destination id already has state for this provider — the same
+            // workflow was open in (or previously occupied) TWO tabs, and the incoming socket is
+            // migrating onto the other's id. Reset the superseded destination's state for this
+            // backend BEFORE moving the source in, so the incoming tab can NEVER inherit it. Cover
+            // EVERY kind of destination state, not just a live agent (codex): a LIVE agent
+            // (orphaned onto the incoming socket → renders into it), a DORMANT durable session
+            // (rebindAgent PRESERVES it when the source has none → the incoming tab resumes the
+            // OTHER tab's conversation on a later provider switch), OR failed-start held mail
+            // (rebindAgent APPENDS it to the migrated source mail → delivered into the incoming
+            // tab). Its socket is already superseded, so its conversation is a lost resume — never
+            // a cross-tab leak. Then rebind the incoming source into the freed id.
+            if (manager.hasAnyState(newKey) || sessionStore.get(newKey) !== undefined) {
               destinationCollision = true;
               manager.reset(newKey);
               logger.warn(
-                `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination id already had a live agent (same workflow in two tabs) — reset the superseded destination so the incoming tab keeps its OWN conversation (no cross-tab leak)`,
+                `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination id already had state (same workflow in two tabs) — reset the superseded destination so the incoming tab can't inherit it (no cross-tab leak)`,
               );
             }
             if (manager.rebindAgent(srcKey, newKey)) {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2684,11 +2684,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (newIdentity) {
         const boundUuid = sessionStore.identityOf(key);
         if (boundUuid && boundUuid !== newIdentity.uuid) {
-          sessionStore.clear(key);
+          // FULL session boundary — reset the LIVE agent too, not just the disk record.
+          // manager.reset() stops the mapped agent (whose backend still holds the PRIOR
+          // workflow's session), clears its pendingResume + held mail, AND clears the
+          // durable exact session. Without this, manager.send would reuse that live agent
+          // and answer with — or act on — the replaced workflow's context.
+          manager.reset(key);
           const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
           if (staleStable) sessionStore.clearStable(staleStable);
           logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow replaced in place (identity uuid changed) — cleared the prior workflow's stale session`,
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow replaced in place (identity uuid changed) — reset the live agent and cleared the prior workflow's stale session`,
           );
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -26,6 +26,7 @@ import {
   armableResume,
   deriveStableKey,
   keepsBackendState,
+  siblingOwnsStableKey,
   workflowIdentityParts,
 } from "./session-store.js";
 import { listSessions, loadTranscript } from "./history.js";
@@ -2849,6 +2850,41 @@ export async function runPanelOrchestrator(): Promise<void> {
       // orchestrator-restart belt-and-suspenders case). Same-provider only. This binds
       // resume to identity: a persistent panel-global chat across workflows would be a
       // separate, separately-authorized feature, not this untrusted path.
+      // #570 — does any OTHER connected tab OWN the session behind `candidateKey`? A stable key
+      // encodes (workflow identity, backend); a sibling OWNS it when it has the SAME workflow
+      // identity AND a RETAINED session on that backend. Ownership is a SET, not a single
+      // current-backend mapping: a provider switch RETIRES (preserves) the old provider's session,
+      // so a tab keeps owning EVERY backend key whose session it still holds — its CURRENT provider
+      // is irrelevant. So derive ownership from the authoritative retained-session state
+      // (tabStableIdentity + the durable/live session), per sibling, per backend — the single
+      // tabStableKey (current-backend) mapping would MISS a retained old-backend session and let a
+      // second honest tab resume it (codex). `candidateBackend` is the backend `candidateKey` was
+      // derived for.
+      const connectedSiblingOwnsStableKey = (
+        candidateKey: string,
+        candidateBackend: string,
+      ): boolean => {
+        for (const t of bridge.tabs()) {
+          if (t.tab_id === panelTab) continue;
+          const siblingAgentKey = t.tab_id + AGENT_KEY_SEP + candidateBackend;
+          // A retained session lives in the durable store (survives a provider-switch retire) or
+          // in the manager's live/pending/held state (spawn window, failed-start mail).
+          const siblingRetainsSession =
+            sessionStore.get(siblingAgentKey) !== undefined || manager.hasAnyState(siblingAgentKey);
+          if (
+            siblingOwnsStableKey({
+              siblingIdentity: tabStableIdentity.get(t.tab_id),
+              candidateKey,
+              candidateBackend,
+              siblingRetainsSession,
+            })
+          ) {
+            return true;
+          }
+        }
+        return false;
+      };
+
       const resumeHint = typeof event.resume === "string" ? event.resume : undefined;
       let armedResume: string | undefined;
       if (resumeHint && (!prev || prev === backend)) {
@@ -2857,24 +2893,20 @@ export async function runPanelOrchestrator(): Promise<void> {
           : undefined;
         // The EXACT tab-id session is unique to THIS tab id, so a hello.resume that matches it is
         // always this tab's own — safe to arm. The STABLE-key session is SHARED by every tab of
-        // the same workflow identity (the same workflow open in two live tabs), so a second tab's
-        // panel-scoped hello.resume matching it would attach that tab to — and contend for — the
-        // FIRST tab's live conversation (codex). Permit a stable-key resume ONLY when no OTHER
-        // connected tab already holds that stable key. This mirrors the seed-fallback collision
-        // guard below; without it the armed path bypassed it.
+        // the same workflow identity, so a second tab's panel-scoped hello.resume matching it would
+        // attach that tab to — and contend for — a sibling's conversation (codex). Permit a
+        // stable-key resume ONLY when no OTHER connected tab OWNS that key's session (current OR
+        // retained on any backend). Mirrors the seed-fallback guard below.
         const exactOwned = sessionStore.get(key) === resumeHint;
         const stableOwned =
           trustedStableKey !== undefined && sessionStore.getStable(trustedStableKey) === resumeHint;
         let otherTabHoldsStableKey = false;
         if (stableOwned && !exactOwned && trustedStableKey !== undefined) {
-          for (const t of bridge.tabs()) {
-            if (t.tab_id !== panelTab && tabStableKey.get(t.tab_id) === trustedStableKey) {
-              otherTabHoldsStableKey = true; // a concurrently-live sibling holds it → don't cross-attach
-              logger.info(
-                `[panel-orchestrator] tab ${panelTab.slice(0, 8)} hello.resume ${resumeHint.slice(0, 8)} matches a stable key ANOTHER live tab holds — dropping (a concurrent sibling must start fresh, not join the live conversation)`,
-              );
-              break;
-            }
+          otherTabHoldsStableKey = connectedSiblingOwnsStableKey(trustedStableKey, backend);
+          if (otherTabHoldsStableKey) {
+            logger.info(
+              `[panel-orchestrator] tab ${panelTab.slice(0, 8)} hello.resume ${resumeHint.slice(0, 8)} matches a stable key ANOTHER connected tab owns (current or retained provider) — dropping (a sibling must start fresh, not join/steal the conversation)`,
+            );
           }
         }
         const owned = armableResume({ exactOwned, stableOwned, otherTabHoldsStableKey });
@@ -2915,17 +2947,14 @@ export async function runPanelOrchestrator(): Promise<void> {
           //
           // COLLISION GUARD: with the durable per-instance uuid the key is globally
           // unique, so the ONLY way two tabs share it is the SAME workflow open in two
-          // live browser tabs. Seed only when THIS tab is the sole connected holder of
-          // the key, so a fresh sibling can never resume another CONCURRENTLY-live
-          // tab's conversation (setStable also poisons the key the moment two live tabs
-          // write distinct sessions to it). When ambiguous we surface fresh — a lost
-          // resume is a mild miss; resuming the WRONG conversation is not.
+          // browser tabs. Seed only when NO OTHER connected tab OWNS the key's session —
+          // current OR retained on any backend — so a fresh sibling can never resume
+          // another tab's conversation (a provider switch RETAINS the old-backend session,
+          // so the owned-set check, not a current-backend mapping, is what catches it).
+          // When ambiguous we surface fresh — a lost resume is a mild miss; resuming the
+          // WRONG conversation is not.
           if (!armedResume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
-            let sameKeyTabs = 0;
-            for (const t of bridge.tabs()) {
-              if (tabStableKey.get(t.tab_id) === skey) sameKeyTabs += 1;
-            }
-            if (sameKeyTabs <= 1) {
+            if (!connectedSiblingOwnsStableKey(skey, backend)) {
               const stableSid = sessionStore.getStable(skey);
               if (stableSid) manager.setResume(key, stableSid);
             }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2720,8 +2720,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           sessionStore.identityOf(key) ??
           (priorTabIdentity ? `${priorTabIdentity.origin}::${priorTabIdentity.uuid}` : undefined);
         const heldGenKeys = [...heldDuringGen.keys()].filter((hk) => panelTabOf(hk) === panelTab);
+        // hasAnyState covers the live agent, an armed pending resume, AND failed-start held
+        // mail (a prepare failure parks queued messages with no agent/session) — so a reset
+        // fires even in the spawn→first-session window or after a prepare failure.
         const hasState =
-          manager.hasLiveAgent(key) || sessionStore.get(key) !== undefined || heldGenKeys.length > 0;
+          manager.hasAnyState(key) || sessionStore.get(key) !== undefined || heldGenKeys.length > 0;
         if (hasState && stateIdentity !== helloIdentity) {
           // FULL session boundary. manager.reset() stops the mapped agent (whose backend
           // still holds the PRIOR workflow's session), clears its pending resume + held

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2541,7 +2541,22 @@ export async function runPanelOrchestrator(): Promise<void> {
           // Retire the old id's routing/prefs — do NOT carry them to a different
           // (or unprovable) workflow. The old workflow's durable session stays on disk
           // (retire() preserved it); its stable identity is dropped from the live maps.
-          heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackend);
+          // Messages the user QUEUED during the previous workflow's local render can't
+          // be delivered to it now (it's no longer the active socket) without leaking
+          // into THIS workflow via the bridge migration alias — so surface an explicit
+          // cancellation rather than silently dropping accepted work (codex review).
+          const retiredHeldKey = migratedFrom + AGENT_KEY_SEP + prevBackend;
+          const retiredHeld = heldDuringGen.get(retiredHeldKey);
+          if (retiredHeld && retiredHeld.length > 0) {
+            bridge.push(
+              {
+                type: "say",
+                text: `⚠️ ${retiredHeld.length} message(s) you queued during the previous workflow's render were cancelled by switching workflows before it finished. Re-send them in that workflow if you still need them.`,
+              },
+              panelTab,
+            );
+          }
+          heldDuringGen.delete(retiredHeldKey);
           tabBackends.delete(migratedFrom);
           headlessTabs.delete(migratedFrom);
           workflowTargets.clear(migratedFrom);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2683,17 +2683,30 @@ export async function runPanelOrchestrator(): Promise<void> {
       // orchestrator restart too.
       if (newIdentity) {
         const boundUuid = sessionStore.identityOf(key);
-        if (boundUuid && boundUuid !== newIdentity.uuid) {
+        const hasExact = sessionStore.get(key) !== undefined;
+        // FAIL CLOSED at the identity boundary: reset the tab's session when the exact
+        // record can't be PROVEN to belong to THIS workflow —
+        //   • a DIFFERENT bound uuid → a saved workflow OVERWRITTEN in place; or
+        //   • an existing record with NO binding (a pre-`u` v2 {s,t} entry, or a migrated
+        //     legacy flat record) → untrusted, so we can't tell whether an in-place
+        //     replacement already happened. Resetting it costs at most a one-time
+        //     lost resume for a pre-upgrade SAVED-workflow chat; NOT resetting risks a
+        //     wrong-resume (the durable exact record and an unowned hello.resume both
+        //     point at it), which is strictly worse.
+        // onSession re-stamps `u` for the fresh session, so this fires at most once.
+        if (boundUuid ? boundUuid !== newIdentity.uuid : hasExact) {
           // FULL session boundary — reset the LIVE agent too, not just the disk record.
           // manager.reset() stops the mapped agent (whose backend still holds the PRIOR
           // workflow's session), clears its pendingResume + held mail, AND clears the
           // durable exact session. Without this, manager.send would reuse that live agent
           // and answer with — or act on — the replaced workflow's context.
           manager.reset(key);
-          const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
-          if (staleStable) sessionStore.clearStable(staleStable);
+          if (boundUuid) {
+            const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
+            if (staleStable) sessionStore.clearStable(staleStable);
+          }
           logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow replaced in place (identity uuid changed) — reset the live agent and cleared the prior workflow's stale session`,
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} exact session not provably this workflow's (${boundUuid ? "identity uuid changed" : "no durable identity binding"}) — reset the live agent and cleared the stale session`,
           );
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -25,6 +25,7 @@ import {
   SessionStore,
   armableResume,
   deriveStableKey,
+  destinationHasCollisionState,
   keepsBackendState,
   siblingOwnsStableKey,
   workflowIdentityParts,
@@ -2635,13 +2636,23 @@ export async function runPanelOrchestrator(): Promise<void> {
             // EVERY kind of destination state, not just a live agent (codex): a LIVE agent
             // (orphaned onto the incoming socket → renders into it), a DORMANT durable session
             // (rebindAgent PRESERVES it when the source has none → the incoming tab resumes the
-            // OTHER tab's conversation on a later provider switch), OR failed-start held mail
+            // OTHER tab's conversation on a later provider switch), failed-start held mail
             // (rebindAgent APPENDS it to the migrated source mail → delivered into the incoming
-            // tab). Its socket is already superseded, so its conversation is a lost resume — never
-            // a cross-tab leak. Then rebind the incoming source into the freed id.
-            if (manager.hasAnyState(newKey) || sessionStore.get(newKey) !== undefined) {
+            // tab), OR a RENDER-HELD queue (heldDuringGen — orchestrator-level, which manager.reset
+            // does NOT clear, and which the source-held re-key below would APPEND to → the
+            // superseded tab's queued message would flush into the incoming tab's agent/canvas on
+            // render completion). Its socket is already superseded, so its conversation is a lost
+            // resume — never a cross-tab leak. Then rebind the incoming source into the freed id.
+            if (
+              destinationHasCollisionState({
+                hasManagerState: manager.hasAnyState(newKey),
+                hasDurableSession: sessionStore.get(newKey) !== undefined,
+                renderHeldCount: heldDuringGen.get(newKey)?.length ?? 0,
+              })
+            ) {
               destinationCollision = true;
               manager.reset(newKey);
+              heldDuringGen.delete(newKey); // destination's render-held queue — clear BEFORE the source re-key appends to it
               logger.warn(
                 `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination id already had state (same workflow in two tabs) — reset the superseded destination so the incoming tab can't inherit it (no cross-tab leak)`,
               );

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2669,11 +2669,37 @@ export async function runPanelOrchestrator(): Promise<void> {
       else headlessTabs.delete(panelTab);
       const key = panelTab + AGENT_KEY_SEP + backend;
 
-      // Reload restore: the panel re-sends the last session id it saw. Honored
-      // only for a SAME-provider (re)connect — a switch always starts fresh. The
-      // orchestrator's own store stays authoritative on the actual spawn.
-      const resume = typeof event.resume === "string" ? event.resume : undefined;
-      if (resume && (!prev || prev === backend)) manager.setResume(key, resume);
+      // Reload restore: the panel re-sends the last session id it saw. HONOR IT ONLY
+      // when it names a session THIS tab's TRUSTED identity already OWNS (#570 P0) — its
+      // exact-tab store entry OR its trusted stable-key entry. The panel's DEFAULT
+      // panel-scoped chat keeps ONE global session id and re-sends it for EVERY workflow,
+      // so a fresh/copied workflow (paste/duplicate/new) would otherwise resume the
+      // PREVIOUS workflow's private conversation — the untrusted hello.resume bypasses the
+      // uuid boundary. An unowned/unrecognized resume is DROPPED (never armed), so it can
+      // NOT short-circuit the stable-key fallback below, which then decides by identity
+      // (fresh for a new workflow; the legit same-workflow session for a real reload —
+      // that session is stable-key-owned, so it is honored HERE too, including the
+      // orchestrator-restart belt-and-suspenders case). Same-provider only. This binds
+      // resume to identity: a persistent panel-global chat across workflows would be a
+      // separate, separately-authorized feature, not this untrusted path.
+      const resumeHint = typeof event.resume === "string" ? event.resume : undefined;
+      let armedResume: string | undefined;
+      if (resumeHint && (!prev || prev === backend)) {
+        const trustedStableKey = newIdentity
+          ? deriveStableKey({ workflowUuid: newIdentity.uuid, origin: newIdentity.origin, backend })
+          : undefined;
+        const owned =
+          sessionStore.get(key) === resumeHint ||
+          (trustedStableKey !== undefined && sessionStore.getStable(trustedStableKey) === resumeHint);
+        if (owned) {
+          armedResume = resumeHint;
+          manager.setResume(key, resumeHint);
+        } else {
+          logger.info(
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} hello.resume ${resumeHint.slice(0, 8)} is not owned by this workflow's trusted identity — dropping (won't cross-resume another workflow's chat)`,
+          );
+        }
+      }
 
       // #570: an UNSAVED workflow's tab id is an ephemeral tmp:<uuid>, regenerated
       // on every panel reload — so on an orchestrator restart that also reloads the
@@ -2707,7 +2733,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           // tab's conversation (setStable also poisons the key the moment two live tabs
           // write distinct sessions to it). When ambiguous we surface fresh — a lost
           // resume is a mild miss; resuming the WRONG conversation is not.
-          if (!resume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
+          if (!armedResume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
             let sameKeyTabs = 0;
             for (const t of bridge.tabs()) {
               if (tabStableKey.get(t.tab_id) === skey) sameKeyTabs += 1;
@@ -2875,7 +2901,10 @@ export async function runPanelOrchestrator(): Promise<void> {
               })();
             }
             // Greet only on a FRESH session (a resume/reconnect already has the thread).
-            if (!resume) {
+            // Keyed on the panel's raw hint (whether it BELIEVES it has a thread), not on
+            // whether we armed it — an unowned-and-dropped hint still means the panel is
+            // showing prior content, so a greeting atop it would be redundant.
+            if (!resumeHint) {
               // Prefer an ALREADY-resolved model if the SDK init raced ahead of this
               // greeting (#376) — otherwise the pre-init label. Remember what we
               // advertised so the onSession correction re-sends only on a real

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2552,18 +2552,25 @@ export async function runPanelOrchestrator(): Promise<void> {
           // be delivered to it now (it's no longer the active socket) without leaking
           // into THIS workflow via the bridge migration alias — so surface an explicit
           // cancellation rather than silently dropping accepted work (codex review).
-          const retiredHeldKey = migratedFrom + AGENT_KEY_SEP + prevBackend;
-          const retiredHeld = heldDuringGen.get(retiredHeldKey);
-          if (retiredHeld && retiredHeld.length > 0) {
+          // heldDuringGen is keyed by the COMPOSITE tab::backend, and the retired tab may
+          // hold queued work under MULTIPLE providers (queued on A, switched provider,
+          // then switched workflow) — sweep EVERY backend for migratedFrom, or the
+          // onRunEnd flush would later respawn stale work for the switched-away workflow.
+          let retiredHeldCount = 0;
+          for (const hk of [...heldDuringGen.keys()]) {
+            if (panelTabOf(hk) !== migratedFrom) continue;
+            retiredHeldCount += heldDuringGen.get(hk)?.length ?? 0;
+            heldDuringGen.delete(hk);
+          }
+          if (retiredHeldCount > 0) {
             bridge.push(
               {
                 type: "say",
-                text: `⚠️ ${retiredHeld.length} message(s) you queued during the previous workflow's render were cancelled by switching workflows before it finished. Re-send them in that workflow if you still need them.`,
+                text: `⚠️ ${retiredHeldCount} message(s) you queued during the previous workflow's render were cancelled by switching workflows before it finished. Re-send them in that workflow if you still need them.`,
               },
               panelTab,
             );
           }
-          heldDuringGen.delete(retiredHeldKey);
           tabBackends.delete(migratedFrom);
           headlessTabs.delete(migratedFrom);
           workflowTargets.clear(migratedFrom);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2743,8 +2743,12 @@ export async function runPanelOrchestrator(): Promise<void> {
           // entry, keyed by ITS uuid, stays valid should it ever be restored.)
           manager.reset(key);
           for (const hk of heldGenKeys) heldDuringGen.delete(hk);
+          // Drop the bridge's buffered deliveries (missed frames + render mailbox) for this
+          // tab too — they belong to the PRIOR workflow; the bridge defers its on-hello
+          // replay until AFTER this handler so this purge lands first (#570 P0).
+          bridge.dropQueuedDeliveries(panelTab);
           logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} per-tab state not provably this workflow's identity — reset the live agent + durable session + render-held queue`,
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} per-tab state not provably this workflow's identity — reset the live agent + durable session + render-held queue + buffered deliveries`,
           );
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2011,6 +2011,9 @@ export async function runPanelOrchestrator(): Promise<void> {
       requestSelfExit(`tab ${tabId.slice(0, 8)} ${reason}`);
     },
     sessionStore,
+    // #570 P0 — bind each persisted exact session to its tab's trusted workflow uuid,
+    // so a saved workflow overwritten in place (same tab id, new uuid) is detectable.
+    identityForKey: (k: string) => tabStableIdentity.get(panelTabOf(k))?.uuid,
   });
   // Let refreshEnvCapabilities() feed a freshly-gathered env block into agents
   // spawned after a ComfyUI restart/reconnect.
@@ -2668,6 +2671,27 @@ export async function runPanelOrchestrator(): Promise<void> {
       if ((event as { headless?: unknown }).headless === true) headlessTabs.add(panelTab);
       else headlessTabs.delete(panelTab);
       const key = panelTab + AGENT_KEY_SEP + backend;
+
+      // #570 P0 — IN-PLACE workflow replacement. The tab-id migration path (above) only
+      // fires when the tab id CHANGES. A SAVED workflow keeps its `wf:<path>` tab id when
+      // its file is OVERWRITTEN with a DIFFERENT workflow (new embedded uuid) — so the
+      // tab-id-keyed exact session record would resume the PRIOR workflow's chat (via
+      // spawn's exact-store hit AND an unowned hello.resume). Detect it by the DURABLE
+      // identity bound to the exact record: if it names a DIFFERENT trusted uuid than this
+      // hello's, the workflow was replaced — clear the stale exact session (and any stale
+      // stable entry) so the new workflow starts fresh. Durable, so it holds across an
+      // orchestrator restart too.
+      if (newIdentity) {
+        const boundUuid = sessionStore.identityOf(key);
+        if (boundUuid && boundUuid !== newIdentity.uuid) {
+          sessionStore.clear(key);
+          const staleStable = deriveStableKey({ workflowUuid: boundUuid, origin: newIdentity.origin, backend });
+          if (staleStable) sessionStore.clearStable(staleStable);
+          logger.info(
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} workflow replaced in place (identity uuid changed) — cleared the prior workflow's stale session`,
+          );
+        }
+      }
 
       // Reload restore: the panel re-sends the last session id it saw. HONOR IT ONLY
       // when it names a session THIS tab's TRUSTED identity already OWNS (#570 P0) — its

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2622,32 +2622,38 @@ export async function runPanelOrchestrator(): Promise<void> {
           // of orphaning the old composite key and starting fresh (codex). Only prevBackend can
           // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
           // live-agent move; the rest are durable-only.
+          let destinationCollision = false;
           for (const b of KNOWN_BACKENDS) {
             const srcKey = migratedFrom + AGENT_KEY_SEP + b;
-            const reboundLive = manager.rebindAgent(srcKey, panelTab + AGENT_KEY_SEP + b);
-            if (reboundLive) {
+            const newKey = panelTab + AGENT_KEY_SEP + b;
+            // COLLISION: the destination id ALREADY has a LIVE agent — the same workflow was open
+            // in TWO tabs and the bridge just SUPERSEDED the destination tab's socket with THIS
+            // incoming one (same-kind takeover). The destination agent is now orphaned onto the
+            // incoming socket: its private chat/session frames route by newKey to the socket the
+            // incoming tab holds, rendering INTO the incoming tab (codex). Reset the superseded
+            // destination agent FIRST — its socket is already gone, so its conversation is a lost
+            // resume, never a leak — then rebind the incoming source into the freed id so the
+            // INCOMING tab keeps its OWN conversation (and its held mail follows correctly below).
+            if (manager.hasLiveAgent(newKey)) {
+              destinationCollision = true;
+              manager.reset(newKey);
+              logger.warn(
+                `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination id already had a live agent (same workflow in two tabs) — reset the superseded destination so the incoming tab keeps its OWN conversation (no cross-tab leak)`,
+              );
+            }
+            if (manager.rebindAgent(srcKey, newKey)) {
               logger.info(
                 `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}) — agent rebound, conversation preserved`,
               );
-              continue;
-            }
-            // rebindAgent returned false. Two cases: (a) no live source agent — moveDurable ran,
-            // the durable session already followed the tab-id change; nothing more to do. (b)
-            // COLLISION — the destination key ALREADY has a live agent (the same workflow open in
-            // TWO tabs, one migrating onto the other's id), so rebind refused WITHOUT moving or
-            // stopping the source, which is STILL LIVE under the old id. Its callbacks/bridge
-            // frames would route through the proven old→new alias into the destination tab,
-            // leaking one tab's private chat/session into the other (codex). RETIRE the orphaned
-            // source agent so it stops emitting; its durable session stays under the old key (a
-            // lost resume — the destination tab's live conversation wins — never a leak).
-            if (manager.hasLiveAgent(srcKey)) {
-              manager.retire(srcKey);
-              bridge.dropQueuedDeliveries(srcKey); // cancel its in-flight commands / parked reads
-              logger.warn(
-                `[panel-orchestrator] tab-id migration ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}): destination already had a live agent — retired the colliding source agent (its conversation is orphaned; no cross-tab leak)`,
-              );
             }
           }
+          // On a collision the superseded destination tab (panelTab) may also have BRIDGE-buffered
+          // frames/renders (missedFrames/mailbox/pending) that the bridge would replay to the
+          // incoming socket right after this handler — leaking the destination's activity into the
+          // incoming tab. Drop them now (raw tab id). Only the destination's queues live under
+          // panelTab; the incoming source's in-flight work is under migratedFrom (its canonical id
+          // at send time) and is untouched, so the proven migration's own continuity is preserved.
+          if (destinationCollision) bridge.dropQueuedDeliveries(panelTab);
           // #570 — carry the PROVEN source identity forward as the tab's prior identity. The
           // rebound agent belongs to it (prevIdentity === newIdentity by sameWorkflow), but the
           // new tab id has no prior identity and the agent may have no durable record yet

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2692,10 +2692,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       }
       const prev = tabBackends.get(panelTab);
       if (prev && prev !== backend) {
-        // Provider switch: retire the previous provider's agent for this tab so it
-        // doesn't linger. The new provider starts a FRESH session (the panel
-        // replays the transcript as context on its first message to seed it).
-        manager.reset(panelTab + AGENT_KEY_SEP + prev);
+        // #570 — Provider switch via re-hello: RETIRE (not reset) the previous provider's
+        // agent so it stops lingering but its identity-bound durable session is PRESERVED. A
+        // provider switch stays on the SAME workflow, so reset() here would irreversibly lose
+        // the prior provider's conversation on an A→B→A re-hello switch (a SAVED wf: workflow
+        // has no stable-key fallback) — matching the set_backend path (codex). The NEW provider
+        // still starts fresh (the panel replays the transcript as context on its first message).
+        manager.retire(panelTab + AGENT_KEY_SEP + prev);
         bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
       }
       tabBackends.set(panelTab, backend);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -21,7 +21,7 @@ import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } fro
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
-import { SessionStore } from "./session-store.js";
+import { SessionStore, deriveStableKey } from "./session-store.js";
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
@@ -1380,9 +1380,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   // #570: for an UNSAVED workflow the panel tab id is an ephemeral tmp:<uuid>,
   // regenerated on every reload, so the tab-keyed session store can't survive an
   // orchestrator restart that also reloads the panel. Map each such tab to a STABLE
-  // resume key (origin + title + backend) computed at hello, so onSession can also
-  // persist under it and a reloaded tab can resume it. tmp: tabs only.
+  // resume key (wfid::origin::uuid::backend, see deriveStableKey) computed at hello, so
+  // onSession can also persist under it and a reloaded tab can resume it. tmp: tabs only.
   const tabStableKey = new Map<string, string>();
+  // The backend-independent components (origin + per-instance uuid) behind each tab's
+  // stable key, so a provider switch via set_backend (which never re-hellos) can RECOMPUTE
+  // the key for the new backend. Without this the stale key would keep the old backend and
+  // the new provider's onSession would persist its session under it — a cross-provider
+  // wrong-resume on a later reconnect (#570). tmp: tabs with a valid uuid only.
+  const tabStableIdentity = new Map<string, { origin: string; uuid: string }>();
   const workflowTargets = new WorkflowTargetStore();
   // Monotonic per-tab sequence for set_workflow_target events. A pinned target is
   // validated asynchronously (resolvePinTarget queries workflow_list), so a later event
@@ -1914,8 +1920,17 @@ export async function runPanelOrchestrator(): Promise<void> {
       // #570: also persist under the tab's STABLE resume key (unsaved workflows),
       // so a panel reload that regenerates the tmp:<uuid> can still resume this
       // conversation. The manager already persisted under the exact tab key.
+      //
+      // BACKEND-MATCH GUARD: tabStableKey is tab-wide but encodes the CURRENT backend.
+      // A provider switch (set_backend) resets the old agent fire-and-forget, so a
+      // late/queued onSession from that retired agent could otherwise write the OLD
+      // provider's session under the NEW provider's stable key — a cross-provider
+      // wrong-resume. Only persist when this callback's backend is still the tab's
+      // current one (the exact-tab store, keyed by the composite key, is unaffected).
       const skey = tabStableKey.get(panelTab);
-      if (skey) sessionStore.setStable(skey, sessionId, panelTab);
+      if (skey && backendOf(key) === backendForTab(panelTab)) {
+        sessionStore.setStable(skey, sessionId, panelTab);
+      }
       bridge.push({ type: "session", session_id: sessionId }, panelTab);
       bridge.broadcastTabList(); // a session started/changed → refresh mirror pickers
       // #376: the ready banner was sent at hello with the PRE-init default model.
@@ -2513,7 +2528,24 @@ export async function runPanelOrchestrator(): Promise<void> {
         // pin can no longer write a stale target / emit a late ack that the bridge's
         // migration map would deliver to the new tab (codex race, tab-id migration edge).
         workflowTargetSeq.delete(migratedFrom);
-        tabStableKey.delete(migratedFrom); // recomputed for the new id below (#570)
+        // #570: CARRY the stable-key mapping onto the new id — don't just drop it. For
+        // a still-unsaved (tmp:) target the seed block below OVERWRITES it when the
+        // replacement hello has a valid uuid, or the fail-closed branch uses it to
+        // RETIRE the persisted session when the replacement hello is degraded (no/
+        // malformed uuid) — without the carry-over a migration through a downgraded
+        // panel would strand a reset-resurrectable entry (a later new_session can't
+        // resolve the key to clear). For a SAVED (wf:) target the exact key owns resume,
+        // so the old unsaved stable session is retired outright.
+        const carriedStable = tabStableKey.get(migratedFrom);
+        const carriedIdentity = tabStableIdentity.get(migratedFrom);
+        tabStableKey.delete(migratedFrom);
+        tabStableIdentity.delete(migratedFrom);
+        if (carriedStable !== undefined) {
+          if (panelTab.startsWith("tmp:")) {
+            tabStableKey.set(panelTab, carriedStable);
+            if (carriedIdentity) tabStableIdentity.set(panelTab, carriedIdentity);
+          } else sessionStore.clearStable(carriedStable);
+        }
       }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live
@@ -2562,46 +2594,71 @@ export async function runPanelOrchestrator(): Promise<void> {
       // on every panel reload — so on an orchestrator restart that also reloads the
       // panel, the tab returns under a never-stored id and forgets everything
       // (neither our tab-keyed store nor the panel's tab-keyed hello.resume can hit).
-      // Anchor a STABLE resume key on what DOES survive that tab's reload — the
-      // ComfyUI origin + workflow title + backend — and seed it as a fallback.
-      // Saved workflows (wf:<path>) already key stably, so this is tmp:-only.
+      // Anchor a STABLE resume key on an identity that DOES survive that tab's reload:
+      // the panel's durable, globally-unique per-instance workflow uuid (see
+      // deriveStableKey). Absent a valid uuid we FAIL CLOSED — no disk fallback rather
+      // than the collision-prone origin+title key. Saved workflows (wf:<path>) already
+      // key stably, so this is tmp:-only.
       if (panelTab.startsWith("tmp:")) {
-        const origin =
-          (typeof helloUrl === "string" && helloUrl.trim() ? helloUrl.trim() : undefined) ??
-          bridge.tabOrigin(panelTab) ??
-          "";
-        const title = typeof event.title === "string" ? event.title : "";
-        const skey = `tmp::${origin}::${title}::${backend}`;
-        tabStableKey.set(panelTab, skey);
-        // Seed the resume fallback ONLY when the panel supplied none and no live
-        // agent owns the key. spawn() prefers the exact-tab store hit over this
-        // pendingResume, so the precise path is never overridden — this only
-        // rescues the churned tmp: id. setResume() no-ops if a live agent exists.
-        //
-        // COLLISION GUARD: origin+title+backend is NOT unique — two unsaved tabs
-        // with the same (default) title collide. Seed only when THIS tab is the sole
-        // connected holder of the key, so a fresh sibling tab can never resume
-        // another CONCURRENTLY-live unsaved tab's conversation (the cross-tab hijack
-        // the migration path also refuses; setStable poisons a key the moment two
-        // live tabs write distinct sessions to it). When ambiguous we surface fresh —
-        // a lost resume is a mild miss; resuming the WRONG conversation is not.
-        //
-        // The SEQUENTIAL same-title case (tab A closed, a later tab B opens with the
-        // same origin+title+backend) intentionally resumes A: by the only identity
-        // that survives a reload — the workflow identity the issue itself names as the
-        // key — B *is* the same workspace. This is bounded by the GC TTL (an abandoned
-        // session ages out) and always yields to the exact-tab store and the panel's
-        // own hello.resume. A truly-unique panel per-instance id (referenced in #568/
-        // #570's thread) would let us tighten even this — a clean future upgrade.
-        if (!resume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
-          let sameKeyTabs = 0;
-          for (const t of bridge.tabs()) {
-            if (tabStableKey.get(t.tab_id) === skey) sameKeyTabs += 1;
+        // TRUSTED origin only: the server-observed handshake origin (the browser sets
+        // it and blocks page JS from forging it), NOT the client-supplied
+        // hello.comfyui_url — otherwise a spoofed origin could let a copied uuid derive
+        // another instance's stable key. Undefined (relay/headless, no handshake
+        // origin) → deriveStableKey fails closed.
+        const origin = bridge.tabServerOrigin(panelTab);
+        // #570 REOPEN: origin+title is NOT unique (unsaved tabs share the default
+        // "Unsaved Workflow" title), so it cross-resumed an unrelated same-title
+        // workflow. deriveStableKey keys on the panel's durable per-instance uuid —
+        // two distinct unsaved workflows can never share it — and returns undefined
+        // when no valid uuid is advertised (old/pre-capability panel), so we skip the
+        // disk fallback entirely rather than reuse the buggy legacy key.
+        const workflowUuid =
+          typeof (event as { workflow_uuid?: unknown }).workflow_uuid === "string"
+            ? ((event as { workflow_uuid?: string }).workflow_uuid as string)
+            : undefined;
+        const skey = deriveStableKey({ workflowUuid, origin, backend });
+        if (skey && origin) {
+          tabStableKey.set(panelTab, skey);
+          // Remember the backend-independent identity so a later set_backend can
+          // recompute the key for the new provider (origin + workflowUuid are both
+          // valid here — skey was derived from them).
+          tabStableIdentity.set(panelTab, { origin, uuid: workflowUuid as string });
+          // Seed the resume fallback ONLY when the panel supplied none and no live
+          // agent owns the key. spawn() prefers the exact-tab store hit over this
+          // pendingResume, so the precise path is never overridden — this only
+          // rescues the churned tmp: id. setResume() no-ops if a live agent exists.
+          //
+          // COLLISION GUARD: with the durable per-instance uuid the key is globally
+          // unique, so the ONLY way two tabs share it is the SAME workflow open in two
+          // live browser tabs. Seed only when THIS tab is the sole connected holder of
+          // the key, so a fresh sibling can never resume another CONCURRENTLY-live
+          // tab's conversation (setStable also poisons the key the moment two live tabs
+          // write distinct sessions to it). When ambiguous we surface fresh — a lost
+          // resume is a mild miss; resuming the WRONG conversation is not.
+          if (!resume && !manager.hasLiveAgent(key) && sessionStore.get(key) === undefined) {
+            let sameKeyTabs = 0;
+            for (const t of bridge.tabs()) {
+              if (tabStableKey.get(t.tab_id) === skey) sameKeyTabs += 1;
+            }
+            if (sameKeyTabs <= 1) {
+              const stableSid = sessionStore.getStable(skey);
+              if (stableSid) manager.setResume(key, stableSid);
+            }
           }
-          if (sameKeyTabs <= 1) {
-            const stableSid = sessionStore.getStable(skey);
-            if (stableSid) manager.setResume(key, stableSid);
-          }
+        } else {
+          // No durable identity (old/pre-capability panel or a malformed uuid). This
+          // is an identity REGRESSION if the tab previously had a valid uuid: we must
+          // RETIRE the session it persisted under that key, not just forget the
+          // mapping. Otherwise a later `new_session` (which resolves the stable key via
+          // this now-absent mapping) can't clear it, and a subsequent valid-uuid hello
+          // would getStable() it back — resurrecting a conversation the user reset (a
+          // wrong-resume). Clearing it degrades that to a lost resume instead. Then
+          // drop the mapping and take no disk fallback — the panel's hello.resume still
+          // covers the common reload; a miss starts fresh.
+          const prior = tabStableKey.get(panelTab);
+          if (prior) sessionStore.clearStable(prior);
+          tabStableKey.delete(panelTab);
+          tabStableIdentity.delete(panelTab);
         }
       }
 
@@ -2813,6 +2870,20 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (prev !== reqBackend) {
         manager.reset(panelTab + AGENT_KEY_SEP + prev);
         bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
+        // #570: the stable resume key ENCODES the backend. This switch never re-hellos,
+        // so RECOMPUTE the key for the new provider from the tab's stored identity —
+        // otherwise the new backend's onSession would persist its session under the OLD
+        // backend's key, and a later reconnect on the old backend would resume the wrong
+        // provider's session. No stored identity (old panel / saved tab) → clear the
+        // mapping and fail closed until the next hello re-establishes it. The prior
+        // backend's own stable entry stays on disk (a legit per-provider session) and is
+        // correctly re-derivable if the user switches back.
+        const ident = tabStableIdentity.get(panelTab);
+        const reBackendKey = ident
+          ? deriveStableKey({ workflowUuid: ident.uuid, origin: ident.origin, backend: reqBackend })
+          : undefined;
+        if (reBackendKey) tabStableKey.set(panelTab, reBackendKey);
+        else tabStableKey.delete(panelTab);
       }
       tabBackends.set(panelTab, reqBackend);
       // Leaving a LOCAL provider frees its VRAM (no other tab still on it) —

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2556,6 +2556,12 @@ export async function runPanelOrchestrator(): Promise<void> {
           // the newly-selected canvas (codex review) — it fails to route instead, and
           // the retired agent ignores the error.
           bridge.revokeTabMigration(migratedFrom);
+          // Complete bridge reset for the OLD id too: its pending in-flight commands, parked
+          // reads, and buffered deliveries must be cancelled — the identity-boundary block
+          // below runs for panelTab (the NEW id), so without this a reply to a command sent
+          // under migratedFrom would still resolve the retired workflow's tool call after the
+          // switch (#570 P0). The socket is unchanged, so only queued WORK is dropped.
+          bridge.dropQueuedDeliveries(migratedFrom);
           manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
             `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} without proven workflow continuity — old agent retired (NOT rebound); each workflow keeps its own conversation`,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -23,6 +23,7 @@ import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
 import {
   SessionStore,
+  armableResume,
   deriveStableKey,
   keepsBackendState,
   workflowIdentityParts,
@@ -2854,9 +2855,29 @@ export async function runPanelOrchestrator(): Promise<void> {
         const trustedStableKey = newIdentity
           ? deriveStableKey({ workflowUuid: newIdentity.uuid, origin: newIdentity.origin, backend })
           : undefined;
-        const owned =
-          sessionStore.get(key) === resumeHint ||
-          (trustedStableKey !== undefined && sessionStore.getStable(trustedStableKey) === resumeHint);
+        // The EXACT tab-id session is unique to THIS tab id, so a hello.resume that matches it is
+        // always this tab's own — safe to arm. The STABLE-key session is SHARED by every tab of
+        // the same workflow identity (the same workflow open in two live tabs), so a second tab's
+        // panel-scoped hello.resume matching it would attach that tab to — and contend for — the
+        // FIRST tab's live conversation (codex). Permit a stable-key resume ONLY when no OTHER
+        // connected tab already holds that stable key. This mirrors the seed-fallback collision
+        // guard below; without it the armed path bypassed it.
+        const exactOwned = sessionStore.get(key) === resumeHint;
+        const stableOwned =
+          trustedStableKey !== undefined && sessionStore.getStable(trustedStableKey) === resumeHint;
+        let otherTabHoldsStableKey = false;
+        if (stableOwned && !exactOwned && trustedStableKey !== undefined) {
+          for (const t of bridge.tabs()) {
+            if (t.tab_id !== panelTab && tabStableKey.get(t.tab_id) === trustedStableKey) {
+              otherTabHoldsStableKey = true; // a concurrently-live sibling holds it → don't cross-attach
+              logger.info(
+                `[panel-orchestrator] tab ${panelTab.slice(0, 8)} hello.resume ${resumeHint.slice(0, 8)} matches a stable key ANOTHER live tab holds — dropping (a concurrent sibling must start fresh, not join the live conversation)`,
+              );
+              break;
+            }
+          }
+        }
+        const owned = armableResume({ exactOwned, stableOwned, otherTabHoldsStableKey });
         if (owned) {
           armedResume = resumeHint;
           manager.setResume(key, resumeHint);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -21,7 +21,12 @@ import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } fro
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
-import { SessionStore, deriveStableKey, workflowIdentityParts } from "./session-store.js";
+import {
+  SessionStore,
+  deriveStableKey,
+  keepsBackendState,
+  workflowIdentityParts,
+} from "./session-store.js";
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
@@ -2739,19 +2744,42 @@ export async function runPanelOrchestrator(): Promise<void> {
         // trusted handshake origin so it proves out; only genuinely identity-less (non-browser)
         // or pre-`u`/legacy clients pay a lost resume (never a cross-workflow leak).
         const helloIdentity = newIdentity ? `${newIdentity.origin}::${newIdentity.uuid}` : undefined;
-        const stateIdentity =
-          sessionStore.identityOf(key) ??
-          (priorTabIdentity ? `${priorTabIdentity.origin}::${priorTabIdentity.uuid}` : undefined);
+        const priorTabIdentityStr = priorTabIdentity
+          ? `${priorTabIdentity.origin}::${priorTabIdentity.uuid}`
+          : undefined;
+        const stateIdentity = sessionStore.identityOf(key) ?? priorTabIdentityStr;
         const provenOwn =
           stateIdentity !== undefined && helloIdentity !== undefined && stateIdentity === helloIdentity;
         if (!provenOwn) {
-          // Tear down every channel for panelTab. manager.reset() stops the agent + clears
-          // pending resume + held mail + durable session, per provider; heldDuringGen is the
-          // render-held queue; dropQueuedDeliveries is the bridge's missed frames + mailbox
-          // (the bridge defers its on-hello replay until AFTER this handler so this lands first).
-          for (const b of KNOWN_BACKENDS) manager.reset(panelTab + AGENT_KEY_SEP + b);
-          for (const hk of [...heldDuringGen.keys()]) {
-            if (panelTabOf(hk) === panelTab) heldDuringGen.delete(hk);
+          // Tear down every channel for panelTab whose state is NOT provably this workflow's.
+          // manager.reset() stops the agent + clears pending resume + held mail + durable
+          // session, PER PROVIDER; heldDuringGen is the render-held queue; dropQueuedDeliveries
+          // is the bridge's missed frames + mailbox (the bridge defers its on-hello replay until
+          // AFTER this handler so this lands first).
+          //
+          // PER-BACKEND ownership (#570 — codex): the reset must be evaluated per provider, NOT
+          // globally off the SELECTED backend. After an orchestrator restart tabStableIdentity is
+          // empty, so if the workflow has a persisted Claude session but this first hello selects
+          // Codex, a global reset would ERASE Claude's still-valid same-workflow session
+          // (irreversible loss on a normal restart + provider switch). A DORMANT backend is KEPT
+          // when its DURABLE identity (Entry.u) matches this hello's workflow identity — provider-
+          // switch continuity for the SAME workflow survives cold start. The CURRENT backend
+          // additionally trusts the tab's PRIOR-hello identity so its spawn-window live agent
+          // (no durable record yet) is covered. Everything unmatched/unbound is torn down.
+          for (const b of KNOWN_BACKENDS) {
+            const bKey = panelTab + AGENT_KEY_SEP + b;
+            if (
+              keepsBackendState({
+                storedIdentity: sessionStore.identityOf(bKey),
+                priorIdentity: priorTabIdentityStr,
+                isCurrentBackend: b === backend,
+                helloIdentity,
+              })
+            ) {
+              continue; // same-workflow session on this provider — keep it resumable
+            }
+            manager.reset(bKey);
+            heldDuringGen.delete(bKey); // render-held work belonging to the torn-down provider
           }
           bridge.dropQueuedDeliveries(panelTab);
         }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -21,7 +21,7 @@ import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } fro
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
 import { SelfRestarter } from "../services/self-restart.js";
-import { SessionStore, deriveStableKey } from "./session-store.js";
+import { SessionStore, deriveStableKey, workflowIdentityParts } from "./session-store.js";
 import { listSessions, loadTranscript } from "./history.js";
 import { uploadImageHttp, resetClient } from "../comfyui/client.js";
 import { logger } from "../utils/logger.js";
@@ -1383,11 +1383,14 @@ export async function runPanelOrchestrator(): Promise<void> {
   // resume key (wfid::origin::uuid::backend, see deriveStableKey) computed at hello, so
   // onSession can also persist under it and a reloaded tab can resume it. tmp: tabs only.
   const tabStableKey = new Map<string, string>();
-  // The backend-independent components (origin + per-instance uuid) behind each tab's
-  // stable key, so a provider switch via set_backend (which never re-hellos) can RECOMPUTE
-  // the key for the new backend. Without this the stale key would keep the old backend and
-  // the new provider's onSession would persist its session under it — a cross-provider
-  // wrong-resume on a later reconnect (#570). tmp: tabs with a valid uuid only.
+  // Each tab's TRUSTED, backend-independent workflow identity (server-observed origin +
+  // durable per-instance uuid). Two uses (#570): (1) the migration discriminator — tell a
+  // same-socket tab-id migration of ONE workflow (identity unchanged) from a SWITCH to a
+  // different workflow (identity changed), so we never rebind one workflow's agent onto
+  // another (P0a); (2) the set_backend recompute — a provider switch never re-hellos, so
+  // the stable key (which encodes the backend) is recomputed from this identity, else the
+  // new provider's onSession would persist under the old backend's key. Tracked for every
+  // tab with a valid identity; cleared when the identity is absent/untrusted.
   const tabStableIdentity = new Map<string, { origin: string; uuid: string }>();
   const workflowTargets = new WorkflowTargetStore();
   // Monotonic per-tab sequence for set_workflow_target events. A pinned target is
@@ -2492,61 +2495,106 @@ export async function runPanelOrchestrator(): Promise<void> {
         typeof (event as { migrated_from?: unknown }).migrated_from === "string"
           ? ((event as { migrated_from?: string }).migrated_from as string)
           : undefined;
+      // #570 P0a: compute this hello's TRUSTED, backend-independent workflow identity
+      // up front — the discriminator for the migration decision below AND (for tmp:
+      // tabs) the resume-key seed further down. serverOrigin is the unspoofable
+      // handshake origin; helloUuid is the panel's durable per-instance uuid.
+      const serverOrigin = bridge.tabServerOrigin(panelTab);
+      const helloUuid =
+        typeof (event as { workflow_uuid?: unknown }).workflow_uuid === "string"
+          ? ((event as { workflow_uuid?: string }).workflow_uuid as string)
+          : undefined;
+      const newIdentity = workflowIdentityParts({ workflowUuid: helloUuid, origin: serverOrigin });
+
       if (migratedFrom && migratedFrom !== panelTab) {
         const prevBackend = tabBackends.get(migratedFrom) ?? backend;
-        const prevKey = migratedFrom + AGENT_KEY_SEP + prevBackend;
-        const newKey = panelTab + AGENT_KEY_SEP + prevBackend;
-        if (manager.rebindAgent(prevKey, newKey)) {
+        const prevIdentity = tabStableIdentity.get(migratedFrom);
+        // The bridge stamps migrated_from on ANY same-socket re-hello under a new tab
+        // id — it sees SOCKET continuity, not WORKFLOW continuity. That covers a
+        // genuine tab-id migration of ONE workflow (tmp:→wf: save, rename, a panel
+        // id-scheme upgrade — the durable uuid is UNCHANGED) AND a SWITCH to a
+        // DIFFERENT workflow on the same browser tab (a DIFFERENT uuid). #570 P0a:
+        // blindly rebinding the old agent onto the new id handed the switched-to
+        // workflow the PREVIOUS one's conversation (setResume refuses the new tab's own
+        // resume while a rebound agent is live) and persisted it under the new key.
+        // Rebind ONLY when the trusted identity is UNCHANGED; on a validated DIFFERENT
+        // identity, treat it as a switch — retire the old agent (keeping its durable
+        // session for when it's reopened) and let the new workflow honor its OWN
+        // resume / stable key / fresh session.
+        const isWorkflowSwitch =
+          prevIdentity !== undefined &&
+          newIdentity !== undefined &&
+          (prevIdentity.uuid !== newIdentity.uuid || prevIdentity.origin !== newIdentity.origin);
+        if (isWorkflowSwitch) {
+          manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
-            `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — agent rebound, conversation preserved`,
+            `[panel-orchestrator] same-socket WORKFLOW SWITCH ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — old agent retired (NOT rebound); each workflow keeps its own conversation`,
           );
-        }
-        // Carry the old tab's runtime prefs to the new id regardless of whether
-        // an agent was live (backend pick, headless flag, pinned workflow
-        // target, held-during-render queue), then retire the old id.
-        if (!tabBackends.has(panelTab) && tabBackends.has(migratedFrom)) {
-          tabBackends.set(panelTab, tabBackends.get(migratedFrom)!);
-        }
-        if (headlessTabs.has(migratedFrom)) headlessTabs.add(panelTab);
-        // MOVE the pinned workflow target, don't discard it (codex review).
-        const pinned = workflowTargets.get(migratedFrom);
-        if (pinned.mode === "pinned") workflowTargets.set(panelTab, pinned);
-        // Re-key messages held during a render so the flush reaches the
-        // REBOUND agent instead of respawning one under the retired key.
-        const prevBackendForHeld = tabBackends.get(migratedFrom) ?? backend;
-        const heldOld = heldDuringGen.get(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
-        if (heldOld?.length) {
-          const heldNewKey = panelTab + AGENT_KEY_SEP + prevBackendForHeld;
-          heldDuringGen.set(heldNewKey, [...(heldDuringGen.get(heldNewKey) ?? []), ...heldOld]);
-          heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
-        }
-        tabBackends.delete(migratedFrom);
-        headlessTabs.delete(migratedFrom);
-        workflowTargets.clear(migratedFrom);
-        // Invalidate any in-flight set_workflow_target(pinned) resolution captured under
-        // the retired id: dropping its sequence makes isCurrent() false, so a late async
-        // pin can no longer write a stale target / emit a late ack that the bridge's
-        // migration map would deliver to the new tab (codex race, tab-id migration edge).
-        workflowTargetSeq.delete(migratedFrom);
-        // #570: CARRY the stable-key mapping onto the new id — don't just drop it. For
-        // a still-unsaved (tmp:) target the seed block below OVERWRITES it when the
-        // replacement hello has a valid uuid, or the fail-closed branch uses it to
-        // RETIRE the persisted session when the replacement hello is degraded (no/
-        // malformed uuid) — without the carry-over a migration through a downgraded
-        // panel would strand a reset-resurrectable entry (a later new_session can't
-        // resolve the key to clear). For a SAVED (wf:) target the exact key owns resume,
-        // so the old unsaved stable session is retired outright.
-        const carriedStable = tabStableKey.get(migratedFrom);
-        const carriedIdentity = tabStableIdentity.get(migratedFrom);
-        tabStableKey.delete(migratedFrom);
-        tabStableIdentity.delete(migratedFrom);
-        if (carriedStable !== undefined) {
-          if (panelTab.startsWith("tmp:")) {
-            tabStableKey.set(panelTab, carriedStable);
-            if (carriedIdentity) tabStableIdentity.set(panelTab, carriedIdentity);
-          } else sessionStore.clearStable(carriedStable);
+          // Retire the old id's routing/prefs — do NOT carry them to a different
+          // workflow. The old workflow's durable session stays on disk (retire()
+          // preserved it); its stable identity is dropped from the live maps.
+          heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackend);
+          tabBackends.delete(migratedFrom);
+          headlessTabs.delete(migratedFrom);
+          workflowTargets.clear(migratedFrom);
+          workflowTargetSeq.delete(migratedFrom);
+          tabStableKey.delete(migratedFrom);
+          tabStableIdentity.delete(migratedFrom);
+        } else {
+          const prevKey = migratedFrom + AGENT_KEY_SEP + prevBackend;
+          const newKey = panelTab + AGENT_KEY_SEP + prevBackend;
+          if (manager.rebindAgent(prevKey, newKey)) {
+            logger.info(
+              `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — agent rebound, conversation preserved`,
+            );
+          }
+          // Carry the old tab's runtime prefs to the new id regardless of whether
+          // an agent was live (backend pick, headless flag, pinned workflow
+          // target, held-during-render queue), then retire the old id.
+          if (!tabBackends.has(panelTab) && tabBackends.has(migratedFrom)) {
+            tabBackends.set(panelTab, tabBackends.get(migratedFrom)!);
+          }
+          if (headlessTabs.has(migratedFrom)) headlessTabs.add(panelTab);
+          // MOVE the pinned workflow target, don't discard it (codex review).
+          const pinned = workflowTargets.get(migratedFrom);
+          if (pinned.mode === "pinned") workflowTargets.set(panelTab, pinned);
+          // Re-key messages held during a render so the flush reaches the
+          // REBOUND agent instead of respawning one under the retired key.
+          const prevBackendForHeld = tabBackends.get(migratedFrom) ?? backend;
+          const heldOld = heldDuringGen.get(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
+          if (heldOld?.length) {
+            const heldNewKey = panelTab + AGENT_KEY_SEP + prevBackendForHeld;
+            heldDuringGen.set(heldNewKey, [...(heldDuringGen.get(heldNewKey) ?? []), ...heldOld]);
+            heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackendForHeld);
+          }
+          tabBackends.delete(migratedFrom);
+          headlessTabs.delete(migratedFrom);
+          workflowTargets.clear(migratedFrom);
+          // Invalidate any in-flight set_workflow_target(pinned) resolution captured under
+          // the retired id: dropping its sequence makes isCurrent() false, so a late async
+          // pin can no longer write a stale target / emit a late ack that the bridge's
+          // migration map would deliver to the new tab (codex race, tab-id migration edge).
+          workflowTargetSeq.delete(migratedFrom);
+          // #570: CARRY the stable-key mapping onto the new id — same workflow (identity
+          // unchanged), so its resume must survive the tab-id change. For a still-unsaved
+          // (tmp:) target the seed block below OVERWRITES it (recomputed for the new
+          // backend); for a SAVED (wf:) target the exact key owns resume, so the old
+          // unsaved stable session is retired outright.
+          const carriedStable = tabStableKey.get(migratedFrom);
+          tabStableKey.delete(migratedFrom);
+          tabStableIdentity.delete(migratedFrom);
+          if (carriedStable !== undefined) {
+            if (panelTab.startsWith("tmp:")) tabStableKey.set(panelTab, carriedStable);
+            else sessionStore.clearStable(carriedStable);
+          }
         }
       }
+
+      // #570: record this tab's TRUSTED identity (every tab) for the migration
+      // discriminator above and the set_backend recompute below. Absent/untrusted →
+      // cleared (fail closed: no proof of continuity → a future migration won't rebind).
+      if (newIdentity) tabStableIdentity.set(panelTab, newIdentity);
+      else tabStableIdentity.delete(panelTab);
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live
       // agent also respawns it (codex-review F2: the set_content_mode frame is
@@ -2600,29 +2648,16 @@ export async function runPanelOrchestrator(): Promise<void> {
       // than the collision-prone origin+title key. Saved workflows (wf:<path>) already
       // key stably, so this is tmp:-only.
       if (panelTab.startsWith("tmp:")) {
-        // TRUSTED origin only: the server-observed handshake origin (the browser sets
-        // it and blocks page JS from forging it), NOT the client-supplied
-        // hello.comfyui_url — otherwise a spoofed origin could let a copied uuid derive
-        // another instance's stable key. Undefined (relay/headless, no handshake
-        // origin) → deriveStableKey fails closed.
-        const origin = bridge.tabServerOrigin(panelTab);
         // #570 REOPEN: origin+title is NOT unique (unsaved tabs share the default
         // "Unsaved Workflow" title), so it cross-resumed an unrelated same-title
-        // workflow. deriveStableKey keys on the panel's durable per-instance uuid —
-        // two distinct unsaved workflows can never share it — and returns undefined
-        // when no valid uuid is advertised (old/pre-capability panel), so we skip the
-        // disk fallback entirely rather than reuse the buggy legacy key.
-        const workflowUuid =
-          typeof (event as { workflow_uuid?: unknown }).workflow_uuid === "string"
-            ? ((event as { workflow_uuid?: string }).workflow_uuid as string)
-            : undefined;
-        const skey = deriveStableKey({ workflowUuid, origin, backend });
-        if (skey && origin) {
+        // workflow. deriveStableKey keys on the panel's durable per-instance uuid +
+        // TRUSTED server-observed origin (newIdentity, computed above) — two distinct
+        // unsaved workflows can never share it — and yields undefined when no valid
+        // uuid / trusted origin, so we skip the disk fallback entirely rather than
+        // reuse the buggy legacy key. (tabStableIdentity is already set above.)
+        const skey = newIdentity ? deriveStableKey({ workflowUuid: helloUuid, origin: serverOrigin, backend }) : undefined;
+        if (skey) {
           tabStableKey.set(panelTab, skey);
-          // Remember the backend-independent identity so a later set_backend can
-          // recompute the key for the new provider (origin + workflowUuid are both
-          // valid here — skey was derived from them).
-          tabStableIdentity.set(panelTab, { origin, uuid: workflowUuid as string });
           // Seed the resume fallback ONLY when the panel supplied none and no live
           // agent owns the key. spawn() prefers the exact-tab store hit over this
           // pendingResume, so the precise path is never overridden — this only
@@ -2878,7 +2913,10 @@ export async function runPanelOrchestrator(): Promise<void> {
         // mapping and fail closed until the next hello re-establishes it. The prior
         // backend's own stable entry stays on disk (a legit per-provider session) and is
         // correctly re-derivable if the user switches back.
-        const ident = tabStableIdentity.get(panelTab);
+        // Only tmp: tabs carry a stable RESUME key (saved workflows key on the exact
+        // wf: path); tabStableIdentity is tracked for every tab (migration discriminator)
+        // so gate the recompute on tmp: to avoid seeding a stable key for a saved tab.
+        const ident = panelTab.startsWith("tmp:") ? tabStableIdentity.get(panelTab) : undefined;
         const reBackendKey = ident
           ? deriveStableKey({ workflowUuid: ident.uuid, origin: ident.origin, backend: reqBackend })
           : undefined;

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2534,6 +2534,13 @@ export async function runPanelOrchestrator(): Promise<void> {
           prevIdentity.uuid === newIdentity.uuid &&
           prevIdentity.origin === newIdentity.origin;
         if (!sameWorkflow) {
+          // FENCE the bridge route FIRST: the bridge already installed a fromId→newId
+          // alias for this same-socket re-hello, and each panel MCP server stays bound
+          // to its original tab id. Revoke it before retiring so a stale / in-flight
+          // panel_* call from the old workflow can't resolve through the alias and mutate
+          // the newly-selected canvas (codex review) — it fails to route instead, and
+          // the retired agent ignores the error.
+          bridge.revokeTabMigration(migratedFrom);
           manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
             `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} without proven workflow continuity — old agent retired (NOT rebound); each workflow keeps its own conversation`,

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2514,6 +2514,12 @@ export async function runPanelOrchestrator(): Promise<void> {
           ? ((event as { workflow_uuid?: string }).workflow_uuid as string)
           : undefined;
       const newIdentity = workflowIdentityParts({ workflowUuid: helloUuid, origin: serverOrigin });
+      // #570 P0 — the tab's identity from its PRIOR hello, captured BEFORE the migration
+      // block / post-block overwrite of tabStableIdentity. For an IN-PLACE workflow
+      // replacement (same tab id, new uuid) this is the identity the tab's still-LIVE agent
+      // and queued work belong to — needed to reset them even before any durable session
+      // record exists (the spawn→first-session window).
+      const priorTabIdentity = tabStableIdentity.get(panelTab);
 
       if (migratedFrom && migratedFrom !== panelTab) {
         const prevBackend = tabBackends.get(migratedFrom) ?? backend;
@@ -2688,41 +2694,45 @@ export async function runPanelOrchestrator(): Promise<void> {
       // stable entry) so the new workflow starts fresh. Durable, so it holds across an
       // orchestrator restart too.
       {
-        // FAIL CLOSED at the identity boundary (#570 P0): an existing EXACT session record
-        // is trusted (kept + resumable) ONLY when PROVEN to belong to THIS workflow — the
-        // record carries a durable identity uuid (Entry.u) AND this hello carries a valid
-        // trusted identity AND they MATCH. Anything else is reset:
-        //   • DIFFERENT bound uuid → a SAVED workflow OVERWRITTEN in place (same wf:<path>
-        //     tab id, new uuid);
-        //   • record with NO binding → a pre-`u` v2 {s,t} or migrated legacy record — can't
-        //     tell whether an in-place replacement already happened;
-        //   • no trusted identity on this hello (old/degraded panel, no server origin) →
-        //     unprovable, and the path-keyed record + an unowned global hello.resume would
-        //     otherwise cross-resume a replaced workflow.
-        // Resetting costs at most a lost resume (one-time on upgrade for a bound record;
-        // per-reload for an identity-less client's SAVED workflow — unsaved tabs churn their
-        // tmp: id so nothing is stored under the reloaded key). A wrong-resume is worse.
-        // onSession re-stamps `u`, so a bound modern client's saved workflow proves out and
-        // is never reset. Runs BEFORE the resume-ownership check and spawn, so neither an
-        // unowned hello.resume nor spawn's exact-store hit can resume a stale session.
-        const boundIdentity = sessionStore.identityOf(key);
-        // The FULL canonical identity (origin+uuid) this hello proves — must equal the
-        // record's bound identity to keep it. Includes origin, so a copied uuid from a
-        // DIFFERENT origin on the same bridge port can't pass (codex).
+        // FAIL CLOSED at the identity boundary (#570 P0). ALL of a tab's per-tab state —
+        // the LIVE agent, its pending resume + held mail, the durable session, AND the
+        // external render-held queue (heldDuringGen) — is trusted (kept) ONLY when the
+        // identity it belongs to PROVABLY matches this hello's identity. Otherwise it is a
+        // workflow REPLACED in place (same tab id, new uuid), a degraded/unbound record, or
+        // a copied uuid from a different origin — TEAR IT ALL DOWN so the new workflow can't
+        // inherit the old one's private conversation.
+        //
+        // Gate on STATE, not on a durable record: a LIVE agent exists in the spawn→first-
+        // session window BEFORE any durable session is written (P0a), and render-held work
+        // can be queued with no session at all (P0b) — both would otherwise leak into the
+        // replacement. The identity the state belongs to is the durable binding (Entry.u),
+        // else the tab's identity from its PRIOR hello (captured before we overwrote it) —
+        // which is how the no-durable-record live-agent window is covered.
+        //
+        // "Both sides have NO identity" counts as PROVEN (no transition): an identity-less
+        // client (no trusted server origin — never had the uuid boundary) is not torn down
+        // on every hello, which would break its ongoing conversation. Closing the in-place
+        // overwrite for such clients is impossible without that breakage — a client-capability
+        // limitation, disclosed. A MODERN client whose record is unbound (pre-`u`/legacy) still
+        // resets: its hello carries an identity, so identity(state)=undefined ≠ identity(hello).
         const helloIdentity = newIdentity ? `${newIdentity.origin}::${newIdentity.uuid}` : undefined;
-        const hasExact = sessionStore.get(key) !== undefined;
-        const provenOwn =
-          hasExact && boundIdentity !== undefined && helloIdentity !== undefined && boundIdentity === helloIdentity;
-        if (hasExact && !provenOwn) {
-          // FULL session boundary — reset the LIVE agent too, not just the disk record.
-          // manager.reset() stops the mapped agent (whose backend still holds the PRIOR
-          // workflow's session), clears its pendingResume + held mail, AND the durable
-          // exact session. Without this, manager.send would reuse that live agent. (The
-          // overwritten workflow's own stable entry, if any, is keyed by ITS uuid and
-          // stays valid should that workflow ever be restored — nothing to clear here.)
+        const stateIdentity =
+          sessionStore.identityOf(key) ??
+          (priorTabIdentity ? `${priorTabIdentity.origin}::${priorTabIdentity.uuid}` : undefined);
+        const heldGenKeys = [...heldDuringGen.keys()].filter((hk) => panelTabOf(hk) === panelTab);
+        const hasState =
+          manager.hasLiveAgent(key) || sessionStore.get(key) !== undefined || heldGenKeys.length > 0;
+        if (hasState && stateIdentity !== helloIdentity) {
+          // FULL session boundary. manager.reset() stops the mapped agent (whose backend
+          // still holds the PRIOR workflow's session), clears its pending resume + held
+          // mail, AND the durable exact session. Then cancel the render-held queue for
+          // this tab across ALL providers, or onRunEnd would flush A's private messages
+          // into the replacement B under the reused key. (The old workflow's own stable
+          // entry, keyed by ITS uuid, stays valid should it ever be restored.)
           manager.reset(key);
+          for (const hk of heldGenKeys) heldDuringGen.delete(hk);
           logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} exact session not provably this workflow's identity — reset the live agent and cleared the stale session`,
+            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} per-tab state not provably this workflow's identity — reset the live agent + durable session + render-held queue`,
           );
         }
       }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2878,10 +2878,14 @@ export async function runPanelOrchestrator(): Promise<void> {
         for (const t of bridge.tabs()) {
           if (t.tab_id === panelTab) continue;
           const siblingAgentKey = t.tab_id + AGENT_KEY_SEP + candidateBackend;
-          // A retained session lives in the durable store (survives a provider-switch retire) or
-          // in the manager's live/pending/held state (spawn window, failed-start mail).
+          // A retained session lives in the durable store (survives a provider-switch retire), in
+          // the manager's live/pending/held state (spawn window, failed-start mail), OR in the
+          // orchestrator-level render-held queue (heldDuringGen) — the full durable/live/pending/
+          // held/render-held owned-set definition.
           const siblingRetainsSession =
-            sessionStore.get(siblingAgentKey) !== undefined || manager.hasAnyState(siblingAgentKey);
+            sessionStore.get(siblingAgentKey) !== undefined ||
+            manager.hasAnyState(siblingAgentKey) ||
+            (heldDuringGen.get(siblingAgentKey)?.length ?? 0) > 0;
           if (
             siblingOwnsStableKey({
               siblingIdentity: tabStableIdentity.get(t.tab_id),

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2614,12 +2614,24 @@ export async function runPanelOrchestrator(): Promise<void> {
           tabStableKey.delete(migratedFrom);
           tabStableIdentity.delete(migratedFrom);
         } else {
-          const prevKey = migratedFrom + AGENT_KEY_SEP + prevBackend;
-          const newKey = panelTab + AGENT_KEY_SEP + prevBackend;
-          if (manager.rebindAgent(prevKey, newKey)) {
-            logger.info(
-              `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — agent rebound, conversation preserved`,
+          // #570 — migrate per-backend state for EVERY provider, not only the currently-selected
+          // one. A saved workflow can hold a DORMANT session on another backend (used Claude,
+          // switched to Codex, then a save/rename changed its wf: tab id while Codex was current):
+          // rebindAgent moves the exact durable session (+ pending resume + held mail) even when
+          // no live agent exists, so switching back to that provider later still resumes instead
+          // of orphaning the old composite key and starting fresh (codex). Only prevBackend can
+          // have a LIVE agent (a provider switch retires the others), so at most one rebind is a
+          // live-agent move; the rest are durable-only.
+          for (const b of KNOWN_BACKENDS) {
+            const reboundLive = manager.rebindAgent(
+              migratedFrom + AGENT_KEY_SEP + b,
+              panelTab + AGENT_KEY_SEP + b,
             );
+            if (reboundLive) {
+              logger.info(
+                `[panel-orchestrator] tab-id migration: ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} (${b}) — agent rebound, conversation preserved`,
+              );
+            }
           }
           // #570 — carry the PROVEN source identity forward as the tab's prior identity. The
           // rebound agent belongs to it (prevIdentity === newIdentity by sameWorkflow), but the

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2713,43 +2713,35 @@ export async function runPanelOrchestrator(): Promise<void> {
         // else the tab's identity from its PRIOR hello (captured before we overwrote it) —
         // which is how the no-durable-record live-agent window is covered.
         //
-        // FAIL CLOSED — state is kept ONLY when POSITIVELY PROVEN: BOTH the state's
-        // identity AND this hello's identity exist AND are equal. An IDENTITY-LESS re-hello
-        // (no trusted server origin / no valid uuid — a relay/old/non-browser client) can NOT
-        // prove continuity, so its state is torn down rather than risk continuing a replaced
-        // workflow's private conversation. A browser panel ALWAYS carries a trusted handshake
-        // origin, so it proves out and is never reset for lack of identity — only genuinely
-        // identity-less (non-browser) or pre-`u`/legacy clients pay the reset. (Disclosed
-        // trade-off: such a client loses conversation continuity across a reload/reconnect —
-        // a lost resume, never a cross-workflow leak.)
+        // INVERTED GATE (#570 P0): decide only whether to KEEP the tab's state, on POSITIVE
+        // identity proof — the state's identity AND this hello's identity both present AND
+        // equal (origin::uuid). When NOT positively proven (a workflow replaced in place, a
+        // cross-origin copied uuid, an unbound pre-`u`/legacy record, OR an identity-less
+        // client that can't prove continuity), tear down EVERYTHING for this tab id
+        // UNCONDITIONALLY — never gate the teardown on state-presence, because a channel we
+        // don't "see" here (a bridge-buffered frame/mailbox item with no manager state) still
+        // leaks. The teardown is idempotent (a no-op per empty channel) and covers the COMPLETE
+        // channel list so a future channel is swept automatically. This kills the whole
+        // "gate missed a channel" class (rebind / cold import / hello.resume / spawn-window /
+        // held-gen / bridge buffers were all the same bug). A browser panel always carries a
+        // trusted handshake origin so it proves out; only genuinely identity-less (non-browser)
+        // or pre-`u`/legacy clients pay a lost resume (never a cross-workflow leak).
         const helloIdentity = newIdentity ? `${newIdentity.origin}::${newIdentity.uuid}` : undefined;
         const stateIdentity =
           sessionStore.identityOf(key) ??
           (priorTabIdentity ? `${priorTabIdentity.origin}::${priorTabIdentity.uuid}` : undefined);
-        const heldGenKeys = [...heldDuringGen.keys()].filter((hk) => panelTabOf(hk) === panelTab);
-        // hasAnyState covers the live agent, an armed pending resume, AND failed-start held
-        // mail (a prepare failure parks queued messages with no agent/session) — so a reset
-        // fires even in the spawn→first-session window or after a prepare failure.
-        const hasState =
-          manager.hasAnyState(key) || sessionStore.get(key) !== undefined || heldGenKeys.length > 0;
         const provenOwn =
           stateIdentity !== undefined && helloIdentity !== undefined && stateIdentity === helloIdentity;
-        if (hasState && !provenOwn) {
-          // FULL session boundary. manager.reset() stops the mapped agent (whose backend
-          // still holds the PRIOR workflow's session), clears its pending resume + held
-          // mail, AND the durable exact session. Then cancel the render-held queue for
-          // this tab across ALL providers, or onRunEnd would flush A's private messages
-          // into the replacement B under the reused key. (The old workflow's own stable
-          // entry, keyed by ITS uuid, stays valid should it ever be restored.)
-          manager.reset(key);
-          for (const hk of heldGenKeys) heldDuringGen.delete(hk);
-          // Drop the bridge's buffered deliveries (missed frames + render mailbox) for this
-          // tab too — they belong to the PRIOR workflow; the bridge defers its on-hello
-          // replay until AFTER this handler so this purge lands first (#570 P0).
+        if (!provenOwn) {
+          // Tear down every channel for panelTab. manager.reset() stops the agent + clears
+          // pending resume + held mail + durable session, per provider; heldDuringGen is the
+          // render-held queue; dropQueuedDeliveries is the bridge's missed frames + mailbox
+          // (the bridge defers its on-hello replay until AFTER this handler so this lands first).
+          for (const b of KNOWN_BACKENDS) manager.reset(panelTab + AGENT_KEY_SEP + b);
+          for (const hk of [...heldDuringGen.keys()]) {
+            if (panelTabOf(hk) === panelTab) heldDuringGen.delete(hk);
+          }
           bridge.dropQueuedDeliveries(panelTab);
-          logger.info(
-            `[panel-orchestrator] tab ${panelTab.slice(0, 8)} per-tab state not provably this workflow's identity — reset the live agent + durable session + render-held queue + buffered deliveries`,
-          );
         }
       }
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2517,22 +2517,30 @@ export async function runPanelOrchestrator(): Promise<void> {
         // blindly rebinding the old agent onto the new id handed the switched-to
         // workflow the PREVIOUS one's conversation (setResume refuses the new tab's own
         // resume while a rebound agent is live) and persisted it under the new key.
-        // Rebind ONLY when the trusted identity is UNCHANGED; on a validated DIFFERENT
-        // identity, treat it as a switch — retire the old agent (keeping its durable
-        // session for when it's reopened) and let the new workflow honor its OWN
-        // resume / stable key / fresh session.
-        const isWorkflowSwitch =
+        //
+        // FAIL CLOSED: rebind ONLY when BOTH the prior and the new trusted identity
+        // exist AND are EQUAL (proven same workflow). Anything else — a different
+        // identity (a workflow switch), OR a missing/untrusted identity on either side
+        // (an old/degraded panel, a malformed hello) — is treated as a switch: RETIRE
+        // the old agent (keeping its durable session for when it's reopened) rather than
+        // risk rebinding a different workflow's conversation. A modern panel sends a
+        // stable uuid for every workflow, so all its legitimate migrations (save/rename)
+        // have equal identity and still rebind; only unprovable cases lose the rebind
+        // (a lost resume — hello.resume still covers the common reload — never a wrong
+        // one).
+        const sameWorkflow =
           prevIdentity !== undefined &&
           newIdentity !== undefined &&
-          (prevIdentity.uuid !== newIdentity.uuid || prevIdentity.origin !== newIdentity.origin);
-        if (isWorkflowSwitch) {
+          prevIdentity.uuid === newIdentity.uuid &&
+          prevIdentity.origin === newIdentity.origin;
+        if (!sameWorkflow) {
           manager.retire(migratedFrom + AGENT_KEY_SEP + prevBackend);
           logger.info(
-            `[panel-orchestrator] same-socket WORKFLOW SWITCH ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} — old agent retired (NOT rebound); each workflow keeps its own conversation`,
+            `[panel-orchestrator] same-socket re-hello ${migratedFrom.slice(0, 12)} → ${panelTab.slice(0, 12)} without proven workflow continuity — old agent retired (NOT rebound); each workflow keeps its own conversation`,
           );
           // Retire the old id's routing/prefs — do NOT carry them to a different
-          // workflow. The old workflow's durable session stays on disk (retire()
-          // preserved it); its stable identity is dropped from the live maps.
+          // (or unprovable) workflow. The old workflow's durable session stays on disk
+          // (retire() preserved it); its stable identity is dropped from the live maps.
           heldDuringGen.delete(migratedFrom + AGENT_KEY_SEP + prevBackend);
           tabBackends.delete(migratedFrom);
           headlessTabs.delete(migratedFrom);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3085,7 +3085,14 @@ export async function runPanelOrchestrator(): Promise<void> {
       }
       const prev = tabBackends.get(panelTab) ?? defaultBackend;
       if (prev !== reqBackend) {
-        manager.reset(panelTab + AGENT_KEY_SEP + prev);
+        // #570 — RETIRE, never reset: a provider switch stays on the SAME workflow, so the old
+        // provider's session must be PRESERVED (stop its live agent, keep its durable exact
+        // record) — otherwise switching back can't resume it. A SAVED (wf:) workflow has NO
+        // stable-key fallback (stable keys are tmp:-only), so reset() here would irreversibly
+        // destroy its prior-provider conversation on a normal A→B→A switch (codex). retire()
+        // stops the agent (so it can't push into the new provider's view) while leaving the
+        // identity-bound session on disk, exactly as the same-socket workflow-switch path does.
+        manager.retire(panelTab + AGENT_KEY_SEP + prev);
         bridge.broadcastTabList(); // live agent dropped on backend switch → refresh dot
         // #570: the stable resume key ENCODES the backend. This switch never re-hellos,
         // so RECOMPUTE the key for the new provider from the tab's stored identity —

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1757,8 +1757,22 @@ export class PanelAgentManager {
       // override the session the orchestrator is actually holding. The store is
       // keyed per (tab, backend), so a provider switch finds no entry here and
       // correctly starts fresh (the panel replays the transcript to seed it).
-      const resume =
-        this.opts.sessionStore?.get(tabId) ?? this.pendingResume.get(tabId);
+      // #570 — the durable exact record wins ONLY when its OWNING identity matches this tab's
+      // current identity. A destination session collided-onto from another tab (the same wf:<path>
+      // or reused key) can carry a DIFFERENT owning identity than the tab connecting now; inheriting
+      // it would attach this tab to another tab's conversation. When the stored identity differs
+      // from the current one, IGNORE the durable record and fall back to the (validated) hint —
+      // this is the last-line guard behind the hello-handler choke point that resets such a record.
+      // Both-unknown (pre-`u` record or identity-less tab) fails OPEN, preserving prior behaviour.
+      const durable = this.opts.sessionStore?.get(tabId);
+      const durableIdentity = this.opts.sessionStore?.identityOf(tabId);
+      const currentIdentity = this.opts.identityForKey?.(tabId);
+      const durableOwnedByThisTab =
+        durable !== undefined &&
+        (durableIdentity === undefined ||
+          currentIdentity === undefined ||
+          durableIdentity === currentIdentity);
+      const resume = (durableOwnedByThisTab ? durable : undefined) ?? this.pendingResume.get(tabId);
       this.pendingResume.delete(tabId);
       agent = this.spawn(tabId, resume);
     }

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -974,6 +974,13 @@ export class PanelAgent {
   // gate, busy/working indicator, anchor tracking, usage meter, onSay commit)
   // lives here; the backend already normalized the provider's native messages.
   private handleEvent(ev: AgentEvent): void {
+    // CLOSED GUARD (#570 P0a): once stopped, emit NOTHING. stop()/retire() set `closed`
+    // fire-and-forget, but the backend's `for await` loop may still yield one buffered
+    // event before it observes the flag — and forwarding it would fire onSession/onSay/
+    // onStream callbacks that the bridge's same-socket migration alias routes to the tab
+    // this agent was retired in favor of (a leak of the old workflow's reply/session into
+    // the switched-to one). Dropping the event is safe: a stopped agent's turn is over.
+    if (this.closed) return;
     // Any event means the turn is alive — reset the idle watchdog. The `result`
     // case below disarms it entirely (turn ended). Placed before the switch so it
     // covers every event type without per-case bumps.

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1369,6 +1369,16 @@ export class PanelAgentManager {
     return this.agents.has(key);
   }
 
+  /** #570 P0 — true when this key holds ANY per-tab live/queued state that reset() would
+   *  tear down: a live agent, an armed pending resume, OR failed-start held mail (a backend
+   *  prepare failure drops the agent but PARKS its queued user messages here, with no
+   *  session). The identity boundary gates on this so an in-place workflow replacement is
+   *  torn down even in the spawn→first-session window or after a prepare failure — otherwise
+   *  the next message re-delivers the prior workflow's parked mail into the replacement. */
+  hasAnyState(key: string): boolean {
+    return this.agents.has(key) || this.pendingResume.has(key) || (this.heldMessages.get(key)?.length ?? 0) > 0;
+  }
+
   /** Composite keys of every live agent. Used to deliver a download-completion
    *  event to the SINGLE live agent when a settled download row carries no tab
    *  stamp (a pre-fix row, or an in-process/mobile caller) — the orchestrator

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1235,6 +1235,10 @@ export interface PanelAgentManagerOptions {
    * auto-restart), independent of whether the panel re-sends `hello.resume`.
    */
   sessionStore?: SessionStore;
+  /** #570 P0 — resolve the trusted workflow-identity uuid for a composite agent key, so a
+   *  persisted exact session is BOUND to the workflow it belongs to (detecting a saved
+   *  workflow overwritten in place: same tab id, new uuid). undefined when unknown. */
+  identityForKey?: (key: string) => string | undefined;
 }
 
 /** Owns one PanelAgent per tab id, spawned lazily on the tab's first message. */
@@ -1312,7 +1316,7 @@ export class PanelAgentManager {
       // Persist the session id to our durable store (resume-after-restart) BEFORE
       // forwarding it to the panel — so it's on disk the moment the SDK reports it.
       onSession: (id, sid, model) => {
-        this.opts.sessionStore?.set(id, sid);
+        this.opts.sessionStore?.set(id, sid, this.opts.identityForKey?.(id));
         this.opts.onSession?.(id, sid, model);
       },
       onTurnAnchor: this.opts.onTurnAnchor,
@@ -1672,7 +1676,11 @@ export class PanelAgentManager {
         this.pendingResume.delete(oldKey);
       }
       const persisted = this.opts.sessionStore?.get(oldKey);
-      if (persisted) this.opts.sessionStore?.set(newKey, persisted);
+      // Carry the identity binding across the tab-id migration (same workflow, so the
+      // uuid is unchanged) — read the OLD entry's binding, since tabStableIdentity for the
+      // new tab may not be populated yet at rebind time.
+      const persistedIdentity = this.opts.sessionStore?.identityOf(oldKey);
+      if (persisted) this.opts.sessionStore?.set(newKey, persisted, persistedIdentity);
       this.opts.sessionStore?.clear(oldKey);
       // Held mail from a failed start migrates too (issue #256) — it exists
       // precisely when NO live agent does, so it must move in the durable pass

--- a/src/orchestrator/panel-agent.ts
+++ b/src/orchestrator/panel-agent.ts
@@ -1832,6 +1832,23 @@ export class PanelAgentManager {
     }
   }
 
+  /** Stop and UNBIND a tab's live agent WITHOUT touching its durable session — used
+   *  when the same browser socket switches to a DIFFERENT workflow (a validated uuid
+   *  change, #570 P0a). Unlike reset() — which CLEARS the durable session for a New
+   *  chat — this preserves sessionStore/pendingResume/held mail, so the retired
+   *  workflow resumes exactly where it left off when reopened, while its now-stopped
+   *  agent can no longer push frames that the bridge migration alias would leak into
+   *  the newly-targeted view. No-op when no live agent owns the key. */
+  retire(tabId: string): void {
+    const agent = this.agents.get(tabId);
+    if (!agent) return;
+    this.agents.delete(tabId);
+    void agent.stop();
+    logger.info(
+      `[panel-orchestrator] tab ${tabId.slice(0, 8)} retired (workflow switch on the same socket) — durable session preserved`,
+    );
+  }
+
   async interrupt(tabId: string, opts: { requeueInFlight?: boolean } = {}): Promise<void> {
     await this.agents.get(tabId)?.interrupt(opts);
   }

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -21,7 +21,11 @@ import { logger } from "../utils/logger.js";
  *    when the tab id is STABLE across a reload (a SAVED workflow: `wf:<path>`).
  *  - `stable` — keyed by a caller-supplied identity that survives a panel reload
  *    even for an UNSAVED workflow, whose tab id is an ephemeral `tmp:<uuid>` that is
- *    REGENERATED every reload. Without this, an orchestrator restart that also
+ *    REGENERATED every reload. See {@link deriveStableKey}: keyed on the panel's
+ *    durable per-instance workflow uuid (globally unique — no cross-workflow
+ *    collision); absent a valid uuid the index is skipped entirely (fail closed —
+ *    never the collision-prone origin+title key). Without this, an orchestrator
+ *    restart that also
  *    reloads the panel brings the tab back under a never-stored `tmp:` id → store
  *    miss → fresh session → conversation gone. The stable index is the resume
  *    FALLBACK: `sessions` (exact tab id) always wins when present, so this never
@@ -51,6 +55,72 @@ interface StoreFileV2 {
   v: 2;
   sessions: Record<string, Entry>;
   stable: Record<string, Entry>;
+}
+
+/**
+ * Derive the STABLE resume key for an UNSAVED-workflow tab (#570).
+ *
+ * #587 keyed this on `origin + title + backend` — the only identity thought to
+ * survive the tmp:<uuid> tab-id churn. But an unsaved workflow's title is the
+ * DEFAULT "Unsaved Workflow" (ComfyUI even re-derives the "(N)" suffix as tabs
+ * open/close), which is NOT unique: two DIFFERENT unsaved workflows collide on one
+ * key. #587 documented the resulting sequential-collision as an accepted limitation
+ * and pointed at a future per-instance id. That limitation is the #570 REOPEN: after
+ * a workflow reset the stable index served an UNRELATED earlier on-disk session for a
+ * turn (the wrong conversation), because a stale same-title sibling shared the key
+ * (the concurrent-collision poison guard can't catch a sequential/cross-restart one).
+ *
+ * The panel now advertises its durable, globally-unique per-instance workflow id
+ * (#186/#386 — minted with crypto.randomUUID, embedded in the graph's `extra` and so
+ * carried across a browser reload by ComfyUI's unsaved-workflow persistence; it is the
+ * very id that keys the durable chat transcript, which DID restore correctly in the
+ * report; and it is FORKED to a fresh uuid whenever a graph is cloned/imported, so
+ * two distinct instances never share it). Key on THAT: two distinct unsaved workflows
+ * can never share a uuid, so the cross-resume is structurally impossible, and the id
+ * survives the reload that regenerates the tmp: tab id. Backend partitions the key
+ * (per-provider sessions); the ComfyUI ORIGIN is folded in too so a uuid replayed from
+ * copied graph metadata onto a DIFFERENT instance can't bridge them. The identifier is
+ * validated against the crypto.randomUUID() shape before it is trusted.
+ *
+ * FAIL CLOSED (#570 reopen): when no VALID uuid is supplied — an older/pre-capability
+ * panel, or a malformed value — we return `undefined` and do NOT fall back to the
+ * origin+title key. That legacy key is the collision mechanism the reopen is about;
+ * reusing it would silently keep the wrong-resume alive for un-upgraded panels. Without
+ * a unique identity the orchestrator simply forgoes the disk fallback: the panel's own
+ * hello.resume still covers the common reload, and a miss starts fresh — a lost resume,
+ * never a wrong one.
+ *
+ * LEGACY RECORDS: a store written by #587 may hold old `tmp::<origin>::<title>::<backend>`
+ * stable entries. The new scheme NEVER produces or reads that key shape, so those records
+ * are inert and age out via GC. We deliberately do NOT migrate them onto a uuid identity:
+ * the legacy key is non-unique, so mapping it to a uuid would let a brand-new same-title
+ * workflow inherit an unrelated abandoned session — reintroducing the exact wrong-resume
+ * this fix removes. The upgrade cost is a lost (not wrong) resume for a pre-upgrade unsaved
+ * session whose panel also fails to send hello.resume — an accepted, bounded trade-off.
+ *
+ * The poison guard (see {@link SessionStore.setStable}) is unchanged and still matters:
+ * the SAME workflow opened in two live browser tabs shares one uuid, and two live tabs
+ * writing distinct sessions to it still poison the key rather than cross-resume.
+ */
+const WORKFLOW_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function deriveStableKey(opts: {
+  workflowUuid?: string | undefined;
+  origin?: string | undefined;
+  backend: string;
+}): string | undefined {
+  const raw = typeof opts.workflowUuid === "string" ? opts.workflowUuid.trim() : "";
+  const uuid = WORKFLOW_UUID_RE.test(raw) ? raw.toLowerCase() : "";
+  if (!uuid) return undefined; // fail closed: no durable identity → no stable resume
+  // The origin MUST be the caller's SERVER-OBSERVED (unspoofable) handshake origin —
+  // never the client-supplied hello.comfyui_url — so a spoofed origin can't let a
+  // copied uuid derive another instance's key. Canonicalized (lowercase, no trailing
+  // slash); absent → fail closed too (a relay/headless client with no handshake origin
+  // simply forgoes the disk fallback rather than keying on an untrusted value).
+  const origin =
+    typeof opts.origin === "string" ? opts.origin.trim().replace(/\/+$/, "").toLowerCase() : "";
+  if (!origin) return undefined;
+  return `wfid::${origin}::${uuid}::${opts.backend}`;
 }
 
 export class SessionStore {

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -151,6 +151,28 @@ export function deriveWorkflowIdentity(opts: {
   return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
+/** #570 — does a connected SIBLING tab own the session behind a candidate stable key? A stable key
+ *  encodes (workflow identity, backend), so a sibling owns it when its identity derives to the SAME
+ *  key for that backend AND it still RETAINS a session there. Ownership is a SET over every backend
+ *  the sibling has ever used, NOT its current provider: a provider switch RETIRES (preserves) the
+ *  old provider's session, so `siblingRetainsSession` (derived from the durable store OR live/held
+ *  state on that backend key) — not the sibling's current-backend mapping — is what proves
+ *  ownership. When true, a second honest tab must NOT arm/resume that key's session. */
+export function siblingOwnsStableKey(opts: {
+  siblingIdentity?: { origin: string; uuid: string } | undefined;
+  candidateKey: string;
+  candidateBackend: string;
+  siblingRetainsSession: boolean;
+}): boolean {
+  if (!opts.siblingIdentity || !opts.siblingRetainsSession) return false;
+  const k = deriveStableKey({
+    workflowUuid: opts.siblingIdentity.uuid,
+    origin: opts.siblingIdentity.origin,
+    backend: opts.candidateBackend,
+  });
+  return k !== undefined && k === opts.candidateKey;
+}
+
 /** #570 — may a panel-scoped `hello.resume` be ARMED? The EXACT tab-id session is unique to this
  *  tab, so a hint matching it (`exactOwned`) is always this tab's own — arm it. The STABLE-key
  *  session is SHARED by every tab of the same workflow identity (the same workflow open in two

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -151,6 +151,27 @@ export function deriveWorkflowIdentity(opts: {
   return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
+/** #570 — per-backend teardown decision at the identity boundary. When a hello is NOT proven
+ *  for the SELECTED backend, each provider's state must be judged on its OWN merits rather than
+ *  globally reset off the selected backend: a DORMANT provider's session is KEPT (resumable)
+ *  only when the identity it belongs to PROVABLY matches this hello's workflow identity — its
+ *  DURABLE stored identity (Entry.u), or, for the CURRENT hello's backend only, the tab's
+ *  PRIOR-hello identity (covering the spawn→first-session live-agent window that has no durable
+ *  record yet). This is what makes an orchestrator restart + provider switch preserve the other
+ *  provider's SAME-workflow conversation instead of erasing it irreversibly. Returns true = KEEP,
+ *  false = reset. Fails closed: any absent/mismatched identity resets. */
+export function keepsBackendState(opts: {
+  storedIdentity?: string | undefined;
+  priorIdentity?: string | undefined;
+  isCurrentBackend: boolean;
+  helloIdentity?: string | undefined;
+}): boolean {
+  const bIdentity = opts.storedIdentity ?? (opts.isCurrentBackend ? opts.priorIdentity : undefined);
+  return (
+    bIdentity !== undefined && opts.helloIdentity !== undefined && bIdentity === opts.helloIdentity
+  );
+}
+
 export class SessionStore {
   /** Entries untouched for longer than this are pruned on load. Resumes are
    *  same-day / few-days in practice; three weeks is a generous ceiling that still

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -151,6 +151,21 @@ export function deriveWorkflowIdentity(opts: {
   return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
+/** #570 — does the DESTINATION of a tab-id migration already hold state for a backend, so the
+ *  incoming tab would inherit/leak it? Covers EVERY kind of per-backend state that must be reset
+ *  before the source is rebound in: manager live/pending/held (`hasManagerState`), a dormant
+ *  durable session (`hasDurableSession`), OR a RENDER-HELD queue (`renderHeldCount` — the
+ *  orchestrator-level heldDuringGen, which manager.reset does NOT clear and which the source-held
+ *  re-key would otherwise APPEND to, flushing the superseded tab's queued message into the incoming
+ *  tab on render completion). Any of these ⇒ collision ⇒ reset + clear the destination's held. */
+export function destinationHasCollisionState(opts: {
+  hasManagerState: boolean;
+  hasDurableSession: boolean;
+  renderHeldCount: number;
+}): boolean {
+  return opts.hasManagerState || opts.hasDurableSession || opts.renderHeldCount > 0;
+}
+
 /** #570 — does a connected SIBLING tab own the session behind a candidate stable key? A stable key
  *  encodes (workflow identity, backend), so a sibling owns it when its identity derives to the SAME
  *  key for that backend AND it still RETAINS a session there. Ownership is a SET over every backend

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -151,6 +151,23 @@ export function deriveWorkflowIdentity(opts: {
   return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
+/** #570 — may a panel-scoped `hello.resume` be ARMED? The EXACT tab-id session is unique to this
+ *  tab, so a hint matching it (`exactOwned`) is always this tab's own — arm it. The STABLE-key
+ *  session is SHARED by every tab of the same workflow identity (the same workflow open in two
+ *  live tabs), so a hint matching it (`stableOwned`) may arm ONLY when no OTHER connected tab holds
+ *  that stable key (`otherTabHoldsStableKey` false) — otherwise a concurrent sibling would attach
+ *  to and contend for the first tab's live conversation (a cross-tab leak). Fail closed: an
+ *  ambiguous stable-key hint is dropped (a fresh sibling is a mild miss; joining the live
+ *  conversation is not). */
+export function armableResume(opts: {
+  exactOwned: boolean;
+  stableOwned: boolean;
+  otherTabHoldsStableKey: boolean;
+}): boolean {
+  if (opts.exactOwned) return true;
+  return opts.stableOwned && !opts.otherTabHoldsStableKey;
+}
+
 /** #570 — per-backend teardown decision at the identity boundary. When a hello is NOT proven
  *  for the SELECTED backend, each provider's state must be judged on its OWN merits rather than
  *  globally reset off the selected backend: a DORMANT provider's session is KEPT (resumable)

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -104,23 +104,46 @@ interface StoreFileV2 {
  */
 const WORKFLOW_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/** The validated + canonicalized (origin, uuid) behind a stable key, or undefined when
+ *  either is missing/untrusted (fail closed). The origin MUST be the caller's
+ *  SERVER-OBSERVED (unspoofable) handshake origin — never the client-supplied
+ *  hello.comfyui_url — so a spoofed origin can't let a copied uuid derive another
+ *  instance's key. Shared by {@link deriveStableKey} (resume key) and
+ *  {@link deriveWorkflowIdentity} (the backend-independent identity used to tell a
+ *  same-socket tab-id MIGRATION of one workflow from a SWITCH to a different one). */
+export function workflowIdentityParts(opts: {
+  workflowUuid?: string | undefined;
+  origin?: string | undefined;
+}): { origin: string; uuid: string } | undefined {
+  const raw = typeof opts.workflowUuid === "string" ? opts.workflowUuid.trim() : "";
+  const uuid = WORKFLOW_UUID_RE.test(raw) ? raw.toLowerCase() : "";
+  if (!uuid) return undefined;
+  const origin =
+    typeof opts.origin === "string" ? opts.origin.trim().replace(/\/+$/, "").toLowerCase() : "";
+  if (!origin) return undefined;
+  return { origin, uuid };
+}
+
 export function deriveStableKey(opts: {
   workflowUuid?: string | undefined;
   origin?: string | undefined;
   backend: string;
 }): string | undefined {
-  const raw = typeof opts.workflowUuid === "string" ? opts.workflowUuid.trim() : "";
-  const uuid = WORKFLOW_UUID_RE.test(raw) ? raw.toLowerCase() : "";
-  if (!uuid) return undefined; // fail closed: no durable identity → no stable resume
-  // The origin MUST be the caller's SERVER-OBSERVED (unspoofable) handshake origin —
-  // never the client-supplied hello.comfyui_url — so a spoofed origin can't let a
-  // copied uuid derive another instance's key. Canonicalized (lowercase, no trailing
-  // slash); absent → fail closed too (a relay/headless client with no handshake origin
-  // simply forgoes the disk fallback rather than keying on an untrusted value).
-  const origin =
-    typeof opts.origin === "string" ? opts.origin.trim().replace(/\/+$/, "").toLowerCase() : "";
-  if (!origin) return undefined;
-  return `wfid::${origin}::${uuid}::${opts.backend}`;
+  const p = workflowIdentityParts(opts);
+  if (!p) return undefined; // fail closed: no durable identity / no trusted origin
+  return `wfid::${p.origin}::${p.uuid}::${opts.backend}`;
+}
+
+/** Backend-INDEPENDENT workflow identity (origin+uuid), for distinguishing a
+ *  same-socket tab-id migration (same identity) from a workflow switch (different
+ *  identity). undefined when the identity can't be trusted (fail closed → treated as
+ *  "no proof of continuity", so a rebind is refused rather than risked). */
+export function deriveWorkflowIdentity(opts: {
+  workflowUuid?: string | undefined;
+  origin?: string | undefined;
+}): string | undefined {
+  const p = workflowIdentityParts(opts);
+  return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
 export class SessionStore {

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -49,6 +49,11 @@ interface Entry {
    *  under this (title-collision) key, so it can no longer be trusted to resume
    *  either. getStable refuses it; only clearStable (a NEW chat) revives the key. */
   p?: boolean;
+  /** EXACT index only: the trusted workflow-identity uuid this session belongs to, so a
+   *  SAVED tab whose file is OVERWRITTEN in place (same `wf:<path>` tab id, new uuid) can
+   *  be detected — the tab-id-keyed exact record would otherwise resume the PRIOR
+   *  workflow's chat. Durable, so the check survives an orchestrator restart (#570 P0). */
+  u?: string;
 }
 
 interface StoreFileV2 {
@@ -196,7 +201,7 @@ export class SessionStore {
             dirty = true;
             continue;
           }
-          const e = v as { s?: unknown; t?: unknown; o?: unknown; p?: unknown };
+          const e = v as { s?: unknown; t?: unknown; o?: unknown; p?: unknown; u?: unknown };
           if (typeof e.s !== "string") {
             dirty = true;
             continue;
@@ -217,6 +222,7 @@ export class SessionStore {
           const entry: Entry = { s: e.s, t };
           if (typeof e.o === "string") entry.o = e.o;
           if (e.p === true) entry.p = true;
+          if (typeof e.u === "string") entry.u = e.u;
           out[k] = entry;
         }
         return out;
@@ -268,15 +274,26 @@ export class SessionStore {
     return s;
   }
 
-  /** Record (and persist) a tab's current session id. No-op if unchanged. */
-  set(tabId: string, sessionId: string): void {
-    if (this.sessions[tabId]?.s === sessionId) {
-      // Same id — refresh the timestamp so an actively-used session never GCs out,
-      // but skip the disk write when the timestamp is already recent.
-      const existing = this.sessions[tabId];
-      if (existing && this.now() - existing.t < 60 * 60 * 1000) return;
+  /** The trusted workflow-identity uuid the exact session under this key belongs to
+   *  (#570 P0), or undefined. Lets the hello handler detect a SAVED workflow overwritten
+   *  in place (same tab id, new uuid) and clear the stale session. */
+  identityOf(tabId: string): string | undefined {
+    return this.sessions[tabId]?.u;
+  }
+
+  /** Record (and persist) a tab's current session id, bound to its trusted workflow
+   *  identity uuid (when known). No-op if BOTH the id and the identity are unchanged. */
+  set(tabId: string, sessionId: string, identityUuid?: string): void {
+    const u = typeof identityUuid === "string" && identityUuid ? identityUuid : undefined;
+    const existing = this.sessions[tabId];
+    if (existing?.s === sessionId && existing.u === u) {
+      // Same id AND identity — refresh the timestamp so an actively-used session never
+      // GCs out, but skip the disk write when the timestamp is already recent.
+      if (this.now() - existing.t < 60 * 60 * 1000) return;
     }
-    this.sessions[tabId] = { s: sessionId, t: this.now() };
+    const entry: Entry = { s: sessionId, t: this.now() };
+    if (u) entry.u = u;
+    this.sessions[tabId] = entry;
     this.flush();
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1559,6 +1559,25 @@ export class UiBridge {
         }
       }
     }
+    // In-flight command promises for this tab: a reply arriving AFTER the workflow was
+    // replaced must NOT resolve the PRIOR workflow's tool call (leaking the replacement's
+    // graph/data back into it). Reject + drop them. (The already-written command may still
+    // EXECUTE in the browser — that is the deferred generation-bound-command residual, which
+    // server-side cancellation cannot retract; this only fences the reply/data flow back.)
+    for (const [rid, p] of this.pending) {
+      if (p.ctx.tabId !== tabId) continue;
+      clearTimeout(p.timer);
+      this.pending.delete(rid);
+      try {
+        p.reject(
+          new Error(
+            `panel tab ${tabId.slice(0, 8)} was replaced by a different workflow — in-flight "${p.cmd}" cancelled so its reply can't resolve the prior workflow's call`,
+          ),
+        );
+      } catch {
+        // reject already settled — nothing to do
+      }
+    }
   }
 
   /** Deliver any buffered render frames to a tab that just (re)connected, plus a

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -114,6 +114,13 @@ interface Conn {
    *  dispatch + the reactive #236 path (which learns from a REAL rejection). Mirrors
    *  the unsupportedCmds "reset on every hello" philosophy for the version dimension. */
   panelVersionAdvertised: boolean;
+  /** #570 P0c — THIS panel build advertised (in its hello) that it enforces the per-command
+   *  workflow-instance stamp: it refuses to run a graph command whose stamped workflow_uuid
+   *  does not match the active canvas. When false (an OLD panel that would silently ignore the
+   *  stamp), the send() preflight FAILS CLOSED for MUTATING graph commands so a stale write
+   *  can't hit the wrong canvas — reads stay allowed. Re-read from every hello (a reconnect may
+   *  be a freshly updated build), never inherited. */
+  enforcesWorkflowStamp: boolean;
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
    *  here, every later call is gated proactively — rejected before it ever
@@ -380,6 +387,14 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
   "refresh_nodes",
 ]);
 
+/** #570 P0c — a graph command that WRITES the canvas (add/remove/connect/move/set_widget/
+ *  clear/load/…). Any `graph_*` command that is NOT in the read-only allowlist mutates, so
+ *  this stays correct as new graph mutators are added without having to enumerate them. Used
+ *  to fail closed when the connected panel does not enforce the per-command workflow stamp. */
+export function isMutatingGraphCommand(cmdName: string): boolean {
+  return cmdName.startsWith("graph_") && !BRIDGE_READONLY_CMDS.has(cmdName);
+}
+
 /** Tight default reply timeout for a MUTATING command with no explicit timeout —
  *  fail fast so the agent isn't blocked on a stuck write. */
 export const BRIDGE_DEFAULT_TIMEOUT_MS = 6000;
@@ -541,6 +556,17 @@ export class UiBridge {
    *  to (the generation-bound-command leak: the server can't retract a frame already
    *  delivered to the browser, but the browser can decline to APPLY a stale one). */
   private resolveTabWorkflowUuid: ((tabId: string) => string | undefined) | null = null;
+  /** #570 P0a — records the mirror subscribers/viewers a same-socket re-hello OPTIMISTICALLY
+   *  moved from the retiring id to the new id, keyed by the RETIRING (from) id. The move
+   *  happens BEFORE the orchestrator can classify the switch as proven/unproven; if it turns
+   *  out UNPROVEN, revokeTabMigration(fromId) uses this to DETACH exactly those moved viewers
+   *  (reverting their input to their own session) and pull them back out of the destination's
+   *  subscriber set — so a phone mirroring workflow A never silently follows into B. Only the
+   *  MOVED sockets are undone, so B's OWN pre-existing viewers are untouched. */
+  private migratedMirror = new Map<
+    string,
+    { to: string; viewers: Set<BridgeSocket>; subs: Set<BridgeSocket> }
+  >();
   /** Injected by the orchestrator: does this tabId have a live agent session?
    *  (SessionStore/PanelAgentManager live there.) Flags desktopTabs() for the
    *  mobile mirror picker's green "session attached" dot. */
@@ -954,18 +980,37 @@ export class UiBridge {
           migratedProvenSupported = this.conns.get(tabId)?.provenSupportedCmds;
           this.conns.delete(tabId);
           // Move mirror subscribers to the migrated tab id so viewers keep this
-          // tab's live feed across a same-socket re-hello.
+          // tab's live feed across a same-socket re-hello. #570 P0a — this is OPTIMISTIC
+          // (it happens before the orchestrator can classify the switch); record exactly
+          // which sockets we move so revokeTabMigration() can pull JUST these back out if
+          // the switch turns out to be to a DIFFERENT workflow (never depending on the
+          // destination's own session ownership to trigger the undo).
+          const movedViewers = new Set<BridgeSocket>();
+          const movedSubs = new Set<BridgeSocket>();
           const migSubs = this.subscribers.get(tabId);
           if (migSubs) {
             this.subscribers.delete(tabId);
             const dest = this.subscribers.get(msg.tab_id as string) ?? new Set<BridgeSocket>();
-            for (const s of migSubs) dest.add(s);
+            for (const s of migSubs) {
+              dest.add(s);
+              movedSubs.add(s);
+            }
             this.subscribers.set(msg.tab_id as string, dest);
           }
           // Re-point any viewers driving the OLD id at the new one so their input
           // keeps reaching this tab's session across the re-hello.
           for (const [s, drivenTab] of this.mirrorViewers) {
-            if (drivenTab === tabId) this.mirrorViewers.set(s, msg.tab_id as string);
+            if (drivenTab === tabId) {
+              this.mirrorViewers.set(s, msg.tab_id as string);
+              movedViewers.add(s);
+            }
+          }
+          if (movedViewers.size || movedSubs.size) {
+            this.migratedMirror.set(tabId, {
+              to: msg.tab_id as string,
+              viewers: movedViewers,
+              subs: movedSubs,
+            });
           }
         }
         tabId = msg.tab_id;
@@ -1018,6 +1063,10 @@ export class UiBridge {
           panelVersionAdvertised:
             typeof (msg as { panel_version?: unknown }).panel_version === "string" &&
             !!(msg as { panel_version?: string }).panel_version,
+          // #570 P0c — re-read from THIS hello, never inherited (a reconnect may be a newly
+          // updated build). Strict === true so any non-true / absent value is non-enforcing.
+          enforcesWorkflowStamp:
+            (msg as { enforces_workflow_stamp?: unknown }).enforces_workflow_stamp === true,
           // Fresh per hello — see the field's doc comment (#236).
           unsupportedCmds: new Set<string>(),
           // INHERITED across a reconnect (the panel code did not get older) so a command
@@ -1229,6 +1278,12 @@ export class UiBridge {
       for (const [from, entry] of this.tabMigrations) {
         if (entry.sock === sock) this.tabMigrations.delete(from);
       }
+      // #570 P0a — prune recorded mirror-migration undo state referencing this dying tab
+      // (a proven-keep switch never calls revokeTabMigration, so its entry would otherwise
+      // linger). Keyed by / pointing at this tab id → inert once it's gone.
+      for (const [from, m] of this.migratedMirror) {
+        if (from === tabId || m.to === tabId) this.migratedMirror.delete(from);
+      }
       // Drop this socket from any mirror subscriptions (it was a viewer).
       for (const [tid, set] of this.subscribers) {
         if (set.delete(sock) && set.size === 0) this.subscribers.delete(tid);
@@ -1337,6 +1392,26 @@ export class UiBridge {
     if (target) {
       for (const [from, entry] of this.tabMigrations) {
         if (entry.to === target) this.tabMigrations.delete(from);
+      }
+    }
+    // #570 P0a — this migration was just REJECTED as a switch to a DIFFERENT workflow, so
+    // UNDO the optimistic mirror move: detach exactly the viewers/subscribers we moved onto
+    // the destination (never the destination's OWN viewers). Detached viewers revert to their
+    // own session; their input stops driving the destination. This runs UNCONDITIONALLY on the
+    // revoke — it does NOT depend on the destination having (or lacking) its own bound session,
+    // which is the gap that let a mirror follow A→B when B already owned an exact session.
+    const moved = this.migratedMirror.get(fromId);
+    if (moved) {
+      this.migratedMirror.delete(fromId);
+      const destSubs = this.subscribers.get(moved.to);
+      if (destSubs) {
+        for (const s of moved.subs) destSubs.delete(s);
+        if (destSubs.size === 0) this.subscribers.delete(moved.to);
+      }
+      for (const s of moved.viewers) {
+        // Only revert a viewer we moved that is STILL pointed at this destination (it may have
+        // since re-attached elsewhere, which we must not clobber).
+        if (this.mirrorViewers.get(s) === moved.to) this.mirrorViewers.delete(s);
       }
     }
   }
@@ -1688,6 +1763,25 @@ export class UiBridge {
       panelVersionProvesUnsupported(cmd.cmd, conn.panelVersion)
     ) {
       return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
+    }
+    // #570 P0c — FAIL CLOSED for a MUTATING graph command when the resolved panel does NOT
+    // enforce the per-command workflow-instance stamp. Such a panel would silently IGNORE the
+    // stamp and could apply a command delivered AFTER a workflow switch to the wrong canvas —
+    // and a delivered frame cannot be retracted, so fencing only the reply can't undo the
+    // mutation. Refusing to DISPATCH it is the only server-side guarantee. Reads (outline,
+    // query, get_state, serialize, …) stay allowed, so an old panel keeps read-only graph
+    // access with a clear "update to edit" error rather than a silent wrong-canvas write.
+    if (isMutatingGraphCommand(cmd.cmd) && !conn.enforcesWorkflowStamp) {
+      return Promise.reject(
+        markDispatched(
+          new Error(
+            `"${cmd.cmd}" needs a panel that enforces per-command workflow targeting, but panel tab ` +
+              `${conn.tabId.slice(0, 8)} does not (update the ComfyUI-MCP panel to edit the graph). ` +
+              `Read-only graph commands (graph_outline, graph_query, graph_get_state) still work.`,
+          ),
+          false,
+        ),
+      );
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {
       if (opts.tabId && UiBridge.isMailboxable(cmd)) {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -389,10 +389,32 @@ export const BRIDGE_READONLY_CMDS: ReadonlySet<string> = new Set<string>([
 
 /** #570 P0c — a graph command that WRITES the canvas (add/remove/connect/move/set_widget/
  *  clear/load/…). Any `graph_*` command that is NOT in the read-only allowlist mutates, so
- *  this stays correct as new graph mutators are added without having to enumerate them. Used
- *  to fail closed when the connected panel does not enforce the per-command workflow stamp. */
+ *  this stays correct as new graph mutators are added without having to enumerate them. */
 export function isMutatingGraphCommand(cmdName: string): boolean {
   return cmdName.startsWith("graph_") && !BRIDGE_READONLY_CMDS.has(cmdName);
+}
+
+/** #570 P0c — the ACTIVE-workflow save/save_as/rename/close commands, but ONLY when they carry
+ *  no explicit `path` (so they act on whatever workflow is CURRENTLY active). A stale one of
+ *  these, delivered after the user switches workflows, would hit the NEW active workflow —
+ *  workflow_close even discards its unsaved work. An explicit `path` names a DETERMINISTIC
+ *  target, so it is not a switch-race victim and is left ungated. */
+const ACTIVE_WORKFLOW_MUTATORS = new Set<string>([
+  "workflow_save",
+  "workflow_save_as",
+  "workflow_rename",
+  "workflow_close",
+]);
+
+/** #570 P0c — commands that MUTATE the currently-active workflow/canvas and must therefore be
+ *  fenced to the workflow they were issued for. Fail closed for these unless the connected
+ *  panel enforces the per-command workflow stamp (`workflow_open`/`workflow_new` are
+ *  navigation/creation with deterministic or new targets — not active-content mutations — so
+ *  they are excluded). Takes the full command so it can read the `path` discriminator. */
+export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown; path?: unknown }): boolean {
+  const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
+  if (isMutatingGraphCommand(name)) return true;
+  return ACTIVE_WORKFLOW_MUTATORS.has(name) && cmd.path === undefined;
 }
 
 /** Tight default reply timeout for a MUTATING command with no explicit timeout —
@@ -1764,14 +1786,16 @@ export class UiBridge {
     ) {
       return Promise.reject(buildPanelTooOldError(cmd.cmd, conn.panelVersion));
     }
-    // #570 P0c — FAIL CLOSED for a MUTATING graph command when the resolved panel does NOT
-    // enforce the per-command workflow-instance stamp. Such a panel would silently IGNORE the
-    // stamp and could apply a command delivered AFTER a workflow switch to the wrong canvas —
-    // and a delivered frame cannot be retracted, so fencing only the reply can't undo the
-    // mutation. Refusing to DISPATCH it is the only server-side guarantee. Reads (outline,
-    // query, get_state, serialize, …) stay allowed, so an old panel keeps read-only graph
-    // access with a clear "update to edit" error rather than a silent wrong-canvas write.
-    if (isMutatingGraphCommand(cmd.cmd) && !conn.enforcesWorkflowStamp) {
+    // #570 P0c — FAIL CLOSED for a command that mutates the ACTIVE workflow/canvas (every
+    // graph_* mutator, plus path-less workflow_save/save_as/rename/close) when the resolved
+    // panel does NOT enforce the per-command workflow-instance stamp. Such a panel would
+    // silently IGNORE the stamp and could apply a command delivered AFTER a workflow switch to
+    // the wrong workflow — a delivered frame cannot be retracted, so fencing only the reply
+    // can't undo the mutation (workflow_close would discard the new workflow's unsaved work).
+    // Refusing to DISPATCH is the only server-side guarantee. Reads (outline, query, get_state,
+    // serialize, …) and path-targeted workflow ops stay allowed, so an old panel keeps
+    // read-only graph access with a clear "update to edit" error, never a silent wrong write.
+    if (requiresWorkflowStampEnforcement(cmd) && !conn.enforcesWorkflowStamp) {
       return Promise.reject(
         markDispatched(
           new Error(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -72,6 +72,11 @@ type SendCtx = {
   mutating: boolean;
   /** Absolute ms after which even an idempotent read stops waiting for reconnect. */
   deadline: number;
+  /** #570 — the trusted per-instance workflow uuid this command was ISSUED FOR (the
+   *  caller's intended tab), stamped onto the outgoing frame so the panel can refuse to
+   *  EXECUTE it against a DIFFERENT workflow it has since switched to. Undefined for a tab
+   *  with no established workflow identity (old panel / relay) → no client-side fence. */
+  workflowUuid?: string;
 };
 
 type Pending = {
@@ -530,6 +535,12 @@ export class UiBridge {
    *  to THIS tab's shared session instead of the viewer's own — that's what makes
    *  it remote control rather than a passive view. Cleared on detach/disconnect. */
   private mirrorViewers = new Map<BridgeSocket, string>();
+  /** #570 — injected by the orchestrator: the trusted per-instance workflow uuid this
+   *  tabId currently maps to (from tabStableIdentity). Used to STAMP each dispatched
+   *  command so the panel can refuse to execute it against a workflow it has since switched
+   *  to (the generation-bound-command leak: the server can't retract a frame already
+   *  delivered to the browser, but the browser can decline to APPLY a stale one). */
+  private resolveTabWorkflowUuid: ((tabId: string) => string | undefined) | null = null;
   /** Injected by the orchestrator: does this tabId have a live agent session?
    *  (SessionStore/PanelAgentManager live there.) Flags desktopTabs() for the
    *  mobile mirror picker's green "session attached" dot. */
@@ -1701,6 +1712,11 @@ export class UiBridge {
         tabId: conn.tabId,
         mutating: !UiBridge.READONLY_CMDS.has(cmd.cmd),
         deadline: Date.now() + timeoutMs,
+        // #570 — resolve from the CALLER'S intended tab (opts.tabId), NOT the canonical
+        // conn.tabId: after a same-socket switch the two differ, and we must stamp the
+        // workflow the command was ISSUED FOR (so the panel, now showing a different one,
+        // declines it) — never the workflow it happens to have landed on.
+        workflowUuid: this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId) ?? undefined,
       };
       this.dispatch(conn, ctx);
     });
@@ -1793,7 +1809,16 @@ export class UiBridge {
     };
     this.pending.set(rid, pending);
     try {
-      conn.sock.send(JSON.stringify({ rid, ...cmd }));
+      // #570 — stamp the intended workflow uuid so the panel refuses to APPLY this command
+      // if it has since switched to a different workflow (a frame already delivered to the
+      // browser cannot be retracted server-side; the client fences execution instead). Only
+      // when resolvable and not already present; an identity-less tab / old panel gets no
+      // stamp and executes as before (fail-open there, but the reply is still server-fenced).
+      const frame: Record<string, unknown> = { rid, ...cmd };
+      if (ctx.workflowUuid && frame.workflow_uuid === undefined) {
+        frame.workflow_uuid = ctx.workflowUuid;
+      }
+      conn.sock.send(JSON.stringify(frame));
     } catch (err) {
       clearTimeout(timer);
       this.pending.delete(rid);
@@ -1916,6 +1941,12 @@ export class UiBridge {
    *  in the orchestrator). */
   setHasSessionPredicate(fn: (tabId: string) => boolean): void {
     this.hasSessionPredicate = fn;
+  }
+
+  /** #570 — inject the tabId → trusted workflow uuid resolver (tabStableIdentity lives in
+   *  the orchestrator). Enables the per-command workflow-instance stamp/fence. */
+  setTabWorkflowUuidResolver(fn: (tabId: string) => string | undefined): void {
+    this.resolveTabWorkflowUuid = fn;
   }
 
   /** The open DESKTOP tabs (non-headless primaries) for the mobile mirror picker. */

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1795,17 +1795,30 @@ export class UiBridge {
     // Refusing to DISPATCH is the only server-side guarantee. Reads (outline, query, get_state,
     // serialize, …) and path-targeted workflow ops stay allowed, so an old panel keeps
     // read-only graph access with a clear "update to edit" error, never a silent wrong write.
-    if (requiresWorkflowStampEnforcement(cmd) && !conn.enforcesWorkflowStamp) {
-      return Promise.reject(
-        markDispatched(
-          new Error(
-            `"${cmd.cmd}" needs a panel that enforces per-command workflow targeting, but panel tab ` +
-              `${conn.tabId.slice(0, 8)} does not (update the ComfyUI-MCP panel to edit the graph). ` +
-              `Read-only graph commands (graph_outline, graph_query, graph_get_state) still work.`,
+    //
+    // Require BOTH (codex): the panel must advertise enforcement AND the command must actually
+    // CARRY a trusted workflow-uuid stamp. Enforcement alone is not enough — if the tab has no
+    // resolvable identity (missing/malformed uuid, relay client), the frame ships UNSTAMPED and
+    // the panel's fence has nothing to compare, so a stale mutation after a switch would run
+    // unfenced despite the "enforces" claim. No stamp ⇒ nothing to fence ⇒ refuse the mutation.
+    if (requiresWorkflowStampEnforcement(cmd)) {
+      const stamp = this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId);
+      const hasTrustedStamp = typeof stamp === "string" && stamp.length > 0;
+      if (!conn.enforcesWorkflowStamp || !hasTrustedStamp) {
+        const why = !conn.enforcesWorkflowStamp
+          ? `panel tab ${conn.tabId.slice(0, 8)} does not enforce per-command workflow targeting ` +
+            `(update the ComfyUI-MCP panel to edit the graph)`
+          : `this workflow has no trusted identity for the panel to fence the command against`;
+        return Promise.reject(
+          markDispatched(
+            new Error(
+              `"${cmd.cmd}" cannot be safely targeted to the active workflow: ${why}. Read-only graph ` +
+                `commands (graph_outline, graph_query, graph_get_state) still work.`,
+            ),
+            false,
           ),
-          false,
-        ),
-      );
+        );
+      }
     }
     if (conn.sock.readyState !== WebSocket.OPEN) {
       if (opts.tabId && UiBridge.isMailboxable(cmd)) {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1306,6 +1306,24 @@ export class UiBridge {
     }
   }
 
+  /** Fence a same-socket migration alias (#570 P0a): drop the `fromId → to` route and
+   *  every other entry that points at the SAME target (fromId's path-compressed chain),
+   *  so a RETIRED workflow's stale / in-flight panel_* calls addressed to fromId can no
+   *  longer resolve THROUGH the alias onto the newly-selected workflow's canvas. Called
+   *  when a same-socket re-hello is NOT a proven same-workflow continuation (a workflow
+   *  SWITCH). The new tab routes directly via its own live connection, so fencing the old
+   *  routes never affects it; a stale call to fromId simply fails to resolve (and its
+   *  now-stopped agent ignores the error) instead of mutating the wrong graph. */
+  revokeTabMigration(fromId: string): void {
+    const target = this.tabMigrations.get(fromId)?.to;
+    this.tabMigrations.delete(fromId);
+    if (target) {
+      for (const [from, entry] of this.tabMigrations) {
+        if (entry.to === target) this.tabMigrations.delete(from);
+      }
+    }
+  }
+
   /** SERVER-TRUSTED: true only when this tab's socket arrived on the token-less
    *  loopback primary listener (a browser on the orchestrator's OWN host), so its
    *  advertised loopback ComfyUI origin really is the orchestrator's local host and

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -406,37 +406,35 @@ export function isMutatingGraphCommand(cmdName: string): boolean {
   return cmdName.startsWith("graph_") && !BRIDGE_READONLY_CMDS.has(cmdName);
 }
 
-/** #570 P0c — workflow mutators that ALWAYS act on the active workflow: their panel executors
- *  take only `{ name }` and ignore any `path`, so a `path` on them is meaningless and never
- *  makes them deterministic. Always gated. */
-const ALWAYS_ACTIVE_WORKFLOW_MUTATORS = new Set<string>(["workflow_save", "workflow_save_as"]);
-
-/** #570 P0c — workflow mutators that target an EXPLICIT `path` when given a real one, else the
- *  active workflow (`path ? target : activeWorkflow` in the panel). A stale one of these,
- *  delivered after the user switches workflows, would hit the NEW active workflow —
- *  workflow_close even discards its unsaved work — UNLESS it names a deterministic path. */
-const PATH_TARGETABLE_WORKFLOW_MUTATORS = new Set<string>(["workflow_rename", "workflow_close"]);
+/** #570 P0c — the four workflow mutators. workflow_save / workflow_save_as ignore any path and
+ *  always target the active workflow; workflow_rename / workflow_close resolve a path selector
+ *  against the panel's OPEN workflows (`path ? openWorkflows.find(path) : activeWorkflow`), which
+ *  the SERVER cannot evaluate — and a path that names a non-active workflow NOW can name the
+ *  active one after an in-place replacement at that path. So the server cannot prove any of these
+ *  stays off the active canvas and gates all four (an enforcing panel resolves the target
+ *  precisely client-side; a non-enforcing panel fails closed — read-only for these ops). */
+const ACTIVE_WORKFLOW_MUTATORS = new Set<string>([
+  "workflow_save",
+  "workflow_save_as",
+  "workflow_rename",
+  "workflow_close",
+]);
 
 /** #570 P0c — commands that MUTATE the currently-active workflow/canvas and must therefore be
  *  fenced to the workflow they were issued for. Fail closed for these unless the connected panel
  *  enforces the per-command workflow stamp (`workflow_open`/`workflow_new` are navigation/creation
- *  with deterministic or new targets — not active-content mutations — so they are excluded).
+ *  with their OWN explicit or new target — not active-content mutations — so they are excluded).
  *
- *  A `path` counts as an EXPLICIT deterministic target ONLY when it is a NON-EMPTY TRIMMED string.
- *  The panel executors treat `path:""` / whitespace as falsy → the ACTIVE workflow (codex), and
- *  the tool schemas allow `path:""`, so an empty/whitespace path is a switch-race victim and MUST
- *  be gated — never let `path !== undefined` alone wave a mutation past the fence. Takes the full
- *  command so it can read the `path` discriminator. */
-export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown; path?: unknown }): boolean {
+ *  Decide by the COMMAND, not by a raw `path` string: the server cannot resolve a workflow path
+ *  selector to a specific open workflow, and an in-place replacement can make a once-non-active
+ *  path resolve to the active workflow — so raw path presence can never prove a rename/close
+ *  stays off the active canvas. Hence all four workflow mutators are gated unconditionally; the
+ *  ENFORCING panel's client-side fence (activeWorkflowFenceApplies) does the precise
+ *  resolved-target check that safely exempts a deterministically non-active target. */
+export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown }): boolean {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   if (isMutatingGraphCommand(name)) return true;
-  if (ALWAYS_ACTIVE_WORKFLOW_MUTATORS.has(name)) return true;
-  if (PATH_TARGETABLE_WORKFLOW_MUTATORS.has(name)) {
-    const path = (cmd as { path?: unknown }).path;
-    const hasExplicitPath = typeof path === "string" && path.trim().length > 0;
-    return !hasExplicitPath; // absent / "" / whitespace ⇒ active workflow ⇒ must be gated
-  }
-  return false;
+  return ACTIVE_WORKFLOW_MUTATORS.has(name);
 }
 
 /** Tight default reply timeout for a MUTATING command with no explicit timeout —

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1536,13 +1536,27 @@ export class UiBridge {
    *   - awaitingReconnect — idempotent reads parked on a mid-command drop, which
    *     resumeAwaitingReconnect() would re-dispatch onto the REPLACEMENT tab's socket and
    *     deliver its graph/data back into the PRIOR workflow's still-running tool call.
-   *  Routing/lifecycle structures (conns, subscribers, migration aliases) are intentionally
-   *  NOT touched here — the socket stays; only queued WORK is dropped. Called by the
-   *  orchestrator's identity-boundary reset, and the bridge defers its on-hello
+   *   - mirror subscribers / viewers — a MIRROR channel is also a per-tab delivery path: a
+   *     phone attached to workflow A keeps receiving this tab's session/say frames and its
+   *     input is stamped for this tab. On a same-socket SWITCH the hello handler already
+   *     MOVED the old id's subscribers/viewers onto the NEW id BEFORE continuity could be
+   *     proven, so on an unproven transition a mirror viewer would silently follow A→B
+   *     without ever attaching to B (codex review). Detach viewers driving this tab (their
+   *     input reverts to their OWN session) and drop this tab's subscriber set (stop feeding
+   *     it B's frames); they can re-attach explicitly if they still want this view.
+   *  The remaining routing/lifecycle structures (conns, migration aliases) are intentionally
+   *  NOT touched here — the socket stays; only queued WORK and unproven mirror bindings are
+   *  dropped. Called by the orchestrator's identity-boundary reset (with the surviving id) and
+   *  the switch retire branch (with the retired id), and the bridge defers its on-hello
    *  replay/flush/resume until AFTER onPanelMessage so this purge lands first. */
   dropQueuedDeliveries(tabId: string): void {
     this.missedFrames.delete(tabId);
     this.mailbox.delete(tabId);
+    // MIRROR teardown (see above): a viewer must not auto-follow an unproven workflow switch.
+    for (const [s, drivenTab] of this.mirrorViewers) {
+      if (drivenTab === tabId) this.mirrorViewers.delete(s);
+    }
+    this.subscribers.delete(tabId);
     const awaiting = this.awaitingReconnect.get(tabId);
     if (awaiting) {
       this.awaitingReconnect.delete(tabId);

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -119,7 +119,15 @@ interface Conn {
    *  does not match the active canvas. When false (an OLD panel that would silently ignore the
    *  stamp), the send() preflight FAILS CLOSED for MUTATING graph commands so a stale write
    *  can't hit the wrong canvas — reads stay allowed. Re-read from every hello (a reconnect may
-   *  be a freshly updated build), never inherited. */
+   *  be a freshly updated build), never inherited.
+   *
+   *  SCOPE (deliberate): this is ACCIDENTAL version-skew protection — an HONEST old panel gets
+   *  read-only graph access until it updates, so a stale in-flight edit can't silently corrupt
+   *  the wrong workflow after a switch. It is NOT a security boundary: the flag is client-
+   *  asserted and the uuid is client-supplied, so a user who MODIFIES their own local panel can
+   *  trivially spoof both. That is a self-attack (their own workflow A leaking into their own
+   *  workflow B) crossing no privacy boundary, so attestation would buy nothing — #570's real
+   *  threat is ACCIDENTAL cross-workflow confusion for an honest user, which this closes. */
   enforcesWorkflowStamp: boolean;
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
@@ -394,27 +402,37 @@ export function isMutatingGraphCommand(cmdName: string): boolean {
   return cmdName.startsWith("graph_") && !BRIDGE_READONLY_CMDS.has(cmdName);
 }
 
-/** #570 P0c — the ACTIVE-workflow save/save_as/rename/close commands, but ONLY when they carry
- *  no explicit `path` (so they act on whatever workflow is CURRENTLY active). A stale one of
- *  these, delivered after the user switches workflows, would hit the NEW active workflow —
- *  workflow_close even discards its unsaved work. An explicit `path` names a DETERMINISTIC
- *  target, so it is not a switch-race victim and is left ungated. */
-const ACTIVE_WORKFLOW_MUTATORS = new Set<string>([
-  "workflow_save",
-  "workflow_save_as",
-  "workflow_rename",
-  "workflow_close",
-]);
+/** #570 P0c — workflow mutators that ALWAYS act on the active workflow: their panel executors
+ *  take only `{ name }` and ignore any `path`, so a `path` on them is meaningless and never
+ *  makes them deterministic. Always gated. */
+const ALWAYS_ACTIVE_WORKFLOW_MUTATORS = new Set<string>(["workflow_save", "workflow_save_as"]);
+
+/** #570 P0c — workflow mutators that target an EXPLICIT `path` when given a real one, else the
+ *  active workflow (`path ? target : activeWorkflow` in the panel). A stale one of these,
+ *  delivered after the user switches workflows, would hit the NEW active workflow —
+ *  workflow_close even discards its unsaved work — UNLESS it names a deterministic path. */
+const PATH_TARGETABLE_WORKFLOW_MUTATORS = new Set<string>(["workflow_rename", "workflow_close"]);
 
 /** #570 P0c — commands that MUTATE the currently-active workflow/canvas and must therefore be
- *  fenced to the workflow they were issued for. Fail closed for these unless the connected
- *  panel enforces the per-command workflow stamp (`workflow_open`/`workflow_new` are
- *  navigation/creation with deterministic or new targets — not active-content mutations — so
- *  they are excluded). Takes the full command so it can read the `path` discriminator. */
+ *  fenced to the workflow they were issued for. Fail closed for these unless the connected panel
+ *  enforces the per-command workflow stamp (`workflow_open`/`workflow_new` are navigation/creation
+ *  with deterministic or new targets — not active-content mutations — so they are excluded).
+ *
+ *  A `path` counts as an EXPLICIT deterministic target ONLY when it is a NON-EMPTY TRIMMED string.
+ *  The panel executors treat `path:""` / whitespace as falsy → the ACTIVE workflow (codex), and
+ *  the tool schemas allow `path:""`, so an empty/whitespace path is a switch-race victim and MUST
+ *  be gated — never let `path !== undefined` alone wave a mutation past the fence. Takes the full
+ *  command so it can read the `path` discriminator. */
 export function requiresWorkflowStampEnforcement(cmd: { cmd?: unknown; path?: unknown }): boolean {
   const name = typeof cmd.cmd === "string" ? cmd.cmd : "";
   if (isMutatingGraphCommand(name)) return true;
-  return ACTIVE_WORKFLOW_MUTATORS.has(name) && cmd.path === undefined;
+  if (ALWAYS_ACTIVE_WORKFLOW_MUTATORS.has(name)) return true;
+  if (PATH_TARGETABLE_WORKFLOW_MUTATORS.has(name)) {
+    const path = (cmd as { path?: unknown }).path;
+    const hasExplicitPath = typeof path === "string" && path.trim().length > 0;
+    return !hasExplicitPath; // absent / "" / whitespace ⇒ active workflow ⇒ must be gated
+  }
+  return false;
 }
 
 /** Tight default reply timeout for a MUTATING command with no explicit timeout —
@@ -1801,6 +1819,12 @@ export class UiBridge {
     // resolvable identity (missing/malformed uuid, relay client), the frame ships UNSTAMPED and
     // the panel's fence has nothing to compare, so a stale mutation after a switch would run
     // unfenced despite the "enforces" claim. No stamp ⇒ nothing to fence ⇒ refuse the mutation.
+    //
+    // NOTE — this gate is ACCIDENTAL version-skew protection (honest old panel ⇒ read-only graph
+    // until updated), NOT a security boundary: the enforcement flag and the uuid are both client-
+    // supplied, so a user who modifies their OWN panel can spoof them — but that only leaks their
+    // own workflow into their own workflow (self-attack, no privacy boundary). See the
+    // enforcesWorkflowStamp field doc. Deliberately no attestation.
     if (requiresWorkflowStampEnforcement(cmd)) {
       const stamp = this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId);
       const hasTrustedStamp = typeof stamp === "string" && stamp.length > 0;

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -115,11 +115,15 @@ interface Conn {
    *  the unsupportedCmds "reset on every hello" philosophy for the version dimension. */
   panelVersionAdvertised: boolean;
   /** #570 P0c — THIS panel build advertised (in its hello) that it enforces the per-command
-   *  workflow-instance stamp: it refuses to run a graph command whose stamped workflow_uuid
-   *  does not match the active canvas. When false (an OLD panel that would silently ignore the
-   *  stamp), the send() preflight FAILS CLOSED for MUTATING graph commands so a stale write
-   *  can't hit the wrong canvas — reads stay allowed. Re-read from every hello (a reconnect may
-   *  be a freshly updated build), never inherited.
+   *  workflow-instance stamp: it refuses to run ANY active-workflow op whose stamped
+   *  workflow_uuid does not match the active canvas — every graph_* command AND the four
+   *  active-workflow mutators (workflow_save / workflow_save_as / workflow_rename /
+   *  workflow_close). The panel fence sits in the command handler (activeWorkflowFenceApplies),
+   *  before every executor, so the guarantee spans all of them, not just graph commands. When
+   *  false (an OLD panel that would silently ignore the stamp), the send() preflight FAILS CLOSED
+   *  for those active-workflow mutations (see requiresWorkflowStampEnforcement) so a stale write
+   *  can't hit the wrong workflow — reads and path-targeted ops stay allowed. Re-read from every
+   *  hello (a reconnect may be a freshly updated build), never inherited.
    *
    *  SCOPE (deliberate): this is ACCIDENTAL version-skew protection — an HONEST old panel gets
    *  read-only graph access until it updates, so a stale in-flight edit can't silently corrupt

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1970,13 +1970,17 @@ export class UiBridge {
     try {
       // #570 — stamp the intended workflow uuid so the panel refuses to APPLY this command
       // if it has since switched to a different workflow (a frame already delivered to the
-      // browser cannot be retracted server-side; the client fences execution instead). Only
-      // when resolvable and not already present; an identity-less tab / old panel gets no
-      // stamp and executes as before (fail-open there, but the reply is still server-fenced).
+      // browser cannot be retracted server-side; the client fences execution instead).
+      //
+      // workflow_uuid is BRIDGE-OWNED metadata, NEVER caller-settable (codex): a caller that
+      // could supply its own workflow_uuid would just set it to the DESTINATION workflow after a
+      // switch and sail past the panel fence. So ALWAYS overwrite with the trusted resolver value
+      // (ctx.workflowUuid), and STRIP any caller-supplied value entirely when we have no trusted
+      // one — an identity-less tab / old panel ships unstamped (mutations are already refused by
+      // the requiresWorkflowStampEnforcement gate above; reads execute, reply still server-fenced).
       const frame: Record<string, unknown> = { rid, ...cmd };
-      if (ctx.workflowUuid && frame.workflow_uuid === undefined) {
-        frame.workflow_uuid = ctx.workflowUuid;
-      }
+      if (ctx.workflowUuid) frame.workflow_uuid = ctx.workflowUuid;
+      else delete frame.workflow_uuid;
       conn.sock.send(JSON.stringify(frame));
     } catch (err) {
       clearTimeout(timer);

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1063,10 +1063,17 @@ export class UiBridge {
         } else {
           logger.debug(`[ui-bridge] tab ${tabId.slice(0, 8)} (re)hello`);
         }
-        // Replay anything this tab's agent produced while the tab had no live
-        // connection (its socket was re-helloed to another workflow). The panel
-        // swaps to this workflow's thread synchronously before these frames can be
-        // processed, so they render + record into the RIGHT conversation.
+        // #570 P0 — run the orchestrator's hello handler FIRST. Its identity-boundary reset
+        // can call dropQueuedDeliveries(tabId) on an UNPROVEN workflow transition (a saved
+        // workflow overwritten in place, reconnecting under the same wf:<path>), so the
+        // buffered items below — which belong to the PRIOR workflow — are NOT replayed into
+        // the replacement (a wrong-conversation/media delivery). For a PROVEN reconnect it
+        // drops nothing, so the replay/flush proceeds exactly as before, just after the ack.
+        this.onPanelMessage?.(msg as PanelEvent);
+        // Replay anything this tab's agent produced while the tab had no live connection
+        // (its socket was re-helloed to another workflow). The panel swaps to this
+        // workflow's thread synchronously, so they render + record into the RIGHT
+        // conversation (or nothing, if the reset above dropped them).
         const missed = this.missedFrames.get(tabId);
         if (missed?.length) {
           this.missedFrames.delete(tabId);
@@ -1084,7 +1091,6 @@ export class UiBridge {
         // Resume any idempotent reads that were dropped mid-command by this tab's
         // previous socket (bounded reconnect grace) onto the fresh connection.
         this.resumeAwaitingReconnect(tabId);
-        this.onPanelMessage?.(msg as PanelEvent);
         return;
       }
 
@@ -1518,6 +1524,17 @@ export class UiBridge {
     logger.info(
       `[ui-bridge] mailboxed "${cmd.cmd}" for offline tab ${tabId.slice(0, 8)} (${box.length} queued)`,
     );
+  }
+
+  /** #570 P0 — DROP a tab's buffered deliveries (missed frames + render mailbox) without
+   *  sending them. Called by the orchestrator's identity-boundary reset on an UNPROVEN
+   *  workflow transition (a saved workflow overwritten in place, reconnecting under the same
+   *  wf:<path>): the buffered items belong to the PRIOR workflow, so replaying them into the
+   *  replacement would leak the prior conversation's say/session/stream + media. Runs BEFORE
+   *  the on-hello replay/flush (which is deferred until after onPanelMessage for this reason). */
+  dropQueuedDeliveries(tabId: string): void {
+    this.missedFrames.delete(tabId);
+    this.mailbox.delete(tabId);
   }
 
   /** Deliver any buffered render frames to a tab that just (re)connected, plus a

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -1526,15 +1526,39 @@ export class UiBridge {
     );
   }
 
-  /** #570 P0 — DROP a tab's buffered deliveries (missed frames + render mailbox) without
-   *  sending them. Called by the orchestrator's identity-boundary reset on an UNPROVEN
-   *  workflow transition (a saved workflow overwritten in place, reconnecting under the same
-   *  wf:<path>): the buffered items belong to the PRIOR workflow, so replaying them into the
-   *  replacement would leak the prior conversation's say/session/stream + media. Runs BEFORE
-   *  the on-hello replay/flush (which is deferred until after onPanelMessage for this reason). */
+  /** #570 P0 — COMPLETE per-tab bridge reset: cancel/clear EVERY per-tab QUEUE that would
+   *  otherwise deliver or re-dispatch the PRIOR workflow's work after an UNPROVEN identity
+   *  transition (a saved workflow overwritten in place, reconnecting under the same
+   *  wf:<path>). Enumerate every per-tabId delivery/dispatch structure so no future queue is
+   *  forgotten:
+   *   - missedFrames  — buffered say/session/stream frames (replayed on hello);
+   *   - mailbox       — finished-render show_media (flushed on hello);
+   *   - awaitingReconnect — idempotent reads parked on a mid-command drop, which
+   *     resumeAwaitingReconnect() would re-dispatch onto the REPLACEMENT tab's socket and
+   *     deliver its graph/data back into the PRIOR workflow's still-running tool call.
+   *  Routing/lifecycle structures (conns, subscribers, migration aliases) are intentionally
+   *  NOT touched here — the socket stays; only queued WORK is dropped. Called by the
+   *  orchestrator's identity-boundary reset, and the bridge defers its on-hello
+   *  replay/flush/resume until AFTER onPanelMessage so this purge lands first. */
   dropQueuedDeliveries(tabId: string): void {
     this.missedFrames.delete(tabId);
     this.mailbox.delete(tabId);
+    const awaiting = this.awaitingReconnect.get(tabId);
+    if (awaiting) {
+      this.awaitingReconnect.delete(tabId);
+      for (const entry of awaiting) {
+        clearTimeout(entry.graceTimer);
+        try {
+          entry.ctx.reject(
+            new Error(
+              `panel tab ${tabId.slice(0, 8)} was replaced by a different workflow before its command ("${entry.ctx.command.cmd}") could resume — cancelled to avoid running it against the new workflow`,
+            ),
+          );
+        } catch {
+          // reject already settled — nothing to do
+        }
+      }
+    }
   }
 
   /** Deliver any buffered render frames to a tab that just (re)connected, plus a


### PR DESCRIPTION
Closes #570

## What #587 missed

#587 shipped a stable resume index for unsaved workflows keyed on `origin + title + backend`, seeded on hello as a fallback when the panel's `hello.resume` is absent. But an unsaved workflow's title is the **default `"Unsaved Workflow"`** (ComfyUI even re-derives the `"(N)"` suffix), so that key is **not unique** — two *different* unsaved workflows collide on one key. The concurrent-collision poison guard only fires when two live tabs write distinct sessions in one process; it **cannot** catch a *sequential / cross-restart* collision. So after a reset/restart the index served an **unrelated earlier same-title workflow's session** (the reopen: resumed `33c86744` for a turn instead of the conversation's `bfedfa9e`). #587 documented this as an accepted limitation pending a per-instance id.

## The fix

That per-instance id now exists. The panel already mints a **durable, reload-surviving, globally-unique** per-instance workflow uuid (`workflowStableUuid()` — #186/#386; embedded in the graph's `extra` so ComfyUI's unsaved-workflow persistence carries it across a reload; **forked** to a fresh uuid on clone/import; it is the very id that keys the durable chat transcript, which restored correctly in the report). The paired panel PR emits it as `workflow_uuid` on every hello.

The orchestrator now keys the stable index on **`wfid::<trusted-origin>::<uuid>::<backend>`** (`deriveStableKey`). Two distinct unsaved workflows can never share a uuid, so the cross-resume is **structurally impossible**, and the id survives the `tmp:<uuid>` tab-id churn that #570 is about.

## Safety — a wrong-resume is strictly worse than a lost-resume

- **Fail closed**: no valid uuid (old/pre-capability panel, or malformed) **or** no trusted origin -> `deriveStableKey` returns `undefined` and the disk fallback is skipped. The legacy `origin+title` key is **never written or read** — migrating it would reintroduce the wrong-resume. `hello.resume` still covers the common reload; a miss starts fresh (**lost**, never wrong).
- **Trusted origin only**: `bridge.tabServerOrigin` (server-observed, browser-set, unspoofable), canonicalized — never the client-supplied `hello.comfyui_url`.
- **Reset can't resurrect**: an identity regression (a valid-uuid tab re-hellos degraded) and a tab-id migration through a degraded panel `clearStable` the prior entry, so a later `new_session` + valid hello can't bring a reset conversation back.
- **Per-provider isolation**: `set_backend` recomputes the key from the stored `(origin, uuid)` identity; `onSession` writes the stable index only when the callback's backend is still the tab's current one, so a late old-agent callback can't poison the new provider's entry.
- **Poison guard unchanged**: the same-workflow-in-two-live-tabs collision still poisons rather than cross-resumes.

## Known trade-off (deliberate)

Until a panel updates, an unsaved workflow's *durable* fallback is unavailable when `hello.resume` is also absent — a **lost** resume, resolved once the paired panel ships (this PR) / self-heals. The only "compatibility path" would be reading the legacy non-unique key, which is exactly the wrong-resume this fixes. Fail-closed is the correct resolution.

## Tests

`session-store.test.ts` extended: two same-title workflows get distinct keys / never cross-resume; same instance keeps one key across a reload; per-backend partition; same-uuid-different-origin can't bridge; fail-closed on no-uuid / no-origin / malformed; origin canonicalization; identity-regression retire; backend-switch per-provider isolation. Paired panel PR: `buildHelloPayload` emits `workflow_uuid`. Full orchestrator suite green (503). (A pre-existing unrelated `node-dev.test.ts` flake fails identically on clean `main`.)

## Review

Self-gated with iterative codex adversarial review (gpt-5.6-terra/high): six cycles each caught and fixed a distinct real wrong-resume path (cross-workflow -> unsafe legacy migration -> identity-regression -> migration-path -> cross-provider-switch -> late-callback / client-origin). The final passes find **no remaining wrong-resume**; codex's residual verdict is a cross-repo-visibility note (the `workflow_uuid` producer lives in the paired panel repo, shipped here) plus the deliberate fail-closed compatibility trade-off above.

Paired with **artokun/comfyui-mcp-panel#481**. Draft — do not merge; session-loss is high-stakes and warrants a human re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
