### PR TITLE
fix(ui-bridge): actionable no-panel guidance after a reconnect drop (panel #436 p4, #442)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -534,6 +534,106 @@ describe("UiBridge (multi-tab)", () => {
     a.close();
   });
 
+  // #436 priority 4: the no-panel guidance must be ACTIONABLE. Before any tab has
+  // connected, "install the pack" is right. But once a tab HAS connected and later
+  // dropped (the post-restart / tab-reload window), the pack is provably installed —
+  // so the guidance must send the user to refresh the ComfyUI browser tab, never to
+  // diagnose a nonexistent install problem (the exact wrong path the report hit).
+  describe("actionable no-panel guidance after a reconnect drop (#436.4)", () => {
+    it("suggests installing the pack ONLY when nothing has ever connected", () => {
+      // Fresh bridge (beforeEach) — no tab has ever helloed.
+      const msg = bridge.status();
+      expect(msg).toMatch(/pack installed/);
+      expect(msg).not.toMatch(/refresh/i);
+    });
+
+    it("after a tab connected then dropped, tells the user to refresh the browser tab (not install)", async () => {
+      const a = await connectPanel("wf:workflows/x.json", "x");
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      a.close();
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+      const msg = bridge.status();
+      expect(msg).toMatch(/refresh/i);
+      expect(msg).toMatch(/browser tab/i);
+      // Must NOT send the agent to diagnose a (nonexistent) install problem.
+      expect(msg).not.toMatch(/pack installed and check the Agent sidebar/);
+    });
+
+    it("a WRITE to the pre-restart id after the drop fails with the refresh guidance appended, keeping 'Connected: none'", async () => {
+      const a = await connectPanel("wf:workflows/x.json", "x");
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      a.close();
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+      const err = await bridge
+        .send({ cmd: "graph_add_node" }, { tabId: "wf:workflows/x.json" })
+        .catch((e) => e as Error);
+      expect(err).toBeInstanceOf(Error);
+      // Machine-readable phrase preserved (retry/transient classifiers + tests key on it)…
+      expect(err.message).toMatch(/no connected tab with id "wf:workflows\/x\.json"\. Connected: none/);
+      // …now with the actionable refresh guidance appended.
+      expect(err.message).toMatch(/refresh/i);
+      // The refusal is BEFORE any socket write — nothing was dispatched (fail-closed).
+      expect(dispatchOutcomeOf(err)).toBe(false);
+    });
+
+    it("a HEADLESS-only history (phone mirror, no desktop tab) never claims the desktop pack is installed", async () => {
+      // A canvas-less mobile/remote pseudo-panel connects then drops. It proves neither
+      // that the sidebar pack is installed nor that a browser tab exists to refresh, so
+      // the zero-tab guidance must stay the conservative "install the pack" wording.
+      const phone = await new Promise<WebSocket>((resolve, reject) => {
+        const s = new WebSocket(`ws://127.0.0.1:${port}`);
+        s.on("open", () => {
+          s.send(JSON.stringify({ type: "hello", tab_id: "phone-1", title: "mirror", headless: true }));
+          resolve(s);
+        });
+        s.on("error", reject);
+      });
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      phone.close();
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+      const msg = bridge.status();
+      expect(msg).toMatch(/pack installed/);
+      expect(msg).not.toMatch(/refresh/i);
+    });
+
+    it("a still-live OTHER tab keeps the exact tab listing (not the refresh guidance)", async () => {
+      const a = await connectPanel("tab-aaaa-1111", "one");
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      const err = await bridge
+        .send({ cmd: "graph_add_node" }, { tabId: "wf:workflows/gone.json" })
+        .catch((e) => e as Error);
+      expect(err.message).toMatch(/Connected: tab-aaaa/);
+      expect(err.message).not.toMatch(/refresh/i);
+      a.close();
+    });
+  });
+
+  // #436 priority 1: reads must be HONEST about the binding — a read cannot resolve a
+  // tab the write path can't. Both a read (graph_outline) and a write (graph_add_node)
+  // routed to the SAME id resolve through the SAME registry, so in the zero-tab window
+  // BOTH refuse identically (no read false-positive), and once a tab is live BOTH reach
+  // it. This is the registry-consistency guarantee the reconnect race violated.
+  describe("read/write resolve against the same tab registry (#436.1)", () => {
+    it("in the zero-tab window a read and a write to the same id BOTH refuse (dispatched:false)", async () => {
+      const a = await connectPanel("wf:workflows/x.json", "x");
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      a.close();
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(0));
+      const readErr = await bridge
+        .send({ cmd: "graph_outline" }, { tabId: "wf:workflows/x.json", timeoutMs: 500 })
+        .catch((e) => e as Error);
+      const writeErr = await bridge
+        .send({ cmd: "graph_add_node" }, { tabId: "wf:workflows/x.json", timeoutMs: 500 })
+        .catch((e) => e as Error);
+      expect(readErr).toBeInstanceOf(Error);
+      expect(writeErr).toBeInstanceOf(Error);
+      // The read did NOT falsely resolve while the write was refused — both dispatched:false.
+      expect(dispatchOutcomeOf(readErr)).toBe(false);
+      expect(dispatchOutcomeOf(writeErr)).toBe(false);
+      expect(readErr.message).toMatch(/no connected tab with id "wf:workflows\/x\.json"/);
+    });
+  });
+
   it("resolves via tab-id migration when a socket re-hellos under a new scheme (tmp:→wf:)", async () => {
     // Simulate the bug scenario: a tab first connects with a random-UUID tab id
     // (the old scheme), an agent binds to it, then the SAME socket re-hellos

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3848,7 +3848,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             deferredBind = true;
             rebindNote =
               " No panel tab is connected yet — cleared the stale binding; this session will " +
-              "follow (bind onto) the tab as soon as one reconnects. Retry your graph tool in a moment.";
+              "follow (bind onto) the tab as soon as one reconnects. Retry your graph tool in a " +
+              "moment; if nothing reconnects shortly, ask the user to refresh (reload) the ComfyUI " +
+              "browser tab, which reconnects the Agent panel after a restart (not an install issue).";
           }
           // Detect the rebind regardless of whether awaitReachable or rebindToActiveTab
           // performed it (either mutates ctx.tabId), so the note is never swallowed.

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -497,6 +497,13 @@ export class UiBridge {
    *  `isHeadless` stays true across a disconnect (see isHeadless). */
   private readonly headlessSeen = new Set<string>();
   private seenTabs = new Set<string>(); // tabIds ever announced — dedup connect logs across reconnect churn
+  /** True once a CANVAS-OWNING (non-headless) tab has helloed — i.e. a real ComfyUI
+   *  browser tab with the comfyui-mcp-panel pack was open this session. Distinct from
+   *  `seenTabs`, which also counts headless mobile/remote pseudo-panels: those prove
+   *  neither that the desktop pack is installed nor that a browser tab exists to
+   *  refresh, so they must NOT drive the "refresh the ComfyUI browser tab" guidance
+   *  (#436.4). Never cleared — a faithful "a real panel tab connected once" mark. */
+  private everConnectedDesktopTab = false;
   /** Frames pushed at a tab with NO live connection, buffered for replay when that
    *  tab re-hellos. Per-workflow sessions re-target ONE socket between workflow tab
    *  ids, so a backgrounded workflow's agent output would otherwise be dropped on
@@ -979,6 +986,12 @@ export class UiBridge {
         // (codex round-8 P1).
         migratedProvenSupported = undefined;
         if (incomingHeadless) this.headlessSeen.add(tabId);
+        // A canvas-owning (non-headless) hello PROVES the comfyui-mcp-panel pack is
+        // installed and a real ComfyUI browser tab was open — the precondition for
+        // the "refresh the browser tab" guidance (#436.4). A headless mobile/remote
+        // pseudo-panel must NOT set this: if only a phone ever connected, there may be
+        // no desktop tab to refresh and no proof the sidebar pack is installed (codex).
+        else this.everConnectedDesktopTab = true;
         this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
         // Log a real connect ONCE per tab id. A reconnect/ping-pong loop (a new
         // socket every couple seconds — e.g. two browser contexts sharing one tab
@@ -1302,12 +1315,37 @@ export class UiBridge {
     }));
   }
 
+  /** True once a real CANVAS-OWNING panel tab has connected during this bridge's
+   *  lifetime. When a later state has zero tabs, this distinguishes "the pack is
+   *  installed and a tab merely dropped" (typically a ComfyUI restart or a browser-tab
+   *  reload) from "nothing has ever connected — the pack may be missing". Drives the
+   *  actionable no-panel guidance below (#436 priority 4): a session that flapped after
+   *  a restart must be told to refresh the ComfyUI browser tab, NOT sent to diagnose a
+   *  nonexistent install problem. Uses `everConnectedDesktopTab` (NOT `seenTabs`) so a
+   *  headless-only history — a phone mirror that connected but no desktop tab — never
+   *  triggers desktop-tab guidance (codex). */
+  private hasEverConnected(): boolean {
+    return this.everConnectedDesktopTab;
+  }
+
+  /** Actionable guidance for a ZERO-tab state, shared by `status()` and the tab-id
+   *  resolution refusal so every "no tab" surface says the same true, actionable
+   *  thing. Once a tab has connected, the pack is installed and the tab just
+   *  disconnected — point the user at refreshing the ComfyUI browser tab (the ONLY
+   *  thing that reliably restores the binding after a restart, per #436). Only when
+   *  nothing has EVER connected do we suggest the pack may be missing. */
+  noPanelGuidance(): string {
+    return this.hasEverConnected()
+      ? "the ComfyUI panel tab is not connected — this is almost always because ComfyUI was just restarted or the browser tab reloaded, which drops the Agent panel's socket. Ask the user to refresh (reload) the ComfyUI browser tab to reconnect the Agent panel, then retry. (The comfyui-mcp-panel pack IS installed — a tab connected earlier this session — so this is a reconnect, not an install problem.)"
+      : "no panel connected — open ComfyUI with the comfyui-mcp-panel pack installed and check the Agent sidebar tab";
+  }
+
   status(): string {
     if (this.portInUse) {
       return `port ${this.port} is held by another comfyui-mcp session — close that session (or whatever owns the port) and reconnect`;
     }
     if (this.conns.size === 0) {
-      return "no panel connected — open ComfyUI with the comfyui-mcp-panel pack installed and check the Agent sidebar tab";
+      return this.noPanelGuidance();
     }
     const lines = this.tabs().map(
       (t) =>
@@ -1338,12 +1376,22 @@ export class UiBridge {
         }
       }
       if (prefixed.length === 1) return prefixed[0];
+      if (prefixed.length > 1) {
+        throw new Error(`tab_id "${tabId}" is ambiguous — matches ${prefixed.length} tabs`);
+      }
+      const connected = this.tabs();
+      // ZERO tabs → this is the post-restart "Connected: none" window. Keep the
+      // machine-readable "no connected tab … Connected: none" phrase intact (the
+      // panel-tools retry/transient classifier and existing tests key on it) but
+      // APPEND the actionable next step so the agent stops diagnosing a nonexistent
+      // install problem and instead surfaces the real fix — refresh the ComfyUI
+      // browser tab (#436 priority 4). Other-tabs-live keeps the exact tab listing.
       throw new Error(
-        prefixed.length > 1
-          ? `tab_id "${tabId}" is ambiguous — matches ${prefixed.length} tabs`
-          : `no connected tab with id "${tabId}". Connected: ${this.tabs()
+        connected.length === 0
+          ? `no connected tab with id "${tabId}". Connected: none — ${this.noPanelGuidance()}`
+          : `no connected tab with id "${tabId}". Connected: ${connected
               .map((t) => `${t.tab_id.slice(0, 8)} (“${t.title}”)`)
-              .join(", ") || "none"}`,
+              .join(", ")}`,
       );
     }
     if (this.conns.size === 1) {


### PR DESCRIPTION
## What / why

Residual of the **reconnect/session-binding race after a ComfyUI restart** cluster (panel `#436`, `#442`).

**Verify-first — what was already shipped (not re-fixed here):**
- Writes await a stable binding before dispatch (no post-restart flap) — `2f8f322` (#436 mechanism).
- Auto-rebind on `Connected: none` + `panel_set_widget` names the rebind call — `af49bc8` (#442 defect 4).
- `panel_set_workflow_target({mode:'current'})` defers/rebinds instead of hard-failing — panel-session-rebind residuals.

**The residual (this PR):** panel `#436` **priority 4** — the "no panel connected" guidance still told the agent the *pack may not be installed*, sending it to diagnose a nonexistent install problem in exactly the post-restart window where the pack is provably installed and the real fix is **refresh the ComfyUI browser tab**. That wording is the literal error the reporter hit:
> `Error: Panel not reachable: no panel connected - open ComfyUI with the comfyui-mcp-panel pack installed and check the Agent sidebar tab`

## Fix (message-only)

- Track `everConnectedDesktopTab` — set only on a **non-headless** hello (a real ComfyUI browser tab with the pack). A headless mobile/remote pseudo-panel does **not** set it, so a phone-only history never triggers desktop-tab guidance.
- `status()` and the tab-id `Connected: none` `resolveTarget` refusal now say **refresh the ComfyUI browser tab** once a real tab has connected; a never-connected (or headless-only) history keeps the conservative install-the-pack wording.
- `panel_set_workflow_target` defer note escalates to the same browser-refresh advice.

**Invariants preserved (fail-closed, #458):** purely message text. The machine-readable phrases (`no connected tab with id "…". Connected: none`, `Panel not reachable`) are intact so the transient/rebind classifiers still fire, and pre-write refusals keep their `dispatched:false` typed flag — a write still never fabricates success.

## Tests

New regression coverage in `ui-bridge.test.ts`:
- install-vs-refresh wording keyed on connection history;
- headless-only history stays conservative (never claims the desktop pack is installed);
- a write to the pre-restart id after the drop carries the refresh guidance **and** keeps `Connected: none` + `dispatched:false`;
- other-tabs-live keeps the exact tab listing (ambiguity/#474 path unaffected);
- **#436.1** read/write resolve against the same registry — a read cannot resolve a tab the write path can't (both refuse `dispatched:false` in the zero-tab window).

`npm run build` + `npm test` green (pre-existing unrelated `node-dev` ripgrep-environment failure only). Codex adversarial self-review (fail-closed + rebind invariants): **PASS** after fixing one flagged P2 (headless-only false positive).

## Scope / not in this PR

- Addresses artokun/comfyui-mcp-panel#436 (priority 4). Priorities 1–3 mechanisms were already shipped; a registry-consistency test for priority 1 is included.
- Addresses artokun/comfyui-mcp-panel#442 defect 4 wording (already shipped; verified). **Defect 5** (a ComfyUI restart closes every workflow tab — data loss) is **panel-side** and left for a separate, live-tested panel PR: it depends on ComfyUI's own open-workflow persistence and blind-patching the reconnect/reload path without the browser rig risks regressing the reconnect flow.
- Not `Closes` (cross-repo + partial): closing keywords deliberately omitted so panel `#442` stays open for defect 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)