### PR TITLE
fix(panel-tools): document panel_open_workflow stale-tab signal (#442 defect 2)

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3890,7 +3890,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_open_workflow",
-      "Open / switch to a workflow by path or filename (from panel_list_workflows). Switches the active tab to it. If the workflow was ALREADY open and its .json changed on disk out-of-band, the result carries stale:true with a stale_hint — the canvas still shows the version this tab loaded (it is NOT auto-reloaded); call panel_load_workflow to load the on-disk version.",
+      "Open / switch to a workflow by path or filename (from panel_list_workflows). Switches the active tab to it. If the workflow was ALREADY open and its .json changed on disk out-of-band, the result carries stale:true (or stale:\"unknown\" when staleness couldn't be verified) with a stale_hint — the canvas still shows the version this tab loaded (it is NOT auto-reloaded); call panel_load_workflow to load the on-disk version.",
       { path: z.string().describe("Workflow path, filename, or key from panel_list_workflows.") },
       // Verify-after-timeout (#215/#319/#496): a backgrounded/frozen or already-open
       // tab can be slow to ack workflow_open even though the switch succeeded. On an

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3890,7 +3890,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_open_workflow",
-      "Open / switch to a workflow by path or filename (from panel_list_workflows). Switches the active tab to it.",
+      "Open / switch to a workflow by path or filename (from panel_list_workflows). Switches the active tab to it. If the workflow was ALREADY open and its .json changed on disk out-of-band, the result carries stale:true with a stale_hint — the canvas still shows the version this tab loaded (it is NOT auto-reloaded); call panel_load_workflow to load the on-disk version.",
       { path: z.string().describe("Workflow path, filename, or key from panel_list_workflows.") },
       // Verify-after-timeout (#215/#319/#496): a backgrounded/frozen or already-open
       // tab can be slow to ack workflow_open even though the switch succeeded. On an


### PR DESCRIPTION
Companion MCP-side change for #442 defect 2. The behavior lands in the panel PR (artokun/comfyui-mcp-panel#fix/panel-wf-file-tools-442); this only enriches the `panel_open_workflow` tool description so agents know to check the new signal.

## What changed
`panel_open_workflow`'s description now documents that, if the workflow was ALREADY open and its `.json` changed on disk out-of-band, the result carries `stale:true` with a `stale_hint` — the canvas still shows the version the tab loaded (it is NOT auto-reloaded), and the caller should call `panel_load_workflow` to load the on-disk version.

The result already passes through verbatim on the success path (`openWorkflowWithVerify` only reshapes on ack-timeout), so no code change is needed for the flags to reach callers.

## Not changed
- Defect 1 (node-resize) already shipped as `panel_resize_node` (#530).
- Defect 3 (save 409) is panel-side only.
- Tool count unchanged — `node scripts/asset-counts.mjs --check` passes.

## Tests / build
`npm run build` clean; asset-counts check passes. (One pre-existing `node-dev.test.ts` failure is environmental — this machine has ripgrep installed so `searchNodePacks` selects the `ripgrep` engine over the `builtin` fallback the test expects; unrelated to this one-line description change.)

Addresses #442 (defect 2). **Do not merge yet** — coordinated with the panel PR before #442 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
