### PR TITLE
fix(tools): stable call_tool escape hatch so direct tools survive panel reconnect (#616)

### DIFF
--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ToolCatalog } from "../../tools/catalog.js";
 import { buildManifest, registerCompactTools, summarize } from "../../tools/compact.js";
-import { collectToolCatalog } from "../../tools/index.js";
+import { collectToolCatalog, registerFullTools } from "../../tools/index.js";
 
 function textOf(result: { content?: Array<{ type: string; text?: string }> }): string {
   return (result.content ?? [])
@@ -206,6 +206,130 @@ describe("compact mode over a real MCP client/server pair", () => {
     })) as { isError?: boolean };
     expect(res.isError).toBe(true);
     expect(textOf(res as never)).toContain("boom");
+  });
+});
+
+describe("full mode + facade escape hatch (#616)", () => {
+  // A code-execution MCP client snapshots the tool surface from tools/list and
+  // exposes each as a callable `tools.mcp__comfyui__<tool>`. After a ComfyUI
+  // restart + panel resume that snapshot can go stale and a cached direct
+  // binding throws "is not a function". registerFullTools guarantees the direct
+  // surface AND the facade (list_tools/describe_tool/call_tool) are advertised
+  // together as ONE consistent snapshot, so `call_tool` is always a stable
+  // route to any direct tool.
+  async function fullPair(opts?: { facade?: boolean }): Promise<Client> {
+    const server = new McpServer({ name: "test-full", version: "0.0.0" });
+    await registerFullTools(server, opts);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-full-client", version: "0.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return client;
+  }
+
+  it("advertises the direct tools AND the facade as one consistent snapshot", async () => {
+    const client = await fullPair();
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    // Direct tools survive (the ones that vanished for the reporter).
+    for (const t of ["get_environment", "health_check", "list_local_models", "calculate"]) {
+      expect(names.has(t), `full surface missing direct tool ${t}`).toBe(true);
+    }
+    // Facade escape hatch is present alongside them.
+    for (const f of ["list_tools", "describe_tool", "call_tool"]) {
+      expect(names.has(f), `full surface missing facade tool ${f}`).toBe(true);
+    }
+  }, 30_000);
+
+  it("routes a direct tool through call_tool (transparent fallback for a stale binding)", async () => {
+    const client = await fullPair();
+    // `calculate` is a pure, offline tool (no ComfyUI connection) — a safe stand-in
+    // for the reporter's get_environment. Reaching it via call_tool proves the
+    // facade dispatches to the SAME direct handler, so a client that lost the
+    // direct binding across a reconnect never dead-ends.
+    const res = await client.callTool({
+      name: "call_tool",
+      arguments: { name: "calculate", args: { spec: "2 + 2" } },
+    });
+    const text = textOf(res as never);
+    expect(text).not.toContain("Unknown tool");
+    expect((res as { isError?: boolean }).isError).not.toBe(true);
+    expect(text).toContain("4");
+  }, 30_000);
+
+  it("honors { facade: false } (COMFYUI_MCP_NO_FACADE opt-out) — direct tools only", async () => {
+    const client = await fullPair({ facade: false });
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    expect(names.has("get_environment")).toBe(true);
+    for (const f of ["list_tools", "describe_tool", "call_tool"]) {
+      expect(names.has(f), `facade should be absent when opted out (${f})`).toBe(false);
+    }
+  }, 30_000);
+
+  it("honors COMFYUI_MCP_NO_FACADE=1 via env (no opts) — direct tools only", async () => {
+    const prev = process.env.COMFYUI_MCP_NO_FACADE;
+    process.env.COMFYUI_MCP_NO_FACADE = "1";
+    try {
+      const client = await fullPair(); // no opts → env decides
+      const names = new Set((await client.listTools()).tools.map((t) => t.name));
+      expect(names.has("get_environment")).toBe(true);
+      expect(names.has("call_tool")).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.COMFYUI_MCP_NO_FACADE;
+      else process.env.COMFYUI_MCP_NO_FACADE = prev;
+    }
+  }, 30_000);
+});
+
+describe("facade collision guard (#616 / codex P1)", () => {
+  // If a direct tool already claims a facade meta-tool name (e.g. an autoloaded
+  // workflow named `call_tool`), the live McpServer would throw on the duplicate
+  // registration and crash startup. The guarantee here is: startup never crashes,
+  // the first (direct) registration keeps the name, and the rest of the facade
+  // still registers. A workflow named after a reserved meta is a namespace
+  // conflict the user created; we warn rather than silently hijack it.
+  it("skips a reserved name via the skip set without throwing", async () => {
+    const server = new McpServer({ name: "test-collide", version: "0.0.0" });
+    // A "direct" tool that squats the call_tool name (stands in for a workflow file).
+    server.tool("call_tool", "A workflow that happens to be named call_tool.", {}, async () => ({
+      content: [{ type: "text" as const, text: "workflow-call_tool" }],
+    }));
+    const catalog = fakeCatalog();
+    // Would throw "call_tool is already registered" without the skip guard.
+    expect(() => registerCompactTools(server, catalog, { skip: new Set(["call_tool"]) })).not.toThrow();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "c", version: "0.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    // The direct tool survives; the other two metas still register.
+    expect(names.has("call_tool")).toBe(true);
+    expect(names.has("list_tools")).toBe(true);
+    expect(names.has("describe_tool")).toBe(true);
+    // And the surviving call_tool is the DIRECT one, not the facade meta.
+    const res = await client.callTool({ name: "call_tool", arguments: {} });
+    expect(textOf(res as never)).toBe("workflow-call_tool");
+  });
+
+  it("does NOT crash even when skip MISSES the collision (the pass-1/pass-2 race backstop)", async () => {
+    // Simulates codex P1b: the catalog-based skip set fails to include a name that
+    // is actually already on the live server (e.g. a reserved-name workflow removed
+    // between the two discovery passes). registerCompactTools's try/catch must
+    // swallow the duplicate-registration throw instead of crashing startup.
+    const server = new McpServer({ name: "test-race", version: "0.0.0" });
+    server.tool("list_tools", "A workflow squatting list_tools.", {}, async () => ({
+      content: [{ type: "text" as const, text: "workflow-list_tools" }],
+    }));
+    // No skip set → the wrapper attempts to register list_tools again and must NOT throw.
+    expect(() => registerCompactTools(server, fakeCatalog())).not.toThrow();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "c", version: "0.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    // The other two metas still register; the squatting direct tool keeps its name.
+    expect(names.has("describe_tool")).toBe(true);
+    expect(names.has("call_tool")).toBe(true);
+    const res = await client.callTool({ name: "list_tools", arguments: {} });
+    expect(textOf(res as never)).toBe("workflow-list_tools");
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { registerAllTools, collectToolCatalog } from "./tools/index.js";
+import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
@@ -121,7 +121,11 @@ async function createConfiguredServer(toolMode: ToolMode = "full"): Promise<McpS
       `Compact tool mode: ${catalog.tools.size} tools available via list_tools/describe_tool/call_tool`,
     );
   } else {
-    await registerAllTools(server);
+    // Full direct surface PLUS the compact facade (list_tools/describe_tool/
+    // call_tool) as a stable reconnect escape hatch — see registerFullTools and
+    // issue #616. One atomic registration pass, completed before the transport
+    // connects below. Opt out of the facade with COMFYUI_MCP_NO_FACADE=1.
+    await registerFullTools(server);
   }
 
   server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { errorToToolResult } from "../utils/errors.js";
+import { logger } from "../utils/logger.js";
 import type { CatalogedTool, ToolCatalog } from "./catalog.js";
 
 /** First sentence of a tool description, hard-capped so the manifest stays token-light. */
@@ -78,8 +79,37 @@ export function buildManifest(
  * MCP client on a non-frontier LLM) where 200 JSON schemas blow the context
  * budget — see issue #97.
  */
-export function registerCompactTools(server: McpServer, catalog: ToolCatalog): void {
-  server.tool(
+export function registerCompactTools(
+  server: McpServer,
+  catalog: ToolCatalog,
+  opts: { skip?: ReadonlySet<string> } = {},
+): void {
+  // A caller may reserve some meta-tool names — e.g. registerFullTools layers the
+  // facade onto the full direct surface, and if the user has an autoloaded
+  // workflow literally named `call_tool`/`list_tools`/`describe_tool`, that name
+  // is ALREADY registered on the live server; re-registering it here would throw
+  // (McpServer rejects duplicate tool names) and take down startup. `skip`
+  // dedups the EXPECTED collisions the caller detected. The try/catch is the
+  // belt-and-suspenders: collision detection relies on a catalog snapshot that
+  // could, in a startup race, disagree with what's actually on the live server
+  // (a workflow file removed between the two discovery passes), so a duplicate
+  // that slips past `skip` is swallowed and logged rather than crashing startup.
+  // In every collision case the FIRST registration (the user's direct tool)
+  // keeps the name; the rest of the facade still registers. (#616)
+  const skip = opts.skip ?? new Set<string>();
+  const register: McpServer["tool"] = ((...args: Parameters<McpServer["tool"]>) => {
+    const name = args[0] as string;
+    if (skip.has(name)) return undefined as unknown as ReturnType<McpServer["tool"]>;
+    try {
+      return server.tool(...args);
+    } catch (err) {
+      logger.warn(
+        `[compact] skipping facade meta-tool '${name}' — already registered (name collision): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined as unknown as ReturnType<McpServer["tool"]>;
+    }
+  }) as McpServer["tool"];
+  register(
     "list_tools",
     "List every comfyui-mcp capability as a token-light catalog: tool names with one-line summaries, grouped by category. Start here. Then use describe_tool to get a tool's parameters and call_tool to run it.",
     {
@@ -95,7 +125,7 @@ export function registerCompactTools(server: McpServer, catalog: ToolCatalog): v
     async (args) => text(buildManifest(catalog, args)),
   );
 
-  server.tool(
+  register(
     "describe_tool",
     "Get the full description and JSON Schema of one tool from the catalog. Always call this before the first call_tool of a tool you haven't used in this session.",
     {
@@ -123,7 +153,7 @@ export function registerCompactTools(server: McpServer, catalog: ToolCatalog): v
     },
   );
 
-  server.tool(
+  register(
     "call_tool",
     "Execute a tool from the catalog by name. Pass its parameters in `args` (object). The result is exactly what the underlying tool returns.",
     {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -63,6 +63,8 @@ import { registerTemplateSchemaTools } from "./template-schema.js";
 import { registerRunTemplateTools } from "./run-template.js";
 import { DefaultsManager } from "../services/defaults-manager.js";
 import { ToolCatalog } from "./catalog.js";
+import { registerCompactTools } from "./compact.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * Every static tool group, in registration order (order is observable in
@@ -198,6 +200,69 @@ export async function registerAllTools(server: McpServer): Promise<void> {
   const gated = withBlindImageGate(server);
   for (const [, register] of TOOL_GROUPS) register(gated);
   await registerAutoloadedWorkflows(gated);
+}
+
+/**
+ * Default (non-compact) registration WITH the compact facade layered on top.
+ *
+ * #616 — reconnect resilience: a code-execution MCP client (the SDK's
+ * `exec_main.mjs` harness that exposes each tool as a callable
+ * `tools.mcp__comfyui__<tool>`) snapshots the tool surface from a `tools/list`.
+ * After the user restarts ComfyUI and the panel session resumes, that snapshot
+ * can go stale — a previously-bound direct tool is briefly absent from the
+ * refreshed surface, and calling the cached binding throws
+ * `TypeError: tools.mcp__comfyui__get_environment is not a function` BEFORE
+ * dispatch. Layering the facade (`list_tools` / `describe_tool` / `call_tool`)
+ * onto the full direct surface guarantees EVERY advertised surface — compact or
+ * full — carries a STABLE `call_tool` escape hatch, so such a client can always
+ * route a missing direct tool through `call_tool({ name, args })` instead of
+ * dead-ending. The direct tools and the facade are registered in ONE atomic
+ * pass here, before the transport is connected, so a resumed turn never sees a
+ * half-built catalog (facade-only) missing the direct tools.
+ *
+ * The facade adds only 3 tools to the surface and reuses the SAME underlying
+ * handlers (via collectToolCatalog), so there is no divergence between a direct
+ * call and its `call_tool` route. Opt out with COMFYUI_MCP_NO_FACADE=1 (env) or
+ * `{ facade: false }`.
+ */
+export async function registerFullTools(
+  server: McpServer,
+  opts: { facade?: boolean } = {},
+): Promise<void> {
+  await registerAllTools(server);
+  const facade = opts.facade ?? process.env.COMFYUI_MCP_NO_FACADE !== "1";
+  if (facade) {
+    // Capture the same registration into a catalog; call_tool dispatches to these
+    // handlers, so the facade route is behaviorally identical to a direct call.
+    // Built and registered in-sequence with the direct surface above and BEFORE
+    // server.connect(), so the whole snapshot is atomic (no half-built tools/list).
+    //
+    // NOTE: this is a SECOND filesystem discovery of autoloaded workflows. In the
+    // (sub-millisecond) window between the two passes a workflow could be added or
+    // removed; the divergence self-heals on the next spawn — call_tool routes
+    // through THIS catalog (internally consistent), and at worst a just-removed
+    // workflow stays directly listed but unreachable via call_tool, or a just-added
+    // one is reachable via call_tool before it appears in the direct list. Neither
+    // drops an established tool. The one race that could otherwise CRASH startup —
+    // a reserved-name workflow present in pass 1 (registered live) but gone from
+    // pass 2's catalog, so `skip` misses it and the facade double-registers — is
+    // caught inside registerCompactTools (it swallows a duplicate-name throw).
+    const catalog = await collectToolCatalog();
+    // Collision guard (fast path): if a user's autoloaded workflow is literally
+    // named after a facade meta-tool, registerAllTools already claimed that name on
+    // the live server. Skip the colliding meta(s) cleanly (no error noise) and keep
+    // the direct tool + the rest of the facade. registerCompactTools's try/catch
+    // still backstops any collision this snapshot-based check misses. (#616 / codex P1)
+    const reserved = ["list_tools", "describe_tool", "call_tool"] as const;
+    const skip = new Set(reserved.filter((name) => catalog.get(name)));
+    if (skip.size > 0) {
+      logger.warn(
+        `[tools] facade meta-tool name(s) already claimed by a direct tool — not layering the facade for: ${[...skip].join(", ")}. ` +
+          `Rename the conflicting workflow file(s) to expose the full facade.`,
+      );
+    }
+    registerCompactTools(server, catalog, { skip });
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #616

## Root cause

After the user restarts ComfyUI and the embedded panel session resumes, a code-execution MCP client (the SDK's `exec_main.mjs` harness that exposes each MCP tool as a callable `tools.mcp__comfyui__<tool>`) can hold a **stale tool-surface snapshot**. A previously-bound direct tool (`get_environment`) is briefly absent from the refreshed surface, so calling the cached binding throws — **before dispatch**:

```
TypeError: tools.mcp__comfyui__get_environment is not a function at exec_main.mjs:2:9
```

The generic facade (`list_tools` / `describe_tool` / `call_tool`) survived. The underlying reason: the comfyui MCP server registered **either** the ~250 direct tools (full mode) **or** only the 3-tool facade (compact mode) — never both. A client whose direct binding went stale across the reconnect had no stable escape hatch to fall back on.

## Fix

Full mode now registers the compact facade **alongside** the direct tools (new `registerFullTools`), in **one atomic registration pass before `server.connect()`** — so a resumed turn never sees a half-built catalog, and **every advertised surface (compact or full) carries a stable `call_tool`**. A client with a stale/missing direct binding can transparently route through `call_tool({ name, args })` instead of dead-ending. `call_tool` dispatches to the **same** blind-gated handlers, so the route is behaviorally identical to a direct call.

- Direct tools **and** the facade are advertised as one consistent snapshot.
- Opt out with `COMFYUI_MCP_NO_FACADE=1` (or `{ facade: false }`).
- Compact mode, the #291 http-lane compact default, `asset-counts` (uses `collectToolCatalog`, unchanged), and the blind-image gate are untouched.

### Collision safety (from adversarial review)

If a user's autoloaded workflow is literally named after a facade meta-tool, `registerFullTools` detects the collision from the catalog and skips that meta cleanly (the direct tool keeps the name). As defense-in-depth against a startup race where the catalog snapshot disagrees with the live server (a reserved-name workflow removed between the two discovery passes), `registerCompactTools` wraps each meta registration in `try/catch` — a duplicate that slips past the skip check is swallowed + logged rather than crashing startup.

## Tests (`src/__tests__/tools/compact.test.ts`)

- Full surface advertises the direct tools **and** the facade as one snapshot.
- A direct tool (`calculate`, pure/offline) routes correctly via `call_tool`.
- `{ facade: false }` and `COMFYUI_MCP_NO_FACADE=1` opt-outs (direct tools only).
- Collision skip preserves the direct tool + the rest of the facade.
- Pass-1/pass-2 race backstop: no crash when the skip set misses the collision.

`npm run build` clean; `npm test` green except the pre-existing, unrelated env-dependent `node-dev` ripgrep test (identical on `origin/main` — ripgrep is installed locally so the builtin-fallback branch isn't exercised).

Adversarial `codex` self-review: 3 rounds, final verdict **PASS** (round-1 P1 name-collision and round-2 P1 startup-race both fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)