### PR TITLE
0.48.29 — consent timeout-survival, reconnect guidance + tool-surface, query-graph bounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.29] - 2026-08-01
+
+### MCP
+
+#### Fixed
+- layer the compact facade onto full mode so a stable call_tool survives panel reconnect (#616) (#620)
+- keep queryApiGraph token-bound so one blob can't starve the node you asked for (#609) (#617)
+- actionable no-panel guidance after a reconnect drop (panel #436, #442) (#615)
+- survive idle-user timeout on the adult-consent card (panel#390) (#610)
+
+
 ## [0.48.28] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.28",
+  "version": "0.48.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.28",
+      "version": "0.48.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.28",
+  "version": "0.48.29",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
mcp 0.48.29. Four merged correctness/consent fixes:

- **#610** consent: survive idle-user timeout on the adult-consent card (panel#390) — my independent codex verified fail-closed.
- **#615** ui-bridge: actionable no-panel guidance after a reconnect drop (panel #436/#442).
- **#617** graph-query: keep queryApiGraph token-bound so one blob can't starve the node you asked for (#609).
- **#620** tools: layer the compact facade onto full mode so a stable call_tool survives panel reconnect (#616).

Non-destructive batch (read/message/tool-surface/consent) — verified via full test suites (2847), all-OS CI, pack-install smoke, my codex on the consent gate + agents' codex PASS. Tag publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)