### PR TITLE
fix(panel): desktop-canvas fall-through for headless-bound set_todo/open_civitai (#624)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1283,6 +1283,180 @@ describe("panel-tools: post-reconnect retry-once (#278/#310/#332/#481)", () => {
   });
 });
 
+describe("panel-tools: desktop-canvas fall-through for headless-bound sessions (#624)", () => {
+  // The mobile / remote pseudo-panel is a HEADLESS bridge client: it accepts only
+  // show_media and rejects every other ServerCommand with "mobile client has no open
+  // canvas". A DESKTOP panel surface command (set_todo footer tray, open_civitai
+  // in-panel browser) must therefore NOT be dispatched at a headless client — it must
+  // resolve the live desktop canvas tab (the same canvas-owning filter graph tools
+  // use) when the session's bound tab is headless, and fail with the REAL reason when
+  // no single canvas can be picked — never surface the misleading mobile string.
+  //
+  // `lastActive` mirrors the real UiBridge.resolveActiveTabId: a sole tab resolves,
+  // an explicit last-active id resolves among 2+, otherwise it throws the ambiguity.
+  function headlessAwareBridge(
+    tabs: Array<{ id: string; headless: boolean }>,
+    lastActive?: string,
+  ) {
+    const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+    const byId = new Map(tabs.map((t) => [t.id, t]));
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        const id = opts?.tabId;
+        if (id && !byId.has(id)) {
+          throw new Error(`no connected tab with id "${id}". Connected: none`);
+        }
+        sent.push({ cmd, tabId: id });
+        return { ok: true, routedTo: id };
+      },
+      push: () => 1,
+      isHeadless: (id: string) => byId.get(id)?.headless === true,
+      canReach: (id: string) => byId.has(id),
+      tabs: () => tabs.map((t) => ({ tab_id: t.id, title: t.id, connected_at: 0 })),
+      resolveActiveTabId: () => {
+        if (lastActive) return lastActive;
+        if (tabs.length === 1) return tabs[0].id;
+        throw new Error("Multiple panel tabs are connected and none is last active — pass tab_id.");
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    return { bridge, sent };
+  }
+
+  const MOBILE_ERR = /mobile client has no open canvas/i;
+
+  beforeAll(() => __panelToolsTestHooks.setRetrySettleMs(0));
+  afterAll(() => __panelToolsTestHooks.setRetrySettleMs(null));
+
+  it("panel_set_todo redirects onto the live desktop canvas when the session is bound to a headless tab", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = headlessAwareBridge([
+      { id: "mobile-tab", headless: true },
+      { id: "desktop-tab", headless: false },
+    ]);
+    // Session bound to the headless mobile tab, but a real desktop canvas is open.
+    const ctx = makePanelToolCtx(bridge, "mobile-tab", store);
+    const res = await defByName("panel_set_todo").handler(
+      { items: [{ text: "step 1", status: "active" }] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect((res.content[0] as { text: string }).text).not.toMatch(MOBILE_ERR);
+    // Dispatched at the DESKTOP canvas, not the headless mobile tab.
+    expect(sent.at(-1)).toMatchObject({ cmd: { cmd: "set_todo" }, tabId: "desktop-tab" });
+    // The session's own binding is left intact (no silent hijack of ctx.tabId).
+    expect(ctx.tabId).toBe("mobile-tab");
+  });
+
+  it("panel_open_civitai redirects onto the live desktop canvas when the session is bound to a headless tab", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = headlessAwareBridge([
+      { id: "mobile-tab", headless: true },
+      { id: "desktop-tab", headless: false },
+    ]);
+    const ctx = makePanelToolCtx(bridge, "mobile-tab", store);
+    const res = await defByName("panel_open_civitai").handler(
+      { tab: "loras", browsingLevels: [1, 2] },
+      ctx,
+    );
+    expect(res.isError).toBeFalsy();
+    expect((res.content[0] as { text: string }).text).not.toMatch(MOBILE_ERR);
+    expect(sent.at(-1)).toMatchObject({ cmd: { cmd: "open_civitai" }, tabId: "desktop-tab" });
+    expect(ctx.tabId).toBe("mobile-tab");
+  });
+
+  it("fails with the REAL reason (not the mobile string) when the ONLY client is canvas-less", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = headlessAwareBridge([{ id: "mobile-tab", headless: true }]);
+    const ctx = makePanelToolCtx(bridge, "mobile-tab", store);
+    const res = await defByName("panel_set_todo").handler({ items: [] }, ctx);
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).not.toMatch(MOBILE_ERR);
+    expect(text).toMatch(/canvas-less|desktop panel canvas|comfyui browser tab/i);
+    // Nothing was blasted at the headless client.
+    expect(sent.length).toBe(0);
+  });
+
+  it("leaves a normal desktop-bound session on the standard ctx.call path (no redirect)", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = headlessAwareBridge([{ id: "desktop-tab", headless: false }]);
+    const ctx = makePanelToolCtx(bridge, "desktop-tab", store);
+    const res = await defByName("panel_set_todo").handler({ items: [] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(sent.at(-1)).toMatchObject({ cmd: { cmd: "set_todo" }, tabId: "desktop-tab" });
+  });
+
+  it("redirects onto the LAST-ACTIVE desktop canvas among multiple desktop tabs", async () => {
+    const store = new WorkflowTargetStore();
+    const { bridge, sent } = headlessAwareBridge(
+      [
+        { id: "mobile-tab", headless: true },
+        { id: "desktop-a", headless: false },
+        { id: "desktop-b", headless: false },
+      ],
+      "desktop-b", // last-active is an interactive desktop tab
+    );
+    const ctx = makePanelToolCtx(bridge, "mobile-tab", store);
+    const res = await defByName("panel_set_todo").handler({ items: [] }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(sent.at(-1)).toMatchObject({ cmd: { cmd: "set_todo" }, tabId: "desktop-b" });
+  });
+
+  it("fails with an ACCURATE ambiguity error (not the mobile string) when 2+ desktop tabs and none is last-active", async () => {
+    const store = new WorkflowTargetStore();
+    // Headless-bound + two desktop tabs + resolveActiveTabId throws (no last-active):
+    // must NOT fall through to ctx.call (that would re-dispatch at the headless tab and
+    // reproduce the mobile string) — it must fail with the real multi-desktop reason.
+    const { bridge, sent } = headlessAwareBridge([
+      { id: "mobile-tab", headless: true },
+      { id: "desktop-a", headless: false },
+      { id: "desktop-b", headless: false },
+    ]);
+    const ctx = makePanelToolCtx(bridge, "mobile-tab", store);
+    const res = await defByName("panel_open_civitai").handler({}, ctx);
+    expect(res.isError).toBe(true);
+    const text = (res.content[0] as { text: string }).text;
+    expect(text).not.toMatch(MOBILE_ERR);
+    expect(text).toMatch(/multiple desktop tabs|pick one/i);
+    expect(sent.length).toBe(0);
+  });
+
+  it("retry-safe set_todo redirect recovers from a transient drop by re-resolving the desktop tab (#481 parity)", async () => {
+    const store = new WorkflowTargetStore();
+    const sent: Array<{ cmd: Record<string, unknown>; tabId?: string }> = [];
+    // Bound to a headless tab. The desktop tab drops mid-send once (throws a transient
+    // "no connected tab") then reconnects under a NEW id — the redirect must re-resolve
+    // and retry the idempotent set_todo onto the reconnected desktop tab.
+    let liveDesktop = "desktop-old";
+    let dropsLeft = 1;
+    const headlessId = "mobile-tab";
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (dropsLeft > 0) {
+          dropsLeft--;
+          liveDesktop = "desktop-new";
+          throw new Error(`no connected tab with id "${opts?.tabId}". Connected: none`);
+        }
+        sent.push({ cmd, tabId: opts?.tabId });
+        return { ok: true, routedTo: opts?.tabId };
+      },
+      push: () => 1,
+      isHeadless: (id: string) => id === headlessId,
+      canReach: (id: string) => id === headlessId || id === liveDesktop,
+      tabs: () => [
+        { tab_id: headlessId, title: "mobile", connected_at: 0 },
+        { tab_id: liveDesktop, title: "desktop", connected_at: 0 },
+      ],
+      resolveActiveTabId: () => liveDesktop,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, headlessId, store);
+    const res = await defByName("panel_set_todo").handler({ items: [] }, ctx);
+    expect(res.isError).toBeFalsy();
+    // Re-resolved onto the RECONNECTED desktop tab, not the stale id or the headless tab.
+    expect(sent.at(-1)).toMatchObject({ cmd: { cmd: "set_todo" }, tabId: "desktop-new" });
+  });
+});
+
 describe("panel-tools: session tabId self-heal (#322 reload / #331 workflow-switch / #332 reconnect)", () => {
   // A minimal fake bridge modelling the ONE fact that matters: which tab ids are
   // currently live. `send` routes only to a live id (throws `no connected tab`

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2505,6 +2505,120 @@ function askSurfaceError(ctx: PanelToolCtx): string | null {
   );
 }
 
+/**
+ * Route a canvas-requiring panel UI command (set_todo, open_civitai) onto the live
+ * DESKTOP canvas tab when THIS session's bound tab is a headless (mobile/remote)
+ * client (#624). The mobile / remote pseudo-panel accepts ONLY show_media and
+ * rejects every other ServerCommand with the (client-authored) string "mobile
+ * client has no open canvas" — a misleading, mobile-specific error even when a real
+ * desktop ComfyUI canvas is open in the same session. These commands render on the
+ * desktop panel surface (the footer TODO tray, the in-panel CivitAI browser), so
+ * when the bound tab is canvas-less we resolve the SAME interactive desktop tab the
+ * graph/workflow tools bind to instead of blasting the command at the headless
+ * client. This is the desktop fall-through; genuine tab-mirror sessions are bound to
+ * the desktop tab already (non-headless) and are therefore untouched.
+ *
+ * Returns:
+ *  - `{ tabId }`  → REDIRECT the dispatch onto the interactive (canvas-owning)
+ *    desktop tab (the sole one, else the last-active one when it is itself a canvas);
+ *  - `{ error }`  → the ONLY connected client is canvas-less, so fail with the REAL
+ *    reason (named honestly) rather than surfacing the raw mobile "no open canvas";
+ *  - `null`       → the bound tab is already a reachable canvas, the choice among 2+
+ *    desktop tabs is ambiguous, or the bridge can't enumerate headlessness — in every
+ *    such case the normal `ctx.call` path (unchanged) runs.
+ */
+function desktopCanvasRedirect(
+  ctx: PanelToolCtx,
+  label: string,
+): { tabId?: string; error?: string } | null {
+  const b = ctx.bridge as unknown as {
+    isHeadless?: (id: string) => boolean;
+    tabs?: () => Array<{ tab_id: string }>;
+    resolveActiveTabId?: () => string;
+  };
+  // Older / lightweight bridges can't classify tabs — leave routing exactly as-is.
+  if (typeof b.isHeadless !== "function" || typeof b.tabs !== "function") return null;
+  // Only intervene when THIS session is bound to a canvas-less (mobile/remote) client.
+  // A desktop-bound session — healthy, or merely orphaned by a reconnect — is left to
+  // the normal ctx.call path and its reconnect/rebind machinery untouched.
+  if (!b.isHeadless(ctx.tabId)) return null;
+  // Bound to a headless client: find the interactive (canvas-owning) DESKTOP tabs, the
+  // SAME filter rebindToActiveTab/ensureReachable use for graph/workflow bindings.
+  const live = b.tabs();
+  const interactive = Array.isArray(live)
+    ? live.filter((t) => !b.isHeadless!(t.tab_id))
+    : [];
+  if (interactive.length === 1) return { tabId: interactive[0].tab_id };
+  if (interactive.length === 0) {
+    return {
+      error:
+        `${label} needs an open ComfyUI desktop panel canvas to render, but this session ` +
+        `is attached to a canvas-less client (a mobile/remote viewer or a headless run) ` +
+        `and no desktop ComfyUI panel tab is connected. Open the ComfyUI browser tab with ` +
+        `the comfyui-mcp-panel pack installed, then retry.`,
+    };
+  }
+  // 2+ interactive desktop tabs: prefer the last-active one when it is itself a canvas.
+  // The bound tab is headless, so we must NOT fall through to ctx.call here — that would
+  // dispatch right back at the canvas-less client and reproduce "mobile client has no
+  // open canvas". When we can't single out one canvas tab, fail with the REAL reason.
+  if (typeof b.resolveActiveTabId === "function") {
+    try {
+      const active = b.resolveActiveTabId();
+      if (active && !b.isHeadless(active)) return { tabId: active };
+    } catch {
+      /* ambiguous active-tab resolution — fall through to the ambiguity error below */
+    }
+  }
+  return {
+    error:
+      `${label} needs an open ComfyUI desktop panel canvas, but this session is bound to ` +
+      `a canvas-less (mobile/remote) client and multiple desktop tabs are open — it can't ` +
+      `pick one automatically. Switch to the ComfyUI tab you want, rebind with ` +
+      `panel_set_workflow_target({mode:"current"}), then retry.`,
+  };
+}
+
+/** Dispatch a command to a SPECIFIC tab id (the #624 desktop-canvas redirect target)
+ *  and wrap the reply in the SAME ok()/fail() envelope ctx.call uses. The redirect
+ *  target came straight from a live `bridge.tabs()` enumeration, so it is already
+ *  reachable — this is a thin send that does NOT mutate ctx.tabId (the session's own
+ *  binding is left intact). For a retry-safe (idempotent full-replace) command it
+ *  mirrors ctx.call's single post-drop retry: on a transient reconnect error it settles
+ *  briefly, RE-RESOLVES the desktop tab (it may have reconnected under a new id), and
+ *  re-sends once before surfacing the error. `reResolve` returns the fresh desktop tab
+ *  id (or undefined to reuse `tabId`). */
+async function dispatchToTab(
+  ctx: PanelToolCtx,
+  tabId: string,
+  cmd: Record<string, unknown>,
+  timeoutMs: number,
+  reResolve?: () => string | undefined,
+): Promise<ToolResult> {
+  try {
+    return ok(await ctx.bridge.send(cmd as { cmd: string }, { tabId, timeoutMs }));
+  } catch (err) {
+    if (isRetrySafeCmd(cmd) && isTransientReconnectError(err)) {
+      try {
+        await sleep(retrySettleMs());
+        const fresh = reResolve?.() ?? tabId;
+        return ok(await ctx.bridge.send(cmd as { cmd: string }, { tabId: fresh, timeoutMs }));
+      } catch (err2) {
+        return fail(err2);
+      }
+    }
+    return fail(err);
+  }
+}
+
+/** Re-resolve the desktop redirect target after a transient drop — returns the fresh
+ *  interactive desktop tab id, or undefined when it can't be re-picked (so the caller
+ *  falls back to the original id for its single retry). */
+function reResolveDesktopTab(ctx: PanelToolCtx, label: string): string | undefined {
+  const r = desktopCanvasRedirect(ctx, label);
+  return r?.tabId;
+}
+
 /** Poll the bridge's late-reply buffer for a validated ask answer that arrived
  *  after the card-reply timeout, up to the grace budget. undefined if none. */
 async function pollLateAskReply(
@@ -3599,7 +3713,24 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       // momentarily backgrounded. set_todo is a non-destructive, idempotent full-
       // replace UI write (already in RETRY_SAFE_CMDS), so give it the same sane 15s
       // bound as the other UI-state writes (workflow_save) instead of a tight 5s.
-      async (args: A, ctx) => ctx.call({ cmd: "set_todo", items: args.items }, 15000),
+      async (args: A, ctx) => {
+        // #624: the footer TODO tray is a DESKTOP panel surface. When this session's
+        // bound tab is a headless (mobile/remote) client, resolve the live desktop
+        // canvas tab instead of dispatching at the headless client — which would
+        // reject with the misleading "mobile client has no open canvas".
+        const redirect = desktopCanvasRedirect(ctx, "panel_set_todo");
+        if (redirect?.error) return fail(redirect.error);
+        if (redirect?.tabId) {
+          return dispatchToTab(
+            ctx,
+            redirect.tabId,
+            { cmd: "set_todo", items: args.items },
+            15000,
+            () => reResolveDesktopTab(ctx, "panel_set_todo"),
+          );
+        }
+        return ctx.call({ cmd: "set_todo", items: args.items }, 15000);
+      },
     ),
     def(
       "panel_open_civitai",
@@ -3645,17 +3776,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           const query = creator
             ? `@${creator}${rawQuery ? " " + rawQuery : " "}`
             : args.query;
-          return await ctx.call(
-            {
-              cmd: "open_civitai",
-              query,
-              tab: args.tab,
-              browsingLevels,
-              filters: args.filters,
-              dock: args.dock,
-            },
-            10000,
-          );
+          const cmd = {
+            cmd: "open_civitai",
+            query,
+            tab: args.tab,
+            browsingLevels,
+            filters: args.filters,
+            dock: args.dock,
+          };
+          // #624: the in-panel CivitAI browser is a DESKTOP panel surface. When this
+          // session's bound tab is a headless (mobile/remote) client, resolve the live
+          // desktop canvas tab instead of dispatching at the headless client — which
+          // would reject with the misleading "mobile client has no open canvas".
+          const redirect = desktopCanvasRedirect(ctx, "panel_open_civitai");
+          if (redirect?.error) return fail(redirect.error);
+          if (redirect?.tabId) {
+            return await dispatchToTab(ctx, redirect.tabId, cmd, 10000, () =>
+              reResolveDesktopTab(ctx, "panel_open_civitai"),
+            );
+          }
+          return await ctx.call(cmd, 10000);
         } catch (err) {
           return fail(err);
         }


### PR DESCRIPTION
## Root cause

`panel_set_todo` and `panel_open_civitai` failed with `mobile client has no open canvas` in a desktop session, while `panel_show_media` succeeded on the same bridge in the same moment.

The exact string is authored by the **mobile app** (`comfyui-mcp-mobile` `bridge_client.dart`), not the orchestrator or panel. That client is a **headless** bridge peer that accepts **only** the `show_media` ServerCommand and rejects **every** other command with `mobile client has no open canvas`. So the discriminator is not the tool code (all three tools dispatch identically via `ctx.call`) — it's that the agent's panel session was **bound to a headless (mobile/remote) tab**, and the two DESKTOP-panel-surface commands (footer TODO tray, in-panel CivitAI browser) were dispatched straight at that canvas-less client. `show_media` "worked" only because the mobile client special-cases it.

## Fix (localized to `src/orchestrator/panel-tools.ts`)

- New `desktopCanvasRedirect(ctx, label)`: when THIS session's bound tab `isHeadless`, resolve the live **interactive (canvas-owning) desktop tab** — the same canvas-owning filter the graph/workflow tools use — and dispatch there instead of at the headless client.
  - Sole interactive desktop tab → redirect to it.
  - 2+ desktop tabs → prefer `resolveActiveTabId()` when it is itself a canvas; otherwise return an **accurate ambiguity error** (never falls back onto the known-headless tab).
  - No desktop canvas connected → **accurate** error naming the real condition, instead of the misleading mobile string.
  - Bound tab is a real desktop canvas (healthy, or merely orphaned by a reconnect) → `null`, i.e. the **unchanged** `ctx.call` path. **Tab-mirror remote control is preserved** (a mirroring phone's session is bound to the desktop tab, not the phone).
- `dispatchToTab` mirrors `ctx.call`'s single post-drop retry for the retry-safe, idempotent `set_todo` (re-resolves the desktop tab, which may reconnect under a new id, before its one retry). `open_civitai` isn't retry-safe, matching `ctx.call`.

## Tests

Added `#624` regression suite in `src/__tests__/orchestrator/panel-tools.test.ts`:
- headless-bound redirect onto the desktop canvas for **both** tools (no `mobile client has no open canvas`),
- last-active selection among multiple desktop tabs,
- accurate ambiguity error with **no** dispatch,
- canvas-less honest error with no dispatch,
- transient-drop + reconnect-under-new-id retry re-resolving onto the new desktop tab,
- unchanged desktop-bound `ctx.call` path.

## Verification

- `npm run build` green; `npm test` green except the known pre-existing `node-dev` ripgrep-env failure.
- Codex self-review: initial pass found 3 P2s (ambiguity fall-through re-hitting the headless tab; lost retry on redirect; missing branch tests) — all addressed; re-review verdict **safe to merge as-is, no blocking items**.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)