### PR TITLE
0.48.30 — version-skew actionable error (#619) + headless-tab routing (#624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.30] - 2026-08-01
+
 ### Fixed
 - **`panel_refresh_nodes` (and any newer bridge command) against an older panel now returns an actionable "update your panel to ≥X.Y.Z" error instead of the opaque `Unknown command "refresh_nodes"` (#619).** The #608 refresh executor shipped in panel 0.11.28; on a 0.11.20 panel the command was unrecognized, but because `refresh_nodes` wasn't in the min-version table it fell back to the 0.11.4 baseline — which a 0.11.20 panel exceeds — so the false-negative guard mistook it for "new enough" and leaked the raw dispatch error. `refresh_nodes` is now tabled at its true minimum (0.11.28), which both quotes the correct remedy version (naming the connected panel version) AND lets the proactive #392 gate reject the first call before dispatch. Class-wide: the "new enough" guard now trusts ONLY authoritative, command-specific minimums, so any UNTABLED command's `Unknown command` reply maps to an actionable "update the panel pack" message rather than a bare passthrough.
+
+### MCP
+
+#### Fixed
+- route set_todo/open_civitai to desktop canvas when session bound to a headless client (#624) (#625)
+- document panel_open_workflow stale-tab signal (#442 defect 2) (#618)
+
 
 ## [0.48.29] - 2026-08-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.29",
+  "version": "0.48.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.29",
+      "version": "0.48.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.29",
+  "version": "0.48.30",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
mcp 0.48.30 — three non-destructive fixes accumulated since 0.48.29 (shipped ahead of the #570/#483 destructive-path batch which needs a rig live-test):

- **#619** ui-bridge: actionable 'update your panel to ≥X.Y.Z' error for refresh_nodes + any untabled bridge command, instead of the opaque `Unknown command`.
- **#624** panel-tools: route panel_set_todo/panel_open_civitai to the live desktop canvas when the session is bound to a headless (mobile-mirror) client — fixes the misleading 'mobile client has no open canvas' on desktop; tab-mirror preserved.
- **#618** panel-tools: document panel_open_workflow stale-tab signal (#442 defect 2).

All codex-passed, CI-green on merge, non-destructive (routing/version-skew/doc) — no live-test required. Tag publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)