### PR TITLE
fix(download): drop superseded-attempt terminal events (panel#489)

### DIFF
--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -139,3 +139,125 @@ describe("control channel (#269 MCP child → orchestrator)", () => {
     expect(bare.listTargetChangeRequests(dir)).toHaveLength(0);
   });
 });
+
+describe("attempt-supersession (panel#489)", () => {
+  const T = "https://host"; // shared target for same-logical-download attempts
+
+  it("stamps the attempt epoch onto the written row", () => {
+    mod.reportDownloadProgress(
+      { id: "s1", name: "seedvr2_dit.safetensors", downloaded: 1, total: 2, bytes_per_sec: 1, status: "downloading", attempt: 12345 },
+      true,
+    );
+    const row = JSON.parse(readFileSync(join(dir, readdirSync(dir).find((f) => f.startsWith("s1-"))!), "utf-8"));
+    expect(row.attempt).toBe(12345);
+  });
+
+  it("drops a late FAILED terminal from a superseded attempt while the retry progresses", () => {
+    // The reported case: two SeedVR2 files. An OLDER attempt (N) fails AFTER a NEWER
+    // attempt (N+1) for the SAME URL-derived id + SAME target has begun and is actively
+    // progressing. attempt N's terminal "error" row is a late artifact of an abandoned
+    // attempt.
+    const dit = "a1b2c3"; // deterministic URL-derived id (same for both attempts)
+    const errorN = { id: dit, target: T, name: "seedvr2_dit.safetensors", status: "error", attempt: 1000 };
+    const downloadingN1 = { id: dit, target: T, name: "seedvr2_dit.safetensors", status: "downloading", attempt: 2000 };
+
+    const newest = mod.newestAttemptEpochs([errorN, downloadingN1]);
+    // The late FAILED terminal of attempt N is SUPERSEDED → must be dropped (no event).
+    expect(mod.isSupersededAttempt(errorN, newest)).toBe(true);
+    // The live progressing row is the current attempt — never suppressed.
+    expect(mod.isSupersededAttempt(downloadingN1, newest)).toBe(false);
+  });
+
+  it("suppresses a superseded attempt's stale DOWNLOADING row too (no duplicate tray/idle-veto row)", () => {
+    // An abandoned attempt (N) that died mid-transfer left a stale "downloading" row; the
+    // retry (N+1) is live. N's row must be dropped so it doesn't duplicate the tray row or
+    // wrongly veto pod idle-stop next to the live retry.
+    const id = "dd77ee";
+    const staleN = { id, target: T, name: "m", status: "downloading", attempt: 1000 };
+    const liveN1 = { id, target: T, name: "m", status: "downloading", attempt: 2000 };
+    const newest = mod.newestAttemptEpochs([staleN, liveN1]);
+    expect(mod.isSupersededAttempt(staleN, newest)).toBe(true);
+    expect(mod.isSupersededAttempt(liveN1, newest)).toBe(false);
+  });
+
+  it("a superseding newer attempt that itself already finished still drops the older terminal", () => {
+    // Newer attempt N+1 completed (done) while the older N left a stale error behind
+    // (distinct per-attempt files). The newest attempt wins regardless of status.
+    const id = "bb22cc";
+    const errorN = { id, target: T, name: "m", status: "error", attempt: 1000 };
+    const doneN1 = { id, target: T, name: "m", status: "done", attempt: 2000 };
+    const newest = mod.newestAttemptEpochs([errorN, doneN1]);
+    expect(mod.isSupersededAttempt(errorN, newest)).toBe(true);
+    expect(mod.isSupersededAttempt(doneN1, newest)).toBe(false); // the current attempt emits
+  });
+
+  it("a genuine CURRENT failure (no newer attempt) still emits", () => {
+    const id = "d4e5f6";
+    const errorNow = { id, target: T, name: "seedvr2_vae.safetensors", status: "error", attempt: 5000 };
+    const newest = mod.newestAttemptEpochs([errorNow]);
+    expect(mod.isSupersededAttempt(errorNow, newest)).toBe(false);
+  });
+
+  it("does NOT suppress a terminal when the newer row is the SAME attempt (equal epoch)", () => {
+    const id = "eeee11";
+    const errorNewer = { id, target: T, name: "m", status: "error", attempt: 3000 };
+    const downloadingSame = { id, target: T, name: "m", status: "downloading", attempt: 3000 };
+    const newest = mod.newestAttemptEpochs([errorNewer, downloadingSame]);
+    expect(mod.isSupersededAttempt(errorNewer, newest)).toBe(false);
+  });
+
+  it("scopes supersession by (id, target): a concurrent LOCAL + POD download of the same URL is independent (#269)", () => {
+    // Same URL-derived id, DIFFERENT targets (local vs pod). A genuine LOCAL failure must
+    // NOT be suppressed just because a POD transfer of the same URL is downloading — they
+    // are independent downloads, not retries of each other. This is the P1-B regression
+    // an id-only scope would have caused.
+    const id = "cafe01";
+    const localError = { id, target: "http://127.0.0.1:8188", name: "m", status: "error", attempt: 1000 };
+    const podDownloading = { id, target: "https://pod-3000.proxy.runpod.net", name: "m", status: "downloading", attempt: 2000 };
+    const newest = mod.newestAttemptEpochs([localError, podDownloading]);
+    // The local failure is genuine for its own target — it still emits.
+    expect(mod.isSupersededAttempt(localError, newest)).toBe(false);
+  });
+
+  it("is conservative for rows missing an attempt epoch (pre-fix writer / non-model reporter)", () => {
+    const id = "legacy1";
+    const errorNoEpoch = { id, target: T, name: "m", status: "error" }; // no attempt
+    const downloadingNoEpoch = { id, target: T, name: "m", status: "downloading" }; // no attempt
+    // A row without an epoch establishes no supersession.
+    expect(mod.newestAttemptEpochs([downloadingNoEpoch]).size).toBe(0);
+    // A row without an epoch is never suppressed, even against an epoched newer row.
+    const newest = mod.newestAttemptEpochs([{ id, target: T, name: "m", status: "downloading", attempt: 9000 }]);
+    expect(mod.isSupersededAttempt(errorNoEpoch, newest)).toBe(false);
+  });
+
+  it("per-attempt files: a retry writes its OWN file so both attempts coexist on disk", () => {
+    // The id is URL-derived, so both attempts share id + target; the attempt epoch in the
+    // filename keeps them in SEPARATE files — the retry can never overwrite the live row.
+    process.env.COMFYUI_URL = T;
+    const id = "pa0001";
+    mod.reportDownloadProgress({ id, name: "m", downloaded: 5, total: 10, bytes_per_sec: 1, status: "downloading", attempt: 2000 }, true);
+    mod.reportDownloadProgress({ id, name: "m", downloaded: 0, total: 0, bytes_per_sec: 0, status: "error", attempt: 1000 }, true);
+    const files = readdirSync(dir).filter((f) => f.startsWith(`${id}-`));
+    expect(files).toHaveLength(2); // two distinct per-attempt files, no overwrite
+    // Both rows are readable; the orchestrator (not this reader) decides which wins.
+    const rows = files.map((f) => JSON.parse(readFileSync(join(dir, f), "utf-8")));
+    expect(rows.some((r) => r.status === "downloading" && r.attempt === 2000)).toBe(true);
+    expect(rows.some((r) => r.status === "error" && r.attempt === 1000)).toBe(true);
+  });
+
+  it("mirrors the orchestrator poll: the superseded attempt's row is filtered out of the emitted rows", () => {
+    // A faithful slice of pollDownloads' phased reconcile: the newer attempt's live
+    // row is broadcast, the older attempt's FAILED row is dropped — so the tray/agent
+    // never sees a FAILED that contradicts the active transfer.
+    const id = "poll01";
+    const rows = [
+      { id, target: T, name: "seedvr2_dit.safetensors", status: "error", attempt: 1000, updated: 1_000 },
+      { id, target: T, name: "seedvr2_dit.safetensors", status: "downloading", attempt: 2000, updated: 2_000 },
+    ];
+    const newest = mod.newestAttemptEpochs(rows);
+    const emitted = rows.filter((r) => !mod.isSupersededAttempt(r, newest));
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].status).toBe("downloading");
+    expect(emitted.some((r) => r.status === "error")).toBe(false);
+  });
+});

--- a/src/__tests__/services/download-progress.test.ts
+++ b/src/__tests__/services/download-progress.test.ts
@@ -245,6 +245,21 @@ describe("attempt-supersession (panel#489)", () => {
     expect(rows.some((r) => r.status === "error" && r.attempt === 1000)).toBe(true);
   });
 
+  it("owner-scopes the progress filename so two processes never share (and clobber) one file", () => {
+    // The attempt epoch alone can tie across processes (same ms); the per-process owner
+    // segment guarantees distinct files regardless, so a late terminal from one process
+    // can never overwrite another process's live row.
+    process.env.COMFYUI_URL = T;
+    const id = "own001";
+    mod.reportDownloadProgress({ id, name: "m", downloaded: 1, total: 2, bytes_per_sec: 1, status: "downloading", attempt: 1000 }, true);
+    const f = readdirSync(dir).find((x) => x.startsWith(`${id}-`))!;
+    expect(f).toContain(`-o${mod.PERSIST_OWNER}`);
+    // A different process (different owner) writing the SAME id+target+epoch lands on a
+    // DIFFERENT file — both rows survive, none is clobbered.
+    writeFileSync(join(dir, `${id}-x-a1000-oOTHEROWNER.json`), JSON.stringify({ id, target: T, name: "m", status: "error", attempt: 1000, updated: 1 }));
+    expect(readdirSync(dir).filter((x) => x.startsWith(`${id}-`))).toHaveLength(2);
+  });
+
   it("mirrors the orchestrator poll: the superseded attempt's row is filtered out of the emitted rows", () => {
     // A faithful slice of pollDownloads' phased reconcile: the newer attempt's live
     // row is broadcast, the older attempt's FAILED row is dropped — so the tray/agent

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -89,7 +89,7 @@ import { readComfyuiCrashLog, formatCrashNote } from "../services/crash-log.js";
 import { QueueMonitor, type StallReport } from "../services/queue-monitor.js";
 import { initRunpodWatcher, getRunpodWatcher, type RunpodStatusFrame, type RunpodAlertFrame } from "../services/runpod-watch.js";
 import { getPod } from "../services/runpod-client.js";
-import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX } from "../services/download-progress.js";
+import { listTargetChangeRequests, consumeTargetChange, ackTargetChange, setProgressDir, CONTROL_PREFIX, newestAttemptEpochs, isSupersededAttempt, downloadAttemptKey } from "../services/download-progress.js";
 import { hasActiveTrainingJob, reconcileStaleTrainingJobs } from "../services/training-jobs.js";
 import {
   buildQueueStatusFrame,
@@ -3685,9 +3685,15 @@ export async function runPanelOrchestrator(): Promise<void> {
   // at which we emit. Keyed by download IDENTITY (row.id), not display name, so
   // two distinct downloads sharing a filename in one batch don't overwrite each
   // other and hide a failure (codex).
+  // Each pending terminal carries its attempt epoch + (id,target) supersession key so a
+  // newer live attempt for the SAME logical download can evict a queued FAILED/done
+  // before it fires (panel#489).
   const downloadDonePending = new Map<
     string,
-    { downloads: Map<string, { name: string; status: string }>; flushAt: number }
+    {
+      downloads: Map<string, { name: string; status: string; attempt?: number; supKey: string }>;
+      flushAt: number;
+    }
   >();
   // Resolve which agent to wake for a settled download row: the stamped tab's
   // agent when it's still live; else the SINGLE live agent (pre-fix/in-process
@@ -3786,7 +3792,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       files = []; // dir not created yet — nothing downloading
     }
     const now = Date.now();
-    const downloads: Array<Record<string, unknown>> = [];
+    // Phase 1: parse every tray row up front (skip control-channel + corrupt files),
+    // so the attempt-supersession map (panel#489) is computed over the WHOLE tray
+    // before any terminal row is acted on.
+    const parsed: Array<{ full: string; row: Record<string, unknown>; status: unknown; updated: number }> = [];
     for (const f of files) {
       if (f.startsWith(CONTROL_PREFIX)) continue; // control channel, not a download row
       const full = join(progressDir, f);
@@ -3797,8 +3806,54 @@ export async function runPanelOrchestrator(): Promise<void> {
         continue; // mid-write or corrupt — retry next tick
       }
       if (!row || typeof row !== "object") continue;
-      const status = row.status;
       const updated = typeof row.updated === "number" ? row.updated : now;
+      parsed.push({ full, row, status: row.status, updated });
+    }
+    // Phase 2: newest attempt epoch per (id, target) (panel#489). A same-URL retry
+    // reuses the deterministic id, so this distinguishes attempt N+1 from attempt N's
+    // abandoned transfer — while the (id, target) scope keeps a concurrent LOCAL and
+    // POD download of the same URL (#269) independent (neither supersedes the other).
+    // Dead "downloading" writers (>60s stale) are excluded so a crashed attempt can't
+    // shadow a real terminal; terminal rows are always kept (the newer attempt that
+    // supersedes may itself have already finished).
+    const freshForAttempts = parsed
+      .filter((p) => p.status !== "downloading" || now - p.updated <= 60000)
+      .map((p) => p.row);
+    const newestAttemptByKey = newestAttemptEpochs(freshForAttempts);
+    // A newer attempt for an (id, target) invalidates any terminal event STILL PENDING
+    // for that same download from an abandoned attempt (the cross-tick case: attempt N's
+    // terminal was observed and queued on an earlier poll, then attempt N+1's row
+    // appeared). Evict the superseded entry from every agent's debounce bucket so no
+    // "download FAILED" turn fires against a download that is actually still progressing.
+    for (const bucket of downloadDonePending.values()) {
+      for (const [idKey, entry] of bucket.downloads) {
+        if (entry.attempt === undefined) continue;
+        const newest = newestAttemptByKey.get(entry.supKey);
+        if (newest !== undefined && newest > entry.attempt) bucket.downloads.delete(idKey);
+      }
+    }
+    const downloads: Array<Record<string, unknown>> = [];
+    for (const { full, row, status, updated } of parsed) {
+      // panel#489: a row from a SUPERSEDED attempt (older `attempt` epoch than the newest
+      // attempt for this (id, target)) is a late artifact of the abandoned attempt a retry
+      // replaced. Drop it entirely — a superseded TERMINAL fires no FAILED/done agent
+      // event, and a superseded "downloading" row is kept off the tray + idle-stop veto so
+      // it can't contradict or duplicate the live retry. Re-read before unlinking so a
+      // writer that replaced the file between the parse above and here isn't clobbered
+      // (only remove a file that STILL belongs to a superseded attempt). Per-attempt files
+      // mean the retry writes a DIFFERENT file, so both coexist and this is deterministic
+      // — never a shared-file race. A genuinely-current row (no newer attempt) is
+      // unaffected and still shows/emits.
+      if (isSupersededAttempt(row, newestAttemptByKey)) {
+        try {
+          const cur = JSON.parse(readFileSync(full, "utf8")) as Record<string, unknown>;
+          if (isSupersededAttempt(cur, newestAttemptByKey)) {
+            unlinkSync(full);
+            downloadRemoveAt.delete(full);
+          }
+        } catch { /* gone or mid-write — nothing to remove */ }
+        continue;
+      }
       if (status === "done" || status === "error") {
         const due = downloadRemoveAt.get(full);
         if (due == null) {
@@ -3811,9 +3866,18 @@ export async function runPanelOrchestrator(): Promise<void> {
           if (key && manager.hasLiveAgent(key)) {
             const bucket =
               downloadDonePending.get(key) ??
-              { downloads: new Map<string, { name: string; status: string }>(), flushAt: 0 };
-            const idKey = String(row.id ?? full);
-            bucket.downloads.set(idKey, { name: String(row.name ?? row.id ?? "model"), status: String(status) });
+              { downloads: new Map<string, { name: string; status: string; attempt?: number; supKey: string }>(), flushAt: 0 };
+            // Identify each pending download by its (id, target) supersession key — NOT
+            // the id alone: a concurrent LOCAL + POD transfer of the same URL shares an id
+            // but must produce TWO #547 outcomes, and the same key lets a newer attempt
+            // evict this entry above. Fall back to the file path when the row has no id.
+            const supKey = downloadAttemptKey(row) ?? ` ${full}`;
+            bucket.downloads.set(supKey, {
+              name: String(row.name ?? row.id ?? "model"),
+              status: String(status),
+              attempt: typeof row.attempt === "number" ? row.attempt : undefined,
+              supKey,
+            });
             bucket.flushAt = now + DOWNLOAD_DONE_DEBOUNCE_MS;
             downloadDonePending.set(key, bucket);
           }
@@ -3849,6 +3913,10 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (now < bucket.flushAt) continue;
       downloadDonePending.delete(key);
       const settled = [...bucket.downloads.values()];
+      // The bucket can be emptied by the supersession eviction above (panel#489) —
+      // a queued terminal cancelled by a newer live attempt. Don't fire an empty
+      // "download_done" turn in that case.
+      if (settled.length === 0) continue;
       manager.injectEvent(key, { kind: "download_done", downloads: settled });
     }
     // MCP-child control channel (#269): runpod_* tools that ran in spawned

--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -896,6 +896,10 @@ export const downloadCacheFs = {
 export interface ProgressMeta {
   id: string;
   name: string;
+  /** Attempt generation/epoch (panel#489): the epoch-ms this download attempt began.
+   *  Stamped onto every progress row so the orchestrator can drop a late terminal row
+   *  from a SUPERSEDED attempt (a same-URL retry reuses the deterministic id). */
+  attempt?: number;
 }
 
 export interface DownloadCacheOptions {
@@ -1709,7 +1713,7 @@ async function streamUrlToFile(
   let bytesPerSec = 0;
   const emit = (status: DownloadProgress["status"], force = false) =>
     reportDownloadProgress(
-      { id: progress.id, name: progress.name, downloaded, total, bytes_per_sec: bytesPerSec, status },
+      { id: progress.id, name: progress.name, attempt: progress.attempt, downloaded, total, bytes_per_sec: bytesPerSec, status },
       force,
     );
   emit("downloading", true); // show the row immediately, even before the first chunk

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -110,7 +110,20 @@ function fileFor(id: string, target?: string, attempt?: number): string {
   // every variant. Absent on rows with no attempt epoch (pre-fix / non-model reporters
   // — they keep the single-file name, unchanged).
   const attemptSeg = Number.isFinite(attempt) ? `-a${attempt}` : "";
-  return join(PROGRESS_DIR, `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${disc}${attemptSeg}.json`);
+  // Per-PROCESS owner segment (codex finding): the attempt epoch alone is not guaranteed
+  // unique across DIFFERENT processes (two children starting the same download in the
+  // same millisecond could tie), which would put two live writers on ONE file and let a
+  // late terminal clobber the other's live row. Owner-scoping the filename — the same
+  // per-process nonce the persisted job store already uses (#515/#529) — makes two
+  // processes ALWAYS write distinct files, so a clobber is impossible regardless of any
+  // epoch tie. (Supersession ordering for a genuinely simultaneous same-ms cross-process
+  // double-start is inherently undefined, but it is non-corrupting: #467/#473 O_EXCL temp
+  // + atomic rename + payload validation, and #529 in-flight adoption normally prevents a
+  // second writer in the first place.)
+  return join(
+    PROGRESS_DIR,
+    `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${disc}${attemptSeg}-o${PERSIST_OWNER}.json`,
+  );
 }
 
 /** Credential-free form of a target URL for persisted rows / control files:

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -39,6 +39,16 @@ export interface DownloadProgress {
   bytes_per_sec: number;
   /** Lifecycle. */
   status: "downloading" | "done" | "error";
+  /** Attempt generation/epoch (panel#489): the epoch-ms at which THIS download
+   *  ATTEMPT began. The tray/progress id is URL-derived (deterministic), so a retry
+   *  of the same URL reuses the SAME id — attempt N and attempt N+1 are otherwise
+   *  indistinguishable. Stamping each attempt's start epoch lets the orchestrator
+   *  DROP a late terminal (failed/done) row from a SUPERSEDED attempt when a newer
+   *  attempt for the same id is already progressing, instead of firing a stale
+   *  "download FAILED" event that contradicts the live transfer. Absent on pre-fix
+   *  rows and non-model reporters — such rows are treated conservatively (never
+   *  suppressed, and never used to suppress). */
+  attempt?: number;
   /** Epoch ms of this snapshot (set on write). */
   updated: number;
   /** The ComfyUI target this download serves (the writer's own COMFYUI_URL at
@@ -82,7 +92,7 @@ export function persistedRecordsEnabled(): boolean {
   return !!channelDir();
 }
 
-function fileFor(id: string, target?: string): string {
+function fileFor(id: string, target?: string, attempt?: number): string {
   // The id is a hex hash from callers, but stay defensive about the filename.
   // Include a TARGET discriminator (codex finding: the same URL downloaded for
   // local AND pod concurrently shared one file — the last writer's target won
@@ -91,7 +101,16 @@ function fileFor(id: string, target?: string): string {
     .update(target ?? `pid:${process.pid}`)
     .digest("hex")
     .slice(0, 8);
-  return join(PROGRESS_DIR, `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${disc}.json`);
+  // Per-ATTEMPT file (panel#489): the id is URL-derived, so attempt N and a retry N+1
+  // share id AND target. Giving each attempt its OWN file (by its start epoch) means a
+  // retry can NEVER clobber the still-live row of the attempt it replaced — both rows
+  // coexist on disk, so the orchestrator deterministically drops the SUPERSEDED
+  // attempt's terminal instead of racing a shared-file overwrite. Readers scan the
+  // shared `${id}-` prefix, so readDownloadProgress/clearDownloadProgress still see
+  // every variant. Absent on rows with no attempt epoch (pre-fix / non-model reporters
+  // — they keep the single-file name, unchanged).
+  const attemptSeg = Number.isFinite(attempt) ? `-a${attempt}` : "";
+  return join(PROGRESS_DIR, `${id.replace(/[^a-zA-Z0-9_.-]/g, "_")}-${disc}${attemptSeg}.json`);
 }
 
 /** Credential-free form of a target URL for persisted rows / control files:
@@ -140,7 +159,10 @@ export function reportDownloadProgress(
     // COMFYUI_MCP_TAB) so the orchestrator can wake EXACTLY that tab's agent when
     // the download settles (#547), the same self-scoping trick `target` uses.
     const tab = p.tab ?? (process.env.COMFYUI_MCP_TAB?.trim() || undefined);
-    writeFileSync(fileFor(p.id, target), JSON.stringify({ ...p, target, tab, updated: now }));
+    // Per-attempt file (panel#489): a retry of the same URL/target writes its OWN file
+    // (keyed by attempt epoch), so it can never overwrite the still-live row of the
+    // attempt it superseded. The orchestrator sees both and drops the superseded one.
+    writeFileSync(fileFor(p.id, target, p.attempt), JSON.stringify({ ...p, target, tab, updated: now }));
   } catch {
     // best-effort — progress is cosmetic, never fail a download over it
   }
@@ -176,6 +198,72 @@ export function readDownloadProgress(id: string): DownloadProgress | null {
   } catch {
     return null; // absent or mid-write — not an error
   }
+}
+
+// ── Attempt-supersession (panel#489) ────────────────────────────────────────
+// The tray/progress id is a deterministic hash of the source URL, so a RETRY of
+// the same URL reuses the SAME id: attempt N and attempt N+1 share an id but are
+// distinct transfers. When attempt N fails (poison-partial discard, network drop)
+// AFTER attempt N+1 for the same id has begun, attempt N's TERMINAL (error/done)
+// row is a LATE artifact of an abandoned attempt — firing a "download FAILED"
+// event off it contradicts the live progress of attempt N+1. These helpers let
+// the orchestrator's tray poll detect and drop such superseded terminals, and the
+// WRITER-side guard (reportDownloadProgress) stops a superseded terminal from ever
+// clobbering the shared on-disk row of a newer attempt for the same (id, target).
+
+interface AttemptRowLike {
+  id?: unknown;
+  status?: unknown;
+  attempt?: unknown;
+  target?: unknown;
+}
+
+/** Supersession scope key: (id, target). Two downloads with the SAME URL-derived id
+ *  but DIFFERENT targets — e.g. the SAME model streamed to LOCAL and to a POD at once
+ *  (#269) — are INDEPENDENT transfers, not retries of each other, so a terminal from
+ *  one must NEVER be treated as superseded by the other. Attempts of the same logical
+ *  download share id AND target. Returns null when the row carries no usable id. A
+ *  missing target (in-process caller / no COMFYUI_URL) collapses to "" — two such
+ *  attempts still share a scope, which is correct (same logical local destination). */
+export function downloadAttemptKey(row: AttemptRowLike): string | null {
+  const id = typeof row?.id === "string" ? row.id : undefined;
+  if (!id) return null;
+  const target = typeof row?.target === "string" ? row.target : "";
+  return `${id}\n${target}`;
+}
+
+/** Newest attempt epoch per (id, target) across the given rows (ANY status — a
+ *  superseding newer attempt may itself be downloading OR already terminal). Rows
+ *  missing an `attempt` epoch (pre-fix writer / non-model reporter) are ignored —
+ *  they never establish supersession. The caller passes rows that have survived the
+ *  dead-writer freshness filter so a crashed attempt's stale row can't shadow a real
+ *  terminal. */
+export function newestAttemptEpochs(rows: AttemptRowLike[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const r of rows) {
+    const attempt = typeof r?.attempt === "number" ? r.attempt : undefined;
+    const k = downloadAttemptKey(r);
+    if (!k || attempt === undefined) continue;
+    const cur = out.get(k);
+    if (cur === undefined || attempt > cur) out.set(k, attempt);
+  }
+  return out;
+}
+
+/** True when `row` belongs to a SUPERSEDED attempt — a strictly-newer attempt for the
+ *  SAME (id, target) exists (panel#489). Applies to ANY status: a superseded attempt's
+ *  late TERMINAL (error/done) must not fire a stale panel event, and its abandoned
+ *  "downloading" row must not linger as a duplicate tray/idle-veto row beside the live
+ *  retry. Both `row` AND the newer attempt must carry `attempt` epochs for a
+ *  supersession to be provable; otherwise returns false (conservative — a genuine
+ *  current row still shows, and pre-fix rows are unaffected). Strictly-greater, so an
+ *  attempt's OWN rows (equal epoch) never suppress themselves. */
+export function isSupersededAttempt(row: AttemptRowLike, newest: Map<string, number>): boolean {
+  const attempt = typeof row?.attempt === "number" ? row.attempt : undefined;
+  const k = downloadAttemptKey(row);
+  if (!k || attempt === undefined) return false;
+  const n = newest.get(k);
+  return n !== undefined && n > attempt;
 }
 
 /** Remove a download's progress file(s) (e.g. on cancel). Target-scoped files

--- a/src/services/download-progress.ts
+++ b/src/services/download-progress.ts
@@ -115,8 +115,9 @@ function fileFor(id: string, target?: string, attempt?: number): string {
   // same millisecond could tie), which would put two live writers on ONE file and let a
   // late terminal clobber the other's live row. Owner-scoping the filename — the same
   // per-process nonce the persisted job store already uses (#515/#529) — makes two
-  // processes ALWAYS write distinct files, so a clobber is impossible regardless of any
-  // epoch tie. (Supersession ordering for a genuinely simultaneous same-ms cross-process
+  // processes write distinct files (barring a ~2^-64 owner-nonce collision), so a
+  // clobber is effectively impossible regardless of any epoch tie. (Supersession
+  // ordering for a genuinely simultaneous same-ms cross-process
   // double-start is inherently undefined, but it is non-corrupting: #467/#473 O_EXCL temp
   // + atomic rename + payload validation, and #529 in-flight adoption normally prevents a
   // second writer in the first place.)

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { existsSync, type Stats } from "node:fs";
 import { readdir, stat, mkdir, readFile, lstat, realpath } from "node:fs/promises";
 import { dirname, join, basename, resolve, relative, sep, isAbsolute, extname } from "node:path";
@@ -134,15 +134,28 @@ export interface LocalModel {
  * Never falls back to a local workspace in remote mode (that dir isn't the remote
  * target). Returns undefined when no usable local path exists.
  */
-/** Strictly-monotonic attempt epoch (panel#489). Normally the wall clock, but never
- *  repeats or goes backward WITHIN this process — so two retries started in the same
- *  millisecond (or across a small clock rollback) still get distinct, increasing
- *  generations. A tie would leave neither attempt able to supersede the other, letting a
- *  stale FAILED slip through. Cross-process ordering still rests on the wall clock (a
- *  later-spawned child is later in real time), which is correct for reconnect respawns. */
+/** A stable per-PROCESS tiebreak (0..999) folded into every attempt epoch so two
+ *  DIFFERENT processes that start an attempt in the very same millisecond still get
+ *  DISTINCT epochs (codex finding). Equal epochs would collide on the per-attempt
+ *  filename (a real clobber) AND defeat supersession (the predicate needs strictly
+ *  greater). Live processes on one host have distinct pids, but a random nonce avoids
+ *  even a pid-reuse tie; the space only needs to separate the rare same-URL,
+ *  same-target, same-ms double-start. */
+const ATTEMPT_TIEBREAK = randomBytes(2).readUInt16BE(0) % 1000;
+
+/** Strictly-monotonic attempt epoch (panel#489). Wall-clock milliseconds DOMINATE the
+ *  ordering (× 1000), so a retry — which starts later in real time — always outranks the
+ *  attempt it replaced, even across a reconnect respawn in a different process. The
+ *  low-order tiebreak makes concurrent same-ms attempts in different processes distinct
+ *  (no filename clobber, decisive supersession). Within THIS process the value never
+ *  repeats or goes backward — two same-ms retries (or a small local clock rollback) still
+ *  get increasing generations; a tie would let a stale FAILED slip through. (Cross-process
+ *  ordering still assumes the wall clock does not jump backward by more than a retry gap —
+ *  a severe NTP step is out of scope, as it is for any wall-clock generation.) */
 let lastAttemptEpoch = 0;
 function nextAttemptEpoch(): number {
-  lastAttemptEpoch = Math.max(Date.now(), lastAttemptEpoch + 1);
+  const base = Date.now() * 1000 + ATTEMPT_TIEBREAK;
+  lastAttemptEpoch = Math.max(base, lastAttemptEpoch + 1);
   return lastAttemptEpoch;
 }
 

--- a/src/services/model-resolver.ts
+++ b/src/services/model-resolver.ts
@@ -134,6 +134,18 @@ export interface LocalModel {
  * Never falls back to a local workspace in remote mode (that dir isn't the remote
  * target). Returns undefined when no usable local path exists.
  */
+/** Strictly-monotonic attempt epoch (panel#489). Normally the wall clock, but never
+ *  repeats or goes backward WITHIN this process — so two retries started in the same
+ *  millisecond (or across a small clock rollback) still get distinct, increasing
+ *  generations. A tie would leave neither attempt able to supersede the other, letting a
+ *  stale FAILED slip through. Cross-process ordering still rests on the wall clock (a
+ *  later-spawned child is later in real time), which is correct for reconnect respawns. */
+let lastAttemptEpoch = 0;
+function nextAttemptEpoch(): number {
+  lastAttemptEpoch = Math.max(Date.now(), lastAttemptEpoch + 1);
+  return lastAttemptEpoch;
+}
+
 function resolveComfyUIBase(): string | undefined {
   return resolveEffectiveComfyUIBase();
 }
@@ -1171,7 +1183,15 @@ export async function downloadModel(
   // Stable id for the panel tray, keyed on the (pre-redirect) URL so resumes and
   // retries map to the same row. Name is the friendly file name.
   const progressId = createHash("sha256").update(request.url).digest("hex").slice(0, 16);
-  const progress = { id: progressId, name: resolvedFilename };
+  // Attempt generation/epoch (panel#489): the id is URL-derived (deterministic), so a
+  // retry of the SAME URL reuses it — attempt N and attempt N+1 are otherwise
+  // indistinguishable. Stamp this attempt's start epoch on every row it writes so the
+  // orchestrator can drop a LATE terminal (failed/done) row from a superseded attempt
+  // once a newer attempt for the same id is already progressing. nextAttemptEpoch()
+  // guarantees STRICT monotonicity within this process, so two same-millisecond retries
+  // never tie (a tie would leave neither able to supersede the other); across processes
+  // the wall clock orders a later spawn after an earlier one.
+  const progress = { id: progressId, name: resolvedFilename, attempt: nextAttemptEpoch() };
   // Tell the job the id the tray rows actually use, so status display + cancel
   // cleanup key on the SAME id even when auth/HF-endpoint rewrote the request URL.
   onTrayId?.(progressId);


### PR DESCRIPTION
## Root cause

The panel emitted a "Model download FAILED" event for two SeedVR2 files while `download_status` for the SAME deterministic download ids showed both transfers actively progressing. The progress/tray id is **URL-derived** (a hash of the source URL), so a **retry of the same URL reuses the same id** — attempt N and attempt N+1 are indistinguishable at the progress-event layer. When an older attempt (N) failed *after* a newer attempt (N+1) for the same id had begun (e.g. a resume attempt fails + discards stale partials, then the same URLs are retried), attempt N's **late terminal (FAILED) event** was delivered to the panel and contradicted the live progress of attempt N+1. The late terminal of an abandoned attempt clobbered/contradicted the live state of the current one.

## Fix — attempt generation/epoch tagging

Tag each download **attempt** with a strict-monotonic generation/epoch (`nextAttemptEpoch()`), stamped on every progress row (`DownloadProgress.attempt` / `ProgressMeta.attempt`), and use it to identify and drop superseded attempts:

- **Per-attempt files** — `fileFor(id, target, attempt)` writes each attempt to its own file (`-a<epoch>`), so a retry can never overwrite the still-live row of the attempt it replaced. Both rows coexist on disk and the orchestrator's decision is deterministic (no shared-file overwrite race). Readers still scan the shared `${id}-` prefix, so `readDownloadProgress`/`clearDownloadProgress` are unaffected.
- **Supersession scoped by `(id, target)`** — `newestAttemptEpochs()` gives the newest epoch per `(id, target)`; `isSupersededAttempt(row, newest)` is true when a strictly-greater epoch exists. A superseded **terminal** fires no FAILED/done agent event; a superseded stale **downloading** row is kept off the tray + idle-stop veto. Scoping by `(id, target)` keeps a concurrent **local + pod** download of the same URL (#269) independent — neither supersedes the other.
- **Orchestrator `pollDownloads`** — parses all rows, computes the newest-epoch map, **evicts** an already-queued terminal from the #547 debounce buckets when a newer attempt appears (the cross-tick case), and drops superseded-attempt rows (re-reading before unlink to avoid a TOCTOU clobber). The #547 bucket is keyed by the same `(id, target)` supKey so a concurrent local+pod pair yields two distinct outcomes rather than colliding.
- **Cross-process robustness** — the epoch scales wall-clock ms ×1000 plus a per-process tiebreak (wall time dominates ordering, so a later retry always outranks the attempt it replaced, even across a reconnect respawn), and the progress filename is **owner-scoped** (per-process nonce, as with #515/#529 persisted records) so two processes can never share/clobber one progress file regardless of an epoch tie.

A genuinely-current failure still emits. #473 poison-partial / resume integrity is untouched — this is a progress-**event/observability** fix only, not a change to download correctness.

## Tests

`src/__tests__/services/download-progress.test.ts` — new regression coverage: attempt N fails after attempt N+1 (same id/target) is progressing → the late terminal is dropped (no FAILED); a superseded stale downloading row is also dropped; a superseding-then-finished newer attempt still drops the older terminal; a genuine current failure still emits; `(id, target)` scope keeps local+pod independent; per-attempt + owner-scoped filenames prevent overwrite; equal-epoch (same attempt) never self-suppresses; rows without an epoch are never suppressed. `build` + `test` green (only the pre-existing `node-dev` ripgrep-env failure remains).

Closes artokun/comfyui-mcp-panel#489

🤖 Generated with [Claude Code](https://claude.com/claude-code)