### PR TITLE
feat(civitai): panel_civitai_results returns inline sample images so the agent can SEE them (#623)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1509,6 +1509,233 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     expect(limit.safeParse(undefined).success).toBe(true);
   });
 
+  // ── #623: panel_civitai_results returns inline sample IMAGE blocks ──────────
+  // The agent recommends models/LoRAs for a VISUAL medium, so it must SEE the
+  // sample thumbnails — not just read titles + counts. These assert the top-N
+  // non-gated samples come back as {type:"image"} blocks, and that gating is
+  // never bypassed (blurred/gated results withhold their pixels).
+
+  // A ctx whose `call` returns a caller-supplied civitai_results reply as the
+  // JSON text payload the real panel would send back.
+  function makeReplyCtx(reply: unknown): { ctx: PanelToolCtx; calls: Forwarded[] } {
+    const calls: Forwarded[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        // Mirror the real ctx.call, which wraps the panel reply via ok() (pretty JSON).
+        return { content: [{ type: "text", text: JSON.stringify(reply, null, 2) }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: { send: async () => reply } as unknown as PanelToolCtx["bridge"],
+      tabId: "test-tab",
+    };
+    return { ctx, calls };
+  }
+
+  // Fake global fetch that returns a tiny image body with an honest Content-Length;
+  // records the URLs it saw. Errors on a redirect request (redirect:"error"), never
+  // reached by the same-origin proxy path in these tests.
+  function stubImageFetch(): { urls: string[]; restore: () => void } {
+    const urls: string[] = [];
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]); // JPEG SOI-ish
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      urls.push(String(input));
+      if (init && init.redirect && init.redirect !== "error") {
+        throw new Error(`unexpected redirect mode: ${init.redirect}`);
+      }
+      return {
+        ok: true,
+        headers: new Map([
+          ["content-type", "image/jpeg"],
+          ["content-length", String(bytes.length)],
+        ]),
+        arrayBuffer: async () => bytes.buffer.slice(0),
+      };
+    }) as unknown as typeof fetch;
+    return { urls, restore: () => void (globalThis.fetch = realFetch) };
+  }
+
+  function imageBlocks(res: ToolResult) {
+    return res.content.filter((c) => c.type === "image");
+  }
+
+  it("civitaiSampleEligible fails CLOSED — pixels only for explicit gated:false (#623)", () => {
+    const { civitaiSampleEligible } = __panelToolsTestHooks;
+    expect(civitaiSampleEligible({ gated: false })).toBe(true); // proven in-level → show
+    expect(civitaiSampleEligible({ gated: true })).toBe(false); // blurred → withhold
+    // Anything ambiguous (older panel omitting the flag, or a junk value) is
+    // withheld — a missing flag must never leak a sample the UI would blur.
+    expect(civitaiSampleEligible({})).toBe(false);
+    expect(civitaiSampleEligible({ gated: undefined })).toBe(false);
+    expect(civitaiSampleEligible({ gated: "false" })).toBe(false);
+  });
+
+  it("panel_civitai_results returns inline image blocks for non-gated results (#623)", async () => {
+    const reply = {
+      total: 2,
+      loading: false,
+      items: [
+        { id: 5, kind: "model", title: "Dreamy LoRA", urls: ["/comfyui_mcp_panel/civitai/media?uuid=a&ext=jpeg"], gated: false },
+        { id: 6, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=b&ext=jpeg", "/full/b"], gated: false },
+      ],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+      const imgs = imageBlocks(res);
+      expect(imgs.length).toBe(2);
+      expect(imgs[0]).toMatchObject({ type: "image", mimeType: "image/jpeg" });
+      expect(typeof (imgs[0] as { data: string }).data).toBe("string");
+      // The original JSON text payload is preserved (additive enrichment).
+      expect(res.content[0].type).toBe("text");
+      expect((res.content[0] as { text: string }).text).toContain('"total": 2');
+      // Each image is labelled with its result id so the agent can map it back.
+      const labels = res.content.filter((c) => c.type === "text").map((c) => (c as { text: string }).text).join("\n");
+      expect(labels).toContain("result id 5");
+      expect(labels).toContain("result id 6");
+      // Only the thumbnail (urls[0]) is fetched, never the full/video url.
+      expect(fetchStub.urls.some((u) => u.includes("uuid=a"))).toBe(true);
+      expect(fetchStub.urls.some((u) => u.includes("/full/b"))).toBe(false);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  it("panel_civitai_results WITHHOLDS pixels for gated/blurred results (#623 gating)", async () => {
+    const reply = {
+      total: 1,
+      loading: false,
+      items: [
+        { id: 9, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=x&ext=jpeg"], gated: true },
+      ],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+      expect(imageBlocks(res).length).toBe(0);
+      // The gated thumbnail is NEVER fetched.
+      expect(fetchStub.urls.length).toBe(0);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  it("panel_civitai_results withholds pixels for an OLDER panel that omits `gated` (fail-closed) (#623)", async () => {
+    // No per-item `gated` flag at all (pre-flag panel build): the fail-closed rule
+    // withholds every sample — a missing flag must never leak a blurred image.
+    const reply = {
+      total: 1,
+      loading: false,
+      items: [{ id: 3, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=z&ext=jpeg"] }],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+      expect(imageBlocks(res).length).toBe(0);
+      expect(fetchStub.urls.length).toBe(0);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  it("panel_civitai_results refuses off-origin / absolute sample URLs (SSRF + auth-header guard) (#623)", async () => {
+    const reply = {
+      total: 3,
+      loading: false,
+      items: [
+        // Absolute off-origin URL — must never be fetched (would leak ComfyUI auth headers).
+        { id: 1, kind: "image", title: null, urls: ["http://evil.example/steal?uuid=a"], gated: false },
+        // Protocol-relative host — also refused.
+        { id: 2, kind: "image", title: null, urls: ["//evil.example/x.jpeg"], gated: false },
+        // Same-origin path but NOT the media proxy — refused.
+        { id: 3, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/download?versionId=9"], gated: false },
+        // Backslash authority trick (`\`→`/` folding) — refused before fetch.
+        { id: 4, kind: "image", title: null, urls: ["/\\evil.example/x.jpeg"], gated: false },
+      ],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+      expect(imageBlocks(res).length).toBe(0);
+      expect(fetchStub.urls.length).toBe(0); // nothing was fetched
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
+  it("panel_civitai_results skips a length-less/oversize sample body (unbounded-read guard) (#623)", async () => {
+    const reply = {
+      total: 2,
+      loading: false,
+      items: [
+        { id: 1, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=nolen&ext=jpeg"], gated: false },
+        { id: 2, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=big&ext=jpeg"], gated: false },
+      ],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: unknown) => {
+      const s = String(input);
+      const headers = new Map<string, string>([["content-type", "image/jpeg"]]);
+      if (s.includes("uuid=big")) headers.set("content-length", String(5 * 1024 * 1024)); // > cap
+      // uuid=nolen: no content-length header at all
+      return {
+        ok: true,
+        headers,
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      };
+    }) as unknown as typeof fetch;
+    try {
+      const res = await defByName("panel_civitai_results").handler({ limit: 20 }, ctx);
+      expect(imageBlocks(res).length).toBe(0); // both refused before/without buffering
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("panel_civitai_results honors images:0 (metadata only, no fetch) (#623)", async () => {
+    const reply = {
+      total: 1,
+      loading: false,
+      items: [{ id: 1, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/media?uuid=q&ext=jpeg"], gated: false }],
+    };
+    const { ctx } = makeReplyCtx(reply);
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ images: 0 }, ctx);
+      expect(imageBlocks(res).length).toBe(0);
+      expect(fetchStub.urls.length).toBe(0);
+    } finally {
+      fetchStub.restore();
+    }
+    const images = defByName("panel_civitai_results").schema.images as {
+      safeParse: (v: unknown) => { success: boolean };
+    };
+    expect(images.safeParse(0).success).toBe(true);
+    expect(images.safeParse(9).success).toBe(false); // > max 8
+    expect(images.safeParse(undefined).success).toBe(true);
+  });
+
+  it("panel_civitai_results caps delivered samples at the requested images count (#623)", async () => {
+    const items = Array.from({ length: 6 }, (_, i) => ({
+      id: i, kind: "image", title: null, urls: [`/comfyui_mcp_panel/civitai/media?uuid=${i}&ext=jpeg`], gated: false,
+    }));
+    const { ctx } = makeReplyCtx({ total: 6, loading: false, items });
+    const fetchStub = stubImageFetch();
+    try {
+      const res = await defByName("panel_civitai_results").handler({ images: 2 }, ctx);
+      expect(imageBlocks(res).length).toBe(2);
+      expect(fetchStub.urls.length).toBe(2);
+    } finally {
+      fetchStub.restore();
+    }
+  });
+
   it("panel_civitai_highlight forwards ids + kind, and requires at least one id", async () => {
     const { ctx, calls } = makeFakeCtx();
     await defByName("panel_civitai_highlight").handler({ ids: [1, "abc"], kind: "media" }, ctx);

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -1655,6 +1655,9 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
         { id: 3, kind: "image", title: null, urls: ["/comfyui_mcp_panel/civitai/download?versionId=9"], gated: false },
         // Backslash authority trick (`\`→`/` folding) — refused before fetch.
         { id: 4, kind: "image", title: null, urls: ["/\\evil.example/x.jpeg"], gated: false },
+        // Same-origin route that merely ENDS WITH the proxy path — refused by the
+        // EXACT-path check (endsWith would have let this reach an auth'd request).
+        { id: 5, kind: "image", title: null, urls: ["/other/comfyui_mcp_panel/civitai/media?uuid=a"], gated: false },
       ],
     };
     const { ctx } = makeReplyCtx(reply);
@@ -1719,6 +1722,30 @@ describe("panel-tools: agent-driven CivitAI + training modals", () => {
     expect(images.safeParse(0).success).toBe(true);
     expect(images.safeParse(9).success).toBe(false); // > max 8
     expect(images.safeParse(undefined).success).toBe(true);
+  });
+
+  it("panel_civitai_results bounds fetch ATTEMPTS, not just successes, on dud URLs (#623)", async () => {
+    // 50 eligible non-gated proxy URLs that all 404: with images:1 the loop must
+    // NOT fire 50 requests — attempts are capped at images + a small slack.
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      id: i, kind: "image", title: null,
+      urls: [`/comfyui_mcp_panel/civitai/media?uuid=${i}&ext=jpeg`], gated: false,
+    }));
+    const { ctx } = makeReplyCtx({ total: 50, loading: false, items });
+    const urls: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: unknown) => {
+      urls.push(String(input));
+      return { ok: false, status: 404, headers: new Map(), arrayBuffer: async () => new ArrayBuffer(0) };
+    }) as unknown as typeof fetch;
+    try {
+      const res = await defByName("panel_civitai_results").handler({ images: 1 }, ctx);
+      expect(imageBlocks(res).length).toBe(0); // all 404 → no images
+      // images:1 + slack(4) = at most 5 network attempts, never all 50.
+      expect(urls.length).toBeLessThanOrEqual(5);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 
   it("panel_civitai_results caps delivered samples at the requested images count (#623)", async () => {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -314,6 +314,10 @@ export const __panelToolsTestHooks = {
   },
   isRetrySafeCmd,
   isTransientReconnectError,
+  // CivitAI sample-image gating (#623): the predicate that decides which results'
+  // pixels may be shown to the agent, and the bounded thumbnail fetcher.
+  civitaiSampleEligible,
+  fetchCivitaiSampleImages,
   // Adult-consent classifier + its exact card labels (#390 gate tests).
   classifyConsentReply,
   CONSENT_YES_LABEL,
@@ -956,6 +960,128 @@ function parseToolResultJson(res: ToolResult): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+// ---- panel_civitai_results inline sample thumbnails (#623) -------------------
+// The agent recommends CivitAI models/LoRAs for a VISUAL medium, so it must be
+// able to SEE the sample images — not just read titles + download counts. The
+// civitai_results reply already carries the panel's same-origin proxy media URLs
+// (/comfyui_mcp_panel/civitai/media?… served by the ComfyUI server the
+// orchestrator is connected to), so we fetch the top-N NON-GATED thumbnails here
+// and hand them back as MCP image content blocks — the same {type:"image"} bytes
+// mechanism panel_show_media / view_image use.
+//
+// NSFW/consent gate preservation is the load-bearing invariant: a result the
+// panel would render as a BLURRED/gated placeholder (rating outside the user's
+// enabled browsing levels) is NEVER fetched, so this vision path can never leak a
+// sample the human-facing UI withholds. See civitaiSampleEligible for the
+// fail-CLOSED gating rule and fetchCivitaiSampleImages for the same-origin lock.
+const CIVITAI_SAMPLE_MAX_BYTES = 4 * 1024 * 1024; // per-thumbnail cap (450px jpeg ≈ tens of KB)
+const CIVITAI_SAMPLE_DEFAULT = 4; // thumbnails delivered by default — bounds context
+const CIVITAI_SAMPLE_MAX = 8; // hard ceiling even if the agent asks for more
+const CIVITAI_SAMPLE_FETCH_TIMEOUT_MS = 8000;
+// The exact same-origin proxy path the panel serves CivitAI media from. urls[0]
+// MUST resolve to this path on the ComfyUI origin or it is not fetched (SSRF /
+// auth-header-exfil guard — see fetchCivitaiSampleImages).
+const CIVITAI_MEDIA_PROXY_PATH = "/comfyui_mcp_panel/civitai/media";
+
+/**
+ * Decide whether a single civitai_results item's sample thumbnail may be shown to
+ * the agent as pixels. FAILS CLOSED: pixels are delivered ONLY when the panel
+ * EXPLICITLY marks the item in-level (`gated === false`).
+ *   • gated === false → newer panel proved it in-level (and, because the panel
+ *     only sets gated=false when a real thumbnail exists, urls[0] is guaranteed to
+ *     be the small thumbnail, never a full-res image) → SHOW.
+ *   • gated === true  → the panel renders a blurred placeholder → WITHHOLD.
+ *   • gated absent    → an OLDER panel that predates the flag: we cannot prove the
+ *     result is in-level (nor that urls[0] is a thumbnail rather than a full-res
+ *     image on a card whose thumbnail was suppressed) → WITHHOLD.
+ * A missing/ambiguous flag therefore NEVER leaks a sample the UI would blur,
+ * regardless of which panel build is connected or which tab is active.
+ */
+function civitaiSampleEligible(item: Record<string, unknown>): boolean {
+  return item.gated === false;
+}
+
+/**
+ * Best-effort fetch of up to `max` NON-GATED sample thumbnails from a parsed
+ * civitai_results reply, as MCP image blocks paired with their result id (so the
+ * agent can map each picture back to the items array). NEVER throws: any fetch
+ * failure, non-image response, oversize body, or unreachable proxy simply yields
+ * fewer (or zero) images — the caller still returns the full text results.
+ *
+ * SECURITY: only the panel's OWN same-origin CivitAI media proxy is fetched. urls[0]
+ * must be a root-absolute path that resolves to CIVITAI_MEDIA_PROXY_PATH on the
+ * ComfyUI origin; absolute/protocol-relative/off-origin/off-path URLs are refused,
+ * and redirects are treated as errors. This prevents a malformed or compromised
+ * panel reply from turning the fetch into an SSRF that exfiltrates the ComfyUI auth
+ * headers comfyuiFetch attaches.
+ */
+async function fetchCivitaiSampleImages(
+  reply: Record<string, unknown>,
+  max: number,
+): Promise<Array<{ id: unknown; image: { type: "image"; data: string; mimeType: string } }>> {
+  const out: Array<{ id: unknown; image: { type: "image"; data: string; mimeType: string } }> = [];
+  if (max <= 0) return out;
+  const items = Array.isArray(reply.items) ? (reply.items as Record<string, unknown>[]) : [];
+  const base = getComfyUIBaseUrl();
+  let baseOrigin: string;
+  try {
+    baseOrigin = new URL(base).origin;
+  } catch {
+    return out; // no resolvable ComfyUI origin — deliver text only
+  }
+  for (const item of items) {
+    if (out.length >= max) break;
+    if (!item || typeof item !== "object") continue;
+    if (!civitaiSampleEligible(item)) continue;
+    const urls = Array.isArray(item.urls) ? item.urls : [];
+    // urls[0] is always the smaller thumbnail/poster (media: [thumb, full];
+    // model: [cover]); the full/video URL is intentionally NOT fetched.
+    const raw = urls.find((u): u is string => typeof u === "string" && u.length > 0);
+    if (!raw) continue;
+    // Refuse anything but a root-absolute same-origin path: no scheme (http:,
+    // file:, data:, …), no protocol-relative //host prefix, and no backslash
+    // (the WHATWG parser folds `\`→`/` for special schemes, so `/\host` could
+    // otherwise resolve to an authority). The strict origin check below is the
+    // real guard; this just refuses the obvious tricks up front.
+    if (!raw.startsWith("/") || raw.startsWith("//") || raw.includes("\\")) continue;
+    let url: URL;
+    try {
+      url = new URL(raw, base);
+    } catch {
+      continue; // unresolvable URL — skip, keep going
+    }
+    // Defense-in-depth: the resolved URL must stay on the ComfyUI origin AND hit
+    // the CivitAI media proxy path — never an arbitrary endpoint.
+    if (url.origin !== baseOrigin) continue;
+    if (!url.pathname.endsWith(CIVITAI_MEDIA_PROXY_PATH)) continue;
+    try {
+      const resp = await comfyuiFetch(url.toString(), {
+        signal: AbortSignal.timeout(CIVITAI_SAMPLE_FETCH_TIMEOUT_MS),
+        // A same-origin URL must not be allowed to 30x-bounce to another host
+        // (which would carry the auth headers off-origin). The proxy streams
+        // bytes directly, so a legitimate response never redirects.
+        redirect: "error",
+      });
+      if (!resp.ok) continue;
+      const mime = (resp.headers.get("content-type") ?? "").split(";")[0].trim();
+      if (!mime.startsWith("image/")) continue; // never inline a video/other body
+      // Require an HONEST, bounded Content-Length so a chunked/length-less body
+      // can't buffer unbounded memory into arrayBuffer(). The proxy always sets it.
+      const declared = Number(resp.headers.get("content-length") ?? "");
+      if (!Number.isFinite(declared) || declared <= 0 || declared > CIVITAI_SAMPLE_MAX_BYTES) continue;
+      const buf = Buffer.from(await resp.arrayBuffer());
+      if (buf.length === 0 || buf.length > CIVITAI_SAMPLE_MAX_BYTES) continue;
+      out.push({
+        id: item.id,
+        image: { type: "image", data: buf.toString("base64"), mimeType: mime },
+      });
+    } catch {
+      // best-effort — skip this thumbnail, the text path is unaffected
+    }
+  }
+  return out;
 }
 
 // ---- panel_run reply interpretation (#213/#331/#248/#194) -------------------
@@ -3663,7 +3789,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
     ),
     def(
       "panel_civitai_results",
-      "READ the CivitAI browser's CURRENT results as text (metadata + media URLs only — you will NOT be shown the images; you reason from the text and pick which URLs matter). This is the READ step of the show-don't-tell flow: rather than answering a 'good X model/LoRA?' question purely in a text table, open the docked browser, read the real results here, then panel_civitai_highlight your picks so the user SEES the cards. Open the browser first with panel_open_civitai. Returns { items, total, loading }. Each item carries EXACTLY these fields and nothing else — a MEDIA item is { id, kind:'image'|'video', title:null, creator, baseModel, type, stats:{ reactions }, prompt (length-capped ~600 chars), urls:[] }; a MODEL item is { id, kind:'model', title (the model's name), creator, baseModel, type, stats:{ downloadCount, thumbsUp }, prompt:null, urls:[] }. Note: stats is a NESTED object (reactions for media; downloadCount+thumbsUp for models), urls is an ARRAY of media URL(s), and media items have title:null while models have prompt:null. Model descriptions are NOT included (they require a separate detail fetch) — do not expect them. Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. `loading:true` means a fetch is still in flight and the panel is reporting what it has so far. The browser must be open — otherwise the panel replies with an honest error.\n\nDISAMBIGUATING AN EMPTY GRID: a `total:0` result is NOT automatically 'no matches'. Newer panels attach status fields you MUST check before concluding anything from an empty set: `error` (e.g. { status:503, message:'CivitAI API 503: Service Unavailable' } — an UPSTREAM failure, retry rather than narrowing filters), and on the favorites tab a `favoritesStatus` (e.g. 'ok' | 'signed_out' | 'no_likes_collection' | 'filtered_out') plus `authenticated`. If `error` is present the grid is empty because the request FAILED, not because nothing matched; if `favoritesStatus` is 'signed_out'/'no_likes_collection' the favorites couldn't be located at all. Only treat total:0 as a true empty result when `error` is null and (off the favorites tab, or favoritesStatus is 'ok').",
+      "READ the CivitAI browser's CURRENT results — metadata AND the actual SAMPLE IMAGES. This is the READ step of the show-don't-tell flow: rather than answering a 'good X model/LoRA?' question from a text table, open the docked browser, read the real results here, then panel_civitai_highlight your picks so the user SEES the cards. You ARE shown pixels now: the top few NON-GATED results' sample thumbnails are fetched and returned as inline IMAGE blocks after the JSON, each preceded by a line naming its result id — so you can actually JUDGE whether a LoRA's samples match the user's request (a visual medium) instead of reasoning from titles + download counts alone. Content gating is preserved: any result the panel would BLUR (a rating outside the user's enabled browsing levels, e.g. on the favorites tab) is WITHHELD — its pixels are never fetched — so this never bypasses the NSFW/consent gate. Control the image budget with `images` (default 4, max 8, 0 = metadata only). Open the browser first with panel_open_civitai. Returns { items, total, loading } as text, then the sample images. Each item carries these fields — a MEDIA item is { id, kind:'image'|'video', title:null, creator, baseModel, type, stats:{ reactions }, prompt (length-capped ~600 chars), urls:[], gated }; a MODEL item is { id, kind:'model', title (the model's name), creator, baseModel, type, stats:{ downloadCount, thumbsUp }, prompt:null, urls:[], gated }. Note: stats is a NESTED object (reactions for media; downloadCount+thumbsUp for models), urls is an ARRAY of media URL(s), and media items have title:null while models have prompt:null. `gated:true` marks a result the panel BLURS (rating outside the enabled browsing levels) — its sample image is withheld from the inline pixels above. Only results explicitly flagged `gated:false` get pixels; an older panel that doesn't send `gated` returns metadata only (no inline samples), never a blurred one. Model descriptions are NOT included (they require a separate detail fetch) — do not expect them. Use this to see what's on screen before you highlight, switch tabs, or open the lightbox. `loading:true` means a fetch is still in flight and the panel is reporting what it has so far. The browser must be open — otherwise the panel replies with an honest error.\n\nDISAMBIGUATING AN EMPTY GRID: a `total:0` result is NOT automatically 'no matches'. Newer panels attach status fields you MUST check before concluding anything from an empty set: `error` (e.g. { status:503, message:'CivitAI API 503: Service Unavailable' } — an UPSTREAM failure, retry rather than narrowing filters), and on the favorites tab a `favoritesStatus` (e.g. 'ok' | 'signed_out' | 'no_likes_collection' | 'filtered_out') plus `authenticated`. If `error` is present the grid is empty because the request FAILED, not because nothing matched; if `favoritesStatus` is 'signed_out'/'no_likes_collection' the favorites couldn't be located at all. Only treat total:0 as a true empty result when `error` is null and (off the favorites tab, or favoritesStatus is 'ok').",
       {
         limit: z
           .number()
@@ -3672,8 +3798,50 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           .max(50)
           .optional()
           .describe("Max results to serialize (1–50, default 20). The grid is ordered as shown to the user."),
+        images: z
+          .number()
+          .int()
+          .min(0)
+          .max(CIVITAI_SAMPLE_MAX)
+          .optional()
+          .describe(
+            `How many top NON-GATED sample thumbnails to fetch and return as inline IMAGE blocks (0–${CIVITAI_SAMPLE_MAX}, default ${CIVITAI_SAMPLE_DEFAULT}). Set 0 for metadata only (e.g. a quick scan where you don't need pixels). Gated/blurred results are always skipped regardless of this count.`,
+          ),
       },
-      async (args: A, ctx) => ctx.call({ cmd: "civitai_results", limit: args.limit }, 10000),
+      async (args: A, ctx) => {
+        const res = await ctx.call({ cmd: "civitai_results", limit: args.limit }, 10000);
+        // Enrich with inline sample pixels (#623). Best-effort + additive: on any
+        // problem we return the untouched text results, so the read path can never
+        // regress to an error just because a thumbnail fetch failed.
+        if (res.isError) return res;
+        const want =
+          args.images === undefined
+            ? CIVITAI_SAMPLE_DEFAULT
+            : Math.max(0, Math.min(Math.floor(Number(args.images) || 0), CIVITAI_SAMPLE_MAX));
+        if (want <= 0) return res;
+        const parsed = parseToolResultJson(res);
+        if (!parsed) return res;
+        let samples: Awaited<ReturnType<typeof fetchCivitaiSampleImages>> = [];
+        try {
+          samples = await fetchCivitaiSampleImages(parsed, want);
+        } catch {
+          samples = [];
+        }
+        if (samples.length === 0) return res;
+        const content: ToolResult["content"] = [...res.content];
+        content.push({
+          type: "text",
+          text:
+            `Sample images for the top ${samples.length} non-gated result(s) below, ` +
+            `each labelled with its result id (map it to the items array). Blurred/gated ` +
+            `results are omitted. Judge the VISUAL match from these pixels, not just the metadata.`,
+        });
+        for (const s of samples) {
+          content.push({ type: "text", text: `— sample for result id ${String(s.id)}:` });
+          content.push(s.image);
+        }
+        return { content };
+      },
     ),
     def(
       "panel_civitai_highlight",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -980,9 +980,15 @@ const CIVITAI_SAMPLE_MAX_BYTES = 4 * 1024 * 1024; // per-thumbnail cap (450px jp
 const CIVITAI_SAMPLE_DEFAULT = 4; // thumbnails delivered by default — bounds context
 const CIVITAI_SAMPLE_MAX = 8; // hard ceiling even if the agent asks for more
 const CIVITAI_SAMPLE_FETCH_TIMEOUT_MS = 8000;
-// The exact same-origin proxy path the panel serves CivitAI media from. urls[0]
-// MUST resolve to this path on the ComfyUI origin or it is not fetched (SSRF /
-// auth-header-exfil guard — see fetchCivitaiSampleImages).
+// Extra fetch ATTEMPTS allowed beyond the requested image count, so a few
+// 404/non-image/oversize URLs don't starve the result — but a malformed reply
+// with many dud eligible URLs still can't trigger unbounded requests (the cap is
+// on attempts, not just successes).
+const CIVITAI_SAMPLE_ATTEMPT_SLACK = 4;
+// The exact same-origin proxy path the panel serves CivitAI media from (appended
+// to the ComfyUI base path). urls[0] MUST resolve to EXACTLY this pathname on the
+// ComfyUI origin or it is not fetched (SSRF / auth-header-exfil guard — see
+// fetchCivitaiSampleImages).
 const CIVITAI_MEDIA_PROXY_PATH = "/comfyui_mcp_panel/civitai/media";
 
 /**
@@ -1025,14 +1031,24 @@ async function fetchCivitaiSampleImages(
   if (max <= 0) return out;
   const items = Array.isArray(reply.items) ? (reply.items as Record<string, unknown>[]) : [];
   const base = getComfyUIBaseUrl();
-  let baseOrigin: string;
+  let baseUrl: URL;
   try {
-    baseOrigin = new URL(base).origin;
+    baseUrl = new URL(base);
   } catch {
     return out; // no resolvable ComfyUI origin — deliver text only
   }
+  const baseOrigin = baseUrl.origin;
+  // The ONE canonical proxy pathname on this ComfyUI = base path + proxy route.
+  // We require an EXACT match (not endsWith), so a same-origin reverse-proxy route
+  // that merely *ends with* the proxy path (e.g. /other/comfyui_mcp_panel/civitai/media)
+  // cannot receive an auth-bearing request.
+  const expectedPath = baseUrl.pathname.replace(/\/+$/, "") + CIVITAI_MEDIA_PROXY_PATH;
+  // Bound total network ATTEMPTS, not just successes: with images:1 and a reply
+  // carrying 50 dud eligible URLs we must not fire 50 fetches.
+  const maxAttempts = max + CIVITAI_SAMPLE_ATTEMPT_SLACK;
+  let attempts = 0;
   for (const item of items) {
-    if (out.length >= max) break;
+    if (out.length >= max || attempts >= maxAttempts) break;
     if (!item || typeof item !== "object") continue;
     if (!civitaiSampleEligible(item)) continue;
     const urls = Array.isArray(item.urls) ? item.urls : [];
@@ -1043,8 +1059,8 @@ async function fetchCivitaiSampleImages(
     // Refuse anything but a root-absolute same-origin path: no scheme (http:,
     // file:, data:, …), no protocol-relative //host prefix, and no backslash
     // (the WHATWG parser folds `\`→`/` for special schemes, so `/\host` could
-    // otherwise resolve to an authority). The strict origin check below is the
-    // real guard; this just refuses the obvious tricks up front.
+    // otherwise resolve to an authority). The strict origin + exact-path checks
+    // below are the real guard; this just refuses the obvious tricks up front.
     if (!raw.startsWith("/") || raw.startsWith("//") || raw.includes("\\")) continue;
     let url: URL;
     try {
@@ -1052,10 +1068,11 @@ async function fetchCivitaiSampleImages(
     } catch {
       continue; // unresolvable URL — skip, keep going
     }
-    // Defense-in-depth: the resolved URL must stay on the ComfyUI origin AND hit
-    // the CivitAI media proxy path — never an arbitrary endpoint.
+    // Defense-in-depth: the resolved URL must stay on the ComfyUI origin AND be
+    // EXACTLY the CivitAI media proxy endpoint — never any other route.
     if (url.origin !== baseOrigin) continue;
-    if (!url.pathname.endsWith(CIVITAI_MEDIA_PROXY_PATH)) continue;
+    if (url.pathname !== expectedPath) continue;
+    attempts++; // count this as a network attempt BEFORE the fetch
     try {
       const resp = await comfyuiFetch(url.toString(), {
         signal: AbortSignal.timeout(CIVITAI_SAMPLE_FETCH_TIMEOUT_MS),


### PR DESCRIPTION
## What & why

`panel_civitai_results` previously returned metadata + proxied URLs only — the agent judging whether a LoRA's SAMPLE images match a user's request was reduced to reading titles + download counts, a materially worse experience for a visual "show-don't-tell" medium (#623).

This makes the agent actually SEE the samples: the tool now fetches the top-N **non-gated** sample thumbnails (the panel's same-origin `/comfyui_mcp_panel/civitai/media` proxy URLs, already in the reply) and returns them as MCP `{type:"image"}` content blocks — the same image-content mechanism `panel_show_media` / `view_image` use — each labelled with its result id so the agent can map picture → metadata.

## NSFW / consent gating preserved (fail-closed)

- Pixels are delivered **only** for results the panel explicitly marks in-level (`gated === false`). `gated:true` (blurred placeholder), a missing flag (older panel), or any junk value → **withheld**. A missing/ambiguous flag never leaks a blurred sample.
- Because the panel sets `gated:false` only when a real thumbnail exists, `urls[0]` on an eligible item is guaranteed to be the small thumbnail — never a full-res image or video.
- The mcp already server-clamps adult browsing levels before the panel fetches; this path adds no way around that.

## Safety bounds

- **SSRF / auth-header lock**: only root-absolute same-origin URLs that resolve to the ComfyUI origin AND end with the `/comfyui_mcp_panel/civitai/media` proxy path are fetched; absolute/protocol-relative/off-origin/off-path URLs are refused, and `redirect:"error"` prevents a 30x off-origin bounce carrying auth headers.
- **Memory**: requires an honest `Content-Length` (finite, >0, ≤ 4 MiB) before buffering; length-less/oversize bodies skipped. (Companion panel PR also caps the proxy read.)
- **Context**: `images` param (default 4, max 8, 0 = metadata only); best-effort — any fetch failure returns the full text results unchanged.

## Tests

New coverage in `panel-tools.test.ts`: fail-closed eligibility; inline-image happy path (+ id labels, thumbnail-only fetch); gated withhold; older-panel withhold; SSRF refusal (off-origin, protocol-relative, wrong same-origin path); length-less/oversize skip; `images:0`; count cap. Full suite green (pre-existing node-dev ripgrep-env failure unrelated). `asset-counts --check` passes (no tool added).

Self-gated with Codex (adversarial review, multiple rounds).

Closes #623
