### PR TITLE
fix(node-authoring): resolve local workspace via shared fallback when COMFYUI_PATH unset (#506)

### DIFF
--- a/src/__tests__/services/node-authoring.test.ts
+++ b/src/__tests__/services/node-authoring.test.ts
@@ -10,6 +10,15 @@ vi.mock("../../config.js", () => {
   return { config };
 });
 
+// Control the effective LOCAL base node-authoring resolves through, so #506's
+// saved-default-workspace behavior is exercised without touching real user
+// config. resolveEffectiveComfyUIBase() prefers COMFYUI_PATH then the saved
+// default; the mock mirrors that: config.comfyuiPath first, else wsMock.saved.
+const wsMock = vi.hoisted(() => ({ saved: undefined as string | undefined }));
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => config.comfyuiPath ?? wsMock.saved,
+}));
+
 import { config } from "../../config.js";
 import {
   scaffoldCustomNode,
@@ -72,6 +81,7 @@ const CUSTOM_NODES = join("/fake/comfy", "custom_nodes");
 
 beforeEach(() => {
   config.comfyuiPath = "/fake/comfy";
+  wsMock.saved = undefined;
   delete process.env.REGISTRY_ACCESS_TOKEN;
 });
 
@@ -214,12 +224,29 @@ describe("scaffoldCustomNode", () => {
     expect(writes).toHaveLength(0);
   });
 
-  it("throws a clear error in remote mode (no comfyuiPath)", () => {
+  it("throws a clear error in remote mode (no comfyuiPath, no saved default)", () => {
     config.comfyuiPath = undefined;
+    wsMock.saved = undefined;
     const { deps } = makeDeps();
     expect(() =>
       scaffoldCustomNode({ name: "x", displayName: "X" }, deps),
     ).toThrow(/local ComfyUI install/i);
+  });
+
+  it("resolves against the saved default workspace when COMFYUI_PATH is unset (#506)", () => {
+    // No COMFYUI_PATH, but a saved default workspace is set — a loopback session
+    // must be treated as local, mirroring get_environment/get_workspace, instead
+    // of being rejected as remote. Scaffold should write under the saved default.
+    config.comfyuiPath = undefined;
+    wsMock.saved = "/saved/ws";
+    const { deps, mkdirs } = makeDeps();
+    const res = scaffoldCustomNode(
+      { name: "my-nodes", displayName: "My Nodes" },
+      deps,
+    );
+    const packDir = resolve(join("/saved/ws", "custom_nodes"), "my-nodes");
+    expect(res.path).toBe(packDir);
+    expect(mkdirs).toContain(packDir);
   });
 
   it("writes a placeholder PublisherId when none is given", () => {
@@ -460,12 +487,33 @@ describe("publishCustomNode", () => {
     expect(() => publishCustomNode({}, deps)).toThrow(ValidationError);
   });
 
-  it("throws a clear error in remote mode when using name", () => {
+  it("throws a clear error in remote mode when using name (no saved default)", () => {
     config.comfyuiPath = undefined;
+    wsMock.saved = undefined;
     process.env.REGISTRY_ACCESS_TOKEN = "tok";
     const deps = depsWithToml(goodToml);
     expect(() => publishCustomNode({ name: "mypack" }, deps)).toThrow(
       /local ComfyUI install/i,
+    );
+  });
+
+  it("resolves name against the saved default workspace when COMFYUI_PATH is unset (#506)", () => {
+    // COMFYUI_PATH unset but a saved default workspace exists — resolving a pack
+    // by name must use it (not reject as remote), so publish runs in the pack dir
+    // under the saved default's custom_nodes/.
+    config.comfyuiPath = undefined;
+    wsMock.saved = "/saved/ws";
+    process.env.REGISTRY_ACCESS_TOKEN = "tok";
+    const runSpy = vi.fn(() => "ok");
+    const deps = makeDeps({
+      existsSync: vi.fn(() => true),
+      readFile: vi.fn(() => goodToml),
+      run: runSpy,
+    }).deps;
+    const res = publishCustomNode({ name: "mypack" }, deps);
+    expect(res.published).toBe(true);
+    expect(runSpy.mock.calls[0][2].cwd).toBe(
+      resolve(join("/saved/ws", "custom_nodes"), "mypack"),
     );
   });
 });

--- a/src/services/node-authoring.ts
+++ b/src/services/node-authoring.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { platform } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import { config } from "../config.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 import { ComfyUIError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -249,18 +249,27 @@ function toClassName(slug: string): string {
 }
 
 /**
- * Resolve the custom_nodes root, throwing a clear error in remote mode where
- * there is no local install path to write into.
+ * Resolve the custom_nodes root, throwing a clear error when there is no local
+ * install path to write into. Resolves the effective LOCAL ComfyUI base the same
+ * way every other filesystem-backed tool does (node-dev, node-verify): COMFYUI_PATH
+ * first, then the saved default workspace (set via set_default_workspace) when
+ * COMFYUI_PATH is unset and we are not targeting a remote ComfyUI. This is what
+ * get_environment / get_workspace already report, so scaffold/publish no longer
+ * reject a loopback session that has a saved default workspace as if it were remote
+ * (#506). Returns undefined only in remote mode or when no local install is known —
+ * then we refuse with a clear, actionable error.
  */
 function customNodesRoot(): string {
-  if (!config.comfyuiPath) {
+  const base = resolveEffectiveComfyUIBase();
+  if (!base) {
     throw new ValidationError(
-      "This operation needs a local ComfyUI install, but config.comfyuiPath is " +
-        "not set (running in remote --comfyui-url mode). Set COMFYUI_PATH to your " +
-        "local ComfyUI directory to scaffold or publish custom nodes.",
+      "This operation needs a local ComfyUI install, but none is configured " +
+        "(COMFYUI_PATH is unset, no saved default workspace, or running in remote " +
+        "--comfyui-url mode). Set COMFYUI_PATH or a default workspace " +
+        "(set_default_workspace) to scaffold or publish custom nodes.",
     );
   }
-  return join(config.comfyuiPath, "custom_nodes");
+  return join(base, "custom_nodes");
 }
 
 /**


### PR DESCRIPTION
Closes #506

## Root cause

`scaffold_custom_node` / `publish_custom_node` (when resolving a pack by `name`) determined the `custom_nodes/` root through **`node-authoring.ts`'s own `customNodesRoot()`**, which gated on the **raw `config.comfyuiPath`** env field:

```ts
if (!config.comfyuiPath) throw ... "remote --comfyui-url mode" ...
return join(config.comfyuiPath, "custom_nodes");
```

So a local loopback session (`http://127.0.0.1:8188`) with **no `COMFYUI_PATH`** but a **saved default workspace** was falsely rejected as remote — even though `get_environment` / `get_workspace` resolve that same install fine.

`get_environment` (and the sibling source tools `node-dev.ts` and `node-verify.ts`) instead resolve through the **shared** `resolveEffectiveComfyUIBase()` fallback:
1. `config.comfyuiPath` (COMFYUI_PATH / auto-detect), else
2. the saved **default workspace** (`set_default_workspace`) when **not** targeting a remote ComfyUI.

`node-dev.ts` was routed through the shared helper in `e24b41d` (#510) and `node-verify.ts`/the shared resolver in #418/#409 — **`node-authoring.ts` was the one source-tool family still bypassing it.** This PR closes that last gap.

## Fix

Route `node-authoring.ts`'s `customNodesRoot()` through `resolveEffectiveComfyUIBase()` (drops the direct `config` import, now unused) and update the refusal message. A local session with a saved default workspace and no `COMFYUI_PATH` is now treated as LOCAL; genuine remote detection is preserved — no resolvable local base still refuses with a clear, actionable error.

## Tests

Added regression tests in `node-authoring.test.ts` (mocking `workspace-env.js` the same way `node-dev.test.ts` / `node-verify.test.ts` do):
- `scaffold_custom_node`: COMFYUI_PATH unset + saved default present → resolves LOCAL under the saved default's `custom_nodes/` (no false remote).
- `publish_custom_node` (by name): same fallback → runs in the pack dir under the saved default.
- Both still refuse with the local-install error when neither COMFYUI_PATH nor a saved default is resolvable.

`npm run build` green; full suite `2872 passed` (only the pre-existing `node-dev` builtin-vs-ripgrep sandbox test fails locally because `rg` is installed here — passes on CI; unrelated to this change).

## Codex self-gate

Codex verdict: **PASS** — confirms the diff makes `node-authoring` use the same shared local-base decision as its shipped siblings (`node-authoring.ts`, `node-dev.ts`, `node-verify.ts` all call `resolveEffectiveComfyUIBase()`), preserves genuine remote refusal, and that the added tests cover node-authoring's own boundary. Two design observations (cloud-mode local fallback; relative saved-default values) are **pre-existing properties of the shared resolver / `setDefaultWorkspace` contract** that node-dev and node-verify already exhibit — not regressions introduced here; the lexical name-jail (`resolvePackDir`) remains intact. Any change there belongs at the shared resolver/workspace-validation layer, not a node-authoring-only exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)