### PR TITLE
docs(download): do NOT probe-resume a sidecar-less partial — corruption-class (#467)

### DIFF
--- a/src/services/download-cache.ts
+++ b/src/services/download-cache.ts
@@ -1226,6 +1226,20 @@ async function streamUrlToFile(
       // sidecar was ever written) got thrown away and re-downloaded from 0 with
       // no log and no signal (#467). Defer the log/diagnostic until we actually
       // truncate (below), so a pre-write failure can't falsely report a discard.
+      //
+      // DO NOT "recover" this case by PROBING the URL for an identity and resuming
+      // on it — that is a SILENT-CORRUPTION path and was rejected (#467, corruption
+      // class). A validator fetched NOW identifies the CURRENT object, not the object
+      // this sidecar-less partial was written against; there is NO recorded write-time
+      // identity to bind the OLD bytes, so a same-size re-upload (or a same-head/tail
+      // replacement whose unsampled middle differs) would append fresh bytes onto a
+      // stale prefix and finalize a corrupt model under a green success. Head/tail
+      // byte-sampling is likewise necessary-but-not-sufficient (the middle is
+      // unverifiable without re-downloading it). The ONLY safe resume is one whose
+      // whole-object identity was recorded at WRITE time — i.e. the sidecar route
+      // above, which HF Xet DOES take now that the X-Linked-Etag from the resolve
+      // redirect is persisted on the first attempt. A genuinely sidecar-less/legacy
+      // partial must therefore RESTART (never-silent), which is exactly what happens.
       effectiveResume = 0;
       if (resumable) resumeDeclinedNoValidator = true;
     }


### PR DESCRIPTION
Closes #467

## TL;DR

After a deep investigation and **three independent Codex adversarial reviews** (including the maintainer's), the "resume a validator-less partial" approach was found to be a **silent-corruption path** and was dropped. The shipping code **already** resolves #467 safely; this PR keeps that behavior and adds a comment documenting *why* the unsafe path must not be re-introduced.

## Why a sidecar-less resume cannot be done safely

A validator fetched **at resume time** (an ETag, Last-Modified, or even HF's content-addressed `X-Linked-Etag`) identifies the **current** remote object — **not** the object a sidecar-*less* partial was written against. With no whole-object identity recorded **at write time**, nothing binds the OLD on-disk bytes to the current object, so a same-size re-upload (or a same-head/tail replacement whose *unsampled middle* differs) would append fresh bytes onto a stale prefix and finalize a **corrupt model under a green success** — the exact #343/#473 corruption class. Head/tail byte-sampling is necessary-but-not-sufficient (the middle is unverifiable without re-downloading it, which defeats resuming).

Codex confirmed this across three rounds: a freshly-probed identity, a size match, and head+tail byte-samples each fail to bind the historical partial.

## What actually fixes #467 (already in the codebase)

- **Resume works** for the reported HF Xet case via the **write-time** `X-Linked-Etag` sidecar: the resolve redirect's content hash is persisted on the *first* attempt, so an interrupted partial resumes via `Range` + `If-Range` (route A), gated by the existing content-addressed change-check (`if (requestedResume && res.status === 206)`), which rejects a changed object and requires cross-origin resumes to re-present a matching content hash.
- **A genuinely sidecar-less / legacy partial RESTARTS, never silently**: a `WARN` log plus a `declined:no-validator` decision surfaced by `download_status` ("no validator was persisted … future downloads capture the validator from the resolve redirect so they CAN resume"). This is the never-discard-silently requirement, already implemented.

A legacy partial with no recorded identity is re-downloaded **once**; thereafter it carries a sidecar and resumes. That single re-download is unavoidable and is the safe outcome — a corrupt append is worse than a re-download.

## Codex verdict on the shipping resume-validity decision

Independently reviewed the resume path **as it stands** (no probe): **no must-fix repository-side silent-corruption bug.** The two residual cases (a same-origin generic-validator resume, and a same-origin content-addressed resume whose 206 omits the hash) are the **standard HTTP `If-Range` conditional-response contract** — inherent/pre-existing protocol trust, not a code bypass — and are handled correctly (a changed object must yield `200` → truncate/restart).

## Diff

A single 14-line documentation comment at the no-sidecar decision point in `streamUrlToFile`, recording the corruption-class reasoning so the probe/byte-verify path is not re-introduced. No behavior change.

**Draft — do not merge.** Suggested resolution: merge the documentation (or close as already-resolved). The unsafe resume is intentionally not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
