### PR TITLE
0.48.31 — CivitAI agent-vision (#623) + download stale-event drop (#489) + workspace fallback (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.31] - 2026-08-01
+
+### MCP
+
+#### Added
+- panel_civitai_results returns inline sample images so the agent can SEE them (#623) (#628)
+
+#### Fixed
+- resolve local workspace via shared fallback when COMFYUI_PATH unset (#506) (#629)
+- drop superseded-attempt terminal events (panel#489) (#627)
+
+
 ## [0.48.30] - 2026-08-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.30",
+  "version": "0.48.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.30",
+      "version": "0.48.31",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.30",
+  "version": "0.48.31",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
mcp 0.48.31 — three merged fixes (non-destructive; #628 civitai is security-codex-verified fail-closed gating + origin-locked fetch):

- **#628 (#623)** panel_civitai_results delivers sample thumbnails to the agent as image content blocks (fail-closed NSFW gating, origin-locked SSRF-safe fetch, bounded). Companion panel #492.
- **#627 (#489)** drop a superseded download attempt's late FAILED event (attempt-generation epoch + per-attempt owner-scoped progress files).
- **#629 (#506)** node-authoring resolves local via the shared saved-default-workspace fallback (matches node-dev/node-verify).

Tag publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)