### PR TITLE
feat(panel-tools): add panel_set_property MCP tool (#488)

### DIFF
--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -412,6 +412,7 @@ const MUTATING_GRAPH_EDIT_CMDS = new Set<string>([
   "graph_connect",
   "graph_disconnect",
   "graph_set_widget",
+  "graph_set_node_property",
   "graph_move_node",
   "graph_resize_node",
   "graph_set_title",
@@ -3339,6 +3340,21 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS,
         );
       },
+    ),
+    def(
+      "panel_set_property",
+      "Set a node's LiteGraph PROPERTY (the right-click → Properties panel), NOT a widget — the counterpart to panel_set_widget, which only reaches `widgets`. Many custom nodes are configured entirely through node properties: e.g. the rgthree Fast Groups Bypasser's filters `matchTitle`, `matchColors`, `sort`, and `toggleRestriction` are node properties, and without `matchTitle` the node enumerates EVERY group in the workflow (a footgun). Sets node.properties[name] and, when the node defines an onPropertyChanged callback (rgthree and many LiteGraph nodes do), invokes it so the change takes effect LIVE (e.g. rgthree re-filters its group list). Returns the previous and new value. Undoable with Ctrl+Z.",
+      {
+        node_id: z.number().int().describe("Node id from panel_graph_outline / panel_query_graph."),
+        name: z
+          .string()
+          .describe("Property name from the node's right-click → Properties panel (e.g. 'matchTitle', 'matchColors', 'sort', 'toggleRestriction')."),
+        value: z
+          .union([z.string(), z.number(), z.boolean(), z.null()])
+          .describe("New property value (string/number/boolean/null). For the rgthree Fast Groups Bypasser, matchTitle is a title substring/regex filter."),
+      },
+      async (args: A, ctx) =>
+        ctx.call({ cmd: "graph_set_node_property", node_id: args.node_id, name: args.name, value: args.value }),
     ),
     def(
       "panel_move_node",


### PR DESCRIPTION
## What

Adds the `panel_set_property` MCP tool beside `panel_set_widget` in `src/orchestrator/panel-tools.ts`. It forwards the new `graph_set_node_property` bridge command to set a node's LiteGraph **property** (right-click → Properties) — the counterpart to `panel_set_widget`, which only reaches `widgets`.

The panel-side executor + unit test ship in the companion PR: **artokun/comfyui-mcp-panel#501**.

## Why

Many custom nodes are configured entirely through node **properties**. Concrete case: the **rgthree Fast Groups Bypasser** filters `matchTitle` / `matchColors` / `sort` / `toggleRestriction` are properties, not widgets — without `matchTitle` the node enumerates every group in the workflow. `panel_set_widget` refuses non-widget targets, so this closes that configuration gap.

## Notes

- `value` accepts `string | number | boolean | null`.
- Properties are a frontend/LiteGraph concept (not backend `/object_info`), so there is **no** fail-closed-against-backend authorization (unlike `set_widget`, #458); the panel handler still refuses an unresolvable node id.
- Registered in `MUTATING_GRAPH_EDIT_CMDS` so it awaits a stable tab binding before dispatch (post-restart/reconnect protection).
- `node scripts/asset-counts.mjs --check` passes: this is a panel tool (`panel_tools` 89 → 90); the README/`docs/plugin.mdx` "182 MCP tools" claim counts the catalog tools only and is unchanged.

Refs artokun/comfyui-mcp-panel#488 (the tracking issue lives in the panel repo; the panel PR carries the closing reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)