### PR TITLE
fix(panel-restart): bound the restart-confirmation card wait (panel #404)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2714,9 +2714,11 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
 
     const res = await defByName("panel_restart_comfyui").handler({}, ctx);
     expect(res.isError).toBeFalsy();
-    expect(toolText(res)).toMatch(/timed out waiting for your confirmation/i);
+    // #404: honest, ACTIONABLE timeout — names the retry AND the restart_comfyui fallback.
+    expect(toolText(res)).toMatch(/no confirmation received within/i);
+    expect(toolText(res)).toMatch(/restart_comfyui/);
     expect(toolText(res)).not.toMatch(/^Cancelled/);
-    // Critically: the reboot was NEVER dispatched.
+    // Critically: the reboot was NEVER dispatched (no auto-confirm).
     expect(dispatched.some((c) => c.cmd === "comfy_reboot")).toBe(false);
   });
 
@@ -2738,6 +2740,81 @@ describe("confirm-card timeout is honest, bounded, and late-answer-safe (#360)",
     await defByName("panel_restart_comfyui").handler({}, ctx);
     expect(forwardedTimeout).toBeGreaterThan(0);
     expect(forwardedTimeout).toBeLessThan(300000);
+  });
+
+  // #404: the confirm-card wait must be bounded by the dedicated restart-confirm
+  // ceiling — NOT the full ~255s remaining budget it used to inherit (which read as an
+  // indefinite hang when a card went unanswered after a prior restart's reconnect).
+  it("panel_restart_comfyui bounds the confirm-card wait by RESTART_CONFIRM_TIMEOUT_MS (not the full ~255s budget)", async () => {
+    // No ask-timing override → the REAL getAskTiming (240s) is in effect, so the forwarded
+    // reply timeout reflects the handler's own confirm budget, not a test clamp.
+    let forwardedTimeout = Infinity;
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") {
+          forwardedTimeout = opts?.timeoutMs ?? 0;
+          return "No, cancel";
+        }
+        return { rebooting: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    await defByName("panel_restart_comfyui").handler({}, ctx);
+    expect(forwardedTimeout).toBeGreaterThan(0);
+    expect(forwardedTimeout).toBeLessThanOrEqual(
+      __panelToolsTestHooks.RESTART_CONFIRM_TIMEOUT_MS,
+    );
+    // And well under the old ~255s inheritance that produced the #404 hang.
+    expect(forwardedTimeout).toBeLessThan(240000);
+  });
+
+  // #404 core regression: an unanswered/undelivered restart confirmation must REJECT with
+  // the actionable timeout error WITHIN the bound — never hang indefinitely — and must
+  // NOT dispatch the reboot (no auto-confirm). Bounded via the fast ask-timing override
+  // so the test proves the fail-fast without waiting the real ceiling.
+  it("panel_restart_comfyui fails fast with an actionable error when the confirmation card is never answered (#404)", async () => {
+    __panelAskTestHooks.setAskTiming({ deadlineMs: 5, graceMs: 15, pollMs: 2 });
+    const dispatched: Array<Record<string, unknown>> = [];
+    const bridge = {
+      // The card is DELIVERED but the tab never replies (backgrounded / reconnecting).
+      send: async (cmd: Record<string, unknown>, opts?: { timeoutMs?: number }) => {
+        if (cmd.cmd === "ask_user") throw REPLY_TIMEOUT_ERR("ask_user", opts?.timeoutMs ?? 0);
+        dispatched.push(cmd);
+        return { rebooting: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const started = Date.now();
+    const res = await defByName("panel_restart_comfyui").handler({}, ctx);
+    // Settled promptly — not an indefinite hang.
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(res.isError).toBeFalsy();
+    const text = toolText(res);
+    expect(text).toMatch(/no confirmation received within/i);
+    expect(text).toMatch(/backgrounded|reconnecting/i);
+    expect(text).toMatch(/restart_comfyui/);
+    // The reboot was NEVER dispatched — the wait is bounded, not the confirmation bypassed.
+    expect(dispatched.some((c) => c.cmd === "comfy_reboot")).toBe(false);
+  });
+
+  // #404: a normally-confirmed restart still proceeds to dispatch the reboot — the bound
+  // is on the WAIT only; a real "yes" is honored exactly as before.
+  it("panel_restart_comfyui still dispatches the reboot on a normal 'yes' confirmation (#404)", async () => {
+    const dispatched: Array<Record<string, unknown>> = [];
+    const bridge = {
+      send: async (cmd: Record<string, unknown>) => {
+        if (cmd.cmd === "ask_user") return "Yes, go ahead";
+        dispatched.push(cmd);
+        return { rebooting: true };
+      },
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "abcd1234");
+
+    const res = await defByName("panel_restart_comfyui").handler({}, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(dispatched.some((c) => c.cmd === "comfy_reboot")).toBe(true);
   });
 
   // #360 mirrors #486: a slow-but-valid answer buffered after the card timeout must

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -242,6 +242,18 @@ let panelRebootTimingOverride: PanelRebootTiming | null = null;
 const MAX_REBOOT_SETTLE_MS = 10_000; // 10s
 const MAX_REBOOT_BUDGET_MS = 240_000; // 240s  → settle+budget ≤ 250s < 300s outer
 
+// #404: hard ceiling on how long the panel_restart_comfyui CONFIRMATION card waits for
+// a yes/no answer. A restart is user-initiated, so a present user answers in seconds;
+// the failure mode is an unanswered/undelivered card AFTER a prior restart's reconnect
+// (the "second restart in one turn" repro: the panel tab is backgrounded or still
+// re-registering, so the card is never seen/answered). Previously the confirm inherited
+// the full remaining ~255s budget, so it blocked for ~4 minutes and read as an
+// indefinite hang (the user killed it at ~2min). Bounding the WAIT here — well under the
+// ~240s ask deadline and the ~300s tools/call budget — makes an unanswered card fail
+// fast with an actionable retry / restart_comfyui hint. It NEVER shortcuts the
+// confirmation itself (no auto-confirm): it bounds only how long we wait for the answer.
+const RESTART_CONFIRM_TIMEOUT_MS = 90_000; // 90s
+
 function parsePositiveNumberEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw == null || raw === "") return fallback;
@@ -304,6 +316,8 @@ export const __panelToolsTestHooks = {
   loopbackProbeUrl,
   /** Compute reboot timing from env WITH the P2 hard caps (bypasses any override). */
   computeRebootTimingFromEnv,
+  /** #404: the hard ceiling on the panel_restart_comfyui confirmation-card wait. */
+  RESTART_CONFIRM_TIMEOUT_MS,
   /** Zero out the post-drop retry settle so retry-once tests don't sleep. */
   setRetrySettleMs(ms: number | null): void {
     retrySettleMsOverride = ms;
@@ -4574,15 +4588,41 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // to the remaining budget (its deadline+grace can't overrun it — see confirm).
         const OVERALL_MAX_MS = 255_000;
         const overallDeadline = Date.now() + OVERALL_MAX_MS;
+        // #404: if the ONLY reachable client is canvas-less (a mobile mirror / remote /
+        // headless viewer), a yes/no card can't render, so the confirm would block with
+        // no way to answer. Detect that up front — exactly as panel_ask does — and fail
+        // fast with an actionable message instead of dispatching a card into the void and
+        // waiting out the whole budget. Points at the headless restart_comfyui fallback,
+        // which needs no panel card. (A normal interactive tab returns null → proceed.)
+        const surfaceErr = askSurfaceError(ctx);
+        if (surfaceErr) {
+          return fail(
+            surfaceErr +
+              " To restart the server without a panel confirmation card, use restart_comfyui.",
+          );
+        }
+        // #404: BOUND the confirmation wait. It previously inherited the full remaining
+        // ~255s budget, so an unanswered/undelivered card (the panel tab backgrounded or
+        // still reconnecting after a PRIOR restart — the second-restart-in-one-turn repro)
+        // blocked for ~4 minutes and read as an indefinite hang. Cap it at
+        // RESTART_CONFIRM_TIMEOUT_MS (still clamped under the outer budget). This bounds
+        // only the WAIT — it never auto-confirms; on timeout we fail fast, below.
+        const confirmBudget = Math.max(
+          1,
+          Math.min(RESTART_CONFIRM_TIMEOUT_MS, overallDeadline - Date.now()),
+        );
         const decision = await ctx.confirm(
           "Restart ComfyUI now? It (and this agent) will go down briefly, then reconnect and resume automatically.",
           "Restart ComfyUI",
-          Math.max(1, overallDeadline - Date.now()),
+          confirmBudget,
         );
         if (decision === "timeout") {
           return ok(
-            "Timed out waiting for your confirmation, so I did NOT restart ComfyUI. " +
-              "Tell me to restart it and I'll go ahead.",
+            `No confirmation received within ${Math.round(confirmBudget / 1000)}s, so I did NOT ` +
+              "restart ComfyUI. The panel tab may be backgrounded or still reconnecting after a " +
+              "previous restart, so the confirmation card wasn't answered. Tell me to restart it " +
+              "and I'll re-ask, or use restart_comfyui to restart the server directly without a " +
+              "panel card.",
           );
         }
         if (decision !== "yes") {


### PR DESCRIPTION
## Problem (panel #404, P1)

`panel_restart_comfyui({})` could remain pending for ~4 minutes — perceived as an indefinite hang and killed at ~2 min — when the restart CONFIRMATION card is not answered/delivered after a reconnect. Repro: install a dep → `panel_restart_comfyui` (restarts + panel reconnects) → install another dep → call `panel_restart_comfyui` AGAIN in the same turn → the second call blocks while ComfyUI stays idle. The non-panel `restart_comfyui` completed in ~11s against the same idle server.

## Root cause

The handler passed the FULL remaining budget to `ctx.confirm`:

```
Math.max(1, overallDeadline - Date.now())   // ~255s
```

So the underlying `bridge.send` reply timer for the `ask_user` card ran to the whole `panel_ask` deadline (~240s + ~15s grace). When the tab is backgrounded or still re-registering after the first restart's reconnect, the card is never seen/answered, so the `await` settled only after ~4 minutes. It was never truly infinite — just bounded by the wrong (far too long) ceiling.

## Fix (localized to `src/orchestrator/panel-tools.ts`)

- **Bound the wait**: new `RESTART_CONFIRM_TIMEOUT_MS = 90_000`; the confirm wait is capped at `min(RESTART_CONFIRM_TIMEOUT_MS, remaining)` — generous for a present user to click, but a hard backstop well under the ask ceiling and the ~300s tools/call budget.
- **Fail fast on a canvas-less surface**: an up-front `askSurfaceError` check (exactly as `panel_ask`) so a card that can't render never blocks the whole budget.
- **Actionable timeout**: on timeout, an honest message noting the tab may be backgrounded/reconnecting and pointing at a retry or the non-panel `restart_comfyui` fallback.
- **No auto-confirm**: only the WAIT is bounded — a real "yes" still dispatches the reboot. The #493/#509 fast-reboot false-timeout / post-confirmation dispatch+recovery path is untouched.

## Tests

- `panel_restart_comfyui fails fast with an actionable error when the confirmation card is never answered (#404)` — rejects with the actionable message WITHIN the bound (asserts settle < 2s), reboot never dispatched.
- `panel_restart_comfyui bounds the confirm-card wait by RESTART_CONFIRM_TIMEOUT_MS (not the full ~255s budget)` — forwarded reply timeout ≤ 90s and < 240s.
- `panel_restart_comfyui still dispatches the reboot on a normal 'yes' confirmation (#404)` — successful path preserved.
- Updated the existing #360 assertion to the new actionable wording.

`npm run build` green; `npm test` green except the pre-existing `node-dev` ripgrep-env failure (unrelated).

## Codex self-gate

Codex reviewed the diff and confirmed the #493/#509 post-confirmation dispatch/recovery section is untouched, surfacing no findings, but then wedged on the test-run step (a known Codex failure mode) and did not emit a final verdict. Build + tests were verified independently here. Maintainer to run an independent codex pass on the diff.

Closes artokun/comfyui-mcp-panel#404

🤖 Generated with [Claude Code](https://claude.com/claude-code)