### PR TITLE
0.48.32 — report-bug consent + panel_set_property + restart-confirm bound + download-resume etag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## Unreleased
 
+## [0.48.32] - 2026-08-01
+
+### MCP
+
+#### Added
+- add panel_set_property MCP tool (#488) (#634)
+
+#### Fixed
+- resume — X-Linked-Etag false-changed across hops deleted valid partial (#467) (#637)
+- bound the restart-confirmation card wait (panel #404) (#635)
+- never file/PR under an ambient gh account unprompted — Worker is the autonomous default (project identity); gh path requires account-awareness + explicit consent (#632)
+
+
 ## [0.48.31] - 2026-08-01
 
 ### MCP

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.31",
+  "version": "0.48.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "comfyui-mcp",
-      "version": "0.48.31",
+      "version": "0.48.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfyui-mcp",
-  "version": "0.48.31",
+  "version": "0.48.32",
   "mcpName": "io.github.artokun/comfyui-mcp",
   "description": "Local-first, agent-native control plane for ComfyUI — MCP server + autonomous sidebar agent that drives your live graph in natural language on ANY LLM: Claude/ChatGPT/Gemini on your subscription (no API key), free local models via Ollama (fully offline), or any hosted model via an OpenAI-compatible endpoint (DeepSeek, GLM, MiMo, OpenRouter). Generate images, video & audio, author and run workflows, manage models and custom nodes; a compact tool-router mode keeps even 4B models effective, and a built-in LLM Arena benchmarks them on real ComfyUI tasks. Also a Claude Code plugin with skills, slash commands, and installer packs. Local, LAN, VPS, or Comfy Cloud.",
   "homepage": "https://comfyui-mcp.artokun.io/docs",


### PR DESCRIPTION
mcp 0.48.32 — five non-destructive/correctness fixes (download-integrity ones independently codex-verified):

- **#632** report-bug skill: never file/PR under an ambient `gh` account unprompted — the Worker (project identity) is the autonomous default; the `gh` path requires account-awareness + explicit consent (Discord-reported consent bug).
- **#634 (#488)** new `panel_set_property` tool — set a node's LiteGraph properties (rgthree matchTitle etc.), the counterpart to panel_set_widget.
- **#635 (panel#404)** panel_restart_comfyui: bound the confirmation-card wait to min(90s, remaining) + fail-fast for canvas-less surface; never auto-confirms.
- **#637 (#467)** download resume: X-Linked-Etag false-changed across HF redirect hops → valid multi-GB partial deleted; now compares like-for-like from the resolve hop + restarts-in-call, corruption-safe (my independent codex verified).
- **#630** doc: why a sidecar-less partial must not be probe-resumed.

Tag publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)