### PR TITLE
feat(providers): add MiniMax as a first-class API-key provider (#355)

### DIFF
--- a/docs/backends.mdx
+++ b/docs/backends.mdx
@@ -81,6 +81,12 @@ placeholder follows the active backend ("Ask Claude…" / "Ask Ollama…").
   `https://api.moonshot.ai/v1`) — distinct from the **Kimi** provider above,
   which is the Kimi Code coding subscription. Override the model with
   `COMFYUI_MCP_MOONSHOT_MODEL` and the base with `COMFYUI_MCP_MOONSHOT_BASE_URL`.
+- **MiniMax** — set `MINIMAX_API_KEY` from
+  [platform.minimax.io](https://platform.minimax.io/console/api-keys). No CLI.
+  The default model is `MiniMax-M3` and the default base is the global endpoint
+  `https://api.minimax.io/v1` (OpenAI-compatible, plain Bearer auth). For the
+  China region, set `COMFYUI_MCP_MINIMAX_BASE_URL=https://api.minimaxi.com/v1`.
+  Override the model with `COMFYUI_MCP_MINIMAX_MODEL`.
 - **Copilot (experimental)** — sign in from the panel's experimental provider
   row. Off by default; enable experimental backends in Settings first.
 - **Ollama (local)** — no sign-in. Install Ollama and pull a tool-calling

--- a/src/__tests__/orchestrator/backend-readiness.test.ts
+++ b/src/__tests__/orchestrator/backend-readiness.test.ts
@@ -177,6 +177,18 @@ describe("backendReadiness", () => {
     else process.env.MOONSHOT_API_KEY = real;
   });
 
+  it("minimax: ready when MINIMAX_API_KEY is set", () => {
+    const real = process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    expect(backendReadiness("minimax", { home: tmp }).ready).toBe(false);
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    const r = backendReadiness("minimax", { home: tmp });
+    expect(r.auth).toBe(true);
+    expect(r.ready).toBe(true);
+    if (real === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = real;
+  });
+
   it("unknown backend is never ready", () => {
     expect(backendReadiness("bogus").ready).toBe(false);
   });

--- a/src/__tests__/services/code-provider-auth.test.ts
+++ b/src/__tests__/services/code-provider-auth.test.ts
@@ -6,6 +6,7 @@ import {
   resolveGlmCodeCredentials,
   resolveKimiCodeOAuth,
   resolveMoonshotCredentials,
+  resolveMiniMaxCredentials,
   resolveOpenAICodexOAuth,
   __testing,
 } from "../../services/code-provider-auth.js";
@@ -51,6 +52,30 @@ describe("resolveMoonshotCredentials", () => {
 
   it("throws when MOONSHOT_API_KEY is not set", () => {
     expect(() => resolveMoonshotCredentials()).toThrow(/MOONSHOT_API_KEY/);
+  });
+});
+
+describe("resolveMiniMaxCredentials", () => {
+  afterEach(() => {
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.COMFYUI_MCP_MINIMAX_BASE_URL;
+  });
+
+  it("reads MINIMAX_API_KEY and default base URL", () => {
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    const creds = resolveMiniMaxCredentials();
+    expect(creds.apiKey).toBe("minimax-test-key");
+    expect(creds.baseUrl).toBe(__testing.MINIMAX_DEFAULT_BASE);
+  });
+
+  it("honors a base URL override (trailing slash stripped)", () => {
+    process.env.MINIMAX_API_KEY = "minimax-test-key";
+    process.env.COMFYUI_MCP_MINIMAX_BASE_URL = "https://api.minimaxi.com/v1/";
+    expect(resolveMiniMaxCredentials().baseUrl).toBe("https://api.minimaxi.com/v1");
+  });
+
+  it("throws when MINIMAX_API_KEY is not set", () => {
+    expect(() => resolveMiniMaxCredentials()).toThrow(/MINIMAX_API_KEY/);
   });
 });
 

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -128,6 +128,7 @@ describe("resolveBackends (#358 — report the ACTUAL backend, never a wrong spe
     expect(resolveBackends("gemini").backend).toBe("Gemini");
     expect(resolveBackends("ollama").backend).toBe("Ollama");
     expect(resolveBackends("copilot").backend).toBe("Copilot");
+    expect(resolveBackends("minimax").backend).toBe("MiniMax");
     expect(resolveBackends("claude").backend).toBe("Claude");
     // Case-insensitive.
     expect(resolveBackends("GROK").backend).toBe("Grok");

--- a/src/__tests__/services/panel-secrets-slots.test.ts
+++ b/src/__tests__/services/panel-secrets-slots.test.ts
@@ -62,6 +62,12 @@ describe("panel-secrets credential slots (canonical .env)", () => {
     expect(process.env.MOONSHOT_API_KEY).toBe("sk-moonshot-abc123");
   });
 
+  it("the minimax slot writes MINIMAX_API_KEY", async () => {
+    const m = await import("../../services/panel-secrets.js");
+    m.setPanelSecret("minimax", "minimax-abc123");
+    expect(process.env.MINIMAX_API_KEY).toBe("minimax-abc123");
+  });
+
   it("rejects an unknown slot", async () => {
     const m = await import("../../services/panel-secrets.js");
     expect(() => m.setPanelSecret("not-a-slot", "x")).toThrow(/unknown credential slot/i);

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -19,6 +19,7 @@ export type BackendId =
   | "glm"
   | "kimi"
   | "moonshot"
+  | "minimax"
   | "ollama"
   | "openrouter"
   | "copilot";

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2181,11 +2181,11 @@ export async function runPanelOrchestrator(): Promise<void> {
   // the next probe uses the new key, and re-push readiness + models to every
   // live tab so the OpenRouter provider flips to "ready" and lists its models
   // without a reconnect.
-  const KEYED_PROVIDERS = ["openrouter", "custom", "glm", "kimi", "moonshot"];
+  const KEYED_PROVIDERS = ["openrouter", "custom", "glm", "kimi", "moonshot", "minimax"];
   const unsubscribeAgentSecrets = onAgentSecretsChanged(() => {
     hydrateAgentSecretsIntoEnv();
     // A key change can affect ANY keyed provider (OpenRouter/Custom endpoints and
-    // the hosted API-key backends GLM / Kimi / Moonshot) — drop each one's cached
+    // the hosted API-key backends GLM / Kimi / Moonshot / MiniMax) — drop each one's cached
     // probe backend + model list so the next probe carries the fresh credentials
     // (and a revoked key immediately stops reading as "ready" from a stale cache).
     for (const b of KEYED_PROVIDERS) {

--- a/src/services/code-provider-auth.ts
+++ b/src/services/code-provider-auth.ts
@@ -21,6 +21,7 @@ const KIMI_OAUTH_TOKEN_URL = "https://api.kimi.com/oauth/token";
 export const GLM_CODE_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4";
 export const KIMI_CODE_DEFAULT_BASE = "https://api.kimi.com/coding/v1";
 export const MOONSHOT_DEFAULT_BASE = "https://api.moonshot.ai/v1";
+export const MINIMAX_DEFAULT_BASE = "https://api.minimax.io/v1";
 
 const TOKEN_REFRESH_SKEW_MS = 120_000;
 
@@ -550,6 +551,23 @@ export function resolveMoonshotCredentials(): MoonshotCredentials {
 }
 
 /**
+ * MiniMax platform API key. Env: MINIMAX_API_KEY. OpenAI-compatible
+ * /v1/chat/completions at the global endpoint (https://api.minimax.io/v1);
+ * set COMFYUI_MCP_MINIMAX_BASE_URL to the China-region endpoint
+ * (https://api.minimaxi.com/v1) or any other OpenAI-compatible host. Auth is a
+ * plain Bearer key — the OpenAI-compatible route needs no GroupId.
+ */
+export function resolveMiniMaxCredentials(): MoonshotCredentials {
+  return resolveKeyedCredentials({
+    envKeys: ["MINIMAX_API_KEY"],
+    missingMessage:
+      "MiniMax requires MINIMAX_API_KEY from platform.minimax.io (https://platform.minimax.io/console/api-keys).",
+    baseUrlEnv: "COMFYUI_MCP_MINIMAX_BASE_URL",
+    defaultBaseUrl: MINIMAX_DEFAULT_BASE,
+  });
+}
+
+/**
  * Resolve credentials for a simple OpenAI-compatible api-key provider by its
  * registry id (see services/openai-provider-registry). This is the one place
  * that marries a `simpleKeyAuth` registry id to its resolver, so the generic
@@ -559,6 +577,7 @@ export function resolveMoonshotCredentials(): MoonshotCredentials {
 export function resolveOpenAiKeyCredentials(id: string): { apiKey: string; baseUrl: string } {
   if (id === "glm") return resolveGlmCodeCredentials();
   if (id === "moonshot") return resolveMoonshotCredentials();
+  if (id === "minimax") return resolveMiniMaxCredentials();
   throw new ValidationError(`No OpenAI api-key credential resolver for provider "${id}".`);
 }
 
@@ -790,6 +809,7 @@ export const __testing = {
   GLM_CODE_DEFAULT_BASE,
   KIMI_CODE_DEFAULT_BASE,
   MOONSHOT_DEFAULT_BASE,
+  MINIMAX_DEFAULT_BASE,
   codexAuthPath,
   kimiCodeAuthPath,
   grokAuthPath,

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -445,6 +445,7 @@ export const BACKEND_LABELS: Record<string, string> = {
   glm: "GLM",
   kimi: "Kimi",
   moonshot: "Kimi K3 (Moonshot)",
+  minimax: "MiniMax",
   ollama: "Ollama",
   openrouter: "OpenRouter",
   copilot: "Copilot",

--- a/src/services/openai-provider-registry.ts
+++ b/src/services/openai-provider-registry.ts
@@ -27,7 +27,7 @@
 // the copy/identity that used to be duplicated.
 
 /** The simple OpenAI-compatible API-key providers, by id. */
-export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot";
+export type OpenAiKeyProviderId = "glm" | "kimi" | "moonshot" | "minimax";
 
 export interface OpenAiKeyProvider {
   /** Panel backend id (a member of orchestrator BackendId). */
@@ -113,6 +113,20 @@ export const OPENAI_KEY_PROVIDERS: OpenAiKeyProvider[] = [
       `🟢 comfyui-mcp agent ready — ${agentLabel} on your Moonshot platform (Kimi K3) API key. Ask away.`,
     degradedMessage:
       "⚠️ The background agent isn't responding — Moonshot (Kimi K3) couldn't start. Set MOONSHOT_API_KEY from platform.kimi.ai, then Disconnect → Connect to retry.",
+    simpleKeyAuth: true,
+  },
+  {
+    id: "minimax",
+    slotLabel: "MiniMax",
+    slotHelp: "MiniMax M3 via the MiniMax platform API key",
+    envKeys: ["MINIMAX_API_KEY"],
+    modelEnv: "COMFYUI_MCP_MINIMAX_MODEL",
+    defaultModel: process.env.COMFYUI_MCP_MINIMAX_MODEL?.trim() || "MiniMax-M3",
+    ackFallbackLabel: "MiniMax",
+    readyMessage: (agentLabel) =>
+      `🟢 comfyui-mcp agent ready — ${agentLabel} on your MiniMax platform API key. Ask away.`,
+    degradedMessage:
+      "⚠️ The background agent isn't responding — MiniMax couldn't start. Set MINIMAX_API_KEY from platform.minimax.io, then Disconnect → Connect to retry.",
     simpleKeyAuth: true,
   },
 ];


### PR DESCRIPTION
## MiniMax — first-class hosted API-key provider (orchestrator side)

Supersedes/replaces the orchestrator-only PR #355 (which was stale and missed the panel wiring entirely). This carries the same registry change on current `main` **plus** a site #355 missed, and lands alongside the companion **comfyui-mcp-panel** PR (`feat/minimax-provider-355`) that wires the ~22 panel provider sites.

MiniMax is a hosted, OpenAI-compatible API-key provider (mirrors the **moonshot**/**glm** pattern):
- Base `https://api.minimax.io/v1` (OpenAI-compatible `/v1/chat/completions`, plain `Authorization: Bearer` — no GroupId), China override `COMFYUI_MCP_MINIMAX_BASE_URL=https://api.minimaxi.com/v1`
- Key `MINIMAX_API_KEY` (from platform.minimax.io), default model `MiniMax-M3`, override `COMFYUI_MCP_MINIMAX_MODEL`
- Verified against MiniMax's official docs (platform.minimax.io/docs/api-reference/text-chat-openai)

### Changes
- **openai-provider-registry.ts** — `minimax` in `OpenAiKeyProviderId` + the `OPENAI_KEY_PROVIDERS` registry (the single source of truth: derives the credential slot, agent-secret allowlist, both `KNOWN_BACKENDS` lists, the generic `makeBackend` factory, connect-ack label/ready/degraded text, and readiness).
- **code-provider-auth.ts** — `MINIMAX_DEFAULT_BASE`, `resolveMiniMaxCredentials()`, wired into `resolveOpenAiKeyCredentials("minimax")`, exported from `__testing`.
- **agent-backend.ts** — `| "minimax"` in `BackendId`.
- **index.ts** — `minimax` in the `KEYED_PROVIDERS` cache-drop list so a key change re-probes with fresh creds.
- **env-capabilities.ts** — `BACKEND_LABELS` `minimax: "MiniMax"`. This map is **not** registry-derived; without it a MiniMax turn's env block reports "unknown" (#358 regression). *(#355 missed this.)*
- **docs/backends.mdx** — document provider, default model/base, China override.
- **tests** — mirror moonshot's: resolver (default base + override + throw), credential slot writes `MINIMAX_API_KEY`, readiness when `MINIMAX_API_KEY` set, and the backend-label case.

### Checks
- `npm run build` (tsc) — clean.
- Touched vitest suites (code-provider-auth, panel-secrets-slots, backend-readiness, env-capabilities, provider-model-hint) — 83 pass. Full suite: 2898 pass / 1 pre-existing environment-dependent failure unrelated to this change (`node-dev.test.ts` expects the "builtin" search engine but ripgrep is installed on the rig).

Draft — do not merge until the companion panel PR is reviewed together (shared provider-list lines coordinated with the parallel pi.dev PR).

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
