### PR TITLE
feat(pi): add pi.dev as a first-class agent backend (#491)

### DIFF
--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -93,6 +93,7 @@ import {
   resolvePiBin,
 } from "../../orchestrator/pi-backend.js";
 import { backendReadiness } from "../../orchestrator/backend-readiness.js";
+import { PI_ENV_API_KEYS } from "../../orchestrator/pi-credentials.js";
 
 const FAKE_BIN = join(tmpdir(), "fake-pi", "pi.exe");
 
@@ -178,10 +179,15 @@ describe("parsePiModels", () => {
 // Provider env keys pi's readiness treats as a verifiable credential — must be
 // cleared for deterministic "no credential" assertions (the dev machine may have
 // one set).
+// Derived from pi's own env map so a newly-covered provider key can never leak
+// the developer's real environment into these assertions, plus the Google Vertex
+// ADC trio (a file path + project + location, not API keys).
 const PI_ENV_KEYS = [
-  "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
-  "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY", "ZAI_API_KEY",
-  "KIMI_API_KEY", "MINIMAX_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS",
+  ...PI_ENV_API_KEYS,
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_CLOUD_PROJECT",
+  "GCLOUD_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
 ];
 function withNoPiEnvKeys<T>(fn: () => T): T {
   const saved: Record<string, string | undefined> = {};
@@ -246,19 +252,38 @@ describe("resolvePiBin / readiness", () => {
     });
   });
 
-  it("detects the broadened credential sources: env key, Google ADC, models.json (P1a-b)", () => {
+  // The per-source rules are exercised exhaustively in pi-credentials.test.ts;
+  // these assert that backendReadiness("pi") is actually wired to them.
+  it("detects the broadened credential sources: env key, Vertex ADC, models.json (P1a-b)", () => {
     withNoPiEnvKeys(() => {
-      // (1) a non-stripped provider env key.
-      process.env.OPENAI_API_KEY = "sk-x";
-      expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
-      delete process.env.OPENAI_API_KEY;
-      // (2) Google ADC — a file path, not an API key (not stripped).
-      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/home/u/adc.json";
+      // (1) a non-stripped provider env key — including ones pi accepts that we
+      // used to miss entirely (cerebras/fireworks/together/anthropic-oauth).
+      for (const key of ["OPENAI_API_KEY", "CEREBRAS_API_KEY", "FIREWORKS_API_KEY", "TOGETHER_API_KEY", "ANTHROPIC_OAUTH_TOKEN"]) {
+        process.env[key] = "sk-x";
+        expect(backendReadiness("pi", { home: workDir }).ready, key).toBe(true);
+        delete process.env[key];
+      }
+      // (2) Google Vertex ADC — pi's ADC path needs an EXISTING credentials file
+      // plus project + location. A dangling path is not a credential.
+      const adc = join(workDir, "adc.json");
+      process.env.GOOGLE_CLOUD_PROJECT = "proj";
+      process.env.GOOGLE_CLOUD_LOCATION = "us-central1";
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = join(workDir, "missing.json");
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(false);
+      writeFileSync(adc, "{}");
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = adc;
       expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-      // (3) a non-empty models.json (custom-provider creds).
+      delete process.env.GOOGLE_CLOUD_PROJECT;
+      delete process.env.GOOGLE_CLOUD_LOCATION;
+      // (3) models.json: only a provider carrying its OWN credential counts —
+      // an endpoint with no key is loaded by pi but its models stay unavailable.
       mkdirSync(join(workDir, ".pi", "agent"), { recursive: true });
-      writeFileSync(join(workDir, ".pi", "agent", "models.json"), '{"my-vllm":{"baseUrl":"http://x/v1"}}');
+      const modelsJson = join(workDir, ".pi", "agent", "models.json");
+      writeFileSync(modelsJson, '{"providers":{"my-vllm":{"baseUrl":"http://x/v1"}}}');
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(false);
+      // …and JSONC is valid here, because pi strips comments before parsing it.
+      writeFileSync(modelsJson, '{\n  // local\n  "providers": { "my-vllm": { "apiKey": "sk-local", },\n  },\n}');
       expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
     });
   });

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -9,7 +9,7 @@
 // invariant on failures, interrupt, tool-secret scoping, and `pi --list-models`
 // parsing.
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
@@ -175,13 +175,61 @@ describe("parsePiModels", () => {
   });
 });
 
+// Provider env keys pi's readiness treats as a verifiable credential — must be
+// cleared for deterministic "no credential" assertions (the dev machine may have
+// one set).
+const PI_ENV_KEYS = [
+  "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
+  "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY", "ZAI_API_KEY",
+  "KIMI_API_KEY", "MINIMAX_API_KEY",
+];
+function withNoPiEnvKeys<T>(fn: () => T): T {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of PI_ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const k of PI_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  }
+}
+
 describe("resolvePiBin / readiness", () => {
-  it("honors the COMFYUI_MCP_PI_PATH override and reads ready when the CLI is present", () => {
+  it("honors the COMFYUI_MCP_PI_PATH override", () => {
     expect(resolvePiBin()).toBe(FAKE_BIN);
-    const r = backendReadiness("pi", { home: workDir });
-    expect(r.backend).toBe("pi");
-    expect(r.cli).toBe(true);
-    expect(r.ready).toBe(true); // ready keys off CLI presence (auth verified at connect)
+  });
+
+  it("REFUSES a .cmd/.bat override (Node can't shell-lessly spawn it) — P1c", () => {
+    const saved = process.env.COMFYUI_MCP_PI_PATH;
+    try {
+      process.env.COMFYUI_MCP_PI_PATH = "C:/tools/pi.cmd";
+      expect(resolvePiBin(workDir)).toBeNull();
+      process.env.COMFYUI_MCP_PI_PATH = "/usr/local/bin/pi.bat";
+      expect(resolvePiBin(workDir)).toBeNull();
+    } finally {
+      process.env.COMFYUI_MCP_PI_PATH = saved;
+    }
+  });
+
+  it("reads ready ONLY when a credential is verifiable — not on CLI presence alone (P1a)", () => {
+    // CLI present but NO credential → NOT ready (list-models isn't an auth probe).
+    withNoPiEnvKeys(() => {
+      const r0 = backendReadiness("pi", { home: workDir });
+      expect(r0.cli).toBe(true);
+      expect(r0.auth).toBeNull(); // unknown, don't nag
+      expect(r0.ready).toBe(false);
+    });
+    // With ~/.pi/agent/auth.json present → ready.
+    mkdirSync(join(workDir, ".pi", "agent"), { recursive: true });
+    writeFileSync(join(workDir, ".pi", "agent", "auth.json"), '{"anthropic":{"type":"api_key","key":"x"}}');
+    const r1 = backendReadiness("pi", { home: workDir });
+    expect(r1.auth).toBe(true);
+    expect(r1.ready).toBe(true);
   });
 
   it("reports not-ready when the CLI is absent", () => {
@@ -213,9 +261,11 @@ describe("PiBackend turns", () => {
       backend.run({ channel: channelOf([{ text: "hi" }, { text: "again" }]) }),
     );
 
-    // First a provisional session (sentinel), then the REAL id from the header.
-    expect(events[0]).toMatchObject({ type: "session", sessionId: "pi-pending", model: "openai/gpt-4o" });
-    expect(events.some((e) => e.type === "session" && (e as { sessionId: string }).sessionId === "sess-abc")).toBe(true);
+    // No provisional/sentinel session is ever emitted (P1b) — the FIRST session
+    // event carries the REAL id parsed from pi's JSON header.
+    expect(events.some((e) => e.type === "session" && (e as { sessionId: string }).sessionId === "pi-pending")).toBe(false);
+    const firstSession = events.find((e) => e.type === "session") as { sessionId: string; model?: string };
+    expect(firstSession).toMatchObject({ sessionId: "sess-abc", model: "openai/gpt-4o" });
     expect(events.filter((e) => e.type === "assistant").map((e) => (e as { text: string }).text)).toEqual([
       "Hello world",
       "Second",
@@ -332,6 +382,25 @@ describe("PiBackend turns", () => {
     expect(events.filter((e) => e.type === "result")).toEqual([
       { type: "result", ok: false, subtype: "error" },
     ]);
+  });
+
+  it("emits NO session event when a fresh turn fails before the JSON header (P1b)", async () => {
+    // A pre-header failure (spawn error, over-long prompt, early exit) must not
+    // persist a bogus session id — run() no longer emits a sentinel up front.
+    hoisted.script.push({ stdout: [], stderr: "boom", exit: 1 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    expect(events.some((e) => e.type === "session")).toBe(false);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "error" },
+    ]);
+  });
+
+  it("emits the resume session id up front (real id, so surfacing it is fine)", async () => {
+    hoisted.script.push({ stdout: [header("sess-r"), delta("ok"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ resume: "sess-existing", channel: channelOf([{ text: "hi" }]) }));
+    expect(events[0]).toMatchObject({ type: "session", sessionId: "sess-existing" });
   });
 
   it("maps a credential-looking failure to provider-setup guidance", async () => {

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -1,0 +1,426 @@
+// Unit tests for the pi.dev CLI backend (pi-backend.ts, issue #491).
+//
+// We cannot run the real `pi` here, so `node:child_process` is mocked: spawn()
+// returns an in-process fake child whose scripted stdout/stderr/exit behavior is
+// set per test. This exercises the real PiBackend end-to-end: executable
+// resolution (env override), spawn argv shaping (--mode json / --session /
+// --model / --provider / positional prompt), the JSON-lines → delta → assistant →
+// result event mapping, session-id capture + resume, the terminal-result
+// invariant on failures, interrupt, tool-secret scoping, and `pi --list-models`
+// parsing.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
+
+const hoisted = vi.hoisted(() => ({
+  spawns: [] as Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }>,
+  procs: [] as Array<Record<string, unknown>>,
+  killed: [] as number[],
+  script: [] as Array<{ stdout?: string[]; stderr?: string; exit?: number | null; hang?: boolean }>,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+
+  function spawnFake(cmd: string, args: string[], opts: Record<string, unknown>) {
+    hoisted.spawns.push({ cmd, args, opts });
+    const proc = new EventEmitter() as InstanceType<typeof EventEmitter> & Record<string, unknown>;
+    proc.pid = 5000 + hoisted.procs.length;
+    proc.exitCode = null;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.stdin = null;
+    proc.kill = () => {
+      if (proc.exitCode === null) {
+        proc.exitCode = 1;
+        proc.emit("exit", 1, "SIGTERM");
+      }
+      return true;
+    };
+    hoisted.procs.push(proc);
+    const step = hoisted.script[Math.min(hoisted.procs.length - 1, hoisted.script.length - 1)] ?? {
+      stdout: ['{"type":"agent_end","messages":[]}\n'],
+      exit: 0,
+    };
+    setTimeout(() => {
+      for (const chunk of step.stdout ?? []) stdout.write(chunk);
+      if (step.stderr) stderr.write(step.stderr);
+      if (!step.hang) {
+        setTimeout(() => {
+          if (proc.exitCode === null) {
+            proc.exitCode = step.exit ?? 0;
+            proc.emit("exit", step.exit ?? 0, null);
+          }
+        }, 5);
+      }
+    }, 5);
+    return proc;
+  }
+
+  return {
+    ...actual,
+    spawn: vi.fn(spawnFake),
+    spawnSync: vi.fn((cmd: string, args: string[]) => {
+      if (/taskkill/i.test(cmd)) {
+        const pid = Number(args[1]);
+        hoisted.killed.push(pid);
+        const proc = hoisted.procs.find((p) => p.pid === pid);
+        if (proc && proc.exitCode === null) {
+          proc.exitCode = 1;
+          (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit("exit", null, "SIGKILL");
+        }
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    }),
+  };
+});
+
+import {
+  PiBackend,
+  parsePiModels,
+  parsePiDurationMs,
+  resolvePiBin,
+} from "../../orchestrator/pi-backend.js";
+import { backendReadiness } from "../../orchestrator/backend-readiness.js";
+
+const FAKE_BIN = join(tmpdir(), "fake-pi", "pi.exe");
+
+async function* channelOf(turns: NeutralTurn[]): AsyncGenerator<NeutralTurn> {
+  for (const t of turns) yield t;
+}
+
+async function collect(gen: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const ev of gen) events.push(ev);
+  return events;
+}
+
+/** One text delta event line. */
+const delta = (s: string) =>
+  `${JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: s } })}\n`;
+const header = (id: string) => `${JSON.stringify({ type: "session", version: 3, id })}\n`;
+const END = '{"type":"agent_end","messages":[]}\n';
+
+let workDir: string;
+
+beforeEach(() => {
+  hoisted.spawns.length = 0;
+  hoisted.procs.length = 0;
+  hoisted.killed.length = 0;
+  hoisted.script.length = 0;
+  // Emulate the POSIX process-group kill path too (Windows uses taskkill via the
+  // spawnSync mock) so interrupt tests behave identically on every platform.
+  vi.spyOn(process, "kill").mockImplementation(((pid: number) => {
+    const target = Math.abs(Number(pid));
+    hoisted.killed.push(target);
+    const proc = hoisted.procs.find((p) => p.pid === target);
+    if (proc && proc.exitCode === null) {
+      proc.exitCode = 1;
+      (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit("exit", null, "SIGKILL");
+    }
+    return true;
+  }) as unknown as typeof process.kill);
+  process.env.COMFYUI_MCP_PI_PATH = FAKE_BIN;
+  delete process.env.COMFYUI_MCP_PI_PRINT_TIMEOUT;
+  workDir = mkdtempSync(join(tmpdir(), "pi-test-"));
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_PI_PATH;
+  rmSync(workDir, { recursive: true, force: true });
+  vi.mocked(process.kill).mockRestore?.();
+});
+
+describe("parsePiModels", () => {
+  it("parses a padded table with a header, id = provider/model", () => {
+    const out = [
+      "provider   model            context   max-out   thinking   images",
+      "anthropic  claude-sonnet-4  200K      64K       yes        yes",
+      "openai     gpt-4o           128K      16K       no         yes",
+      "",
+    ].join("\n");
+    const models = parsePiModels(out);
+    expect(models.map((m) => m.id)).toEqual(["anthropic/claude-sonnet-4", "openai/gpt-4o"]);
+    expect(models[0]!.label).toBe("claude-sonnet-4");
+  });
+
+  it("strips ANSI and skips separator rules", () => {
+    const out = "[32manthropic[0m  claude-3-5-sonnet  200K\n────────  ──────  ──────\n";
+    expect(parsePiModels(out).map((m) => m.id)).toEqual(["anthropic/claude-3-5-sonnet"]);
+  });
+
+  it("returns [] for garbage / prose", () => {
+    expect(parsePiModels("Something went wrong.\nPlease configure a provider.")).toEqual([]);
+  });
+
+  it("parsePiDurationMs handles duration forms", () => {
+    expect(parsePiDurationMs("45m")).toBe(45 * 60_000);
+    expect(parsePiDurationMs("1h30m")).toBe(90 * 60_000);
+    expect(parsePiDurationMs("banana")).toBeNull();
+  });
+});
+
+describe("resolvePiBin / readiness", () => {
+  it("honors the COMFYUI_MCP_PI_PATH override and reads ready when the CLI is present", () => {
+    expect(resolvePiBin()).toBe(FAKE_BIN);
+    const r = backendReadiness("pi", { home: workDir });
+    expect(r.backend).toBe("pi");
+    expect(r.cli).toBe(true);
+    expect(r.ready).toBe(true); // ready keys off CLI presence (auth verified at connect)
+  });
+
+  it("reports not-ready when the CLI is absent", () => {
+    delete process.env.COMFYUI_MCP_PI_PATH;
+    const savedPath = process.env.PATH;
+    const savedLad = process.env.LOCALAPPDATA;
+    process.env.PATH = workDir;
+    process.env.LOCALAPPDATA = workDir;
+    try {
+      const r = backendReadiness("pi", { home: workDir });
+      expect(r.ready).toBe(false);
+      expect(r.cli).toBe(false);
+    } finally {
+      process.env.PATH = savedPath;
+      if (savedLad === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = savedLad;
+    }
+  });
+});
+
+describe("PiBackend turns", () => {
+  it("streams JSON deltas, captures + re-emits the session id, and resumes with --session on turn 2", async () => {
+    hoisted.script.push(
+      { stdout: [header("sess-abc"), delta("Hello "), delta("world"), END], exit: 0 },
+      { stdout: [header("sess-abc"), delta("Second"), END], exit: 0 },
+    );
+    const backend = new PiBackend({ cwd: workDir, model: "openai/gpt-4o", systemAppend: "PERSONA" });
+    const events = await collect(
+      backend.run({ channel: channelOf([{ text: "hi" }, { text: "again" }]) }),
+    );
+
+    // First a provisional session (sentinel), then the REAL id from the header.
+    expect(events[0]).toMatchObject({ type: "session", sessionId: "pi-pending", model: "openai/gpt-4o" });
+    expect(events.some((e) => e.type === "session" && (e as { sessionId: string }).sessionId === "sess-abc")).toBe(true);
+    expect(events.filter((e) => e.type === "assistant").map((e) => (e as { text: string }).text)).toEqual([
+      "Hello world",
+      "Second",
+    ]);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: true, subtype: "end_turn" },
+      { type: "result", ok: true, subtype: "end_turn" },
+    ]);
+
+    // Turn 1: fresh (no --session), --mode json, persona prepended, model set.
+    const t1 = hoisted.spawns[0]!;
+    expect(t1.cmd).toBe(FAKE_BIN);
+    expect(t1.args).not.toContain("--session");
+    expect(t1.args).toContain("--mode");
+    expect(t1.args[t1.args.indexOf("--mode") + 1]).toBe("json");
+    expect(t1.args[t1.args.indexOf("--model") + 1]).toBe("openai/gpt-4o");
+    expect(t1.args[t1.args.length - 1]).toContain("PERSONA");
+    expect(t1.args[t1.args.length - 1]).toContain("hi");
+    // Turn 2: resumes the captured session id, no persona.
+    const t2 = hoisted.spawns[1]!;
+    expect(t2.args[t2.args.indexOf("--session") + 1]).toBe("sess-abc");
+    expect(t2.args[t2.args.length - 1]).toBe("again");
+  });
+
+  it("emits per-tool events from tool_execution_* lines", async () => {
+    hoisted.script.push({
+      stdout: [
+        header("s1"),
+        '{"type":"tool_execution_start","toolCallId":"c1","toolName":"bash","args":{"command":"ls"}}\n',
+        '{"type":"tool_execution_end","toolCallId":"c1","toolName":"bash","result":{},"isError":false}\n',
+        delta("done"),
+        END,
+      ],
+      exit: 0,
+    });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "run ls" }]) }));
+    const tools = events.filter((e) => e.type === "tool_call") as Array<{ name: string; phase: string }>;
+    expect(tools.map((t) => `${t.name}:${t.phase}`)).toEqual(["bash:start", "bash:end"]);
+  });
+
+  it("uses --session from opts.resume and skips the persona", async () => {
+    hoisted.script.push({ stdout: [header("sess-r"), delta("resumed"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir, systemAppend: "PERSONA" });
+    await collect(backend.run({ resume: "sess-existing", channel: channelOf([{ text: "back" }]) }));
+    const t1 = hoisted.spawns[0]!;
+    expect(t1.args[t1.args.indexOf("--session") + 1]).toBe("sess-existing");
+    expect(t1.args[t1.args.length - 1]).toBe("back"); // no persona preamble
+  });
+
+  it("drops a bare claude id (no --model) but honors a provider-prefixed id", async () => {
+    hoisted.script.push({ stdout: [header("s"), delta("x"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir });
+    await collect(backend.run({ model: "claude-opus-4-8", channel: channelOf([{ text: "q" }]) }));
+    expect(hoisted.spawns[0]!.args).not.toContain("--model");
+    await backend.setModel("anthropic/claude-sonnet-4");
+    hoisted.script.push({ stdout: [header("s"), delta("y"), END], exit: 0 });
+    await collect(backend.run({ resume: "s", channel: channelOf([{ text: "q2" }]) }));
+    const t2 = hoisted.spawns[1]!;
+    expect(t2.args[t2.args.indexOf("--model") + 1]).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("passes --provider when configured", async () => {
+    hoisted.script.push({ stdout: [header("s"), delta("ok"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir, provider: "openai" });
+    await collect(backend.run({ channel: channelOf([{ text: "q" }]) }));
+    const t1 = hoisted.spawns[0]!;
+    expect(t1.args[t1.args.indexOf("--provider") + 1]).toBe("openai");
+  });
+
+  it("spawns pi WITHOUT ComfyUI tool-only secrets but keeps its own provider keys", async () => {
+    const saved = {
+      RUNPOD_API_KEY: process.env.RUNPOD_API_KEY,
+      CIVITAI_API_TOKEN: process.env.CIVITAI_API_TOKEN,
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    };
+    process.env.RUNPOD_API_KEY = "rp-tool-secret";
+    process.env.CIVITAI_API_TOKEN = "civ-tool-secret";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-pi-key";
+    try {
+      hoisted.script.push({ stdout: [header("s"), delta("ok"), END], exit: 0 });
+      const backend = new PiBackend({ cwd: workDir });
+      await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+      const env = hoisted.spawns[0]!.opts.env as Record<string, string | undefined>;
+      expect(env.RUNPOD_API_KEY).toBeUndefined(); // tool secret — stripped
+      expect(env.CIVITAI_API_TOKEN).toBeUndefined(); // tool secret — stripped
+      expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-pi-key"); // pi's own provider key — kept
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+
+  it("surfaces a failed exit as error + failed result (terminal-result invariant)", async () => {
+    hoisted.script.push({ stdout: [header("s")], stderr: "boom: quota exceeded", exit: 7 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    const err = events.find((e) => e.type === "error") as { message: string };
+    expect(err.message).toContain("code 7");
+    expect(err.message).toContain("quota exceeded");
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "error" },
+    ]);
+  });
+
+  it("maps a credential-looking failure to provider-setup guidance", async () => {
+    hoisted.script.push({ stdout: [], stderr: "no provider configured: set an API key", exit: 1 });
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    const err = events.find((e) => e.type === "error") as { message: string };
+    expect(err.message).toMatch(/provider credentials|API key|login/i);
+  });
+
+  it("interrupt kills the in-flight child tree and yields a cancelled result", async () => {
+    hoisted.script.push({ hang: true });
+    const backend = new PiBackend({ cwd: workDir });
+    const gen = backend.run({ channel: channelOf([{ text: "long job" }]) });
+    const events: AgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of gen) events.push(ev);
+    })();
+    await vi.waitFor(() => expect(hoisted.spawns.length).toBe(1));
+    await backend.interrupt();
+    await drain;
+    expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "cancelled" },
+    ]);
+  });
+
+  it("honors an interrupt that lands BEFORE the child is assigned (spawn window)", async () => {
+    hoisted.script.push({ hang: true });
+    const backend = new PiBackend({ cwd: workDir });
+    const gen = backend.run({ channel: channelOf([{ text: "long job" }]) });
+    const events: AgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of gen) events.push(ev);
+    })();
+    await backend.interrupt();
+    await drain;
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: false, subtype: "cancelled" },
+    ]);
+    if (hoisted.procs[0]) expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
+  });
+
+  it("an idle interrupt expires and does not cancel the next turn (stale-flag regression)", async () => {
+    hoisted.script.push({ stdout: [header("s"), delta("fine"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir });
+    await backend.interrupt();
+    await new Promise((r) => setTimeout(r, 650));
+    const events = await collect(backend.run({ channel: channelOf([{ text: "hi" }]) }));
+    expect(events.filter((e) => e.type === "result")).toEqual([
+      { type: "result", ok: true, subtype: "end_turn" },
+    ]);
+    expect(hoisted.killed).toEqual([]);
+  });
+
+  it("kills the child when the generator is abandoned mid-turn without close()", async () => {
+    hoisted.script.push({ stdout: [header("s"), delta("partial ")], hang: true });
+    const backend = new PiBackend({ cwd: workDir });
+    const gen = backend.run({ channel: channelOf([{ text: "long" }]) });
+    let ev = await gen.next();
+    while (!ev.done && (ev.value as { type: string }).type !== "stream_start") {
+      ev = await gen.next();
+    }
+    await gen.return(undefined);
+    expect(hoisted.killed).toContain(hoisted.procs[0]!.pid);
+  });
+
+  it("rejects an over-32K prompt on Windows with a legible error", async () => {
+    if (process.platform !== "win32") return;
+    const backend = new PiBackend({ cwd: workDir });
+    const events = await collect(backend.run({ channel: channelOf([{ text: "x".repeat(31_000) }]) }));
+    expect(hoisted.spawns).toHaveLength(0);
+    const err = events.find((e) => e.type === "error") as { message: string };
+    expect(err.message).toMatch(/too large/i);
+  });
+
+  it("prepare() fails fast with install guidance when pi is missing", async () => {
+    delete process.env.COMFYUI_MCP_PI_PATH;
+    const savedPath = process.env.PATH;
+    const savedLad = process.env.LOCALAPPDATA;
+    process.env.PATH = workDir;
+    process.env.LOCALAPPDATA = workDir;
+    try {
+      const backend = new PiBackend({ cwd: workDir });
+      await expect(backend.prepare()).rejects.toThrow(/pi\.dev/);
+    } finally {
+      process.env.PATH = savedPath;
+      if (savedLad === undefined) delete process.env.LOCALAPPDATA;
+      else process.env.LOCALAPPDATA = savedLad;
+    }
+  });
+});
+
+describe("PiBackend.listModels", () => {
+  it("runs `pi --list-models` and parses the table", async () => {
+    hoisted.script.push({
+      stdout: ["provider   model     context\nopenai     gpt-4o    128K\n"],
+      exit: 0,
+    });
+    const backend = new PiBackend({ cwd: workDir });
+    const models = await backend.listModels();
+    expect(hoisted.spawns[0]!.args).toEqual(["--list-models"]);
+    expect(models.map((m) => m.id)).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("rejects with setup guidance on a non-zero exit", async () => {
+    hoisted.script.push({ stdout: [], stderr: "boom", exit: 2 });
+    const backend = new PiBackend({ cwd: workDir });
+    await expect(backend.listModels()).rejects.toThrow(/pi is installed|configured/i);
+  });
+});

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -188,6 +188,9 @@ const PI_ENV_KEYS = [
   "GOOGLE_CLOUD_PROJECT",
   "GCLOUD_PROJECT",
   "GOOGLE_CLOUD_LOCATION",
+  // Scrubbed too so a developer's real roaming profile can never be consulted by
+  // a probe here (belt-and-braces: the ADC check already needs project+location).
+  "APPDATA",
 ];
 function withNoPiEnvKeys<T>(fn: () => T): T {
   const saved: Record<string, string | undefined> = {};

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -41,6 +41,7 @@ vi.mock("node:child_process", async (importOriginal) => {
       if (proc.exitCode === null) {
         proc.exitCode = 1;
         proc.emit("exit", 1, "SIGTERM");
+        proc.emit("close", 1, "SIGTERM"); // PiBackend settles on 'close', not 'exit'
       }
       return true;
     };
@@ -57,6 +58,7 @@ vi.mock("node:child_process", async (importOriginal) => {
           if (proc.exitCode === null) {
             proc.exitCode = step.exit ?? 0;
             proc.emit("exit", step.exit ?? 0, null);
+            proc.emit("close", step.exit ?? 0, null); // 'close' = stdio drained
           }
         }, 5);
       }
@@ -74,7 +76,9 @@ vi.mock("node:child_process", async (importOriginal) => {
         const proc = hoisted.procs.find((p) => p.pid === pid);
         if (proc && proc.exitCode === null) {
           proc.exitCode = 1;
-          (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit("exit", null, "SIGKILL");
+          const emit = (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit;
+          emit.call(proc, "exit", null, "SIGKILL");
+          emit.call(proc, "close", null, "SIGKILL");
         }
       }
       return { status: 0, stdout: "", stderr: "" };
@@ -123,7 +127,9 @@ beforeEach(() => {
     const proc = hoisted.procs.find((p) => p.pid === target);
     if (proc && proc.exitCode === null) {
       proc.exitCode = 1;
-      (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit("exit", null, "SIGKILL");
+      const emit = (proc as { emit: (ev: string, ...a: unknown[]) => void }).emit;
+      emit.call(proc, "exit", null, "SIGKILL");
+      emit.call(proc, "close", null, "SIGKILL");
     }
     return true;
   }) as unknown as typeof process.kill);
@@ -151,8 +157,10 @@ describe("parsePiModels", () => {
     expect(models[0]!.label).toBe("claude-sonnet-4");
   });
 
-  it("strips ANSI and skips separator rules", () => {
-    const out = "[32manthropic[0m  claude-3-5-sonnet  200K\n────────  ──────  ──────\n";
+  it("strips real ANSI escapes and skips separator rules", () => {
+    // Real ANSI escapes include the ESC (\x1b) byte — the parser must strip the
+    // whole CSI sequence, not just the "[32m" tail (else the token keeps \x1b).
+    const out = "\x1b[32manthropic\x1b[0m  claude-3-5-sonnet  200K\n────────  ──────  ──────\n";
     expect(parsePiModels(out).map((m) => m.id)).toEqual(["anthropic/claude-3-5-sonnet"]);
   });
 
@@ -275,6 +283,17 @@ describe("PiBackend turns", () => {
     const backend = new PiBackend({ cwd: workDir, provider: "openai" });
     await collect(backend.run({ channel: channelOf([{ text: "q" }]) }));
     const t1 = hoisted.spawns[0]!;
+    expect(t1.args[t1.args.indexOf("--provider") + 1]).toBe("openai");
+  });
+
+  it("still drops a bare claude id EVEN when a provider is configured (no --model leak)", async () => {
+    // Regression: a set --provider must not whitelist the panel's bare claude
+    // default — `pi --provider openai --model claude-opus-5` would fail every turn.
+    hoisted.script.push({ stdout: [header("s"), delta("ok"), END], exit: 0 });
+    const backend = new PiBackend({ cwd: workDir, provider: "openai" });
+    await collect(backend.run({ model: "claude-opus-5", channel: channelOf([{ text: "q" }]) }));
+    const t1 = hoisted.spawns[0]!;
+    expect(t1.args).not.toContain("--model");
     expect(t1.args[t1.args.indexOf("--provider") + 1]).toBe("openai");
   });
 

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -191,6 +191,8 @@ const PI_ENV_KEYS = [
   // Scrubbed too so a developer's real roaming profile can never be consulted by
   // a probe here (belt-and-braces: the ADC check already needs project+location).
   "APPDATA",
+  // …and so a developer who relocated their own pi config can't leak it in.
+  "PI_CODING_AGENT_DIR",
 ];
 function withNoPiEnvKeys<T>(fn: () => T): T {
   const saved: Record<string, string | undefined> = {};

--- a/src/__tests__/orchestrator/pi-backend.test.ts
+++ b/src/__tests__/orchestrator/pi-backend.test.ts
@@ -181,7 +181,7 @@ describe("parsePiModels", () => {
 const PI_ENV_KEYS = [
   "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
   "DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY", "ZAI_API_KEY",
-  "KIMI_API_KEY", "MINIMAX_API_KEY",
+  "KIMI_API_KEY", "MINIMAX_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS",
 ];
 function withNoPiEnvKeys<T>(fn: () => T): T {
   const saved: Record<string, string | undefined> = {};
@@ -217,19 +217,50 @@ describe("resolvePiBin / readiness", () => {
   });
 
   it("reads ready ONLY when a credential is verifiable — not on CLI presence alone (P1a)", () => {
-    // CLI present but NO credential → NOT ready (list-models isn't an auth probe).
     withNoPiEnvKeys(() => {
+      // CLI present but NO credential source → NOT ready (list-models isn't an
+      // auth probe).
       const r0 = backendReadiness("pi", { home: workDir });
       expect(r0.cli).toBe(true);
       expect(r0.auth).toBeNull(); // unknown, don't nag
       expect(r0.ready).toBe(false);
+
+      // An EMPTY / structurally-useless auth.json must NOT count (never green on
+      // mere file existence — P1a-a).
+      mkdirSync(join(workDir, ".pi", "agent"), { recursive: true });
+      writeFileSync(join(workDir, ".pi", "agent", "auth.json"), "{}");
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(false);
+      writeFileSync(join(workDir, ".pi", "agent", "auth.json"), '{"anthropic":{}}');
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(false);
+      writeFileSync(join(workDir, ".pi", "agent", "auth.json"), "{ not json");
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(false);
+
+      // A VALID auth.json entry → ready.
+      writeFileSync(
+        join(workDir, ".pi", "agent", "auth.json"),
+        '{"anthropic":{"type":"api_key","key":"sk-ant-x"}}',
+      );
+      const r1 = backendReadiness("pi", { home: workDir });
+      expect(r1.auth).toBe(true);
+      expect(r1.ready).toBe(true);
     });
-    // With ~/.pi/agent/auth.json present → ready.
-    mkdirSync(join(workDir, ".pi", "agent"), { recursive: true });
-    writeFileSync(join(workDir, ".pi", "agent", "auth.json"), '{"anthropic":{"type":"api_key","key":"x"}}');
-    const r1 = backendReadiness("pi", { home: workDir });
-    expect(r1.auth).toBe(true);
-    expect(r1.ready).toBe(true);
+  });
+
+  it("detects the broadened credential sources: env key, Google ADC, models.json (P1a-b)", () => {
+    withNoPiEnvKeys(() => {
+      // (1) a non-stripped provider env key.
+      process.env.OPENAI_API_KEY = "sk-x";
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
+      delete process.env.OPENAI_API_KEY;
+      // (2) Google ADC — a file path, not an API key (not stripped).
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = "/home/u/adc.json";
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      // (3) a non-empty models.json (custom-provider creds).
+      mkdirSync(join(workDir, ".pi", "agent"), { recursive: true });
+      writeFileSync(join(workDir, ".pi", "agent", "models.json"), '{"my-vllm":{"baseUrl":"http://x/v1"}}');
+      expect(backendReadiness("pi", { home: workDir }).ready).toBe(true);
+    });
   });
 
   it("reports not-ready when the CLI is absent", () => {
@@ -314,6 +345,33 @@ describe("PiBackend turns", () => {
     const t1 = hoisted.spawns[0]!;
     expect(t1.args[t1.args.indexOf("--session") + 1]).toBe("sess-existing");
     expect(t1.args[t1.args.length - 1]).toBe("back"); // no persona preamble
+  });
+
+  it("re-asserts the capabilityNote on EVERY turn — fresh AND resume (P0a-resume)", async () => {
+    // The heavy systemAppend preamble is first-turn-only, but the capability note
+    // (pi has no ComfyUI tools) must reach resumed/long-running sessions too.
+    const NOTE = "PI-HAS-NO-COMFYUI-TOOLS";
+    // Fresh session, two turns: both must carry the note; the persona only turn 1.
+    hoisted.script.push(
+      { stdout: [header("s1"), delta("a"), END], exit: 0 },
+      { stdout: [header("s1"), delta("b"), END], exit: 0 },
+    );
+    const fresh = new PiBackend({ cwd: workDir, systemAppend: "PERSONA", capabilityNote: NOTE });
+    await collect(fresh.run({ channel: channelOf([{ text: "one" }, { text: "two" }]) }));
+    const f1 = hoisted.spawns[0]!.args.at(-1)!;
+    const f2 = hoisted.spawns[1]!.args.at(-1)!;
+    expect(f1).toContain("PERSONA");
+    expect(f1).toContain(NOTE);
+    expect(f2).not.toContain("PERSONA"); // heavy preamble suppressed after turn 1
+    expect(f2).toContain(NOTE); // but the note persists
+
+    // RESUMED session: no persona, but the note is still asserted.
+    hoisted.script.push({ stdout: [header("s2"), delta("c"), END], exit: 0 });
+    const resumed = new PiBackend({ cwd: workDir, systemAppend: "PERSONA", capabilityNote: NOTE });
+    await collect(resumed.run({ resume: "s-old", channel: channelOf([{ text: "back" }]) }));
+    const r1 = hoisted.spawns[2]!.args.at(-1)!;
+    expect(r1).not.toContain("PERSONA");
+    expect(r1).toContain(NOTE);
   });
 
   it("drops a bare claude id (no --model) but honors a provider-prefixed id", async () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -442,18 +442,19 @@ describe("Google Vertex ADC", () => {
     expect(piVertexAdcUsable(tmp, env, { GOOGLE_CLOUD_LOCATION: "us-central1" })).toBe(true);
   });
 
-  it("uses the stored GCLOUD_PROJECT alias only after the primary project source is absent", () => {
+  it("ignores a stored GCLOUD_PROJECT alias and preserves the ambient alias", () => {
     const keyFile = join(tmp, "sa.json");
     writeFileSync(keyFile, "{}");
+    // Pi never reads the alias from a stored auth record.
     expect(
       piVertexAdcUsable(
         tmp,
         bareEnv({ GOOGLE_CLOUD_LOCATION: "us-central1", GOOGLE_APPLICATION_CREDENTIALS: keyFile }),
         { GCLOUD_PROJECT: "stored-alias" },
       ),
-    ).toBe(true);
-    // Stored alias is nullish-preferred over ambient alias. An explicit empty
-    // value therefore blocks the otherwise-working ambient alias.
+    ).toBe(false);
+    // A stored alias must neither satisfy readiness nor shadow the real ambient
+    // alias; only stored GOOGLE_CLOUD_PROJECT participates in the nullish chain.
     expect(
       piVertexAdcUsable(
         tmp,
@@ -464,7 +465,7 @@ describe("Google Vertex ADC", () => {
         }),
         { GCLOUD_PROJECT: "" },
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("gcloud's well-known ADC file counts when the env var is unset", () => {
@@ -753,6 +754,24 @@ describe("pi selected-provider readiness", () => {
         bareEnv({ COMFYUI_MCP_PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-ant" }),
       ),
     ).toBe(true);
+  });
+
+  it("keeps selected provider values raw, matching pi's CLI arguments", () => {
+    // Whitespace is part of the explicit --provider value; trimming it here
+    // would green anthropic even though pi receives a different provider name.
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_PROVIDER: " anthropic ", ANTHROPIC_API_KEY: "sk-ant" }),
+      ),
+    ).toBe(false);
+    // The model prefix is passed through just as literally.
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_MODEL: " anthropic /claude-sonnet", ANTHROPIC_API_KEY: "sk-ant" }),
+      ),
+    ).toBe(false);
   });
 
   it("accepts every Bedrock AWS credential-chain source, including a keyless stored profile", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -166,6 +166,22 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(true);
   });
 
+  it("stored-record ownership follows JS truthiness", () => {
+    // `{}` and `[]` are TRUTHY in JS, so they DO own the provider (pi suppresses
+    // ambient auth); null/false/0 do not. The panel's Python mirror has to match
+    // this explicitly, since Python's own truthiness differs for `{}`/`[]`.
+    for (const [body, ready] of [
+      ['{"openai":{}}', false],
+      ['{"openai":[]}', false],
+      ['{"openai":null}', true],
+      ['{"openai":false}', true],
+      ['{"openai":0}', true],
+    ] as const) {
+      writePiFile(tmp, "auth.json", body);
+      expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk" })), body).toBe(ready);
+    }
+  });
+
   it("a stored google-vertex record suppresses ambient ADC too", () => {
     const keyFile = join(tmp, "sa.json");
     writeFileSync(keyFile, "{}");
@@ -195,6 +211,28 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
     expect(piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: alt }))).toBe(true);
     expect(piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: "~/alt-config" }))).toBe(true);
+    // A RELATIVE override resolves against PI's cwd, which we cannot know — so
+    // the file-backed sources are unreadable rather than probed against OUR cwd.
+    expect(piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: "alt-config" }))).toBe(false);
+    // …env credentials are unaffected by an unresolvable config dir.
+    expect(
+      piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: "alt-config", XAI_API_KEY: "sk" })),
+    ).toBe(true);
+  });
+
+  it("a stored cloudflare record still needs its account id", () => {
+    writePiFile(tmp, "auth.json", '{"cloudflare-workers-ai":{"type":"api_key","key":"k"}}');
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+    // …supplied either by the record's own env block…
+    writePiFile(
+      tmp,
+      "auth.json",
+      '{"cloudflare-workers-ai":{"type":"api_key","key":"k","env":{"CLOUDFLARE_ACCOUNT_ID":"a"}}}',
+    );
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(true);
+    // …or by the environment.
+    writePiFile(tmp, "auth.json", '{"cloudflare-workers-ai":{"type":"api_key","key":"k"}}');
+    expect(piCredentialPresent(tmp, bareEnv({ CLOUDFLARE_ACCOUNT_ID: "a" }))).toBe(true);
   });
 
   it("an env-interpolated key naming a STRIPPED var is NOT a credential", () => {
@@ -421,6 +459,17 @@ describe("models.json", () => {
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
     // minLength 1 accepts a SPACE — trimming here would false-red a config pi loads.
     writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"ok":{"name":" "}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("a WRONG-TYPED or bad-headers provider field invalidates the file", () => {
+    // pi's schema types these; a violation discards the file, so the sibling's
+    // good key never reaches pi either.
+    writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"x"},"bad":{"apiKey":1}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"x","headers":{"X-T":1}}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"x","headers":{"X-T":"1"}}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -127,19 +127,57 @@ describe("auth.json records", () => {
 
   it("oauth record needs something that can produce a live token", () => {
     const now = 1_800_000_000_000;
-    const futureSec = Math.floor(now / 1000) + 3600;
     expect(authRecordUsable({ type: "oauth", access: "at", refresh: "rt", expires: 1 }, bareEnv(), now)).toBe(true);
     // refresh alone: pi can always re-mint an access token, even when expired.
     expect(authRecordUsable({ type: "oauth", refresh: "rt" }, bareEnv(), now)).toBe(true);
-    expect(authRecordUsable({ type: "oauth", expires: futureSec }, bareEnv(), now)).toBe(false);
+    expect(authRecordUsable({ type: "oauth", expires: now + 3600_000 }, bareEnv(), now)).toBe(false);
     // access with no refresh and a PAST/absent expiry cannot be renewed: pi sees
     // it as expired and tries to refresh with no refresh token.
     expect(authRecordUsable({ type: "oauth", access: "at" }, bareEnv(), now)).toBe(false);
     expect(authRecordUsable({ type: "oauth", access: "at", expires: 999 }, bareEnv(), now)).toBe(false);
-    // …a still-live access token is ready. Accepted in seconds OR milliseconds,
-    // since pi doesn't document the unit.
-    expect(authRecordUsable({ type: "oauth", access: "at", expires: futureSec }, bareEnv(), now)).toBe(true);
+    // `expires` is MILLISECONDS for pi, so a seconds-scaled value reads as long
+    // expired — which it is, as far as pi is concerned.
+    expect(
+      authRecordUsable({ type: "oauth", access: "at", expires: Math.floor(now / 1000) + 3600 }, bareEnv(), now),
+    ).toBe(false);
+    // pi refreshes anything inside its five-minute minimum-validity window, so
+    // access-only that close to expiry is NOT usable…
+    expect(authRecordUsable({ type: "oauth", access: "at", expires: now + 60_000 }, bareEnv(), now)).toBe(false);
+    // …but comfortably-live access alone is.
     expect(authRecordUsable({ type: "oauth", access: "at", expires: now + 3600_000 }, bareEnv(), now)).toBe(true);
+  });
+
+  it("a KEYLESS google-vertex record resolves through ADC (pi's /login writes one)", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    // pi's Vertex login writes {type:"api_key", env:{…}} with NO key, and its
+    // resolver falls back to ADC — this must NOT read as "not signed in".
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({
+        "google-vertex": {
+          type: "api_key",
+          env: {
+            GOOGLE_CLOUD_PROJECT: "p",
+            GOOGLE_CLOUD_LOCATION: "l",
+            GOOGLE_APPLICATION_CREDENTIALS: keyFile,
+          },
+        },
+      }),
+    );
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(true);
+    // …but only when the ADC trio actually resolves.
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({ "google-vertex": { type: "api_key", env: { GOOGLE_CLOUD_PROJECT: "p" } } }),
+    );
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+    // A keyless record is also satisfied by GOOGLE_CLOUD_API_KEY (pi does
+    // `credential?.key ?? env("GOOGLE_CLOUD_API_KEY")`).
+    writePiFile(tmp, "auth.json", JSON.stringify({ "google-vertex": { type: "api_key" } }));
+    expect(piCredentialPresent(tmp, bareEnv({ GOOGLE_CLOUD_API_KEY: "k" }))).toBe(true);
   });
 
   it("an UNRECOGNISED credential type is not a credential (and blocks env fallback)", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -497,6 +497,8 @@ describe("models.json", () => {
       '{"id":"m","cost":{"input":"free","output":1,"cacheRead":1,"cacheWrite":1}}',
       '{"id":"m","thinkingLevelMap":{"low":3}}', // string | null
       '{"id":"m","compat":"yes"}',
+      '{"id":"m","cost":{"input":1,"output":1,"cacheRead":1,"cacheWrite":1,"tiers":[{}]}}',
+      '{"id":"m","name":null}', // Type.Optional rejects a PRESENT null
     ]) {
       writePiFile(tmp, "models.json", `{"providers":{${good},"p":{"apiKey":"x","models":[${bad}]}}}`);
       expect(piModelsJsonUsable(modelsPath(), bareEnv()), bad).toBe(false);
@@ -525,6 +527,14 @@ describe("models.json", () => {
       '{"providers":{"p":{"apiKey":"x","modelOverrides":{"m":{"reasoning":"yes"}}}}}',
     );
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+
+  it("bedrock is keyed by pi's provider id (amazon-bedrock) for stored ownership", () => {
+    // Getting the id wrong would mean a stored record never suppresses the
+    // ambient token it owns.
+    expect(piCredentialPresent(tmp, bareEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }))).toBe(true);
+    writePiFile(tmp, "auth.json", '{"amazon-bedrock":{"type":"api_key"}}');
+    expect(piCredentialPresent(tmp, bareEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }))).toBe(false);
   });
 
   it("UNDECLARED extra fields are left alone (pi declares no additionalProperties)", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -462,6 +462,17 @@ describe("models.json", () => {
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 
+  it("a space-padded credentials path is NOT resolved (pi uses the literal value)", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    const env = {
+      GOOGLE_CLOUD_PROJECT: "p",
+      GOOGLE_CLOUD_LOCATION: "l",
+      GOOGLE_APPLICATION_CREDENTIALS: `  ${keyFile}  `,
+    };
+    expect(piVertexAdcUsable(tmp, bareEnv(env))).toBe(false);
+  });
+
   it("a WRONG-TYPED or bad-headers provider field invalidates the file", () => {
     // pi's schema types these; a violation discards the file, so the sibling's
     // good key never reaches pi either.
@@ -470,6 +481,34 @@ describe("models.json", () => {
     writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"x","headers":{"X-T":1}}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
     writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"x","headers":{"X-T":"1"}}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("a model definition violating pi's schema invalidates the file", () => {
+    const good = '"good":{"apiKey":"sk"}';
+    for (const bad of [
+      '{"id":"m","reasoning":"yes"}', // Type.Boolean
+      '{"id":"m","contextWindow":0}', // provider-composer rejects <= 0
+      '{"id":"m","maxTokens":-1}',
+      '{"id":"m","name":""}', // minLength 1
+      '{"id":"m","headers":{"X":1}}', // Record<string,string>
+      '{"id":"m","input":["video"]}', // "text" | "image"
+    ]) {
+      writePiFile(tmp, "models.json", `{"providers":{${good},"p":{"apiKey":"x","models":[${bad}]}}}`);
+      expect(piModelsJsonUsable(modelsPath(), bareEnv()), bad).toBe(false);
+    }
+    // A fully-valid definition loads.
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"p":{"apiKey":"x","models":[{"id":"m","reasoning":true,"contextWindow":8192,"input":["text","image"],"headers":{"X":"1"}}]}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("UNDECLARED extra fields are left alone (pi declares no additionalProperties)", () => {
+    // Being stricter than pi here would false-red a file it loads fine.
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"x","note":"","future":{"a":1}}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -75,7 +75,6 @@ describe("pi provider env keys", () => {
       "MINIMAX_CN_API_KEY",
       "MOONSHOT_API_KEY",
       "OPENCODE_API_KEY",
-      "CLOUDFLARE_API_KEY",
       "XIAOMI_API_KEY",
       "QWEN_TOKEN_PLAN_API_KEY",
       "COPILOT_GITHUB_TOKEN",
@@ -158,6 +157,35 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(home, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(false);
     // …but an unrelated provider's env key still counts.
     expect(piCredentialPresent(home, bareEnv({ XAI_API_KEY: "sk" }))).toBe(true);
+  });
+
+  it("a FALSY stored entry does not own the provider (pi gates on `if (stored)`)", () => {
+    // pi falls back to the ambient key when the stored value is null, so
+    // suppressing on mere key-presence would false-red a working install.
+    writePiFile(tmp, "auth.json", '{"openai":null}');
+    expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(true);
+  });
+
+  it("a stored google-vertex record suppresses ambient ADC too", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    const adcEnv = {
+      GOOGLE_CLOUD_PROJECT: "p",
+      GOOGLE_CLOUD_LOCATION: "l",
+      GOOGLE_APPLICATION_CREDENTIALS: keyFile,
+    };
+    expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(true);
+    // A stored (but unusable) google-vertex record owns the provider, so pi
+    // never consults ADC for it.
+    writePiFile(tmp, "auth.json", '{"google-vertex":{"type":"api_key","key":""}}');
+    expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(false);
+  });
+
+  it("CLOUDFLARE_API_KEY alone is not a credential — the account id is required", () => {
+    expect(piCredentialPresent(tmp, bareEnv({ CLOUDFLARE_API_KEY: "k" }))).toBe(false);
+    expect(
+      piCredentialPresent(tmp, bareEnv({ CLOUDFLARE_API_KEY: "k", CLOUDFLARE_ACCOUNT_ID: "a" })),
+    ).toBe(true);
   });
 
   it("honours PI_CODING_AGENT_DIR (with ~ expansion)", () => {
@@ -375,18 +403,33 @@ describe("models.json", () => {
     expect(piModelsJsonUsable(modelsPath(), bareEnv({ MY_GW_KEY: "sk" }))).toBe(true);
   });
 
-  it("an `oauth` provider entry is a credential — but only pi's literal \"radius\"", () => {
-    writePiFile(tmp, "models.json", '{"providers":{"radius":{"oauth":"radius"}}}');
+  it("an `oauth` provider entry is a credential — but only pi's literal \"radius\" WITH a baseUrl", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"radius":{"oauth":"radius","baseUrl":"https://r/v1"}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    // provider-composer throws `"baseUrl" is required when "oauth" is set`.
+    writePiFile(tmp, "models.json", '{"providers":{"radius":{"oauth":"radius"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
     // pi's schema is a literal; any other value makes pi reject the whole file.
     writePiFile(tmp, "models.json", '{"providers":{"x":{"oauth":"nope"}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
   });
 
-  it("a BLANK string on any provider field invalidates the file (pi's minLength 1)", () => {
+  it("an EMPTY string on any provider field invalidates the file (pi's minLength 1)", () => {
     writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"bad":{"name":""}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
     writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"ok":{"name":"Fine"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    // minLength 1 accepts a SPACE — trimming here would false-red a config pi loads.
+    writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"ok":{"name":" "}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("a model definition without a usable `id` invalidates the file", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"sk","models":[{}]}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"sk","models":[{"id":""}]}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"p":{"apiKey":"sk","models":[{"id":"m"}]}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -252,6 +252,11 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
   });
 
+  it("accepts OAuth for a non-Anthropic OAuth-capable provider", () => {
+    writePiFile(tmp, "auth.json", JSON.stringify({ xai: { type: "oauth", refresh: "r" } }));
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(true);
+  });
+
   it("does not fall back when pi's truthy stored template resolves to whitespace", () => {
     writePiFile(
       tmp,

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -1,0 +1,347 @@
+// pi.dev (#491) credential-detection precision.
+//
+// The bug class these guard: pi reporting "ready" when nothing on this machine
+// can authenticate (→ green chip, then the first turn fails), or "not ready"
+// when a perfectly good credential IS present (→ the user is told to sign in
+// while already signed in). Every rule asserted here is transcribed from pi's
+// own source; see pi-credentials.ts for the file-by-file citations.
+//
+// All probes take an injected `home` + `env`, so nothing here reads the
+// developer's real ~/.pi or their real environment.
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PI_ENV_API_KEYS,
+  authRecordUsable,
+  credentialValueUsable,
+  piAuthJsonUsable,
+  piCredentialPresent,
+  piEnvKeysReachingPi,
+  piModelsJsonUsable,
+  piVertexAdcUsable,
+  stripJsonComments,
+} from "../../orchestrator/pi-credentials.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "pi-cred-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+/** An env with NO pi-relevant keys, so a case under test is the only signal. */
+function bareEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...extra };
+}
+
+/** Write <home>/.pi/agent/<name> with `body`. */
+function writePiFile(home: string, name: string, body: string): string {
+  const dir = join(home, ".pi", "agent");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, name);
+  writeFileSync(file, body);
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// (a) provider env vars
+// ---------------------------------------------------------------------------
+
+describe("pi provider env keys", () => {
+  // These four were missing and are the reported false "not ready" cases.
+  it.each(["CEREBRAS_API_KEY", "FIREWORKS_API_KEY", "TOGETHER_API_KEY", "ANTHROPIC_OAUTH_TOKEN"])(
+    "%s alone is a credential",
+    (key) => {
+      expect(piCredentialPresent(tmp, bareEnv({ [key]: "sk-test" }))).toBe(true);
+    },
+  );
+
+  it("covers pi's whole envMap (spot-check of the long tail)", () => {
+    for (const key of [
+      "ANTHROPIC_AUTH_TOKEN",
+      "ANT_LING_API_KEY",
+      "AZURE_OPENAI_API_KEY",
+      "NVIDIA_API_KEY",
+      "GOOGLE_CLOUD_API_KEY",
+      "RADIUS_API_KEY",
+      "AI_GATEWAY_API_KEY",
+      "ZAI_CODING_CN_API_KEY",
+      "MINIMAX_CN_API_KEY",
+      "MOONSHOT_API_KEY",
+      "OPENCODE_API_KEY",
+      "CLOUDFLARE_API_KEY",
+      "XIAOMI_API_KEY",
+      "QWEN_TOKEN_PLAN_API_KEY",
+      "COPILOT_GITHUB_TOKEN",
+    ]) {
+      expect(PI_ENV_API_KEYS, `${key} missing from pi's env map`).toContain(key);
+      expect(piCredentialPresent(tmp, bareEnv({ [key]: "sk-test" })), key).toBe(true);
+    }
+  });
+
+  it("an empty / whitespace-only key is NOT a credential", () => {
+    expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "" }))).toBe(false);
+    expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "   " }))).toBe(false);
+  });
+
+  it("no credential source at all → not ready", () => {
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+  });
+
+  it("keys our spawn env STRIPS never green pi (they never reach it)", () => {
+    // GEMINI_API_KEY / HF_TOKEN are ComfyUI tool-only secrets: buildAgentSpawnEnv()
+    // deletes them, so pi cannot see them even though pi's own envMap lists them.
+    const reaching = piEnvKeysReachingPi();
+    expect(PI_ENV_API_KEYS).toContain("GEMINI_API_KEY");
+    expect(PI_ENV_API_KEYS).toContain("HF_TOKEN");
+    expect(reaching).not.toContain("GEMINI_API_KEY");
+    expect(reaching).not.toContain("HF_TOKEN");
+    expect(piCredentialPresent(tmp, bareEnv({ GEMINI_API_KEY: "k", HF_TOKEN: "k" }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) auth.json records
+// ---------------------------------------------------------------------------
+
+describe("auth.json records", () => {
+  it("a well-formed api_key record is a credential", () => {
+    expect(authRecordUsable({ type: "api_key", key: "sk-ant-abc" })).toBe(true);
+  });
+
+  it("MALFORMED: api_key record with no `key` is NOT a credential", () => {
+    expect(authRecordUsable({ type: "api_key" })).toBe(false);
+    expect(authRecordUsable({ type: "api_key", key: "" })).toBe(false);
+    expect(authRecordUsable({ type: "api_key", key: "   " })).toBe(false);
+    expect(authRecordUsable({ type: "api_key", key: 42 })).toBe(false);
+  });
+
+  it("MALFORMED: an empty record `{}` is NOT a credential", () => {
+    expect(authRecordUsable({})).toBe(false);
+  });
+
+  it("oauth record needs at least one token", () => {
+    expect(authRecordUsable({ type: "oauth", access: "at", refresh: "rt", expires: 1 })).toBe(true);
+    expect(authRecordUsable({ type: "oauth", refresh: "rt" })).toBe(true);
+    expect(authRecordUsable({ type: "oauth", expires: 123 })).toBe(false);
+  });
+
+  it("an EXPIRED oauth record with a refresh token is still ready (pi auto-refreshes)", () => {
+    expect(authRecordUsable({ type: "oauth", access: "a", refresh: "r", expires: 1 })).toBe(true);
+  });
+
+  it("`key` env-interpolation resolves from the entry env, then the process env", () => {
+    expect(credentialValueUsable("$MY_KEY", undefined, bareEnv({ MY_KEY: "sk" }))).toBe(true);
+    expect(credentialValueUsable("${MY_KEY}", undefined, bareEnv({ MY_KEY: "sk" }))).toBe(true);
+    expect(credentialValueUsable("$MY_KEY", { MY_KEY: "sk" }, bareEnv())).toBe(true);
+    // Nothing to resolve to → not a credential (pi would send an empty key).
+    expect(credentialValueUsable("$MY_KEY", undefined, bareEnv())).toBe(false);
+    expect(credentialValueUsable("${A}_${B}", undefined, bareEnv({ A: "x" }))).toBe(false);
+    expect(credentialValueUsable("${A}_${B}", undefined, bareEnv({ A: "x", B: "y" }))).toBe(true);
+  });
+
+  it("a `!command` key is accepted unverified (we never execute it to probe)", () => {
+    expect(credentialValueUsable("!security find-generic-password -ws anthropic")).toBe(true);
+  });
+
+  it("a file with only malformed records does NOT green pi", () => {
+    const home = tmp;
+    writePiFile(home, "auth.json", JSON.stringify({ anthropic: {}, openai: { type: "api_key" } }));
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+    expect(piCredentialPresent(home, bareEnv())).toBe(false);
+  });
+
+  it("one good record among malformed ones IS enough", () => {
+    const home = tmp;
+    writePiFile(
+      home,
+      "auth.json",
+      JSON.stringify({ anthropic: {}, openai: { type: "api_key", key: "sk-real" } }),
+    );
+    expect(piCredentialPresent(home, bareEnv())).toBe(true);
+  });
+
+  it("missing / empty / corrupt / non-object auth.json → not a credential", () => {
+    const home = tmp;
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+    writePiFile(home, "auth.json", "");
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+    writePiFile(home, "auth.json", "{ not json");
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+    writePiFile(home, "auth.json", "{}");
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+    writePiFile(home, "auth.json", "[]");
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+  });
+
+  it("auth.json is plain JSON for pi — a commented one is broken and must not green", () => {
+    const home = tmp;
+    writePiFile(home, "auth.json", '{\n  // mine\n  "openai": { "type": "api_key", "key": "sk" }\n}');
+    expect(piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), bareEnv())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) Google Vertex ADC
+// ---------------------------------------------------------------------------
+
+describe("Google Vertex ADC", () => {
+  const project = { GOOGLE_CLOUD_PROJECT: "proj", GOOGLE_CLOUD_LOCATION: "us-central1" };
+
+  it("credentials file that EXISTS + project + location → ready", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    const env = bareEnv({ ...project, GOOGLE_APPLICATION_CREDENTIALS: keyFile });
+    expect(piVertexAdcUsable(tmp, env)).toBe(true);
+    expect(piCredentialPresent(tmp, env)).toBe(true);
+  });
+
+  it("NONEXISTENT credentials path → NOT ready (the old false green)", () => {
+    const env = bareEnv({ ...project, GOOGLE_APPLICATION_CREDENTIALS: join(tmp, "gone.json") });
+    expect(piVertexAdcUsable(tmp, env)).toBe(false);
+    expect(piCredentialPresent(tmp, env)).toBe(false);
+  });
+
+  it("credentials file without project/location → NOT ready (pi's ADC path needs all three)", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    expect(piVertexAdcUsable(tmp, bareEnv({ GOOGLE_APPLICATION_CREDENTIALS: keyFile }))).toBe(false);
+    expect(
+      piVertexAdcUsable(tmp, bareEnv({ GOOGLE_APPLICATION_CREDENTIALS: keyFile, GOOGLE_CLOUD_PROJECT: "p" })),
+    ).toBe(false);
+  });
+
+  it("GCLOUD_PROJECT is accepted as the project fallback", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    const env = bareEnv({
+      GCLOUD_PROJECT: "proj",
+      GOOGLE_CLOUD_LOCATION: "us-central1",
+      GOOGLE_APPLICATION_CREDENTIALS: keyFile,
+    });
+    expect(piVertexAdcUsable(tmp, env)).toBe(true);
+  });
+
+  it("gcloud's well-known ADC file counts when the env var is unset", () => {
+    const dir = join(tmp, ".config", "gcloud");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "application_default_credentials.json"), "{}");
+    expect(piVertexAdcUsable(tmp, bareEnv(project))).toBe(true);
+    // …but only with project + location.
+    expect(piVertexAdcUsable(tmp, bareEnv())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) models.json — JSONC accepted, empty entries rejected
+// ---------------------------------------------------------------------------
+
+describe("models.json", () => {
+  const modelsPath = () => join(tmp, ".pi", "agent", "models.json");
+
+  it("JSONC (line comments + trailing commas) is VALID — pi strips them too", () => {
+    writePiFile(
+      tmp,
+      "models.json",
+      `{
+  // my local gateway
+  "providers": {
+    "mygw": {
+      "baseUrl": "http://localhost:1234",
+      "apiKey": "sk-local", // inline note
+    },
+  },
+}`,
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(true);
+  });
+
+  it("a `//` sequence inside a STRING is not treated as a comment", () => {
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"gw":{"baseUrl":"http://x/v1","apiKey":"sk-a"}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("EMPTY provider entry does NOT green pi", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"mygw":{}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+  });
+
+  it("empty `providers` map, or a file with no `providers` key, does NOT green pi", () => {
+    writePiFile(tmp, "models.json", '{"providers":{}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    // The old check counted TOP-LEVEL keys, so this one-key file greened pi.
+    writePiFile(tmp, "models.json", '{"note":"todo"}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+
+  it("a provider with only baseUrl/models (no credential) does NOT green pi", () => {
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"mygw":{"baseUrl":"http://localhost:1234","models":[{"id":"m"}]}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+
+  it("a provider apiKey referencing an UNSET env var does NOT green pi", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"mygw":{"apiKey":"$MY_GW_KEY"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    expect(piModelsJsonUsable(modelsPath(), bareEnv({ MY_GW_KEY: "sk" }))).toBe(true);
+  });
+
+  it("an `oauth` provider entry is a credential", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"radius":{"oauth":"radius"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("missing / corrupt models.json → not a credential", () => {
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", "{ not json");
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+});
+
+describe("stripJsonComments", () => {
+  it("removes line comments and trailing commas but preserves strings", () => {
+    expect(stripJsonComments('{"a":1} // tail')).toBe('{"a":1} ');
+    expect(stripJsonComments('{"a":[1,2,],}')).toBe('{"a":[1,2]}');
+    expect(stripJsonComments('{"url":"http://x//y"}')).toBe('{"url":"http://x//y"}');
+  });
+
+  it("does NOT handle block comments — pi doesn't either, so such a file is broken for pi too", () => {
+    const body = '{\n/* note */\n"providers":{"g":{"apiKey":"sk"}}\n}';
+    writePiFile(tmp, "models.json", body);
+    expect(piModelsJsonUsable(join(tmp, ".pi", "agent", "models.json"), bareEnv())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end readiness wiring
+// ---------------------------------------------------------------------------
+
+describe("piCredentialPresent source precedence", () => {
+  it("any ONE credible source is enough", () => {
+    // env only
+    expect(piCredentialPresent(tmp, bareEnv({ XAI_API_KEY: "k" }))).toBe(true);
+    // auth.json only
+    writePiFile(tmp, "auth.json", JSON.stringify({ xai: { type: "api_key", key: "k" } }));
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(true);
+  });
+
+  it("a home with an empty .pi tree and a bare env is NOT ready", () => {
+    mkdirSync(join(tmp, ".pi", "agent"), { recursive: true });
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+  });
+});

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -306,6 +306,11 @@ describe("auth.json records", () => {
     expect(credentialValueUsable("$MY_KEY", undefined, bareEnv())).toBe(false);
     expect(credentialValueUsable("${A}_${B}", undefined, bareEnv({ A: "x" }))).toBe(false);
     expect(credentialValueUsable("${A}_${B}", undefined, bareEnv({ A: "x", B: "y" }))).toBe(true);
+    // pi's resolver uses `entryEnv[name] || process.env[name]`, so an empty
+    // scoped value falls through to the inherited process value.
+    expect(
+      credentialValueUsable("$MY_KEY", { MY_KEY: "" }, bareEnv({ MY_KEY: "sk-from-process" })),
+    ).toBe(true);
   });
 
   it("a `!command` key is accepted unverified (we never execute it to probe)", () => {
@@ -416,6 +421,50 @@ describe("Google Vertex ADC", () => {
       GOOGLE_APPLICATION_CREDENTIALS: keyFile,
     });
     expect(piVertexAdcUsable(tmp, env)).toBe(true);
+  });
+
+  it("a stored empty Vertex field blocks the ambient value under pi's nullish merge", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    const env = bareEnv({ ...project, GOOGLE_APPLICATION_CREDENTIALS: keyFile });
+    expect(
+      piVertexAdcUsable(tmp, env, { GOOGLE_CLOUD_PROJECT: "", GOOGLE_CLOUD_LOCATION: "us-central1" }),
+    ).toBe(false);
+    expect(
+      piVertexAdcUsable(
+        tmp,
+        env,
+        { GOOGLE_CLOUD_PROJECT: "proj", GOOGLE_CLOUD_LOCATION: "us-central1", GOOGLE_APPLICATION_CREDENTIALS: "" },
+      ),
+    ).toBe(false);
+    // No stored value is nullish/absent and must fall through to the ambient
+    // source; pi also accepts GCLOUD_PROJECT as the final project alias.
+    expect(piVertexAdcUsable(tmp, env, { GOOGLE_CLOUD_LOCATION: "us-central1" })).toBe(true);
+  });
+
+  it("uses the stored GCLOUD_PROJECT alias only after the primary project source is absent", () => {
+    const keyFile = join(tmp, "sa.json");
+    writeFileSync(keyFile, "{}");
+    expect(
+      piVertexAdcUsable(
+        tmp,
+        bareEnv({ GOOGLE_CLOUD_LOCATION: "us-central1", GOOGLE_APPLICATION_CREDENTIALS: keyFile }),
+        { GCLOUD_PROJECT: "stored-alias" },
+      ),
+    ).toBe(true);
+    // Stored alias is nullish-preferred over ambient alias. An explicit empty
+    // value therefore blocks the otherwise-working ambient alias.
+    expect(
+      piVertexAdcUsable(
+        tmp,
+        bareEnv({
+          GCLOUD_PROJECT: "ambient-alias",
+          GOOGLE_CLOUD_LOCATION: "us-central1",
+          GOOGLE_APPLICATION_CREDENTIALS: keyFile,
+        }),
+        { GCLOUD_PROJECT: "" },
+      ),
+    ).toBe(false);
   });
 
   it("gcloud's well-known ADC file counts when the env var is unset", () => {
@@ -722,6 +771,43 @@ describe("pi selected-provider readiness", () => {
       JSON.stringify({ "amazon-bedrock": { type: "api_key", env: { AWS_PROFILE: "work" } } }),
     );
     expect(piCredentialPresent(tmp, bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock" }))).toBe(true);
+  });
+
+  it("uses stored Bedrock AWS_PROFILE only, with nullish precedence", () => {
+    // amazon-bedrock.ts reads every AWS source except AWS_PROFILE through
+    // ctx.env. Record-local bearer/static/ECS/IRSA values therefore cannot
+    // authenticate.
+    for (const env of [
+      { AWS_BEARER_TOKEN_BEDROCK: "stored-bearer" },
+      { AWS_ACCESS_KEY_ID: "stored-id", AWS_SECRET_ACCESS_KEY: "stored-secret" },
+      { AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/id" },
+      { AWS_CONTAINER_CREDENTIALS_FULL_URI: "http://169.254.170.2/creds" },
+      { AWS_WEB_IDENTITY_TOKEN_FILE: "/var/run/token" },
+    ]) {
+      writePiFile(tmp, "auth.json", JSON.stringify({ "amazon-bedrock": { type: "api_key", env } }));
+      expect(piCredentialPresent(tmp, bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock" })), env).toBe(false);
+    }
+
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({ "amazon-bedrock": { type: "api_key", env: { AWS_PROFILE: "stored-profile" } } }),
+    );
+    expect(piCredentialPresent(tmp, bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock" }))).toBe(true);
+
+    // An explicit empty profile is not absent: pi's `??` merge suppresses the
+    // ambient AWS_PROFILE (while other ambient chain sources may still apply).
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({ "amazon-bedrock": { type: "api_key", env: { AWS_PROFILE: "" } } }),
+    );
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock", AWS_PROFILE: "ambient-profile" }),
+      ),
+    ).toBe(false);
   });
 
   it("rejects a command with no command text and preserves whitespace entry-env ownership", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -197,6 +197,18 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(home, bareEnv({ XAI_API_KEY: "sk" }))).toBe(true);
   });
 
+  it("a `null` auth.json breaks pi's auth layer — nothing counts, not even an env key", () => {
+    // pi indexes the parsed value (`this.data[provider]`), which throws for null.
+    writePiFile(tmp, "auth.json", "null");
+    expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(false);
+    // …but an array / string / number all index harmlessly to undefined for pi,
+    // so they must NOT suppress a working ambient key.
+    for (const body of ["[]", '"nope"', "42"]) {
+      writePiFile(tmp, "auth.json", body);
+      expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk" })), body).toBe(true);
+    }
+  });
+
   it("a FALSY stored entry does not own the provider (pi gates on `if (stored)`)", () => {
     // pi falls back to the ambient key when the stored value is null, so
     // suppressing on mere key-presence would false-red a working install.

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -527,6 +527,21 @@ describe("models.json", () => {
       '{"providers":{"p":{"apiKey":"x","modelOverrides":{"m":{"reasoning":"yes"}}}}}',
     );
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    // An OVERRIDE's contextWindow/maxTokens carry no positivity constraint (that
+    // is a ModelDefinition-only runtime check), so 0 is a config pi accepts.
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"p":{"apiKey":"x","modelOverrides":{"m":{"contextWindow":0}}}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    // An UNDECLARED thinkingLevelMap key is fine (no additionalProperties rule).
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"p":{"apiKey":"x","models":[{"id":"m","thinkingLevelMap":{"future":false}}]}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 
   it("bedrock is keyed by pi's provider id (amazon-bedrock) for stored ownership", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -232,7 +232,7 @@ describe("auth.json records", () => {
     }
   });
 
-  it("a stored google-vertex record suppresses ambient ADC too", () => {
+  it("a keyless stored google-vertex record falls through to ambient ADC", () => {
     const keyFile = join(tmp, "sa.json");
     writeFileSync(keyFile, "{}");
     const adcEnv = {
@@ -241,10 +241,10 @@ describe("auth.json records", () => {
       GOOGLE_APPLICATION_CREDENTIALS: keyFile,
     };
     expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(true);
-    // A stored (but unusable) google-vertex record owns the provider, so pi
-    // never consults ADC for it.
+    // pi's resolver checks `if (key)`; an empty stored key is keyless and must
+    // therefore use the valid ADC fallback rather than suppressing it.
     writePiFile(tmp, "auth.json", '{"google-vertex":{"type":"api_key","key":""}}');
-    expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(false);
+    expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(true);
   });
 
   it("CLOUDFLARE_API_KEY alone is not a credential — the account id is required", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -188,11 +188,11 @@ describe("auth.json records", () => {
     expect(authRecordUsable({ key: "x" })).toBe(false);
   });
 
-  it("a stored-but-unusable record suppresses that provider's env key", () => {
+  it("an unusable stored api-key record falls through to that provider's env key", () => {
     const home = tmp;
     writePiFile(home, "auth.json", JSON.stringify({ openai: { type: "api_key" } }));
     // pi will not consult OPENAI_API_KEY: the stored record owns `openai`.
-    expect(piCredentialPresent(home, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(false);
+    expect(piCredentialPresent(home, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(true);
     // …but an unrelated provider's env key still counts.
     expect(piCredentialPresent(home, bareEnv({ XAI_API_KEY: "sk" }))).toBe(true);
   });
@@ -221,7 +221,7 @@ describe("auth.json records", () => {
     // ambient auth); null/false/0 do not. The panel's Python mirror has to match
     // this explicitly, since Python's own truthiness differs for `{}`/`[]`.
     for (const [body, ready] of [
-      ['{"openai":{}}', true],
+      ['{"openai":{}}', false],
       ['{"openai":[]}', false],
       ['{"openai":null}', true],
       ['{"openai":false}', true],

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -493,6 +493,10 @@ describe("models.json", () => {
       '{"id":"m","name":""}', // minLength 1
       '{"id":"m","headers":{"X":1}}', // Record<string,string>
       '{"id":"m","input":["video"]}', // "text" | "image"
+      '{"id":"m","cost":{}}', // ModelCost requires all four rates
+      '{"id":"m","cost":{"input":"free","output":1,"cacheRead":1,"cacheWrite":1}}',
+      '{"id":"m","thinkingLevelMap":{"low":3}}', // string | null
+      '{"id":"m","compat":"yes"}',
     ]) {
       writePiFile(tmp, "models.json", `{"providers":{${good},"p":{"apiKey":"x","models":[${bad}]}}}`);
       expect(piModelsJsonUsable(modelsPath(), bareEnv()), bad).toBe(false);
@@ -504,6 +508,23 @@ describe("models.json", () => {
       '{"providers":{"p":{"apiKey":"x","models":[{"id":"m","reasoning":true,"contextWindow":8192,"input":["text","image"],"headers":{"X":"1"}}]}}}',
     );
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("a fully-specified cost/override block is accepted", () => {
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"p":{"apiKey":"x","models":[{"id":"m","cost":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0}}],' +
+        '"modelOverrides":{"m":{"reasoning":true,"thinkingLevelMap":{"low":"1k","off":null}}}}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    // …and a malformed override invalidates the file, like any other violation.
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"p":{"apiKey":"x","modelOverrides":{"m":{"reasoning":"yes"}}}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
   });
 
   it("UNDECLARED extra fields are left alone (pi declares no additionalProperties)", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -594,12 +594,14 @@ describe("models.json", () => {
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 
-  it("bedrock is keyed by pi's provider id (amazon-bedrock) for stored ownership", () => {
+  it("Bedrock uses pi's amazon-bedrock id and its keyless record falls through to AWS auth", () => {
     // Getting the id wrong would mean a stored record never suppresses the
     // ambient token it owns.
     expect(piCredentialPresent(tmp, bareEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }))).toBe(true);
     writePiFile(tmp, "auth.json", '{"amazon-bedrock":{"type":"api_key"}}');
-    expect(piCredentialPresent(tmp, bareEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }))).toBe(false);
+    // amazon-bedrock is the deliberate exception to generic stored ownership:
+    // its provider resolver consults bearer/AWS sources after a keyless record.
+    expect(piCredentialPresent(tmp, bareEnv({ AWS_BEARER_TOKEN_BEDROCK: "t" }))).toBe(true);
   });
 
   it("UNDECLARED extra fields are left alone (pi declares no additionalProperties)", () => {
@@ -679,5 +681,54 @@ describe("piCredentialPresent source precedence", () => {
   it("a home with an empty .pi tree and a bare env is NOT ready", () => {
     mkdirSync(join(tmp, ".pi", "agent"), { recursive: true });
     expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+  });
+});
+
+describe("pi selected-provider readiness", () => {
+  it("does not green a configured provider from an unrelated credential", () => {
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_PROVIDER: "anthropic", OPENAI_API_KEY: "sk-openai" }),
+      ),
+    ).toBe(false);
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_MODEL: "anthropic/claude-sonnet", OPENAI_API_KEY: "sk-openai" }),
+      ),
+    ).toBe(false);
+    expect(
+      piCredentialPresent(
+        tmp,
+        bareEnv({ COMFYUI_MCP_PI_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "sk-ant" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts every Bedrock AWS credential-chain source, including a keyless stored profile", () => {
+    for (const env of [
+      { AWS_PROFILE: "dev" },
+      { AWS_ACCESS_KEY_ID: "id", AWS_SECRET_ACCESS_KEY: "secret" },
+      { AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/id" },
+      { AWS_CONTAINER_CREDENTIALS_FULL_URI: "http://169.254.170.2/creds" },
+      { AWS_WEB_IDENTITY_TOKEN_FILE: "/var/run/token" },
+    ]) {
+      expect(piCredentialPresent(tmp, bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock", ...env }))).toBe(true);
+    }
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({ "amazon-bedrock": { type: "api_key", env: { AWS_PROFILE: "work" } } }),
+    );
+    expect(piCredentialPresent(tmp, bareEnv({ COMFYUI_MCP_PI_PROVIDER: "amazon-bedrock" }))).toBe(true);
+  });
+
+  it("rejects a command with no command text and preserves whitespace entry-env ownership", () => {
+    expect(credentialValueUsable("!")).toBe(false);
+    expect(credentialValueUsable("!   ")).toBe(false);
+    expect(
+      credentialValueUsable("$OPENAI_API_KEY", { OPENAI_API_KEY: "   " }, { OPENAI_API_KEY: "sk-real" }),
+    ).toBe(false);
   });
 });

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -247,6 +247,22 @@ describe("auth.json records", () => {
     expect(piCredentialPresent(tmp, bareEnv(adcEnv))).toBe(true);
   });
 
+  it("does not treat OAuth as usable for an API-key-only provider", () => {
+    writePiFile(tmp, "auth.json", JSON.stringify({ openai: { type: "oauth", refresh: "r" } }));
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+  });
+
+  it("does not fall back when pi's truthy stored template resolves to whitespace", () => {
+    writePiFile(
+      tmp,
+      "auth.json",
+      JSON.stringify({ openai: { type: "api_key", key: "$OPENAI_API_KEY", env: { OPENAI_API_KEY: "   " } } }),
+    );
+    // Pi resolves entry env with `||`: whitespace is truthy, wins over ambient,
+    // then fails authentication. Readiness must not skip that failed ownership.
+    expect(piCredentialPresent(tmp, bareEnv({ OPENAI_API_KEY: "sk-ambient" }))).toBe(false);
+  });
+
   it("CLOUDFLARE_API_KEY alone is not a credential — the account id is required", () => {
     expect(piCredentialPresent(tmp, bareEnv({ CLOUDFLARE_API_KEY: "k" }))).toBe(false);
     expect(

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -126,10 +126,23 @@ describe("auth.json records", () => {
     expect(authRecordUsable({})).toBe(false);
   });
 
-  it("oauth record needs at least one token", () => {
+  it("oauth record needs something that can produce a live token", () => {
     expect(authRecordUsable({ type: "oauth", access: "at", refresh: "rt", expires: 1 })).toBe(true);
+    // refresh alone: pi can always re-mint an access token.
     expect(authRecordUsable({ type: "oauth", refresh: "rt" })).toBe(true);
     expect(authRecordUsable({ type: "oauth", expires: 123 })).toBe(false);
+    // access alone with no expiry and no refresh cannot be renewed → malformed.
+    expect(authRecordUsable({ type: "oauth", access: "at" })).toBe(false);
+    expect(authRecordUsable({ type: "oauth", access: "at", expires: 999 })).toBe(true);
+  });
+
+  it("an env-interpolated key naming a STRIPPED var is NOT a credential", () => {
+    // GEMINI_API_KEY is a ComfyUI tool secret: buildAgentSpawnEnv() deletes it,
+    // so it resolves for US and to nothing for pi.
+    expect(credentialValueUsable("$GEMINI_API_KEY", undefined, bareEnv({ GEMINI_API_KEY: "k" }))).toBe(false);
+    expect(credentialValueUsable("$OPENAI_API_KEY", undefined, bareEnv({ OPENAI_API_KEY: "k" }))).toBe(true);
+    // …unless the record supplies it itself, which pi injects into pi's env.
+    expect(credentialValueUsable("$GEMINI_API_KEY", { GEMINI_API_KEY: "k" }, bareEnv())).toBe(true);
   });
 
   it("an EXPIRED oauth record with a refresh token is still ready (pi auto-refreshes)", () => {
@@ -217,6 +230,18 @@ describe("Google Vertex ADC", () => {
     ).toBe(false);
   });
 
+  it("a RELATIVE credentials path is NOT ready (unverifiable — pi's cwd is unknown here)", () => {
+    const env = bareEnv({ ...project, GOOGLE_APPLICATION_CREDENTIALS: "missing.json" });
+    expect(piVertexAdcUsable(tmp, env)).toBe(false);
+  });
+
+  it("a %APPDATA%\\gcloud ADC file does NOT count — pi only probes ~/.config/gcloud", () => {
+    const appData = join(tmp, "AppData", "Roaming");
+    mkdirSync(join(appData, "gcloud"), { recursive: true });
+    writeFileSync(join(appData, "gcloud", "application_default_credentials.json"), "{}");
+    expect(piVertexAdcUsable(tmp, bareEnv({ ...project, APPDATA: appData }))).toBe(false);
+  });
+
   it("GCLOUD_PROJECT is accepted as the project fallback", () => {
     const keyFile = join(tmp, "sa.json");
     writeFileSync(keyFile, "{}");
@@ -301,9 +326,37 @@ describe("models.json", () => {
     expect(piModelsJsonUsable(modelsPath(), bareEnv({ MY_GW_KEY: "sk" }))).toBe(true);
   });
 
-  it("an `oauth` provider entry is a credential", () => {
+  it("an `oauth` provider entry is a credential — but only pi's literal \"radius\"", () => {
     writePiFile(tmp, "models.json", '{"providers":{"radius":{"oauth":"radius"}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+    // pi's schema is a literal; any other value makes pi reject the whole file.
+    writePiFile(tmp, "models.json", '{"providers":{"x":{"oauth":"nope"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+
+  it("a MALFORMED sibling provider discards the whole file, as it does for pi", () => {
+    // pi validates models.json as a unit and throws it away on any violation, so
+    // the good provider's key never reaches pi either.
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"good":{"apiKey":"sk-a"},"bad":{"models":"not-an-array"}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk-a"},"bad":{"apiKey":""}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    // …and the same file with the sibling fixed IS a credential.
+    writePiFile(
+      tmp,
+      "models.json",
+      '{"providers":{"good":{"apiKey":"sk-a"},"ok":{"baseUrl":"http://x/v1","models":[]}}}',
+    );
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
+  });
+
+  it("an apiKey naming a STRIPPED var does not green pi", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"gw":{"apiKey":"$HF_TOKEN"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv({ HF_TOKEN: "k" }))).toBe(false);
   });
 
   it("missing / corrupt models.json → not a credential", () => {

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -221,7 +221,7 @@ describe("auth.json records", () => {
     // ambient auth); null/false/0 do not. The panel's Python mirror has to match
     // this explicitly, since Python's own truthiness differs for `{}`/`[]`.
     for (const [body, ready] of [
-      ['{"openai":{}}', false],
+      ['{"openai":{}}', true],
       ['{"openai":[]}', false],
       ['{"openai":null}', true],
       ['{"openai":false}', true],

--- a/src/__tests__/orchestrator/pi-credentials.test.ts
+++ b/src/__tests__/orchestrator/pi-credentials.test.ts
@@ -127,13 +127,46 @@ describe("auth.json records", () => {
   });
 
   it("oauth record needs something that can produce a live token", () => {
-    expect(authRecordUsable({ type: "oauth", access: "at", refresh: "rt", expires: 1 })).toBe(true);
-    // refresh alone: pi can always re-mint an access token.
-    expect(authRecordUsable({ type: "oauth", refresh: "rt" })).toBe(true);
-    expect(authRecordUsable({ type: "oauth", expires: 123 })).toBe(false);
-    // access alone with no expiry and no refresh cannot be renewed → malformed.
-    expect(authRecordUsable({ type: "oauth", access: "at" })).toBe(false);
-    expect(authRecordUsable({ type: "oauth", access: "at", expires: 999 })).toBe(true);
+    const now = 1_800_000_000_000;
+    const futureSec = Math.floor(now / 1000) + 3600;
+    expect(authRecordUsable({ type: "oauth", access: "at", refresh: "rt", expires: 1 }, bareEnv(), now)).toBe(true);
+    // refresh alone: pi can always re-mint an access token, even when expired.
+    expect(authRecordUsable({ type: "oauth", refresh: "rt" }, bareEnv(), now)).toBe(true);
+    expect(authRecordUsable({ type: "oauth", expires: futureSec }, bareEnv(), now)).toBe(false);
+    // access with no refresh and a PAST/absent expiry cannot be renewed: pi sees
+    // it as expired and tries to refresh with no refresh token.
+    expect(authRecordUsable({ type: "oauth", access: "at" }, bareEnv(), now)).toBe(false);
+    expect(authRecordUsable({ type: "oauth", access: "at", expires: 999 }, bareEnv(), now)).toBe(false);
+    // …a still-live access token is ready. Accepted in seconds OR milliseconds,
+    // since pi doesn't document the unit.
+    expect(authRecordUsable({ type: "oauth", access: "at", expires: futureSec }, bareEnv(), now)).toBe(true);
+    expect(authRecordUsable({ type: "oauth", access: "at", expires: now + 3600_000 }, bareEnv(), now)).toBe(true);
+  });
+
+  it("an UNRECOGNISED credential type is not a credential (and blocks env fallback)", () => {
+    // pi's resolveProviderAuth dispatches only "oauth"/"api_key" and returns
+    // undefined otherwise — and a stored credential owns the provider, so it
+    // does not fall back to the env either.
+    expect(authRecordUsable({ type: "future", key: "x" })).toBe(false);
+    expect(authRecordUsable({ key: "x" })).toBe(false);
+  });
+
+  it("a stored-but-unusable record suppresses that provider's env key", () => {
+    const home = tmp;
+    writePiFile(home, "auth.json", JSON.stringify({ openai: { type: "api_key" } }));
+    // pi will not consult OPENAI_API_KEY: the stored record owns `openai`.
+    expect(piCredentialPresent(home, bareEnv({ OPENAI_API_KEY: "sk" }))).toBe(false);
+    // …but an unrelated provider's env key still counts.
+    expect(piCredentialPresent(home, bareEnv({ XAI_API_KEY: "sk" }))).toBe(true);
+  });
+
+  it("honours PI_CODING_AGENT_DIR (with ~ expansion)", () => {
+    const alt = join(tmp, "alt-config");
+    mkdirSync(alt, { recursive: true });
+    writeFileSync(join(alt, "auth.json"), JSON.stringify({ openai: { type: "api_key", key: "sk" } }));
+    expect(piCredentialPresent(tmp, bareEnv())).toBe(false);
+    expect(piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: alt }))).toBe(true);
+    expect(piCredentialPresent(tmp, bareEnv({ PI_CODING_AGENT_DIR: "~/alt-config" }))).toBe(true);
   });
 
   it("an env-interpolated key naming a STRIPPED var is NOT a credential", () => {
@@ -161,6 +194,16 @@ describe("auth.json records", () => {
 
   it("a `!command` key is accepted unverified (we never execute it to probe)", () => {
     expect(credentialValueUsable("!security find-generic-password -ws anthropic")).toBe(true);
+  });
+
+  it("pi's `$$` / `$!` escapes are literals, not references", () => {
+    // pi reads "$$MY_KEY" as the literal string "$MY_KEY"; treating it as a
+    // reference to an unset MY_KEY would false-red a working key.
+    expect(credentialValueUsable("$$MY_KEY", undefined, bareEnv())).toBe(true);
+    expect(credentialValueUsable("sk-$!literal", undefined, bareEnv())).toBe(true);
+    // …a real reference alongside an escape is still resolved.
+    expect(credentialValueUsable("$$literal-$REAL", undefined, bareEnv())).toBe(false);
+    expect(credentialValueUsable("$$literal-$REAL", undefined, bareEnv({ REAL: "x" }))).toBe(true);
   });
 
   it("a file with only malformed records does NOT green pi", () => {
@@ -240,6 +283,12 @@ describe("Google Vertex ADC", () => {
     mkdirSync(join(appData, "gcloud"), { recursive: true });
     writeFileSync(join(appData, "gcloud", "application_default_credentials.json"), "{}");
     expect(piVertexAdcUsable(tmp, bareEnv({ ...project, APPDATA: appData }))).toBe(false);
+  });
+
+  it("a DIRECTORY at the credentials path is not a credential", () => {
+    const dir = join(tmp, "not-a-file");
+    mkdirSync(dir, { recursive: true });
+    expect(piVertexAdcUsable(tmp, bareEnv({ ...project, GOOGLE_APPLICATION_CREDENTIALS: dir }))).toBe(false);
   });
 
   it("GCLOUD_PROJECT is accepted as the project fallback", () => {
@@ -332,6 +381,13 @@ describe("models.json", () => {
     // pi's schema is a literal; any other value makes pi reject the whole file.
     writePiFile(tmp, "models.json", '{"providers":{"x":{"oauth":"nope"}}}');
     expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+  });
+
+  it("a BLANK string on any provider field invalidates the file (pi's minLength 1)", () => {
+    writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"bad":{"name":""}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(false);
+    writePiFile(tmp, "models.json", '{"providers":{"good":{"apiKey":"sk"},"ok":{"name":"Fine"}}}');
+    expect(piModelsJsonUsable(modelsPath(), bareEnv())).toBe(true);
   });
 
   it("a MALFORMED sibling provider discards the whole file, as it does for pi", () => {

--- a/src/orchestrator/agent-backend.ts
+++ b/src/orchestrator/agent-backend.ts
@@ -15,6 +15,7 @@ export type BackendId =
   | "chatgpt"
   | "gemini"
   | "antigravity"
+  | "pi"
   | "grok"
   | "glm"
   | "kimi"
@@ -253,6 +254,27 @@ export const ANTIGRAVITY_CAPABILITIES: AgentCapabilities = {
   slashCommands: false,
   hooks: false,
   vision: false, // no documented image input in -p mode
+};
+
+/** Capability descriptor for the pi.dev CLI backend (`pi`, issue #491) — the
+ *  open-source multi-provider coding agent from earendil-works. Unlike agy, pi
+ *  exposes a DOCUMENTED machine-readable JSON-lines event stream (`--mode json`)
+ *  with real text deltas, per-tool events, and a resumable session id — so this
+ *  is a spawn-per-turn adapter that parses that stream. inProcessMcp is false and
+ *  there is NO config-MCP path either: pi has no MCP client at all (its tools are
+ *  built-ins + TS extensions), so a pi turn does NOT get the ComfyUI panel_* /
+ *  comfyui tools — a real limitation surfaced in the ready banner. vision=false
+ *  (no documented headless image input). Models come from `pi --list-models`. */
+export const PI_CAPABILITIES: AgentCapabilities = {
+  persistentChannel: true, // spawn-per-turn, continuity via `pi --session <id>`
+  streamingDeltas: true, // `--mode json` text_delta events
+  interruptMidTurn: true, // kill the in-flight child tree; next turn continues
+  forkAtAnchor: false, // whole-session resume only (no per-turn anchor wired)
+  inProcessMcp: false, // pi has no MCP client at all (built-in tools + extensions)
+  modelEnumeration: true, // `pi --list-models`
+  slashCommands: false,
+  hooks: false,
+  vision: false, // no documented headless image input
 };
 
 /** Capability descriptor for the Grok CLI ACP backend (xAI / Grok Build).

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -40,7 +40,7 @@ const CLI_NAMES: Record<string, string[]> = {
   codex: ["codex", "codex.cmd", "codex.exe"],
   gemini: ["gemini", "gemini.cmd", "gemini.exe"],
   grok: ["grok", "grok.cmd", "grok.exe"],
-  pi: ["pi", "pi.cmd", "pi.exe"],
+  pi: ["pi", "pi.exe"], // no .cmd — Node can't shell-lessly spawn it (see resolvePiBin)
   ollama: ["ollama", "ollama.exe"],
   lmstudio: ["lms", "lms.exe"],
   llamacpp: ["llama-server", "llama-server.exe"],
@@ -49,12 +49,17 @@ const CLI_NAMES: Record<string, string[]> = {
 /** Common provider API-key env vars pi (issue #491) can authenticate with. A
  *  definite login is auth.json OR any of these; used only to UPGRADE pi's auth
  *  signal from "unknown" to "yes" (never to false-flag not-signed-in). Not
- *  exhaustive — pi supports many providers; these are the common coding ones. */
+ *  exhaustive — pi supports many providers; these are the common coding ones.
+ *  IMPORTANT: this list MUST only contain keys that actually REACH pi's spawn
+ *  env. pi is spawned via buildAgentSpawnEnv() (no keep-list), which STRIPS the
+ *  ComfyUI tool-only secrets — so GEMINI_API_KEY / GOOGLE_API_KEY are
+ *  deliberately EXCLUDED: they never reach pi, and listing them would flag
+ *  "authenticated" for a user whose only key is one pi never sees (its first
+ *  turn would then fail). Google/HF providers for pi must go in
+ *  ~/.pi/agent/auth.json instead (documented in pi-backend.ts). */
 const PI_PROVIDER_ENV_KEYS: readonly string[] = [
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
-  "GEMINI_API_KEY",
-  "GOOGLE_API_KEY",
   "XAI_API_KEY",
   "OPENROUTER_API_KEY",
   "DEEPSEEK_API_KEY",

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -70,18 +70,58 @@ const PI_PROVIDER_ENV_KEYS: readonly string[] = [
   "MINIMAX_API_KEY",
 ];
 
-/** True when pi has a VERIFIABLE provider credential: its auth file
- *  (~/.pi/agent/auth.json — API keys and `/login` subscriptions) exists, OR a
- *  non-stripped provider key is in env. This is the honest "ready" signal (pi's
- *  `--list-models` is not an auth probe), and the connect handler uses it too so
- *  a keyless pi is degraded up front instead of greeted green (#491 codex P1a).
- *  A credential we can't see (some other pi config) reads false here — we
- *  under-claim rather than false-greet. */
+/** True when a pi provider credential is detectable from ANY documented source.
+ *  pi's `--list-models` is NOT an auth probe, so this — not the CLI's presence —
+ *  is the honest "ready" signal, and the connect handler uses it too so a
+ *  credential-less pi is degraded up front instead of greeted green (#491 codex
+ *  P1a). Two rules (codex round 3):
+ *    - NEVER green on pure file EXISTENCE: ~/.pi/agent/auth.json is PARSED and
+ *      must carry a structurally-usable entry (an empty/corrupt file is not a
+ *      credential).
+ *    - Detect EVERY documented source so a working pi isn't falsely degraded:
+ *      a valid auth.json, a non-stripped provider env key, Google ADC
+ *      (GOOGLE_APPLICATION_CREDENTIALS — a file path, not stripped), or a
+ *      non-empty ~/.pi/agent/models.json (custom-provider creds).
+ *  Since a REAL usability check needs a turn, we err toward "ready" when any
+ *  credible source exists — false only when NONE is detectable. */
 export function piCredentialPresent(home: string = homedir()): boolean {
-  return (
-    fileExists(home, ".pi", "agent", "auth.json") ||
-    PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim())
-  );
+  if (piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"))) return true;
+  if (PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim())) return true;
+  // Google Vertex ADC: a service-account key file path (NOT an API key, so not
+  // stripped by buildAgentSpawnEnv) — pi's Vertex provider authenticates with it.
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim()) return true;
+  if (piModelsJsonUsable(join(home, ".pi", "agent", "models.json"))) return true;
+  return false;
+}
+
+/** Parse ~/.pi/agent/auth.json and report whether it carries a usable credential
+ *  — an object with ≥1 entry whose value is a non-empty string OR a non-empty
+ *  object (an api_key/oauth record). An empty/`{}`/`{"anthropic":{}}`/corrupt
+ *  file returns false (never green on mere existence). Never throws. */
+function piAuthJsonUsable(file: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+    return Object.values(parsed as Record<string, unknown>).some(
+      (v) =>
+        (typeof v === "string" && v.trim() !== "") ||
+        (!!v && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length > 0),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** A non-empty ~/.pi/agent/models.json (custom provider/model definitions, which
+ *  can carry provider credentials) counts as a credible source. Requires a
+ *  parseable non-empty object — not mere existence. Never throws. */
+function piModelsJsonUsable(file: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
+    return !!parsed && typeof parsed === "object" && !Array.isArray(parsed) && Object.keys(parsed).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /** Well-known Ollama install locations probed in addition to PATH (the Windows

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -15,6 +15,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { readOAuthStatus } from "../services/code-provider-auth.js";
 import { resolveAgyBin } from "./antigravity-backend.js";
+import { resolvePiBin } from "./pi-backend.js";
 import type { OAuthStatusRecord } from "../services/panel-secrets.js";
 import { simpleKeyProvider } from "../services/openai-provider-registry.js";
 
@@ -39,10 +40,30 @@ const CLI_NAMES: Record<string, string[]> = {
   codex: ["codex", "codex.cmd", "codex.exe"],
   gemini: ["gemini", "gemini.cmd", "gemini.exe"],
   grok: ["grok", "grok.cmd", "grok.exe"],
+  pi: ["pi", "pi.cmd", "pi.exe"],
   ollama: ["ollama", "ollama.exe"],
   lmstudio: ["lms", "lms.exe"],
   llamacpp: ["llama-server", "llama-server.exe"],
 };
+
+/** Common provider API-key env vars pi (issue #491) can authenticate with. A
+ *  definite login is auth.json OR any of these; used only to UPGRADE pi's auth
+ *  signal from "unknown" to "yes" (never to false-flag not-signed-in). Not
+ *  exhaustive — pi supports many providers; these are the common coding ones. */
+const PI_PROVIDER_ENV_KEYS: readonly string[] = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "XAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "ZAI_API_KEY",
+  "KIMI_API_KEY",
+  "MINIMAX_API_KEY",
+];
 
 /** Well-known Ollama install locations probed in addition to PATH (the Windows
  *  installer adds PATH for NEW shells only — an orchestrator started from an
@@ -245,6 +266,20 @@ export function backendReadiness(
     // installers' well-known locations (%LOCALAPPDATA%\agy\bin, ~/.local/bin).
     const cli = !!resolveAgyBin(home);
     return { backend: "antigravity", cli, auth: cli ? null : false, ready: cli };
+  }
+  if (b === "pi") {
+    // pi.dev CLI (`pi`, issue #491) — a multi-provider coding agent. Auth lives
+    // in ~/.pi/agent/auth.json (API keys + `/login` subscriptions) or provider
+    // env vars. We can prove a definite login when auth.json exists OR a common
+    // provider key is set; otherwise auth is UNKNOWN (null, don't nag) when the
+    // CLI is present, since pi may be configured a way we can't cheaply see. The
+    // real failure surfaces via the first turn's actionable credential error.
+    const cli = !!resolvePiBin(home);
+    const authKnown =
+      fileExists(home, ".pi", "agent", "auth.json") ||
+      PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim());
+    const auth = authKnown ? true : cli ? null : false;
+    return { backend: "pi", cli, auth, ready: cli };
   }
   if (b === "grok") {
     const cli = onPath(CLI_NAMES.grok);

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -16,8 +16,14 @@ import { join } from "node:path";
 import { readOAuthStatus } from "../services/code-provider-auth.js";
 import { resolveAgyBin } from "./antigravity-backend.js";
 import { resolvePiBin } from "./pi-backend.js";
+// pi's credential detection is large enough (pi's whole env map + auth.json /
+// models.json / Vertex-ADC parsing) to live in its own module; re-exported below
+// so existing importers of `piCredentialPresent` are unaffected.
+import { piCredentialPresent } from "./pi-credentials.js";
 import type { OAuthStatusRecord } from "../services/panel-secrets.js";
 import { simpleKeyProvider } from "../services/openai-provider-registry.js";
+
+export { piCredentialPresent } from "./pi-credentials.js";
 
 export type BackendReadiness = {
   backend: string;
@@ -45,84 +51,6 @@ const CLI_NAMES: Record<string, string[]> = {
   lmstudio: ["lms", "lms.exe"],
   llamacpp: ["llama-server", "llama-server.exe"],
 };
-
-/** Common provider API-key env vars pi (issue #491) can authenticate with. A
- *  definite login is auth.json OR any of these; used only to UPGRADE pi's auth
- *  signal from "unknown" to "yes" (never to false-flag not-signed-in). Not
- *  exhaustive — pi supports many providers; these are the common coding ones.
- *  IMPORTANT: this list MUST only contain keys that actually REACH pi's spawn
- *  env. pi is spawned via buildAgentSpawnEnv() (no keep-list), which STRIPS the
- *  ComfyUI tool-only secrets — so GEMINI_API_KEY / GOOGLE_API_KEY are
- *  deliberately EXCLUDED: they never reach pi, and listing them would flag
- *  "authenticated" for a user whose only key is one pi never sees (its first
- *  turn would then fail). Google/HF providers for pi must go in
- *  ~/.pi/agent/auth.json instead (documented in pi-backend.ts). */
-const PI_PROVIDER_ENV_KEYS: readonly string[] = [
-  "ANTHROPIC_API_KEY",
-  "OPENAI_API_KEY",
-  "XAI_API_KEY",
-  "OPENROUTER_API_KEY",
-  "DEEPSEEK_API_KEY",
-  "GROQ_API_KEY",
-  "MISTRAL_API_KEY",
-  "ZAI_API_KEY",
-  "KIMI_API_KEY",
-  "MINIMAX_API_KEY",
-];
-
-/** True when a pi provider credential is detectable from ANY documented source.
- *  pi's `--list-models` is NOT an auth probe, so this — not the CLI's presence —
- *  is the honest "ready" signal, and the connect handler uses it too so a
- *  credential-less pi is degraded up front instead of greeted green (#491 codex
- *  P1a). Two rules (codex round 3):
- *    - NEVER green on pure file EXISTENCE: ~/.pi/agent/auth.json is PARSED and
- *      must carry a structurally-usable entry (an empty/corrupt file is not a
- *      credential).
- *    - Detect EVERY documented source so a working pi isn't falsely degraded:
- *      a valid auth.json, a non-stripped provider env key, Google ADC
- *      (GOOGLE_APPLICATION_CREDENTIALS — a file path, not stripped), or a
- *      non-empty ~/.pi/agent/models.json (custom-provider creds).
- *  Since a REAL usability check needs a turn, we err toward "ready" when any
- *  credible source exists — false only when NONE is detectable. */
-export function piCredentialPresent(home: string = homedir()): boolean {
-  if (piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"))) return true;
-  if (PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim())) return true;
-  // Google Vertex ADC: a service-account key file path (NOT an API key, so not
-  // stripped by buildAgentSpawnEnv) — pi's Vertex provider authenticates with it.
-  if (process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim()) return true;
-  if (piModelsJsonUsable(join(home, ".pi", "agent", "models.json"))) return true;
-  return false;
-}
-
-/** Parse ~/.pi/agent/auth.json and report whether it carries a usable credential
- *  — an object with ≥1 entry whose value is a non-empty string OR a non-empty
- *  object (an api_key/oauth record). An empty/`{}`/`{"anthropic":{}}`/corrupt
- *  file returns false (never green on mere existence). Never throws. */
-function piAuthJsonUsable(file: string): boolean {
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
-    return Object.values(parsed as Record<string, unknown>).some(
-      (v) =>
-        (typeof v === "string" && v.trim() !== "") ||
-        (!!v && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length > 0),
-    );
-  } catch {
-    return false;
-  }
-}
-
-/** A non-empty ~/.pi/agent/models.json (custom provider/model definitions, which
- *  can carry provider credentials) counts as a credible source. Requires a
- *  parseable non-empty object — not mere existence. Never throws. */
-function piModelsJsonUsable(file: string): boolean {
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"));
-    return !!parsed && typeof parsed === "object" && !Array.isArray(parsed) && Object.keys(parsed).length > 0;
-  } catch {
-    return false;
-  }
-}
 
 /** Well-known Ollama install locations probed in addition to PATH (the Windows
  *  installer adds PATH for NEW shells only — an orchestrator started from an
@@ -332,10 +260,17 @@ export function backendReadiness(
     // env vars. UNLIKE agy, `pi --list-models` is NOT an auth probe (it prints
     // the built-in catalog with no key), so readiness must NOT key off the CLI
     // alone — that would greet a keyless pi green-ready and then fail its first
-    // turn (issue #491 codex P1a). We report ready ONLY when a usable credential
-    // is verifiable (auth.json OR a non-stripped provider key in env); when the
-    // CLI is present but no credential is verifiable, auth is UNKNOWN (null) and
-    // ready is FALSE — the panel then shows "configure a provider", not green.
+    // turn (issue #491 codex P1a). We report ready ONLY when a WELL-FORMED,
+    // PRESENT credential is verifiable — see pi-credentials.ts, which mirrors
+    // pi's own resolution (its full provider env map minus the keys our spawn
+    // env strips, a parsed auth.json record that actually carries a key/token, a
+    // JSONC models.json provider with its own apiKey/oauth, or Google Vertex ADC
+    // with an existing credentials file plus project+location). When the CLI is
+    // present but no credential is verifiable, auth is UNKNOWN (null) and ready
+    // is FALSE — the panel then shows "configure a provider", not green.
+    // Residual (accepted, and the UI wording must not over-promise): a present
+    // but revoked/quota-exhausted key is indistinguishable from a good one here
+    // and still fails on the first turn.
     const cli = !!resolvePiBin(home);
     const authKnown = piCredentialPresent(home);
     const auth = authKnown ? true : cli ? null : false;

--- a/src/orchestrator/backend-readiness.ts
+++ b/src/orchestrator/backend-readiness.ts
@@ -70,6 +70,20 @@ const PI_PROVIDER_ENV_KEYS: readonly string[] = [
   "MINIMAX_API_KEY",
 ];
 
+/** True when pi has a VERIFIABLE provider credential: its auth file
+ *  (~/.pi/agent/auth.json — API keys and `/login` subscriptions) exists, OR a
+ *  non-stripped provider key is in env. This is the honest "ready" signal (pi's
+ *  `--list-models` is not an auth probe), and the connect handler uses it too so
+ *  a keyless pi is degraded up front instead of greeted green (#491 codex P1a).
+ *  A credential we can't see (some other pi config) reads false here — we
+ *  under-claim rather than false-greet. */
+export function piCredentialPresent(home: string = homedir()): boolean {
+  return (
+    fileExists(home, ".pi", "agent", "auth.json") ||
+    PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim())
+  );
+}
+
 /** Well-known Ollama install locations probed in addition to PATH (the Windows
  *  installer adds PATH for NEW shells only — an orchestrator started from an
  *  older shell would false-flag "not installed"). */
@@ -275,16 +289,17 @@ export function backendReadiness(
   if (b === "pi") {
     // pi.dev CLI (`pi`, issue #491) — a multi-provider coding agent. Auth lives
     // in ~/.pi/agent/auth.json (API keys + `/login` subscriptions) or provider
-    // env vars. We can prove a definite login when auth.json exists OR a common
-    // provider key is set; otherwise auth is UNKNOWN (null, don't nag) when the
-    // CLI is present, since pi may be configured a way we can't cheaply see. The
-    // real failure surfaces via the first turn's actionable credential error.
+    // env vars. UNLIKE agy, `pi --list-models` is NOT an auth probe (it prints
+    // the built-in catalog with no key), so readiness must NOT key off the CLI
+    // alone — that would greet a keyless pi green-ready and then fail its first
+    // turn (issue #491 codex P1a). We report ready ONLY when a usable credential
+    // is verifiable (auth.json OR a non-stripped provider key in env); when the
+    // CLI is present but no credential is verifiable, auth is UNKNOWN (null) and
+    // ready is FALSE — the panel then shows "configure a provider", not green.
     const cli = !!resolvePiBin(home);
-    const authKnown =
-      fileExists(home, ".pi", "agent", "auth.json") ||
-      PI_PROVIDER_ENV_KEYS.some((k) => !!process.env[k]?.trim());
+    const authKnown = piCredentialPresent(home);
     const auth = authKnown ? true : cli ? null : false;
-    return { backend: "pi", cli, auth, ready: cli };
+    return { backend: "pi", cli, auth, ready: cli && authKnown };
   }
   if (b === "grok") {
     const cli = onPath(CLI_NAMES.grok);

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -69,6 +69,7 @@ import {
 import { CodexBackend } from "./codex-backend.js";
 import { GeminiBackend, GEMINI_DEFAULT_MODEL } from "./gemini-backend.js";
 import { AntigravityBackend } from "./antigravity-backend.js";
+import { PiBackend } from "./pi-backend.js";
 import { GrokBackend, GROK_DEFAULT_MODEL } from "./grok-backend.js";
 import { OllamaBackend, OLLAMA_SYSTEM_PROMPT, type OllamaBackendDeps } from "./ollama-backend.js";
 import { ChatGptOAuthBackend, CHATGPT_DEFAULT_MODEL } from "./chatgpt-oauth-backend.js";
@@ -1219,6 +1220,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // Antigravity (`agy`, issue #262): no default on purpose — unset means the
   // account's own default model; the live catalog comes from `agy models`.
   const antigravityModel = process.env.COMFYUI_MCP_ANTIGRAVITY_MODEL;
+  // pi.dev (`pi`, issue #491): no default on purpose — unset means pi's own
+  // configured default provider/model. When set, COMFYUI_MCP_PI_MODEL accepts a
+  // bare model id or pi's "provider/model" form; COMFYUI_MCP_PI_PROVIDER pins the
+  // provider (--provider). The live catalog comes from `pi --list-models`.
+  const piModel = process.env.COMFYUI_MCP_PI_MODEL;
+  const piProvider = process.env.COMFYUI_MCP_PI_PROVIDER;
   const grokModel = process.env.COMFYUI_MCP_GROK_MODEL ?? GROK_DEFAULT_MODEL;
   // Ollama (local LLMs, issue #97): the model is a local tag applied PER
   // REQUEST — switching live is free. Default = OUR FINE-TUNE,
@@ -1360,6 +1367,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     "chatgpt",
     "gemini",
     "antigravity",
+    "pi",
     "grok",
     // Simple api-key providers (glm/kimi/moonshot) come from the registry.
     ...OPENAI_KEY_PROVIDER_IDS,
@@ -1692,6 +1700,17 @@ export async function runPanelOrchestrator(): Promise<void> {
         mcpServers: makeHttpBackendMcpServers(panelTabId),
       });
     }
+    if (backend === "pi") {
+      // pi has NO MCP client, so it gets NO mcpServers (comfyui/panel tools are
+      // unavailable to pi turns — see pi-backend.ts). It runs as a coding/chat
+      // agent on the user's own provider.
+      return new PiBackend({
+        cwd: comfyuiPath ?? process.cwd(),
+        ...(piModel ? { model: piModel } : {}),
+        ...(piProvider ? { provider: piProvider } : {}),
+        systemAppend: sysAppend,
+      });
+    }
     if (backend === "grok") {
       return new GrokBackend({
         cwd: comfyuiPath ?? process.cwd(),
@@ -1828,6 +1847,12 @@ export async function runPanelOrchestrator(): Promise<void> {
             ? new AntigravityBackend({
                 cwd: comfyuiPath ?? process.cwd(),
                 ...(antigravityModel ? { model: antigravityModel } : {}),
+              })
+          : backend === "pi"
+            ? new PiBackend({
+                cwd: comfyuiPath ?? process.cwd(),
+                ...(piModel ? { model: piModel } : {}),
+                ...(piProvider ? { provider: piProvider } : {}),
               })
           : backend === "grok"
               ? new GrokBackend({ cwd: comfyuiPath ?? process.cwd(), model: grokModel })
@@ -2350,6 +2375,7 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "codex") return codexModel;
     if (backend === "gemini") return geminiModel;
     if (backend === "antigravity") return antigravityModel;
+    if (backend === "pi") return piModel;
     if (backend === "grok") return grokModel;
     if (backend === "ollama") return ollamaModel;
     if (backend === "openrouter") return openrouterModel;
@@ -3019,6 +3045,7 @@ export async function runPanelOrchestrator(): Promise<void> {
       const isCg = backend === "chatgpt";
       const isGm = backend === "gemini";
       const isAg = backend === "antigravity";
+      const isPi = backend === "pi";
       const isGk = backend === "grok";
       // glm/kimi/moonshot share one registry-driven ack (label + ready + degraded).
       const reg = openAiKeyProvider(backend);
@@ -3081,6 +3108,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? (geminiModel ?? (models[0] as { value?: string }).value ?? "Gemini")
                 : isAg
                   ? (antigravityModel ?? (models[0] as { value?: string }).value ?? "Antigravity")
+                : isPi
+                  ? (piModel ?? (models[0] as { value?: string }).value ?? "Pi")
                 : isGk
                   ? (grokModel ?? (models[0] as { value?: string }).value ?? "Grok")
                 : isOl
@@ -3158,6 +3187,8 @@ export async function runPanelOrchestrator(): Promise<void> {
                 ? "⚠️ The background agent isn't responding — the Gemini CLI couldn't start. Make sure the Gemini CLI is installed and signed in (run `gemini` once and complete the Google sign-in), then Disconnect → Connect to retry."
                 : isAg
                   ? "⚠️ The background agent isn't responding — the Antigravity CLI couldn't answer `agy models`. Install it from https://antigravity.google, run `agy` once and complete the Google Sign-In, then Disconnect → Connect to retry."
+                : isPi
+                  ? "⚠️ The background agent isn't responding — the pi CLI couldn't run `pi --list-models`. Install it from https://pi.dev (`curl -fsSL https://pi.dev/install.sh | sh`), configure a provider (set a provider API key or run `pi` once and `/login`), then Disconnect → Connect to retry."
                 : isGk
                   ? "⚠️ The background agent isn't responding — the Grok CLI couldn't start. Make sure Grok is installed and signed in (run `grok` once and complete the xAI sign-in), then Disconnect → Connect to retry."
                 : isOl

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1716,12 +1716,15 @@ export async function runPanelOrchestrator(): Promise<void> {
       // pi has NO MCP client, so it gets NO mcpServers (comfyui/panel tools are
       // unavailable to pi turns — see pi-backend.ts). It runs as a coding/chat
       // agent on the user's own provider. The panel prompt claims panel_*/comfyui
-      // tools it can't run, so append PI_CAPABILITY_OVERRIDE to correct that.
+      // tools it can't run, so PI_CAPABILITY_OVERRIDE is passed as capabilityNote
+      // — re-asserted on EVERY turn (incl. resume), not folded into the
+      // first-turn-only systemAppend (#491 codex P0a-resume).
       return new PiBackend({
         cwd: comfyuiPath ?? process.cwd(),
         ...(piModel ? { model: piModel } : {}),
         ...(piProvider ? { provider: piProvider } : {}),
-        systemAppend: sysAppend + PI_CAPABILITY_OVERRIDE,
+        systemAppend: sysAppend,
+        capabilityNote: PI_CAPABILITY_OVERRIDE,
       });
     }
     if (backend === "grok") {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -3102,9 +3102,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           {
             type: "say",
             text:
-              "⚠️ pi has no provider credential configured — the connection would greet ready and then fail on your first message. " +
-              "Configure a provider: set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY) and restart the orchestrator, " +
-              "or run `pi` once and `/login` (stored in ~/.pi/agent/auth.json), then Disconnect → Connect. https://pi.dev",
+              "⚠️ pi has no usable provider credential — the connection would greet ready and then fail on your first message. " +
+              "Configure a provider: set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY / CEREBRAS_API_KEY) and restart the orchestrator, " +
+              "or run `pi` once and `/login` (stored in ~/.pi/agent/auth.json), then Disconnect → Connect. " +
+              "If you already did one of those, check the entry is complete — an ~/.pi/agent/auth.json record with no `key`, " +
+              "a models.json provider with no `apiKey`, or GOOGLE_APPLICATION_CREDENTIALS pointing at a missing file cannot authenticate. https://pi.dev",
           },
           panelTab,
         );

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -85,7 +85,7 @@ import { resolveOpenAiKeyCredentials } from "../services/code-provider-auth.js";
 import { CopilotBackend, COPILOT_DEFAULT_MODEL } from "./copilot-backend.js";
 import { SYSTEM as MODEL_CARD_SYSTEM } from "./ai-proposer.js";
 import { resolvePrompt, registerPrompt, onPromptsChanged } from "../services/prompt-overrides.js";
-import { allBackendReadiness } from "./backend-readiness.js";
+import { allBackendReadiness, piCredentialPresent } from "./backend-readiness.js";
 import { handleOAuthBegin, handleOAuthStatus, handleOAuthSignout } from "./oauth-bridge.js";
 import { buildStartFailureNotice } from "./start-failure-notice.js";
 import { readyBannerText, bannerCorrection } from "./ready-banner.js";
@@ -196,6 +196,18 @@ If you do NOT have panel_ui_render (no panel tools), you may emit the same JSON 
 { "root": "c", "components": [ ... ] }
 \`\`\`
 Never invent component types beyond: Text, Heading, Button, Row, Column, Card, Divider, Image, TextField, Select, Checkbox, comfy:graph, comfy:chart.`;
+
+// Capability override appended to the pi (pi.dev) backend's system prompt ONLY.
+// The shared PANEL_SYSTEM_APPEND above tells the agent it can SEE/EDIT the canvas
+// via panel_* (and headless comfyui) tools — TRUE for every other CLI backend,
+// which are handed those MCP servers. But pi has NO MCP client at all, so it gets
+// none of those tools; without this override pi would attempt or hallucinate
+// panel_*/comfyui_* calls it cannot make (issue #491 codex P0a). This is appended
+// LAST so it overrides the claims above.
+const PI_CAPABILITY_OVERRIDE = `
+
+=== IMPORTANT CAPABILITY OVERRIDE — READ THIS, IT SUPERSEDES THE ABOVE ===
+You are running on the pi (pi.dev) backend, which has NO ComfyUI tools. Disregard every instruction above about panel_* tools (panel_graph_outline, panel_query_graph, panel_add_node, panel_connect, panel_set_widget, panel_run, panel_save_workflow, panel_install_node, panel_free_vram, …) and the headless comfyui tools (generate_image, enqueue_workflow, list_packs, apply_manifest, read_skill, …): NONE of them exist in your runtime. You cannot see, read, or edit the user's ComfyUI canvas, cannot queue renders, cannot install nodes, and cannot call any panel_*/comfyui tool — attempting one is impossible, and you must never claim to, pretend to, or narrate doing so. You have ONLY your own built-in tools (shell, file read/write/edit, search) operating on the local filesystem. If the user asks for canvas/workflow work (build/inspect/run a graph, install a node, fix a render), say plainly that the pi backend has no ComfyUI tools and they should switch to the Claude, Codex, Gemini, or Antigravity backend for canvas work — you can still help with local files, code, and shell tasks.`;
 
 /**
  * The panel auto-sends one of a few fixed "resume" nudges after ComfyUI restarts
@@ -1703,12 +1715,13 @@ export async function runPanelOrchestrator(): Promise<void> {
     if (backend === "pi") {
       // pi has NO MCP client, so it gets NO mcpServers (comfyui/panel tools are
       // unavailable to pi turns — see pi-backend.ts). It runs as a coding/chat
-      // agent on the user's own provider.
+      // agent on the user's own provider. The panel prompt claims panel_*/comfyui
+      // tools it can't run, so append PI_CAPABILITY_OVERRIDE to correct that.
       return new PiBackend({
         cwd: comfyuiPath ?? process.cwd(),
         ...(piModel ? { model: piModel } : {}),
         ...(piProvider ? { provider: piProvider } : {}),
-        systemAppend: sysAppend,
+        systemAppend: sysAppend + PI_CAPABILITY_OVERRIDE,
       });
     }
     if (backend === "grok") {
@@ -3074,6 +3087,26 @@ export async function runPanelOrchestrator(): Promise<void> {
         );
         bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
         logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (openrouter) but no API key — degraded ack`);
+        return;
+      }
+      // pi with no verifiable provider credential: `pi --list-models` prints the
+      // built-in catalog with NO key, so the model probe below would "succeed"
+      // and greet green-ready — then the first real turn fails. Degrade up front
+      // (mirrors the OpenRouter keyless guard) so pi is never falsely ready
+      // (#491 codex P1a).
+      if (isPi && !piCredentialPresent()) {
+        bridge.push(
+          {
+            type: "say",
+            text:
+              "⚠️ pi has no provider credential configured — the connection would greet ready and then fail on your first message. " +
+              "Configure a provider: set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY) and restart the orchestrator, " +
+              "or run `pi` once and `/login` (stored in ~/.pi/agent/auth.json), then Disconnect → Connect. https://pi.dev",
+          },
+          panelTab,
+        );
+        bridge.push({ type: "ack", ok: false, kind: "degraded" }, panelTab);
+        logger.warn(`[panel-orchestrator] tab ${panelTab.slice(0, 8)} connected (pi) but no verifiable provider credential — degraded ack`);
         return;
       }
       // Custom endpoint with no URL: don't dial a guess — degrade up front

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -115,7 +115,20 @@ function killProcessTree(pid: number | undefined): void {
  */
 export function resolvePiBin(home: string = homedir()): string | null {
   const override = process.env.COMFYUI_MCP_PI_PATH?.trim();
-  if (override) return override;
+  if (override) {
+    // Apply the SAME .cmd/.bat refusal as PATH discovery below — the override
+    // must NOT be an escape hatch around it. Node cannot shell-lessly spawn a
+    // .cmd/.bat, and we never spawn through a shell (the prompt is user data —
+    // shell-quoting it would be an injection risk). A shim override is ignored
+    // with a warning so the actionable "install pi/pi.exe" path fires.
+    if (/\.(cmd|bat)$/i.test(override)) {
+      logger.warn(
+        `[pi-backend] COMFYUI_MCP_PI_PATH points at a shell shim (${override}); Node cannot spawn a .cmd/.bat shell-lessly — ignoring it. Point COMFYUI_MCP_PI_PATH at the real pi/pi.exe.`,
+      );
+      return null;
+    }
+    return override;
+  }
   // A `.cmd`/`.bat` shim is deliberately NOT accepted for SPAWNING: Node refuses
   // shell-less `.cmd` spawns post-CVE-2024-27980, and we never spawn through a
   // shell (the prompt is user data — shell-quoting it would be an injection
@@ -292,14 +305,23 @@ export class PiBackend implements AgentBackend {
     const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
 
     const resumeId = (opts.resume ?? opts.sessionId) || null;
+    // Guard against a legacy-persisted bogus sentinel (older builds emitted one
+    // before the header arrived); never resume from it.
     if (resumeId && resumeId !== PI_SESSION_SENTINEL) this.piSessionId = resumeId;
     this.needsSystemPreamble = !this.piSessionId && !!this.deps.systemAppend;
 
-    yield {
-      type: "session",
-      sessionId: this.piSessionId ?? PI_SESSION_SENTINEL,
-      ...(this.model ? { model: this.model } : {}),
-    };
+    // Report a session id ONLY when it is REAL: on resume we already hold the
+    // caller's id, so surface it up front; on a FRESH conversation we emit NO
+    // session event until pi's JSON header reveals the real uuid (runTurn pushes
+    // it then). This prevents a pre-header failure (spawn error, over-long
+    // prompt, early exit) from persisting a bogus "pending" id up the stack.
+    if (this.piSessionId) {
+      yield {
+        type: "session",
+        sessionId: this.piSessionId,
+        ...(this.model ? { model: this.model } : {}),
+      };
+    }
 
     for await (const turn of opts.channel) {
       yield* this.runTurn(turn, cwd, opts.onActivity);

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -1,0 +1,675 @@
+// pi.dev CLI backend (issue #491, "include pi.dev as an agent") — the provider
+// adapter behind the AgentBackend port for `pi`, the open-source multi-provider
+// coding agent from earendil-works (https://pi.dev). Unlike codex/gemini (ACP /
+// app-server), `pi` exposes a DOCUMENTED machine-readable event stream via its
+// `--mode json` flag (JSON-lines on stdout), which this adapter parses — so it
+// gets real streaming deltas, per-tool progress, and a RESUMABLE session id, a
+// step up from the plain-text antigravity adapter it is otherwise modeled on.
+//
+//   turn N=1 (fresh)   pi --mode json [--model m] [--provider p] "<prompt>"
+//   turn N>1 / resume  pi --session <id> --mode json ... "<prompt>"
+//   interrupt()        kill the in-flight child process tree
+//   listModels()       parse `pi --list-models` (padded text table)
+//
+// SESSION: `pi --mode json` prints a session header `{"type":"session","id":...}`
+// as its first line. We capture that uuid and drive continuity with
+// `--session <id>` (pi accepts a session file OR id), and REPORT it up the stack
+// so PanelAgent can persist it and resume across restarts. This is genuine
+// per-conversation continuity, not antigravity's "latest conversation" sentinel.
+//
+// NO MCP — IMPORTANT LIMITATION: pi has NO Model Context Protocol client (verified
+// against the earendil-works/pi repo tree, CHANGELOG, and extensions docs — pi's
+// tool surface is its OWN built-in tools (bash/read/write/edit/grep/…) plus
+// TypeScript extensions registered via `pi.registerTool()`, never external MCP
+// servers). So unlike every other CLI backend here, pi CANNOT be handed our
+// `comfyui` (stdio) + `panel` (http) MCP servers — a pi turn drives the local
+// workspace with pi's own tools but does not get the ComfyUI panel_* / comfyui
+// tools. This is surfaced honestly in the ready banner. (Full ComfyUI-tool parity
+// would require shipping a pi EXTENSION that bridges to the panel HTTP MCP —
+// tracked as follow-up, out of scope for #491's "include pi as an agent".)
+//
+// AUTH: pi resolves credentials from (1) `~/.pi/agent/auth.json` (API keys and
+// OAuth subscriptions written by `/login`), then (2) provider env vars
+// (ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, …). We
+// spawn with buildAgentSpawnEnv() (no keep-list): the ComfyUI TOOL secrets
+// (RunPod/CivitAI/RunComfy/Registry, and the Google/HF keys that panel-secrets
+// classifies as tool secrets) are stripped so an LLM-vendor process never sees a
+// tool credential — pi's own provider keys (ANTHROPIC/OPENAI/XAI/OpenRouter/…)
+// are NOT tool secrets and pass through untouched, and its subscription auth
+// lives in auth.json regardless. A pi user who wants the Google/HuggingFace
+// providers via env should put those keys in ~/.pi/agent/auth.json (their env
+// vars are ComfyUI-tool-scoped and intentionally withheld from agent subprocesses).
+//
+// LIMITS (flagged honestly):
+//   - No ComfyUI MCP tools (see above).
+//   - The prompt rides argv, so it is visible in the OS process list for the
+//     child's lifetime and is capped at ~32K chars on Windows (preflighted).
+//   - No documented image-input path for headless mode → vision=false (image
+//     refs are already named in the turn text as a fallback).
+//   - `pi --list-models` prints pi's built-in provider CATALOG (not gated on
+//     which keys are configured), so it proves the CLI launches but is NOT an
+//     auth probe — a keyless pi can greet ready and then fail the first turn with
+//     an actionable provider/credential error.
+
+import { spawn, spawnSync, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "../utils/logger.js";
+import { errorText, promptText } from "./error-text.js";
+import { buildAgentSpawnEnv } from "../services/panel-secrets.js";
+import {
+  type AgentBackend,
+  type AgentEvent,
+  type BackendStartOptions,
+  type ModelChoice,
+  type NeutralTurn,
+  PI_CAPABILITIES,
+} from "./agent-backend.js";
+
+/** The per-turn child: stdin ignored (pi takes the prompt via argv), stdout +
+ *  stderr piped. */
+type PiChild = ChildProcessByStdio<null, Readable, Readable>;
+
+function msgOf(err: unknown): string {
+  return errorText(err);
+}
+
+/** Kill an entire process tree (identical posture to the other CLI backends):
+ *  Windows taskkill /T /F; POSIX negative-pid process-group signal with a
+ *  single-pid fallback. Best-effort — teardown must never throw. */
+function killProcessTree(pid: number | undefined): void {
+  if (!Number.isFinite(pid)) return;
+  const p = pid as number;
+  if (process.platform === "win32") {
+    try {
+      spawnSync("taskkill", ["/PID", String(p), "/T", "/F"], { windowsHide: true });
+    } catch {
+      try {
+        process.kill(p);
+      } catch {
+        // already gone
+      }
+    }
+    return;
+  }
+  try {
+    process.kill(-p, "SIGTERM");
+  } catch {
+    try {
+      process.kill(p, "SIGTERM");
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/**
+ * Resolve the `pi` executable. Order: COMFYUI_MCP_PI_PATH (explicit escape hatch)
+ * → PATH (pi / pi.cmd / pi.exe) → the official installer's well-known locations
+ * (~/.local/bin/pi from `curl -fsSL https://pi.dev/install.sh | sh`, plus the
+ * usual Homebrew / Windows spots). Returns an absolute path when found on disk,
+ * the bare name as a last resort, or null when clearly absent. We never spawn
+ * through a shell — the prompt is user data.
+ */
+export function resolvePiBin(home: string = homedir()): string | null {
+  const override = process.env.COMFYUI_MCP_PI_PATH?.trim();
+  if (override) return override;
+  const names = process.platform === "win32" ? ["pi.exe", "pi.cmd", "pi"] : ["pi"];
+  const sep = process.platform === "win32" ? ";" : ":";
+  for (const dir of (process.env.PATH || "").split(sep).filter(Boolean)) {
+    for (const name of names) {
+      try {
+        const full = join(dir, name);
+        if (existsSync(full)) return full;
+      } catch {
+        // unreadable PATH entry — skip
+      }
+    }
+  }
+  const wellKnown =
+    process.platform === "win32"
+      ? [
+          join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), "pi", "bin", "pi.exe"),
+          join(home, ".local", "bin", "pi.exe"),
+        ]
+      : [join(home, ".local", "bin", "pi"), "/usr/local/bin/pi", "/opt/homebrew/bin/pi"];
+  for (const p of wellKnown) {
+    try {
+      if (existsSync(p)) return p;
+    } catch {
+      // skip
+    }
+  }
+  return null;
+}
+
+/** Parse a Go/JS-style duration ("45m", "5m0s", "1h30m") to ms; null when
+ *  unparseable. (Shared shape with the antigravity adapter.) */
+export function parsePiDurationMs(s: string): number | null {
+  const m = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(s.trim());
+  if (!m || (!m[1] && !m[2] && !m[3])) return null;
+  return (Number(m[1] ?? 0) * 3600 + Number(m[2] ?? 0) * 60 + Number(m[3] ?? 0)) * 1000;
+}
+
+/** Strip ANSI escape sequences (pi's TUI heritage may color even table output). */
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\[[0-9;?]*[ -/]*[@-~]/g, "");
+}
+
+/**
+ * Parse `pi --list-models` output into ModelChoices. The format is a padded text
+ * table with columns `provider  model  context  max-out  thinking  images`
+ * (whitespace-aligned, no documented machine contract), so this is deliberately
+ * TOLERANT: strip ANSI, drop the header/separator rows, split each data row on
+ * runs of 2+ spaces, and take the provider + model columns. The id is
+ * `provider/model` (pi's `--model` accepts that prefixed form and it disambiguates
+ * the same model offered by multiple providers); the label is the bare model id.
+ * Returns [] when nothing parses (the panel degrades gracefully on an empty list).
+ */
+export function parsePiModels(output: string): ModelChoice[] {
+  const out: ModelChoice[] = [];
+  const seen = new Set<string>();
+  for (const raw of stripAnsi(output).split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Separator rules (─ === +-| etc.).
+    if (/^[-=─│+|_\s]+$/.test(line)) continue;
+    const cols = line.split(/\s{2,}/).map((c) => c.trim()).filter(Boolean);
+    if (cols.length < 2) continue;
+    const provider = cols[0]!;
+    const modelId = cols[1]!;
+    // Header row.
+    if (/^provider$/i.test(provider) && /^model$/i.test(modelId)) continue;
+    // Plausible provider + model ids: id-ish charset, model has a digit or dash
+    // (filters prose), neither is an obvious column header word.
+    if (!/^[a-z0-9][\w.:-]*$/i.test(provider)) continue;
+    if (!/^[a-z0-9][\w.:@/-]*$/i.test(modelId)) continue;
+    if (!/[\d-]/.test(modelId)) continue;
+    const id = `${provider}/${modelId}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, label: modelId });
+  }
+  return out;
+}
+
+/** Provider config the pi backend needs. */
+export interface PiBackendDeps {
+  /** Working directory for pi. */
+  cwd?: string;
+  /** Model for turns (passed via --model; accepts "provider/id"). Unset = pi's
+   *  configured default provider/model. */
+  model?: string;
+  /** Provider for turns (passed via --provider). Unset = pi's default. */
+  provider?: string;
+  /** Panel system prompt — prepended to the FIRST turn (pi headless has no
+   *  system-prompt flag we rely on). */
+  systemAppend?: string;
+}
+
+/** Sentinel session id used ONLY for the up-front session event of a FRESH
+ *  conversation, before pi's `--mode json` header reveals the real uuid. It is
+ *  never passed back to `--session` (guarded), so a turn that dies before the
+ *  header can't poison resume with a bogus id. */
+const PI_SESSION_SENTINEL = "pi-pending";
+
+/**
+ * The pi.dev CLI adapter. One instance per PanelAgent; spawn-per-turn, so there
+ * is no persistent child between turns — only the in-flight one. Continuity is
+ * pi's own session store, addressed by the captured session id.
+ */
+export class PiBackend implements AgentBackend {
+  readonly id = "pi" as const;
+  readonly capabilities = PI_CAPABILITIES;
+  private deps: PiBackendDeps;
+  private model: string | undefined;
+  private provider: string | undefined;
+  private bin: string | null | undefined; // undefined = not yet resolved
+  /** The in-flight per-turn child (interrupt/close kill its tree). */
+  private child: PiChild | null = null;
+  private interrupted = false;
+  /** True from runTurn entry until settle — a turn is definitely in flight. */
+  private turnActive = false;
+  /** Expiry for an interrupt armed while NO turn was active (see antigravity's
+   *  identical rationale: survive a Stop-after-Send race without poisoning the
+   *  user's next unrelated message). */
+  private idleInterruptExpiry: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  /** The real pi session id: from the JSON header (fresh) or opts.resume. Drives
+   *  `--session` on every turn after it is known, and is REPORTED to PanelAgent
+   *  for cross-restart resume. Null until the first header of a fresh session. */
+  private piSessionId: string | null = null;
+  private needsSystemPreamble = false;
+
+  constructor(deps: PiBackendDeps = {}) {
+    this.deps = deps;
+    this.model = deps.model;
+    this.provider = deps.provider;
+  }
+
+  private resolveBin(): string {
+    if (this.bin === undefined) this.bin = resolvePiBin();
+    if (!this.bin) {
+      throw new Error(
+        "pi CLI (`pi`) not found. Install it from https://pi.dev " +
+          "(macOS/Linux: `curl -fsSL https://pi.dev/install.sh | sh`), configure a provider " +
+          "(set a provider API key, or run `pi` once and `/login`), then reconnect. You can " +
+          "also point COMFYUI_MCP_PI_PATH at the executable.",
+      );
+    }
+    return this.bin;
+  }
+
+  /** One-time preflight: resolve the executable so a missing install fails fast
+   *  with the actionable message above (mirrors the other CLI backends). */
+  async prepare(): Promise<void> {
+    if (this.disposed) throw new Error("pi backend is closed.");
+    this.resolveBin();
+  }
+
+  /**
+   * Drive the session: one `pi --mode json` child per neutral turn, continuity
+   * via `--session <capturedId>`. The channel async-iteration IS the turn gate
+   * (PanelAgent releases one batch per turn).
+   */
+  async *run(opts: BackendStartOptions): AsyncGenerator<AgentEvent> {
+    await this.prepare();
+    // The panel may pass a Claude id in opts.model (its own default) — that is
+    // NOT a valid pi model. Only honor opts.model when it looks like a pi id
+    // (contains a "/" provider prefix, which our listModels always emits); a bare
+    // claude-* id is dropped so pi uses its configured default instead.
+    if (opts.model && this.acceptableModel(opts.model)) this.model = opts.model;
+    const cwd = opts.cwd ?? this.deps.cwd ?? process.cwd();
+
+    const resumeId = (opts.resume ?? opts.sessionId) || null;
+    if (resumeId && resumeId !== PI_SESSION_SENTINEL) this.piSessionId = resumeId;
+    this.needsSystemPreamble = !this.piSessionId && !!this.deps.systemAppend;
+
+    yield {
+      type: "session",
+      sessionId: this.piSessionId ?? PI_SESSION_SENTINEL,
+      ...(this.model ? { model: this.model } : {}),
+    };
+
+    for await (const turn of opts.channel) {
+      yield* this.runTurn(turn, cwd, opts.onActivity);
+    }
+  }
+
+  /** Whether `model` is usable for pi: our listModels ids are always
+   *  `provider/model`, so require a "/" (or an explicit provider set). A bare
+   *  claude-* id (the panel's Anthropic-side default leaking through opts.model)
+   *  is rejected so pi keeps its configured default. */
+  private acceptableModel(model: string): boolean {
+    return model.includes("/") || !!this.provider;
+  }
+
+  /** Run ONE turn = one `pi --mode json` child. Parses the JSON-lines event
+   *  stream: text deltas stream as assistant deltas, tool_execution_* map to
+   *  tool_call events, the session header reveals the resumable id. Exit 0 commits
+   *  the accumulated text + a successful result; a non-zero exit (or spawn
+   *  failure) surfaces an error + failed result. Exactly one terminal result per
+   *  turn (PanelAgent's gate depends on it). */
+  private async *runTurn(
+    turn: NeutralTurn,
+    cwd: string,
+    onActivity?: () => void,
+  ): AsyncGenerator<AgentEvent> {
+    let text = promptText(turn.text);
+    if (this.needsSystemPreamble && this.deps.systemAppend) {
+      text =
+        `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
+        `The user's first message follows.\n\n${text}`;
+      this.needsSystemPreamble = false;
+    }
+    // Image refs: no documented headless image input — the refs are already named
+    // in the turn text (vision=false tells the panel up front).
+
+    const bin = this.resolveBin();
+    const resuming = !!this.piSessionId;
+    const args = [
+      ...(resuming ? ["--session", this.piSessionId as string] : []),
+      "--mode",
+      "json",
+      ...(this.provider ? ["--provider", this.provider] : []),
+      ...(this.model ? ["--model", this.model] : []),
+      text,
+    ];
+
+    // A Stop can land while this turn is still starting up — see the antigravity
+    // adapter's note: `interrupted` is cleared on SETTLE, not here, so it survives
+    // setup. A pending idle-armed interrupt is now aimed at THIS turn.
+    this.turnActive = true;
+    if (this.idleInterruptExpiry) {
+      clearTimeout(this.idleInterruptExpiry);
+      this.idleInterruptExpiry = null;
+    }
+
+    // Windows caps the whole command line at ~32K, and the prompt rides argv.
+    if (process.platform === "win32") {
+      const cmdLen = bin.length + args.reduce((n, a) => n + a.length + 3, 0);
+      if (cmdLen > 30_000) {
+        this.turnActive = false;
+        yield {
+          type: "error",
+          message:
+            `This message is too large for the pi CLI (${cmdLen} chars; Windows caps a command line at ~32K, and pi takes the prompt as an argument). ` +
+            "Send a shorter message, or start a fresh chat to drop replayed context.",
+        };
+        yield { type: "result", ok: false, subtype: "error" };
+        return;
+      }
+    }
+
+    const queue: AgentEvent[] = [];
+    let wake: (() => void) | null = null;
+    let done = false;
+    const push = (ev: AgentEvent) => {
+      queue.push(ev);
+      wake?.();
+      wake = null;
+    };
+    const finish = () => {
+      done = true;
+      wake?.();
+      wake = null;
+    };
+
+    let assistantText = "";
+    let errOut = "";
+    let streamOpen = false;
+    let lineBuf = "";
+
+    /** Handle one parsed JSON event line from pi's --mode json stream. */
+    const handleEvent = (ev: Record<string, unknown>): void => {
+      const t = ev.type;
+      if (t === "session") {
+        // First line: the resumable session uuid. Report it up so PanelAgent
+        // persists the REAL id (not the up-front sentinel) for cross-restart
+        // resume, and drive continuity from it on the next turn.
+        const id = typeof ev.id === "string" ? ev.id : null;
+        if (id && id !== this.piSessionId) {
+          this.piSessionId = id;
+          push({ type: "session", sessionId: id, ...(this.model ? { model: this.model } : {}) });
+        }
+        return;
+      }
+      if (t === "message_update") {
+        const ame = ev.assistantMessageEvent as { type?: unknown; delta?: unknown } | undefined;
+        const delta = typeof ame?.delta === "string" ? ame.delta : "";
+        if (!delta) return;
+        const kind = typeof ame?.type === "string" ? ame.type : "";
+        const thinking = /think|reason/i.test(kind);
+        if (!thinking) assistantText += delta;
+        if (!streamOpen) {
+          streamOpen = true;
+          push({ type: "stream_start", id: null });
+        }
+        push({ type: "assistant_delta", text: delta, ...(thinking ? { thinking: true } : {}) });
+        return;
+      }
+      if (t === "tool_execution_start") {
+        const name = typeof ev.toolName === "string" ? ev.toolName : "tool";
+        push({ type: "tool_call", name, phase: "start", detail: ev.args });
+        return;
+      }
+      if (t === "tool_execution_end") {
+        const name = typeof ev.toolName === "string" ? ev.toolName : "tool";
+        push({ type: "tool_call", name, phase: "end", detail: { isError: ev.isError === true } });
+        return;
+      }
+      // agent_start / turn_start / message_start / message_end / turn_end /
+      // agent_end / queue_update / compaction_* / *_retry_* — no panel event
+      // needed; the process exit is the turn's terminal signal.
+    };
+
+    const consumeLines = (chunk: string): void => {
+      lineBuf += chunk;
+      let nl: number;
+      while ((nl = lineBuf.indexOf("\n")) >= 0) {
+        const line = lineBuf.slice(0, nl).trim();
+        lineBuf = lineBuf.slice(nl + 1);
+        if (!line) continue;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue; // non-JSON noise (shouldn't happen on stdout in json mode)
+        }
+        if (parsed && typeof parsed === "object") handleEvent(parsed as Record<string, unknown>);
+      }
+    };
+
+    let child: PiChild;
+    try {
+      child = spawn(bin, args, {
+        cwd,
+        env: buildAgentSpawnEnv(), // strip ComfyUI tool secrets; pi's own provider keys pass through
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
+      }) as PiChild;
+    } catch (err) {
+      this.turnActive = false;
+      yield { type: "error", message: `Could not start pi: ${msgOf(err)}` };
+      yield { type: "result", ok: false, subtype: "error" };
+      return;
+    }
+    this.child = child;
+
+    // LIVENESS heartbeat: a pi turn may run long tool calls with quiet stretches.
+    const heartbeat = setInterval(() => {
+      try {
+        onActivity?.();
+      } catch {
+        // watchdog bump must never throw
+      }
+    }, 15_000);
+    heartbeat.unref?.();
+
+    // HARD CEILING: bound a frozen child. Configurable; default 45m + 2m grace.
+    const timeout = process.env.COMFYUI_MCP_PI_PRINT_TIMEOUT?.trim() || "45m";
+    let ceilingHit = false;
+    let ceilingForce: ReturnType<typeof setTimeout> | null = null;
+    const ceilingMs = (parsePiDurationMs(timeout) ?? 45 * 60_000) + 120_000;
+    const ceiling = setTimeout(() => {
+      ceilingHit = true;
+      killProcessTree(child.pid);
+      ceilingForce = setTimeout(() => settle(null), 10_000);
+      ceilingForce.unref?.();
+    }, ceilingMs);
+    ceiling.unref?.();
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      try {
+        onActivity?.();
+      } catch {
+        // watchdog bump must never break the reader
+      }
+      consumeLines(chunk);
+    });
+    child.stderr.on("data", (chunk: string) => {
+      try {
+        onActivity?.();
+      } catch {
+        // ignore
+      }
+      errOut += chunk;
+    });
+
+    let settled = false;
+    const settle = (code: number | null, spawnErr?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearInterval(heartbeat);
+      clearTimeout(ceiling);
+      if (ceilingForce) clearTimeout(ceilingForce);
+      if (this.child === child) this.child = null;
+      // Flush any trailing buffered line (no final newline).
+      if (lineBuf.trim()) consumeLines("\n");
+      if (streamOpen) push({ type: "stream_end" });
+      const finalText = assistantText.trim();
+      if (this.interrupted) {
+        if (finalText) push({ type: "assistant", text: finalText });
+        push({ type: "result", ok: false, subtype: "cancelled" });
+      } else if (ceilingHit) {
+        push({
+          type: "error",
+          message:
+            `pi did not finish within ${timeout} (+2m grace) and was terminated, which usually means a frozen CLI. ` +
+            "Try again; raise COMFYUI_MCP_PI_PRINT_TIMEOUT for genuinely long jobs.",
+        });
+        push({ type: "result", ok: false, subtype: "timeout" });
+      } else if (spawnErr || code !== 0) {
+        const stderrTail = stripAnsi(errOut).trim().split(/\r?\n/).slice(-3).join(" ").trim();
+        const authish = /sign.?in|log.?in|auth|credential|unauthoriz|api.?key|no provider/i.test(
+          stderrTail + finalText,
+        );
+        const message = spawnErr
+          ? /ENOENT/i.test(spawnErr.message)
+            ? "pi CLI (`pi`) could not be launched — it may have been uninstalled. Reinstall from https://pi.dev and reconnect."
+            : `pi failed to start: ${spawnErr.message}`
+          : authish
+            ? `pi has no usable provider credentials. Configure one — set a provider API key (e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY) or run \`pi\` once and \`/login\` — then send your message again.${stderrTail ? ` (pi: ${stderrTail})` : ""}`
+            : `pi exited with code ${code}.${stderrTail ? ` ${stderrTail}` : ""}`;
+        push({ type: "error", message });
+        push({ type: "result", ok: false, subtype: "error" });
+      } else {
+        if (finalText) push({ type: "assistant", text: finalText });
+        push({ type: "result", ok: true, subtype: "end_turn" });
+      }
+      // Clear the interrupt HERE (turn end), not at turn start — it was consumed
+      // to pick this turn's result, so the next turn starts clean.
+      this.interrupted = false;
+      this.turnActive = false;
+      finish();
+    };
+    child.on("error", (err) => settle(null, err));
+    child.on("exit", (code) => settle(code));
+
+    // An interrupt can arrive while spawn() is in flight — honor it now (after the
+    // exit/error listeners are attached, so the kill's exit event is observed).
+    if (this.interrupted) killProcessTree(child.pid);
+
+    try {
+      while (true) {
+        while (queue.length) yield queue.shift()!;
+        if (done) break;
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      }
+      while (queue.length) yield queue.shift()!;
+    } finally {
+      if (!settled) {
+        // ABANDONED mid-turn (consumer dropped the generator without close()).
+        settled = true;
+        clearInterval(heartbeat);
+        clearTimeout(ceiling);
+        if (ceilingForce) clearTimeout(ceilingForce);
+        killProcessTree(child.pid);
+        if (this.child === child) this.child = null;
+        this.turnActive = false;
+        this.interrupted = false;
+      }
+    }
+  }
+
+  /** Stop the current turn: kill the in-flight child's process tree. The next
+   *  turn continues the pi session (`--session <id>`) with whatever pi recorded. */
+  async interrupt(): Promise<void> {
+    this.interrupted = true;
+    if (this.idleInterruptExpiry) clearTimeout(this.idleInterruptExpiry);
+    this.idleInterruptExpiry = null;
+    if (!this.turnActive) {
+      const t = setTimeout(() => {
+        this.idleInterruptExpiry = null;
+        if (!this.turnActive) this.interrupted = false;
+      }, 500);
+      t.unref?.();
+      this.idleInterruptExpiry = t;
+    }
+    const child = this.child;
+    if (!child) return; // spawn window — run() kills it as soon as it exists
+    killProcessTree(child.pid);
+  }
+
+  /** Switch the model for subsequent turns (--model is per-spawn, so this is free
+   *  — no respawn dance). Rejects ids that don't look like pi ids. */
+  async setModel(model: string): Promise<void> {
+    if (this.acceptableModel(model)) this.model = model;
+  }
+
+  /**
+   * Enumerate pi's provider/model catalog via `pi --list-models` (a padded text
+   * table). Also serves as the "CLI can launch" probe for the connect ack — note
+   * it is NOT an auth probe (pi lists its built-in catalog regardless of which
+   * keys are configured).
+   */
+  async listModels(): Promise<ModelChoice[]> {
+    const bin = this.resolveBin();
+    return await new Promise<ModelChoice[]>((resolve, reject) => {
+      let out = "";
+      let err = "";
+      let child: PiChild;
+      try {
+        child = spawn(bin, ["--list-models"], {
+          cwd: this.deps.cwd ?? process.cwd(),
+          env: buildAgentSpawnEnv(),
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        }) as PiChild;
+      } catch (e) {
+        reject(new Error(`Could not run \`pi --list-models\`: ${msgOf(e)}`));
+        return;
+      }
+      const timer = setTimeout(() => {
+        killProcessTree(child.pid);
+        reject(new Error("`pi --list-models` timed out after 30s."));
+      }, 30_000);
+      timer.unref?.();
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (c: string) => (out += c));
+      child.stderr.on("data", (c: string) => (err += c));
+      child.on("error", (e) => {
+        clearTimeout(timer);
+        reject(new Error(`Could not run \`pi --list-models\`: ${e.message}`));
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve(parsePiModels(out));
+        } else {
+          const tail = stripAnsi(err || out).trim().split(/\r?\n/).slice(-2).join(" ");
+          reject(
+            new Error(
+              `\`pi --list-models\` exited with code ${code}${tail ? ` (${tail})` : ""}. ` +
+                "Make sure pi is installed (https://pi.dev) and a provider is configured.",
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  /** Dispose: kill any in-flight child tree. Idempotent, safe when never started. */
+  async close(): Promise<void> {
+    this.disposed = true;
+    const child = this.child;
+    this.child = null;
+    if (child) {
+      this.interrupted = true;
+      killProcessTree(child.pid);
+    }
+    if (this.idleInterruptExpiry) {
+      clearTimeout(this.idleInterruptExpiry);
+      this.idleInterruptExpiry = null;
+    }
+  }
+}

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -226,8 +226,15 @@ export interface PiBackendDeps {
   /** Provider for turns (passed via --provider). Unset = pi's default. */
   provider?: string;
   /** Panel system prompt — prepended to the FIRST turn (pi headless has no
-   *  system-prompt flag we rely on). */
+   *  system-prompt flag we rely on). Suppressed on resume (the session already
+   *  carries it). */
   systemAppend?: string;
+  /** A short capability note re-asserted on EVERY turn (fresh AND resume) — pi's
+   *  correction that it has NO ComfyUI panel/comfyui tools. Unlike systemAppend
+   *  it is NOT suppressed on resume, so a resumed or long-running pi session (the
+   *  common path) is always told the truth about its capability (#491 codex
+   *  P0a-resume). Kept small so re-sending it every turn is cheap. */
+  capabilityNote?: string;
 }
 
 /** Sentinel session id used ONLY for the up-front session event of a FRESH
@@ -351,11 +358,22 @@ export class PiBackend implements AgentBackend {
     onActivity?: () => void,
   ): AsyncGenerator<AgentEvent> {
     let text = promptText(turn.text);
+    // System blocks, in order: the heavy panel preamble (FIRST fresh turn only)
+    // then the capability note (EVERY turn — fresh AND resume). The note comes
+    // LAST so, on the first turn, it overrides the preamble's panel_*-tools claim;
+    // on resumed/subsequent turns it is re-asserted alone, so a long-running or
+    // resumed pi session is never left believing it has ComfyUI tools it can't
+    // run (#491 codex P0a-resume).
+    const sysBlocks: string[] = [];
     if (this.needsSystemPreamble && this.deps.systemAppend) {
-      text =
-        `<system>\n${this.deps.systemAppend}\n</system>\n\n` +
-        `The user's first message follows.\n\n${text}`;
+      sysBlocks.push(this.deps.systemAppend);
       this.needsSystemPreamble = false;
+    }
+    if (this.deps.capabilityNote) sysBlocks.push(this.deps.capabilityNote);
+    if (sysBlocks.length) {
+      text =
+        `<system>\n${sysBlocks.join("\n\n")}\n</system>\n\n` +
+        `The user's message follows.\n\n${text}`;
     }
     // Image refs: no documented headless image input — the refs are already named
     // in the turn text (vision=false tells the panel up front).

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -29,8 +29,11 @@
 // tracked as follow-up, out of scope for #491's "include pi as an agent".)
 //
 // AUTH: pi resolves credentials from (1) `~/.pi/agent/auth.json` (API keys and
-// OAuth subscriptions written by `/login`), then (2) provider env vars
-// (ANTHROPIC_API_KEY, OPENAI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, …). We
+// OAuth subscriptions written by `/login`), (2) provider env vars (pi's full map
+// is transcribed in pi-credentials.ts), (3) a `~/.pi/agent/models.json` custom
+// provider carrying its own apiKey/oauth, and (4) Google Vertex ADC. Detection
+// of all four — which is what drives readiness, since `--list-models` is not an
+// auth probe — lives in pi-credentials.ts. We
 // spawn with buildAgentSpawnEnv() (no keep-list): the ComfyUI TOOL secrets
 // (RunPod/CivitAI/RunComfy/Registry, and the Google/HF keys that panel-secrets
 // classifies as tool secrets) are stripped so an LLM-vendor process never sees a

--- a/src/orchestrator/pi-backend.ts
+++ b/src/orchestrator/pi-backend.ts
@@ -116,7 +116,12 @@ function killProcessTree(pid: number | undefined): void {
 export function resolvePiBin(home: string = homedir()): string | null {
   const override = process.env.COMFYUI_MCP_PI_PATH?.trim();
   if (override) return override;
-  const names = process.platform === "win32" ? ["pi.exe", "pi.cmd", "pi"] : ["pi"];
+  // A `.cmd`/`.bat` shim is deliberately NOT accepted for SPAWNING: Node refuses
+  // shell-less `.cmd` spawns post-CVE-2024-27980, and we never spawn through a
+  // shell (the prompt is user data — shell-quoting it would be an injection
+  // risk). The official installer ships a real `pi`/`pi.exe`; a .cmd-only install
+  // reads as "not found" here with actionable guidance (same stance as agy).
+  const names = process.platform === "win32" ? ["pi.exe", "pi"] : ["pi"];
   const sep = process.platform === "win32" ? ";" : ":";
   for (const dir of (process.env.PATH || "").split(sep).filter(Boolean)) {
     for (const name of names) {
@@ -153,10 +158,12 @@ export function parsePiDurationMs(s: string): number | null {
   return (Number(m[1] ?? 0) * 3600 + Number(m[2] ?? 0) * 60 + Number(m[3] ?? 0)) * 1000;
 }
 
-/** Strip ANSI escape sequences (pi's TUI heritage may color even table output). */
+/** Strip ANSI escape sequences (pi's TUI heritage may color even table output).
+ *  The ESC byte (\x1b) is part of the match — without it a colored token keeps
+ *  its leading control char and fails id validation. */
 function stripAnsi(s: string): string {
   // eslint-disable-next-line no-control-regex
-  return s.replace(/\[[0-9;?]*[ -/]*[@-~]/g, "");
+  return s.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
 }
 
 /**
@@ -299,12 +306,15 @@ export class PiBackend implements AgentBackend {
     }
   }
 
-  /** Whether `model` is usable for pi: our listModels ids are always
-   *  `provider/model`, so require a "/" (or an explicit provider set). A bare
-   *  claude-* id (the panel's Anthropic-side default leaking through opts.model)
-   *  is rejected so pi keeps its configured default. */
+  /** Whether `model` is usable for pi. The one thing we MUST reject is the
+   *  panel's Anthropic-side default (a bare `claude-*` id with no provider
+   *  prefix) leaking through opts.model — passing it to `pi --model` would fail
+   *  every turn (and setting `--provider` alongside it does NOT rescue it, so the
+   *  provider flag must NOT whitelist it). Everything else — our own
+   *  `provider/model` picker ids, or an explicit id the user configured — passes. */
   private acceptableModel(model: string): boolean {
-    return model.includes("/") || !!this.provider;
+    if (/^claude/i.test(model) && !model.includes("/")) return false;
+    return true;
   }
 
   /** Run ONE turn = one `pi --mode json` child. Parses the JSON-lines event
@@ -503,12 +513,14 @@ export class PiBackend implements AgentBackend {
     });
 
     let settled = false;
+    let exitFallback: ReturnType<typeof setTimeout> | null = null;
     const settle = (code: number | null, spawnErr?: Error) => {
       if (settled) return;
       settled = true;
       clearInterval(heartbeat);
       clearTimeout(ceiling);
       if (ceilingForce) clearTimeout(ceilingForce);
+      if (exitFallback) clearTimeout(exitFallback);
       if (this.child === child) this.child = null;
       // Flush any trailing buffered line (no final newline).
       if (lineBuf.trim()) consumeLines("\n");
@@ -550,10 +562,19 @@ export class PiBackend implements AgentBackend {
       finish();
     };
     child.on("error", (err) => settle(null, err));
-    child.on("exit", (code) => settle(code));
+    // Settle on 'close' (all stdio drained), NOT 'exit': Node permits stdout to
+    // still hold buffered data at 'exit', so settling there could drop a final
+    // JSONL line (the last delta or the session header). 'exit' only arms a short
+    // fallback in case a stray inherited pipe keeps stdout open past the process.
+    child.on("exit", (code) => {
+      if (settled || exitFallback) return;
+      exitFallback = setTimeout(() => settle(code), 2000);
+      exitFallback.unref?.();
+    });
+    child.on("close", (code) => settle(code));
 
     // An interrupt can arrive while spawn() is in flight — honor it now (after the
-    // exit/error listeners are attached, so the kill's exit event is observed).
+    // exit/close/error listeners are attached, so the kill's events are observed).
     if (this.interrupted) killProcessTree(child.pid);
 
     try {
@@ -641,7 +662,8 @@ export class PiBackend implements AgentBackend {
         clearTimeout(timer);
         reject(new Error(`Could not run \`pi --list-models\`: ${e.message}`));
       });
-      child.on("exit", (code) => {
+      // 'close' (stdio drained), not 'exit' — the full table must be captured.
+      child.on("close", (code) => {
         clearTimeout(timer);
         if (code === 0) {
           resolve(parsePiModels(out));

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -27,7 +27,7 @@
 // here — a user who hand-edits their own auth.json to lie is out of scope (this
 // is a local single-trust-domain project).
 
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { TOOL_ONLY_SECRET_ENV_KEYS } from "../services/panel-secrets.js";
@@ -45,48 +45,52 @@ import { TOOL_ONLY_SECRET_ENV_KEYS } from "../services/panel-secrets.js";
  * buildAgentSpawnEnv() strips. Keep this list a faithful copy of pi's map; do the
  * subtraction there, not by editing this array.
  */
-export const PI_ENV_API_KEYS: readonly string[] = [
-  // anthropic (special-cased in pi: three accepted vars, any one suffices)
-  "ANTHROPIC_API_KEY",
-  "ANTHROPIC_AUTH_TOKEN",
-  "ANTHROPIC_OAUTH_TOKEN",
-  // envMap, in pi's own order
-  "ANT_LING_API_KEY", // ant-ling
-  "QWEN_TOKEN_PLAN_API_KEY", // qwen-token-plan
-  "QWEN_TOKEN_PLAN_CN_API_KEY", // qwen-token-plan-cn
-  "OPENAI_API_KEY", // openai
-  "AZURE_OPENAI_API_KEY", // azure-openai-responses
-  "NVIDIA_API_KEY", // nvidia
-  "DEEPSEEK_API_KEY", // deepseek
-  "GEMINI_API_KEY", // google  (stripped before it reaches pi — see below)
-  "GOOGLE_CLOUD_API_KEY", // google-vertex (api-key mode)
-  "GROQ_API_KEY", // groq
-  "CEREBRAS_API_KEY", // cerebras
-  "XAI_API_KEY", // xai
-  "RADIUS_API_KEY", // radius
-  "OPENROUTER_API_KEY", // openrouter
-  "AI_GATEWAY_API_KEY", // vercel-ai-gateway
-  "ZAI_API_KEY", // zai
-  "ZAI_CODING_CN_API_KEY", // zai-coding-cn
-  "MISTRAL_API_KEY", // mistral
-  "MINIMAX_API_KEY", // minimax
-  "MINIMAX_CN_API_KEY", // minimax-cn
-  "MOONSHOT_API_KEY", // moonshotai / moonshotai-cn
-  "HF_TOKEN", // huggingface (stripped before it reaches pi — see below)
-  "FIREWORKS_API_KEY", // fireworks
-  "TOGETHER_API_KEY", // together
-  "OPENCODE_API_KEY", // opencode / opencode-go
-  "KIMI_API_KEY", // kimi-coding
-  "CLOUDFLARE_API_KEY", // cloudflare-workers-ai / cloudflare-ai-gateway
-  "XIAOMI_API_KEY", // xiaomi
-  "XIAOMI_TOKEN_PLAN_CN_API_KEY", // xiaomi-token-plan-cn
-  "XIAOMI_TOKEN_PLAN_AMS_API_KEY", // xiaomi-token-plan-ams
-  "XIAOMI_TOKEN_PLAN_SGP_API_KEY", // xiaomi-token-plan-sgp
-  "COPILOT_GITHUB_TOKEN", // github-copilot (special-cased in pi)
-  // Documented in packages/coding-agent/docs/providers.md (bedrock) but absent
-  // from `envMap`, which only covers api-key providers.
-  "AWS_BEARER_TOKEN_BEDROCK",
-];
+export const PI_PROVIDER_ENV_KEYS: Readonly<Record<string, readonly string[]>> = {
+  // anthropic is special-cased in pi: three accepted vars, any one suffices.
+  anthropic: ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN"],
+  // envMap, in pi's own order.
+  "ant-ling": ["ANT_LING_API_KEY"],
+  "qwen-token-plan": ["QWEN_TOKEN_PLAN_API_KEY"],
+  "qwen-token-plan-cn": ["QWEN_TOKEN_PLAN_CN_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  "azure-openai-responses": ["AZURE_OPENAI_API_KEY"],
+  nvidia: ["NVIDIA_API_KEY"],
+  deepseek: ["DEEPSEEK_API_KEY"],
+  google: ["GEMINI_API_KEY"], // stripped before it reaches pi — see below
+  "google-vertex": ["GOOGLE_CLOUD_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  cerebras: ["CEREBRAS_API_KEY"],
+  xai: ["XAI_API_KEY"],
+  radius: ["RADIUS_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  "vercel-ai-gateway": ["AI_GATEWAY_API_KEY"],
+  zai: ["ZAI_API_KEY"],
+  "zai-coding-cn": ["ZAI_CODING_CN_API_KEY"],
+  mistral: ["MISTRAL_API_KEY"],
+  minimax: ["MINIMAX_API_KEY"],
+  "minimax-cn": ["MINIMAX_CN_API_KEY"],
+  moonshotai: ["MOONSHOT_API_KEY"],
+  "moonshotai-cn": ["MOONSHOT_API_KEY"],
+  huggingface: ["HF_TOKEN"], // stripped before it reaches pi — see below
+  fireworks: ["FIREWORKS_API_KEY"],
+  together: ["TOGETHER_API_KEY"],
+  opencode: ["OPENCODE_API_KEY"],
+  "opencode-go": ["OPENCODE_API_KEY"],
+  "kimi-coding": ["KIMI_API_KEY"],
+  "cloudflare-workers-ai": ["CLOUDFLARE_API_KEY"],
+  "cloudflare-ai-gateway": ["CLOUDFLARE_API_KEY"],
+  xiaomi: ["XIAOMI_API_KEY"],
+  "xiaomi-token-plan-cn": ["XIAOMI_TOKEN_PLAN_CN_API_KEY"],
+  "xiaomi-token-plan-ams": ["XIAOMI_TOKEN_PLAN_AMS_API_KEY"],
+  "xiaomi-token-plan-sgp": ["XIAOMI_TOKEN_PLAN_SGP_API_KEY"],
+  "github-copilot": ["COPILOT_GITHUB_TOKEN"], // special-cased in pi
+  // Documented in packages/coding-agent/docs/providers.md but absent from
+  // `envMap`, which only covers the api-key providers.
+  bedrock: ["AWS_BEARER_TOKEN_BEDROCK"],
+};
+
+/** Flat view of every credential env var pi reads. */
+export const PI_ENV_API_KEYS: readonly string[] = Object.values(PI_PROVIDER_ENV_KEYS).flat();
 
 /**
  * The subset of `PI_ENV_API_KEYS` that actually SURVIVES into pi's spawn env.
@@ -119,8 +123,44 @@ export function stripJsonComments(input: string): string {
     .replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (m, tail) => tail ?? (m[0] === '"' ? m : ""));
 }
 
-/** Matches pi's `$VAR` / `${VAR}` interpolation tokens in a credential value. */
-const ENV_REF = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+/** Valid env-var name per pi's resolver (`[A-Za-z_][A-Za-z0-9_]*`). */
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*/;
+
+/**
+ * Every env var a credential value interpolates, in pi's parse order.
+ *
+ * Hand-scanned rather than regex'd because pi's resolver has escapes: in a
+ * non-command value `$$` is a literal `$` and `$!` a literal `!`. A regex would
+ * read `"$$MY_KEY"` as a reference to MY_KEY when pi reads it as the literal
+ * string `$MY_KEY` — that mis-parse false-REDs a perfectly good key.
+ */
+function envRefsIn(value: string): string[] {
+  const names: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] !== "$") continue;
+    const next = value[i + 1];
+    if (next === "$" || next === "!") {
+      i++; // escaped literal — consume both, reference nothing
+      continue;
+    }
+    if (next === "{") {
+      const end = value.indexOf("}", i + 2);
+      if (end === -1) continue;
+      const name = value.slice(i + 2, end);
+      if (ENV_NAME.test(name) && ENV_NAME.exec(name)?.[0] === name) {
+        names.push(name);
+        i = end;
+      }
+      continue;
+    }
+    const m = ENV_NAME.exec(value.slice(i + 1));
+    if (m) {
+      names.push(m[0]);
+      i += m[0].length;
+    }
+  }
+  return names;
+}
 
 /**
  * Is a stored credential VALUE (auth.json `key`, models.json `apiKey`) plausibly
@@ -130,9 +170,10 @@ const ENV_REF = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
  *                      running it, and running a user command during a readiness
  *                      probe is not acceptable — so we accept it unverified.
  *   `$VAR` / `${VAR}` → interpolated from the entry's own `env` block first, then
- *                      the process env. If a referenced var is missing there is
- *                      nothing to resolve to, so this is NOT a credential.
- *   literal          → accepted as-is.
+ *                      the process env. pi resolves the WHOLE template to
+ *                      undefined if any referenced var is unset, so one missing
+ *                      var means this is not a credential.
+ *   literal          → accepted as-is (including `$$`/`$!` escapes).
  *
  * Empty / non-string / whitespace-only is never a credential.
  */
@@ -146,7 +187,6 @@ export function credentialValueUsable(
   if (!value) return false;
   // `!command` — unverifiable without executing it; err toward ready.
   if (value.startsWith("!")) return true;
-  if (!value.includes("$")) return true;
   // Every referenced var must resolve to something non-empty IN THE ENV PI WILL
   // ACTUALLY SEE. Order matches pi: the entry's own `env` block first (pi injects
   // it for the provider), then the inherited process env — but a var our spawn
@@ -154,21 +194,13 @@ export function credentialValueUsable(
   // and to nothing for pi. Treating it as present would be exactly the false
   // green this whole module exists to prevent.
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
-  let resolvable = true;
-  value.replace(ENV_REF, (_m, braced: string | undefined, bare: string | undefined) => {
-    const name = braced ?? bare ?? "";
+  for (const name of envRefsIn(value)) {
     const fromEntry = entryEnv?.[name];
-    if (typeof fromEntry === "string" && fromEntry.trim() !== "") return "";
-    if (stripped.has(name) || !procEnv[name]?.trim()) resolvable = false;
-    return "";
-  });
-  return resolvable;
+    if (typeof fromEntry === "string" && fromEntry.trim() !== "") continue;
+    if (stripped.has(name) || !procEnv[name]?.trim()) return false;
+  }
+  return true;
 }
-
-/** Field names that carry credential material on an auth.json record whose
- *  `type` we don't recognise (forward-compat with a pi that adds a new
- *  credential kind). A record with none of these is not a credential. */
-const CREDENTIAL_FIELDS = ["key", "access", "refresh", "token", "apiKey"] as const;
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
@@ -176,6 +208,21 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 
 function nonEmptyString(v: unknown): boolean {
   return typeof v === "string" && v.trim() !== "";
+}
+
+/**
+ * Is `expires` a timestamp still in the future?
+ *
+ * pi's OAuthCredential carries `expires` as a number without documenting its
+ * unit, and this codebase has already been bitten by the seconds-vs-milliseconds
+ * ambiguity (see hasValidPanelOAuth). So accept the value as live if it is in the
+ * future under EITHER reading — that way a genuinely live token is never
+ * false-REDed, while a stale 1970-era value (the malformed case) is future under
+ * neither and correctly reads dead.
+ */
+function expiresInFuture(expires: unknown, nowMs: number): boolean {
+  if (typeof expires !== "number" || !Number.isFinite(expires)) return false;
+  return expires > nowMs || expires * 1000 > nowMs;
 }
 
 /**
@@ -187,37 +234,38 @@ function nonEmptyString(v: unknown): boolean {
  *
  * Note `key` is OPTIONAL in pi's TYPE but mandatory in FACT — a `{"type":"api_key"}`
  * record resolves to no key and pi's first request goes out unauthenticated. That
- * record used to green this provider; it no longer does. Same for an oauth record
- * with neither token.
+ * record used to green this provider; it no longer does.
  *
- * `expires` is deliberately NOT enforced: pi auto-refreshes expired OAuth tokens
- * from `refresh` (docs/providers.md), so an expired-but-refreshable record is
- * genuinely ready and rejecting it would be a false "not signed in".
+ * An UNRECOGNISED `type` is not a credential either: pi's resolveProviderAuth
+ * dispatches only "oauth" and "api_key" and returns undefined for anything else
+ * (packages/ai/src/auth/resolve.ts) — and, because a stored credential owns the
+ * provider, it does not fall back to the env. So such a record is strictly worse
+ * than no record at all.
  */
-export function authRecordUsable(record: unknown, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+export function authRecordUsable(
+  record: unknown,
+  procEnv: NodeJS.ProcessEnv = process.env,
+  nowMs: number = Date.now(),
+): boolean {
   if (!isPlainObject(record)) return false;
   const type = record.type;
   if (type === "api_key") {
     return credentialValueUsable(record.key, isPlainObject(record.env) ? record.env : undefined, procEnv);
   }
   if (type === "oauth") {
-    // pi's OAuthCredential declares refresh + access + expires as ALL required,
-    // and that is what `/login` writes. We don't demand all three (that would
-    // false-red a partially-migrated record), but we do require something that
-    // can actually produce a live token:
-    //   - a `refresh` token: pi can always re-mint access, so ready regardless
-    //     of `expires` (an expired-but-refreshable record IS ready — refusing it
-    //     would be a false "not signed in").
-    //   - otherwise an `access` token is only credible alongside the numeric
-    //     `expires` that tells pi whether it is still live; access-only with no
-    //     expiry and no refresh cannot be renewed and is a malformed record.
+    // pi declares refresh + access + expires as all required, and that is what
+    // `/login` writes. We don't demand all three (that would false-red a
+    // partially-migrated record), but we do require something that can actually
+    // produce a live token:
+    //   - a `refresh` token: pi re-mints access from it, so an EXPIRED record is
+    //     still ready — refusing it would be a false "not signed in".
+    //   - otherwise an `access` token that has NOT expired yet. Access-only with
+    //     no refresh and a past (or absent) expiry cannot be renewed: pi sees it
+    //     as expired and tries to refresh with no refresh token.
     if (nonEmptyString(record.refresh)) return true;
-    return nonEmptyString(record.access) && typeof record.expires === "number";
+    return nonEmptyString(record.access) && expiresInFuture(record.expires, nowMs);
   }
-  // Unknown/absent `type`: accept only if some recognised credential field
-  // carries material, so `{}` and `{"type":"api_key"}` stay not-ready while a
-  // future credential kind still reads as ready.
-  return CREDENTIAL_FIELDS.some((f) => nonEmptyString(record[f]));
+  return false;
 }
 
 function readFileOrNull(file: string): string | null {
@@ -234,15 +282,27 @@ function readFileOrNull(file: string): string | null {
  * the JSONC path it uses for models.json, so a commented auth.json is broken for
  * pi and must not green here. Never throws.
  */
-export function piAuthJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+export function piAuthJsonUsable(
+  file: string,
+  procEnv: NodeJS.ProcessEnv = process.env,
+  nowMs: number = Date.now(),
+): boolean {
+  return Object.values(piAuthRecords(file)).some((rec) => authRecordUsable(rec, procEnv, nowMs));
+}
+
+/** The parsed auth.json map, or `{}` when missing/corrupt. Used both for
+ *  usability and to know WHICH providers have a stored record at all — pi's
+ *  resolver states "a stored credential owns the provider: ambient/env is
+ *  consulted only when nothing is stored", so a stored record suppresses that
+ *  provider's env keys whether or not it works. Never throws. */
+function piAuthRecords(file: string): Record<string, unknown> {
   const raw = readFileOrNull(file);
-  if (raw === null) return false;
+  if (raw === null) return {};
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!isPlainObject(parsed)) return false;
-    return Object.values(parsed).some((rec) => authRecordUsable(rec, procEnv));
+    return isPlainObject(parsed) ? parsed : {};
   } catch {
-    return false;
+    return {};
   }
 }
 
@@ -295,16 +355,21 @@ export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = pr
  *  permissive so we never false-red a file pi accepts. */
 function providerEntryValid(entry: unknown): boolean {
   if (!isPlainObject(entry)) return false;
-  if (entry.apiKey !== undefined && !nonEmptyString(entry.apiKey)) return false;
   if (entry.oauth !== undefined && entry.oauth !== "radius") return false;
-  if (entry.baseUrl !== undefined && !nonEmptyString(entry.baseUrl)) return false;
-  if (entry.models !== undefined && !Array.isArray(entry.models)) return false;
-  return true;
+  if (entry.models !== undefined && (!Array.isArray(entry.models) || !entry.models.every(isPlainObject)))
+    return false;
+  // pi's schema declares its string fields with minLength 1, so ANY blank string
+  // (`name: ""`, `baseUrl: ""`, `apiKey: ""`, …) fails validation and makes pi
+  // discard the whole file. Checking the shape generically covers the fields we
+  // haven't enumerated without having to reproduce the full TypeBox schema.
+  return Object.values(entry).every((v) => typeof v !== "string" || v.trim() !== "");
 }
 
-function fileExistsSafe(file: string): boolean {
+/** True only for an existing REGULAR file — a directory at a credentials path is
+ *  not a credential (existsSync alone would say yes). Never throws. */
+function isRegularFile(file: string): boolean {
   try {
-    return existsSync(file);
+    return statSync(file).isFile();
   } catch {
     return false;
   }
@@ -334,12 +399,52 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
     // "unverifiable" has to mean not-ready here or a dangling `missing.json`
     // greens pi. gcloud always writes an absolute path, so this costs nothing
     // real.
-    return isAbsolute(explicit) && fileExistsSafe(explicit);
+    return isAbsolute(explicit) && isRegularFile(explicit);
   }
   // gcloud's well-known ADC file — pi's fallback is this literal POSIX path, so
   // we probe exactly that and no other location (a %APPDATA%\gcloud file would
   // green a credential pi does not look for).
-  return fileExistsSafe(join(home, ".config", "gcloud", "application_default_credentials.json"));
+  return isRegularFile(join(home, ".config", "gcloud", "application_default_credentials.json"));
+}
+
+/**
+ * pi's agent config directory — where auth.json and models.json live.
+ *
+ * pi resolves this as `PI_CODING_AGENT_DIR` (with `~` expansion) falling back to
+ * `<home>/.pi/agent` (packages/coding-agent/src/config.ts). The override is not a
+ * secret, so buildAgentSpawnEnv passes it straight through to pi — meaning a user
+ * who relocated their pi config was reading as "not signed in" while pi itself
+ * found the credentials fine.
+ */
+export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.env): string {
+  const override = procEnv.PI_CODING_AGENT_DIR?.trim();
+  if (override) {
+    if (override === "~") return home;
+    if (override.startsWith("~/") || override.startsWith("~\\")) return join(home, override.slice(2));
+    return override;
+  }
+  return join(home, ".pi", "agent");
+}
+
+/**
+ * Is any provider authenticated purely by an env var?
+ *
+ * Per pi's resolver, "a stored credential owns the provider: ambient/env is
+ * consulted only when nothing is stored" — so a provider that HAS a record in
+ * auth.json never falls back to its env key. If we got here the stored record was
+ * not usable, which means that provider is dead and its env key must not green
+ * pi. Every OTHER provider's env keys still count.
+ */
+function piEnvCredentialPresent(
+  storedProviders: Record<string, unknown>,
+  procEnv: NodeJS.ProcessEnv,
+): boolean {
+  const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
+  for (const [provider, keys] of Object.entries(PI_PROVIDER_ENV_KEYS)) {
+    if (Object.prototype.hasOwnProperty.call(storedProviders, provider)) continue;
+    if (keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) return true;
+  }
+  return false;
 }
 
 /**
@@ -351,10 +456,14 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
 export function piCredentialPresent(
   home: string = homedir(),
   procEnv: NodeJS.ProcessEnv = process.env,
+  nowMs: number = Date.now(),
 ): boolean {
-  if (piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), procEnv)) return true;
-  if (piEnvKeysReachingPi().some((k) => !!procEnv[k]?.trim())) return true;
+  const agentDir = piAgentDir(home, procEnv);
+  const authFile = join(agentDir, "auth.json");
+  const stored = piAuthRecords(authFile);
+  if (Object.values(stored).some((rec) => authRecordUsable(rec, procEnv, nowMs))) return true;
+  if (piEnvCredentialPresent(stored, procEnv)) return true;
   if (piVertexAdcUsable(home, procEnv)) return true;
-  if (piModelsJsonUsable(join(home, ".pi", "agent", "models.json"), procEnv)) return true;
+  if (piModelsJsonUsable(join(agentDir, "models.json"), procEnv)) return true;
   return false;
 }

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -310,6 +310,9 @@ export function authRecordUsable(
     return true;
   }
   if (type === "oauth") {
+    // pi only dispatches OAuth records to providers that implement that flow.
+    // An OAuth-shaped record for an API-key-only provider is not a credential.
+    if (provider !== "anthropic") return false;
     // A refresh token lets pi re-mint access, so a partial migrated record with
     // one remains usable even when its stored access token is expired. Without
     // it, an access token needs to survive pi's five-minute refresh window.
@@ -719,10 +722,13 @@ function piEnvCredentialPresent(
     // absent, falsy, or cannot resolve. A record's mere existence must not hide
     // that same provider's working ambient key.
     const storedEnv = isPlainObject(stored) && isPlainObject(stored.env) ? stored.env : undefined;
+    const storedTemplateResolvesTruthy =
+      isPlainObject(stored) && typeof stored.key === "string" &&
+      envRefsIn(stored.key).every((name) => !!(storedEnv?.[name] || procEnv[name]));
     const storedCanSupplyKey =
       isPlainObject(stored) &&
       stored.type === "api_key" &&
-      credentialValueUsable(stored.key, storedEnv, procEnv);
+      (credentialValueUsable(stored.key, storedEnv, procEnv) || storedTemplateResolvesTruthy);
     const storedIsOrdinaryApiKey = isPlainObject(stored) && stored.type === "api_key";
     if (providerHasStoredCredential(storedProviders, provider) && (!storedIsOrdinaryApiKey || storedCanSupplyKey)) continue;
     if (!keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) continue;

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -417,6 +417,13 @@ function isFiniteNumber(v: unknown): boolean {
   return typeof v === "number" && Number.isFinite(v);
 }
 
+/** Type.Number() with no positivity constraint — ModelOverride's contextWindow /
+ *  maxTokens, which provider-composer's `<= 0` check does NOT apply to (that
+ *  check is on ModelDefinition only), so 0 is a config pi accepts. */
+function optFiniteNumber(v: unknown): boolean {
+  return v === undefined || isFiniteNumber(v);
+}
+
 /** ModelCostSchema: input/output/cacheRead/cacheWrite are REQUIRED Type.Number();
  *  `tiers` is an optional array. A `cost: {}` (or a string rate) fails the schema
  *  and pi throws the whole models.json away. */
@@ -443,11 +450,18 @@ function costTierValid(tier: unknown): boolean {
   );
 }
 
-/** ThinkingLevelMapSchema: every level maps to a string or null. */
+/** ThinkingLevelMapSchema: each DECLARED level maps to a string or null. Only the
+ *  declared keys are checked — pi's object schemas set no additionalProperties
+ *  restriction, so an unknown key is fine and rejecting it would false-red. */
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
 function optThinkingLevelMap(v: unknown): boolean {
   if (v === undefined) return true;
   if (!isPlainObject(v)) return false;
-  return Object.values(v).every((x) => x === null || typeof x === "string");
+  return THINKING_LEVELS.every((lvl) => {
+    const x = v[lvl];
+    return x === undefined || x === null || typeof x === "string";
+  });
 }
 
 /** ModelOverrideSchema — the same fields as a model definition, all optional and
@@ -459,7 +473,7 @@ function modelOverrideValid(v: unknown): boolean {
   if (!optThinkingLevelMap(v.thinkingLevelMap)) return false;
   if (!optModelInput(v.input)) return false;
   if (!optModelCost(v.cost, false)) return false;
-  if (!optPositiveNumber(v.contextWindow) || !optPositiveNumber(v.maxTokens)) return false;
+  if (!optFiniteNumber(v.contextWindow) || !optFiniteNumber(v.maxTokens)) return false;
   if (!optStringRecord(v.headers)) return false;
   if (v.compat !== undefined && !isPlainObject(v.compat)) return false;
   return true;

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -604,13 +604,13 @@ export function piVertexAdcUsable(
   // Vertex uses nullish (not truthy) per-field fallback. An explicitly-empty
   // stored project/path therefore blocks the ambient value just as it does in
   // pi; treating it as `||` would false-green a broken stored record.
-  // google-vertex resolves these as a four-level nullish chain: stored primary,
-  // ambient primary, stored alias, then ambient alias. In particular, a stored
-  // empty GCLOUD_PROJECT must block an ambient alias rather than acting like an
-  // `||` fallback.
+  // google-vertex resolves the project as stored GOOGLE_CLOUD_PROJECT, ambient
+  // GOOGLE_CLOUD_PROJECT, then ambient GCLOUD_PROJECT. GCLOUD_PROJECT is never
+  // read from a stored auth record. In particular, an explicitly-empty stored
+  // primary still blocks both ambient fallbacks under nullish semantics.
   const project =
     readNullishScoped(entryEnv, procEnv, "GOOGLE_CLOUD_PROJECT") ??
-    readNullishScoped(entryEnv, procEnv, "GCLOUD_PROJECT");
+    procEnv.GCLOUD_PROJECT;
   const location = readNullishScoped(entryEnv, procEnv, "GOOGLE_CLOUD_LOCATION");
   if (!nonEmptyString(project) || !nonEmptyString(location)) return false;
   // NOT trimmed: pi uses the literal value, so a space-padded path that
@@ -690,9 +690,9 @@ function piBedrockCredentialUsable(
  * A bare model has no reliable static provider mapping, so it retains pi's
  * normal default-selection behaviour rather than guessing. */
 function configuredPiProvider(procEnv: NodeJS.ProcessEnv): string | undefined {
-  const explicit = procEnv.COMFYUI_MCP_PI_PROVIDER?.trim();
+  const explicit = procEnv.COMFYUI_MCP_PI_PROVIDER;
   if (explicit) return explicit;
-  const model = procEnv.COMFYUI_MCP_PI_MODEL?.trim();
+  const model = procEnv.COMFYUI_MCP_PI_MODEL;
   const slash = model?.indexOf("/") ?? -1;
   return slash > 0 ? model!.slice(0, slash) : undefined;
 }

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -258,11 +258,24 @@ export function authRecordUsable(
   record: unknown,
   procEnv: NodeJS.ProcessEnv = process.env,
   nowMs: number = Date.now(),
+  provider?: string,
 ): boolean {
   if (!isPlainObject(record)) return false;
   const type = record.type;
   if (type === "api_key") {
-    return credentialValueUsable(record.key, isPlainObject(record.env) ? record.env : undefined, procEnv);
+    const entryEnv = isPlainObject(record.env) ? record.env : undefined;
+    if (!credentialValueUsable(record.key, entryEnv, procEnv)) return false;
+    // Companion config (cloudflare's account/gateway ids) may come from the
+    // record's own `env` block or the environment; without it pi's resolver
+    // returns undefined and the stored key is useless.
+    const required = provider ? PI_PROVIDER_ENV_REQUIRED[provider] : undefined;
+    if (required) {
+      return required.every((k) => {
+        const fromEntry = entryEnv?.[k];
+        return (typeof fromEntry === "string" && fromEntry.trim() !== "") || !!procEnv[k]?.trim();
+      });
+    }
+    return true;
   }
   if (type === "oauth") {
     // pi declares refresh + access + expires as all required, and that is what
@@ -299,7 +312,9 @@ export function piAuthJsonUsable(
   procEnv: NodeJS.ProcessEnv = process.env,
   nowMs: number = Date.now(),
 ): boolean {
-  return Object.values(piAuthRecords(file)).some((rec) => authRecordUsable(rec, procEnv, nowMs));
+  return Object.entries(piAuthRecords(file)).some(([provider, rec]) =>
+    authRecordUsable(rec, procEnv, nowMs, provider),
+  );
 }
 
 /** The parsed auth.json map, or `{}` when missing/corrupt. Used both for
@@ -380,11 +395,21 @@ function providerEntryValid(entry: unknown): boolean {
     if (!entry.models.every((m) => isPlainObject(m) && typeof m.id === "string" && m.id.length > 0))
       return false;
   }
-  // pi's schema declares its string fields with minLength 1, so an EMPTY string
-  // (`name: ""`, `baseUrl: ""`, …) fails validation and makes pi discard the
-  // whole file. Checked generically to cover the fields we haven't enumerated
-  // without reproducing the full TypeBox schema. Length, NOT trim: minLength 1
-  // accepts `" "`, so trimming here would false-red a config pi loads fine.
+  // Fields pi declares as `Type.String({minLength: 1})`: present means it must
+  // BE a non-empty string. A wrong TYPE (`apiKey: 1`) fails the schema just as
+  // hard as an empty one, and pi throws the whole file away either way.
+  for (const field of ["apiKey", "baseUrl", "name", "api"]) {
+    const v = entry[field];
+    if (v !== undefined && (typeof v !== "string" || v.length === 0)) return false;
+  }
+  // `headers` is a string->string map for pi; a non-string value fails the schema.
+  if (entry.headers !== undefined) {
+    if (!isPlainObject(entry.headers)) return false;
+    if (!Object.values(entry.headers).every((v) => typeof v === "string")) return false;
+  }
+  // Anything we have NOT enumerated: only reject an EMPTY string, which fails
+  // minLength 1 for every string field pi declares. Length, NOT trim — minLength
+  // 1 accepts `" "`, so trimming would false-red a config pi loads fine.
   return Object.values(entry).every((v) => typeof v !== "string" || v.length > 0);
 }
 
@@ -439,12 +464,17 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
  * who relocated their pi config was reading as "not signed in" while pi itself
  * found the credentials fine.
  */
-export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.env): string {
+export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.env): string | null {
   const override = procEnv.PI_CODING_AGENT_DIR?.trim();
   if (override) {
     if (override === "~") return home;
     if (override.startsWith("~/") || override.startsWith("~\\")) return join(home, override.slice(2));
-    return override;
+    // A RELATIVE override resolves against pi's own cwd, which readiness cannot
+    // know — so we cannot say whether a config lives there. Null (= don't read
+    // file-backed credentials) rather than guessing against OUR cwd, which could
+    // green a config pi will never see. Same stance as a relative
+    // GOOGLE_APPLICATION_CREDENTIALS.
+    return isAbsolute(override) ? override : null;
   }
   return join(home, ".pi", "agent");
 }
@@ -494,14 +524,18 @@ export function piCredentialPresent(
   nowMs: number = Date.now(),
 ): boolean {
   const agentDir = piAgentDir(home, procEnv);
-  const authFile = join(agentDir, "auth.json");
-  const stored = piAuthRecords(authFile);
-  if (Object.values(stored).some((rec) => authRecordUsable(rec, procEnv, nowMs))) return true;
+  // agentDir null = a relative PI_CODING_AGENT_DIR we cannot resolve; the
+  // file-backed sources are unreadable, but env/ADC still apply.
+  const stored = agentDir ? piAuthRecords(join(agentDir, "auth.json")) : {};
+  if (
+    Object.entries(stored).some(([provider, rec]) => authRecordUsable(rec, procEnv, nowMs, provider))
+  )
+    return true;
   if (piEnvCredentialPresent(stored, procEnv)) return true;
   // Vertex ADC is ambient credential too, so a stored google-vertex record owns
   // that provider and suppresses it (same rule as the env keys above).
   if (!providerHasStoredCredential(stored, "google-vertex") && piVertexAdcUsable(home, procEnv))
     return true;
-  if (piModelsJsonUsable(join(agentDir, "models.json"), procEnv)) return true;
+  if (agentDir && piModelsJsonUsable(join(agentDir, "models.json"), procEnv)) return true;
   return false;
 }

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -147,17 +147,19 @@ export function credentialValueUsable(
   // `!command` — unverifiable without executing it; err toward ready.
   if (value.startsWith("!")) return true;
   if (!value.includes("$")) return true;
-  // Every referenced var must resolve to something non-empty, from the entry's
-  // own `env` map (pi consults it first) or the process env.
+  // Every referenced var must resolve to something non-empty IN THE ENV PI WILL
+  // ACTUALLY SEE. Order matches pi: the entry's own `env` block first (pi injects
+  // it for the provider), then the inherited process env — but a var our spawn
+  // env STRIPS is never inherited, so `"key": "$GEMINI_API_KEY"` resolves for us
+  // and to nothing for pi. Treating it as present would be exactly the false
+  // green this whole module exists to prevent.
+  const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   let resolvable = true;
   value.replace(ENV_REF, (_m, braced: string | undefined, bare: string | undefined) => {
     const name = braced ?? bare ?? "";
     const fromEntry = entryEnv?.[name];
-    const resolved =
-      typeof fromEntry === "string" && fromEntry.trim() !== ""
-        ? fromEntry
-        : procEnv[name];
-    if (!resolved || !String(resolved).trim()) resolvable = false;
+    if (typeof fromEntry === "string" && fromEntry.trim() !== "") return "";
+    if (stripped.has(name) || !procEnv[name]?.trim()) resolvable = false;
     return "";
   });
   return resolvable;
@@ -199,9 +201,18 @@ export function authRecordUsable(record: unknown, procEnv: NodeJS.ProcessEnv = p
     return credentialValueUsable(record.key, isPlainObject(record.env) ? record.env : undefined, procEnv);
   }
   if (type === "oauth") {
-    // Either token alone is enough to get pi a request: `access` is used
-    // directly, `refresh` mints a new one.
-    return nonEmptyString(record.access) || nonEmptyString(record.refresh);
+    // pi's OAuthCredential declares refresh + access + expires as ALL required,
+    // and that is what `/login` writes. We don't demand all three (that would
+    // false-red a partially-migrated record), but we do require something that
+    // can actually produce a live token:
+    //   - a `refresh` token: pi can always re-mint access, so ready regardless
+    //     of `expires` (an expired-but-refreshable record IS ready — refusing it
+    //     would be a false "not signed in").
+    //   - otherwise an `access` token is only credible alongside the numeric
+    //     `expires` that tells pi whether it is still live; access-only with no
+    //     expiry and no refresh cannot be renewed and is a malformed record.
+    if (nonEmptyString(record.refresh)) return true;
+    return nonEmptyString(record.access) && typeof record.expires === "number";
   }
   // Unknown/absent `type`: accept only if some recognised credential field
   // carries material, so `{}` and `{"type":"api_key"}` stay not-ready while a
@@ -260,14 +271,35 @@ export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = pr
     if (!isPlainObject(parsed)) return false;
     const providers = parsed.providers;
     if (!isPlainObject(providers)) return false;
-    return Object.values(providers).some(
+    const entries = Object.values(providers);
+    // pi validates the WHOLE file against ModelsConfigSchema and DISCARDS it on
+    // any violation — so one malformed sibling provider means none of the file's
+    // credentials reach pi. Reproduce that all-or-nothing behaviour rather than
+    // greening off a single good-looking entry.
+    if (!entries.every((p) => providerEntryValid(p))) return false;
+    return entries.some(
       (p) =>
         isPlainObject(p) &&
-        (credentialValueUsable(p.apiKey, undefined, procEnv) || nonEmptyString(p.oauth)),
+        (credentialValueUsable(p.apiKey, undefined, procEnv) || p.oauth === "radius"),
     );
   } catch {
     return false;
   }
+}
+
+/** The subset of pi's ProviderConfigSchema we can check cheaply: `apiKey` and
+ *  `baseUrl` are non-empty strings when present, `oauth` is the literal
+ *  "radius", `models` is an array. This is NOT full TypeBox validation — it
+ *  only has to catch the violations that would make pi throw the file away
+ *  while our detector called it a credential. Anything we can't check is left
+ *  permissive so we never false-red a file pi accepts. */
+function providerEntryValid(entry: unknown): boolean {
+  if (!isPlainObject(entry)) return false;
+  if (entry.apiKey !== undefined && !nonEmptyString(entry.apiKey)) return false;
+  if (entry.oauth !== undefined && entry.oauth !== "radius") return false;
+  if (entry.baseUrl !== undefined && !nonEmptyString(entry.baseUrl)) return false;
+  if (entry.models !== undefined && !Array.isArray(entry.models)) return false;
+  return true;
 }
 
 function fileExistsSafe(file: string): boolean {
@@ -297,16 +329,17 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
   if (!project || !location) return false;
   const explicit = procEnv.GOOGLE_APPLICATION_CREDENTIALS?.trim();
   if (explicit) {
-    // A relative path is resolved against pi's cwd, which we don't control here;
-    // only absolute paths are checkable, so accept a relative one unverified
-    // rather than false-flag it.
-    return isAbsolute(explicit) ? fileExistsSafe(explicit) : true;
+    // Must point at a file that is actually there. A RELATIVE path resolves
+    // against pi's cwd, which readiness cannot know — so it is unverifiable, and
+    // "unverifiable" has to mean not-ready here or a dangling `missing.json`
+    // greens pi. gcloud always writes an absolute path, so this costs nothing
+    // real.
+    return isAbsolute(explicit) && fileExistsSafe(explicit);
   }
-  // gcloud's default ADC location. pi's fallback is the POSIX path; on Windows
-  // gcloud actually writes under %APPDATA%, so accept either.
-  if (fileExistsSafe(join(home, ".config", "gcloud", "application_default_credentials.json"))) return true;
-  const appData = procEnv.APPDATA;
-  return !!appData && fileExistsSafe(join(appData, "gcloud", "application_default_credentials.json"));
+  // gcloud's well-known ADC file — pi's fallback is this literal POSIX path, so
+  // we probe exactly that and no other location (a %APPDATA%\gcloud file would
+  // green a credential pi does not look for).
+  return fileExistsSafe(join(home, ".config", "gcloud", "application_default_credentials.json"));
 }
 
 /**

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -347,6 +347,21 @@ export function piAuthJsonUsable(
  *  resolver states "a stored credential owns the provider: ambient/env is
  *  consulted only when nothing is stored", so a stored record suppresses that
  *  provider's env keys whether or not it works. Never throws. */
+/** True only when auth.json parses to literal `null`. pi stores the parsed value
+ *  as-is and then indexes it (`this.data[provider]`), which THROWS for null — so
+ *  no provider resolves at all and even a good ambient env key cannot be used.
+ *  Deliberately narrow: `[]`, a string or a number all index harmlessly to
+ *  undefined for pi, so those must NOT suppress ambient credentials. */
+function piAuthStoreBroken(file: string): boolean {
+  const raw = readFileOrNull(file);
+  if (raw === null) return false;
+  try {
+    return JSON.parse(raw) === null;
+  } catch {
+    return false;
+  }
+}
+
 function piAuthRecords(file: string): Record<string, unknown> {
   const raw = readFileOrNull(file);
   if (raw === null) return {};
@@ -681,7 +696,11 @@ export function piCredentialPresent(
   const agentDir = piAgentDir(home, procEnv);
   // agentDir null = a relative PI_CODING_AGENT_DIR we cannot resolve; the
   // file-backed sources are unreadable, but env/ADC still apply.
-  const stored = agentDir ? piAuthRecords(join(agentDir, "auth.json")) : {};
+  const authFile = agentDir ? join(agentDir, "auth.json") : null;
+  // A `null` auth.json breaks pi's auth layer outright — nothing resolves, so no
+  // source counts, not even an otherwise-good env key.
+  if (authFile && piAuthStoreBroken(authFile)) return false;
+  const stored = authFile ? piAuthRecords(authFile) : {};
   if (
     Object.entries(stored).some(([provider, rec]) =>
       authRecordUsable(rec, procEnv, nowMs, { provider, home }),

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -214,6 +214,18 @@ export function credentialValueUsable(
   return true;
 }
 
+/** Read `key` as pi would for a provider: the stored record's own `env` block
+ *  first (pi injects it), then the inherited process env. */
+function readScoped(
+  entryEnv: Record<string, unknown> | undefined,
+  procEnv: NodeJS.ProcessEnv,
+  key: string,
+): string | undefined {
+  const fromEntry = entryEnv?.[key];
+  if (typeof fromEntry === "string" && fromEntry !== "") return fromEntry;
+  return procEnv[key];
+}
+
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
@@ -222,19 +234,21 @@ function nonEmptyString(v: unknown): boolean {
   return typeof v === "string" && v.trim() !== "";
 }
 
+/** pi refreshes any OAuth token with less than this much life left
+ *  (DEFAULT_OAUTH_MINIMUM_VALIDITY_MS in packages/ai/src/auth/resolve.ts). */
+const OAUTH_MINIMUM_VALIDITY_MS = 5 * 60 * 1000;
+
 /**
- * Is `expires` a timestamp still in the future?
+ * Is `expires` far enough in the future that pi can use the token as-is?
  *
- * pi's OAuthCredential carries `expires` as a number without documenting its
- * unit, and this codebase has already been bitten by the seconds-vs-milliseconds
- * ambiguity (see hasValidPanelOAuth). So accept the value as live if it is in the
- * future under EITHER reading — that way a genuinely live token is never
- * false-REDed, while a stale 1970-era value (the malformed case) is future under
- * neither and correctly reads dead.
+ * pi compares `expires` directly against `Date.now() + minimumValidityMs`, so it
+ * is MILLISECONDS — not seconds — and anything inside the five-minute window is
+ * treated as needing a refresh. That matters only for the access-only case
+ * below: with a `refresh` token pi just re-mints, so this is never consulted.
  */
-function expiresInFuture(expires: unknown, nowMs: number): boolean {
+function expiresUsableWithoutRefresh(expires: unknown, nowMs: number): boolean {
   if (typeof expires !== "number" || !Number.isFinite(expires)) return false;
-  return expires > nowMs || expires * 1000 > nowMs;
+  return expires > nowMs + OAUTH_MINIMUM_VALIDITY_MS;
 }
 
 /**
@@ -258,12 +272,23 @@ export function authRecordUsable(
   record: unknown,
   procEnv: NodeJS.ProcessEnv = process.env,
   nowMs: number = Date.now(),
-  provider?: string,
+  ctx: { provider?: string; home?: string } = {},
 ): boolean {
   if (!isPlainObject(record)) return false;
+  const provider = ctx.provider;
   const type = record.type;
   if (type === "api_key") {
     const entryEnv = isPlainObject(record.env) ? record.env : undefined;
+    // pi's Vertex `/login` writes `{type:"api_key", env:{GOOGLE_CLOUD_PROJECT, …}}`
+    // with NO `key`, and its resolver does `credential?.key ?? env(...)` then
+    // falls back to ADC. So a keyless vertex record IS a credential when the ADC
+    // trio resolves (from the record's own env first, then the process env) — it
+    // used to read as "not signed in" for a working Vertex login.
+    if (record.key === undefined && provider === "google-vertex") {
+      if (credentialValueUsable(readScoped(entryEnv, procEnv, "GOOGLE_CLOUD_API_KEY"), entryEnv, procEnv))
+        return true;
+      return piVertexAdcUsable(ctx.home ?? homedir(), procEnv, entryEnv);
+    }
     if (!credentialValueUsable(record.key, entryEnv, procEnv)) return false;
     // Companion config (cloudflare's account/gateway ids) may come from the
     // record's own `env` block or the environment; without it pi's resolver
@@ -284,11 +309,11 @@ export function authRecordUsable(
     // produce a live token:
     //   - a `refresh` token: pi re-mints access from it, so an EXPIRED record is
     //     still ready — refusing it would be a false "not signed in".
-    //   - otherwise an `access` token that has NOT expired yet. Access-only with
-    //     no refresh and a past (or absent) expiry cannot be renewed: pi sees it
-    //     as expired and tries to refresh with no refresh token.
+    //   - otherwise an `access` token with more than pi's five-minute minimum
+    //     validity left. Access-only inside that window (or past it) cannot be
+    //     renewed: pi decides it needs a refresh and has no refresh token.
     if (nonEmptyString(record.refresh)) return true;
-    return nonEmptyString(record.access) && expiresInFuture(record.expires, nowMs);
+    return nonEmptyString(record.access) && expiresUsableWithoutRefresh(record.expires, nowMs);
   }
   return false;
 }
@@ -313,7 +338,7 @@ export function piAuthJsonUsable(
   nowMs: number = Date.now(),
 ): boolean {
   return Object.entries(piAuthRecords(file)).some(([provider, rec]) =>
-    authRecordUsable(rec, procEnv, nowMs, provider),
+    authRecordUsable(rec, procEnv, nowMs, { provider }),
   );
 }
 
@@ -551,13 +576,20 @@ function isRegularFile(file: string): boolean {
  * GOOGLE_APPLICATION_CREDENTIALS pointing at a deleted key file used to green
  * pi), and project/location must be set.
  */
-export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
-  const project = procEnv.GOOGLE_CLOUD_PROJECT?.trim() || procEnv.GCLOUD_PROJECT?.trim();
-  const location = procEnv.GOOGLE_CLOUD_LOCATION?.trim();
+export function piVertexAdcUsable(
+  home: string,
+  procEnv: NodeJS.ProcessEnv = process.env,
+  entryEnv?: Record<string, unknown>,
+): boolean {
+  // A stored record's provider-scoped `env` block wins over the ambient env,
+  // because pi injects it for that provider.
+  const read = (k: string) => readScoped(entryEnv, procEnv, k);
+  const project = read("GOOGLE_CLOUD_PROJECT")?.trim() || read("GCLOUD_PROJECT")?.trim();
+  const location = read("GOOGLE_CLOUD_LOCATION")?.trim();
   if (!project || !location) return false;
   // NOT trimmed: pi uses the literal value, so a space-padded path that
   // resolves for us would not resolve for pi.
-  const explicit = procEnv.GOOGLE_APPLICATION_CREDENTIALS;
+  const explicit = read("GOOGLE_APPLICATION_CREDENTIALS");
   if (explicit) {
     // Must point at a file that is actually there. A RELATIVE path resolves
     // against pi's cwd, which readiness cannot know — so it is unverifiable, and
@@ -651,7 +683,9 @@ export function piCredentialPresent(
   // file-backed sources are unreadable, but env/ADC still apply.
   const stored = agentDir ? piAuthRecords(join(agentDir, "auth.json")) : {};
   if (
-    Object.entries(stored).some(([provider, rec]) => authRecordUsable(rec, procEnv, nowMs, provider))
+    Object.entries(stored).some(([provider, rec]) =>
+      authRecordUsable(rec, procEnv, nowMs, { provider, home }),
+    )
   )
     return true;
   if (piEnvCredentialPresent(stored, procEnv)) return true;

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -202,37 +202,36 @@ export function credentialValueUsable(
   // it cannot authenticate. Do not let a lone `!` greet the user green.
   if (value.startsWith("!")) return value.slice(1).trim() !== "";
   // Every referenced var must resolve to something non-empty IN THE ENV PI WILL
-  // ACTUALLY SEE. Order matches pi: the entry's own `env` block first (pi injects
-  // it for the provider), then the inherited process env — but a var our spawn
+  // ACTUALLY SEE. `resolveEnvConfigValue` uses the entry's own `env` block with
+  // `||` fallback to the inherited process env — but a var our spawn
   // env STRIPS is never inherited, so `"key": "$GEMINI_API_KEY"` resolves for us
   // and to nothing for pi. Treating it as present would be exactly the false
   // green this whole module exists to prevent.
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   for (const name of envRefsIn(value)) {
-    const hasEntryValue = !!entryEnv && Object.prototype.hasOwnProperty.call(entryEnv, name);
-    if (hasEntryValue) {
-      const fromEntry = entryEnv![name];
-      // `resolveEnvConfigValue` uses `entryEnv[name] || process.env[name]`.
-      // Thus an empty entry falls through, but a whitespace-only entry OWNS the
-      // value and blocks a good inherited key. It is not a usable credential.
-      if (typeof fromEntry !== "string" || fromEntry.trim() === "") return false;
-      continue;
-    }
-    if (stripped.has(name) || !procEnv[name]?.trim()) return false;
+    const fromEntry = entryEnv?.[name];
+    // pi's resolver is exactly `entryEnv?.[name] || process.env[name]`. An
+    // empty entry therefore falls through to process.env; whitespace remains
+    // truthy, wins, and cannot authenticate.
+    const resolved = fromEntry || procEnv[name];
+    if (stripped.has(name) && !fromEntry) return false;
+    if (!nonEmptyString(resolved)) return false;
   }
   return true;
 }
 
-/** Read `key` as pi would for a provider: the stored record's own `env` block
- *  first (pi injects it), then the inherited process env. */
-function readScoped(
+/**
+ * Read a provider-scoped value with pi's `??` merge semantics.  A number of
+ * bespoke providers deliberately let an explicitly-empty stored setting block
+ * the ambient value; do not accidentally turn that into `||` fallback.
+ */
+function readNullishScoped(
   entryEnv: Record<string, unknown> | undefined,
   procEnv: NodeJS.ProcessEnv,
   key: string,
-): string | undefined {
+): unknown {
   const fromEntry = entryEnv?.[key];
-  if (typeof fromEntry === "string" && fromEntry !== "") return fromEntry;
-  return procEnv[key];
+  return fromEntry ?? procEnv[key];
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -247,14 +246,6 @@ function nonEmptyString(v: unknown): boolean {
  *  (DEFAULT_OAUTH_MINIMUM_VALIDITY_MS in packages/ai/src/auth/resolve.ts). */
 const OAUTH_MINIMUM_VALIDITY_MS = 5 * 60 * 1000;
 
-/**
- * Is `expires` far enough in the future that pi can use the token as-is?
- *
- * pi compares `expires` directly against `Date.now() + minimumValidityMs`, so it
- * is MILLISECONDS — not seconds — and anything inside the five-minute window is
- * treated as needing a refresh. That matters only for the access-only case
- * below: with a `refresh` token pi just re-mints, so this is never consulted.
- */
 function expiresUsableWithoutRefresh(expires: unknown, nowMs: number): boolean {
   if (typeof expires !== "number" || !Number.isFinite(expires)) return false;
   return expires > nowMs + OAUTH_MINIMUM_VALIDITY_MS;
@@ -267,9 +258,9 @@ function expiresUsableWithoutRefresh(expires: unknown, nowMs: number): boolean {
  *   ApiKeyCredential { type: "api_key"; key?: string; env?: ProviderEnv }
  *   OAuthCredential  { type: "oauth"; refresh: string; access: string; expires: number }
  *
- * Note `key` is OPTIONAL in pi's TYPE but mandatory in FACT — a `{"type":"api_key"}`
- * record resolves to no key and pi's first request goes out unauthenticated. That
- * record used to green this provider; it no longer does.
+ * Note `key` is OPTIONAL in pi's TYPE. Whether a keyless api-key record is
+ * usable is provider-specific: Vertex and Bedrock deliberately support it,
+ * while ordinary key providers can fall back to their ambient key.
  *
  * An UNRECOGNISED `type` is not a credential either: pi's resolveProviderAuth
  * dispatches only "oauth" and "api_key" and returns undefined for anything else
@@ -299,7 +290,9 @@ export function authRecordUsable(
     // trio resolves (from the record's own env first, then the process env) — it
     // used to read as "not signed in" for a working Vertex login.
     if (record.key === undefined && provider === "google-vertex") {
-      if (credentialValueUsable(readScoped(entryEnv, procEnv, "GOOGLE_CLOUD_API_KEY"), entryEnv, procEnv))
+      // google-vertex reads `credential.key ?? ctx.env(...)`: scoped `env` does
+      // not supply GOOGLE_CLOUD_API_KEY, and only the process env is ambient.
+      if (credentialValueUsable(procEnv.GOOGLE_CLOUD_API_KEY, undefined, procEnv))
         return true;
       return piVertexAdcUsable(ctx.home ?? homedir(), procEnv, entryEnv);
     }
@@ -317,15 +310,9 @@ export function authRecordUsable(
     return true;
   }
   if (type === "oauth") {
-    // pi declares refresh + access + expires as all required, and that is what
-    // `/login` writes. We don't demand all three (that would false-red a
-    // partially-migrated record), but we do require something that can actually
-    // produce a live token:
-    //   - a `refresh` token: pi re-mints access from it, so an EXPIRED record is
-    //     still ready — refusing it would be a false "not signed in".
-    //   - otherwise an `access` token with more than pi's five-minute minimum
-    //     validity left. Access-only inside that window (or past it) cannot be
-    //     renewed: pi decides it needs a refresh and has no refresh token.
+    // A refresh token lets pi re-mint access, so a partial migrated record with
+    // one remains usable even when its stored access token is expired. Without
+    // it, an access token needs to survive pi's five-minute refresh window.
     if (nonEmptyString(record.refresh)) return true;
     return nonEmptyString(record.access) && expiresUsableWithoutRefresh(record.expires, nowMs);
   }
@@ -614,22 +601,28 @@ export function piVertexAdcUsable(
   procEnv: NodeJS.ProcessEnv = process.env,
   entryEnv?: Record<string, unknown>,
 ): boolean {
-  // A stored record's provider-scoped `env` block wins over the ambient env,
-  // because pi injects it for that provider.
-  const read = (k: string) => readScoped(entryEnv, procEnv, k);
-  const project = read("GOOGLE_CLOUD_PROJECT")?.trim() || read("GCLOUD_PROJECT")?.trim();
-  const location = read("GOOGLE_CLOUD_LOCATION")?.trim();
-  if (!project || !location) return false;
+  // Vertex uses nullish (not truthy) per-field fallback. An explicitly-empty
+  // stored project/path therefore blocks the ambient value just as it does in
+  // pi; treating it as `||` would false-green a broken stored record.
+  // google-vertex resolves these as a four-level nullish chain: stored primary,
+  // ambient primary, stored alias, then ambient alias. In particular, a stored
+  // empty GCLOUD_PROJECT must block an ambient alias rather than acting like an
+  // `||` fallback.
+  const project =
+    readNullishScoped(entryEnv, procEnv, "GOOGLE_CLOUD_PROJECT") ??
+    readNullishScoped(entryEnv, procEnv, "GCLOUD_PROJECT");
+  const location = readNullishScoped(entryEnv, procEnv, "GOOGLE_CLOUD_LOCATION");
+  if (!nonEmptyString(project) || !nonEmptyString(location)) return false;
   // NOT trimmed: pi uses the literal value, so a space-padded path that
   // resolves for us would not resolve for pi.
-  const explicit = read("GOOGLE_APPLICATION_CREDENTIALS");
-  if (explicit) {
+  const explicit = readNullishScoped(entryEnv, procEnv, "GOOGLE_APPLICATION_CREDENTIALS");
+  if (explicit !== undefined) {
     // Must point at a file that is actually there. A RELATIVE path resolves
     // against pi's cwd, which readiness cannot know — so it is unverifiable, and
     // "unverifiable" has to mean not-ready here or a dangling `missing.json`
     // greens pi. gcloud always writes an absolute path, so this costs nothing
     // real.
-    return isAbsolute(explicit) && isRegularFile(explicit);
+    return typeof explicit === "string" && isAbsolute(explicit) && isRegularFile(explicit);
   }
   // gcloud's well-known ADC file — pi's fallback is this literal POSIX path, so
   // we probe exactly that and no other location (a %APPDATA%\gcloud file would
@@ -672,18 +665,24 @@ export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.en
  * provider records, a keyless Bedrock `api_key` record deliberately falls
  * through to these sources (amazon-bedrock.ts): an explicit stored AWS_PROFILE,
  * an ambient profile, static access-key pair, ECS task role, or web identity.
+ * Only the PROFILE comes from a stored `env` block. Every other AWS source is
+ * read from ctx.env (the ambient spawn environment).
  */
 function piBedrockCredentialUsable(
   entryEnv: Record<string, unknown> | undefined,
   procEnv: NodeJS.ProcessEnv,
 ): boolean {
-  const read = (key: string) => readScoped(entryEnv, procEnv, key);
-  if (nonEmptyString(read("AWS_BEARER_TOKEN_BEDROCK"))) return true;
-  if (nonEmptyString(read("AWS_PROFILE"))) return true;
-  if (nonEmptyString(read("AWS_ACCESS_KEY_ID")) && nonEmptyString(read("AWS_SECRET_ACCESS_KEY"))) return true;
-  if (nonEmptyString(read("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))) return true;
-  if (nonEmptyString(read("AWS_CONTAINER_CREDENTIALS_FULL_URI"))) return true;
-  return nonEmptyString(read("AWS_WEB_IDENTITY_TOKEN_FILE"));
+  if (nonEmptyString(procEnv.AWS_BEARER_TOKEN_BEDROCK)) return true;
+  const storedProfile = entryEnv?.AWS_PROFILE;
+  // `credential.env?.AWS_PROFILE ?? ctx.env("AWS_PROFILE")`: an explicitly
+  // empty stored profile suppresses the ambient profile, but no stored property
+  // (or null) falls through to it.
+  const profile = storedProfile ?? procEnv.AWS_PROFILE;
+  if (nonEmptyString(profile)) return true;
+  if (nonEmptyString(procEnv.AWS_ACCESS_KEY_ID) && nonEmptyString(procEnv.AWS_SECRET_ACCESS_KEY)) return true;
+  if (nonEmptyString(procEnv.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)) return true;
+  if (nonEmptyString(procEnv.AWS_CONTAINER_CREDENTIALS_FULL_URI)) return true;
+  return nonEmptyString(procEnv.AWS_WEB_IDENTITY_TOKEN_FILE);
 }
 
 /** The effective provider selected by the pi spawn flags. `--provider` wins;

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -89,6 +89,18 @@ export const PI_PROVIDER_ENV_KEYS: Readonly<Record<string, readonly string[]>> =
   bedrock: ["AWS_BEARER_TOKEN_BEDROCK"],
 };
 
+/**
+ * Extra env vars a provider needs ALONGSIDE its key when authenticating purely
+ * from the environment. pi's cloudflare-auth.ts returns undefined unless both the
+ * key and the account id are present (plus the gateway id for the AI Gateway),
+ * so the key alone is not a credential. Only providers whose companion
+ * requirement is confirmed in pi's source are listed here.
+ */
+const PI_PROVIDER_ENV_REQUIRED: Readonly<Record<string, readonly string[]>> = {
+  "cloudflare-workers-ai": ["CLOUDFLARE_ACCOUNT_ID"],
+  "cloudflare-ai-gateway": ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_GATEWAY_ID"],
+};
+
 /** Flat view of every credential env var pi reads. */
 export const PI_ENV_API_KEYS: readonly string[] = Object.values(PI_PROVIDER_ENV_KEYS).flat();
 
@@ -355,14 +367,25 @@ export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = pr
  *  permissive so we never false-red a file pi accepts. */
 function providerEntryValid(entry: unknown): boolean {
   if (!isPlainObject(entry)) return false;
-  if (entry.oauth !== undefined && entry.oauth !== "radius") return false;
-  if (entry.models !== undefined && (!Array.isArray(entry.models) || !entry.models.every(isPlainObject)))
-    return false;
-  // pi's schema declares its string fields with minLength 1, so ANY blank string
-  // (`name: ""`, `baseUrl: ""`, `apiKey: ""`, …) fails validation and makes pi
-  // discard the whole file. Checking the shape generically covers the fields we
-  // haven't enumerated without having to reproduce the full TypeBox schema.
-  return Object.values(entry).every((v) => typeof v !== "string" || v.trim() !== "");
+  if (entry.oauth !== undefined) {
+    if (entry.oauth !== "radius") return false;
+    // provider-composer.ts throws `"baseUrl" is required when "oauth" is set`,
+    // which discards the file — so an oauth entry without one is not a credential.
+    if (typeof entry.baseUrl !== "string" || entry.baseUrl.length === 0) return false;
+  }
+  if (entry.models !== undefined) {
+    if (!Array.isArray(entry.models)) return false;
+    // Every model definition needs an id; a `{}` model is not a usable model and
+    // fails the schema, taking the whole file with it.
+    if (!entry.models.every((m) => isPlainObject(m) && typeof m.id === "string" && m.id.length > 0))
+      return false;
+  }
+  // pi's schema declares its string fields with minLength 1, so an EMPTY string
+  // (`name: ""`, `baseUrl: ""`, …) fails validation and makes pi discard the
+  // whole file. Checked generically to cover the fields we haven't enumerated
+  // without reproducing the full TypeBox schema. Length, NOT trim: minLength 1
+  // accepts `" "`, so trimming here would false-red a config pi loads fine.
+  return Object.values(entry).every((v) => typeof v !== "string" || v.length > 0);
 }
 
 /** True only for an existing REGULAR file — a directory at a credentials path is
@@ -441,10 +464,22 @@ function piEnvCredentialPresent(
 ): boolean {
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   for (const [provider, keys] of Object.entries(PI_PROVIDER_ENV_KEYS)) {
-    if (Object.prototype.hasOwnProperty.call(storedProviders, provider)) continue;
-    if (keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) return true;
+    if (providerHasStoredCredential(storedProviders, provider)) continue;
+    if (!keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) continue;
+    // Some providers need companion config alongside the key — without it pi's
+    // resolver returns undefined and the key is useless on its own.
+    const required = PI_PROVIDER_ENV_REQUIRED[provider];
+    if (required && !required.every((k) => !!procEnv[k]?.trim())) continue;
+    return true;
   }
   return false;
+}
+
+/** Does auth.json carry a stored credential for `provider`? pi's resolver gates
+ *  on `if (stored)`, so a null/false entry is NOT a stored credential and the
+ *  ambient env is still consulted — only a truthy record takes ownership. */
+function providerHasStoredCredential(storedProviders: Record<string, unknown>, provider: string): boolean {
+  return !!storedProviders[provider];
 }
 
 /**
@@ -463,7 +498,10 @@ export function piCredentialPresent(
   const stored = piAuthRecords(authFile);
   if (Object.values(stored).some((rec) => authRecordUsable(rec, procEnv, nowMs))) return true;
   if (piEnvCredentialPresent(stored, procEnv)) return true;
-  if (piVertexAdcUsable(home, procEnv)) return true;
+  // Vertex ADC is ambient credential too, so a stored google-vertex record owns
+  // that provider and suppresses it (same rule as the env keys above).
+  if (!providerHasStoredCredential(stored, "google-vertex") && piVertexAdcUsable(home, procEnv))
+    return true;
   if (piModelsJsonUsable(join(agentDir, "models.json"), procEnv)) return true;
   return false;
 }

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -245,6 +245,12 @@ function nonEmptyString(v: unknown): boolean {
 /** pi refreshes any OAuth token with less than this much life left
  *  (DEFAULT_OAUTH_MINIMUM_VALIDITY_MS in packages/ai/src/auth/resolve.ts). */
 const OAUTH_MINIMUM_VALIDITY_MS = 5 * 60 * 1000;
+// Providers whose current pi resolver accepts auth.json OAuth credentials.
+// Radius OAuth is configured through models.json (`oauth: "radius"` + baseUrl),
+// not an auth.json OAuth record, so it is deliberately not listed here.
+const PI_OAUTH_AUTH_PROVIDERS = new Set([
+  "anthropic", "github-copilot", "kimi-coding", "openai-codex", "openrouter", "xai",
+]);
 
 function expiresUsableWithoutRefresh(expires: unknown, nowMs: number): boolean {
   if (typeof expires !== "number" || !Number.isFinite(expires)) return false;
@@ -312,7 +318,7 @@ export function authRecordUsable(
   if (type === "oauth") {
     // pi only dispatches OAuth records to providers that implement that flow.
     // An OAuth-shaped record for an API-key-only provider is not a credential.
-    if (provider !== "anthropic") return false;
+    if (provider !== undefined && !PI_OAUTH_AUTH_PROVIDERS.has(provider)) return false;
     // A refresh token lets pi re-mint access, so a partial migrated record with
     // one remains usable even when its stored access token is expired. Without
     // it, an access token needs to survive pi's five-minute refresh window.

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -285,11 +285,11 @@ export function authRecordUsable(
       return credentialValueUsable(record.key, entryEnv, procEnv) || piBedrockCredentialUsable(entryEnv, procEnv);
     }
     // pi's Vertex `/login` writes `{type:"api_key", env:{GOOGLE_CLOUD_PROJECT, …}}`
-    // with NO `key`, and its resolver does `credential?.key ?? env(...)` then
+    // with a falsy `key`, and its resolver tests `if (key)` before falling
     // falls back to ADC. So a keyless vertex record IS a credential when the ADC
     // trio resolves (from the record's own env first, then the process env) — it
     // used to read as "not signed in" for a working Vertex login.
-    if (record.key === undefined && provider === "google-vertex") {
+    if (!record.key && provider === "google-vertex") {
       // google-vertex reads `credential.key ?? ctx.env(...)`: scoped `env` does
       // not supply GOOGLE_CLOUD_API_KEY, and only the process env is ambient.
       if (credentialValueUsable(procEnv.GOOGLE_CLOUD_API_KEY, undefined, procEnv))

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -86,7 +86,7 @@ export const PI_PROVIDER_ENV_KEYS: Readonly<Record<string, readonly string[]>> =
   "github-copilot": ["COPILOT_GITHUB_TOKEN"], // special-cased in pi
   // Documented in packages/coding-agent/docs/providers.md but absent from
   // `envMap`, which only covers the api-key providers.
-  bedrock: ["AWS_BEARER_TOKEN_BEDROCK"],
+  "amazon-bedrock": ["AWS_BEARER_TOKEN_BEDROCK"],
 };
 
 /**
@@ -431,8 +431,16 @@ function optModelCost(v: unknown, required: boolean): boolean {
     }
     if (!isFiniteNumber(v[f])) return false;
   }
-  if (v.tiers !== undefined && (!Array.isArray(v.tiers) || !v.tiers.every(isPlainObject))) return false;
+  if (v.tiers !== undefined && (!Array.isArray(v.tiers) || !v.tiers.every(costTierValid))) return false;
   return true;
+}
+
+/** ModelCostTierSchema: inputTokensAbove + the four rates, all required numbers. */
+function costTierValid(tier: unknown): boolean {
+  if (!isPlainObject(tier)) return false;
+  return ["inputTokensAbove", "input", "output", "cacheRead", "cacheWrite"].every((f) =>
+    isFiniteNumber(tier[f]),
+  );
 }
 
 /** ThinkingLevelMapSchema: every level maps to a string or null. */

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -374,43 +374,85 @@ export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = pr
   }
 }
 
-/** The subset of pi's ProviderConfigSchema we can check cheaply: `apiKey` and
- *  `baseUrl` are non-empty strings when present, `oauth` is the literal
- *  "radius", `models` is an array. This is NOT full TypeBox validation — it
- *  only has to catch the violations that would make pi throw the file away
- *  while our detector called it a credential. Anything we can't check is left
- *  permissive so we never false-red a file pi accepts. */
+/*
+ * models.json schema validation, transcribed from pi's TypeBox schemas in
+ * packages/coding-agent/src/core/model-config.ts:
+ *
+ *   ModelsConfigSchema   { providers: Record<string, ProviderConfig> }
+ *   ProviderConfigSchema { name?, baseUrl?, apiKey?, api?: String{minLength:1},
+ *                          oauth?: Literal"radius", headers?: Record<string,string>,
+ *                          compat?, authHeader?: Boolean,
+ *                          models?: ModelDefinition[], modelOverrides?: Record<…> }
+ *   ModelDefinitionSchema{ id: String{minLength:1}, name?/api?/baseUrl?: String{minLength:1},
+ *                          reasoning?: Boolean, thinkingLevelMap?, input?: ("text"|"image")[],
+ *                          cost?, contextWindow?/maxTokens?: Number, headers?: Record<string,string>,
+ *                          compat? }
+ *
+ * This matters because pi validates the file as a UNIT and DISCARDS it whole on
+ * any violation — so one malformed provider means none of the file's credentials
+ * reach pi. Fields whose sub-schemas we have not transcribed (compat, cost,
+ * thinkingLevelMap, modelOverrides) are only shape-checked, and UNDECLARED extra
+ * keys are left alone because the schemas declare no additionalProperties
+ * restriction — being stricter than pi there would false-red a file it loads.
+ */
+function optNonEmptyString(v: unknown): boolean {
+  return v === undefined || (typeof v === "string" && v.length > 0);
+}
+
+function optBoolean(v: unknown): boolean {
+  return v === undefined || typeof v === "boolean";
+}
+
+/** Type.Record(Type.String(), Type.String()) — every value must be a string. */
+function optStringRecord(v: unknown): boolean {
+  return v === undefined || (isPlainObject(v) && Object.values(v).every((x) => typeof x === "string"));
+}
+
+/** Type.Number(), plus provider-composer's runtime `<= 0` rejection. */
+function optPositiveNumber(v: unknown): boolean {
+  return v === undefined || (typeof v === "number" && Number.isFinite(v) && v > 0);
+}
+
+function modelDefinitionValid(model: unknown): boolean {
+  if (!isPlainObject(model)) return false;
+  if (typeof model.id !== "string" || model.id.length === 0) return false;
+  if (!optNonEmptyString(model.name) || !optNonEmptyString(model.api) || !optNonEmptyString(model.baseUrl))
+    return false;
+  if (!optBoolean(model.reasoning)) return false;
+  if (!optPositiveNumber(model.contextWindow) || !optPositiveNumber(model.maxTokens)) return false;
+  if (!optStringRecord(model.headers)) return false;
+  if (
+    model.input !== undefined &&
+    (!Array.isArray(model.input) || !model.input.every((x) => x === "text" || x === "image"))
+  )
+    return false;
+  if (model.cost !== undefined && !isPlainObject(model.cost)) return false;
+  if (model.compat !== undefined && !isPlainObject(model.compat)) return false;
+  if (model.thinkingLevelMap !== undefined && !isPlainObject(model.thinkingLevelMap)) return false;
+  return true;
+}
+
 function providerEntryValid(entry: unknown): boolean {
   if (!isPlainObject(entry)) return false;
+  if (
+    !optNonEmptyString(entry.name) ||
+    !optNonEmptyString(entry.baseUrl) ||
+    !optNonEmptyString(entry.apiKey) ||
+    !optNonEmptyString(entry.api)
+  )
+    return false;
   if (entry.oauth !== undefined) {
     if (entry.oauth !== "radius") return false;
-    // provider-composer.ts throws `"baseUrl" is required when "oauth" is set`,
-    // which discards the file — so an oauth entry without one is not a credential.
+    // provider-composer.ts throws `"baseUrl" is required when "oauth" is set`.
     if (typeof entry.baseUrl !== "string" || entry.baseUrl.length === 0) return false;
   }
-  if (entry.models !== undefined) {
-    if (!Array.isArray(entry.models)) return false;
-    // Every model definition needs an id; a `{}` model is not a usable model and
-    // fails the schema, taking the whole file with it.
-    if (!entry.models.every((m) => isPlainObject(m) && typeof m.id === "string" && m.id.length > 0))
-      return false;
-  }
-  // Fields pi declares as `Type.String({minLength: 1})`: present means it must
-  // BE a non-empty string. A wrong TYPE (`apiKey: 1`) fails the schema just as
-  // hard as an empty one, and pi throws the whole file away either way.
-  for (const field of ["apiKey", "baseUrl", "name", "api"]) {
-    const v = entry[field];
-    if (v !== undefined && (typeof v !== "string" || v.length === 0)) return false;
-  }
-  // `headers` is a string->string map for pi; a non-string value fails the schema.
-  if (entry.headers !== undefined) {
-    if (!isPlainObject(entry.headers)) return false;
-    if (!Object.values(entry.headers).every((v) => typeof v === "string")) return false;
-  }
-  // Anything we have NOT enumerated: only reject an EMPTY string, which fails
-  // minLength 1 for every string field pi declares. Length, NOT trim — minLength
-  // 1 accepts `" "`, so trimming would false-red a config pi loads fine.
-  return Object.values(entry).every((v) => typeof v !== "string" || v.length > 0);
+  if (!optStringRecord(entry.headers)) return false;
+  if (!optBoolean(entry.authHeader)) return false;
+  if (entry.compat !== undefined && !isPlainObject(entry.compat)) return false;
+  if (entry.modelOverrides !== undefined && !isPlainObject(entry.modelOverrides)) return false;
+  if (entry.models !== undefined && (!Array.isArray(entry.models) || !entry.models.every(modelDefinitionValid)))
+    return false;
+  return true;
 }
 
 /** True only for an existing REGULAR file — a directory at a credentials path is
@@ -440,7 +482,9 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
   const project = procEnv.GOOGLE_CLOUD_PROJECT?.trim() || procEnv.GCLOUD_PROJECT?.trim();
   const location = procEnv.GOOGLE_CLOUD_LOCATION?.trim();
   if (!project || !location) return false;
-  const explicit = procEnv.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  // NOT trimmed: pi uses the literal value, so a space-padded path that
+  // resolves for us would not resolve for pi.
+  const explicit = procEnv.GOOGLE_APPLICATION_CREDENTIALS;
   if (explicit) {
     // Must point at a file that is actually there. A RELATIVE path resolves
     // against pi's cwd, which readiness cannot know — so it is unverifiable, and
@@ -465,7 +509,8 @@ export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = pro
  * found the credentials fine.
  */
 export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.env): string | null {
-  const override = procEnv.PI_CODING_AGENT_DIR?.trim();
+  // NOT trimmed, for the same reason as GOOGLE_APPLICATION_CREDENTIALS above.
+  const override = procEnv.PI_CODING_AGENT_DIR;
   if (override) {
     if (override === "~") return home;
     if (override.startsWith("~/") || override.startsWith("~\\")) return join(home, override.slice(2));

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -413,6 +413,55 @@ function optPositiveNumber(v: unknown): boolean {
   return v === undefined || (typeof v === "number" && Number.isFinite(v) && v > 0);
 }
 
+function isFiniteNumber(v: unknown): boolean {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/** ModelCostSchema: input/output/cacheRead/cacheWrite are REQUIRED Type.Number();
+ *  `tiers` is an optional array. A `cost: {}` (or a string rate) fails the schema
+ *  and pi throws the whole models.json away. */
+function optModelCost(v: unknown, required: boolean): boolean {
+  if (v === undefined) return true;
+  if (!isPlainObject(v)) return false;
+  for (const f of ["input", "output", "cacheRead", "cacheWrite"]) {
+    if (v[f] === undefined) {
+      // Required on ModelDefinition's cost, optional on a ModelOverride's.
+      if (required) return false;
+      continue;
+    }
+    if (!isFiniteNumber(v[f])) return false;
+  }
+  if (v.tiers !== undefined && (!Array.isArray(v.tiers) || !v.tiers.every(isPlainObject))) return false;
+  return true;
+}
+
+/** ThinkingLevelMapSchema: every level maps to a string or null. */
+function optThinkingLevelMap(v: unknown): boolean {
+  if (v === undefined) return true;
+  if (!isPlainObject(v)) return false;
+  return Object.values(v).every((x) => x === null || typeof x === "string");
+}
+
+/** ModelOverrideSchema — the same fields as a model definition, all optional and
+ *  with no `id`. */
+function modelOverrideValid(v: unknown): boolean {
+  if (!isPlainObject(v)) return false;
+  if (!optNonEmptyString(v.name)) return false;
+  if (!optBoolean(v.reasoning)) return false;
+  if (!optThinkingLevelMap(v.thinkingLevelMap)) return false;
+  if (!optModelInput(v.input)) return false;
+  if (!optModelCost(v.cost, false)) return false;
+  if (!optPositiveNumber(v.contextWindow) || !optPositiveNumber(v.maxTokens)) return false;
+  if (!optStringRecord(v.headers)) return false;
+  if (v.compat !== undefined && !isPlainObject(v.compat)) return false;
+  return true;
+}
+
+/** Type.Array(Type.Union([Literal"text", Literal"image"])). */
+function optModelInput(v: unknown): boolean {
+  return v === undefined || (Array.isArray(v) && v.every((x) => x === "text" || x === "image"));
+}
+
 function modelDefinitionValid(model: unknown): boolean {
   if (!isPlainObject(model)) return false;
   if (typeof model.id !== "string" || model.id.length === 0) return false;
@@ -421,14 +470,13 @@ function modelDefinitionValid(model: unknown): boolean {
   if (!optBoolean(model.reasoning)) return false;
   if (!optPositiveNumber(model.contextWindow) || !optPositiveNumber(model.maxTokens)) return false;
   if (!optStringRecord(model.headers)) return false;
-  if (
-    model.input !== undefined &&
-    (!Array.isArray(model.input) || !model.input.every((x) => x === "text" || x === "image"))
-  )
-    return false;
-  if (model.cost !== undefined && !isPlainObject(model.cost)) return false;
+  if (!optModelInput(model.input)) return false;
+  if (!optModelCost(model.cost, true)) return false;
+  if (!optThinkingLevelMap(model.thinkingLevelMap)) return false;
+  // ProviderCompatSchema is a union of three all-optional shapes; a shape check
+  // is the faithful limit without transcribing 24 fields whose only effect is
+  // wire-format tweaks.
   if (model.compat !== undefined && !isPlainObject(model.compat)) return false;
-  if (model.thinkingLevelMap !== undefined && !isPlainObject(model.thinkingLevelMap)) return false;
   return true;
 }
 
@@ -449,7 +497,10 @@ function providerEntryValid(entry: unknown): boolean {
   if (!optStringRecord(entry.headers)) return false;
   if (!optBoolean(entry.authHeader)) return false;
   if (entry.compat !== undefined && !isPlainObject(entry.compat)) return false;
-  if (entry.modelOverrides !== undefined && !isPlainObject(entry.modelOverrides)) return false;
+  if (entry.modelOverrides !== undefined) {
+    if (!isPlainObject(entry.modelOverrides)) return false;
+    if (!Object.values(entry.modelOverrides).every(modelOverrideValid)) return false;
+  }
   if (entry.models !== undefined && (!Array.isArray(entry.models) || !entry.models.every(modelDefinitionValid)))
     return false;
   return true;
@@ -513,7 +564,12 @@ export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.en
   const override = procEnv.PI_CODING_AGENT_DIR;
   if (override) {
     if (override === "~") return home;
-    if (override.startsWith("~/") || override.startsWith("~\\")) return join(home, override.slice(2));
+    // pi expands `~\` only on Windows; on POSIX that string is a RELATIVE path
+    // (a directory literally named "~\cfg"), so expanding it here would green a
+    // config pi reads from somewhere else entirely.
+    const tildeSlash =
+      override.startsWith("~/") || (process.platform === "win32" && override.startsWith("~\\"));
+    if (tildeSlash) return join(home, override.slice(2));
     // A RELATIVE override resolves against pi's own cwd, which readiness cannot
     // know — so we cannot say whether a config lives there. Null (= don't read
     // file-backed credentials) rather than guessing against OUR cwd, which could

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -1,0 +1,327 @@
+// pi.dev (#491) credential DETECTION — "does a usable provider credential exist
+// on this machine?", answered from disk + env only.
+//
+// Why this is its own module: `pi --list-models` is NOT an auth probe (it prints
+// the built-in catalog with no key at all), so unlike every other CLI backend the
+// connect-time model probe cannot tell us whether pi can actually authenticate.
+// Readiness therefore has to reproduce pi's own credential resolution. The rules
+// below are transcribed from pi's source (earendil-works/pi @ main) rather than
+// guessed; each is cited at its use site so a future reader can re-verify:
+//
+//   packages/ai/src/env-api-keys.ts          — `envMap` + the anthropic/copilot specials
+//   packages/ai/src/auth/types.ts            — ApiKeyCredential / OAuthCredential shapes
+//   packages/coding-agent/src/core/auth-storage.ts — auth.json is plain JSON.parse
+//   packages/coding-agent/src/core/model-config.ts — models.json is JSONC + `{providers:{…}}`
+//   packages/coding-agent/src/utils/json.ts  — the exact stripJsonComments behaviour
+//   packages/ai/src/providers/google-vertex.ts — Vertex ADC (creds path + project + location)
+//
+// PRECISION BAR (deliberate): "ready" means a plausible, WELL-FORMED, PRESENT
+// credential source — not a proven-working one. A revoked key, an exhausted quota
+// or a typo'd secret is invisible from disk and still fails on the first turn;
+// that residual is accepted and the panel/banner wording must not over-promise.
+// What we do NOT accept is greening on a source that CANNOT authenticate no
+// matter what: a record with no key at all, a credentials path pointing at a file
+// that isn't there, or an empty provider stanza.
+//
+// Scope note: this is accidental-wrongness only. There is no adversarial model
+// here — a user who hand-edits their own auth.json to lie is out of scope (this
+// is a local single-trust-domain project).
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { TOOL_ONLY_SECRET_ENV_KEYS } from "../services/panel-secrets.js";
+
+/**
+ * Every env var pi reads as a provider credential.
+ *
+ * Transcribed from `envMap` in packages/ai/src/env-api-keys.ts, plus the three
+ * exported anthropic constants (ANTHROPIC_AUTH_TOKEN / ANTHROPIC_OAUTH_TOKEN /
+ * ANTHROPIC_API_KEY) and the github-copilot special case, which live outside the
+ * map. Ordered by provider id to keep it diff-able against pi's file.
+ *
+ * NOT every entry here necessarily reaches pi's subprocess — see
+ * `piEnvKeysReachingPi()`, which subtracts the ComfyUI tool-only secrets that
+ * buildAgentSpawnEnv() strips. Keep this list a faithful copy of pi's map; do the
+ * subtraction there, not by editing this array.
+ */
+export const PI_ENV_API_KEYS: readonly string[] = [
+  // anthropic (special-cased in pi: three accepted vars, any one suffices)
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_OAUTH_TOKEN",
+  // envMap, in pi's own order
+  "ANT_LING_API_KEY", // ant-ling
+  "QWEN_TOKEN_PLAN_API_KEY", // qwen-token-plan
+  "QWEN_TOKEN_PLAN_CN_API_KEY", // qwen-token-plan-cn
+  "OPENAI_API_KEY", // openai
+  "AZURE_OPENAI_API_KEY", // azure-openai-responses
+  "NVIDIA_API_KEY", // nvidia
+  "DEEPSEEK_API_KEY", // deepseek
+  "GEMINI_API_KEY", // google  (stripped before it reaches pi — see below)
+  "GOOGLE_CLOUD_API_KEY", // google-vertex (api-key mode)
+  "GROQ_API_KEY", // groq
+  "CEREBRAS_API_KEY", // cerebras
+  "XAI_API_KEY", // xai
+  "RADIUS_API_KEY", // radius
+  "OPENROUTER_API_KEY", // openrouter
+  "AI_GATEWAY_API_KEY", // vercel-ai-gateway
+  "ZAI_API_KEY", // zai
+  "ZAI_CODING_CN_API_KEY", // zai-coding-cn
+  "MISTRAL_API_KEY", // mistral
+  "MINIMAX_API_KEY", // minimax
+  "MINIMAX_CN_API_KEY", // minimax-cn
+  "MOONSHOT_API_KEY", // moonshotai / moonshotai-cn
+  "HF_TOKEN", // huggingface (stripped before it reaches pi — see below)
+  "FIREWORKS_API_KEY", // fireworks
+  "TOGETHER_API_KEY", // together
+  "OPENCODE_API_KEY", // opencode / opencode-go
+  "KIMI_API_KEY", // kimi-coding
+  "CLOUDFLARE_API_KEY", // cloudflare-workers-ai / cloudflare-ai-gateway
+  "XIAOMI_API_KEY", // xiaomi
+  "XIAOMI_TOKEN_PLAN_CN_API_KEY", // xiaomi-token-plan-cn
+  "XIAOMI_TOKEN_PLAN_AMS_API_KEY", // xiaomi-token-plan-ams
+  "XIAOMI_TOKEN_PLAN_SGP_API_KEY", // xiaomi-token-plan-sgp
+  "COPILOT_GITHUB_TOKEN", // github-copilot (special-cased in pi)
+  // Documented in packages/coding-agent/docs/providers.md (bedrock) but absent
+  // from `envMap`, which only covers api-key providers.
+  "AWS_BEARER_TOKEN_BEDROCK",
+];
+
+/**
+ * The subset of `PI_ENV_API_KEYS` that actually SURVIVES into pi's spawn env.
+ *
+ * pi is spawned with `buildAgentSpawnEnv()` (no keep-list), which deletes the
+ * ComfyUI tool-only secrets. A key that gets stripped must never green pi:
+ * `GEMINI_API_KEY` and `HF_TOKEN` are ComfyUI tool secrets, so a user whose ONLY
+ * credential is one of those has a pi that cannot authenticate — its first turn
+ * would fail. Those users must put the key in ~/.pi/agent/auth.json instead.
+ *
+ * Derived (not hand-maintained) so that changing the secret allowlists in
+ * panel-secrets.ts automatically keeps pi's readiness honest.
+ */
+export function piEnvKeysReachingPi(): string[] {
+  const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
+  return PI_ENV_API_KEYS.filter((k) => !stripped.has(k));
+}
+
+/**
+ * pi's JSONC pre-pass, byte-for-byte the same behaviour as `stripJsonComments`
+ * in packages/coding-agent/src/utils/json.ts: strips `//` line comments and
+ * trailing commas before `}`/`]`, while leaving anything inside a string literal
+ * alone. Block comments are deliberately NOT handled — pi doesn't handle them
+ * either, and a models.json using slash-star comments fails to load for pi too,
+ * so accepting it here would green a file pi itself rejects.
+ */
+export function stripJsonComments(input: string): string {
+  return input
+    .replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/g, (m) => (m[0] === '"' ? m : ""))
+    .replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (m, tail) => tail ?? (m[0] === '"' ? m : ""));
+}
+
+/** Matches pi's `$VAR` / `${VAR}` interpolation tokens in a credential value. */
+const ENV_REF = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+
+/**
+ * Is a stored credential VALUE (auth.json `key`, models.json `apiKey`) plausibly
+ * resolvable? pi accepts three forms (docs/providers.md + resolveConfigValue):
+ *
+ *   `!some command`  → executed, output cached. We cannot verify it without
+ *                      running it, and running a user command during a readiness
+ *                      probe is not acceptable — so we accept it unverified.
+ *   `$VAR` / `${VAR}` → interpolated from the entry's own `env` block first, then
+ *                      the process env. If a referenced var is missing there is
+ *                      nothing to resolve to, so this is NOT a credential.
+ *   literal          → accepted as-is.
+ *
+ * Empty / non-string / whitespace-only is never a credential.
+ */
+export function credentialValueUsable(
+  raw: unknown,
+  entryEnv?: Record<string, unknown>,
+  procEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof raw !== "string") return false;
+  const value = raw.trim();
+  if (!value) return false;
+  // `!command` — unverifiable without executing it; err toward ready.
+  if (value.startsWith("!")) return true;
+  if (!value.includes("$")) return true;
+  // Every referenced var must resolve to something non-empty, from the entry's
+  // own `env` map (pi consults it first) or the process env.
+  let resolvable = true;
+  value.replace(ENV_REF, (_m, braced: string | undefined, bare: string | undefined) => {
+    const name = braced ?? bare ?? "";
+    const fromEntry = entryEnv?.[name];
+    const resolved =
+      typeof fromEntry === "string" && fromEntry.trim() !== ""
+        ? fromEntry
+        : procEnv[name];
+    if (!resolved || !String(resolved).trim()) resolvable = false;
+    return "";
+  });
+  return resolvable;
+}
+
+/** Field names that carry credential material on an auth.json record whose
+ *  `type` we don't recognise (forward-compat with a pi that adds a new
+ *  credential kind). A record with none of these is not a credential. */
+const CREDENTIAL_FIELDS = ["key", "access", "refresh", "token", "apiKey"] as const;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function nonEmptyString(v: unknown): boolean {
+  return typeof v === "string" && v.trim() !== "";
+}
+
+/**
+ * Does one ~/.pi/agent/auth.json record carry a usable credential?
+ *
+ * Shapes from packages/ai/src/auth/types.ts:
+ *   ApiKeyCredential { type: "api_key"; key?: string; env?: ProviderEnv }
+ *   OAuthCredential  { type: "oauth"; refresh: string; access: string; expires: number }
+ *
+ * Note `key` is OPTIONAL in pi's TYPE but mandatory in FACT — a `{"type":"api_key"}`
+ * record resolves to no key and pi's first request goes out unauthenticated. That
+ * record used to green this provider; it no longer does. Same for an oauth record
+ * with neither token.
+ *
+ * `expires` is deliberately NOT enforced: pi auto-refreshes expired OAuth tokens
+ * from `refresh` (docs/providers.md), so an expired-but-refreshable record is
+ * genuinely ready and rejecting it would be a false "not signed in".
+ */
+export function authRecordUsable(record: unknown, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+  if (!isPlainObject(record)) return false;
+  const type = record.type;
+  if (type === "api_key") {
+    return credentialValueUsable(record.key, isPlainObject(record.env) ? record.env : undefined, procEnv);
+  }
+  if (type === "oauth") {
+    // Either token alone is enough to get pi a request: `access` is used
+    // directly, `refresh` mints a new one.
+    return nonEmptyString(record.access) || nonEmptyString(record.refresh);
+  }
+  // Unknown/absent `type`: accept only if some recognised credential field
+  // carries material, so `{}` and `{"type":"api_key"}` stay not-ready while a
+  // future credential kind still reads as ready.
+  return CREDENTIAL_FIELDS.some((f) => nonEmptyString(record[f]));
+}
+
+function readFileOrNull(file: string): string | null {
+  try {
+    return readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse ~/.pi/agent/auth.json and report whether ANY provider record is usable.
+ * Plain `JSON.parse` — pi reads this file with JSON.parse (auth-storage.ts), NOT
+ * the JSONC path it uses for models.json, so a commented auth.json is broken for
+ * pi and must not green here. Never throws.
+ */
+export function piAuthJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = readFileOrNull(file);
+  if (raw === null) return false;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed)) return false;
+    return Object.values(parsed).some((rec) => authRecordUsable(rec, procEnv));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse ~/.pi/agent/models.json and report whether a CUSTOM provider carries its
+ * own credential.
+ *
+ * Two corrections over "the file is a non-empty object":
+ *  - JSONC: pi runs stripJsonComments() before JSON.parse (model-config.ts), so a
+ *    models.json with `//` comments or trailing commas is perfectly valid FOR PI.
+ *    Rejecting it read as "not signed in" for a working install.
+ *  - Shape + emptiness: the schema is `{ providers: { <id>: {…} } }`. The old
+ *    check counted top-level keys, so `{"providers":{}}` (one key) and even
+ *    `{"note":"todo"}` greened pi. A provider entry only supplies auth when it
+ *    has a resolvable `apiKey` or an `oauth` mode; per docs/models.md an entry
+ *    without one is loaded but its models stay UNAVAILABLE, so it is not a
+ *    credential.
+ *
+ * Never throws.
+ */
+export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = readFileOrNull(file);
+  if (raw === null) return false;
+  try {
+    const parsed: unknown = JSON.parse(stripJsonComments(raw));
+    if (!isPlainObject(parsed)) return false;
+    const providers = parsed.providers;
+    if (!isPlainObject(providers)) return false;
+    return Object.values(providers).some(
+      (p) =>
+        isPlainObject(p) &&
+        (credentialValueUsable(p.apiKey, undefined, procEnv) || nonEmptyString(p.oauth)),
+    );
+  } catch {
+    return false;
+  }
+}
+
+function fileExistsSafe(file: string): boolean {
+  try {
+    return existsSync(file);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Google Vertex via Application Default Credentials.
+ *
+ * pi's google-vertex provider (packages/ai/src/providers/google-vertex.ts) needs
+ * ALL THREE of a credentials FILE, a project and a location for the ADC/service-
+ * account path — GOOGLE_APPLICATION_CREDENTIALS alone cannot authenticate. It
+ * also falls back to gcloud's well-known ADC file when the var is unset, which we
+ * now honour (that user IS ready and used to read as not).
+ *
+ * The two real corrections here: the referenced file must EXIST (a stale
+ * GOOGLE_APPLICATION_CREDENTIALS pointing at a deleted key file used to green
+ * pi), and project/location must be set.
+ */
+export function piVertexAdcUsable(home: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+  const project = procEnv.GOOGLE_CLOUD_PROJECT?.trim() || procEnv.GCLOUD_PROJECT?.trim();
+  const location = procEnv.GOOGLE_CLOUD_LOCATION?.trim();
+  if (!project || !location) return false;
+  const explicit = procEnv.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  if (explicit) {
+    // A relative path is resolved against pi's cwd, which we don't control here;
+    // only absolute paths are checkable, so accept a relative one unverified
+    // rather than false-flag it.
+    return isAbsolute(explicit) ? fileExistsSafe(explicit) : true;
+  }
+  // gcloud's default ADC location. pi's fallback is the POSIX path; on Windows
+  // gcloud actually writes under %APPDATA%, so accept either.
+  if (fileExistsSafe(join(home, ".config", "gcloud", "application_default_credentials.json"))) return true;
+  const appData = procEnv.APPDATA;
+  return !!appData && fileExistsSafe(join(appData, "gcloud", "application_default_credentials.json"));
+}
+
+/**
+ * True when a pi provider credential is detectable from ANY source pi documents.
+ * This — not the CLI's presence — is the honest "ready" signal for pi, and the
+ * connect handler uses it too so a credential-less pi is degraded up front
+ * instead of greeted green (#491).
+ */
+export function piCredentialPresent(
+  home: string = homedir(),
+  procEnv: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (piAuthJsonUsable(join(home, ".pi", "agent", "auth.json"), procEnv)) return true;
+  if (piEnvKeysReachingPi().some((k) => !!procEnv[k]?.trim())) return true;
+  if (piVertexAdcUsable(home, procEnv)) return true;
+  if (piModelsJsonUsable(join(home, ".pi", "agent", "models.json"), procEnv)) return true;
+  return false;
+}

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -198,7 +198,9 @@ export function credentialValueUsable(
   const value = raw.trim();
   if (!value) return false;
   // `!command` — unverifiable without executing it; err toward ready.
-  if (value.startsWith("!")) return true;
+  // pi executes the text AFTER `!`; an empty command resolves to undefined, so
+  // it cannot authenticate. Do not let a lone `!` greet the user green.
+  if (value.startsWith("!")) return value.slice(1).trim() !== "";
   // Every referenced var must resolve to something non-empty IN THE ENV PI WILL
   // ACTUALLY SEE. Order matches pi: the entry's own `env` block first (pi injects
   // it for the provider), then the inherited process env — but a var our spawn
@@ -207,8 +209,15 @@ export function credentialValueUsable(
   // green this whole module exists to prevent.
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   for (const name of envRefsIn(value)) {
-    const fromEntry = entryEnv?.[name];
-    if (typeof fromEntry === "string" && fromEntry.trim() !== "") continue;
+    const hasEntryValue = !!entryEnv && Object.prototype.hasOwnProperty.call(entryEnv, name);
+    if (hasEntryValue) {
+      const fromEntry = entryEnv![name];
+      // `resolveEnvConfigValue` uses `entryEnv[name] || process.env[name]`.
+      // Thus an empty entry falls through, but a whitespace-only entry OWNS the
+      // value and blocks a good inherited key. It is not a usable credential.
+      if (typeof fromEntry !== "string" || fromEntry.trim() === "") return false;
+      continue;
+    }
     if (stripped.has(name) || !procEnv[name]?.trim()) return false;
   }
   return true;
@@ -279,6 +288,11 @@ export function authRecordUsable(
   const type = record.type;
   if (type === "api_key") {
     const entryEnv = isPlainObject(record.env) ? record.env : undefined;
+    if (provider === "amazon-bedrock") {
+      // Bedrock is deliberately unlike ordinary api-key providers: its resolver
+      // falls through from a keyless stored record to AWS's credential chain.
+      return credentialValueUsable(record.key, entryEnv, procEnv) || piBedrockCredentialUsable(entryEnv, procEnv);
+    }
     // pi's Vertex `/login` writes `{type:"api_key", env:{GOOGLE_CLOUD_PROJECT, …}}`
     // with NO `key`, and its resolver does `credential?.key ?? env(...)` then
     // falls back to ADC. So a keyless vertex record IS a credential when the ADC
@@ -390,7 +404,11 @@ function piAuthRecords(file: string): Record<string, unknown> {
  *
  * Never throws.
  */
-export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = process.env): boolean {
+export function piModelsJsonUsable(
+  file: string,
+  procEnv: NodeJS.ProcessEnv = process.env,
+  provider?: string,
+): boolean {
   const raw = readFileOrNull(file);
   if (raw === null) return false;
   try {
@@ -404,10 +422,10 @@ export function piModelsJsonUsable(file: string, procEnv: NodeJS.ProcessEnv = pr
     // credentials reach pi. Reproduce that all-or-nothing behaviour rather than
     // greening off a single good-looking entry.
     if (!entries.every((p) => providerEntryValid(p))) return false;
-    return entries.some(
-      (p) =>
-        isPlainObject(p) &&
-        (credentialValueUsable(p.apiKey, undefined, procEnv) || p.oauth === "radius"),
+    return Object.entries(providers).some(([id, p]) =>
+      (!provider || id === provider) &&
+      isPlainObject(p) &&
+      (credentialValueUsable(p.apiKey, undefined, procEnv) || p.oauth === "radius"),
     );
   } catch {
     return false;
@@ -650,6 +668,37 @@ export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.en
 }
 
 /**
+ * The AWS sources accepted by pi's amazon-bedrock provider. Unlike ordinary
+ * provider records, a keyless Bedrock `api_key` record deliberately falls
+ * through to these sources (amazon-bedrock.ts): an explicit stored AWS_PROFILE,
+ * an ambient profile, static access-key pair, ECS task role, or web identity.
+ */
+function piBedrockCredentialUsable(
+  entryEnv: Record<string, unknown> | undefined,
+  procEnv: NodeJS.ProcessEnv,
+): boolean {
+  const read = (key: string) => readScoped(entryEnv, procEnv, key);
+  if (nonEmptyString(read("AWS_BEARER_TOKEN_BEDROCK"))) return true;
+  if (nonEmptyString(read("AWS_PROFILE"))) return true;
+  if (nonEmptyString(read("AWS_ACCESS_KEY_ID")) && nonEmptyString(read("AWS_SECRET_ACCESS_KEY"))) return true;
+  if (nonEmptyString(read("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))) return true;
+  if (nonEmptyString(read("AWS_CONTAINER_CREDENTIALS_FULL_URI"))) return true;
+  return nonEmptyString(read("AWS_WEB_IDENTITY_TOKEN_FILE"));
+}
+
+/** The effective provider selected by the pi spawn flags. `--provider` wins;
+ * otherwise pi treats the prefix of `--model provider/model` as the provider.
+ * A bare model has no reliable static provider mapping, so it retains pi's
+ * normal default-selection behaviour rather than guessing. */
+function configuredPiProvider(procEnv: NodeJS.ProcessEnv): string | undefined {
+  const explicit = procEnv.COMFYUI_MCP_PI_PROVIDER?.trim();
+  if (explicit) return explicit;
+  const model = procEnv.COMFYUI_MCP_PI_MODEL?.trim();
+  const slash = model?.indexOf("/") ?? -1;
+  return slash > 0 ? model!.slice(0, slash) : undefined;
+}
+
+/**
  * Is any provider authenticated purely by an env var?
  *
  * Per pi's resolver, "a stored credential owns the provider: ambient/env is
@@ -661,9 +710,11 @@ export function piAgentDir(home: string, procEnv: NodeJS.ProcessEnv = process.en
 function piEnvCredentialPresent(
   storedProviders: Record<string, unknown>,
   procEnv: NodeJS.ProcessEnv,
+  onlyProvider?: string,
 ): boolean {
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   for (const [provider, keys] of Object.entries(PI_PROVIDER_ENV_KEYS)) {
+    if (onlyProvider && provider !== onlyProvider) continue;
     if (providerHasStoredCredential(storedProviders, provider)) continue;
     if (!keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) continue;
     // Some providers need companion config alongside the key — without it pi's
@@ -701,9 +752,48 @@ export function piCredentialPresent(
   // source counts, not even an otherwise-good env key.
   if (authFile && piAuthStoreBroken(authFile)) return false;
   const stored = authFile ? piAuthRecords(authFile) : {};
+  const selectedProvider = configuredPiProvider(procEnv);
+  if (selectedProvider) {
+    const selected = stored[selectedProvider];
+    if (authRecordUsable(selected, procEnv, nowMs, { provider: selectedProvider, home })) return true;
+    // Bedrock's own resolver intentionally consults the AWS chain even with a
+    // keyless stored record; generic stored-record ownership does not apply.
+    if (
+      selectedProvider === "amazon-bedrock" &&
+      (!providerHasStoredCredential(stored, "amazon-bedrock") ||
+        (isPlainObject(selected) && selected.type === "api_key")) &&
+      piBedrockCredentialUsable(
+        isPlainObject(selected) && isPlainObject(selected.env) ? selected.env : undefined,
+        procEnv,
+      )
+    )
+      return true;
+    if (piEnvCredentialPresent(stored, procEnv, selectedProvider)) return true;
+    if (
+      selectedProvider === "google-vertex" &&
+      !providerHasStoredCredential(stored, "google-vertex") &&
+      piVertexAdcUsable(home, procEnv)
+    )
+      return true;
+    return !!agentDir && piModelsJsonUsable(join(agentDir, "models.json"), procEnv, selectedProvider);
+  }
   if (
     Object.entries(stored).some(([provider, rec]) =>
       authRecordUsable(rec, procEnv, nowMs, { provider, home }),
+    )
+  )
+    return true;
+  const bedrockStored = stored["amazon-bedrock"];
+  // The Bedrock resolver is the one exception to ordinary stored-record
+  // ownership: a valid api_key record with no `key` still falls through to the
+  // AWS chain. An unrecognised/non-api-key stored record remains dead, as pi's
+  // generic credential resolver never hands it to the provider.
+  if (
+    (!providerHasStoredCredential(stored, "amazon-bedrock") ||
+      (isPlainObject(bedrockStored) && bedrockStored.type === "api_key")) &&
+    piBedrockCredentialUsable(
+      isPlainObject(bedrockStored) && isPlainObject(bedrockStored.env) ? bedrockStored.env : undefined,
+      procEnv,
     )
   )
     return true;

--- a/src/orchestrator/pi-credentials.ts
+++ b/src/orchestrator/pi-credentials.ts
@@ -714,7 +714,17 @@ function piEnvCredentialPresent(
   const stripped = new Set<string>(TOOL_ONLY_SECRET_ENV_KEYS);
   for (const [provider, keys] of Object.entries(PI_PROVIDER_ENV_KEYS)) {
     if (onlyProvider && provider !== onlyProvider) continue;
-    if (providerHasStoredCredential(storedProviders, provider)) continue;
+    const stored = storedProviders[provider];
+    // Pi's ordinary api-key helper falls back to ctx.env when its stored key is
+    // absent, falsy, or cannot resolve. A record's mere existence must not hide
+    // that same provider's working ambient key.
+    const storedEnv = isPlainObject(stored) && isPlainObject(stored.env) ? stored.env : undefined;
+    const storedCanSupplyKey =
+      isPlainObject(stored) &&
+      stored.type === "api_key" &&
+      credentialValueUsable(stored.key, storedEnv, procEnv);
+    const storedIsOrdinaryApiKey = isPlainObject(stored) && stored.type === "api_key";
+    if (providerHasStoredCredential(storedProviders, provider) && (!storedIsOrdinaryApiKey || storedCanSupplyKey)) continue;
     if (!keys.some((k) => !stripped.has(k) && !!procEnv[k]?.trim())) continue;
     // Some providers need companion config alongside the key — without it pi's
     // resolver returns undefined and the key is useless on its own.

--- a/src/orchestrator/ready-banner.ts
+++ b/src/orchestrator/ready-banner.ts
@@ -31,7 +31,11 @@ export function readyBannerText(backend: string, label: string, customBaseUrl = 
     case "antigravity":
       return `🟢 comfyui-mcp agent ready — ${label} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.`;
     case "pi":
-      return `🟢 comfyui-mcp agent ready — ${label} via the pi CLI on your own provider. Note: pi has no ComfyUI tools (no MCP) — it works with its own coding tools on the local workspace, not the panel canvas. Ask away.`;
+      // Deliberately hedged: readiness for pi is a DISK check (a well-formed,
+      // present credential), never a proven-working one — a revoked key or a
+      // spent quota only shows up on the first real turn, so don't promise more
+      // than "we found a credential" (#491).
+      return `🟢 comfyui-mcp agent ready — ${label} via the pi CLI on your own provider credential (found on this machine; pi checks it on your first message). Note: pi has no ComfyUI tools (no MCP) — it works with its own coding tools on the local workspace, not the panel canvas. Ask away.`;
     case "grok":
       return `🟢 comfyui-mcp agent ready — ${label} on your Grok (xAI) account. Ask away.`;
     case "ollama":

--- a/src/orchestrator/ready-banner.ts
+++ b/src/orchestrator/ready-banner.ts
@@ -30,6 +30,8 @@ export function readyBannerText(backend: string, label: string, customBaseUrl = 
       return `🟢 comfyui-mcp agent ready — ${label} on your Google account (Gemini Code Assist). Ask away.`;
     case "antigravity":
       return `🟢 comfyui-mcp agent ready — ${label} on your Google AI subscription via Antigravity CLI. Note: agy turns show final answers only (no live tool progress). Ask away.`;
+    case "pi":
+      return `🟢 comfyui-mcp agent ready — ${label} via the pi CLI on your own provider. Note: pi has no ComfyUI tools (no MCP) — it works with its own coding tools on the local workspace, not the panel canvas. Ask away.`;
     case "grok":
       return `🟢 comfyui-mcp agent ready — ${label} on your Grok (xAI) account. Ask away.`;
     case "ollama":

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -487,6 +487,7 @@ export const BACKEND_LABELS: Record<string, string> = {
   chatgpt: "ChatGPT",
   gemini: "Gemini",
   antigravity: "Antigravity",
+  pi: "Pi",
   grok: "Grok",
   glm: "GLM",
   kimi: "Kimi",


### PR DESCRIPTION
Adds **pi.dev** (`pi`, [earendil-works/pi](https://github.com/earendil-works/pi)) as a selectable agent backend.

## Integration type: CLI coding agent (mirrors `antigravity`, NOT a hosted-key provider)
pi is a multi-provider coding-agent CLI, so `PiBackend` is a spawn-per-turn adapter — but pi exposes a **documented JSON-lines event stream** (`pi --mode json`), so unlike agy's plain-text mode it gets real streaming deltas, per-tool events, and a **resumable session id** (`--session <id>`). Models via `pi --list-models`; auth via `~/.pi/agent/auth.json` or provider env keys.

## Key design points
- **No MCP (honest limitation):** pi has no MCP client at all (built-in tools + TS extensions only) — verified against the repo tree / CHANGELOG / extension docs. `PiBackend` is constructed with **no `mcpServers`**, so a pi turn drives the local workspace with pi's own tools but has **no ComfyUI panel_*/comfyui tools**. Surfaced in the ready banner. Full ComfyUI-tool parity would need a pi extension (follow-up).
- **Secret scoping:** spawned via `buildAgentSpawnEnv()` (no keep-list) — ComfyUI tool secrets (RunPod/CivitAI/HF/Google/…) are stripped; pi's own provider keys (ANTHROPIC/OPENAI/XAI/OpenRouter/…) pass through. Readiness deliberately does NOT treat GEMINI/GOOGLE keys as pi-auth since those are stripped from pi's env.

## Sites touched
`agent-backend.ts` (BackendId + `PI_CAPABILITIES`), **`pi-backend.ts` (new)**, `index.ts` (env vars, `KNOWN_BACKENDS`, `makeBackend`, probe, `currentModelFor`, connect-ack label + degraded text), `ready-banner.ts`, `env-capabilities.ts` (`BACKEND_LABELS`), `backend-readiness.ts` (`CLI_NAMES` + readiness branch). Panel chip is a companion PR.

## Tests / gates
- New `pi-backend.test.ts` (23 tests, mirrors antigravity): JSON-stream parsing, session capture/resume, terminal-result invariant, interrupt / spawn-window / idle-expiry / abandonment, `close`-drain, `parsePiModels`, model acceptance, tool-secret scoping.
- `npm run build` + full suite green (2915 pass); vocabulary gate green on LF (pi adds a backend, no tool-surface change). Rebased on current `main` (after MiniMax #640).
- Self-gated with codex; P0/P1 findings fixed (settle on `close` not `exit`; ANSI ESC byte; `.cmd` spawn refusal; provider-set claude-leak; GEMINI/GOOGLE false-auth).

**Live-test note:** end-to-end needs a real pi install + provider key (not available in CI); the wiring is unit-tested.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
