### PR TITLE
fix(install_panel): verify the panel actually changed + detect shadow copies (#639, #641)

### DIFF
--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -82,6 +82,8 @@ function makeDeps(opts: {
     comfyuiPath: () => opts.comfyuiPath,
     env: () => opts.env ?? {},
     existsSync: (p) => p === CUSTOM_NODES || p in files,
+    // Files map holds regular files (pyproject, web assets) — CUSTOM_NODES is a dir.
+    probeFile: (p) => p in files,
     isSymlink: (p) => symlinks.has(p),
     isDirectory: (p) => !nonDirs.has(p),
     realPath: (p) => opts.realPaths?.[p],
@@ -264,6 +266,22 @@ describe("ensurePanelInstalled policy matrix", () => {
     expect(res.action).toBe("unavailable");
     expect(res.reason).toMatch(/enumerate|confirm the panel is missing/i);
     expect(h.installs).toEqual([]);
+  });
+
+  it("#641: on-load install NO-OPs but a served shadow exists → 'shadowed', not 'unavailable'", async () => {
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        // A served backup copy is present; the canonical install never lands.
+        [join(CUSTOM_NODES, bak, "web", "js", "comfyui-mcp-panel.js")]: "// old panel",
+      },
+      // No onInstall → Manager no-op, canonical dir never appears.
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("shadowed");
+    expect(res.reason).toMatch(/shadow/i);
   });
 
   it("#641: present WITH a shadow → 'shadowed' (surfaces the trap on load)", async () => {
@@ -726,6 +744,26 @@ describe("runPanelAction shadow detection (#641)", () => {
     await expect(runPanelAction("update", h.deps)).rejects.toThrow(bakName);
   });
 
+  it("#641: update advances the canonical version but a SERVED shadow (content, no pyproject) exists → NOT success", async () => {
+    const bak = ".comfyui-agent-panel-0.11.28.bak";
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+        // Served shadow: web asset present, NO pyproject.
+        [join(CUSTOM_NODES, bak, "web", "js", "comfyui-mcp-panel.js")]: "// old panel",
+      },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      // The real dir genuinely advances on disk...
+      onUpdate: ({ files }) => {
+        files[join(realDir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    // ...but the served shadow means the browser may still load the old copy.
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(/shadow/i);
+  });
+
   it("update: shadow removed → success", async () => {
     const h = makeDeps({
       comfyuiPath: COMFY,
@@ -812,6 +850,107 @@ describe("findPanelShadows (#641)", () => {
     expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(bak);
   });
 
+  it("#641(a): flags '.comfyui-agent-panel-0.11.28.bak' (marker LAST) with web assets, no pyproject", () => {
+    // The .bak marker is at the END of the remainder (rest = "-0.11.28.bak"),
+    // and there is no pyproject — both the broadened name heuristic and the
+    // CONTENT signal must catch it.
+    const bak = ".comfyui-agent-panel-0.11.28.bak";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        // The served web asset — the CONTENT signal.
+        [join(CUSTOM_NODES, bak, "web", "js", "comfyui-mcp-panel.js")]: "// panel",
+      },
+    });
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(bak);
+  });
+
+  it("#641(b): a served copy with UNREADABLE pyproject fails CLOSED (flagged, not omitted)", () => {
+    // Name is neither canonical nor backup-shaped, so ONLY the content signal +
+    // fail-closed behavior can catch it. pyproject exists but read throws.
+    const stray = "panel-restore-dir";
+    const pyPath = join(CUSTOM_NODES, stray, "pyproject.toml");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [stray],
+      files: {
+        [join(CUSTOM_NODES, stray, "web", "js", "comfyui-mcp-panel.js")]: "// panel",
+        [pyPath]: "corrupt",
+      },
+    });
+    deps.readFile = (p) => {
+      if (p === pyPath) throw new Error("EIO: pyproject unreadable");
+      return "";
+    };
+    const s = findPanelShadows(realDir, deps);
+    expect(s.map((x) => x.name)).toContain(stray);
+    // Identity couldn't be verified → version undefined (a POSSIBLE shadow).
+    expect(s.find((x) => x.name === stray)?.version).toBeUndefined();
+  });
+
+  it("#641(c): canonical-only (no other served copy) → no shadow", () => {
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: {
+        [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(realDir, "web", "js", "comfyui-mcp-panel.js")]: "// panel",
+      },
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("flags a NON-backup-named dir purely by served web content", () => {
+    const stray = "my-vendored-panel";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [stray],
+      files: {
+        [join(CUSTOM_NODES, stray, "web", "img", "comfyui-mcp-wordmark.svg")]: "<svg/>",
+      },
+    });
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(stray);
+  });
+
+  it("FAILS CLOSED when a content probe is INDETERMINATE (probeFile undefined)", () => {
+    const stray = "opaque-dir";
+    const marker = join(CUSTOM_NODES, stray, "web", "js", "comfyui-mcp-panel.js");
+    const { deps } = makeDeps({ comfyuiPath: COMFY, dirs: [stray] });
+    // Marker probe can't confirm absence (EACCES) → undefined, not false.
+    deps.probeFile = (p) => (p === marker ? undefined : false);
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(stray);
+  });
+
+  it("does NOT treat a DIRECTORY named like the asset as a served copy", () => {
+    // A dir 'comfyui-mcp-panel.js' (not a file) must NOT count as a served asset.
+    const stray = "unrelated-node";
+    const markerAsDir = join(CUSTOM_NODES, stray, "web", "js", "comfyui-mcp-panel.js");
+    const { deps } = makeDeps({ comfyuiPath: COMFY, dirs: [stray] });
+    deps.probeFile = (p) => (p === markerAsDir ? false : false); // exists but a dir → false
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("exempts a backup-NAMED symlink alias that resolves to the canonical dir", () => {
+    // ".comfyui-agent-panel.bak" is a junction -> the canonical dir; realpath
+    // proves same physical dir → serves the SAME assets → NOT a shadow.
+    const alias = ".comfyui-agent-panel.bak";
+    const canonical = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const real = "/real/fs/comfyui-mcp-panel";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [alias],
+      files: {
+        [join(canonical, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+      },
+      realPaths: {
+        [canonical]: real,
+        [join(CUSTOM_NODES, alias)]: real, // alias resolves to canonical
+      },
+    });
+    expect(findPanelShadows(canonical, deps)).toEqual([]);
+  });
+
   it("does NOT block on a regular FILE that merely shares a backup name", () => {
     const bak = ".comfyui-agent-panel.bak-0.11.28";
     const { deps } = makeDeps({
@@ -820,6 +959,44 @@ describe("findPanelShadows (#641)", () => {
       nonDirEntries: [bak], // it's a FILE, not a served extension dir
     });
     expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("FAILS CLOSED when directory classification is INDETERMINATE (stat error)", () => {
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const bakDir = join(CUSTOM_NODES, bak);
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: { [join(bakDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+    });
+    // Transient stat failure → undefined (can't confirm it's a file) → must NOT skip.
+    deps.isDirectory = (p) => (p === bakDir ? undefined : true);
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(bak);
+  });
+
+  it("flags a distinct case-variant serving copy when NO canonical is resolved", () => {
+    // canonicalDir undefined + a case-variant dir serving panel content: it must
+    // be content-checked (flagged), not exempted by a case-insensitive name.
+    const variant = "ComfyUI-MCP-Panel";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [variant],
+      files: {
+        [join(CUSTOM_NODES, variant, "web", "js", "comfyui-mcp-panel.js")]: "// panel",
+      },
+    });
+    expect(findPanelShadows(undefined, deps).map((x) => x.name)).toContain(variant);
+  });
+
+  it("still exempts the EXACT canonical name when no canonical is resolved", () => {
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: {
+        [join(realDir, "web", "js", "comfyui-mcp-panel.js")]: "// panel",
+      },
+    });
+    expect(findPanelShadows(undefined, deps)).toEqual([]);
   });
 
   it("does NOT flag an unrelated custom node", () => {
@@ -948,6 +1125,29 @@ describe("looksLikePanelBackupName (#641)", () => {
     expect(looksLikePanelBackupName("comfyui-agent-panel-copy")).toBe(true);
     expect(looksLikePanelBackupName(".comfyui-agent-panel~")).toBe(true);
     expect(looksLikePanelBackupName("comfyui-mcp-panel~")).toBe(true);
+    // Marker LAST (version between the name and the .bak token).
+    expect(looksLikePanelBackupName(".comfyui-agent-panel-0.11.28.bak")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-mcp-panel-2026.old")).toBe(true);
+  });
+
+  it("does NOT flag a same-prefixed but non-backup sibling ('-holder' contains 'old')", () => {
+    // 'old' appears as a substring of 'holder' but not as a boundary token.
+    expect(looksLikePanelBackupName("comfyui-agent-panel-holder")).toBe(false);
+    expect(looksLikePanelBackupName(".comfyui-agent-panel-holder")).toBe(false);
+  });
+
+  it("does NOT flag a backup of an unrelated SIBLING node", () => {
+    // These are backups of "comfyui-agent-panel-tools"/"...-holder", NOT the panel.
+    expect(looksLikePanelBackupName("comfyui-agent-panel-tools-old")).toBe(false);
+    expect(looksLikePanelBackupName("comfyui-agent-panel-holder-backup")).toBe(false);
+    expect(looksLikePanelBackupName(".comfyui-agent-panel-tools~")).toBe(false);
+    expect(looksLikePanelBackupName("comfyui-agent-panel-tools.bak")).toBe(false);
+  });
+
+  it("ALLOWS descriptive text AFTER the first backup marker", () => {
+    expect(looksLikePanelBackupName("comfyui-agent-panel-backup-2026-final")).toBe(true);
+    expect(looksLikePanelBackupName(".comfyui-agent-panel~snapshot")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-mcp-panel.bak.final")).toBe(true);
   });
 
   it("does NOT flag the canonical names or unrelated extensions", () => {

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 // Mock config so importing panel-installer doesn't trigger real port detection.
 // (We drive comfyuiPath via the injected deps, not the mocked config, but the
@@ -13,6 +15,12 @@ import {
   ensurePanelInstalled,
   panelStatus,
   runPanelAction,
+  classifyPanelUpdate,
+  resolveGitRevision,
+  looksLikeManagerNoOp,
+  findPanelShadows,
+  looksLikePanelBackupName,
+  readQueueCounts,
   PanelInstallError,
   PANEL_REGISTRY_ID,
   PANEL_VERSION,
@@ -40,11 +48,31 @@ function makeDeps(opts: {
   files?: Record<string, string>; // path -> pyproject contents
   dirs?: string[]; // custom_nodes subdir names
   symlinks?: string[]; // absolute dir paths that are symlinks
+  nonDirEntries?: string[]; // custom_nodes entries that are FILES, not dirs
+  realPaths?: Record<string, string>; // path -> canonical realpath (else undefined)
   reachable?: boolean;
+  /** Raw ComfyUI-Manager queue status the `update` mock returns as details. */
+  updateDetails?: unknown;
+  /** Queue status the `install`/`reinstall` mocks return as details. */
+  installDetails?: unknown;
+  reinstallDetails?: unknown;
+  /** Per-dir git-HEAD sha (absolute dir path -> sha). Read via gitRevision. */
+  revs?: Record<string, string>;
+  /**
+   * Side effect the `update` mock runs against the live `files`/`revs` maps to
+   * simulate what actually landed on disk (advance/remove pyproject or sha).
+   */
+  onUpdate?: (ctx: { files: Record<string, string>; revs: Record<string, string> }) => void;
+  /** Side effect the `install` mock runs to simulate the pack landing. */
+  onInstall?: (ctx: { files: Record<string, string>; revs: Record<string, string> }) => void;
+  /** Side effect the `reinstall` mock runs to simulate the pack landing. */
+  onReinstall?: (ctx: { files: Record<string, string>; revs: Record<string, string> }) => void;
 } = {}): Harness {
   const files = opts.files ?? {};
+  const revs = opts.revs ?? {};
   const dirs = opts.dirs ?? [];
   const symlinks = new Set(opts.symlinks ?? []);
+  const nonDirs = new Set((opts.nonDirEntries ?? []).map((n) => join(CUSTOM_NODES, n)));
   const installs: Harness["installs"] = [];
   const updates: Harness["updates"] = [];
   const reinstalls: Harness["reinstalls"] = [];
@@ -55,20 +83,32 @@ function makeDeps(opts: {
     env: () => opts.env ?? {},
     existsSync: (p) => p === CUSTOM_NODES || p in files,
     isSymlink: (p) => symlinks.has(p),
+    isDirectory: (p) => !nonDirs.has(p),
+    realPath: (p) => opts.realPaths?.[p],
     readdir: (p) => (p === CUSTOM_NODES ? dirs : []),
     readFile: (p) => files[p] ?? "",
+    gitRevision: (dir) => revs[dir],
     isReachable: async () => opts.reachable ?? true,
     install: async (o) => {
       installs.push(o);
-      return { mechanism: "manager-http", message: "installed" };
+      opts.onInstall?.({ files, revs });
+      return { mechanism: "manager-http", message: "installed", details: opts.installDetails };
     },
     update: async (o) => {
       updates.push(o);
-      return { mechanism: "manager-http", message: "updated" };
+      // Mutate the on-disk view BEFORE returning, so the post-update re-read in
+      // runPanelAction sees exactly what "landed" (or didn't).
+      opts.onUpdate?.({ files, revs });
+      return {
+        mechanism: "manager-http",
+        message: "updated",
+        details: opts.updateDetails,
+      };
     },
     reinstall: async (o) => {
       reinstalls.push(o);
-      return { mechanism: "manager-http", message: "reinstalled" };
+      opts.onReinstall?.({ files, revs });
+      return { mechanism: "manager-http", message: "reinstalled", details: opts.reinstallDetails };
     },
   };
   return { deps, installs, updates, reinstalls };
@@ -173,11 +213,73 @@ describe("detectPanelInstall", () => {
 
 describe("ensurePanelInstalled policy matrix", () => {
   it("missing → installs nightly (restart required)", async () => {
-    const h = makeDeps({ comfyuiPath: COMFY });
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      // Simulate the pack landing so the new post-install verification passes.
+      onInstall: ({ files }) => {
+        files[join(dir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
     const res = await ensurePanelInstalled({ deps: h.deps });
     expect(res.action).toBe("installed");
     expect(res.restartRequired).toBe(true);
+    expect(res.installedVersion).toBe("0.11.32");
     expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("#639: missing → install does NOT land → unavailable (not fabricated 'installed')", async () => {
+    // No onInstall → Manager 'queued' but nothing on disk.
+    const h = makeDeps({ comfyuiPath: COMFY });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(res.reason).toMatch(/could not be verified|no-op/i);
+    expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("#641: missing → install lands but a shadow exists → 'shadowed', not 'installed'", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: { [join(CUSTOM_NODES, bak, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      onInstall: ({ files }) => {
+        files[join(dir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("shadowed");
+    expect(res.reason).toMatch(/shadow/i);
+  });
+
+  it("#639: unreliable pre-scan (readdir fails) → unavailable, does NOT auto-install blind", async () => {
+    // Panel exists in a non-fast-path dir; enumeration fails so detection can't
+    // see it. Auto-install must NOT run (would create a duplicate) nor fabricate.
+    const h = makeDeps({ comfyuiPath: COMFY });
+    h.deps.readdir = () => {
+      throw new Error("EACCES: scandir");
+    };
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("unavailable");
+    expect(res.reason).toMatch(/enumerate|confirm the panel is missing/i);
+    expect(h.installs).toEqual([]);
+  });
+
+  it("#641: present WITH a shadow → 'shadowed' (surfaces the trap on load)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(CUSTOM_NODES, bak, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+    });
+    const res = await ensurePanelInstalled({ deps: h.deps });
+    expect(res.action).toBe("shadowed");
+    expect(h.installs).toEqual([]); // never re-installs a present panel
   });
 
   it("present → up-to-date (no churn on load, no install call)", async () => {
@@ -266,7 +368,14 @@ describe("ensurePanelInstalled policy matrix", () => {
 
 describe("runPanelAction", () => {
   it("install targets nightly and flags restart required", async () => {
-    const h = makeDeps({ comfyuiPath: COMFY });
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      // Simulate the pack landing on disk so the post-op presence check passes.
+      onInstall: ({ files }) => {
+        files[join(dir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
     const r = await runPanelAction("install", h.deps);
     expect(r.action).toBe("install");
     expect(r.restartRequired).toBe(true);
@@ -274,22 +383,276 @@ describe("runPanelAction", () => {
     expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
   });
 
-  it("update calls updateCustomNode for the panel", async () => {
+  it("#639: install where the pack never lands → throws, not silent success", async () => {
+    // No onInstall → Manager "queued" but nothing on disk.
+    const h = makeDeps({ comfyuiPath: COMFY });
+    await expect(runPanelAction("install", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.installs).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("update calls updateCustomNode for the panel (version moves → success)", async () => {
     const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
     const h = makeDeps({
       comfyuiPath: COMFY,
-      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID) },
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      updateDetails: {
+        total_count: 1,
+        done_count: 1,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+      // Simulate the pack actually advancing on disk.
+      onUpdate: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
     });
     const r = await runPanelAction("update", h.deps);
     expect(r.action).toBe("update");
     expect(h.updates).toEqual([{ id: PANEL_REGISTRY_ID }]);
+    expect(r.previousVersion).toBe("0.11.28");
+    expect(r.installedVersion).toBe("0.11.32");
+    expect(r.restartRequired).toBe(true);
+    expect(r.message).toMatch(/0\.11\.28.*0\.11\.32/);
   });
 
-  it("reinstall targets nightly", async () => {
-    const h = makeDeps({ comfyuiPath: COMFY });
+  it("#639: git-HEAD advances WITHOUT a version bump (nightly) → updated + restart", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      // Version string stays, but the commit sha advances.
+      onUpdate: ({ revs }) => {
+        revs[dir] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      },
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(r.installedVersion).toBe("0.11.32");
+    expect(r.restartRequired).toBe(true);
+    expect(r.message).toMatch(/updated/i);
+  });
+
+  // #639 — the core silent-fabricate-success regression guard.
+  it("#639: Manager reports done but on-disk version UNCHANGED → throws, not success", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      // Real installs are git checkouts — exercise that path with an UNCHANGED
+      // HEAD, which must NOT be mistaken for "already current".
+      revs: { [dir]: "dddddddddddddddddddddddddddddddddddddddd" },
+      // The exact stale-3.x no-op signature from the issue: total_count 0 yet
+      // done_count 2 — the queue "drains" trivially while nothing is enqueued.
+      updateDetails: {
+        total_count: 0,
+        done_count: 2,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+      // No onUpdate → nothing changes on disk.
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    // The update was actually attempted (not short-circuited).
+    expect(h.updates).toEqual([{ id: PANEL_REGISTRY_ID }]);
+    // And the diagnostic names the stale-Manager cause + the still-installed version.
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /did NOT apply|stale ComfyUI-Manager|0\.11\.28/,
+    );
+  });
+
+  it("#639: unchanged version AND unchanged git-HEAD + coherent counts → fails closed (not success)", async () => {
+    // An unchanged LOCAL git-HEAD is NOT proof of being at the upstream tip — it
+    // only proves nothing was pulled, which is exactly the no-op. So even a git
+    // checkout with identical pre/post HEAD and coherent-looking counts must NOT
+    // report success.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+      revs: { [dir]: "cccccccccccccccccccccccccccccccccccccccc" },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      // No onUpdate → version AND git-HEAD both unchanged.
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /could not verify|did not change/i,
+    );
+  });
+
+  it("#639: version unchanged, NO git identity, 'coherent' counts → fails closed (not success)", async () => {
+    // Queue counts are queue-WIDE drain counters, NOT task-correlated, so
+    // coherent-looking counts alone must NOT be treated as proof of work.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      // No revs → gitRevision returns undefined for the dir.
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /could not verify|did not change/i,
+    );
+  });
+
+  it("#639: post-update version UNREADABLE → fail-closed, not silent success", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      updateDetails: {
+        total_count: 1,
+        done_count: 1,
+        in_progress_count: 0,
+        pending_count: 0,
+        is_processing: false,
+      },
+      // Simulate the pack dir becoming unreadable after the op (pyproject gone).
+      // NOTE: destructure `files` from the ctx wrapper so we mutate the real map.
+      onUpdate: ({ files }) => {
+        delete files[pyPath];
+      },
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /could not verify|NOT reporting success/i,
+    );
+  });
+
+  it("reinstall targets nightly (verifies pack landed)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      onReinstall: ({ files }) => {
+        files[join(dir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
     const r = await runPanelAction("reinstall", h.deps);
     expect(h.reinstalls).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
     expect(r.message).toMatch(/RESTART ComfyUI/);
+    expect(r.installedVersion).toBe("0.11.32");
+  });
+
+  it("#639: reinstall where the pack never lands → throws, not silent success", async () => {
+    // reinstallCustomNode does NOT verify presence downstream (unlike install),
+    // so the panel-layer post-op check is what fails this closed.
+    const h = makeDeps({ comfyuiPath: COMFY });
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+    expect(h.reinstalls).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
+  it("#639: reinstall on a PRE-EXISTING panel + stale no-op counts → throws (present ≠ executed)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    // Panel already present; Manager reports the stale-3.x no-op (total 0/done 2)
+    // and never actually reinstalls. Presence alone must NOT be read as success.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      reinstallDetails: { total_count: 0, done_count: 2, is_processing: false },
+    });
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toThrow(
+      /did NOT execute|stale ComfyUI-Manager/,
+    );
+  });
+
+  it("#639: install on a PRE-EXISTING panel + stale no-op counts → throws (present ≠ executed)", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      installDetails: { total_count: 0, done_count: 2, is_processing: false },
+    });
+    await expect(runPanelAction("install", h.deps)).rejects.toThrow(
+      /did NOT execute|stale ComfyUI-Manager/,
+    );
+  });
+
+  it("#639: reinstall that ACTUALLY moves the version SUCCEEDS despite stale queue-wide counts", async () => {
+    // Movement is proven on disk; the queue-wide { total:0, done:2 } must NOT
+    // veto a change the disk already proves.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      reinstallDetails: { total_count: 0, done_count: 2, is_processing: false },
+      onReinstall: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    const r = await runPanelAction("reinstall", h.deps);
+    expect(r.installedVersion).toBe("0.11.32");
+    expect(r.restartRequired).toBe(true);
+  });
+
+  it("#639: unreliable PRE-op scan must NOT be read as absent→present (no fabricated fresh install)", async () => {
+    // Panel already present in a NON-fast-path dir. The pre-op enumeration fails
+    // (transient), so detection can't see it; a no-op reinstall leaves it as-is.
+    // The reliability guard must refuse to infer a fresh install.
+    const weird = "weird-panel-dir";
+    const pyPath = join(CUSTOM_NODES, weird, "pyproject.toml");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      reinstallDetails: { total_count: 1, done_count: 1, is_processing: false },
+    });
+    let calls = 0;
+    h.deps.readdir = (p) => {
+      calls += 1;
+      if (calls === 1) throw new Error("EAGAIN transient scandir failure");
+      return p === CUSTOM_NODES ? [weird] : [];
+    };
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
+  });
+
+  it("#639: pre-op pyproject READ failure (present-but-unreadable) → not absent→present", async () => {
+    // Pre-existing canonical panel whose FIRST pyproject read throws (transient),
+    // SECOND succeeds; Manager does a stale no-op. The read failure must make the
+    // pre-op absence inconclusive so the tool does NOT fabricate a fresh install.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const contents = pyproject(PANEL_REGISTRY_ID, "0.11.28");
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [pyPath]: contents },
+      reinstallDetails: { total_count: 1, done_count: 1, is_processing: false },
+    });
+    let reads = 0;
+    h.deps.readFile = (p) => {
+      if (p === pyPath) {
+        reads += 1;
+        if (reads === 1) throw new Error("EBUSY transient read failure");
+      }
+      return contents;
+    };
+    await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
+      PanelInstallError,
+    );
   });
 
   it("REFUSES on a dev symlink", async () => {
@@ -340,6 +703,269 @@ describe("runPanelAction", () => {
   });
 });
 
+describe("runPanelAction shadow detection (#641)", () => {
+  const realDir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+  const bakName = ".comfyui-agent-panel.bak-0.11.28";
+  const bakDir = join(CUSTOM_NODES, bakName);
+
+  it("update: a .bak shadow present → throws shadow diagnostic even if version moved", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bakName],
+      files: {
+        [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+        [join(bakDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      // Real dir DOES advance on disk — but the shadow can still win in the browser.
+      onUpdate: ({ files }) => {
+        files[join(realDir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(/shadow/i);
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(bakName);
+  });
+
+  it("update: shadow removed → success", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      onUpdate: ({ files }) => {
+        files[join(realDir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    const r = await runPanelAction("update", h.deps);
+    expect(r.installedVersion).toBe("0.11.32");
+    expect(r.message).toMatch(/updated/i);
+  });
+
+  it("install: a shadow present → throws shadow diagnostic, not success", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bakName],
+      files: { [join(bakDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      onInstall: ({ files }) => {
+        files[join(realDir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    await expect(runPanelAction("install", h.deps)).rejects.toThrow(/shadow/i);
+  });
+
+  it("update: a LONE .bak (no real dir) is not mistaken for canonical → still flagged", async () => {
+    // Only the backup exists. detectPanelInstall must NOT resolve it as the
+    // install, and the shadow check must still fire.
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bakName],
+      files: { [join(bakDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+    });
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(/shadow/i);
+  });
+
+  it("update: fails closed when custom_nodes cannot be enumerated (indeterminate)", async () => {
+    const h = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28") },
+      updateDetails: { total_count: 1, done_count: 1, is_processing: false },
+      onUpdate: ({ files }) => {
+        files[join(realDir, "pyproject.toml")] = pyproject(PANEL_REGISTRY_ID, "0.11.32");
+      },
+    });
+    // ACL that denies directory enumeration but allows direct path access.
+    h.deps.readdir = () => {
+      throw new Error("EACCES: permission denied, scandir");
+    };
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /cannot be confirmed|inspect custom_nodes/i,
+    );
+  });
+});
+
+describe("findPanelShadows (#641)", () => {
+  const realDir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+
+  it("flags a dot-prefixed .bak panel copy (pyproject name match)", () => {
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        [join(CUSTOM_NODES, bak, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+    });
+    const s = findPanelShadows(realDir, deps);
+    expect(s.map((x) => x.name)).toContain(bak);
+    expect(s[0].version).toBe("0.11.28");
+  });
+
+  it("flags a web-only backup by dir name even without a panel pyproject", () => {
+    const bak = ".comfyui-mcp-panel.bak";
+    const { deps } = makeDeps({ comfyuiPath: COMFY, dirs: [bak] });
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(bak);
+  });
+
+  it("flags an editor '~' backup dir (web-only, no pyproject)", () => {
+    const bak = ".comfyui-agent-panel~";
+    const { deps } = makeDeps({ comfyuiPath: COMFY, dirs: [bak] });
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(bak);
+  });
+
+  it("does NOT block on a regular FILE that merely shares a backup name", () => {
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      nonDirEntries: [bak], // it's a FILE, not a served extension dir
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("does NOT flag an unrelated custom node", () => {
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["some-other-node"],
+      files: {
+        [join(CUSTOM_NODES, "some-other-node", "pyproject.toml")]: pyproject("other-pack"),
+      },
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("does NOT false-flag an unrelated panel-adjacent node (comfyui-agent-panel-tools)", () => {
+    const tools = "comfyui-agent-panel-tools";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [tools],
+      files: {
+        [join(CUSTOM_NODES, tools, "pyproject.toml")]: pyproject(tools, "1.0.0"),
+      },
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("does NOT false-flag a HIDDEN unrelated node (.comfyui-agent-panel-tools)", () => {
+    const tools = ".comfyui-agent-panel-tools";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [tools],
+      files: {
+        [join(CUSTOM_NODES, tools, "pyproject.toml")]: pyproject(
+          "comfyui-agent-panel-tools",
+          "1.0.0",
+        ),
+      },
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("does NOT flag the canonical dir itself", () => {
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+    });
+    expect(findPanelShadows(realDir, deps)).toEqual([]);
+  });
+
+  it("FAILS CLOSED (flags) a distinct-case dir when realpath is unavailable", () => {
+    // Without physical identity we cannot prove "ComfyUI-MCP-Panel" is the same
+    // dir as the canonical, so we must NOT case-fold it away — flag it.
+    const preserved = "ComfyUI-MCP-Panel";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [preserved],
+      files: {
+        [join(realDir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(CUSTOM_NODES, preserved, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+      // No realPaths → realPath() returns undefined → fail closed.
+    });
+    expect(findPanelShadows(realDir, deps).map((x) => x.name)).toContain(preserved);
+  });
+
+  it("exempts a preserved-case canonical dir by PHYSICAL identity (same realpath)", () => {
+    const preserved = "ComfyUI-MCP-Panel";
+    const canonical = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const real = "/real/fs/comfyui-mcp-panel";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [preserved],
+      files: {
+        [join(canonical, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(CUSTOM_NODES, preserved, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+      },
+      // Both names resolve to the SAME physical dir (case-insensitive volume).
+      realPaths: {
+        [canonical]: real,
+        [join(CUSTOM_NODES, preserved)]: real,
+      },
+    });
+    expect(findPanelShadows(canonical, deps)).toEqual([]);
+  });
+
+  it("FLAGS a distinct-case coexisting dir (different realpath, case-sensitive volume)", () => {
+    const other = "ComfyUI-MCP-Panel";
+    const canonical = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [other],
+      files: {
+        [join(canonical, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(CUSTOM_NODES, other, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+      // Distinct physical dirs — must NOT be exempted.
+      realPaths: {
+        [canonical]: "/real/fs/comfyui-mcp-panel",
+        [join(CUSTOM_NODES, other)]: "/real/fs/ComfyUI-MCP-Panel",
+      },
+    });
+    expect(findPanelShadows(canonical, deps).map((x) => x.name)).toContain(other);
+  });
+
+  it("throws (indeterminate) when custom_nodes cannot be enumerated", () => {
+    const { deps } = makeDeps({ comfyuiPath: COMFY });
+    deps.readdir = () => {
+      throw new Error("EACCES");
+    };
+    expect(() => findPanelShadows(realDir, deps)).toThrow(/EACCES/);
+  });
+
+  it("returns [] in remote/cloud mode", () => {
+    const { deps } = makeDeps({ comfyuiPath: COMFY, local: false });
+    expect(findPanelShadows(undefined, deps)).toEqual([]);
+  });
+});
+
+describe("looksLikePanelBackupName (#641)", () => {
+  it("flags dot-prefixed and backup-token panel copies", () => {
+    expect(looksLikePanelBackupName(".comfyui-agent-panel.bak-0.11.28")).toBe(true);
+    expect(looksLikePanelBackupName(".comfyui-mcp-panel")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-agent-panel.bak")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-mcp-panel-backup")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-agent-panel.old")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-agent-panel-copy")).toBe(true);
+    expect(looksLikePanelBackupName(".comfyui-agent-panel~")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-mcp-panel~")).toBe(true);
+  });
+
+  it("does NOT flag the canonical names or unrelated extensions", () => {
+    expect(looksLikePanelBackupName("comfyui-mcp-panel")).toBe(false);
+    expect(looksLikePanelBackupName("comfyui-agent-panel")).toBe(false);
+    expect(looksLikePanelBackupName("comfyui-agent-panel-tools")).toBe(false);
+    // A HIDDEN unrelated panel-adjacent node must NOT be flagged by name alone.
+    expect(looksLikePanelBackupName(".comfyui-agent-panel-tools")).toBe(false);
+    expect(looksLikePanelBackupName("some-unrelated-node")).toBe(false);
+  });
+
+  it("flags a HIDDEN exact-name copy but not the plain canonical name", () => {
+    expect(looksLikePanelBackupName(".comfyui-agent-panel")).toBe(true);
+    expect(looksLikePanelBackupName(".comfyui-mcp-panel")).toBe(true);
+    expect(looksLikePanelBackupName("comfyui-agent-panel")).toBe(false);
+  });
+});
+
 describe("panelStatus", () => {
   it("never throws and reports not-applicable in remote/cloud mode", async () => {
     const { deps } = makeDeps({ comfyuiPath: undefined });
@@ -376,5 +1002,275 @@ describe("panelStatus", () => {
     expect(s.installed).toBe(false);
     expect(s.targetVersion).toBe(PANEL_VERSION);
     expect(s.note).toMatch(/install/i);
+  });
+
+  it("#641: reports a shadow copy in the note and shadows[] (never throws)", async () => {
+    const real = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const bak = ".comfyui-agent-panel.bak-0.11.28";
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [bak],
+      files: {
+        [join(real, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32"),
+        [join(CUSTOM_NODES, bak, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.28"),
+      },
+    });
+    const s = await panelStatus(deps);
+    expect(s.installed).toBe(true);
+    expect(s.installedVersion).toBe("0.11.32");
+    expect(s.shadows.map((x) => x.name)).toContain(bak);
+    expect(s.note).toMatch(/shadow/i);
+  });
+
+  it("has an empty shadows[] when there is no backup dir", async () => {
+    const real = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      files: { [join(real, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.32") },
+    });
+    const s = await panelStatus(deps);
+    expect(s.shadows).toEqual([]);
+  });
+});
+
+describe("classifyPanelUpdate (#639 verification core)", () => {
+  const coherent = {
+    total_count: 1,
+    done_count: 1,
+    in_progress_count: 0,
+    pending_count: 0,
+    is_processing: false,
+  };
+  // The stale 3.x no-op the issue reported verbatim.
+  const noOpCounts = {
+    total_count: 0,
+    done_count: 2,
+    in_progress_count: 0,
+    pending_count: 0,
+    is_processing: false,
+  };
+
+  it("version moved → updated", () => {
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "0.11.28", installedVersion: "0.11.32" },
+        coherent,
+      ).outcome,
+    ).toBe("updated");
+  });
+
+  it("git-HEAD moved (version unchanged) → updated", () => {
+    expect(
+      classifyPanelUpdate(
+        {
+          previousVersion: "0.11.32",
+          installedVersion: "0.11.32",
+          previousRev: "aaaa",
+          installedRev: "bbbb",
+        },
+        coherent,
+      ).outcome,
+    ).toBe("updated");
+  });
+
+  it("version unchanged + no-op counts (total 0 / done 2), no git → no-op", () => {
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "0.11.28", installedVersion: "0.11.28" },
+        noOpCounts,
+      ).outcome,
+    ).toBe("no-op");
+  });
+
+  it("version unchanged + done > total incoherence, no git → no-op", () => {
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "1.0.0", installedVersion: "1.0.0" },
+        { total_count: 1, done_count: 5 },
+      ).outcome,
+    ).toBe("no-op");
+  });
+
+  it("identical git-HEAD + no-op counts → no-op (unchanged HEAD is NOT proof of currency)", () => {
+    expect(
+      classifyPanelUpdate(
+        {
+          previousVersion: "0.11.28",
+          installedVersion: "0.11.28",
+          previousRev: "cccc",
+          installedRev: "cccc",
+        },
+        noOpCounts,
+      ).outcome,
+    ).toBe("no-op");
+  });
+
+  it("identical git-HEAD + coherent counts → unverified (never 'already-current')", () => {
+    expect(
+      classifyPanelUpdate(
+        {
+          previousVersion: "0.11.32",
+          installedVersion: "0.11.32",
+          previousRev: "cccc",
+          installedRev: "cccc",
+        },
+        coherent,
+      ).outcome,
+    ).toBe("unverified");
+  });
+
+  it("version unchanged + coherent counts but NO git identity → unverified (not success)", () => {
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "0.11.32", installedVersion: "0.11.32" },
+        coherent,
+      ).outcome,
+    ).toBe("unverified");
+  });
+
+  it("no post-update identity at all → unverified", () => {
+    expect(
+      classifyPanelUpdate({ previousVersion: "1.0.0" }, coherent).outcome,
+    ).toBe("unverified");
+  });
+
+  it("no pre-update baseline → unverified (can't prove a move)", () => {
+    expect(
+      classifyPanelUpdate({ installedVersion: "1.0.0" }, coherent).outcome,
+    ).toBe("unverified");
+  });
+
+  it("version unchanged + no queue evidence + no git → unverified (not success)", () => {
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "1.0.0", installedVersion: "1.0.0" },
+        undefined,
+      ).outcome,
+    ).toBe("unverified");
+    expect(
+      classifyPanelUpdate(
+        { previousVersion: "1.0.0", installedVersion: "1.0.0" },
+        "cm-cli text output",
+      ).outcome,
+    ).toBe("unverified");
+  });
+
+  it("looksLikeManagerNoOp flags total 0 and done>total, not coherent work", () => {
+    expect(looksLikeManagerNoOp({ total_count: 0, done_count: 2 })).toBe(true);
+    expect(looksLikeManagerNoOp({ total_count: 1, done_count: 5 })).toBe(true);
+    expect(looksLikeManagerNoOp({ total_count: 1, done_count: 1 })).toBe(false);
+    expect(looksLikeManagerNoOp({ total_count: 2, done_count: 2 })).toBe(false);
+    expect(looksLikeManagerNoOp(undefined)).toBe(false); // no counts → not a proven no-op
+    expect(looksLikeManagerNoOp("cm-cli text")).toBe(false);
+  });
+
+  it("readQueueCounts ignores non-object details", () => {
+    expect(readQueueCounts(undefined)).toEqual({});
+    expect(readQueueCounts("string")).toEqual({});
+    expect(readQueueCounts({ total_count: 3, done_count: 3 })).toMatchObject({
+      total: 3,
+      done: 3,
+    });
+  });
+});
+
+describe("resolveGitRevision (real fs)", () => {
+  const roots: string[] = [];
+  function newRepo(): string {
+    const root = mkdtempSync(join(tmpdir(), "panel-git-"));
+    roots.push(root);
+    mkdirSync(join(root, ".git"), { recursive: true });
+    return root;
+  }
+  afterAll(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+  });
+
+  const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+  it("resolves a symbolic HEAD via a loose ref", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(root, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(join(root, ".git", "refs", "heads", "main"), `${SHA}\n`);
+    expect(resolveGitRevision(root)).toBe(SHA);
+  });
+
+  it("resolves a symbolic HEAD via packed-refs when no loose ref exists", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/nightly\n");
+    writeFileSync(
+      join(root, ".git", "packed-refs"),
+      `# pack-refs with: peeled fully-peeled sorted\n${SHA} refs/heads/nightly\n`,
+    );
+    expect(resolveGitRevision(root)).toBe(SHA);
+  });
+
+  it("resolves a detached HEAD (inline sha)", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), `${SHA}\n`);
+    expect(resolveGitRevision(root)).toBe(SHA);
+  });
+
+  it("resolves a SHA-256 (64-char) object id", () => {
+    const sha256 = "a".repeat(64);
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(root, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(join(root, ".git", "refs", "heads", "main"), `${sha256}\n`);
+    expect(resolveGitRevision(root)).toBe(sha256);
+  });
+
+  it("follows a .git FILE pointer (worktree/submodule layout)", () => {
+    const root = newRepo();
+    // Real git dir lives elsewhere; .git is a file pointing at it.
+    const realGit = mkdtempSync(join(tmpdir(), "panel-gitdir-"));
+    roots.push(realGit);
+    writeFileSync(join(realGit, "HEAD"), `${SHA}\n`);
+    // Overwrite .git as a FILE pointer (rm the dir first).
+    rmSync(join(root, ".git"), { recursive: true, force: true });
+    writeFileSync(join(root, ".git"), `gitdir: ${realGit}\n`);
+    expect(resolveGitRevision(root)).toBe(SHA);
+  });
+
+  it("resolves a linked worktree ref via commondir (shared refs)", () => {
+    const root = newRepo();
+    // Per-worktree gitdir holds HEAD + commondir; shared refs live in commondir.
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+    const common = mkdtempSync(join(tmpdir(), "panel-common-"));
+    roots.push(common);
+    writeFileSync(join(root, ".git", "commondir"), `${common}\n`);
+    mkdirSync(join(common, "refs", "heads"), { recursive: true });
+    writeFileSync(join(common, "refs", "heads", "main"), `${SHA}\n`);
+    expect(resolveGitRevision(root)).toBe(SHA);
+  });
+
+  it("returns undefined for a non-git dir (never throws)", () => {
+    const root = mkdtempSync(join(tmpdir(), "panel-nogit-"));
+    roots.push(root);
+    expect(resolveGitRevision(root)).toBeUndefined();
+  });
+
+  it("returns undefined for a NON-sha loose ref (transient/corrupt), never a fake sha", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(root, ".git", "refs", "heads"), { recursive: true });
+    // Transient garbage / symbolic content — must NOT be treated as a commit sha.
+    writeFileSync(join(root, ".git", "refs", "heads", "main"), "ref: refs/heads/other\n");
+    expect(resolveGitRevision(root)).toBeUndefined();
+  });
+
+  it("returns undefined for a detached HEAD that isn't a sha", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "updating\n");
+    expect(resolveGitRevision(root)).toBeUndefined();
+  });
+
+  it("rejects an ABBREVIATED (truncated) hex id — only full 40/64 accepted", () => {
+    const root = newRepo();
+    writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(root, ".git", "refs", "heads"), { recursive: true });
+    writeFileSync(join(root, ".git", "refs", "heads", "main"), "deadbee\n"); // 7 hex
+    expect(resolveGitRevision(root)).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,13 @@ function ensurePanelOnLoad(): void {
         case "skipped":
           logger.debug("Panel auto-install: disabled via COMFYUI_MCP_PANEL_AUTOINSTALL.", res);
           break;
+        case "shadowed":
+          logger.warn(
+            "Panel auto-install: a SHADOW copy in custom_nodes may be served instead of the real panel (#641). " +
+              "Move the backup dir OUT of custom_nodes and hard-refresh the ComfyUI tab.",
+            res,
+          );
+          break;
         default:
           logger.debug("Panel auto-install: unavailable.", res);
       }

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -17,8 +17,15 @@
 //   - install/update/reinstall queue via ComfyUI-Manager; ComfyUI must be
 //     RESTARTED to load the new/updated node (we never auto-restart).
 
-import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { basename, isAbsolute, join } from "node:path";
 import { config, isLocalMode } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { parsePyproject } from "./node-authoring.js";
@@ -73,13 +80,103 @@ export interface PanelInstallerDeps {
   existsSync: (p: string) => boolean;
   /** True when `p` is a symlink/junction (dev install). Never throws. */
   isSymlink: (p: string) => boolean;
+  /** True when `p` is a directory (following symlinks). Never throws. */
+  isDirectory: (p: string) => boolean;
+  /**
+   * Canonical physical path of `p` (resolves symlinks + the real on-disk case),
+   * or undefined if it can't be resolved. Used to decide whether two entries are
+   * the SAME directory independent of case-sensitivity quirks. Never throws.
+   */
+  realPath: (p: string) => string | undefined;
   readdir: (p: string) => string[];
   readFile: (p: string) => string;
+  /**
+   * Resolve the git commit sha the pack dir's checkout is currently at (HEAD),
+   * or undefined if it isn't a git checkout / can't be resolved. Used to detect
+   * a `nightly` (git-HEAD) update that advanced the COMMIT without bumping the
+   * pyproject version string. Never throws.
+   */
+  gitRevision: (dir: string) => string | undefined;
   /** Is the target ComfyUI reachable right now? Never throws. */
   isReachable: () => Promise<boolean>;
   install: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
   update: (opts: { id: string }) => Promise<NodeOpResult>;
   reinstall: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
+}
+
+/**
+ * Resolve the current commit sha of a git checkout at `dir` by reading its
+ * `.git` metadata directly (no subprocess). Handles a normal `.git/` dir, a
+ * `.git` FILE pointer (worktrees/submodules: `gitdir: <path>`), a symbolic HEAD
+ * (`ref: refs/heads/<branch>`) resolved via loose refs then `packed-refs`, and a
+ * detached HEAD (raw sha). Returns undefined and NEVER throws on any failure.
+ */
+export function resolveGitRevision(dir: string): string | undefined {
+  const read = (p: string): string | undefined => {
+    try {
+      return readFileSync(p, "utf-8");
+    } catch {
+      return undefined;
+    }
+  };
+  try {
+    let base = join(dir, ".git");
+    let st;
+    try {
+      st = lstatSync(base);
+    } catch {
+      return undefined;
+    }
+    if (st.isFile()) {
+      const pointer = (read(base) ?? "").trim();
+      const m = pointer.match(/^gitdir:\s*(.+)$/);
+      if (!m) return undefined;
+      base = isAbsolute(m[1]) ? m[1] : join(dir, m[1]);
+    }
+    const head = (read(join(base, "HEAD")) ?? "").trim();
+    if (!head) return undefined;
+    const refM = head.match(/^ref:\s*(.+)$/);
+    if (!refM) {
+      // Detached HEAD → the sha is inline.
+      // A FULL SHA-1 (40) or SHA-256 (64) object id — never a truncated value.
+      return /^([0-9a-f]{40}|[0-9a-f]{64})$/i.test(head) ? head : undefined;
+    }
+    const refPath = refM[1].trim();
+    // A resolved ref value must be a real commit sha — never return transient or
+    // symbolic content (e.g. "ref: ...", "updating") that would look like a
+    // spurious HEAD move and fabricate a successful update.
+    const asSha = (v: string | undefined): string | undefined => {
+      const t = (v ?? "").trim();
+      // FULL SHA-1 (40) or SHA-256 (64) only — reject truncated/abbreviated ids.
+      return /^([0-9a-f]{40}|[0-9a-f]{64})$/i.test(t) ? t : undefined;
+    };
+    // A linked worktree keeps HEAD in its per-worktree gitdir but the shared refs
+    // (loose + packed-refs) in `commondir`. Search the gitdir first, then it.
+    const searchDirs = [base];
+    const commondir = (read(join(base, "commondir")) ?? "").trim();
+    if (commondir) {
+      searchDirs.push(isAbsolute(commondir) ? commondir : join(base, commondir));
+    }
+    for (const d of searchDirs) {
+      const loose = asSha(read(join(d, refPath)));
+      if (loose) return loose;
+      const packed = read(join(d, "packed-refs"));
+      if (packed) {
+        for (const line of packed.split(/\r?\n/)) {
+          if (!line || line.startsWith("#") || line.startsWith("^")) continue;
+          const sp = line.indexOf(" ");
+          if (sp <= 0) continue;
+          if (line.slice(sp + 1).trim() === refPath) {
+            const sha = asSha(line.slice(0, sp));
+            if (sha) return sha;
+          }
+        }
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export const defaultDeps: PanelInstallerDeps = {
@@ -94,8 +191,25 @@ export const defaultDeps: PanelInstallerDeps = {
       return false;
     }
   },
+  isDirectory: (p) => {
+    try {
+      // statSync follows symlinks: a dir symlink IS web-served, so it counts.
+      return statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  realPath: (p) => {
+    try {
+      // .native returns the real on-disk case on Windows/macOS.
+      return realpathSync.native(p);
+    } catch {
+      return undefined;
+    }
+  },
   readdir: (p) => readdirSync(p),
   readFile: (p) => readFileSync(p, "utf-8"),
+  gitRevision: (dir) => resolveGitRevision(dir),
   isReachable: async () => {
     try {
       await getSystemStats();
@@ -121,8 +235,22 @@ export interface PanelDetection {
   dir?: string;
   /** Installed version, read from the matched dir's pyproject.toml. */
   version?: string;
+  /**
+   * Current git commit sha of the matched dir's checkout (if it is one). Lets an
+   * `update` detect a `nightly` git-HEAD advance that did NOT bump the version
+   * string, and prove a genuine no-change (identical pre/post sha).
+   */
+  gitRev?: string;
   /** The matched dir is a symlink/junction → dev install, manage manually. */
   isDevSymlink: boolean;
+  /**
+   * False when the pre-op inspection was INCONCLUSIVE — the custom_nodes
+   * enumeration failed, OR a candidate's pyproject existed but could not be
+   * read/parsed (it might be the panel we failed to read). A `installed: false`
+   * verdict is then NOT a proven absence, so action paths must not treat it as a
+   * fresh-install (absent→present) baseline — that would fabricate success.
+   */
+  scanReliable?: boolean;
 }
 
 /**
@@ -160,18 +288,28 @@ export async function detectPanelInstall(
           version = undefined;
         }
       }
-      return { applicable: true, installed: true, dir, version, isDevSymlink: true };
+      return {
+        applicable: true,
+        installed: true,
+        dir,
+        version,
+        gitRev: deps.gitRevision(dir),
+        isDevSymlink: true,
+      };
     }
   }
 
   // Candidate dirs: fast-path names first, then any other subdir.
   const candidates: string[] = FAST_PATH_DIRS.map((n) => join(customNodes, n));
+  let scanReliable = true;
   if (deps.existsSync(customNodes)) {
     let entries: string[] = [];
     try {
       entries = deps.readdir(customNodes);
     } catch {
+      // Enumeration FAILED — a "not installed" verdict from here is unreliable.
       entries = [];
+      scanReliable = false;
     }
     for (const e of entries) {
       const full = join(customNodes, e);
@@ -180,12 +318,22 @@ export async function detectPanelInstall(
   }
 
   for (const dir of candidates) {
+    // Never resolve a backup/copy-shaped dir (e.g. ".comfyui-agent-panel.bak-*")
+    // as the canonical install — it is a shadow, handled by findPanelShadows
+    // (#641). The FAST_PATH canonical names are never backup-shaped.
+    if (looksLikePanelBackupName(basename(dir))) continue;
     const pyproject = join(dir, "pyproject.toml");
     if (!deps.existsSync(pyproject)) continue;
     let parsed: { projectName?: string; version?: string };
     try {
       parsed = parsePyproject(deps.readFile(pyproject));
     } catch {
+      // A candidate pyproject EXISTS but could not be read/parsed — this dir
+      // MIGHT be the panel we failed to read. A resulting "not installed" verdict
+      // is therefore NOT conclusive: mark the scan unreliable so callers don't
+      // treat it as a proven absence (which would fabricate an absent→present
+      // install). Read reliability is folded into scanReliable.
+      scanReliable = false;
       continue;
     }
     if (parsed.projectName === PANEL_REGISTRY_ID) {
@@ -194,12 +342,213 @@ export async function detectPanelInstall(
         installed: true,
         dir,
         version: parsed.version,
+        gitRev: deps.gitRevision(dir),
         isDevSymlink: deps.isSymlink(dir),
+        scanReliable,
       };
     }
   }
 
-  return { applicable: true, installed: false, isDevSymlink: false };
+  return { applicable: true, installed: false, isDevSymlink: false, scanReliable };
+}
+
+// ---------------------------------------------------------------------------
+// Shadow detection (#641)
+//
+// ComfyUI serves EVERY directory under custom_nodes as a web extension —
+// INCLUDING dot-prefixed ones (the Python node loader skips dotdirs, but the web
+// server does NOT). So a leftover backup like `.comfyui-agent-panel.bak-0.11.28`
+// is served live at /extensions/.comfyui-agent-panel.bak-0.11.28/... and, because
+// "." sorts before "c", can WIN registration and shadow the real panel. The disk
+// pyproject of the canonical dir then reads the new version while the browser
+// keeps loading the old one — a silent fabricated-success just like the #639
+// no-op. We scan custom_nodes for ANY panel-serving dir other than the canonical
+// install and fail closed when one exists.
+// ---------------------------------------------------------------------------
+
+export interface PanelShadow {
+  /** custom_nodes subdir name (e.g. ".comfyui-agent-panel.bak-0.11.28"). */
+  name: string;
+  /** Version read from its pyproject, if any. */
+  version?: string;
+}
+
+/** Canonical panel dir basenames — a legitimate install lives at one of these. */
+function isCanonicalPanelName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (FAST_PATH_DIRS as readonly string[]).some((n) => n === lower);
+}
+
+/**
+ * Whether two paths are the SAME on-disk directory, by PHYSICAL identity:
+ * realpath resolves symlinks + the real filesystem case, which is authoritative
+ * regardless of case-sensitivity. On a case-INSENSITIVE volume "ComfyUI-MCP-Panel"
+ * and "comfyui-mcp-panel" resolve to the same real path (one dir → exempt the
+ * canonical); on a case-SENSITIVE volume (Linux, or a case-sensitive APFS/macOS
+ * volume) they resolve to DISTINCT real paths (two dirs → never exempt the
+ * shadow). When realpath cannot resolve EITHER side, physical identity is
+ * unknown, so we FAIL CLOSED and exempt only an EXACT string match — never
+ * case-fold a possibly-distinct directory into the canonical.
+ */
+function samePathCI(
+  a: string | undefined,
+  b: string | undefined,
+  deps: PanelInstallerDeps,
+): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const ra = deps.realPath(a);
+  const rb = deps.realPath(b);
+  if (ra && rb) return ra === rb; // authoritative physical identity
+  // realpath unavailable → can't prove identity → only exact-equal is "same".
+  return false;
+}
+
+/**
+ * A dir NAME that looks like a leftover panel copy/backup — the shadowing trap
+ * from #641. The name must START WITH a canonical panel base name (after an
+ * optional leading dot) and then be EITHER exactly that name while hidden (a
+ * dot-prefixed copy of the real panel) OR followed by a backup/copy token.
+ * Deliberately NARROW: an unrelated extension like "comfyui-agent-panel-tools"
+ * (or a hidden ".comfyui-agent-panel-tools") must NOT match — those are caught
+ * only by an exact pyproject `name` == comfyui-agent-panel test elsewhere.
+ */
+export function looksLikePanelBackupName(name: string): boolean {
+  const hidden = name.startsWith(".");
+  const core = (hidden ? name.slice(1) : name).toLowerCase();
+  const base = (FAST_PATH_DIRS as readonly string[]).find(
+    (n) => core === n || core.startsWith(n),
+  );
+  if (!base) return false;
+  const rest = core.slice(base.length);
+  // Exactly a canonical name: a HIDDEN copy (".comfyui-agent-panel") shadows the
+  // real panel; a plain "comfyui-agent-panel" IS the real install (not a backup).
+  if (rest === "") return hidden;
+  // An editor "~" backup suffix (e.g. ".comfyui-agent-panel~") is a backup.
+  if (rest.includes("~") || name.includes("~")) return true;
+  // Otherwise the remainder must be a backup/copy suffix, not a different node.
+  return /^[._-](bak|backup|old|copy|orig|save|prev|previous)([._-]|\d|$)/i.test(rest);
+}
+
+/**
+ * Find panel-serving dirs under custom_nodes that would SHADOW the canonical
+ * install — any dir (other than the true canonical) whose pyproject `name` is
+ * the panel, OR whose basename is backup/copy-shaped (covers web-only backups
+ * that dropped pyproject). LOCAL-only.
+ *
+ * THROWS if custom_nodes exists but cannot be enumerated: shadow inspection is
+ * then INDETERMINATE and the ACTION paths must fail closed rather than assume
+ * "no shadow". (panelStatus wraps this and stays non-throwing.)
+ */
+export function findPanelShadows(
+  canonicalDir: string | undefined,
+  deps: PanelInstallerDeps = defaultDeps,
+): PanelShadow[] {
+  const comfyPath = deps.comfyuiPath();
+  if (!deps.isLocalMode() || !comfyPath) return [];
+  const customNodes = join(comfyPath, "custom_nodes");
+  if (!deps.existsSync(customNodes)) return [];
+
+  // Intentionally NOT swallowed — a failed enumeration is indeterminate, not
+  // proof of "no shadows". Callers decide how to handle it.
+  const entries = deps.readdir(customNodes);
+
+  const shadows: PanelShadow[] = [];
+  for (const name of entries) {
+    const dir = join(customNodes, name);
+    // ComfyUI serves DIRECTORIES as web extensions — a regular file that happens
+    // to share the name is not served and must not block actions.
+    if (!deps.isDirectory(dir)) continue;
+    const isBackup = looksLikePanelBackupName(name);
+    // Exempt the ONE true canonical install (physical identity). A backup-shaped
+    // name is NEVER exempted, even if it was (mis)selected as canonicalDir.
+    if (!isBackup && samePathCI(dir, canonicalDir, deps)) continue;
+    // With no canonical resolved, don't flag a canonically-NAMED dir (it is most
+    // likely the real install). Backup-shaped names are still flagged.
+    if (!isBackup && !canonicalDir && isCanonicalPanelName(name)) continue;
+
+    let isPanelCopy = isBackup;
+    let version: string | undefined;
+    const pyproject = join(dir, "pyproject.toml");
+    if (deps.existsSync(pyproject)) {
+      try {
+        const parsed = parsePyproject(deps.readFile(pyproject));
+        if (parsed.projectName === PANEL_REGISTRY_ID) {
+          isPanelCopy = true;
+          version = parsed.version;
+        }
+      } catch {
+        // ignore — rely on the backup-name heuristic
+      }
+    }
+    if (isPanelCopy) shadows.push({ name, version });
+  }
+  return shadows;
+}
+
+/** Fail closed when a shadowing panel dir exists (used by install/update/reinstall). */
+function assertNoPanelShadow(
+  action: string,
+  canonicalDir: string | undefined,
+  deps: PanelInstallerDeps,
+): void {
+  let shadows: PanelShadow[];
+  try {
+    shadows = findPanelShadows(canonicalDir, deps);
+  } catch (err) {
+    // Indeterminate: we could not enumerate custom_nodes, so we CANNOT rule out a
+    // shadowing backup. Fail closed rather than fabricate success.
+    throw new PanelInstallError(
+      `Panel ${action} cannot be confirmed: unable to inspect custom_nodes for ` +
+        `shadowing panel copies (${err instanceof Error ? err.message : String(err)}). ` +
+        `A leftover backup dir there could shadow the real panel in the browser ` +
+        `(#641). NOT reporting success — check custom_nodes for stray panel copies ` +
+        `(especially dot-prefixed ".comfyui-agent-panel.bak-*"), then retry.`,
+    );
+  }
+  if (shadows.length === 0) return;
+  const names = shadows
+    .map((s) => `"${s.name}"${s.version ? ` (${s.version})` : ""}`)
+    .join(", ");
+  throw new PanelInstallError(
+    `Panel ${action} cannot be confirmed: a SHADOW copy of the panel exists in ` +
+      `custom_nodes — ${names}. ComfyUI serves EVERY dir under custom_nodes as a web ` +
+      `extension (including dot-prefixed ones the node loader hides), and such a ` +
+      `copy can WIN registration by sort order (e.g. ".comfyui-agent-panel.bak-*" ` +
+      `sorts before "comfyui-agent-panel"), so the BROWSER may keep loading the old ` +
+      `panel even though the real dir on disk is up to date (#641). NOT reporting ` +
+      `success. Remove or MOVE the offending dir OUT of custom_nodes (e.g. to a temp ` +
+      `folder), then hard-refresh the ComfyUI tab. A backup belongs anywhere EXCEPT ` +
+      `under custom_nodes.`,
+  );
+}
+
+/**
+ * Non-throwing shadow describe for the fire-and-forget on-load ensure. Returns a
+ * human warning when a shadow exists OR the inspection was indeterminate, else
+ * undefined. (The explicit tool paths use the throwing assertNoPanelShadow.)
+ */
+function describePanelShadow(
+  canonicalDir: string | undefined,
+  deps: PanelInstallerDeps,
+): string | undefined {
+  let shadows: PanelShadow[];
+  try {
+    shadows = findPanelShadows(canonicalDir, deps);
+  } catch (err) {
+    return (
+      `could not inspect custom_nodes for shadowing panel copies ` +
+      `(${err instanceof Error ? err.message : String(err)}) — a stray ` +
+      `".comfyui-agent-panel.bak-*" there could shadow the panel in the browser (#641)`
+    );
+  }
+  if (shadows.length === 0) return undefined;
+  const names = shadows.map((s) => `"${s.name}"`).join(", ");
+  return (
+    `${shadows.length} shadow copy/copies in custom_nodes (${names}) are ALSO ` +
+    `web-served and can win registration by sort order — the browser may load the ` +
+    `OLD panel. Move them OUT of custom_nodes, then hard-refresh the ComfyUI tab (#641)`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -211,6 +560,7 @@ export type EnsureAction =
   | "up-to-date"
   | "skipped-dev"
   | "skipped"
+  | "shadowed" // installed/present, but a #641 shadow copy will win in the browser
   | "unavailable";
 
 export interface EnsureResult {
@@ -288,16 +638,64 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
   }
 
   if (!detection.installed) {
+    // #639 — if the pre-op enumeration FAILED, "not installed" is unreliable: a
+    // pre-existing panel in a non-fast-path dir may have been missed. Installing
+    // blind risks a duplicate (shadow), and we could not honestly claim a fresh
+    // install, so skip and report unavailable rather than fabricate "installed".
+    if (detection.scanReliable === false) {
+      return {
+        action: "unavailable",
+        reason:
+          "Could not enumerate custom_nodes to confirm the panel is missing; " +
+          "skipping auto-install to avoid a duplicate/unverified install.",
+      };
+    }
     await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+    // #639 — VERIFY it actually landed (fresh re-read); never log "installed"
+    // from the Manager result alone (a stale 3.x no-op drains the queue trivially).
+    const post = await detectPanelInstall(deps);
+    if (!post.installed || !post.version) {
+      return {
+        action: "unavailable",
+        reason:
+          `Panel auto-install could not be verified on disk — ComfyUI-Manager ` +
+          `reported the queue drained but the pack is not present. Likely a stale ` +
+          `ComfyUI-Manager 3.x no-op (#639/#424). Install the panel from source or ` +
+          `update ComfyUI-Manager, then restart ComfyUI.`,
+      };
+    }
+    // #641 — a shadow copy would make the browser load the wrong panel.
+    const shadow = describePanelShadow(post.dir, deps);
+    if (shadow) {
+      return {
+        action: "shadowed",
+        reason: `Installed ${PANEL_REGISTRY_ID} (${post.version}) but ${shadow}.`,
+        dir: post.dir,
+        installedVersion: post.version,
+        restartRequired: true,
+      };
+    }
     return {
       action: "installed",
-      reason: `Installed ${PANEL_REGISTRY_ID} (${PANEL_VERSION}).`,
+      reason: `Installed ${PANEL_REGISTRY_ID} (${post.version}).`,
+      dir: post.dir,
+      installedVersion: post.version,
       restartRequired: true,
     };
   }
 
   // Present already. We never diff nightly on load (no clean version), so we
-  // leave it untouched — the explicit `update` action refreshes on demand.
+  // leave it untouched — the explicit `update` action refreshes on demand. But a
+  // #641 shadow copy still mis-serves the panel, so surface it if present.
+  const shadow = describePanelShadow(detection.dir, deps);
+  if (shadow) {
+    return {
+      action: "shadowed",
+      reason: shadow,
+      dir: detection.dir,
+      installedVersion: detection.version,
+    };
+  }
   return {
     action: "up-to-date",
     dir: detection.dir,
@@ -338,6 +736,12 @@ export interface PanelStatus {
   installedVersion?: string;
   isDevSymlink: boolean;
   targetVersion: string;
+  /**
+   * #641 — other panel-serving dirs under custom_nodes that SHADOW the real
+   * install in the browser (e.g. a ".comfyui-agent-panel.bak-*" backup). When
+   * non-empty, the SERVED panel may not match `installedVersion` on disk.
+   */
+  shadows: PanelShadow[];
   note: string;
 }
 
@@ -349,6 +753,27 @@ export async function panelStatus(
     () =>
       ({ applicable: false, installed: false, isDevSymlink: false }) as PanelDetection,
   );
+
+  let shadows: PanelShadow[] = [];
+  let shadowInspectFailed = false;
+  if (detection.applicable) {
+    try {
+      shadows = findPanelShadows(detection.dir, deps);
+    } catch {
+      shadowInspectFailed = true;
+    }
+  }
+  const shadowNote = shadowInspectFailed
+    ? ` NOTE (#641): could not enumerate custom_nodes to check for shadowing panel ` +
+      `backups — a stray ".comfyui-agent-panel.bak-*" there could shadow the real ` +
+      `panel in the browser. Check manually.`
+    : shadows.length > 0
+      ? ` WARNING (#641): ${shadows.length} shadow copy/copies in custom_nodes (${shadows
+          .map((s) => `"${s.name}"`)
+          .join(", ")}) are ALSO served as web extensions and may shadow the real ` +
+        `panel in the browser (dot-prefixed dirs win by sort order). Remove/move ` +
+        `them OUT of custom_nodes, then hard-refresh the ComfyUI tab.`
+      : "";
 
   let note: string;
   if (!detection.applicable) {
@@ -372,15 +797,198 @@ export async function panelStatus(
     installedVersion: detection.version,
     isDevSymlink: detection.isDevSymlink,
     targetVersion: PANEL_VERSION,
-    note,
+    shadows,
+    note: note + shadowNote,
   };
 }
 
 export interface PanelActionResult {
   action: "install" | "update" | "reinstall";
   result: NodeOpResult;
-  restartRequired: true;
+  restartRequired: boolean;
   message: string;
+  /** update only — installed version read from disk BEFORE the op (if known). */
+  previousVersion?: string;
+  /** update only — installed version RE-READ from disk AFTER the op (if known). */
+  installedVersion?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Update verification (#639)
+//
+// ComfyUI-Manager reports its queue "drained" as soon as done_count >= total_count
+// (see runManagerQueue). A stale/legacy Manager 3.x returns total_count:0 with a
+// non-zero done_count — the drain check passes TRIVIALLY (2 >= 0) while nothing is
+// ever enqueued, so the pack on disk is untouched. Trusting that signal as proof
+// of work is the silent fabricate-success bug (#639, same root cause as #424).
+//
+// The fix: after an `update`, RE-READ the installed identity fresh from disk (the
+// pyproject version AND the git-HEAD sha) and require PROVEN movement to claim
+// success. Nothing moved → fail closed. Never trust the Manager counts as proof
+// of work (they are queue-wide, not task-correlated); they only sharpen the
+// failure diagnostic. Shadow copies (#641) are checked separately.
+// ---------------------------------------------------------------------------
+
+interface QueueCounts {
+  total?: number;
+  done?: number;
+  inProgress?: number;
+  pending?: number;
+  processing?: boolean;
+}
+
+/**
+ * Best-effort extraction of ComfyUI-Manager queue counts from a NodeOpResult's
+ * raw `details`. Returns `{}` when `details` isn't a manager-http queue status
+ * object (e.g. the cm-cli path returns a string). Never throws.
+ */
+export function readQueueCounts(details: unknown): QueueCounts {
+  if (!details || typeof details !== "object") return {};
+  const d = details as Record<string, unknown>;
+  const num = (v: unknown) => (typeof v === "number" ? v : undefined);
+  return {
+    total: num(d.total_count),
+    done: num(d.done_count),
+    inProgress: num(d.in_progress_count),
+    pending: num(d.pending_count),
+    processing: typeof d.is_processing === "boolean" ? (d.is_processing as boolean) : undefined,
+  };
+}
+
+/**
+ * The stale ComfyUI-Manager 3.x silent no-op signature: the queue "drained" but
+ * the requested task was never really run. Either nothing was ever enqueued
+ * (total_count:0 — the drain check `done >= total` passes trivially) or the
+ * counts are incoherent (done > total, impossible in a real queue). These are
+ * NEVER produced by a task that actually executed, so they are a safe FAILURE
+ * signal (used only to fail closed / sharpen diagnostics, never to claim work).
+ */
+export function looksLikeManagerNoOp(details: unknown): boolean {
+  const c = readQueueCounts(details);
+  const nothingEnqueued = c.total === 0;
+  const incoherent =
+    c.total !== undefined && c.done !== undefined && c.done > c.total;
+  return nothingEnqueued || incoherent;
+}
+
+export type UpdateOutcome =
+  | "updated" // version OR git-HEAD moved on disk → the update definitely applied.
+  | "no-op" // nothing moved AND Manager shows the stale-3.x no-op signature.
+  | "unverified"; // nothing provably moved / can't read post identity — fail closed.
+
+export interface UpdateVerdict {
+  outcome: UpdateOutcome;
+  previousVersion?: string;
+  installedVersion?: string;
+  previousRev?: string;
+  installedRev?: string;
+  counts: QueueCounts;
+}
+
+export interface PanelUpdateIdentity {
+  previousVersion?: string;
+  installedVersion?: string;
+  previousRev?: string;
+  installedRev?: string;
+}
+
+/**
+ * Decide whether an `update` actually advanced the panel on disk. Heart of the
+ * #639 fix.
+ *
+ * SUCCESS REQUIRES PROVEN MOVEMENT. We compare the pre/post ON-DISK identity —
+ * the pyproject version AND the git-HEAD commit sha (post RE-READ fresh from
+ * disk, never cached) — and only report `updated` when one of them actually
+ * MOVED. The panel tracks the `nightly` (git-HEAD) channel, so a commit can
+ * advance WITHOUT a version bump; a moved sha therefore also counts as updated.
+ *
+ * Crucially, an UNCHANGED local git-HEAD is NOT proof of being current: it only
+ * proves nothing was pulled locally — which is exactly the #639 no-op. Local
+ * HEAD says nothing about the upstream tip, so we never treat "HEAD unchanged"
+ * as success. When nothing moved we fail closed: `no-op` when the Manager counts
+ * show the stale-3.x signature (total_count:0, or the incoherent done>total), and
+ * `unverified` otherwise. The queue counts are queue-WIDE drain counters (not
+ * correlated to this task), so they are used ONLY to sharpen the FAILURE
+ * diagnostic — NEVER as positive proof that work happened.
+ */
+export function classifyPanelUpdate(
+  identity: PanelUpdateIdentity,
+  details: unknown,
+): UpdateVerdict {
+  const { previousVersion, installedVersion, previousRev, installedRev } = identity;
+  const counts = readQueueCounts(details);
+  const base = { ...identity, counts };
+
+  // Can't read ANY post-update identity → cannot confirm anything landed.
+  if (!installedVersion && !installedRev) {
+    return { ...base, outcome: "unverified" };
+  }
+
+  // Something moved on disk (version bump OR git-HEAD advance) → update applied.
+  const versionMoved =
+    !!previousVersion && !!installedVersion && installedVersion !== previousVersion;
+  const revMoved = !!previousRev && !!installedRev && installedRev !== previousRev;
+  if (versionMoved || revMoved) return { ...base, outcome: "updated" };
+
+  // Nothing provably moved. Use the Manager counts ONLY to name the failure:
+  // the stale-3.x no-op signature → the reported no-op; otherwise we simply
+  // couldn't confirm.
+  if (looksLikeManagerNoOp(details)) return { ...base, outcome: "no-op" };
+
+  return { ...base, outcome: "unverified" };
+}
+
+/** Turn an update verdict into an honest result — or throw when it did not apply. */
+function finalizeUpdate(
+  verdict: UpdateVerdict,
+  post: PanelDetection,
+  result: NodeOpResult,
+): PanelActionResult {
+  const { outcome, previousVersion, installedVersion, counts } = verdict;
+  const dirNote = post.dir ? ` at ${post.dir}` : "";
+
+  if (outcome === "updated") {
+    const from = verdict.previousVersion ?? verdict.previousRev?.slice(0, 8) ?? "?";
+    const to = verdict.installedVersion ?? verdict.installedRev?.slice(0, 8) ?? "?";
+    return {
+      action: "update",
+      result,
+      restartRequired: true,
+      message:
+        `Panel updated (${from} → ${to}) via ComfyUI-Manager (${PANEL_VERSION}). ` +
+        `RESTART ComfyUI to load the updated panel node.`,
+      previousVersion,
+      installedVersion,
+    };
+  }
+
+  // Nothing provably moved → NEVER report success. An unchanged local git-HEAD /
+  // version cannot distinguish "already at the upstream tip" from "the update
+  // silently no-op'd", so we fail closed with an honest, actionable diagnostic.
+  if (outcome === "no-op") {
+    throw new PanelInstallError(
+      `Panel update did NOT apply: nothing changed on disk${dirNote} (installed ` +
+        `version still ${previousVersion ?? "unknown"}) after ComfyUI-Manager ` +
+        `reported the queue drained. Manager reported done_count=` +
+        `${counts.done ?? "?"} with total_count=${counts.total ?? "?"} — it never ` +
+        `actually enqueued the update. This is the stale ComfyUI-Manager 3.x silent ` +
+        `no-op (#639, same root cause as #424). Fix: update ComfyUI-Manager on the ` +
+        `host (git pull in custom_nodes/ComfyUI-Manager, or pip install -U ` +
+        `comfyui_manager) and retry, or reinstall the panel from source (git pull ` +
+        `the panel dir / reinstall the pack), then RESTART ComfyUI.`,
+    );
+  }
+
+  // unverified — no proof it advanced, and no clear no-op signature either.
+  throw new PanelInstallError(
+    `Could not verify the panel update applied: the installed version ` +
+      `(${installedVersion ?? "unreadable"}) and git-HEAD did not change` +
+      `${dirNote} after ComfyUI-Manager reported the queue drained. NOT reporting ` +
+      `success — an unchanged checkout can't prove you are at the latest nightly ` +
+      `versus a silent no-op. You may already be current; otherwise ComfyUI-Manager ` +
+      `may be stale (#424). RESTART ComfyUI and re-check the version, or reinstall ` +
+      `the panel from source.`,
+  );
 }
 
 /**
@@ -417,13 +1025,113 @@ export async function runPanelAction(
     );
   }
 
-  let result: NodeOpResult;
-  if (action === "install") {
-    result = await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
-  } else if (action === "update") {
-    result = await deps.update({ id: PANEL_REGISTRY_ID });
-  } else {
-    result = await deps.reinstall({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+  // Capture the on-disk identity BEFORE the op (from the guard detection we just
+  // did — read fresh, not cached elsewhere).
+  const wasPresent = detection.installed;
+  const previousVersion = detection.version;
+  const previousRev = detection.gitRev;
+
+  if (action === "update") {
+    const result = await deps.update({ id: PANEL_REGISTRY_ID });
+    // #639 — VERIFY the update actually advanced the pack. Re-read the installed
+    // identity FRESH from disk (never trust Manager's queue-drained signal, nor
+    // any value captured before the op), then classify honestly.
+    const post = await detectPanelInstall(deps);
+    // #641 — a shadowing copy makes the SERVED panel differ from post.version, so
+    // even a real version advance is a fabricated success. Fail closed first.
+    assertNoPanelShadow(action, post.dir, deps);
+    // #639 req — the installed VERSION must be readable post-update, else we
+    // cannot verify the applied version (fail closed; never trust a HEAD move
+    // alone when the pyproject version can't be read).
+    if (!post.installed || !post.version) {
+      throw new PanelInstallError(
+        `Could not verify the panel update applied: the pack is ${
+          post.installed ? "present but its version is unreadable" : "not present"
+        } after ComfyUI-Manager reported the queue drained. NOT reporting success. ` +
+          `Re-check the pack and retry, or reinstall the panel from source, then ` +
+          `RESTART ComfyUI.`,
+      );
+    }
+    const verdict = classifyPanelUpdate(
+      {
+        previousVersion,
+        installedVersion: post.version,
+        previousRev,
+        installedRev: post.gitRev,
+      },
+      result.details,
+    );
+    return finalizeUpdate(verdict, post, result);
+  }
+
+  // install / reinstall.
+  const result =
+    action === "install"
+      ? await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION })
+      : await deps.reinstall({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+
+  // #639 — VERIFY the pack afterward. installCustomNode verifies presence
+  // downstream (#232), but reinstallCustomNode does NOT — it returns as soon as
+  // the Manager queue drains, which the stale 3.x no-op passes trivially. Re-read
+  // fresh from disk here so BOTH paths fail closed rather than fabricate success.
+  const post = await detectPanelInstall(deps);
+  if (!post.installed || !post.version) {
+    throw new PanelInstallError(
+      `Panel ${action} did NOT land: the pack is ${
+        post.installed ? "present but its version is unreadable" : "not present"
+      } in custom_nodes after ComfyUI-Manager reported the queue drained. This is ` +
+        `the stale ComfyUI-Manager 3.x silent no-op (#639, same root cause as #424): ` +
+        `NOT reporting success. Fix: update ComfyUI-Manager on the host (git pull in ` +
+        `custom_nodes/ComfyUI-Manager, or pip install -U comfyui_manager) and retry, ` +
+        `or install the panel from source, then RESTART ComfyUI.`,
+    );
+  }
+  // #641 — fail closed if a shadow copy would win registration in the browser.
+  assertNoPanelShadow(action, post.dir, deps);
+
+  // SUCCESS REQUIRES PROVEN CHANGE (mirrors the update path): the pack went from
+  // ABSENT→present (fresh install landed), or its version/git-HEAD moved. Proven
+  // disk movement is checked FIRST — the ComfyUI-Manager queue counts are
+  // queue-WIDE (not task-correlated), so they must NEVER veto a change the disk
+  // already proves.
+  const versionMoved =
+    !!previousVersion && !!post.version && post.version !== previousVersion;
+  const revMoved =
+    !!previousRev && !!post.gitRev && post.gitRev !== previousRev;
+  // Only a RELIABLE pre-op scan may establish absent→present. If the pre-op
+  // enumeration failed (indeterminate), a "was absent" baseline is untrustworthy
+  // — a pre-existing panel in a non-fast-path dir could have been missed — so we
+  // do NOT infer a fresh install from it (that would fabricate success).
+  const reliablyAbsent = !wasPresent && detection.scanReliable !== false;
+  const changed = reliablyAbsent || versionMoved || revMoved;
+
+  if (!changed) {
+    // Nothing provably changed. Use the stale-3.x no-op count signature ONLY here
+    // (not as a veto above) to sharpen the failure diagnostic.
+    if (looksLikeManagerNoOp(result.details)) {
+      const c = readQueueCounts(result.details);
+      throw new PanelInstallError(
+        `Panel ${action} did NOT execute: ComfyUI-Manager reported the queue ` +
+          `drained without actually enqueuing the task (total_count=` +
+          `${c.total ?? "?"}, done_count=${c.done ?? "?"}), so the pack on disk ` +
+          `(${PANEL_REGISTRY_ID} ${post.version}) is unchanged — likely a stale ` +
+          `pre-existing copy. This is the stale ComfyUI-Manager 3.x silent no-op ` +
+          `(#639, same root cause as #424): NOT reporting success. Fix: update ` +
+          `ComfyUI-Manager on the host (git pull in custom_nodes/ComfyUI-Manager, ` +
+          `or pip install -U comfyui_manager) and retry, or install the panel from ` +
+          `source, then RESTART ComfyUI.`,
+      );
+    }
+    throw new PanelInstallError(
+      `Panel ${action} did NOT change anything on disk: the pack is still ` +
+        `${PANEL_REGISTRY_ID} ${post.version} (git-HEAD unchanged) after ` +
+        `ComfyUI-Manager reported the queue drained. NOT reporting success — an ` +
+        `unchanged checkout can't prove the ${action} actually executed versus a ` +
+        `silent no-op (stale ComfyUI-Manager 3.x, #424). If you meant to refresh or ` +
+        `upgrade, update ComfyUI-Manager on the host and retry, use ` +
+        `install_panel(action='update'), or install the panel from source, then ` +
+        `RESTART ComfyUI.`,
+    );
   }
 
   return {
@@ -431,7 +1139,10 @@ export async function runPanelAction(
     result,
     restartRequired: true,
     message:
-      `Panel ${action} queued via ComfyUI-Manager (${PANEL_VERSION}). ` +
-      `RESTART ComfyUI to load the ${action === "update" ? "updated" : "new"} panel node.`,
+      `Panel ${action} applied via ComfyUI-Manager: pack ${
+        wasPresent ? "advanced to" : "installed on disk at"
+      } ${PANEL_REGISTRY_ID} ${post.version}. RESTART ComfyUI to load the panel node.`,
+    previousVersion,
+    installedVersion: post.version,
   };
 }

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -78,10 +78,25 @@ export interface PanelInstallerDeps {
   /** Process env (for the opt-out flag). */
   env: () => NodeJS.ProcessEnv;
   existsSync: (p: string) => boolean;
+  /**
+   * Tri-state REGULAR-FILE probe: true = a regular file exists at `p`, false =
+   * confirmed not-a-servable-file (ENOENT, ENOTDIR, or it exists but is a
+   * directory), undefined = could not determine (EACCES/EIO/…). Used to detect a
+   * served web asset — only a regular file is served, and unlike existsSync
+   * (which collapses every error to false), an indeterminate probe lets the
+   * shadow scan fail closed instead of silently omitting a served copy. Never
+   * throws.
+   */
+  probeFile: (p: string) => boolean | undefined;
   /** True when `p` is a symlink/junction (dev install). Never throws. */
   isSymlink: (p: string) => boolean;
-  /** True when `p` is a directory (following symlinks). Never throws. */
-  isDirectory: (p: string) => boolean;
+  /**
+   * Tri-state directory check (following symlinks): true = directory, false =
+   * CONFIRMED non-directory (a regular file), undefined = COULD NOT DETERMINE
+   * (stat error). Callers must only SKIP an entry on an explicit `false`; an
+   * undefined must be treated as a possible directory (fail closed). Never throws.
+   */
+  isDirectory: (p: string) => boolean | undefined;
   /**
    * Canonical physical path of `p` (resolves symlinks + the real on-disk case),
    * or undefined if it can't be resolved. Used to decide whether two entries are
@@ -184,6 +199,15 @@ export const defaultDeps: PanelInstallerDeps = {
   comfyuiPath: () => config.comfyuiPath,
   env: () => process.env,
   existsSync,
+  probeFile: (p) => {
+    try {
+      return statSync(p).isFile(); // true = regular file, false = exists but a dir
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      // ENOENT/ENOTDIR = confirmed no servable file here; else indeterminate.
+      return code === "ENOENT" || code === "ENOTDIR" ? false : undefined;
+    }
+  },
   isSymlink: (p) => {
     try {
       return lstatSync(p).isSymbolicLink();
@@ -196,7 +220,9 @@ export const defaultDeps: PanelInstallerDeps = {
       // statSync follows symlinks: a dir symlink IS web-served, so it counts.
       return statSync(p).isDirectory();
     } catch {
-      return false;
+      // Could not determine — return undefined so the caller fails closed rather
+      // than treating a served backup as a skippable "file".
+      return undefined;
     }
   },
   realPath: (p) => {
@@ -373,10 +399,14 @@ export interface PanelShadow {
   version?: string;
 }
 
-/** Canonical panel dir basenames — a legitimate install lives at one of these. */
-function isCanonicalPanelName(name: string): boolean {
-  const lower = name.toLowerCase();
-  return (FAST_PATH_DIRS as readonly string[]).some((n) => n === lower);
+/**
+ * EXACT (case-sensitive) canonical panel dir basename. Used only to avoid
+ * flagging the real install when no canonical dir was resolved; a case-VARIANT
+ * (e.g. "ComfyUI-MCP-Panel" on a case-sensitive volume) is NOT exempted here —
+ * it is content-checked like any other dir so a distinct serving copy is caught.
+ */
+function isExactCanonicalPanelName(name: string): boolean {
+  return (FAST_PATH_DIRS as readonly string[]).includes(name);
 }
 
 /**
@@ -405,13 +435,23 @@ function samePathCI(
 }
 
 /**
- * A dir NAME that looks like a leftover panel copy/backup — the shadowing trap
- * from #641. The name must START WITH a canonical panel base name (after an
+ * The remainder (after the canonical base) of a panel BACKUP name: only
+ * separators / digits / dots may precede the FIRST backup marker, which is
+ * either "~" or a whole-word backup keyword. Descriptive text AFTER the marker is
+ * allowed (e.g. "-backup-2026-final", "~snapshot"); a non-backup word BEFORE the
+ * marker ("-tools-old", "-holder-backup") means it is a backup of a DIFFERENT
+ * (sibling) node, not the panel, so it must NOT match.
+ */
+const PANEL_BACKUP_REST =
+  /^[._\-0-9]*(?:~|(?:bak|backup|old|copy|orig|save|prev|previous)(?![a-z]))/i;
+
+/**
+ * A dir NAME that looks like a leftover copy/backup OF THE PANEL — the shadowing
+ * trap from #641. The name must START WITH a canonical panel base name (after an
  * optional leading dot) and then be EITHER exactly that name while hidden (a
- * dot-prefixed copy of the real panel) OR followed by a backup/copy token.
- * Deliberately NARROW: an unrelated extension like "comfyui-agent-panel-tools"
- * (or a hidden ".comfyui-agent-panel-tools") must NOT match — those are caught
- * only by an exact pyproject `name` == comfyui-agent-panel test elsewhere.
+ * dot-prefixed copy of the real panel) OR a panel-backup suffix (see
+ * PANEL_BACKUP_REST). Copies that dropped their name are caught by the CONTENT
+ * signal instead.
  */
 export function looksLikePanelBackupName(name: string): boolean {
   const hidden = name.startsWith(".");
@@ -424,17 +464,47 @@ export function looksLikePanelBackupName(name: string): boolean {
   // Exactly a canonical name: a HIDDEN copy (".comfyui-agent-panel") shadows the
   // real panel; a plain "comfyui-agent-panel" IS the real install (not a backup).
   if (rest === "") return hidden;
-  // An editor "~" backup suffix (e.g. ".comfyui-agent-panel~") is a backup.
-  if (rest.includes("~") || name.includes("~")) return true;
-  // Otherwise the remainder must be a backup/copy suffix, not a different node.
-  return /^[._-](bak|backup|old|copy|orig|save|prev|previous)([._-]|\d|$)/i.test(rest);
+  return PANEL_BACKUP_REST.test(rest);
+}
+
+/**
+ * Web-extension asset paths ComfyUI serves for the panel. A custom_nodes dir that
+ * contains ANY of these is served as the panel's frontend (at /extensions/<dir>/…)
+ * and therefore shadows the canonical install regardless of its dir name or
+ * pyproject — this is the #641 CONTENT signal, spelling-independent.
+ */
+const PANEL_WEB_MARKERS = [
+  ["web", "js", "comfyui-mcp-panel.js"],
+  ["web", "img", "comfyui-mcp-wordmark.svg"],
+] as const;
+
+/**
+ * Tri-state: does `dir` serve the panel's web-extension assets? true = a marker
+ * is present, false = all markers CONFIRMED absent, undefined = a probe FAILED
+ * (indeterminate). Callers must treat undefined as a POSSIBLE shadow (fail
+ * closed), never as "no assets". Never throws.
+ */
+function servesPanelWebAssets(
+  dir: string,
+  deps: PanelInstallerDeps,
+): boolean | undefined {
+  let probeFailed = false;
+  for (const seg of PANEL_WEB_MARKERS) {
+    const r = deps.probeFile(join(dir, ...seg));
+    if (r === true) return true;
+    if (r === undefined) probeFailed = true; // indeterminate — can't confirm absent
+  }
+  return probeFailed ? undefined : false;
 }
 
 /**
  * Find panel-serving dirs under custom_nodes that would SHADOW the canonical
- * install — any dir (other than the true canonical) whose pyproject `name` is
- * the panel, OR whose basename is backup/copy-shaped (covers web-only backups
- * that dropped pyproject). LOCAL-only.
+ * install — any dir (other than the true canonical) that ComfyUI would SERVE as
+ * the panel's web extension. Detection is CONTENT-first (the dir serves the
+ * panel's web assets → spelling-independent), plus a cheap name heuristic and an
+ * exact pyproject-name match. FAILS CLOSED on uncertainty: a served copy whose
+ * pyproject is unreadable/absent is still flagged (as a possible shadow with no
+ * version), never silently omitted. LOCAL-only.
  *
  * THROWS if custom_nodes exists but cannot be enumerated: shadow inspection is
  * then INDETERMINATE and the ACTION paths must fail closed rather than assume
@@ -447,27 +517,44 @@ export function findPanelShadows(
   const comfyPath = deps.comfyuiPath();
   if (!deps.isLocalMode() || !comfyPath) return [];
   const customNodes = join(comfyPath, "custom_nodes");
-  if (!deps.existsSync(customNodes)) return [];
 
-  // Intentionally NOT swallowed — a failed enumeration is indeterminate, not
-  // proof of "no shadows". Callers decide how to handle it.
-  const entries = deps.readdir(customNodes);
+  // Enumerate custom_nodes. A missing dir (ENOENT) legitimately means "no
+  // shadows"; ANY other failure (EACCES/EIO/…) is INDETERMINATE — NOT swallowed,
+  // so the action paths fail closed rather than assume "no shadows".
+  let entries: string[];
+  try {
+    entries = deps.readdir(customNodes);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return [];
+    throw err;
+  }
 
   const shadows: PanelShadow[] = [];
   for (const name of entries) {
     const dir = join(customNodes, name);
-    // ComfyUI serves DIRECTORIES as web extensions — a regular file that happens
-    // to share the name is not served and must not block actions.
-    if (!deps.isDirectory(dir)) continue;
+    // ComfyUI serves DIRECTORIES as web extensions — a regular FILE that happens
+    // to share the name is not served and must not block actions. Skip ONLY on a
+    // CONFIRMED non-directory; an undefined (stat error) is indeterminate and
+    // must NOT omit a possible served backup → fail closed by continuing to check.
+    if (deps.isDirectory(dir) === false) continue;
+    // PHYSICAL IDENTITY FIRST: a symlink/junction/alias that resolves to the
+    // canonical dir serves the SAME (updated) assets → it is NOT a shadow, even
+    // if its NAME is backup-shaped (e.g. ".comfyui-agent-panel.bak" ->
+    // comfyui-mcp-panel). realpath-unavailable falls back to exact-string only.
+    if (samePathCI(dir, canonicalDir, deps)) continue;
+    // With no canonical resolved, don't flag a dir whose name is EXACTLY a
+    // canonical basename (it is most likely the real install). Case-variant or
+    // backup-shaped names are still content-checked below — never exempted here.
+    if (!canonicalDir && isExactCanonicalPanelName(name)) continue;
     const isBackup = looksLikePanelBackupName(name);
-    // Exempt the ONE true canonical install (physical identity). A backup-shaped
-    // name is NEVER exempted, even if it was (mis)selected as canonicalDir.
-    if (!isBackup && samePathCI(dir, canonicalDir, deps)) continue;
-    // With no canonical resolved, don't flag a canonically-NAMED dir (it is most
-    // likely the real install). Backup-shaped names are still flagged.
-    if (!isBackup && !canonicalDir && isCanonicalPanelName(name)) continue;
 
-    let isPanelCopy = isBackup;
+    // CONTENT signal: does this dir serve the panel's web assets? If so it is a
+    // shadow no matter how it is named or whether its pyproject is readable. An
+    // INDETERMINATE probe (undefined) is treated as a possible shadow (fail
+    // closed) — only a CONFIRMED-absent (false) clears the content signal.
+    const servesPanel = servesPanelWebAssets(dir, deps) !== false;
+
+    let isPanelCopy = isBackup || servesPanel;
     let version: string | undefined;
     const pyproject = join(dir, "pyproject.toml");
     if (deps.existsSync(pyproject)) {
@@ -477,8 +564,11 @@ export function findPanelShadows(
           isPanelCopy = true;
           version = parsed.version;
         }
+        // else: pyproject readable but a different name. If it still SERVES panel
+        // assets (isPanelCopy) it remains a shadow with an unknown panel version.
       } catch {
-        // ignore — rely on the backup-name heuristic
+        // FAIL CLOSED: unreadable pyproject does NOT clear a content/name signal.
+        // A served copy we cannot identify is a POSSIBLE shadow, not "no shadow".
       }
     }
     if (isPanelCopy) shadows.push({ name, version });
@@ -508,7 +598,10 @@ function assertNoPanelShadow(
   }
   if (shadows.length === 0) return;
   const names = shadows
-    .map((s) => `"${s.name}"${s.version ? ` (${s.version})` : ""}`)
+    .map(
+      (s) =>
+        `"${s.name}"${s.version ? ` (${s.version})` : " (identity could not be verified)"}`,
+    )
     .join(", ");
   throw new PanelInstallError(
     `Panel ${action} cannot be confirmed: a SHADOW copy of the panel exists in ` +
@@ -518,8 +611,9 @@ function assertNoPanelShadow(
       `sorts before "comfyui-agent-panel"), so the BROWSER may keep loading the old ` +
       `panel even though the real dir on disk is up to date (#641). NOT reporting ` +
       `success. Remove or MOVE the offending dir OUT of custom_nodes (e.g. to a temp ` +
-      `folder), then hard-refresh the ComfyUI tab. A backup belongs anywhere EXCEPT ` +
-      `under custom_nodes.`,
+      `folder) — or, if its identity could not be verified, make its pyproject.toml ` +
+      `readable so it can be identified — then hard-refresh the ComfyUI tab. A ` +
+      `backup belongs anywhere EXCEPT under custom_nodes.`,
   );
 }
 
@@ -654,7 +748,23 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
     // #639 — VERIFY it actually landed (fresh re-read); never log "installed"
     // from the Manager result alone (a stale 3.x no-op drains the queue trivially).
     const post = await detectPanelInstall(deps);
-    if (!post.installed || !post.version) {
+    const landed = post.installed && !!post.version;
+    // #641 — report a shadow FIRST: a served backup copy explains a wrong panel in
+    // the browser whether or not the canonical install landed this run.
+    const shadow = describePanelShadow(post.dir, deps);
+    if (shadow) {
+      return {
+        action: "shadowed",
+        reason: landed
+          ? `Installed ${PANEL_REGISTRY_ID} (${post.version}) but ${shadow}.`
+          : `Panel auto-install could not be verified on disk (likely a stale ` +
+            `ComfyUI-Manager no-op, #639/#424), AND ${shadow}`,
+        dir: post.dir,
+        installedVersion: post.version,
+        restartRequired: landed ? true : undefined,
+      };
+    }
+    if (!landed) {
       return {
         action: "unavailable",
         reason:
@@ -662,17 +772,6 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
           `reported the queue drained but the pack is not present. Likely a stale ` +
           `ComfyUI-Manager 3.x no-op (#639/#424). Install the panel from source or ` +
           `update ComfyUI-Manager, then restart ComfyUI.`,
-      };
-    }
-    // #641 — a shadow copy would make the browser load the wrong panel.
-    const shadow = describePanelShadow(post.dir, deps);
-    if (shadow) {
-      return {
-        action: "shadowed",
-        reason: `Installed ${PANEL_REGISTRY_ID} (${post.version}) but ${shadow}.`,
-        dir: post.dir,
-        installedVersion: post.version,
-        restartRequired: true,
       };
     }
     return {
@@ -1075,6 +1174,10 @@ export async function runPanelAction(
   // the Manager queue drains, which the stale 3.x no-op passes trivially. Re-read
   // fresh from disk here so BOTH paths fail closed rather than fabricate success.
   const post = await detectPanelInstall(deps);
+  // #641 — fail closed on a shadow FIRST: a served backup copy is the more
+  // actionable diagnostic (it explains a wrong panel in the browser) and is named
+  // with its specific remedy, even when the canonical install itself did not land.
+  assertNoPanelShadow(action, post.dir, deps);
   if (!post.installed || !post.version) {
     throw new PanelInstallError(
       `Panel ${action} did NOT land: the pack is ${
@@ -1086,8 +1189,6 @@ export async function runPanelAction(
         `or install the panel from source, then RESTART ComfyUI.`,
     );
   }
-  // #641 — fail closed if a shadow copy would win registration in the browser.
-  assertNoPanelShadow(action, post.dir, deps);
 
   // SUCCESS REQUIRES PROVEN CHANGE (mirrors the update path): the pack went from
   // ABSENT→present (fresh install landed), or its version/git-HEAD moved. Proven


### PR DESCRIPTION
## What & why

`install_panel({action:"update"})` returned a **success** payload (`done_count:2`, `is_processing:false`, `restartRequired:true`) while **nothing changed on disk** — the pack stayed at 0.11.28 with 0.11.32 available. A stale bundled **ComfyUI-Manager 3.x** returns `total_count:0`/`done_count:2`; the queue drain check (`done_count >= total_count`) passes trivially (`2 >= 0`) while the task is **never enqueued**. The tool trusted that signal as proof of work → silent **fabricate-success** (#639, same class as #232 / #364 / #458).

**#641** sharpened it: a leftover backup dir under `custom_nodes` (e.g. `.comfyui-agent-panel.bak-0.11.28`) is **also served as a web extension** (the Python node loader skips dot-dirs, the web server does not), and `.` sorts before `c`, so the **stale backup wins registration**. The browser keeps loading the old panel even though the real dir's `pyproject` reads the new version — verifying the file alone can't catch it.

## The fix — success now requires PROVEN, VERIFIED change

- **update**: after the op, re-read the installed identity **fresh from disk** (pyproject `version` **and** git-HEAD sha) and report success only when version **or** HEAD actually moved. Nothing moved → **fail closed** (names the stale-Manager no-op via the `total_count:0` / `done>total` signature, else "could not verify"). Post-version must be readable. Manager queue counts are queue-wide (not task-correlated) → used **only** to sharpen the failure diagnostic, never as proof of work.
- **install / reinstall**: mirror it — success requires **absent→present** (from a *reliable* pre-op scan) or version/HEAD movement; a pre-existing pack that didn't change fails closed. `installCustomNode` already verifies presence downstream (#232); `reinstallCustomNode` did not.
- **#641 shadow detection**: `findPanelShadows` scans `custom_nodes` (directories only) for any **other** panel-serving dir — pyproject `name == comfyui-agent-panel`, or a backup/copy-shaped name (dot-prefixed, `.bak`/`backup`/`old`/`copy`/`~`, …). `install`/`update`/`reinstall` **fail closed** when one exists (naming the offending dir + remedy); `install_panel(status)` reports `shadows`; the on-load ensure gets a `shadowed` action. Canonical-dir exemption uses **realpath physical identity** — correct on case-sensitive Linux **and** case-insensitive Windows/macOS, and **fails closed** when realpath can't resolve.
- **Fail-closed on every indeterminate input**: unreadable `custom_nodes` enumeration, transient/unreadable `pyproject`, unreadable/abbreviated git ref (only full 40/64-char SHA-1/SHA-256 accepted). On-load auto-install verifies the pack landed **and** no shadow before logging `installed`, and skips installing when it can't confirm the panel is missing.

Honest-success paths preserved: version bump, nightly git-HEAD advance without a version bump, and genuine fresh install all still succeed.

## Scope / trust model

Local single-trust-domain; gated on **accidental fabricate-success** only. No adversarial/attestation machinery.

## Tests

77 new/updated cases in `src/__tests__/services/panel-installer.test.ts` covering: the reported no-op (incl. on a git checkout), version/HEAD movement, already-current fail-closed, unreadable post-identity, `.bak-*`/`~` shadows (update/install/reinstall/status/on-load), realpath identity vs distinct-case coexistence, indeterminate enumeration/read, SHA-1/SHA-256/abbreviated ref parsing, and git worktree `commondir`. `npm run build` + touched-area tests green.

> Note: the one failing test in the full suite (`node-dev.test.ts` › `searchNodePacks` `ripgrep` vs `builtin`) is a pre-existing environment assumption (ripgrep on PATH), unrelated to this change.

## Adversarial self-gate

Ran my own codex adversarial review (`gpt-5.6-terra`) to a **clean verdict** across iterations (each round's findings applied + re-reviewed). Final verdict: no P0/P1/P2.

Closes #639
Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)