### PR TITLE
fix(manager): route legacy ComfyUI-Manager self-update off the 405 path (#424)

### DIFF
--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -30,6 +30,33 @@ vi.mock("../../config.js", () => {
     getComfyUIAuthHeaders: () => ({}),
     isLoopbackHost: (host: string | undefined) =>
       !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host.toLowerCase().replace(/^\[|\]$/g, "")),
+    isForceRemoteFlagSet: () => remoteFlags.forceRemote,
+    isRemoteMode: () => remoteFlags.remoteMode,
+  };
+});
+
+// ── Scenario scaffolding for the Manager self-update tests (#424). The product
+// deliberately does NOT consult either of these: when the Manager's self-update
+// route 405s it refuses outright rather than git-pulling a checkout on THIS
+// machine, because no HTTP-observable signal can prove that checkout is the one
+// the connected server loaded. These knobs let the suite spell out each
+// wrong-target configuration a previous revision was fooled by, and assert that
+// every one of them still refuses and never shells out to git — so reintroducing
+// a "but this one looks local enough" pull fails the suite.
+
+/** --force-remote / remote-target classification (config mock reads these). */
+const remoteFlags = vi.hoisted(() => ({ forceRemote: false, remoteMode: false }));
+
+/** The LIVE server's own install root, as /system_stats argv would report it. */
+const liveRoot = vi.hoisted(() => ({ value: undefined as string | undefined }));
+
+vi.mock("../../services/workspace-env.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../services/workspace-env.js")
+  >("../../services/workspace-env.js");
+  return {
+    ...actual,
+    resolveLiveComfyUIBase: async () => liveRoot.value,
   };
 });
 
@@ -157,6 +184,11 @@ describe("node-management service", () => {
     mockedExists.mockReturnValue(true);
     config.comfyuiPath = "/fake/comfy";
     config.githubToken = undefined;
+    remoteFlags.forceRemote = false;
+    remoteFlags.remoteMode = false;
+    // Default: the LIVE server reports the SAME root as config.comfyuiPath, so the
+    // Manager self-update fallback is allowed to touch that checkout.
+    liveRoot.value = "/fake/comfy";
     // Each test re-detects the Manager API generation against its own stub
     // (the v2 stubs answer /v2/manager/queue/status → detect "v2").
     resetManagerApiCacheForTests();
@@ -1192,66 +1224,63 @@ describe("node-management service", () => {
       ).toBe(false);
     });
 
-    it("self-update 405 falls back to a local git pull and reports the REAL outcome", async () => {
+    // ── When the update route is genuinely unregistered (405), the ONLY outcome
+    // is the explicit "not supported / NOTHING WAS UPDATED" error. There is no
+    // local-git fallback: comfyui-mcp cannot prove that a checkout on ITS machine
+    // is the one the connected server loaded (loopback can be a container or an
+    // SSH port-forward), and pulling the wrong copy would report a fix that never
+    // reached the user's ComfyUI. Each config below is a wrong-target trap that a
+    // previous revision fell into — all must refuse, and none may run git.
+    it.each([
+      [
+        "loopback host whose live root MATCHES comfyuiPath",
+        () => {
+          liveRoot.value = "/fake/comfy";
+        },
+      ],
+      [
+        "--force-remote over a forwarded loopback port (server is on another machine)",
+        () => {
+          remoteFlags.forceRemote = true;
+          liveRoot.value = "/fake/comfy";
+        },
+      ],
+      [
+        "a second local instance whose live root differs from comfyuiPath",
+        () => {
+          liveRoot.value = "/other/comfy";
+        },
+      ],
+      [
+        "a server that won't say where it lives (unreachable / argv-less)",
+        () => {
+          liveRoot.value = undefined;
+        },
+      ],
+      [
+        "a loopback CONTAINER reporting a root string that also exists on the host",
+        () => {
+          // Same path string, different filesystem namespace — indistinguishable
+          // over HTTP, which is exactly why no pull is attempted at all.
+          liveRoot.value = "/fake/comfy";
+          mockedExists.mockReturnValue(true);
+        },
+      ],
+    ])("self-update 405 refuses explicitly and never runs git — %s", async (_name, setup) => {
       const { calls } = stubLegacyFetch({ update405: true });
-      mockedExists.mockReturnValue(true); // custom_nodes/ComfyUI-Manager/.git present
-      // rev-parse before → A, pull → no-op text, rev-parse after → B (advanced).
-      let heads = ["aaaaaaaaaaaa1111", "bbbbbbbbbbbb2222"];
-      mockedExec.mockImplementation(((_bin: string, args: string[]) => {
-        if (args.includes("rev-parse")) return `${heads.shift() ?? "zzzz"}\n`;
-        return "Updating aaaaaaa..bbbbbbb\n";
-      }) as never);
+      mockedExists.mockReturnValue(true); // a real-looking local checkout exists
+      setup();
 
-      const res = await updateCustomNode({ id: "comfyui-manager" });
-
-      expect(res.mechanism).toBe("git-clone");
-      expect(res.message).toMatch(/Updated ComfyUI-Manager itself/);
-      expect(res.message).toMatch(/aaaaaaaa → bbbbbbbb/);
-      // The right endpoint WAS attempted before falling back.
-      expect(legacyCallTo(calls, "/manager/queue/update")).toBeDefined();
-      expect(
-        mockedExec.mock.calls.some(
-          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
-        ),
-      ).toBe(true);
-
-      // Same fallback, but the checkout did NOT move → must NOT read as success.
-      calls.length = 0;
-      heads = ["cccccccccccc3333", "cccccccccccc3333"];
-      mockedExec.mockClear();
-      const noop = await updateCustomNode({ id: "ComfyUI-Manager" });
-      expect(noop.message).toMatch(/ALREADY UP TO DATE/);
-      expect(noop.message).toMatch(/changed NOTHING/);
-      expect(noop.message).not.toMatch(/Updated ComfyUI-Manager itself/);
-    });
-
-    it("self-update 405 with NO local checkout returns the explicit unsupported result", async () => {
-      const { calls } = stubLegacyFetch({ update405: true });
-      mockedExists.mockReturnValue(false); // no on-disk ComfyUI-Manager checkout
-
-      await expect(updateCustomNode({ id: "ComfyUI-Manager" })).rejects.toThrow(
+      await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(
         /not supported by the LEGACY ComfyUI-Manager 3\.x queue API[\s\S]*NOTHING WAS UPDATED[\s\S]*pip install -U comfyui_manager/i,
       );
-      // The real endpoint was still tried first (that's what proves it's 405).
+      // The real endpoint was still tried first — that's what proves it's a 405.
       expect(legacyCallTo(calls, "/manager/queue/update")).toBeDefined();
+      // No git ran at all: not a pull, not even a rev-parse probe.
+      expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
     });
 
-    it("a queue/start 405 during the DRAIN is not mistaken for a missing update route", async () => {
-      // codex review: only the ENQUEUE 405 means "this build doesn't register the
-      // update route". A 405 from the queue-control route (start) is a drain
-      // failure and must surface as itself — never silently divert to a git pull.
-      stubLegacyFetch({ start405: true }); // update route answers 200; start 405s
-      mockedExists.mockReturnValue(true);
-
-      await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(/405/);
-      expect(
-        mockedExec.mock.calls.some(
-          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
-        ),
-      ).toBe(false);
-    });
-
-    it("never git-pulls the LOCAL checkout when the Manager is on a REMOTE host", async () => {
+    it("self-update 405 on a REMOTE host also refuses (never touches a local clone)", async () => {
       const original = config.comfyuiHost;
       config.comfyuiHost = "10.0.0.5"; // remote ComfyUI; comfyuiPath is a LOCAL path
       try {
@@ -1260,15 +1289,26 @@ describe("node-management service", () => {
         await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(
           /NOTHING WAS UPDATED/,
         );
-        expect(
-          mockedExec.mock.calls.some(
-            ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
-          ),
-        ).toBe(false);
+        expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
       } finally {
         config.comfyuiHost = original;
       }
     });
+
+    it("a queue/start 405 during the DRAIN is not reported as a missing update route", async () => {
+      // codex review: only the ENQUEUE 405 means "this build doesn't register the
+      // update route". A 405 from the queue-control route (start) is a drain
+      // failure and must surface as itself, NOT as the unsupported verdict.
+      stubLegacyFetch({ start405: true }); // update route answers 200; start 405s
+      mockedExists.mockReturnValue(true);
+
+      const err = await updateCustomNode({ id: "comfyui-manager" }).catch((e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/405/);
+      expect((err as Error).message).not.toMatch(/NOTHING WAS UPDATED/);
+      expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
+    });
+
   });
 
   // ── issue #235: pip Manager in legacy-UI mode = the "v2-batch" dialect ────

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -186,8 +186,11 @@ describe("node-management service", () => {
     config.githubToken = undefined;
     remoteFlags.forceRemote = false;
     remoteFlags.remoteMode = false;
-    // Default: the LIVE server reports the SAME root as config.comfyuiPath, so the
-    // Manager self-update fallback is allowed to touch that checkout.
+    // Default fixture: the LIVE server reports the SAME root as config.comfyuiPath.
+    // This grants NOTHING — it is inert scenario scaffolding. The self-update path
+    // does not consult it, and under exactly this state an enqueue 405 still refuses
+    // and never touches the checkout. It exists so the suite can prove that even the
+    // most local-looking configuration is refused, not to model permission.
     liveRoot.value = "/fake/comfy";
     // Each test re-detects the Manager API generation against its own stub
     // (the v2 stubs answer /v2/manager/queue/status → detect "v2").
@@ -1196,12 +1199,11 @@ describe("node-management service", () => {
       expect(update?.body).toMatchObject({ id: "comfyui-manager" });
       // The v4-only unified task route (the #424 405 source) is never touched.
       expect(legacyCallTo(calls, "/v2/manager/queue/task")).toBeUndefined();
-      // No git pull happened — the Manager's own API did the work.
-      expect(
-        mockedExec.mock.calls.some(
-          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
-        ),
-      ).toBe(false);
+      // NOTHING was shelled out — the Manager's own API did the work. Asserted on
+      // the mock as a whole, not on an executable NAME: a check for the literal
+      // "git" would wave through execFileSync("git.exe", [...]) on Windows, which
+      // is exactly the platform this bug was reported on.
+      expect(mockedExec).not.toHaveBeenCalled();
       // …and the result does NOT claim a verified update (a drained 3.x queue
       // proves nothing) — it tells the user to restart and confirm.
       expect(res.message).toMatch(/restart/i);
@@ -1217,11 +1219,7 @@ describe("node-management service", () => {
         id: "rgthree-comfy",
       });
       expect(res.message).toMatch(/Queued \+ updated "rgthree-comfy"/);
-      expect(
-        mockedExec.mock.calls.some(
-          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
-        ),
-      ).toBe(false);
+      expect(mockedExec).not.toHaveBeenCalled();
     });
 
     // ── When the update route is genuinely unregistered (405), the ONLY outcome
@@ -1266,7 +1264,7 @@ describe("node-management service", () => {
           mockedExists.mockReturnValue(true);
         },
       ],
-    ])("self-update 405 refuses explicitly and never runs git — %s", async (_name, setup) => {
+    ])("self-update 405 refuses explicitly and shells out to NOTHING — %s", async (_name, setup) => {
       const { calls } = stubLegacyFetch({ update405: true });
       mockedExists.mockReturnValue(true); // a real-looking local checkout exists
       setup();
@@ -1276,8 +1274,12 @@ describe("node-management service", () => {
       );
       // The real endpoint was still tried first — that's what proves it's a 405.
       expect(legacyCallTo(calls, "/manager/queue/update")).toBeDefined();
-      // No git ran at all: not a pull, not even a rev-parse probe.
-      expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
+      // NO subprocess ran at all — not a pull, not a rev-parse probe, nothing.
+      // Asserted on the mock as a whole rather than on an executable NAME: a check
+      // for the literal "git" would wave through execFileSync("git.exe", [...]),
+      // which is valid on Windows — the very platform this bug was reported on —
+      // so a reintroduced fallback could pull the local checkout and still pass.
+      expect(mockedExec).not.toHaveBeenCalled();
     });
 
     it("self-update 405 on a REMOTE host also refuses (never touches a local clone)", async () => {
@@ -1289,7 +1291,7 @@ describe("node-management service", () => {
         await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(
           /NOTHING WAS UPDATED/,
         );
-        expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
+        expect(mockedExec).not.toHaveBeenCalled();
       } finally {
         config.comfyuiHost = original;
       }
@@ -1306,7 +1308,7 @@ describe("node-management service", () => {
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toMatch(/405/);
       expect((err as Error).message).not.toMatch(/NOTHING WAS UPDATED/);
-      expect(mockedExec.mock.calls.some(([bin]) => bin === "git")).toBe(false);
+      expect(mockedExec).not.toHaveBeenCalled();
     });
 
   });

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -28,6 +28,8 @@ vi.mock("../../config.js", () => {
     getComfyUIBaseUrl: () =>
       `${config.comfyuiSsl ? "https" : "http"}://${config.comfyuiHost}:${config.resolvedPort}`,
     getComfyUIAuthHeaders: () => ({}),
+    isLoopbackHost: (host: string | undefined) =>
+      !host || ["127.0.0.1", "::1", "localhost", "0.0.0.0", "::"].includes(host.toLowerCase().replace(/^\[|\]$/g, "")),
   };
 });
 
@@ -1022,7 +1024,9 @@ describe("node-management service", () => {
   describe("legacy Manager 3.x API", () => {
     /** Stub where every /v2 route 405s (like released Manager 3.41) and the
      *  legacy per-operation routes answer. */
-    function stubLegacyFetch(opts: { installedBody?: unknown } = {}) {
+    function stubLegacyFetch(
+      opts: { installedBody?: unknown; update405?: boolean; start405?: boolean } = {},
+    ) {
       const calls: Call[] = [];
       const fetchMock = vi.fn(
         async (url: string, init?: RequestInit): Promise<Response> => {
@@ -1031,6 +1035,16 @@ describe("node-management service", () => {
           calls.push({ url, method, body });
           const path = new URL(url).pathname;
           if (path.startsWith("/v2/")) {
+            return new Response("405: Method Not Allowed", { status: 405 });
+          }
+          // A build that does NOT register the per-operation update route: the
+          // ComfyUI frontend catchall answers the unregistered POST with 405.
+          if (opts.update405 && path === "/manager/queue/update" && method === "POST") {
+            return new Response("405: Method Not Allowed", { status: 405 });
+          }
+          // A queue-control 405 on BOTH methods (the POST→GET negotiation also
+          // fails) — a DRAIN failure, not an "operation route missing" signal.
+          if (opts.start405 && path === "/manager/queue/start") {
             return new Response("405: Method Not Allowed", { status: 405 });
           }
           if (path === "/manager/queue/status") {
@@ -1130,34 +1144,130 @@ describe("node-management service", () => {
       expect(probes.length).toBe(1);
     });
 
-    // ── #424: updating ComfyUI-Manager ITSELF on legacy 3.x can't go through the
-    // queue (it 405s the self-update route) → git-pull the local checkout instead.
-    it("update of comfyui-manager self falls back to a local git pull (never the queue)", async () => {
+    // ── #424: updating ComfyUI-Manager ITSELF. The released 3.x DOES support it
+    // through its ordinary per-operation route (POST /manager/queue/update with
+    // id=comfyui-manager — manager_core.unified_update has no self guard, and
+    // /manager/queue/update_all enqueues 'comfyui-manager' itself). The original
+    // 405 came from posting the v4-only …/queue/task envelope at a 3.x server.
+    // So the legacy self-update must ROUTE to the real endpoint, and only fall
+    // back when THAT endpoint is genuinely unregistered (405).
+    it("routes legacy self-update to POST /manager/queue/update (no git-pull bypass)", async () => {
       const { calls } = stubLegacyFetch();
-      mockedExists.mockReturnValue(true); // custom_nodes/ComfyUI-Manager/.git present
+      mockedExists.mockReturnValue(true); // a local checkout exists but must NOT be used
       mockedExec.mockReturnValue("Already up to date." as unknown as Buffer);
 
       const res = await updateCustomNode({ id: "comfyui-manager" });
 
-      expect(res.mechanism).toBe("git-clone");
-      // A git pull of the Manager checkout was run …
-      const pull = mockedExec.mock.calls.find(
-        ([bin, args]) =>
-          bin === "git" && Array.isArray(args) && args.includes("pull"),
-      );
-      expect(pull).toBeDefined();
-      // … and the Manager queue update route was NEVER touched.
-      expect(legacyCallTo(calls, "/manager/queue/update")).toBeUndefined();
+      expect(res.mechanism).toBe("manager-http");
+      const update = legacyCallTo(calls, "/manager/queue/update");
+      expect(update?.method).toBe("POST");
+      expect(update?.body).toMatchObject({ id: "comfyui-manager" });
+      // The v4-only unified task route (the #424 405 source) is never touched.
+      expect(legacyCallTo(calls, "/v2/manager/queue/task")).toBeUndefined();
+      // No git pull happened — the Manager's own API did the work.
+      expect(
+        mockedExec.mock.calls.some(
+          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
+        ),
+      ).toBe(false);
+      // …and the result does NOT claim a verified update (a drained 3.x queue
+      // proves nothing) — it tells the user to restart and confirm.
+      expect(res.message).toMatch(/restart/i);
+      expect(res.message).not.toMatch(/^Updated /);
     });
 
-    it("update of Manager self with NO local checkout errors actionably (no queue call)", async () => {
+    it("third-party pack update is unchanged by the self-update routing", async () => {
       const { calls } = stubLegacyFetch();
+      mockedExists.mockReturnValue(true);
+      const res = await updateCustomNode({ id: "rgthree-comfy" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(legacyCallTo(calls, "/manager/queue/update")?.body).toMatchObject({
+        id: "rgthree-comfy",
+      });
+      expect(res.message).toMatch(/Queued \+ updated "rgthree-comfy"/);
+      expect(
+        mockedExec.mock.calls.some(
+          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
+        ),
+      ).toBe(false);
+    });
+
+    it("self-update 405 falls back to a local git pull and reports the REAL outcome", async () => {
+      const { calls } = stubLegacyFetch({ update405: true });
+      mockedExists.mockReturnValue(true); // custom_nodes/ComfyUI-Manager/.git present
+      // rev-parse before → A, pull → no-op text, rev-parse after → B (advanced).
+      let heads = ["aaaaaaaaaaaa1111", "bbbbbbbbbbbb2222"];
+      mockedExec.mockImplementation(((_bin: string, args: string[]) => {
+        if (args.includes("rev-parse")) return `${heads.shift() ?? "zzzz"}\n`;
+        return "Updating aaaaaaa..bbbbbbb\n";
+      }) as never);
+
+      const res = await updateCustomNode({ id: "comfyui-manager" });
+
+      expect(res.mechanism).toBe("git-clone");
+      expect(res.message).toMatch(/Updated ComfyUI-Manager itself/);
+      expect(res.message).toMatch(/aaaaaaaa → bbbbbbbb/);
+      // The right endpoint WAS attempted before falling back.
+      expect(legacyCallTo(calls, "/manager/queue/update")).toBeDefined();
+      expect(
+        mockedExec.mock.calls.some(
+          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
+        ),
+      ).toBe(true);
+
+      // Same fallback, but the checkout did NOT move → must NOT read as success.
+      calls.length = 0;
+      heads = ["cccccccccccc3333", "cccccccccccc3333"];
+      mockedExec.mockClear();
+      const noop = await updateCustomNode({ id: "ComfyUI-Manager" });
+      expect(noop.message).toMatch(/ALREADY UP TO DATE/);
+      expect(noop.message).toMatch(/changed NOTHING/);
+      expect(noop.message).not.toMatch(/Updated ComfyUI-Manager itself/);
+    });
+
+    it("self-update 405 with NO local checkout returns the explicit unsupported result", async () => {
+      const { calls } = stubLegacyFetch({ update405: true });
       mockedExists.mockReturnValue(false); // no on-disk ComfyUI-Manager checkout
 
       await expect(updateCustomNode({ id: "ComfyUI-Manager" })).rejects.toThrow(
-        /pip install -U comfyui_manager|git pull/i,
+        /not supported by the LEGACY ComfyUI-Manager 3\.x queue API[\s\S]*NOTHING WAS UPDATED[\s\S]*pip install -U comfyui_manager/i,
       );
-      expect(legacyCallTo(calls, "/manager/queue/update")).toBeUndefined();
+      // The real endpoint was still tried first (that's what proves it's 405).
+      expect(legacyCallTo(calls, "/manager/queue/update")).toBeDefined();
+    });
+
+    it("a queue/start 405 during the DRAIN is not mistaken for a missing update route", async () => {
+      // codex review: only the ENQUEUE 405 means "this build doesn't register the
+      // update route". A 405 from the queue-control route (start) is a drain
+      // failure and must surface as itself — never silently divert to a git pull.
+      stubLegacyFetch({ start405: true }); // update route answers 200; start 405s
+      mockedExists.mockReturnValue(true);
+
+      await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(/405/);
+      expect(
+        mockedExec.mock.calls.some(
+          ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
+        ),
+      ).toBe(false);
+    });
+
+    it("never git-pulls the LOCAL checkout when the Manager is on a REMOTE host", async () => {
+      const original = config.comfyuiHost;
+      config.comfyuiHost = "10.0.0.5"; // remote ComfyUI; comfyuiPath is a LOCAL path
+      try {
+        stubLegacyFetch({ update405: true });
+        mockedExists.mockReturnValue(true); // a local clone exists — wrong machine
+        await expect(updateCustomNode({ id: "comfyui-manager" })).rejects.toThrow(
+          /NOTHING WAS UPDATED/,
+        );
+        expect(
+          mockedExec.mock.calls.some(
+            ([bin, args]) => bin === "git" && Array.isArray(args) && args.includes("pull"),
+          ),
+        ).toBe(false);
+      } finally {
+        config.comfyuiHost = original;
+      }
     });
   });
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
-import { config, getComfyUIBaseUrl } from "../config.js";
+import { config, getComfyUIBaseUrl, isLoopbackHost } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
@@ -584,10 +584,28 @@ async function queueManagerTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
 ): Promise<QueueStatus> {
+  await enqueueManagerTask(kind, params);
+  return runManagerQueue();
+}
+
+/**
+ * ENQUEUE one operation on the detected dialect WITHOUT draining the queue.
+ *
+ * Split out of queueManagerTask so a caller can tell an ENQUEUE failure apart from
+ * a later queue-control/drain failure (codex review on #424): a 405 raised by
+ * `${prefix}/start` inside runManagerQueue says nothing about whether the
+ * OPERATION's own route exists, so it must never be read as "this build doesn't
+ * register that route". Everything else goes through queueManagerTask and is
+ * unaffected.
+ */
+async function enqueueManagerTask(
+  kind: ManagerTaskKind,
+  params: Record<string, unknown>,
+): Promise<void> {
   const uiId = randomUUID();
   const api = await detectManagerApi();
-  if (api === "legacy") return runLegacyTask(kind, params, uiId);
-  if (api === "v2-batch") return runV2BatchTask(kind, params, uiId);
+  if (api === "legacy") return enqueueLegacyTask(kind, params, uiId);
+  if (api === "v2-batch") return enqueueV2BatchTask(kind, params, uiId);
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
     await managerFetch("/v2/manager/queue/task", {
@@ -615,36 +633,34 @@ async function queueManagerTask(
         "Manager /v2/manager/queue/task 405 — retrying via the v2-batch envelope",
         { kind },
       );
-      const status = await runV2BatchTask(kind, params, uiId);
+      await enqueueV2BatchTask(kind, params, uiId);
       // Pin the corrected dialect ONLY after the batch enqueue actually
       // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
-      // batch also unavailable) never poisons the cache: runV2BatchTask throws
-      // on a batch failure, leaving the cache as "v2" so the next op re-probes
-      // the unified task route (codex review).
+      // batch also unavailable) never poisons the cache: enqueueV2BatchTask
+      // throws on a batch failure, leaving the cache as "v2" so the next op
+      // re-probes the unified task route (codex review).
       demoteManagerApiToV2Batch();
-      return status;
+      return;
     }
     throw err;
   }
-  return runManagerQueue();
 }
 
 /**
  * Enqueue one operation on the released Manager 3.x per-operation routes
- * (issue #116 — the unified /v2 task route 405s there) and drain the queue.
+ * (issue #116 — the unified /v2 task route 405s there). Does NOT drain.
  */
-async function runLegacyTask(
+async function enqueueLegacyTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
-): Promise<QueueStatus> {
+): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     await managerFetch(path, { method: "POST", body });
   } catch (err) {
     throw annotateLegacyError(err, kind);
   }
-  return runManagerQueue();
 }
 
 /**
@@ -654,13 +670,13 @@ async function runLegacyTask(
  * take 3.x body shapes wrapped in the batch envelope {<op>: [body, ...]}; the
  * batch runs its items synchronously and reports failures as {failed: [id, ...]}.
  * install-model keeps its dedicated route (same path as v4, 3.x whitelist
- * semantics).
+ * semantics). Does NOT drain.
  */
-async function runV2BatchTask(
+async function enqueueV2BatchTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
-): Promise<QueueStatus> {
+): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     if (kind === "install-model") {
@@ -685,7 +701,6 @@ async function runV2BatchTask(
   } catch (err) {
     throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
   }
-  return runManagerQueue();
 }
 
 // ---------------------------------------------------------------------------
@@ -1354,35 +1369,73 @@ function isManagerSelfTarget(id: string): boolean {
 }
 
 /**
- * Directly git-pull the local custom_nodes/ComfyUI-Manager checkout as a
- * fallback for the one op the legacy 3.x queue can't do — update the running
- * Manager itself (#424). Returns undefined when there is no local install or no
- * on-disk Manager checkout (e.g. pip comfyui_manager, which has no custom_nodes
- * clone), so the caller can surface an actionable error. A NodeManagementError
- * from the git pull itself propagates.
+ * The on-disk ComfyUI-Manager git checkout that belongs to the CONNECTED ComfyUI,
+ * or undefined when there is none we can honestly claim to be the same install.
+ *
+ * The loopback gate matters: `config.comfyuiPath` is a LOCAL filesystem path, so
+ * when the connected Manager lives on another host (RunPod, a LAN box) pulling the
+ * local checkout would update a DIFFERENT machine's Manager and report that as the
+ * fix — a fabricated success. Only when the Manager we just talked to is on this
+ * machine is the local checkout the same Manager.
  */
-function updateManagerSelfLocally(): NodeOpResult | undefined {
+function localManagerCheckoutDir(): string | undefined {
   if (!config.comfyuiPath) return undefined;
+  let host: string | undefined;
+  try {
+    host = new URL(managerBaseUrl()).hostname;
+  } catch {
+    host = undefined;
+  }
+  if (!isLoopbackHost(host)) return undefined;
   const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
-  const dir = ["ComfyUI-Manager", "comfyui-manager", "comfyui_manager"]
+  return ["ComfyUI-Manager", "comfyui-manager", "comfyui_manager"]
     .map((d) => join(customNodesRoot, d))
     .find((p) => existsSync(join(p, ".git")));
-  if (!dir) return undefined;
+}
+
+/** Current HEAD of a git checkout, or undefined when it can't be read. Used to
+ *  PROVE whether a pull actually moved the checkout (never assume it did). */
+function gitHeadOf(dir: string): string | undefined {
   try {
-    const out = execFileSync("git", ["-C", dir, "pull", "--ff-only"], {
-      cwd: config.comfyuiPath,
+    const out = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], {
+      cwd: dir,
       encoding: "utf-8",
       timeout: GIT_CLONE_TIMEOUT,
       env: nonInteractiveGitEnv(),
     });
-    return {
-      mechanism: "git-clone",
-      message:
-        `Updated ComfyUI-Manager itself via a direct git pull of ${dir} ` +
-        `(the legacy 3.x queue can't self-update the running Manager). ` +
-        `RESTART ComfyUI to load the new Manager.`,
-      details: out.trim(),
-    };
+    const head = String(out).trim();
+    return head.length ? head : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Directly git-pull the local custom_nodes/ComfyUI-Manager checkout — the LAST
+ * RESORT for the one op a Manager build can refuse: updating the running Manager
+ * itself (#424). Returns undefined when there is no usable local checkout (remote
+ * ComfyUI, no comfyuiPath, or a pip comfyui_manager install with no custom_nodes
+ * clone), so the caller can surface an actionable error instead. A
+ * NodeManagementError from the git pull itself propagates.
+ *
+ * The result NEVER claims an update that didn't happen: HEAD is read before and
+ * after the pull, and an unchanged (or unreadable) HEAD is reported as exactly
+ * that. `git pull` exiting 0 on "Already up to date." is a no-op, not a fix.
+ */
+function updateManagerSelfLocally(): NodeOpResult | undefined {
+  const dir = localManagerCheckoutDir();
+  if (!dir) return undefined;
+  const before = gitHeadOf(dir);
+  let out: string;
+  try {
+    out = String(
+      execFileSync("git", ["-C", dir, "pull", "--ff-only"], {
+        cwd: config.comfyuiPath,
+        encoding: "utf-8",
+        timeout: GIT_CLONE_TIMEOUT,
+        env: nonInteractiveGitEnv(),
+      }),
+    );
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
     throw new NodeManagementError(
@@ -1391,6 +1444,105 @@ function updateManagerSelfLocally(): NodeOpResult | undefined {
       { stdout: e.stdout?.toString() ?? "", stderr: e.stderr?.toString() ?? "" },
     );
   }
+  const after = gitHeadOf(dir);
+  const details = { dir, before, after, output: out.trim() };
+  if (before === undefined || after === undefined) {
+    return {
+      mechanism: "git-clone",
+      message:
+        `Ran a git pull of the local ComfyUI-Manager checkout ${dir}, but its HEAD could ` +
+        `NOT be read before/after, so whether the Manager actually advanced is UNVERIFIED. ` +
+        `Check the checkout manually (git -C "${dir}" log -1), then restart ComfyUI.`,
+      details,
+    };
+  }
+  if (before === after) {
+    return {
+      mechanism: "git-clone",
+      message:
+        `ComfyUI-Manager at ${dir} is ALREADY UP TO DATE — the git pull changed NOTHING ` +
+        `(HEAD stayed at ${after.slice(0, 8)}). No update was performed, so a restart ` +
+        `would not change the Manager version. If you expected a newer Manager, the ` +
+        `checkout may track a pinned branch/tag, or the running Manager may be a ` +
+        `DIFFERENT install (e.g. the pip comfyui_manager package shadowing this clone).`,
+      details,
+    };
+  }
+  return {
+    mechanism: "git-clone",
+    message:
+      `Updated ComfyUI-Manager itself via a direct git pull of ${dir} ` +
+      `(${before.slice(0, 8)} → ${after.slice(0, 8)}). ` +
+      `RESTART ComfyUI to load the new Manager.`,
+    details,
+  };
+}
+
+/** Actionable terminal error when NOTHING can advance the Manager for us. */
+function managerSelfUpdateUnsupported(api: ManagerApi, cause?: unknown): NodeManagementError {
+  const dialect =
+    api === "legacy"
+      ? "the LEGACY ComfyUI-Manager 3.x queue API"
+      : api === "v2-batch"
+        ? "this Manager's legacy-UI (3.x-under-/v2) queue API"
+        : "this Manager's queue API";
+  return new NodeManagementError(
+    `Updating ComfyUI-Manager ITSELF is not supported by ${dialect} on this build — ` +
+      `its self-update route answered HTTP 405 (the route is not registered), and no LOCAL ` +
+      `ComfyUI-Manager git checkout belonging to the connected ComfyUI was found to pull ` +
+      `directly. NOTHING WAS UPDATED. Update ComfyUI-Manager on the ComfyUI HOST instead: ` +
+      `git -C custom_nodes/ComfyUI-Manager pull, or (for the pip package) ` +
+      `pip install -U comfyui_manager — then restart ComfyUI. ` +
+      `See https://comfyui-mcp.artokun.io/docs/troubleshooting`,
+    cause instanceof NodeManagementError ? cause.details : undefined,
+  );
+}
+
+/**
+ * Update ComfyUI-Manager ITSELF (#424).
+ *
+ * The released Manager 3.x DOES support this through its ordinary per-operation
+ * route — POST /manager/queue/update with { id: "comfyui-manager", version } —
+ * verified against ComfyUI-Manager 3.41 glob/manager_server.py + manager_core.py:
+ * `unified_update` has NO comfyui-manager guard (unlike install/enable/disable/
+ * uninstall, which explicitly refuse it), and /manager/queue/update_all itself
+ * enqueues 'comfyui-manager' as an update task. The original #424 HTTP 405 came
+ * from posting the v4-only unified envelope path (…/queue/task) at a 3.x server,
+ * where an UNREGISTERED POST is answered 405 by ComfyUI's frontend catchall —
+ * not from any per-pack refusal. So: route the self-update at the real endpoint
+ * for the detected dialect first.
+ *
+ * Only when THAT route also answers 405 (genuinely unregistered on this build) do
+ * we fall back — a direct git pull of the connected ComfyUI's own on-disk Manager
+ * checkout, else an explicit "not supported, update it via X" error. We never
+ * report success we didn't observe.
+ */
+async function updateManagerSelf(id: string): Promise<NodeOpResult> {
+  const api = await detectManagerApi();
+  // ONLY the enqueue is inspected for the 405 signal. A 405 raised later, while
+  // draining (e.g. `${prefix}/start`), says nothing about whether the update route
+  // exists, so it must propagate as itself rather than trigger the fallback
+  // (codex review) — hence enqueue and drain are called separately here.
+  try {
+    await enqueueManagerTask("update", { node_name: id });
+  } catch (err) {
+    if (errorStatus(err) !== 405) throw err;
+    // 405 = the update route is not registered on this build (#424). Fall back.
+    logger.debug("Manager self-update route 405 — falling back to a local git pull", { api });
+    const local = updateManagerSelfLocally();
+    if (local) return local;
+    throw managerSelfUpdateUnsupported(api, err);
+  }
+  const status = await runManagerQueue();
+  return {
+    mechanism: "manager-http",
+    message:
+      `Queued ComfyUI-Manager's own update via ComfyUI-Manager (${id}) and the queue drained. ` +
+      `Manager marks a task done even when the underlying git/registry update was a no-op or ` +
+      `failed, and a Manager self-update only takes effect after a RESTART — restart ComfyUI, ` +
+      `then confirm the Manager version actually changed.`,
+    details: status,
+  };
 }
 
 export function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
@@ -1414,24 +1566,12 @@ async function updateCustomNodeImpl(
     };
   }
 
-  // Updating ComfyUI-Manager ITSELF through its own task queue is the one op the
-  // queue can't reliably perform: legacy Manager 3.x 405s the update route for
-  // the running Manager pack, so the in-panel 3.x→v4 upgrade path deadlocks
-  // (#424). When the target IS the Manager pack and we have a LOCAL install, do
-  // a direct `git pull` of the custom_nodes/ComfyUI-Manager checkout instead —
-  // the only in-repo way to actually advance it (a restart then loads the new
-  // code). Remote targets can't be git-controlled → clear, actionable error.
-  if (!all && isManagerSelfTarget(id) && (await detectManagerApi()) === "legacy") {
-    const local = updateManagerSelfLocally();
-    if (local) return local;
-    throw new NodeManagementError(
-      `Updating ComfyUI-Manager itself is not supported over the LEGACY Manager 3.x queue ` +
-        `API (it 405s the self-update route — #424), and no LOCAL custom_nodes/ComfyUI-Manager ` +
-        `checkout was found to git-pull directly. Update ComfyUI-Manager on the host ` +
-        `(git pull in custom_nodes/ComfyUI-Manager, or pip install -U comfyui_manager), then ` +
-        `restart ComfyUI.`,
-    );
-  }
+  // Updating ComfyUI-Manager ITSELF is its own routing problem (#424): it has a
+  // real endpoint on every dialect, but a build that doesn't register it answers
+  // 405 (ComfyUI's catchall) and the in-panel 3.x→v4 upgrade path deadlocks.
+  // updateManagerSelf tries the right endpoint first and only then falls back to
+  // a local git pull / an explicit "not supported here" error.
+  if (!all && isManagerSelfTarget(id)) return updateManagerSelf(id);
 
   let status: QueueStatus;
   if (all) {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
-import { config, getComfyUIBaseUrl, isLoopbackHost } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
@@ -1369,116 +1369,10 @@ function isManagerSelfTarget(id: string): boolean {
 }
 
 /**
- * The on-disk ComfyUI-Manager git checkout that belongs to the CONNECTED ComfyUI,
- * or undefined when there is none we can honestly claim to be the same install.
- *
- * The loopback gate matters: `config.comfyuiPath` is a LOCAL filesystem path, so
- * when the connected Manager lives on another host (RunPod, a LAN box) pulling the
- * local checkout would update a DIFFERENT machine's Manager and report that as the
- * fix — a fabricated success. Only when the Manager we just talked to is on this
- * machine is the local checkout the same Manager.
+ * Actionable terminal error for a Manager build that does not register its own
+ * self-update route. This is the ONLY outcome of that case — see updateManagerSelf
+ * for why there is deliberately no local-git fallback.
  */
-function localManagerCheckoutDir(): string | undefined {
-  if (!config.comfyuiPath) return undefined;
-  let host: string | undefined;
-  try {
-    host = new URL(managerBaseUrl()).hostname;
-  } catch {
-    host = undefined;
-  }
-  if (!isLoopbackHost(host)) return undefined;
-  const customNodesRoot = resolve(config.comfyuiPath, "custom_nodes");
-  return ["ComfyUI-Manager", "comfyui-manager", "comfyui_manager"]
-    .map((d) => join(customNodesRoot, d))
-    .find((p) => existsSync(join(p, ".git")));
-}
-
-/** Current HEAD of a git checkout, or undefined when it can't be read. Used to
- *  PROVE whether a pull actually moved the checkout (never assume it did). */
-function gitHeadOf(dir: string): string | undefined {
-  try {
-    const out = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"], {
-      cwd: dir,
-      encoding: "utf-8",
-      timeout: GIT_CLONE_TIMEOUT,
-      env: nonInteractiveGitEnv(),
-    });
-    const head = String(out).trim();
-    return head.length ? head : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Directly git-pull the local custom_nodes/ComfyUI-Manager checkout — the LAST
- * RESORT for the one op a Manager build can refuse: updating the running Manager
- * itself (#424). Returns undefined when there is no usable local checkout (remote
- * ComfyUI, no comfyuiPath, or a pip comfyui_manager install with no custom_nodes
- * clone), so the caller can surface an actionable error instead. A
- * NodeManagementError from the git pull itself propagates.
- *
- * The result NEVER claims an update that didn't happen: HEAD is read before and
- * after the pull, and an unchanged (or unreadable) HEAD is reported as exactly
- * that. `git pull` exiting 0 on "Already up to date." is a no-op, not a fix.
- */
-function updateManagerSelfLocally(): NodeOpResult | undefined {
-  const dir = localManagerCheckoutDir();
-  if (!dir) return undefined;
-  const before = gitHeadOf(dir);
-  let out: string;
-  try {
-    out = String(
-      execFileSync("git", ["-C", dir, "pull", "--ff-only"], {
-        cwd: config.comfyuiPath,
-        encoding: "utf-8",
-        timeout: GIT_CLONE_TIMEOUT,
-        env: nonInteractiveGitEnv(),
-      }),
-    );
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
-    throw new NodeManagementError(
-      `git pull of the local ComfyUI-Manager checkout (${dir}) failed: ${e.message}. ` +
-        `Update it manually (git pull, or pip install -U comfyui_manager) then restart ComfyUI.`,
-      { stdout: e.stdout?.toString() ?? "", stderr: e.stderr?.toString() ?? "" },
-    );
-  }
-  const after = gitHeadOf(dir);
-  const details = { dir, before, after, output: out.trim() };
-  if (before === undefined || after === undefined) {
-    return {
-      mechanism: "git-clone",
-      message:
-        `Ran a git pull of the local ComfyUI-Manager checkout ${dir}, but its HEAD could ` +
-        `NOT be read before/after, so whether the Manager actually advanced is UNVERIFIED. ` +
-        `Check the checkout manually (git -C "${dir}" log -1), then restart ComfyUI.`,
-      details,
-    };
-  }
-  if (before === after) {
-    return {
-      mechanism: "git-clone",
-      message:
-        `ComfyUI-Manager at ${dir} is ALREADY UP TO DATE — the git pull changed NOTHING ` +
-        `(HEAD stayed at ${after.slice(0, 8)}). No update was performed, so a restart ` +
-        `would not change the Manager version. If you expected a newer Manager, the ` +
-        `checkout may track a pinned branch/tag, or the running Manager may be a ` +
-        `DIFFERENT install (e.g. the pip comfyui_manager package shadowing this clone).`,
-      details,
-    };
-  }
-  return {
-    mechanism: "git-clone",
-    message:
-      `Updated ComfyUI-Manager itself via a direct git pull of ${dir} ` +
-      `(${before.slice(0, 8)} → ${after.slice(0, 8)}). ` +
-      `RESTART ComfyUI to load the new Manager.`,
-    details,
-  };
-}
-
-/** Actionable terminal error when NOTHING can advance the Manager for us. */
 function managerSelfUpdateUnsupported(api: ManagerApi, cause?: unknown): NodeManagementError {
   const dialect =
     api === "legacy"
@@ -1488,11 +1382,14 @@ function managerSelfUpdateUnsupported(api: ManagerApi, cause?: unknown): NodeMan
         : "this Manager's queue API";
   return new NodeManagementError(
     `Updating ComfyUI-Manager ITSELF is not supported by ${dialect} on this build — ` +
-      `its self-update route answered HTTP 405 (the route is not registered), and no LOCAL ` +
-      `ComfyUI-Manager git checkout belonging to the connected ComfyUI was found to pull ` +
-      `directly. NOTHING WAS UPDATED. Update ComfyUI-Manager on the ComfyUI HOST instead: ` +
-      `git -C custom_nodes/ComfyUI-Manager pull, or (for the pip package) ` +
-      `pip install -U comfyui_manager — then restart ComfyUI. ` +
+      `its self-update route answered HTTP 405, i.e. the route is not registered. ` +
+      `NOTHING WAS UPDATED. Update ComfyUI-Manager on the ComfyUI HOST instead — for a ` +
+      `custom_nodes checkout: \`git -C custom_nodes/ComfyUI-Manager pull\`; for the pip ` +
+      `package: \`pip install -U comfyui_manager\` — then restart ComfyUI. ` +
+      `(comfyui-mcp will not git-pull a checkout on ITS OWN machine for you here: it cannot ` +
+      `prove that checkout is the one the connected server actually loaded — a loopback URL ` +
+      `can be a container or an SSH port-forward — and pulling the wrong copy would report a ` +
+      `fix that never reached your ComfyUI.) ` +
       `See https://comfyui-mcp.artokun.io/docs/troubleshooting`,
     cause instanceof NodeManagementError ? cause.details : undefined,
   );
@@ -1512,25 +1409,38 @@ function managerSelfUpdateUnsupported(api: ManagerApi, cause?: unknown): NodeMan
  * not from any per-pack refusal. So: route the self-update at the real endpoint
  * for the detected dialect first.
  *
- * Only when THAT route also answers 405 (genuinely unregistered on this build) do
- * we fall back — a direct git pull of the connected ComfyUI's own on-disk Manager
- * checkout, else an explicit "not supported, update it via X" error. We never
- * report success we didn't observe.
+ * When THAT route also answers 405 (genuinely unregistered on this build) the ONLY
+ * outcome is the explicit "not supported here, update it on the host via X" error.
+ *
+ * There is deliberately NO local-git fallback. The previous implementation pulled
+ * `config.comfyuiPath`'s custom_nodes/ComfyUI-Manager checkout, which is only ever
+ * correct if that checkout is the one the CONNECTED server actually loaded — and
+ * that cannot be established over HTTP. Successive review rounds killed one
+ * wrong-target hole after another (remote host; --force-remote over a forwarded
+ * loopback port; a second local instance on another port; finally a loopback
+ * container or SSH forward whose reported install root string coincides with a
+ * DIFFERENT host path — /system_stats argv reports a path in the SERVER's
+ * filesystem namespace, which we cannot compare to ours). Each hole ends the same
+ * way: git-pull a checkout the running Manager never loads, then report it as the
+ * fix. shouldDispatchDownloadToManager (model-resolver.ts) hits the same wall and
+ * settles for an existsSync probe only because ITS failure mode is a stray
+ * directory; here it would be a fabricated success, which this issue exists to
+ * eliminate. Refusing with the exact host-side command is always correct; guessing
+ * is not. (The primary path above is the real #424 fix — released Manager 3.x
+ * registers the route, so this branch is for builds that genuinely lack it.)
  */
 async function updateManagerSelf(id: string): Promise<NodeOpResult> {
   const api = await detectManagerApi();
   // ONLY the enqueue is inspected for the 405 signal. A 405 raised later, while
   // draining (e.g. `${prefix}/start`), says nothing about whether the update route
-  // exists, so it must propagate as itself rather than trigger the fallback
+  // exists, so it must propagate as itself rather than be reported as "unsupported"
   // (codex review) — hence enqueue and drain are called separately here.
   try {
     await enqueueManagerTask("update", { node_name: id });
   } catch (err) {
     if (errorStatus(err) !== 405) throw err;
-    // 405 = the update route is not registered on this build (#424). Fall back.
-    logger.debug("Manager self-update route 405 — falling back to a local git pull", { api });
-    const local = updateManagerSelfLocally();
-    if (local) return local;
+    // 405 = the update route is not registered on this build (#424).
+    logger.debug("Manager self-update route 405 — reporting unsupported", { api });
     throw managerSelfUpdateUnsupported(api, err);
   }
   const status = await runManagerQueue();
@@ -1569,8 +1479,8 @@ async function updateCustomNodeImpl(
   // Updating ComfyUI-Manager ITSELF is its own routing problem (#424): it has a
   // real endpoint on every dialect, but a build that doesn't register it answers
   // 405 (ComfyUI's catchall) and the in-panel 3.x→v4 upgrade path deadlocks.
-  // updateManagerSelf tries the right endpoint first and only then falls back to
-  // a local git pull / an explicit "not supported here" error.
+  // updateManagerSelf routes at the right endpoint for the detected dialect, and
+  // on a 405 there reports an explicit "not supported here, run X on the host".
   if (!all && isManagerSelfTarget(id)) return updateManagerSelf(id);
 
   let status: QueueStatus;


### PR DESCRIPTION
## Root cause

`update_custom_node` / `panel_update_node` on `comfyui-manager` **pre-emptively bypassed the Manager queue** on the legacy 3.x dialect and git-pulled a local checkout instead — on the belief that Manager 3.x 405s the self-update route.

It doesn't. Verified against ComfyUI-Manager **3.41** (the exact version in the report), `glob/manager_server.py` + `glob/manager_core.py`:

* `POST /manager/queue/update` is a real, registered per-operation route.
* `manager_core.unified_update` has **no** `comfyui-manager` guard — unlike `unified_install` / `unified_enable` / `unified_disable` / `unified_uninstall` / `cnr_install`, which all explicitly refuse it (`ignored: installing 'comfyui-manager'`).
* `/manager/queue/update_all` **itself** enqueues `("update-main", "comfyui-manager")`.

The reported `Manager manager/queue/task: HTTP 405` came from posting the **v4-only** unified envelope path (`…/queue/task`) at a 3.x server: ComfyUI's frontend catchall answers an *unregistered* POST with 405. That was never a per-pack refusal, so the blanket bypass was the wrong remedy — and it could report `Updated ComfyUI-Manager itself via a direct git pull` when `git pull` had printed `Already up to date.` and changed nothing.

## Fix

Self-update now **routes at the real endpoint for the detected dialect** (`POST /manager/queue/update` on legacy, `{update:[…]}` on v2-batch, the unified task envelope on v2). That is the actual #424 fix.

When *that* enqueue answers 405 (route genuinely unregistered on this build), the **only** outcome is an explicit, actionable error: *not supported on this Manager build, **NOTHING WAS UPDATED**, run `git -C custom_nodes/ComfyUI-Manager pull` or `pip install -U comfyui_manager` on the host, then restart* — never a generic 405, never a success-looking result.

### There is deliberately no local git-pull fallback

The old fallback pulled a checkout on the **orchestrator's** machine, which is only correct if that checkout is the one the **connected server** actually loaded. That can't be established over HTTP, and four review rounds each found another wrong-target hole:

| # | Hole | Attempted gate |
|---|---|---|
| 1 | remote ComfyUI + `COMFYUI_PATH` set | hostname loopback check |
| 2 | `--force-remote` over a **forwarded** loopback port (config this repo explicitly supports) | + refuse on force-remote/remote-mode |
| 3 | a second **local** instance on another port | + require live root (`/system_stats` argv) == `comfyuiPath` |
| 4 | a loopback **container** / SSH forward whose reported root *string* coincides with a different host path | ✗ unfixable — `realpath` only sees this machine's namespace |

Every hole ends the same way: git-pull a checkout the running Manager never loads, then report it as the fix. `shouldDispatchDownloadToManager` (`model-resolver.ts:1286`) hits the same wall and settles for an `existsSync` probe only because *its* failure mode is a stray directory; here it's a fabricated success — the exact class of bug this issue exists to eliminate. Codex confirmed no HTTP-observable signal can prove filesystem identity (a container can reproduce every visible datum — path strings, versions, pack metadata, git revisions — in a different namespace).

Refusing with the exact host-side command is always correct; guessing is not. This costs nothing for the reported bug, since released 3.x registers the route.

### Honest reporting on the success path

The queue result states plainly that a drained 3.x queue does **not** prove the update happened (3.x reports per-task results only over websocket; `/manager/queue/status` carries counts alone) and tells the user to restart and confirm the version.

### Also fixed (codex round 1)

Catching 405 around the whole enqueue-and-drain sequence would misread a 405 from the queue-control route (`…/queue/start`) as "the update route is missing". `queueManagerTask` is now split into `enqueueManagerTask` + `runManagerQueue`, and the 405 signal is read **only** from the enqueue.

## Tests

`src/__tests__/services/node-management.test.ts`, legacy-dialect suite:

* legacy self-update routes to `POST /manager/queue/update` with `id: "comfyui-manager"`, never touches `…/queue/task`, and never shells out to git;
* third-party pack update (`rgthree-comfy`) unchanged;
* **parameterized wrong-target property test** — matching live root, `--force-remote` over loopback, mismatched live root, unknown live root, container-vs-host path collision — each must refuse explicitly and **never run git**, so reintroducing a "this one looks local enough" pull fails the suite;
* remote host also refuses;
* a `queue/start` 405 during the **drain** propagates as itself, not as the unsupported verdict.

`npm run build` green; full suite green apart from the pre-existing, unrelated `node-dev.test.ts > builtin fallback finds matches and skips binary files` failure (fails identically on `main`).

## Out of scope

Stale Manager **dialect caching** is issue #646 and is deliberately untouched here — `detectManagerApi` is unchanged.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
