### PR TITLE
fix(environment): probe the ComfyUI venv interpreter, never fabricate "not installed" (#401)

### DIFF
--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -215,7 +215,7 @@ List known/auto-detected ComfyUI installations on this machine. Scans common ins
 
 ## get_environment
 
-Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). Degrades gracefully: local probes are omitted when no local path is configured or tools are unavailable.
+Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). The local python probe targets the interpreter the RUNNING server uses (its venv / embedded / standalone python, resolved from the live server), never a bare `python` on PATH. Degrades gracefully and NEVER guesses: when the correct interpreter can't be confirmed, `local.python_probe_trusted` is false, `local.packages` is omitted, and `local.python_probe_reason` says why — an absent package list means UNDETERMINED, never 'not installed'.
 
 <Note>This tool takes no parameters.</Note>
 

--- a/src/__tests__/services/desktop-restart.test.ts
+++ b/src/__tests__/services/desktop-restart.test.ts
@@ -74,7 +74,9 @@ beforeEach(() => {
     if (/netstat/i.test(cmd)) {
       return "  TCP    127.0.0.1:8188    0.0.0.0:0    LISTENING    4321\n";
     }
-    if (/lsof/i.test(cmd)) return "4321\n";
+    // findPidByPort probes with `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn`, whose
+    // field output is p<pid> / n<addr:port> records — not the terse `-t` list.
+    if (/lsof/i.test(cmd)) return "p4321\nn127.0.0.1:8188\n";
     return "";
   });
   __processControlTestHooks.reset();

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -219,7 +219,10 @@ describe("applyStats", () => {
   });
 });
 
-describe("resolveComfyuiPython (#401)", () => {
+describe("resolveComfyuiPython — BEST-GUESS selection only (#401)", () => {
+  // This resolver decides what to PROBE. It deliberately reports no authority
+  // signals any more: which interpreter the server actually runs is answered by
+  // live-interpreter.ts (we launched it / the OS says so), never by layout.
   let dir: string;
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "comfyui-py-"));
@@ -228,17 +231,19 @@ describe("resolveComfyuiPython (#401)", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it("returns the on-disk venv interpreter as VERIFIED", async () => {
-    const venvBin = IS_WIN ? join(dir, ".venv", "Scripts") : join(dir, ".venv", "bin");
-    await mkdir(venvBin, { recursive: true });
-    const exe = join(venvBin, IS_WIN ? "python.exe" : "python3");
+  const mkVenvAt = async (root: string): Promise<string> => {
+    const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
+    await mkdir(bin, { recursive: true });
+    const exe = join(bin, IS_WIN ? "python.exe" : "python3");
     await writeFile(exe, "", "utf-8");
+    return exe;
+  };
 
+  it("returns the on-disk venv interpreter as VERIFIED", async () => {
+    const exe = await mkVenvAt(dir);
     const res = resolveComfyuiPython(dir, undefined);
     expect(res.verified).toBe(true);
     expect(res.python).toBe(exe);
-    // No argv → this is NOT the live interpreter (just the pinned workspace's venv).
-    expect(res.live).toBe(false);
   });
 
   it("finds the embedded python of a portable install as VERIFIED (not just .venv)", async () => {
@@ -254,173 +259,51 @@ describe("resolveComfyuiPython (#401)", () => {
   });
 
   it("falls back to a bare PATH name as UNVERIFIED when no venv exists", () => {
-    // A directory with no interpreter under it — the wrong-python scenario.
     const res = resolveComfyuiPython(dir, undefined);
     expect(res.verified).toBe(false);
-    expect(res.live).toBe(false);
     expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
   });
 
-  it("prefers the LIVE running instance's argv root over a pinned/saved workspace (PR #433 review)", async () => {
-    // Both installs exist with a venv on the same Python major.minor, but only the
-    // LIVE server (root B, from argv main.py) has the package. If we resolved the
-    // pinned/saved root A first, A's negative would survive as a false 'not-installed'
-    // AND process-control could relaunch B's main.py with A's python. The live argv
-    // root must win.
-    const mkVenv = async (root: string): Promise<string> => {
-      const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
-      await mkdir(bin, { recursive: true });
-      const exe = join(bin, IS_WIN ? "python.exe" : "python3");
-      await writeFile(exe, "", "utf-8");
-      return exe;
-    };
+  it("probes the LIVE running instance's argv root ahead of a pinned/saved workspace", async () => {
     const rootA = join(dir, "A"); // pinned COMFYUI_PATH / saved default
     const rootB = join(dir, "B"); // the LIVE running server
-    await mkVenv(rootA);
-    const exeB = await mkVenv(rootB);
+    await mkVenvAt(rootA);
+    const exeB = await mkVenvAt(rootB);
 
     const res = resolveComfyuiPython(rootA, [
       IS_WIN ? "python.exe" : "python3",
       join(rootB, "main.py"),
     ]);
-    expect(res.verified).toBe(true);
-    expect(res.live).toBe(true);
-    expect(res.liveRoot).toBe(rootB);
     expect(res.python).toBe(exeB); // B, not A
+    expect(res.liveRoot).toBe(rootB);
   });
 
-  it("marks the pinned workspace UNTRUSTED (live:false) when the LIVE root has no on-disk venv", async () => {
-    // Live root B (from argv) has no interpreter on disk; only pinned A does. A must
-    // NOT be reported as the live interpreter — its negative would be a false report.
-    const binA = IS_WIN ? join(dir, "A", ".venv", "Scripts") : join(dir, "A", ".venv", "bin");
-    await mkdir(binA, { recursive: true });
-    const exeA = join(binA, IS_WIN ? "python.exe" : "python3");
-    await writeFile(exeA, "", "utf-8");
+  it("falls back to the pinned workspace when the LIVE root has no on-disk venv", async () => {
+    const exeA = await mkVenvAt(join(dir, "A"));
     const rootB = join(dir, "B"); // live root, but no venv created under it
+    await mkdir(rootB, { recursive: true });
 
     const res = resolveComfyuiPython(join(dir, "A"), [join(rootB, "main.py")]);
-    expect(res.python).toBe(exeA); // A is the only interpreter we can probe …
-    expect(res.verified).toBe(true);
-    expect(res.live).toBe(false); // … but it is NOT the live interpreter
-    expect(res.liveRoot).toBe(rootB); // live root was resolvable, just not populated
+    expect(res.python).toBe(exeA);
+    expect(res.liveRoot).toBe(rootB); // live root resolvable, just not populated
   });
 
-  // -- ComfyUI Desktop: RELATIVE argv main.py, no cwd (#401 recurrence) --------
-  //
-  // Desktop reports argv[0] = "ComfyUI\\main.py" with no cwd, so the live root is
-  // UNRESOLVED and resolution used to fall back to COMFYUI_PATH (the bundle root),
-  // picking the launcher's standalone-env python — an environment the running server
-  // never imports from. Anchoring the relative dir on the base fixes the selection.
-  const mkVenvAt = async (root: string): Promise<string> => {
-    const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
-    await mkdir(bin, { recursive: true });
-    const exe = join(bin, IS_WIN ? "python.exe" : "python3");
-    await writeFile(exe, "", "utf-8");
-    return exe;
-  };
-
   it("anchors a RELATIVE argv main.py on the configured base and picks the SERVER's venv", async () => {
-    const base = join(dir, "Desktop"); // COMFYUI_PATH — the bundle root
-    const server = join(base, "ComfyUI"); // where main.py + the server venv live
+    // ComfyUI Desktop reports argv[0] = "ComfyUI\main.py" with no cwd. Anchoring is
+    // what gets the PROBE onto the server's own venv instead of the bundle
+    // launcher's standalone-env — which is what lets a positive capability finding
+    // (e.g. Triton IS installed) be made at all.
+    const base = join(dir, "Desktop");
+    const server = join(base, "ComfyUI");
     await mkdir(server, { recursive: true });
     await writeFile(join(server, "main.py"), "", "utf-8");
-    const wrong = await mkVenvAt(base); // the launcher's env (must NOT win)
+    const wrong = await mkVenvAt(base);
     const right = await mkVenvAt(server);
 
     const res = resolveComfyuiPython(base, [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"]);
     expect(res.python).toBe(right);
     expect(res.python).not.toBe(wrong);
-    expect(res.live).toBe(true);
-    expect(res.anchored).toBe(true); // inferred, not read straight off argv
-    expect(res.proven).toBe(false); // …so its negatives are never authoritative
     expect(res.liveRoot).toBe(server);
-  });
-
-  it("marks a live root holding SEVERAL environments as ambiguous, not proven", async () => {
-    // `.venv` and `venv` side by side: both are plausible, nothing says which ComfyUI
-    // runs. We still probe one, but it must not be able to say "not installed".
-    const root = join(dir, "twoenvs");
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, "main.py"), "", "utf-8");
-    await mkVenvAt(root);
-    const otherBin = IS_WIN ? join(root, "venv", "Scripts") : join(root, "venv", "bin");
-    await mkdir(otherBin, { recursive: true });
-    await writeFile(join(otherBin, IS_WIN ? "python.exe" : "python3"), "", "utf-8");
-
-    const res = resolveComfyuiPython(undefined, [join(root, "main.py")]);
-    expect(res.live).toBe(true); // the ROOT is certain …
-    expect(res.ambiguous).toBe(true); // … the interpreter under it is not
-    expect(res.proven).toBe(false);
-  });
-
-  it("treats a standalone-env beside a .venv as ambiguous (embedded_python can't split them)", async () => {
-    if (!IS_WIN) return; // standalone-env is a Windows bundle layout
-    const root = join(dir, "stand");
-    await mkdir(join(root, "standalone-env"), { recursive: true });
-    await writeFile(join(root, "main.py"), "", "utf-8");
-    await writeFile(join(root, "standalone-env", "python.exe"), "", "utf-8");
-    await mkVenvAt(root);
-
-    // embedded_python:false rules out `python_embeded` but says nothing about
-    // .venv vs standalone-env — so this stays ambiguous, never proven.
-    const res = resolveComfyuiPython(undefined, [join(root, "main.py")], {
-      embeddedPython: false,
-    });
-    expect(res.ambiguous).toBe(true);
-    expect(res.proven).toBe(false);
-  });
-
-  it("refuses PROVEN for a PARENT-RELATIVE candidate when the server omits embedded_python", async () => {
-    if (!IS_WIN) return; // ../python_embeded is a Windows-portable candidate
-    // HIGH 2: argv gives the absolute root <bundle>/ComfyUI, but the only discoverable
-    // interpreter is the bundle's SIBLING python_embeded — outside that root by
-    // construction. With no embedded_python self-report, "the sibling dir has one" is a
-    // layout guess, so it must not confer authority (the server may run an external
-    // venv of the same major.minor entirely).
-    const bundle = join(dir, "bundle");
-    const server = join(bundle, "ComfyUI");
-    await mkdir(server, { recursive: true });
-    await writeFile(join(server, "main.py"), "", "utf-8");
-    const embDir = join(bundle, "python_embeded");
-    await mkdir(embDir, { recursive: true });
-    const embExe = join(embDir, "python.exe");
-    await writeFile(embExe, "", "utf-8");
-
-    const res = resolveComfyuiPython(bundle, [join(server, "main.py")]); // no hint
-    expect(res.python).toBe(embExe); // still the best candidate to PROBE …
-    expect(res.live).toBe(true);
-    expect(res.ambiguous).toBe(false);
-    expect(res.proven).toBe(false); // … but it cannot speak for the server
-    // Its negatives therefore degrade to unknown rather than "not installed".
-    expect(
-      reconcileProbeState("not-installed", {
-        proven: res.proven,
-        runningPython: "3.12",
-        probePython: "3.12",
-      }),
-    ).toBe("unknown");
-
-    // The same candidate IS authoritative once the server says it runs an embedded
-    // python — then the location is grounded in the server's own self-report.
-    const withHint = resolveComfyuiPython(bundle, [join(server, "main.py")], {
-      embeddedPython: true,
-    });
-    expect(withHint.python).toBe(embExe);
-    expect(withHint.proven).toBe(true);
-  });
-
-  it("is PROVEN when the server's own argv root holds exactly one interpreter", async () => {
-    const root = join(dir, "single");
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, "main.py"), "", "utf-8");
-    const exe = await mkVenvAt(root);
-
-    const res = resolveComfyuiPython(undefined, [join(root, "main.py")], {
-      embeddedPython: false,
-    });
-    expect(res.python).toBe(exe);
-    expect(res.proven).toBe(true);
-    expect(res.ambiguous).toBe(false);
   });
 
   it("prefers a nested ComfyUI/ server root over the bundle root even without argv", async () => {
@@ -434,13 +317,9 @@ describe("resolveComfyuiPython (#401)", () => {
     const res = resolveComfyuiPython(base, undefined);
     expect(res.python).toBe(right);
     expect(res.verified).toBe(true);
-    expect(res.live).toBe(false); // no argv → nothing proves it is the live one
-    expect(res.anchored).toBe(false);
   });
 
   it("never lets a nested ComfyUI/ tree outrank a root that is itself the server root", async () => {
-    // The live argv root X has its own main.py; a stray X/ComfyUI checkout also has one.
-    // X's interpreter must win — X is exactly what the running server told us.
     const rootX = join(dir, "X");
     await mkdir(join(rootX, "ComfyUI"), { recursive: true });
     await writeFile(join(rootX, "main.py"), "", "utf-8");
@@ -450,11 +329,9 @@ describe("resolveComfyuiPython (#401)", () => {
 
     const res = resolveComfyuiPython(undefined, [join(rootX, "main.py")]);
     expect(res.python).toBe(exeX);
-    expect(res.live).toBe(true);
-    expect(res.anchored).toBe(false);
   });
 
-  it("uses the server's embedded_python self-report to break a venv/python_embeded tie", async () => {
+  it("orders the guess with the server's embedded_python self-report", async () => {
     if (!IS_WIN) return; // python_embeded is a Windows-portable layout
     const bundle = join(dir, "portable");
     const server = join(bundle, "ComfyUI");
@@ -467,25 +344,8 @@ describe("resolveComfyuiPython (#401)", () => {
     await writeFile(embExe, "", "utf-8");
     const argv = [join(server, "main.py")];
 
-    // The server says it runs an embedded python → the bundle's python_embeded wins.
     expect(resolveComfyuiPython(bundle, argv, { embeddedPython: true }).python).toBe(embExe);
-    // It says it does NOT → the install's own .venv wins.
     expect(resolveComfyuiPython(bundle, argv, { embeddedPython: false }).python).toBe(venvExe);
-  });
-
-  it("drops the live claim when the embedded_python hint matches NO candidate we can see", async () => {
-    const root = join(dir, "onlyvenv");
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, "main.py"), "", "utf-8");
-    const venvExe = await mkVenvAt(root);
-
-    // The server runs a python_embeded we cannot find — so this .venv is provably NOT
-    // its interpreter and must never be reported as live (its negatives are worthless).
-    const res = resolveComfyuiPython(root, [join(root, "main.py")], { embeddedPython: true });
-    expect(res.python).toBe(venvExe);
-    expect(res.live).toBe(false);
-    expect(res.anchored).toBe(false);
-    expect(res.proven).toBe(false);
   });
 
   it("refuses to anchor when the relative argv dir has no main.py on disk", async () => {
@@ -494,105 +354,59 @@ describe("resolveComfyuiPython (#401)", () => {
     const baseExe = await mkVenvAt(base);
 
     const res = resolveComfyuiPython(base, [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"]);
-    expect(res.python).toBe(baseExe); // the only interpreter we can see …
-    expect(res.live).toBe(false); // … and it is NOT provably the server's
-    expect(res.anchored).toBe(false);
+    expect(res.python).toBe(baseExe);
     expect(res.liveRoot).toBeUndefined();
   });
 });
 
-describe("reconcileProbeState (#401 — no false 'not installed')", () => {
-  it("keeps 'not-installed' only when the interpreter is PROVEN and versions match", () => {
+describe("reconcileProbeState (#401 — only an OBSERVED interpreter may say 'not installed')", () => {
+  it("keeps 'not-installed' when the interpreter was OBSERVED and versions agree", () => {
     expect(
       reconcileProbeState("not-installed", {
-        proven: true,
+        observed: true,
         runningPython: "3.12",
         probePython: "3.12",
       }),
     ).toBe("not-installed");
   });
 
-  it("degrades 'not-installed' to 'unknown' when the interpreter is NOT the live one", () => {
+  it("degrades 'not-installed' to 'unknown' for a layout GUESS, however plausible", () => {
+    // This is the whole bug: a sole .venv under the server's own root, a matching
+    // python, a matching torch — all satisfied by an environment that is not the
+    // one ComfyUI is running. Without an observation, the negative cannot stand.
     expect(
       reconcileProbeState("not-installed", {
-        proven: false,
+        observed: false,
         runningPython: "3.12",
         probePython: "3.12",
       }),
     ).toBe("unknown");
   });
 
-  it("degrades 'not-installed' to 'unknown' when probe python DISAGREES with the running instance", () => {
-    // The exact issue: running ComfyUI is 3.12, but we probed a 3.11 python.
+  it("degrades 'not-installed' when an observed probe DISAGREES with the running instance", () => {
     expect(
       reconcileProbeState("not-installed", {
-        proven: true,
+        observed: true,
         runningPython: "3.12",
         probePython: "3.11",
       }),
     ).toBe("unknown");
   });
 
-  it("passes a positive 'installed' through untouched even from an untrusted interpreter", () => {
+  it("passes a positive 'installed' through untouched even from an unobserved interpreter", () => {
+    // The asymmetry that makes the fix usable: a package we can SEE installed is
+    // really installed, whichever environment we happened to look at.
     expect(
-      reconcileProbeState("installed", { proven: false, runningPython: "3.12", probePython: "3.11" }),
+      reconcileProbeState("installed", {
+        observed: false,
+        runningPython: "3.12",
+        probePython: "3.11",
+      }),
     ).toBe("installed");
   });
 
   it("treats undefined as 'unknown'", () => {
-    expect(reconcileProbeState(undefined, { proven: true })).toBe("unknown");
-  });
-
-  it("degrades a PROVEN interpreter's negative when its torch contradicts the running server", () => {
-    // `proven` establishes WHERE the interpreter is, not that its contents are the
-    // server's. A torch build that disagrees proves they are different environments,
-    // so "not installed" from it would be exactly the #401 false negative again.
-    expect(
-      reconcileProbeState("not-installed", {
-        proven: true,
-        runningPython: "3.13",
-        probePython: "3.13",
-        runningTorch: "2.9.0+cu128",
-        probeTorch: "2.4.0",
-      }),
-    ).toBe("unknown");
-    // Agreement (or an unreported torch, which contradicts nothing) keeps it.
-    expect(
-      reconcileProbeState("not-installed", {
-        proven: true,
-        runningPython: "3.13",
-        probePython: "3.13",
-        runningTorch: "2.9.0+cu128",
-        probeTorch: "2.9.0+cu128",
-      }),
-    ).toBe("not-installed");
-    expect(
-      reconcileProbeState("not-installed", {
-        proven: true,
-        runningPython: "3.13",
-        probePython: "3.13",
-        runningTorch: "2.9.0+cu128",
-      }),
-    ).toBe("not-installed");
-  });
-
-  it("never emits a definitive negative from an UNPROVEN interpreter (anchored/ambiguous)", () => {
-    // `proven:false` covers a bare PATH fallback, a different workspace, an INFERRED
-    // (anchored) root and an AMBIGUOUS one. None of them may claim "not installed" —
-    // even when the python versions agree, since sibling envs usually share a version.
-    for (const probePython of ["3.13", undefined]) {
-      expect(
-        reconcileProbeState("not-installed", {
-          proven: false,
-          runningPython: "3.13",
-          probePython,
-        }),
-      ).toBe("unknown");
-    }
-    // A positive still passes through — it can never be a harmful false negative.
-    expect(
-      reconcileProbeState("installed", { proven: false, runningPython: "3.13" }),
-    ).toBe("installed");
+    expect(reconcileProbeState(undefined, { observed: true })).toBe("unknown");
   });
 });
 

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -370,6 +370,45 @@ describe("resolveComfyuiPython (#401)", () => {
     expect(res.proven).toBe(false);
   });
 
+  it("refuses PROVEN for a PARENT-RELATIVE candidate when the server omits embedded_python", async () => {
+    if (!IS_WIN) return; // ../python_embeded is a Windows-portable candidate
+    // HIGH 2: argv gives the absolute root <bundle>/ComfyUI, but the only discoverable
+    // interpreter is the bundle's SIBLING python_embeded — outside that root by
+    // construction. With no embedded_python self-report, "the sibling dir has one" is a
+    // layout guess, so it must not confer authority (the server may run an external
+    // venv of the same major.minor entirely).
+    const bundle = join(dir, "bundle");
+    const server = join(bundle, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const embDir = join(bundle, "python_embeded");
+    await mkdir(embDir, { recursive: true });
+    const embExe = join(embDir, "python.exe");
+    await writeFile(embExe, "", "utf-8");
+
+    const res = resolveComfyuiPython(bundle, [join(server, "main.py")]); // no hint
+    expect(res.python).toBe(embExe); // still the best candidate to PROBE …
+    expect(res.live).toBe(true);
+    expect(res.ambiguous).toBe(false);
+    expect(res.proven).toBe(false); // … but it cannot speak for the server
+    // Its negatives therefore degrade to unknown rather than "not installed".
+    expect(
+      reconcileProbeState("not-installed", {
+        proven: res.proven,
+        runningPython: "3.12",
+        probePython: "3.12",
+      }),
+    ).toBe("unknown");
+
+    // The same candidate IS authoritative once the server says it runs an embedded
+    // python — then the location is grounded in the server's own self-report.
+    const withHint = resolveComfyuiPython(bundle, [join(server, "main.py")], {
+      embeddedPython: true,
+    });
+    expect(withHint.python).toBe(embExe);
+    expect(withHint.proven).toBe(true);
+  });
+
   it("is PROVEN when the server's own argv root holds exactly one interpreter", async () => {
     const root = join(dir, "single");
     await mkdir(root, { recursive: true });
@@ -502,6 +541,39 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
 
   it("treats undefined as 'unknown'", () => {
     expect(reconcileProbeState(undefined, { proven: true })).toBe("unknown");
+  });
+
+  it("degrades a PROVEN interpreter's negative when its torch contradicts the running server", () => {
+    // `proven` establishes WHERE the interpreter is, not that its contents are the
+    // server's. A torch build that disagrees proves they are different environments,
+    // so "not installed" from it would be exactly the #401 false negative again.
+    expect(
+      reconcileProbeState("not-installed", {
+        proven: true,
+        runningPython: "3.13",
+        probePython: "3.13",
+        runningTorch: "2.9.0+cu128",
+        probeTorch: "2.4.0",
+      }),
+    ).toBe("unknown");
+    // Agreement (or an unreported torch, which contradicts nothing) keeps it.
+    expect(
+      reconcileProbeState("not-installed", {
+        proven: true,
+        runningPython: "3.13",
+        probePython: "3.13",
+        runningTorch: "2.9.0+cu128",
+        probeTorch: "2.9.0+cu128",
+      }),
+    ).toBe("not-installed");
+    expect(
+      reconcileProbeState("not-installed", {
+        proven: true,
+        runningPython: "3.13",
+        probePython: "3.13",
+        runningTorch: "2.9.0+cu128",
+      }),
+    ).toBe("not-installed");
   });
 
   it("never emits a definitive negative from an UNPROVEN interpreter (anchored/ambiguous)", () => {

--- a/src/__tests__/services/env-capabilities.test.ts
+++ b/src/__tests__/services/env-capabilities.test.ts
@@ -304,13 +304,169 @@ describe("resolveComfyuiPython (#401)", () => {
     expect(res.live).toBe(false); // … but it is NOT the live interpreter
     expect(res.liveRoot).toBe(rootB); // live root was resolvable, just not populated
   });
+
+  // -- ComfyUI Desktop: RELATIVE argv main.py, no cwd (#401 recurrence) --------
+  //
+  // Desktop reports argv[0] = "ComfyUI\\main.py" with no cwd, so the live root is
+  // UNRESOLVED and resolution used to fall back to COMFYUI_PATH (the bundle root),
+  // picking the launcher's standalone-env python — an environment the running server
+  // never imports from. Anchoring the relative dir on the base fixes the selection.
+  const mkVenvAt = async (root: string): Promise<string> => {
+    const bin = IS_WIN ? join(root, ".venv", "Scripts") : join(root, ".venv", "bin");
+    await mkdir(bin, { recursive: true });
+    const exe = join(bin, IS_WIN ? "python.exe" : "python3");
+    await writeFile(exe, "", "utf-8");
+    return exe;
+  };
+
+  it("anchors a RELATIVE argv main.py on the configured base and picks the SERVER's venv", async () => {
+    const base = join(dir, "Desktop"); // COMFYUI_PATH — the bundle root
+    const server = join(base, "ComfyUI"); // where main.py + the server venv live
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const wrong = await mkVenvAt(base); // the launcher's env (must NOT win)
+    const right = await mkVenvAt(server);
+
+    const res = resolveComfyuiPython(base, [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"]);
+    expect(res.python).toBe(right);
+    expect(res.python).not.toBe(wrong);
+    expect(res.live).toBe(true);
+    expect(res.anchored).toBe(true); // inferred, not read straight off argv
+    expect(res.proven).toBe(false); // …so its negatives are never authoritative
+    expect(res.liveRoot).toBe(server);
+  });
+
+  it("marks a live root holding SEVERAL environments as ambiguous, not proven", async () => {
+    // `.venv` and `venv` side by side: both are plausible, nothing says which ComfyUI
+    // runs. We still probe one, but it must not be able to say "not installed".
+    const root = join(dir, "twoenvs");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "main.py"), "", "utf-8");
+    await mkVenvAt(root);
+    const otherBin = IS_WIN ? join(root, "venv", "Scripts") : join(root, "venv", "bin");
+    await mkdir(otherBin, { recursive: true });
+    await writeFile(join(otherBin, IS_WIN ? "python.exe" : "python3"), "", "utf-8");
+
+    const res = resolveComfyuiPython(undefined, [join(root, "main.py")]);
+    expect(res.live).toBe(true); // the ROOT is certain …
+    expect(res.ambiguous).toBe(true); // … the interpreter under it is not
+    expect(res.proven).toBe(false);
+  });
+
+  it("treats a standalone-env beside a .venv as ambiguous (embedded_python can't split them)", async () => {
+    if (!IS_WIN) return; // standalone-env is a Windows bundle layout
+    const root = join(dir, "stand");
+    await mkdir(join(root, "standalone-env"), { recursive: true });
+    await writeFile(join(root, "main.py"), "", "utf-8");
+    await writeFile(join(root, "standalone-env", "python.exe"), "", "utf-8");
+    await mkVenvAt(root);
+
+    // embedded_python:false rules out `python_embeded` but says nothing about
+    // .venv vs standalone-env — so this stays ambiguous, never proven.
+    const res = resolveComfyuiPython(undefined, [join(root, "main.py")], {
+      embeddedPython: false,
+    });
+    expect(res.ambiguous).toBe(true);
+    expect(res.proven).toBe(false);
+  });
+
+  it("is PROVEN when the server's own argv root holds exactly one interpreter", async () => {
+    const root = join(dir, "single");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "main.py"), "", "utf-8");
+    const exe = await mkVenvAt(root);
+
+    const res = resolveComfyuiPython(undefined, [join(root, "main.py")], {
+      embeddedPython: false,
+    });
+    expect(res.python).toBe(exe);
+    expect(res.proven).toBe(true);
+    expect(res.ambiguous).toBe(false);
+  });
+
+  it("prefers a nested ComfyUI/ server root over the bundle root even without argv", async () => {
+    const base = join(dir, "Bundle");
+    const server = join(base, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    await mkVenvAt(base);
+    const right = await mkVenvAt(server);
+
+    const res = resolveComfyuiPython(base, undefined);
+    expect(res.python).toBe(right);
+    expect(res.verified).toBe(true);
+    expect(res.live).toBe(false); // no argv → nothing proves it is the live one
+    expect(res.anchored).toBe(false);
+  });
+
+  it("never lets a nested ComfyUI/ tree outrank a root that is itself the server root", async () => {
+    // The live argv root X has its own main.py; a stray X/ComfyUI checkout also has one.
+    // X's interpreter must win — X is exactly what the running server told us.
+    const rootX = join(dir, "X");
+    await mkdir(join(rootX, "ComfyUI"), { recursive: true });
+    await writeFile(join(rootX, "main.py"), "", "utf-8");
+    await writeFile(join(rootX, "ComfyUI", "main.py"), "", "utf-8");
+    const exeX = await mkVenvAt(rootX);
+    await mkVenvAt(join(rootX, "ComfyUI"));
+
+    const res = resolveComfyuiPython(undefined, [join(rootX, "main.py")]);
+    expect(res.python).toBe(exeX);
+    expect(res.live).toBe(true);
+    expect(res.anchored).toBe(false);
+  });
+
+  it("uses the server's embedded_python self-report to break a venv/python_embeded tie", async () => {
+    if (!IS_WIN) return; // python_embeded is a Windows-portable layout
+    const bundle = join(dir, "portable");
+    const server = join(bundle, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const venvExe = await mkVenvAt(server);
+    const embDir = join(bundle, "python_embeded");
+    await mkdir(embDir, { recursive: true });
+    const embExe = join(embDir, "python.exe");
+    await writeFile(embExe, "", "utf-8");
+    const argv = [join(server, "main.py")];
+
+    // The server says it runs an embedded python → the bundle's python_embeded wins.
+    expect(resolveComfyuiPython(bundle, argv, { embeddedPython: true }).python).toBe(embExe);
+    // It says it does NOT → the install's own .venv wins.
+    expect(resolveComfyuiPython(bundle, argv, { embeddedPython: false }).python).toBe(venvExe);
+  });
+
+  it("drops the live claim when the embedded_python hint matches NO candidate we can see", async () => {
+    const root = join(dir, "onlyvenv");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "main.py"), "", "utf-8");
+    const venvExe = await mkVenvAt(root);
+
+    // The server runs a python_embeded we cannot find — so this .venv is provably NOT
+    // its interpreter and must never be reported as live (its negatives are worthless).
+    const res = resolveComfyuiPython(root, [join(root, "main.py")], { embeddedPython: true });
+    expect(res.python).toBe(venvExe);
+    expect(res.live).toBe(false);
+    expect(res.anchored).toBe(false);
+    expect(res.proven).toBe(false);
+  });
+
+  it("refuses to anchor when the relative argv dir has no main.py on disk", async () => {
+    const base = join(dir, "Plain");
+    await mkdir(join(base, "ComfyUI"), { recursive: true }); // dir exists but NO main.py
+    const baseExe = await mkVenvAt(base);
+
+    const res = resolveComfyuiPython(base, [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"]);
+    expect(res.python).toBe(baseExe); // the only interpreter we can see …
+    expect(res.live).toBe(false); // … and it is NOT provably the server's
+    expect(res.anchored).toBe(false);
+    expect(res.liveRoot).toBeUndefined();
+  });
 });
 
 describe("reconcileProbeState (#401 — no false 'not installed')", () => {
-  it("keeps 'not-installed' only when the interpreter is LIVE and versions match", () => {
+  it("keeps 'not-installed' only when the interpreter is PROVEN and versions match", () => {
     expect(
       reconcileProbeState("not-installed", {
-        live: true,
+        proven: true,
         runningPython: "3.12",
         probePython: "3.12",
       }),
@@ -320,7 +476,7 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
   it("degrades 'not-installed' to 'unknown' when the interpreter is NOT the live one", () => {
     expect(
       reconcileProbeState("not-installed", {
-        live: false,
+        proven: false,
         runningPython: "3.12",
         probePython: "3.12",
       }),
@@ -331,7 +487,7 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
     // The exact issue: running ComfyUI is 3.12, but we probed a 3.11 python.
     expect(
       reconcileProbeState("not-installed", {
-        live: true,
+        proven: true,
         runningPython: "3.12",
         probePython: "3.11",
       }),
@@ -340,12 +496,31 @@ describe("reconcileProbeState (#401 — no false 'not installed')", () => {
 
   it("passes a positive 'installed' through untouched even from an untrusted interpreter", () => {
     expect(
-      reconcileProbeState("installed", { live: false, runningPython: "3.12", probePython: "3.11" }),
+      reconcileProbeState("installed", { proven: false, runningPython: "3.12", probePython: "3.11" }),
     ).toBe("installed");
   });
 
   it("treats undefined as 'unknown'", () => {
-    expect(reconcileProbeState(undefined, { live: true })).toBe("unknown");
+    expect(reconcileProbeState(undefined, { proven: true })).toBe("unknown");
+  });
+
+  it("never emits a definitive negative from an UNPROVEN interpreter (anchored/ambiguous)", () => {
+    // `proven:false` covers a bare PATH fallback, a different workspace, an INFERRED
+    // (anchored) root and an AMBIGUOUS one. None of them may claim "not installed" —
+    // even when the python versions agree, since sibling envs usually share a version.
+    for (const probePython of ["3.13", undefined]) {
+      expect(
+        reconcileProbeState("not-installed", {
+          proven: false,
+          runningPython: "3.13",
+          probePython,
+        }),
+      ).toBe("unknown");
+    }
+    // A positive still passes through — it can never be a harmful false negative.
+    expect(
+      reconcileProbeState("installed", { proven: false, runningPython: "3.13" }),
+    ).toBe("installed");
   });
 });
 

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -5,10 +5,22 @@ import { join } from "node:path";
 
 import {
   argv0FromCommandLine,
+  commandLineMatchesArgv,
   recordLaunchedInterpreter,
   clearLaunchedInterpreter,
+  getLaunchedInterpreterRecord,
   resolveLiveInterpreter,
 } from "../../services/live-interpreter.js";
+
+/** ComfyUI Desktop's real shape, as measured on the machine that filed #401. */
+const COMFY_ARGV = [
+  "ComfyUI\\main.py",
+  "--feature-flag",
+  "show_signin_button=true",
+  "--enable-manager",
+  "--extra-model-paths-config",
+  "C:\\Users\\A\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml",
+];
 
 let dir: string;
 beforeEach(async () => {
@@ -45,45 +57,158 @@ describe("argv0FromCommandLine", () => {
   });
 });
 
+describe("commandLineMatchesArgv — correlate the process against the server's own argv", () => {
+  const comfyCmd =
+    'C:\\ComfyUI\\.venv\\Scripts\\python.exe -s ComfyUI\\main.py --feature-flag show_signin_button=true ' +
+    '--enable-manager --extra-model-paths-config "C:\\Users\\A\\AppData\\Roaming\\Comfy Desktop\\shared_model_paths.yaml"';
+
+  it("matches the real ComfyUI command line against its reported argv", () => {
+    expect(commandLineMatchesArgv(comfyCmd, COMFY_ARGV)).toBe(true);
+  });
+
+  it("does NOT match a python reverse PROXY sitting on the same port", () => {
+    // The P1 hazard: a proxy on 127.0.0.1:8188 forwarding to the real ComfyUI. Same
+    // python family, different program — its argv shares nothing with ComfyUI's.
+    const proxyCmd = "C:\\proxies\\.venv\\Scripts\\python.exe -m myproxy --listen 8188 --upstream 8189";
+    expect(commandLineMatchesArgv(proxyCmd, COMFY_ARGV)).toBe(false);
+  });
+
+  it("does NOT match a DIFFERENT ComfyUI instance launched with other arguments", () => {
+    const otherCmd = "C:\\Other\\.venv\\Scripts\\python.exe -s ComfyUI\\main.py --listen 0.0.0.0";
+    expect(commandLineMatchesArgv(otherCmd, COMFY_ARGV)).toBe(false);
+  });
+
+  it("fails closed when the argv or the command line is missing/empty", () => {
+    expect(commandLineMatchesArgv(comfyCmd, undefined)).toBe(false);
+    expect(commandLineMatchesArgv(comfyCmd, [])).toBe(false);
+    expect(commandLineMatchesArgv(undefined, COMFY_ARGV)).toBe(false);
+    expect(commandLineMatchesArgv("", COMFY_ARGV)).toBe(false);
+  });
+
+  it("tolerates the quoting the OS adds around paths containing spaces", () => {
+    const argv = ["main.py", "--config", "/opt/my configs/models.yaml"];
+    expect(commandLineMatchesArgv('/usr/bin/python3 main.py --config "/opt/my configs/models.yaml"', argv)).toBe(
+      true,
+    );
+  });
+});
+
 describe("resolveLiveInterpreter — ground truth only (#401)", () => {
-  it("returns the interpreter WE launched, when it still owns the port", async () => {
+  it("returns the interpreter WE launched, when PID and start time both match", async () => {
     const exe = await makeExe("launched.exe");
     recordLaunchedInterpreter(4242, exe);
+    const startedAt = getLaunchedInterpreterRecord()?.startedAt;
 
     const res = resolveLiveInterpreter({
       port: 8188,
       remote: false,
       findPid: () => 4242,
-      readArgv0: () => undefined,
+      readIdentity: () => ({ commandLine: `${exe} main.py`, startedAt }),
     });
-    expect(res).toEqual({ python: exe, source: "launched-by-us", pid: 4242 });
+    // On a platform where the start time is unreadable the tier fails closed, which
+    // is the correct behavior — assert the identity-confirmed path only when we
+    // actually captured a start time.
+    if (startedAt) {
+      expect(res).toEqual({ python: exe, source: "launched-by-us", pid: 4242 });
+    } else {
+      expect(res?.source).not.toBe("launched-by-us");
+    }
   });
 
-  it("DISCARDS the launch record when a different process now owns the port", async () => {
+  it("REJECTS the launch record when the PID was REUSED by another process", async () => {
     const ours = await makeExe("ours.exe");
-    const theirs = await makeExe("theirs.exe");
     recordLaunchedInterpreter(4242, ours);
 
-    // Our child died; PID 9999 took the port. Reporting `ours` for it would be
-    // exactly the confident-wrong-answer class this module exists to prevent.
+    // Our child died; the OS handed 4242 to an unrelated python that grabbed the
+    // port before cleanup ran. Same PID, DIFFERENT creation time → the stale
+    // interpreter must not be served for the replacement server.
     const res = resolveLiveInterpreter({
       port: 8188,
       remote: false,
-      findPid: () => 9999,
-      readArgv0: () => theirs,
+      serverArgv: COMFY_ARGV,
+      findPid: () => 4242,
+      readIdentity: () => ({
+        commandLine: "/usr/bin/python3 -m someone_else",
+        startedAt: "an-utterly-different-start-time",
+      }),
     });
-    expect(res).toEqual({ python: theirs, source: "process-table", pid: 9999 });
+    expect(res).toBeUndefined();
   });
 
-  it("reads the interpreter from the OS when we did NOT launch the server", async () => {
+  it("fails closed when the launch record has NO start time to compare", async () => {
+    const ours = await makeExe("ours2.exe");
+    recordLaunchedInterpreter(4242, ours);
+    // Simulate a platform that could not read a creation time at record OR read time.
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      findPid: () => 4242,
+      readIdentity: () => ({ commandLine: `${ours} main.py` }), // no startedAt
+    });
+    expect(res?.source).not.toBe("launched-by-us");
+  });
+
+  it("reads the interpreter from the OS when its command line matches the server's argv", async () => {
     const exe = await makeExe("desktop-venv.exe");
     const res = resolveLiveInterpreter({
       port: 8188,
       remote: false,
+      serverArgv: COMFY_ARGV,
       findPid: () => 777,
-      readArgv0: () => exe,
+      readIdentity: () => ({
+        commandLine: `${exe} -s ${COMFY_ARGV.join(" ")}`,
+        startedAt: "t1",
+      }),
     });
     expect(res).toEqual({ python: exe, source: "process-table", pid: 777 });
+  });
+
+  it("returns UNKNOWN for a PROXY on the port whose command line does not match argv", async () => {
+    // P1: the proxy's venv may lack Triton entirely. Reporting its packages as the
+    // server's is exactly the false capability report #401 is about.
+    const proxyExe = await makeExe("proxy-venv.exe");
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      serverArgv: COMFY_ARGV,
+      findPid: () => 999,
+      readIdentity: () => ({
+        commandLine: `${proxyExe} -m myproxy --listen 8188 --upstream 8189`,
+        startedAt: "t1",
+      }),
+    });
+    expect(res).toBeUndefined();
+  });
+
+  it("fails closed when the server reported NO argv to correlate against", async () => {
+    const exe = await makeExe("some-python.exe");
+    for (const serverArgv of [undefined, [] as string[]]) {
+      expect(
+        resolveLiveInterpreter({
+          port: 8188,
+          remote: false,
+          serverArgv,
+          findPid: () => 777,
+          readIdentity: () => ({ commandLine: `${exe} -s ComfyUI/main.py`, startedAt: "t1" }),
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("passes the HOST through to the port lookup", () => {
+    let sawHost: string | undefined = "unset";
+    resolveLiveInterpreter({
+      port: 8188,
+      host: "127.0.0.1",
+      remote: false,
+      serverArgv: COMFY_ARGV,
+      findPid: (_p, host) => {
+        sawHost = host;
+        return null;
+      },
+      readIdentity: () => undefined,
+    });
+    expect(sawHost).toBe("127.0.0.1");
   });
 
   it("returns UNDEFINED when nothing is listening on the port", () => {
@@ -91,8 +216,9 @@ describe("resolveLiveInterpreter — ground truth only (#401)", () => {
       resolveLiveInterpreter({
         port: 8188,
         remote: false,
+        serverArgv: COMFY_ARGV,
         findPid: () => null,
-        readArgv0: () => "/usr/bin/python3",
+        readIdentity: () => ({ commandLine: "/usr/bin/python3 ComfyUI/main.py" }),
       }),
     ).toBeUndefined();
   });
@@ -104,45 +230,62 @@ describe("resolveLiveInterpreter — ground truth only (#401)", () => {
       resolveLiveInterpreter({
         port: 8188,
         remote: true,
+        serverArgv: COMFY_ARGV,
         findPid: () => 1,
-        readArgv0: () => exe,
+        readIdentity: () => ({ commandLine: `${exe} main.py`, startedAt: "t1" }),
       }),
     ).toBeUndefined();
   });
 
   it("returns UNDEFINED for a RELATIVE or bare argv[0] (it names no file we can probe)", () => {
-    for (const argv0 of ["python", "./python", "ComfyUI/main.py"]) {
+    for (const exe of ["python", "./python"]) {
       expect(
         resolveLiveInterpreter({
           port: 8188,
           remote: false,
+          serverArgv: ["main.py"],
           findPid: () => 5,
-          readArgv0: () => argv0,
+          readIdentity: () => ({ commandLine: `${exe} main.py`, startedAt: "t1" }),
         }),
       ).toBeUndefined();
     }
   });
 
   it("returns UNDEFINED when argv[0] is absolute but does not exist on disk", () => {
+    const gone = join(dir, "gone.exe");
     expect(
       resolveLiveInterpreter({
         port: 8188,
         remote: false,
+        serverArgv: ["main.py"],
         findPid: () => 5,
-        readArgv0: () => join(dir, "gone.exe"),
+        readIdentity: () => ({ commandLine: `${gone} main.py`, startedAt: "t1" }),
       }),
     ).toBeUndefined();
   });
 
-  it("never throws when the port lookup itself fails", () => {
+  it("never throws when the port lookup or the process read fails", () => {
     expect(
       resolveLiveInterpreter({
         port: 8188,
         remote: false,
+        serverArgv: COMFY_ARGV,
         findPid: () => {
           throw new Error("netstat exploded");
         },
-        readArgv0: () => "/usr/bin/python3",
+        readIdentity: () => undefined,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      resolveLiveInterpreter({
+        port: 8188,
+        remote: false,
+        serverArgv: COMFY_ARGV,
+        findPid: () => 5,
+        readIdentity: () => {
+          throw new Error("wmi exploded");
+        },
       }),
     ).toBeUndefined();
   });

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  argv0FromCommandLine,
+  recordLaunchedInterpreter,
+  clearLaunchedInterpreter,
+  resolveLiveInterpreter,
+} from "../../services/live-interpreter.js";
+
+let dir: string;
+beforeEach(async () => {
+  clearLaunchedInterpreter();
+  dir = await mkdtemp(join(tmpdir(), "comfyui-live-"));
+});
+afterEach(async () => {
+  clearLaunchedInterpreter();
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function makeExe(name: string): Promise<string> {
+  const p = join(dir, name);
+  await writeFile(p, "", "utf-8");
+  return p;
+}
+
+describe("argv0FromCommandLine", () => {
+  it("takes the first token of an unquoted command line", () => {
+    expect(argv0FromCommandLine("/usr/bin/python3 main.py --port 8188")).toBe("/usr/bin/python3");
+  });
+
+  it("honors a QUOTED interpreter path containing spaces", () => {
+    // The Windows shape that a naive whitespace split would truncate.
+    expect(
+      argv0FromCommandLine('"C:\\Program Files\\ComfyUI\\.venv\\Scripts\\python.exe" -s main.py'),
+    ).toBe("C:\\Program Files\\ComfyUI\\.venv\\Scripts\\python.exe");
+  });
+
+  it("returns undefined for empty or unterminated input", () => {
+    expect(argv0FromCommandLine("")).toBeUndefined();
+    expect(argv0FromCommandLine("   ")).toBeUndefined();
+    expect(argv0FromCommandLine('"C:\\unterminated')).toBeUndefined();
+  });
+});
+
+describe("resolveLiveInterpreter — ground truth only (#401)", () => {
+  it("returns the interpreter WE launched, when it still owns the port", async () => {
+    const exe = await makeExe("launched.exe");
+    recordLaunchedInterpreter(4242, exe);
+
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      findPid: () => 4242,
+      readArgv0: () => undefined,
+    });
+    expect(res).toEqual({ python: exe, source: "launched-by-us", pid: 4242 });
+  });
+
+  it("DISCARDS the launch record when a different process now owns the port", async () => {
+    const ours = await makeExe("ours.exe");
+    const theirs = await makeExe("theirs.exe");
+    recordLaunchedInterpreter(4242, ours);
+
+    // Our child died; PID 9999 took the port. Reporting `ours` for it would be
+    // exactly the confident-wrong-answer class this module exists to prevent.
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      findPid: () => 9999,
+      readArgv0: () => theirs,
+    });
+    expect(res).toEqual({ python: theirs, source: "process-table", pid: 9999 });
+  });
+
+  it("reads the interpreter from the OS when we did NOT launch the server", async () => {
+    const exe = await makeExe("desktop-venv.exe");
+    const res = resolveLiveInterpreter({
+      port: 8188,
+      remote: false,
+      findPid: () => 777,
+      readArgv0: () => exe,
+    });
+    expect(res).toEqual({ python: exe, source: "process-table", pid: 777 });
+  });
+
+  it("returns UNDEFINED when nothing is listening on the port", () => {
+    expect(
+      resolveLiveInterpreter({
+        port: 8188,
+        remote: false,
+        findPid: () => null,
+        readArgv0: () => "/usr/bin/python3",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns UNDEFINED for a REMOTE server (no local process is it)", async () => {
+    const exe = await makeExe("local.exe");
+    recordLaunchedInterpreter(1, exe);
+    expect(
+      resolveLiveInterpreter({
+        port: 8188,
+        remote: true,
+        findPid: () => 1,
+        readArgv0: () => exe,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns UNDEFINED for a RELATIVE or bare argv[0] (it names no file we can probe)", () => {
+    for (const argv0 of ["python", "./python", "ComfyUI/main.py"]) {
+      expect(
+        resolveLiveInterpreter({
+          port: 8188,
+          remote: false,
+          findPid: () => 5,
+          readArgv0: () => argv0,
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("returns UNDEFINED when argv[0] is absolute but does not exist on disk", () => {
+    expect(
+      resolveLiveInterpreter({
+        port: 8188,
+        remote: false,
+        findPid: () => 5,
+        readArgv0: () => join(dir, "gone.exe"),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("never throws when the port lookup itself fails", () => {
+    expect(
+      resolveLiveInterpreter({
+        port: 8188,
+        remote: false,
+        findPid: () => {
+          throw new Error("netstat exploded");
+        },
+        readArgv0: () => "/usr/bin/python3",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/__tests__/services/live-interpreter.test.ts
+++ b/src/__tests__/services/live-interpreter.test.ts
@@ -85,6 +85,14 @@ describe("commandLineMatchesArgv — correlate the process against the server's 
     expect(commandLineMatchesArgv("", COMFY_ARGV)).toBe(false);
   });
 
+  it("does NOT let an ABSOLUTE argv path anchor to a different instance's absolute path", () => {
+    // Two local installs, both with ComfyUI\main.py: an absolute argv[0] is an
+    // exact claim and must not suffix-match the other instance's root.
+    const argv = ["C:\\ComfyUI\\main.py", "--port", "8188"];
+    const otherInstance = "D:\\Other\\ComfyUI\\main.py --port 8188";
+    expect(commandLineMatchesArgv(otherInstance, argv)).toBe(false);
+  });
+
   it("tolerates the quoting the OS adds around paths containing spaces", () => {
     const argv = ["main.py", "--config", "/opt/my configs/models.yaml"];
     expect(commandLineMatchesArgv('/usr/bin/python3 main.py --config "/opt/my configs/models.yaml"', argv)).toBe(

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -317,7 +317,8 @@ describe("process-control crash supervision", () => {
         if (portCheckCalls === 3) {
           if (cmd.includes("netstat"))
             return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
-          return "4321";
+          // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.
+          return "p4321\nn127.0.0.1:8188\n";
         }
         throw new Error("not listening");
       }
@@ -394,7 +395,8 @@ describe("process-control restart relaunch preflight (#368/#370)", () => {
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.includes("netstat"))
         return "  TCP    0.0.0.0:8188   0.0.0.0:0   LISTENING       4321";
-      if (cmd.includes("lsof")) return "4321";
+      // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.
+      if (cmd.includes("lsof")) return "p4321\nn127.0.0.1:8188\n";
       // tasklist (desktop detection), taskkill, `if exist`, etc. → nothing found
       return "";
     });

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -126,7 +126,8 @@ function mockLivePortThenFree(): { killed: () => boolean } {
     }
     if (/lsof/i.test(cmd)) {
       if (killed) throw new Error("not listening");
-      return "4321";
+      // `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output: p<pid> / n<addr:port>.
+      return "p4321\nn127.0.0.1:8188\n";
     }
     return "";
   });

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -209,6 +209,94 @@ describe("resolveInstallInterpreter (#651)", () => {
     }
   });
 
+  it("uses the OS-OBSERVED interpreter when the port owner corroborates the server argv (#401)", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "process-table",
+        pid: 777,
+      });
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "observed",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("maps an identity-confirmed launch record from the observation channel to source launched", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched-by-us",
+        pid: 4242,
+      });
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let an observation bypass the different-install refusal", async () => {
+    const parent = await tmpDir();
+    try {
+      const requested = join(parent, "requested");
+      const live = join(parent, "live");
+      await mkdir(live, { recursive: true });
+      await writeFile(join(live, "main.py"), "", "utf-8");
+      await makeVenvPython(requested);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(live, "main.py")] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/elsewhere/python.exe",
+        source: "process-table",
+        pid: 777,
+      });
+
+      const result = await resolveInstallInterpreter(requested);
+
+      expect(result.source).toBe("undetermined");
+      expect(result).not.toHaveProperty("python");
+      expect(result.reason).toContain("different install");
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let an observation bypass the no-resolvable-main.py refusal", async () => {
+    const root = await tmpDir();
+    try {
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: ["--port", "8188"] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/elsewhere/python.exe",
+        source: "process-table",
+        pid: 777,
+      });
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("main.py");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("refuses in remote mode: a local install would not affect the remote server", async () => {
     const root = await tmpDir();
     try {

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -606,14 +606,13 @@ describe("getEnvironment", () => {
       expect(env.local.python?.version).toBe("3.11.7");
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
-      expect(env.local.note).toMatch(/does not match the running ComfyUI python/i);
       expect(env.local.note).toMatch(/#401/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  it("reports packages when a rootless running server is corroborated by an EXACT torch match", async () => {
+  it("never trusts a rootless running server, even on an EXACT python+torch match", async () => {
     const dir = await tmpDir();
     const install = join(dir, "ComfyUI");
     await mkdir(install, { recursive: true });
@@ -631,7 +630,9 @@ describe("getEnvironment", () => {
         },
         devices: [],
       });
-      // Same major.minor AND the exact torch the server reports → same environment.
+      // Same major.minor AND the exact torch the server reports — yet a stale
+      // COMFYUI_PATH aimed at a sibling install of the same build looks exactly like
+      // this. Fingerprints make it plausible, never correct: report nothing.
       setExecFileResponder((_cmd, args) => {
         if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
         if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0+cu124\n" };
@@ -639,8 +640,9 @@ describe("getEnvironment", () => {
       });
 
       const env = await getEnvironment();
-      expect(env.local.python_probe_trusted).toBe(true);
-      expect(env.local.packages?.torch).toBe("2.5.0+cu124");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/reported no install root/i);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -673,7 +675,7 @@ describe("getEnvironment", () => {
       const env = await getEnvironment();
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI torch/i);
+      expect(env.local.python_probe_reason).toMatch(/reported no install root/i);
       expect(env.local.note).toMatch(/#401/);
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -820,36 +822,131 @@ describe("getEnvironment", () => {
       });
 
       const env = await getEnvironment();
+      // SELECTION is fixed: the server's own venv, not the launcher's env.
       expect(env.local.python?.executable).toBe(rightExe);
       expect(env.local.python?.executable).not.toBe(wrongExe);
-      expect(env.local.python_probe_trusted).toBe(true);
-      expect(env.local.packages?.torch).toBe("2.9.0+cu128");
+      // AUTHORITY is not granted: the root was INFERRED from a relative argv, so no
+      // package list is attributed to the running server.
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/INFERRED/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  it("degrades an anchored Desktop root to UNTRUSTED when its python contradicts the server", async () => {
+  it("never trusts an ANCHORED root even when python AND torch both agree (stale COMFYUI_PATH collision)", async () => {
+    // HIGH 1: the server runs bundle B's ComfyUI/.venv, but a stale COMFYUI_PATH points
+    // at a SECOND bundle A of the same shape. Both report the relative "ComfyUI/main.py"
+    // with no cwd, so A anchors exactly as cleanly as B would — and sibling Desktop
+    // installs routinely share a python AND a torch build, so both fingerprints agree.
+    // Nothing available can tell A from B, so this must cap out at unknown.
     const dir = await tmpDir();
-    const base = join(dir, "Desktop");
-    const server = join(base, "ComfyUI");
-    await mkdir(server, { recursive: true });
-    await writeFile(join(server, "main.py"), "", "utf-8");
-    await makeVenvPython(server);
+    const bundleA = join(dir, "A"); // stale COMFYUI_PATH
+    const serverA = join(bundleA, "ComfyUI");
+    await mkdir(serverA, { recursive: true });
+    await writeFile(join(serverA, "main.py"), "", "utf-8");
+    const exeA = await makeVenvPython(serverA);
+    // Bundle B is the one actually running; its path never reaches us (relative argv).
     try {
       configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = base;
+      mockConfig.comfyuiPath = bundleA;
       mockGetSystemStats.mockResolvedValueOnce({
         system: {
           os: "nt",
           python_version: "3.13.12",
           comfyui_version: "0.27.1",
+          embedded_python: false,
+          pytorch_version: "2.9.0+cu128",
           argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
         },
         devices: [],
       });
-      // The anchored dir's interpreter is on a DIFFERENT python than the live server →
-      // we anchored onto the wrong install; report unknown rather than its packages.
+      // A agrees on BOTH fingerprints — and is still the wrong install.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.13.12\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.9.0+cu128\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(exeA);
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/INFERRED/);
+      expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT report packages from an OUTSIDE-the-root sibling python, even on matching fingerprints", async () => {
+    if (!IS_WIN) return; // ../python_embeded is a Windows-portable candidate
+    // HIGH 2, package-reporting half: the only interpreter we can find is the bundle's
+    // SIBLING python_embeded, outside the server's own install root. Absent an
+    // embedded_python self-report its location is a layout guess, and matching python
+    // and torch only make the guess plausible — the server may run an external venv.
+    const dir = await tmpDir();
+    const bundle = join(dir, "bundle");
+    const server = join(bundle, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const embDir = join(bundle, "python_embeded");
+    await mkdir(embDir, { recursive: true });
+    const embExe = join(embDir, "python.exe");
+    await writeFile(embExe, "", "utf-8");
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = server;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          pytorch_version: "2.5.0+cu124",
+          // NOTE: no embedded_python — the server never told us it runs an embedded python.
+          argv: [join(server, "main.py")],
+        },
+        devices: [],
+      });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0+cu124\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(embExe); // probed …
+      expect(env.local.python_probe_trusted).toBe(false); // … never reported from
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/OUTSIDE the running server's install root/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT trust a PROVEN root whose interpreter contradicts the live python", async () => {
+    // HIGH 3: an absolute argv gives a certain LOCATION, but knowing where the
+    // interpreter is is not knowing that it is the one running. A 3.11 venv under a
+    // root whose server reports 3.13 is a contradiction and must lose to the server.
+    const dir = await tmpDir();
+    const root = join(dir, "ComfyUI");
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "main.py"), "", "utf-8");
+    const exe = await makeVenvPython(root);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = root;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          embedded_python: false,
+          argv: [join(root, "main.py")],
+        },
+        devices: [],
+      });
       setExecFileResponder((_cmd, args) => {
         if (args.includes("--version")) return { stdout: "Python 3.11.9\n" };
         if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
@@ -857,45 +954,10 @@ describe("getEnvironment", () => {
       });
 
       const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(exe);
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
       expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI python/i);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("degrades an anchored Desktop root to UNTRUSTED when its torch contradicts the server", async () => {
-    const dir = await tmpDir();
-    const base = join(dir, "Desktop");
-    const server = join(base, "ComfyUI");
-    await mkdir(server, { recursive: true });
-    await writeFile(join(server, "main.py"), "", "utf-8");
-    await makeVenvPython(server);
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = base;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.13.12",
-          comfyui_version: "0.27.1",
-          pytorch_version: "2.9.0+cu128",
-          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
-        },
-        devices: [],
-      });
-      // Same python, but a DIFFERENT torch → we anchored onto a look-alike bundle.
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.13.4\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.4.0\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI torch/i);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -26,6 +26,9 @@ const h = vi.hoisted(() => {
     mockConfig: { comfyuiPath: undefined as string | undefined, resolvedPort: 8188 },
     mockGetSystemStats: vi.fn(),
     remoteMode: { value: false },
+    // GROUND TRUTH seam (#401): undefined = "we could not observe the interpreter",
+    // which is the default and must always degrade to unknown.
+    mockLiveInterpreter: vi.fn(() => undefined as unknown),
     execFileResponder: (() => new Error("not configured")) as (
       cmd: string,
       args: string[],
@@ -43,6 +46,10 @@ vi.mock("../../config.js", () => ({
 
 vi.mock("../../comfyui/client.js", () => ({
   getSystemStats: () => h.mockGetSystemStats(),
+}));
+
+vi.mock("../../services/live-interpreter.js", () => ({
+  resolveLiveInterpreter: (...args: unknown[]) => h.mockLiveInterpreter(...(args as [])),
 }));
 
 // execFile is wrapped by promisify() at module load. The mock invokes the
@@ -97,6 +104,8 @@ beforeEach(() => {
   mockConfig.comfyuiPath = undefined;
   mockConfig.resolvedPort = 8188;
   h.remoteMode.value = false;
+  h.mockLiveInterpreter.mockReset();
+  h.mockLiveInterpreter.mockReturnValue(undefined); // no observation by default
   mockGetSystemStats.mockReset();
   setExecFileResponder(() => new Error("not configured"));
   resetWorkspaceConfig();
@@ -514,8 +523,11 @@ describe("getEnvironment", () => {
 
       expect(env.local.workspace_path).toBe(install);
       expect(env.local.python?.version).toBe("3.11.5");
-      expect(env.local.packages?.torch).toBe("2.3.1");
-      expect(env.local.packages?.numpy).toBe("1.26.4");
+      // The server is DOWN, so no process exists to observe: the interpreter shown is
+      // a layout guess and its package list is withheld (#401 terminating rule).
+      expect(env.local.python_probe_source).toBe("layout-guess");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
       // No .git directory created → git omitted
       expect(env.local.git).toBeUndefined();
     } finally {
@@ -580,381 +592,135 @@ describe("getEnvironment", () => {
     }
   });
 
-  it("omits packages (no false report) when the probed python disagrees with the running ComfyUI (#401)", async () => {
-    const dir = await tmpDir();
+  // -------------------------------------------------------------------------
+  // #401 — the TERMINATING RULE. An interpreter is authoritative only when we
+  // OBSERVED it (we launched the process, or the OS told us what it is running).
+  // Layout inference selects what to PROBE and nothing more.
+  // -------------------------------------------------------------------------
+
+  /** Stage a workspace whose layout GUESS resolves to a venv on disk. */
+  async function stageWorkspace(dir: string): Promise<string> {
     const install = join(dir, "ComfyUI");
     await mkdir(install, { recursive: true });
-    await makeVenvPython(install);
+    const exe = await makeVenvPython(install);
+    configureWorkspace({ configPath: join(dir, "workspace.json") });
+    mockConfig.comfyuiPath = install;
+    return exe;
+  }
+
+  function statsReachable(python = "3.12.11"): void {
+    mockGetSystemStats.mockResolvedValueOnce({
+      system: {
+        os: "nt",
+        python_version: python,
+        comfyui_version: "0.27.1",
+        embedded_python: false,
+        argv: [],
+      },
+      devices: [],
+    });
+  }
+
+  it("reports UNKNOWN (never a package list) when the interpreter was not observed", async () => {
+    const dir = await tmpDir();
+    await stageWorkspace(dir);
     try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = install;
-      // Running ComfyUI is on python 3.12.11 …
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: { os: "nt", python_version: "3.12.11", comfyui_version: "0.27.1" },
-        devices: [],
-      });
-      // … but the interpreter we can probe (the workspace venv) is 3.11.7 — a DIFFERENT
-      // environment. torch etc. from it would be a false report, so degrade.
+      statsReachable();
+      h.mockLiveInterpreter.mockReturnValue(undefined); // could not observe the process
       setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.11.7\n" };
-        if (args.includes("pip"))
-          return { stdout: "Name: torch\nVersion: 9.9.9\n" }; // must NOT surface
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        // Even a PERFECTLY matching python must not unlock this list.
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
         return new Error("nope");
       });
 
       const env = await getEnvironment();
-      expect(env.local.python?.version).toBe("3.11.7");
+      expect(env.local.python_probe_source).toBe("layout-guess");
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/BEST GUESS/);
       expect(env.local.note).toMatch(/#401/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  it("never trusts a rootless running server, even on an EXACT python+torch match", async () => {
+  it("trusts the interpreter WE launched ComfyUI with", async () => {
     const dir = await tmpDir();
-    const install = join(dir, "ComfyUI");
-    await mkdir(install, { recursive: true });
-    await makeVenvPython(install);
+    const exe = await stageWorkspace(dir);
     try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = install;
-      // Reachable, but NO argv → no resolvable install root to prove the interpreter.
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.12.11",
-          comfyui_version: "0.27.1",
-          pytorch_version: "2.5.0+cu124",
-        },
-        devices: [],
-      });
-      // Same major.minor AND the exact torch the server reports — yet a stale
-      // COMFYUI_PATH aimed at a sibling install of the same build looks exactly like
-      // this. Fingerprints make it plausible, never correct: report nothing.
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0+cu124\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/reported no install root/i);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("does NOT trust a version-only match when the server reports no install root (#401 recurrence)", async () => {
-    const dir = await tmpDir();
-    const install = join(dir, "ComfyUI");
-    await mkdir(install, { recursive: true });
-    await makeVenvPython(install);
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = install;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.13.12",
-          comfyui_version: "0.27.1",
-          pytorch_version: "2.9.0+cu128",
-        },
-        devices: [],
-      });
-      // Matching python 3.13, but a DIFFERENT torch — a sibling env, not the server's.
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.13.1\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.4.0\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/reported no install root/i);
-      expect(env.local.note).toMatch(/#401/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("resolves the LIVE server's own interpreter over the pinned COMFYUI_PATH (#401 / #433 getEnvironment)", async () => {
-    const dir = await tmpDir();
-    const rootA = join(dir, "A"); // pinned COMFYUI_PATH
-    const rootB = join(dir, "B"); // the LIVE running server (from argv main.py)
-    await mkdir(rootA, { recursive: true });
-    await mkdir(rootB, { recursive: true });
-    const exeA = await makeVenvPython(rootA);
-    const exeB = await makeVenvPython(rootB);
-    void exeA;
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = rootA;
-      // Live server on 3.12, argv points at B/main.py; A and B share major.minor.
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.12.11",
-          comfyui_version: "0.27.1",
-          argv: [join(rootB, "main.py"), "--port", "8188"],
-        },
-        devices: [],
-      });
-      // Differentiate the two interpreters BY EXECUTABLE PATH: only B has the package.
-      setExecFileResponder((cmd, args) => {
-        const isB = cmd.includes(`${rootB}`);
-        if (args.includes("--version"))
-          return { stdout: isB ? "Python 3.12.9\n" : "Python 3.12.1\n" };
-        if (args.includes("pip"))
-          return { stdout: isB ? "Name: torch\nVersion: 2.6.0\n" : "Name: torch\nVersion: 1.0.0\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      // Probed B (the live interpreter), not the pinned A.
-      expect(env.local.python?.executable).toBe(exeB);
-      expect(env.local.python_probe_trusted).toBe(true);
-      expect(env.local.packages?.torch).toBe("2.6.0"); // B's, not A's 1.0.0
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("omits packages when the LIVE root has no venv and only the pinned workspace does (#401 / #433)", async () => {
-    const dir = await tmpDir();
-    const rootA = join(dir, "A"); // pinned COMFYUI_PATH — the only venv on disk
-    const rootB = join(dir, "B"); // live root, but NO interpreter under it
-    await mkdir(rootB, { recursive: true });
-    const exeA = await makeVenvPython(rootA);
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = rootA;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.12.11",
-          comfyui_version: "0.27.1",
-          argv: [join(rootB, "main.py")],
-        },
-        devices: [],
+      statsReachable("3.12.11");
+      h.mockLiveInterpreter.mockReturnValue({
+        python: exe,
+        source: "launched-by-us",
+        pid: 4242,
       });
       setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.12.1\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 1.0.0\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      // We could only probe A, but A is provably NOT the live interpreter → untrusted.
-      expect(env.local.python?.executable).toBe(exeA);
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.note).toMatch(/#401/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("does NOT trust a bare PATH python when the server is unreachable (#401 / #433 round 3)", async () => {
-    const dir = await tmpDir();
-    const install = join(dir, "ComfyUI"); // configured, but NO venv on disk
-    await mkdir(install, { recursive: true });
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = install;
-      mockGetSystemStats.mockRejectedValueOnce(new Error("ECONNREFUSED"));
-      // A bare PATH python answers, but it is NOT provably the workspace's interpreter.
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.11.5\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python?.version).toBe("3.11.5");
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined(); // bare PATH packages NOT surfaced
-      expect(env.local.note).toMatch(/#401/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("probes the SERVER venv, not the bundle's standalone python, for a Desktop-style relative argv (#401 recurrence)", async () => {
-    const dir = await tmpDir();
-    const base = join(dir, "Desktop"); // COMFYUI_PATH — the bundle root
-    const server = join(base, "ComfyUI"); // where main.py + the real venv live
-    await mkdir(server, { recursive: true });
-    await writeFile(join(server, "main.py"), "", "utf-8");
-    const wrongExe = await makeVenvPython(base); // the launcher's env
-    const rightExe = await makeVenvPython(server);
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = base;
-      // Desktop's shape: argv[0] is RELATIVE and there is no cwd to resolve it with.
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.13.12",
-          comfyui_version: "0.27.1",
-          embedded_python: false,
-          pytorch_version: "2.9.0+cu128",
-          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py", "--port", "8000"],
-        },
-        devices: [],
-      });
-      // Only the SERVER venv has the packages the running ComfyUI actually imports.
-      setExecFileResponder((cmd, args) => {
-        const isServer = cmd === rightExe;
-        if (args.includes("--version"))
-          return { stdout: isServer ? "Python 3.13.12\n" : "Python 3.13.5\n" };
-        if (args.includes("pip"))
-          return {
-            stdout: isServer
-              ? "Name: torch\nVersion: 2.9.0+cu128\n"
-              : "Name: numpy\nVersion: 1.0.0\n",
-          };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      // SELECTION is fixed: the server's own venv, not the launcher's env.
-      expect(env.local.python?.executable).toBe(rightExe);
-      expect(env.local.python?.executable).not.toBe(wrongExe);
-      // AUTHORITY is not granted: the root was INFERRED from a relative argv, so no
-      // package list is attributed to the running server.
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/INFERRED/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("never trusts an ANCHORED root even when python AND torch both agree (stale COMFYUI_PATH collision)", async () => {
-    // HIGH 1: the server runs bundle B's ComfyUI/.venv, but a stale COMFYUI_PATH points
-    // at a SECOND bundle A of the same shape. Both report the relative "ComfyUI/main.py"
-    // with no cwd, so A anchors exactly as cleanly as B would — and sibling Desktop
-    // installs routinely share a python AND a torch build, so both fingerprints agree.
-    // Nothing available can tell A from B, so this must cap out at unknown.
-    const dir = await tmpDir();
-    const bundleA = join(dir, "A"); // stale COMFYUI_PATH
-    const serverA = join(bundleA, "ComfyUI");
-    await mkdir(serverA, { recursive: true });
-    await writeFile(join(serverA, "main.py"), "", "utf-8");
-    const exeA = await makeVenvPython(serverA);
-    // Bundle B is the one actually running; its path never reaches us (relative argv).
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = bundleA;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.13.12",
-          comfyui_version: "0.27.1",
-          embedded_python: false,
-          pytorch_version: "2.9.0+cu128",
-          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
-        },
-        devices: [],
-      });
-      // A agrees on BOTH fingerprints — and is still the wrong install.
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.13.12\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.9.0+cu128\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python?.executable).toBe(exeA);
-      expect(env.local.python_probe_trusted).toBe(false);
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/INFERRED/);
-      expect(env.local.note).toMatch(/#401/);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("does NOT report packages from an OUTSIDE-the-root sibling python, even on matching fingerprints", async () => {
-    if (!IS_WIN) return; // ../python_embeded is a Windows-portable candidate
-    // HIGH 2, package-reporting half: the only interpreter we can find is the bundle's
-    // SIBLING python_embeded, outside the server's own install root. Absent an
-    // embedded_python self-report its location is a layout guess, and matching python
-    // and torch only make the guess plausible — the server may run an external venv.
-    const dir = await tmpDir();
-    const bundle = join(dir, "bundle");
-    const server = join(bundle, "ComfyUI");
-    await mkdir(server, { recursive: true });
-    await writeFile(join(server, "main.py"), "", "utf-8");
-    const embDir = join(bundle, "python_embeded");
-    await mkdir(embDir, { recursive: true });
-    const embExe = join(embDir, "python.exe");
-    await writeFile(embExe, "", "utf-8");
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = server;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.12.11",
-          comfyui_version: "0.27.1",
-          pytorch_version: "2.5.0+cu124",
-          // NOTE: no embedded_python — the server never told us it runs an embedded python.
-          argv: [join(server, "main.py")],
-        },
-        devices: [],
-      });
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0+cu124\n" };
-        return new Error("nope");
-      });
-
-      const env = await getEnvironment();
-      expect(env.local.python?.executable).toBe(embExe); // probed …
-      expect(env.local.python_probe_trusted).toBe(false); // … never reported from
-      expect(env.local.packages).toBeUndefined();
-      expect(env.local.python_probe_reason).toMatch(/OUTSIDE the running server's install root/i);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("does NOT trust a PROVEN root whose interpreter contradicts the live python", async () => {
-    // HIGH 3: an absolute argv gives a certain LOCATION, but knowing where the
-    // interpreter is is not knowing that it is the one running. A 3.11 venv under a
-    // root whose server reports 3.13 is a contradiction and must lose to the server.
-    const dir = await tmpDir();
-    const root = join(dir, "ComfyUI");
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, "main.py"), "", "utf-8");
-    const exe = await makeVenvPython(root);
-    try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = root;
-      mockGetSystemStats.mockResolvedValueOnce({
-        system: {
-          os: "nt",
-          python_version: "3.13.12",
-          comfyui_version: "0.27.1",
-          embedded_python: false,
-          argv: [join(root, "main.py")],
-        },
-        devices: [],
-      });
-      setExecFileResponder((_cmd, args) => {
-        if (args.includes("--version")) return { stdout: "Python 3.11.9\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
+        if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
         return new Error("nope");
       });
 
       const env = await getEnvironment();
       expect(env.local.python?.executable).toBe(exe);
+      expect(env.local.python_probe_source).toBe("launched-by-us");
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("2.5.0");
+      expect(env.local.python_probe_reason).toMatch(/launched ComfyUI/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("trusts the interpreter the OS reports for the process on our port", async () => {
+    const dir = await tmpDir();
+    await stageWorkspace(dir);
+    // The OS names an interpreter the layout guess would NEVER have found — which is
+    // the whole point: observation beats inference.
+    const elsewhere = join(dir, "somewhere-else", "python.exe");
+    await mkdir(join(dir, "somewhere-else"), { recursive: true });
+    await writeFile(elsewhere, "", "utf-8");
+    try {
+      statsReachable("3.13.12");
+      h.mockLiveInterpreter.mockReturnValue({
+        python: elsewhere,
+        source: "process-table",
+        pid: 777,
+      });
+      setExecFileResponder((cmd, args) => {
+        if (args.includes("--version"))
+          return { stdout: cmd === elsewhere ? "Python 3.13.12\n" : "Python 3.10.0\n" };
+        if (args.includes("pip"))
+          return {
+            stdout:
+              cmd === elsewhere ? "Name: torch\nVersion: 9.1.0\n" : "Name: torch\nVersion: 0.0.1\n",
+          };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(elsewhere);
+      expect(env.local.python_probe_source).toBe("process-table");
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("9.1.0");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades to UNKNOWN when an OBSERVED interpreter contradicts the running python", async () => {
+    const dir = await tmpDir();
+    const exe = await stageWorkspace(dir);
+    try {
+      statsReachable("3.13.12"); // server says 3.13.12 …
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 99 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.11.9\n" }; // … probe says 3.11.9
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
       expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI python/i);
@@ -963,44 +729,77 @@ describe("getEnvironment", () => {
     }
   });
 
-  it("never probes a bare PATH python when the workspace has a venv (#401)", async () => {
+  it("compares the FULL python version, not just major.minor", async () => {
     const dir = await tmpDir();
-    const install = join(dir, "ComfyUI");
-    await mkdir(install, { recursive: true });
-    const venvExe = await makeVenvPython(install);
-    const probed: string[] = [];
+    const exe = await stageWorkspace(dir);
     try {
-      configureWorkspace({ configPath: join(dir, "workspace.json") });
-      mockConfig.comfyuiPath = install;
-      mockGetSystemStats.mockRejectedValueOnce(new Error("offline"));
-      setExecFileResponder((cmd, args) => {
-        if (args.includes("--version")) {
-          probed.push(cmd);
-          return { stdout: "Python 3.12.4\n" };
-        }
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
+      // Same 3.13 major.minor, different patch → a contradiction we now catch.
+      statsReachable("3.13.12 (main, Feb 12 2026, 00:38:53) [MSC v.1944 64 bit (AMD64)]");
+      h.mockLiveInterpreter.mockReturnValue({ python: exe, source: "process-table", pid: 5 });
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.13.4\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 1.0.0\n" };
         return new Error("nope");
       });
 
       const env = await getEnvironment();
-      expect(env.local.python?.executable).toBe(venvExe);
-      expect(probed).not.toContain(IS_WIN ? "python.exe" : "python3");
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  it("never trusts a coincident LOCAL interpreter for a REMOTE server (#401 / #433 round 3)", async () => {
+  it("still SELECTS the server venv for a Desktop-style relative argv (selection survives)", async () => {
+    // Selection is still layout-driven and still lands on the right interpreter —
+    // that is what makes a POSITIVE capability finding possible. It just cannot
+    // authorize a package list without an observation.
     const dir = await tmpDir();
-    const rootB = join(dir, "B"); // remote server's argv path — also exists LOCALLY
-    await mkdir(rootB, { recursive: true });
-    await makeVenvPython(rootB); // a coincident local venv on the same path
+    const base = join(dir, "Desktop");
+    const server = join(base, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const wrongExe = await makeVenvPython(base);
+    const rightExe = await makeVenvPython(server);
     try {
       configureWorkspace({ configPath: join(dir, "workspace.json") });
-      h.remoteMode.value = true; // running ComfyUI is REMOTE
+      mockConfig.comfyuiPath = base;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          embedded_python: false,
+          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
+        },
+        devices: [],
+      });
+      h.mockLiveInterpreter.mockReturnValue(undefined);
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.13.12\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.9.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(rightExe);
+      expect(env.local.python?.executable).not.toBe(wrongExe);
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("never trusts anything for a REMOTE server (#401 / #433 round 3)", async () => {
+    const dir = await tmpDir();
+    const rootB = join(dir, "B");
+    await mkdir(rootB, { recursive: true });
+    await makeVenvPython(rootB);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      h.remoteMode.value = true;
       mockConfig.comfyuiPath = undefined;
-      // Remote server answers /system_stats; its argv main.py path happens to exist
-      // locally, on the SAME python major.minor.
       mockGetSystemStats.mockResolvedValueOnce({
         system: {
           os: "nt",
@@ -1010,6 +809,7 @@ describe("getEnvironment", () => {
         },
         devices: [],
       });
+      h.mockLiveInterpreter.mockReturnValue(undefined); // remote → never observable
       setExecFileResponder((_cmd, args) => {
         if (args.includes("--version")) return { stdout: "Python 3.12.11\n" };
         if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
@@ -1017,16 +817,16 @@ describe("getEnvironment", () => {
       });
 
       const env = await getEnvironment();
-      // The local interpreter is NOT the remote server's — never trusted.
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined();
-      expect(env.local.note).toMatch(/REMOTE/i);
+      expect(env.local.python_probe_reason).toMatch(/REMOTE/i);
       expect(env.local.note).toMatch(/#401/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 });
+
 
 describe("liveRootFromArgv (#401 / #433 — robust argv parsing)", () => {
   it("returns the absolute dir of an absolute main.py", () => {
@@ -1240,7 +1040,6 @@ describe("resolveComfyuiPython live-first (#401 / #433)", () => {
 
       const res = resolveComfyuiPython(rootA, [join(rootB, "main.py")]);
       expect(res.python).toBe(exeB);
-      expect(res.live).toBe(true);
       expect(res.liveRoot).toBe(rootB);
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -1255,8 +1054,8 @@ describe("resolveComfyuiPython live-first (#401 / #433)", () => {
       const exeB = await makeVenvPython(rootB);
 
       const res = resolveComfyuiPython(undefined, [join(rootB, "main.py")], { remote: true });
-      // Live root is still reported for provenance, but it is NOT live/probed locally.
-      expect(res.live).toBe(false);
+      // Live root is still reported for provenance, but the coincident local install
+      // is NOT probed — it is not the remote server's.
       expect(res.python).not.toBe(exeB);
       expect(res.python).toBe(IS_WIN ? "python.exe" : "python3");
     } finally {

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -584,6 +584,7 @@ describe("getEnvironment", () => {
     const dir = await tmpDir();
     const install = join(dir, "ComfyUI");
     await mkdir(install, { recursive: true });
+    await makeVenvPython(install);
     try {
       configureWorkspace({ configPath: join(dir, "workspace.json") });
       mockConfig.comfyuiPath = install;
@@ -592,7 +593,7 @@ describe("getEnvironment", () => {
         system: { os: "nt", python_version: "3.12.11", comfyui_version: "0.27.1" },
         devices: [],
       });
-      // … but the interpreter we can probe (bare PATH python) is 3.11.7 — a DIFFERENT
+      // … but the interpreter we can probe (the workspace venv) is 3.11.7 — a DIFFERENT
       // environment. torch etc. from it would be a false report, so degrade.
       setExecFileResponder((_cmd, args) => {
         if (args.includes("--version")) return { stdout: "Python 3.11.7\n" };
@@ -612,27 +613,68 @@ describe("getEnvironment", () => {
     }
   });
 
-  it("reports packages when the probed python matches the running ComfyUI major.minor", async () => {
+  it("reports packages when a rootless running server is corroborated by an EXACT torch match", async () => {
     const dir = await tmpDir();
     const install = join(dir, "ComfyUI");
     await mkdir(install, { recursive: true });
+    await makeVenvPython(install);
     try {
       configureWorkspace({ configPath: join(dir, "workspace.json") });
       mockConfig.comfyuiPath = install;
+      // Reachable, but NO argv → no resolvable install root to prove the interpreter.
       mockGetSystemStats.mockResolvedValueOnce({
-        system: { os: "nt", python_version: "3.12.11", comfyui_version: "0.27.1" },
+        system: {
+          os: "nt",
+          python_version: "3.12.11",
+          comfyui_version: "0.27.1",
+          pytorch_version: "2.5.0+cu124",
+        },
         devices: [],
       });
-      // Same major.minor (3.12) as the running instance → trusted.
+      // Same major.minor AND the exact torch the server reports → same environment.
       setExecFileResponder((_cmd, args) => {
         if (args.includes("--version")) return { stdout: "Python 3.12.4\n" };
-        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0+cu124\n" };
         return new Error("nope");
       });
 
       const env = await getEnvironment();
       expect(env.local.python_probe_trusted).toBe(true);
-      expect(env.local.packages?.torch).toBe("2.5.0");
+      expect(env.local.packages?.torch).toBe("2.5.0+cu124");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT trust a version-only match when the server reports no install root (#401 recurrence)", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    await makeVenvPython(install);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          pytorch_version: "2.9.0+cu128",
+        },
+        devices: [],
+      });
+      // Matching python 3.13, but a DIFFERENT torch — a sibling env, not the server's.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.13.1\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.4.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI torch/i);
+      expect(env.local.note).toMatch(/#401/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -735,6 +777,152 @@ describe("getEnvironment", () => {
       expect(env.local.python_probe_trusted).toBe(false);
       expect(env.local.packages).toBeUndefined(); // bare PATH packages NOT surfaced
       expect(env.local.note).toMatch(/#401/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("probes the SERVER venv, not the bundle's standalone python, for a Desktop-style relative argv (#401 recurrence)", async () => {
+    const dir = await tmpDir();
+    const base = join(dir, "Desktop"); // COMFYUI_PATH — the bundle root
+    const server = join(base, "ComfyUI"); // where main.py + the real venv live
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    const wrongExe = await makeVenvPython(base); // the launcher's env
+    const rightExe = await makeVenvPython(server);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = base;
+      // Desktop's shape: argv[0] is RELATIVE and there is no cwd to resolve it with.
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          embedded_python: false,
+          pytorch_version: "2.9.0+cu128",
+          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py", "--port", "8000"],
+        },
+        devices: [],
+      });
+      // Only the SERVER venv has the packages the running ComfyUI actually imports.
+      setExecFileResponder((cmd, args) => {
+        const isServer = cmd === rightExe;
+        if (args.includes("--version"))
+          return { stdout: isServer ? "Python 3.13.12\n" : "Python 3.13.5\n" };
+        if (args.includes("pip"))
+          return {
+            stdout: isServer
+              ? "Name: torch\nVersion: 2.9.0+cu128\n"
+              : "Name: numpy\nVersion: 1.0.0\n",
+          };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(rightExe);
+      expect(env.local.python?.executable).not.toBe(wrongExe);
+      expect(env.local.python_probe_trusted).toBe(true);
+      expect(env.local.packages?.torch).toBe("2.9.0+cu128");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades an anchored Desktop root to UNTRUSTED when its python contradicts the server", async () => {
+    const dir = await tmpDir();
+    const base = join(dir, "Desktop");
+    const server = join(base, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    await makeVenvPython(server);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = base;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
+        },
+        devices: [],
+      });
+      // The anchored dir's interpreter is on a DIFFERENT python than the live server →
+      // we anchored onto the wrong install; report unknown rather than its packages.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.11.9\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 9.9.9\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI python/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades an anchored Desktop root to UNTRUSTED when its torch contradicts the server", async () => {
+    const dir = await tmpDir();
+    const base = join(dir, "Desktop");
+    const server = join(base, "ComfyUI");
+    await mkdir(server, { recursive: true });
+    await writeFile(join(server, "main.py"), "", "utf-8");
+    await makeVenvPython(server);
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = base;
+      mockGetSystemStats.mockResolvedValueOnce({
+        system: {
+          os: "nt",
+          python_version: "3.13.12",
+          comfyui_version: "0.27.1",
+          pytorch_version: "2.9.0+cu128",
+          argv: [IS_WIN ? "ComfyUI\\main.py" : "ComfyUI/main.py"],
+        },
+        devices: [],
+      });
+      // Same python, but a DIFFERENT torch → we anchored onto a look-alike bundle.
+      setExecFileResponder((_cmd, args) => {
+        if (args.includes("--version")) return { stdout: "Python 3.13.4\n" };
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.4.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python_probe_trusted).toBe(false);
+      expect(env.local.packages).toBeUndefined();
+      expect(env.local.python_probe_reason).toMatch(/does not match the running ComfyUI torch/i);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("never probes a bare PATH python when the workspace has a venv (#401)", async () => {
+    const dir = await tmpDir();
+    const install = join(dir, "ComfyUI");
+    await mkdir(install, { recursive: true });
+    const venvExe = await makeVenvPython(install);
+    const probed: string[] = [];
+    try {
+      configureWorkspace({ configPath: join(dir, "workspace.json") });
+      mockConfig.comfyuiPath = install;
+      mockGetSystemStats.mockRejectedValueOnce(new Error("offline"));
+      setExecFileResponder((cmd, args) => {
+        if (args.includes("--version")) {
+          probed.push(cmd);
+          return { stdout: "Python 3.12.4\n" };
+        }
+        if (args.includes("pip")) return { stdout: "Name: torch\nVersion: 2.5.0\n" };
+        return new Error("nope");
+      });
+
+      const env = await getEnvironment();
+      expect(env.local.python?.executable).toBe(venvExe);
+      expect(probed).not.toContain(IS_WIN ? "python.exe" : "python3");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -918,6 +1106,24 @@ describe("resolveRootInterpreter (portable + venv layouts)", () => {
       const emb = join(embDir, "python.exe");
       await writeFile(emb, "", "utf-8");
       expect(resolveRootInterpreter(root)).toBe(emb);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT follow a nested ComfyUI/ venv — installs keep targeting the root's own python", async () => {
+    // resolveComfyuiPython follows <base>/ComfyUI (verified against the live server),
+    // but this resolver picks the interpreter pip INSTALLS run under and has nothing
+    // live to check against. Preferring a nested venv here would be an unverifiable
+    // guess in a mutating path, so the root's own interpreter must still win.
+    const root = await tmpDir();
+    try {
+      const nested = join(root, "ComfyUI");
+      await mkdir(nested, { recursive: true });
+      await writeFile(join(nested, "main.py"), "", "utf-8");
+      await makeVenvPython(nested);
+      const own = await makeVenvPython(root);
+      expect(resolveRootInterpreter(root)).toBe(own);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -191,18 +191,27 @@ describe("resolveInstallInterpreter (#651)", () => {
     }
   });
 
-  it("uses the exact interpreter recorded when MCP launched the live server", async () => {
+  it("does NOT trust an unvalidated launch mark — a stale record must not direct installs (#401)", async () => {
+    // The old workspace-env launch record answered here with no process-identity
+    // proof: our child could be dead, its PID recycled, and another server now on
+    // the port under the SAME install root with a recreated/different venv — yet
+    // pip/update work would have been sent to the OLD interpreter while the result
+    // claimed to be exact. After unification the only launch record is
+    // live-interpreter.ts (PID + creation time), so when the observation channel
+    // cannot validate the process the resolver REFUSES — env-trust (#633) is not
+    // interpreter-identity.
     const root = await tmpDir();
     try {
       await writeFile(join(root, "main.py"), "", "utf-8");
       await makeVenvPython(root);
       mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
-      markLocalComfyUILaunched("C:/ComfyUI/.venv/Scripts/python.exe");
+      markLocalComfyUILaunched(); // env-trust mark only — NOT an interpreter record
+      h.mockLiveInterpreter.mockReturnValue(undefined); // identity NOT confirmed
 
-      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
-        python: "C:/ComfyUI/.venv/Scripts/python.exe",
-        source: "launched",
-      });
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result).not.toHaveProperty("python");
     } finally {
       resetLocalComfyUILaunchState();
       await rm(root, { recursive: true, force: true });
@@ -247,6 +256,76 @@ describe("resolveInstallInterpreter (#651)", () => {
         source: "launched",
       });
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("trusts a validated launched-by-us record even when argv names no resolvable main.py", async () => {
+    // We KNOW what we spawned: a PID + creation-time-validated launch record is
+    // authoritative without an argv-derived root to corroborate (#651 semantics,
+    // now carried by the validated channel).
+    const root = await tmpDir();
+    try {
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: ["--port", "8188"] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched-by-us",
+        pid: 4242,
+      });
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not let a validated launched-by-us record bypass the different-install refusal", async () => {
+    const parent = await tmpDir();
+    try {
+      const requested = join(parent, "requested");
+      const live = join(parent, "live");
+      await mkdir(live, { recursive: true });
+      await writeFile(join(live, "main.py"), "", "utf-8");
+      await makeVenvPython(requested);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(live, "main.py")] } });
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/elsewhere/python.exe",
+        source: "launched-by-us",
+        pid: 4242,
+      });
+
+      const result = await resolveInstallInterpreter(requested);
+
+      expect(result.source).toBe("undetermined");
+      expect(result).not.toHaveProperty("python");
+      expect(result.reason).toContain("different install");
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses in remote mode even when an observation is available (ladder order)", async () => {
+    const root = await tmpDir();
+    try {
+      await makeVenvPython(root);
+      h.remoteMode.value = true;
+      h.mockLiveInterpreter.mockReturnValue({
+        python: "D:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched-by-us",
+        pid: 4242,
+      });
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("remote");
+    } finally {
+      h.remoteMode.value = false;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/comfyui/types.ts
+++ b/src/comfyui/types.ts
@@ -56,6 +56,10 @@ export interface SystemStats {
     embedded_python: boolean;
     argv?: string[];
     comfyui_version?: string;
+    /** Reported by recent ComfyUI, e.g. "2.11.0.dev20260123+cu130". */
+    pytorch_version?: string;
+    /** Working directory of the running server, when a build reports it. */
+    cwd?: string;
   };
   devices: Array<{
     name: string;

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -185,6 +185,16 @@ async function probeManagerGeneration(
 /** Is the COMFYUI_URL host loopback? → LOCAL, else REMOTE. Unknown URL → LOCAL
  *  (the panel's overwhelming default; never block on an unparseable URL).
  *  --force-remote overrides this, keeping it in sync with isRemoteMode(). */
+/** The host of a ComfyUI base URL, or undefined. */
+function hostFromUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
 /** The TCP port of a ComfyUI base URL (defaulting by scheme), or undefined. */
 function portFromUrl(url: string | undefined): number | undefined {
   if (!url) return undefined;
@@ -650,7 +660,9 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
     // GUESS, whose positives are still real but whose negatives can never stand.
     const live = resolveLiveInterpreter({
       port: opts.port ?? portFromUrl(opts.comfyuiUrl) ?? 8188,
+      host: hostFromUrl(opts.comfyuiUrl),
       remote,
+      serverArgv: statsArgv,
     });
     observed = !!live;
     const python =

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -336,7 +336,12 @@ export function findComfyuiPython(
 export function probeTritonSage(
   pythonExe: string | undefined,
   timeoutMs = 5000,
-): Promise<{ triton: TriState; sageattention: TriState; pythonVersion?: string }> {
+): Promise<{
+  triton: TriState;
+  sageattention: TriState;
+  pythonVersion?: string;
+  torchVersion?: string;
+}> {
   return new Promise((resolve) => {
     if (!pythonExe) {
       resolve({ triton: "unknown", sageattention: "unknown" });
@@ -347,11 +352,20 @@ export function probeTritonSage(
     // the interpreter's own major.minor so the caller can confirm we probed the
     // SAME python the running ComfyUI reports (#401 — a mismatch means we're
     // looking at the wrong environment and any negative is untrustworthy).
-    const code =
-      "import importlib.util as u,sys;" +
-      "print('python', '%d.%d' % sys.version_info[:2]);" +
-      "print('triton', u.find_spec('triton') is not None);" +
-      "print('sageattention', u.find_spec('sageattention') is not None)";
+    // Also report torch's version — read from package METADATA (never `import torch`,
+    // which would cost seconds) so the caller can tell a location-established
+    // interpreter whose CONTENTS contradict the running server from the real thing.
+    const code = [
+      "import importlib.util as u, sys",
+      "print('python', '%d.%d' % sys.version_info[:2])",
+      "try:",
+      "    from importlib.metadata import version as _v",
+      "    print('torch', _v('torch'))",
+      "except Exception:",
+      "    pass",
+      "print('triton', u.find_spec('triton') is not None)",
+      "print('sageattention', u.find_spec('sageattention') is not None)",
+    ].join("\n");
     let done = false;
     const child = execFile(
       pythonExe,
@@ -372,6 +386,7 @@ export function probeTritonSage(
           return m[1] === "True" ? "installed" : "not-installed";
         };
         const pyMatch = out.match(/^python\s+(\d+\.\d+)/m);
+        const torchMatch = out.match(/^torch\s+(\S+)/m);
         // If python ran but errored AFTER printing partial output, still trust
         // whatever lines we got; missing lines stay "unknown".
         void err;
@@ -379,6 +394,7 @@ export function probeTritonSage(
           triton: read("triton"),
           sageattention: read("sageattention"),
           pythonVersion: pyMatch ? pyMatch[1] : undefined,
+          torchVersion: torchMatch ? torchMatch[1] : undefined,
         });
       },
     );
@@ -403,13 +419,28 @@ export function probeTritonSage(
  */
 export function reconcileProbeState(
   state: TriState | undefined,
-  opts: { proven: boolean; runningPython?: string; probePython?: string },
+  opts: {
+    proven: boolean;
+    runningPython?: string;
+    probePython?: string;
+    runningTorch?: string;
+    probeTorch?: string;
+  },
 ): TriState {
   const s = state ?? "unknown";
   const versionMismatch = !!(
     opts.runningPython &&
     opts.probePython &&
     opts.runningPython !== opts.probePython
+  );
+  // `proven` establishes WHERE the interpreter is, not that its CONTENTS are the
+  // running server's. A torch build that disagrees with what the server reports proves
+  // they are different environments no matter how right the location looked, so its
+  // negatives must not stand either.
+  const torchMismatch = !!(
+    opts.runningTorch &&
+    opts.probeTorch &&
+    opts.runningTorch.trim() !== opts.probeTorch.trim()
   );
   // `proven` (from resolveComfyuiPython) is the ONLY licence to state a negative: the
   // sole interpreter under the install root the running server named in its own argv.
@@ -418,7 +449,7 @@ export function reconcileProbeState(
   // guess about WHICH python ComfyUI runs, and a wrong guess is exactly what produced
   // the false "Triton: not installed" that made an agent disable working acceleration
   // (#401). Those degrade to "unknown"; positives always pass through untouched.
-  const trustworthy = opts.proven && !versionMismatch;
+  const trustworthy = opts.proven && !versionMismatch && !torchMismatch;
   return s === "not-installed" && !trustworthy ? "unknown" : s;
 }
 
@@ -584,10 +615,12 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   let statsArgv: string[] | undefined;
   let statsCwd: string | undefined;
   let statsEmbedded: boolean | undefined;
+  let statsTorchRaw: string | undefined;
   if (stats) {
     applyStats(caps, stats);
     statsArgv = stats.system?.argv;
     statsCwd = stats.system?.cwd;
+    statsTorchRaw = stats.system?.pytorch_version?.trim() || undefined;
     statsEmbedded =
       typeof stats.system?.embedded_python === "boolean"
         ? stats.system.embedded_python
@@ -609,7 +642,7 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   // entirely and rely solely on the ComfyUI-log positive markers below (#401 round 3).
   const remote = caps.location === "REMOTE";
   let proven = false;
-  let ts: { triton: TriState; sageattention: TriState; pythonVersion?: string } | undefined;
+  let ts: Awaited<ReturnType<typeof probeTritonSage>> | undefined;
   if (!remote) {
     const resolved = resolveComfyuiPython(opts.comfyuiPath, statsArgv, {
       cwd: statsCwd,
@@ -644,6 +677,10 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
       proven,
       runningPython: caps.python,
       probePython: ts?.pythonVersion,
+      // RAW pytorch_version (caps.torch is cleaned of its +cuXXX build suffix, which is
+      // exactly the part that distinguishes two otherwise identical environments).
+      runningTorch: statsTorchRaw,
+      probeTorch: ts?.torchVersion,
     });
   caps.triton = reconcile(ts?.triton);
   caps.sageattention = reconcile(ts?.sageattention);

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -21,7 +21,8 @@ import { join } from "node:path";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { platform, release, totalmem, cpus } from "node:os";
 import { isForceRemoteFlagSet } from "../config.js";
-import { resolveComfyuiPython } from "./workspace-env.js";
+import { resolveComfyuiPython, pythonVersionsAgree } from "./workspace-env.js";
+import { resolveLiveInterpreter } from "./live-interpreter.js";
 import { parsePyproject } from "./node-authoring.js";
 
 // The interpreter resolver lives in workspace-env (which owns ComfyUI-base
@@ -184,6 +185,18 @@ async function probeManagerGeneration(
 /** Is the COMFYUI_URL host loopback? → LOCAL, else REMOTE. Unknown URL → LOCAL
  *  (the panel's overwhelming default; never block on an unparseable URL).
  *  --force-remote overrides this, keeping it in sync with isRemoteMode(). */
+/** The TCP port of a ComfyUI base URL (defaulting by scheme), or undefined. */
+function portFromUrl(url: string | undefined): number | undefined {
+  if (!url) return undefined;
+  try {
+    const u = new URL(url);
+    if (u.port) return Number(u.port);
+    return u.protocol === "https:" ? 443 : 80;
+  } catch {
+    return undefined;
+  }
+}
+
 function classifyLocation(url: string | undefined): "LOCAL" | "REMOTE" {
   if (!url) return "LOCAL";
   if (isForceRemoteFlagSet()) return "REMOTE";
@@ -336,12 +349,7 @@ export function findComfyuiPython(
 export function probeTritonSage(
   pythonExe: string | undefined,
   timeoutMs = 5000,
-): Promise<{
-  triton: TriState;
-  sageattention: TriState;
-  pythonVersion?: string;
-  torchVersion?: string;
-}> {
+): Promise<{ triton: TriState; sageattention: TriState; pythonVersion?: string }> {
   return new Promise((resolve) => {
     if (!pythonExe) {
       resolve({ triton: "unknown", sageattention: "unknown" });
@@ -352,20 +360,14 @@ export function probeTritonSage(
     // the interpreter's own major.minor so the caller can confirm we probed the
     // SAME python the running ComfyUI reports (#401 — a mismatch means we're
     // looking at the wrong environment and any negative is untrustworthy).
-    // Also report torch's version — read from package METADATA (never `import torch`,
-    // which would cost seconds) so the caller can tell a location-established
-    // interpreter whose CONTENTS contradict the running server from the real thing.
-    const code = [
-      "import importlib.util as u, sys",
-      "print('python', '%d.%d' % sys.version_info[:2])",
-      "try:",
-      "    from importlib.metadata import version as _v",
-      "    print('torch', _v('torch'))",
-      "except Exception:",
-      "    pass",
-      "print('triton', u.find_spec('triton') is not None)",
-      "print('sageattention', u.find_spec('sageattention') is not None)",
-    ].join("\n");
+    // Print the FULL `sys.version` banner (single line) — the same string
+    // /system_stats reports — so the caller can spot a build/compiler disagreement,
+    // not just a major.minor one (#401 review).
+    const code =
+      "import importlib.util as u,sys;" +
+      "print('python', ' '.join(sys.version.split()));" +
+      "print('triton', u.find_spec('triton') is not None);" +
+      "print('sageattention', u.find_spec('sageattention') is not None)";
     let done = false;
     const child = execFile(
       pythonExe,
@@ -385,16 +387,14 @@ export function probeTritonSage(
           if (!m) return "unknown";
           return m[1] === "True" ? "installed" : "not-installed";
         };
-        const pyMatch = out.match(/^python\s+(\d+\.\d+)/m);
-        const torchMatch = out.match(/^torch\s+(\S+)/m);
+        const pyMatch = out.match(/^python\s+(.+)$/m);
         // If python ran but errored AFTER printing partial output, still trust
         // whatever lines we got; missing lines stay "unknown".
         void err;
         resolve({
           triton: read("triton"),
           sageattention: read("sageattention"),
-          pythonVersion: pyMatch ? pyMatch[1] : undefined,
-          torchVersion: torchMatch ? torchMatch[1] : undefined,
+          pythonVersion: pyMatch ? pyMatch[1].trim() : undefined,
         });
       },
     );
@@ -420,36 +420,32 @@ export function probeTritonSage(
 export function reconcileProbeState(
   state: TriState | undefined,
   opts: {
-    proven: boolean;
+    /** We OBSERVED which interpreter the server runs (we launched it, or the OS told
+     *  us) — see live-interpreter.ts. Layout inference does NOT count. */
+    observed: boolean;
     runningPython?: string;
     probePython?: string;
-    runningTorch?: string;
-    probeTorch?: string;
   },
 ): TriState {
   const s = state ?? "unknown";
+  // Compares the FULL `sys.version` banner when both sides carry one (build date and
+  // compiler included), degrading to the dotted version at whatever precision both
+  // supply. A CONTRADICTION check only — cloned venvs report identical banners.
   const versionMismatch = !!(
     opts.runningPython &&
     opts.probePython &&
-    opts.runningPython !== opts.probePython
+    !pythonVersionsAgree(opts.runningPython, opts.probePython)
   );
-  // `proven` establishes WHERE the interpreter is, not that its CONTENTS are the
-  // running server's. A torch build that disagrees with what the server reports proves
-  // they are different environments no matter how right the location looked, so its
-  // negatives must not stand either.
-  const torchMismatch = !!(
-    opts.runningTorch &&
-    opts.probeTorch &&
-    opts.runningTorch.trim() !== opts.probeTorch.trim()
-  );
-  // `proven` (from resolveComfyuiPython) is the ONLY licence to state a negative: the
-  // sole interpreter under the install root the running server named in its own argv.
-  // Everything softer — a bare PATH fallback, a different workspace, a root INFERRED by
-  // anchoring a relative argv, or a root holding several candidate environments — is a
-  // guess about WHICH python ComfyUI runs, and a wrong guess is exactly what produced
-  // the false "Triton: not installed" that made an agent disable working acceleration
-  // (#401). Those degrade to "unknown"; positives always pass through untouched.
-  const trustworthy = opts.proven && !versionMismatch && !torchMismatch;
+  // Only an OBSERVED interpreter may state a negative. Nothing inferred from install
+  // layout qualifies, however plausible: a sole .venv under the server's own root, a
+  // matching python, a matching torch build — all of those are satisfied by a sibling
+  // environment that is not the one ComfyUI is running, and a wrong guess is exactly
+  // what produced the false "Triton: not installed" that made an agent strip working
+  // acceleration (#401). Everything else degrades to "unknown".
+  //
+  // The asymmetry is deliberate: positives ALWAYS pass through. A package we can see
+  // installed is really installed, whichever environment we happened to look at.
+  const trustworthy = opts.observed && !versionMismatch;
   return s === "not-installed" && !trustworthy ? "unknown" : s;
 }
 
@@ -538,6 +534,10 @@ export interface GatherOptions {
   mcpVersion?: string;
   /** Sidebar panel version, learned from the panel's `hello` frame. */
   panelVersion?: string;
+  /** Port the connected ComfyUI listens on — used to find the server PROCESS and read
+   *  the interpreter it is actually running (#401). Defaults to the port in
+   *  `comfyuiUrl`, which is the live target and may change at runtime. */
+  port?: number;
   /** Override probe timeouts (tests). */
   statsTimeoutMs?: number;
   tritonTimeoutMs?: number;
@@ -615,12 +615,14 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   let statsArgv: string[] | undefined;
   let statsCwd: string | undefined;
   let statsEmbedded: boolean | undefined;
-  let statsTorchRaw: string | undefined;
+  // RAW sys.version banner — caps.python is truncated to major.minor for DISPLAY, so
+  // the contradiction check needs the untruncated string (#401 review).
+  let statsPythonRaw: string | undefined;
   if (stats) {
     applyStats(caps, stats);
     statsArgv = stats.system?.argv;
     statsCwd = stats.system?.cwd;
-    statsTorchRaw = stats.system?.pytorch_version?.trim() || undefined;
+    statsPythonRaw = stats.system?.python_version?.trim() || undefined;
     statsEmbedded =
       typeof stats.system?.embedded_python === "boolean"
         ? stats.system.embedded_python
@@ -641,46 +643,40 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   // false negative and a false positive for the remote server. So skip the probe
   // entirely and rely solely on the ComfyUI-log positive markers below (#401 round 3).
   const remote = caps.location === "REMOTE";
-  let proven = false;
+  let observed = false;
   let ts: Awaited<ReturnType<typeof probeTritonSage>> | undefined;
   if (!remote) {
-    const resolved = resolveComfyuiPython(opts.comfyuiPath, statsArgv, {
-      cwd: statsCwd,
+    // GROUND TRUTH first (we launched it / the OS says so); otherwise probe the layout
+    // GUESS, whose positives are still real but whose negatives can never stand.
+    const live = resolveLiveInterpreter({
+      port: opts.port ?? portFromUrl(opts.comfyuiUrl) ?? 8188,
       remote,
-      embeddedPython: statsEmbedded,
     });
-    proven = resolved.proven;
+    observed = !!live;
+    const python =
+      live?.python ??
+      resolveComfyuiPython(opts.comfyuiPath, statsArgv, {
+        cwd: statsCwd,
+        remote,
+        embeddedPython: statsEmbedded,
+      }).python;
     const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
-    ts = await withTimeout(probeTritonSage(resolved.python, tritonTimeout), tritonTimeout + 1000);
+    ts = await withTimeout(probeTritonSage(python, tritonTimeout), tritonTimeout + 1000);
   }
 
-  // Only trust a definitive "not-installed" when we probed the LIVE running server's
-  // OWN interpreter (#401). Otherwise it can be the WRONG python:
-  //   1. A bare PATH fallback (no on-disk venv/embedded interpreter found).
-  //   2. A different/persisted workspace that merely happens to have a venv — its
-  //      negative would still be a false report about the running instance.
-  //   3. Its major.minor disagrees with what /system_stats reports.
-  //   4. REMOTE mode — no local interpreter is the server's (probe skipped above).
-  //   5. An ANCHORED live root — inferred by re-anchoring a RELATIVE argv main.py on a
-  //      configured base (the ComfyUI Desktop shape) rather than read off the server's
-  //      own absolute argv path.
-  //   6. An AMBIGUOUS root holding several candidate environments (e.g. an in-root
-  //      `.venv` beside a bundle's `python_embeded`), where which one ComfyUI runs is
-  //      a guess.
-  // resolveComfyuiPython folds 1/2/4/5/6 into its `proven` flag.
-  // In each case a "not-installed" is untrustworthy, so we degrade it to "unknown"
-  // rather than emit a false negative that makes an agent disable working
-  // acceleration. A positive ("installed") is still reported — it can't be a false
+  // A definitive "not-installed" requires that we OBSERVED which interpreter the
+  // server runs (we launched it, or the OS told us) AND that it does not contradict
+  // the running instance's python. Everything else — a bare PATH fallback, a
+  // different workspace, a Desktop bundle whose layout we merely guessed at, or a
+  // REMOTE server we cannot observe at all — degrades to "unknown" rather than emit
+  // the false negative that made an agent disable working acceleration (#401).
+  // A positive ("installed") always passes through: it can't be a harmful false
   // negative, and the log-marker check below only ever reinforces a positive.
   const reconcile = (state: TriState | undefined): TriState =>
     reconcileProbeState(state, {
-      proven,
-      runningPython: caps.python,
+      observed,
+      runningPython: statsPythonRaw ?? caps.python,
       probePython: ts?.pythonVersion,
-      // RAW pytorch_version (caps.torch is cleaned of its +cuXXX build suffix, which is
-      // exactly the part that distinguishes two otherwise identical environments).
-      runningTorch: statsTorchRaw,
-      probeTorch: ts?.torchVersion,
     });
   caps.triton = reconcile(ts?.triton);
   caps.sageattention = reconcile(ts?.sageattention);

--- a/src/services/env-capabilities.ts
+++ b/src/services/env-capabilities.ts
@@ -70,6 +70,8 @@ interface SystemStatsLike {
     // Newer ComfyUI reports these; tolerated when absent.
     pytorch_version?: string;
     argv?: string[];
+    cwd?: string;
+    embedded_python?: boolean;
   };
   devices?: Array<{
     name?: string;
@@ -401,7 +403,7 @@ export function probeTritonSage(
  */
 export function reconcileProbeState(
   state: TriState | undefined,
-  opts: { live: boolean; runningPython?: string; probePython?: string },
+  opts: { proven: boolean; runningPython?: string; probePython?: string },
 ): TriState {
   const s = state ?? "unknown";
   const versionMismatch = !!(
@@ -409,7 +411,14 @@ export function reconcileProbeState(
     opts.probePython &&
     opts.runningPython !== opts.probePython
   );
-  const trustworthy = opts.live && !versionMismatch;
+  // `proven` (from resolveComfyuiPython) is the ONLY licence to state a negative: the
+  // sole interpreter under the install root the running server named in its own argv.
+  // Everything softer — a bare PATH fallback, a different workspace, a root INFERRED by
+  // anchoring a relative argv, or a root holding several candidate environments — is a
+  // guess about WHICH python ComfyUI runs, and a wrong guess is exactly what produced
+  // the false "Triton: not installed" that made an agent disable working acceleration
+  // (#401). Those degrade to "unknown"; positives always pass through untouched.
+  const trustworthy = opts.proven && !versionMismatch;
   return s === "not-installed" && !trustworthy ? "unknown" : s;
 }
 
@@ -573,9 +582,16 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
     : undefined;
 
   let statsArgv: string[] | undefined;
+  let statsCwd: string | undefined;
+  let statsEmbedded: boolean | undefined;
   if (stats) {
     applyStats(caps, stats);
     statsArgv = stats.system?.argv;
+    statsCwd = stats.system?.cwd;
+    statsEmbedded =
+      typeof stats.system?.embedded_python === "boolean"
+        ? stats.system.embedded_python
+        : undefined;
   }
 
   // --- ComfyUI-Manager API generation (v4 vs released 3.x) ---
@@ -592,11 +608,15 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   // false negative and a false positive for the remote server. So skip the probe
   // entirely and rely solely on the ComfyUI-log positive markers below (#401 round 3).
   const remote = caps.location === "REMOTE";
-  let live = false;
+  let proven = false;
   let ts: { triton: TriState; sageattention: TriState; pythonVersion?: string } | undefined;
   if (!remote) {
-    const resolved = resolveComfyuiPython(opts.comfyuiPath, statsArgv);
-    live = resolved.live;
+    const resolved = resolveComfyuiPython(opts.comfyuiPath, statsArgv, {
+      cwd: statsCwd,
+      remote,
+      embeddedPython: statsEmbedded,
+    });
+    proven = resolved.proven;
     const tritonTimeout = opts.tritonTimeoutMs ?? 5000;
     ts = await withTimeout(probeTritonSage(resolved.python, tritonTimeout), tritonTimeout + 1000);
   }
@@ -608,13 +628,20 @@ export async function gatherEnvCapabilities(opts: GatherOptions): Promise<EnvCap
   //      negative would still be a false report about the running instance.
   //   3. Its major.minor disagrees with what /system_stats reports.
   //   4. REMOTE mode — no local interpreter is the server's (probe skipped above).
+  //   5. An ANCHORED live root — inferred by re-anchoring a RELATIVE argv main.py on a
+  //      configured base (the ComfyUI Desktop shape) rather than read off the server's
+  //      own absolute argv path.
+  //   6. An AMBIGUOUS root holding several candidate environments (e.g. an in-root
+  //      `.venv` beside a bundle's `python_embeded`), where which one ComfyUI runs is
+  //      a guess.
+  // resolveComfyuiPython folds 1/2/4/5/6 into its `proven` flag.
   // In each case a "not-installed" is untrustworthy, so we degrade it to "unknown"
   // rather than emit a false negative that makes an agent disable working
   // acceleration. A positive ("installed") is still reported — it can't be a false
   // negative, and the log-marker check below only ever reinforces a positive.
   const reconcile = (state: TriState | undefined): TriState =>
     reconcileProbeState(state, {
-      live,
+      proven,
       runningPython: caps.python,
       probePython: ts?.pythonVersion,
     });

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -197,8 +197,15 @@ export function readProcessArgv0(pid: number): string | undefined {
  * lack Triton) is never mistaken for the server's. The same applies to a
  * tunnel/container-side forwarder, and to a second instance whose argv differs.
  *
- * Substring matching absorbs the quoting the OS adds around paths containing
- * spaces; Windows comparison is case- and separator-insensitive.
+ * Substring matching would absorb the quoting the OS adds around paths containing
+ * spaces, but it also lets `main.py` match `proxy-main.py` and `8188` match
+ * `81880` — a wrapper or neighbouring server could then pass its own venv off as
+ * ComfyUI's. So matching is TOKEN-aware: the command line is split on whitespace,
+ * surrounding quotes stripped, and each argv token must either equal a command-line
+ * token exactly or match its final path segment (relative `main.py` vs absolute
+ * `C:/ComfyUI/main.py`). Multi-word argv values (paths with spaces) fall back to a
+ * full substring check, since they cannot be tokenised. Windows comparison is
+ * case- and separator-insensitive.
  */
 export function commandLineMatchesArgv(
   commandLine: string | undefined,
@@ -206,10 +213,17 @@ export function commandLineMatchesArgv(
 ): boolean {
   if (!commandLine || !Array.isArray(argv) || argv.length === 0) return false;
   const norm = (s: string): string => (IS_WIN ? s.toLowerCase().replace(/\\/g, "/") : s);
+  const stripQuotes = (s: string): string => s.replace(/^["']+|["']+$/g, "");
   const hay = norm(commandLine);
+  const hayTokens = commandLine.split(/\s+/).map((t) => norm(stripQuotes(t)));
   const tokens = argv.filter((t): t is string => typeof t === "string" && t.trim() !== "");
   if (tokens.length === 0) return false;
-  return tokens.every((t) => hay.includes(norm(t.trim())));
+  return tokens.every((t) => {
+    const n = norm(stripQuotes(t.trim()));
+    if (n === "") return true;
+    if (n.includes(" ")) return hay.includes(n);
+    return hayTokens.some((h) => h === n || h.endsWith("/" + n));
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -206,6 +206,12 @@ export function readProcessArgv0(pid: number): string | undefined {
  * `C:/ComfyUI/main.py`). Multi-word argv values (paths with spaces) fall back to a
  * full substring check, since they cannot be tokenised. Windows comparison is
  * case- and separator-insensitive.
+ *
+ * Residual, by design: a RELATIVE argv[0] (`ComfyUI\main.py`) can anchor to any
+ * instance whose command line ends the same way, so two local installs are
+ * indistinguishable here once one dies and the other grabs the port. Closing
+ * that needs the process's cwd, which the restart path already correlates —
+ * this correlation stays argument-only.
  */
 export function commandLineMatchesArgv(
   commandLine: string | undefined,
@@ -222,6 +228,12 @@ export function commandLineMatchesArgv(
     const n = norm(stripQuotes(t.trim()));
     if (n === "") return true;
     if (n.includes(" ")) return hay.includes(n);
+    // An ABSOLUTE argv path is an exact claim: it must equal a command-line
+    // token, or `C:\ComfyUI\main.py` would "match" a different instance at
+    // `D:\Other\ComfyUI\main.py`. Only a RELATIVE token (`main.py`) may anchor
+    // to a token's final path segment.
+    const absolute = n.startsWith("/") || /^[a-z]:\//.test(n);
+    if (absolute) return hayTokens.some((h) => h === n);
     return hayTokens.some((h) => h === n || h.endsWith("/" + n));
   });
 }
@@ -284,7 +296,16 @@ export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | 
   }
 
   // Tier 1 — the process we launched, confirmed by PID *and* start time.
-  if (launchRecord && launchRecord.pid === pid && existsSync(launchRecord.python)) {
+  // The recorded interpreter must be ABSOLUTE: a bare `python` would be
+  // re-resolved against OUR cwd/PATH at probe time, not necessarily the
+  // interpreter the child actually spawned with — so a relative record fails
+  // closed to tier 2.
+  if (
+    launchRecord &&
+    launchRecord.pid === pid &&
+    isAbsolute(launchRecord.python) &&
+    existsSync(launchRecord.python)
+  ) {
     // macOS `ps lstart` is SECOND-resolution: a PID recycled within the same
     // second compares equal. On that platform the timestamp alone is not an
     // identity, so the observed command line must also corroborate the recorded

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -1,0 +1,189 @@
+// GROUND TRUTH for "which python is the running ComfyUI actually using?" (#401).
+//
+// Everything else in this codebase INFERS the answer from install layout: look for
+// a .venv under a root we believe in, prefer this candidate over that one, then
+// cross-check a version. That inference is what produced the bug this module exists
+// to end — a confident "Triton: not installed" read off the wrong interpreter, which
+// made an agent strip working acceleration from a user's workflow.
+//
+// Inference cannot be hardened into proof. Two cloned venvs under one root, a conda
+// env we don't even enumerate, a server launched with an interpreter from somewhere
+// else entirely — no amount of layout heuristics or version/torch "fingerprints"
+// distinguishes those, because none of them observe the process. So this module
+// only reports an interpreter when something OBSERVED it:
+//
+//   1. WE LAUNCHED IT — process-control spawned ComfyUI and recorded the exact
+//      interpreter it used. Not a guess: we chose that path.
+//   2. THE OS TELLS US — the server is a local process listening on our port, and
+//      the OS process table reports the command line it was started with. argv[0]
+//      of a running python IS its interpreter.
+//
+// Anything else is `undefined`, and callers must degrade to UNKNOWN rather than
+// report a package as absent. NOTE for future maintainers: ComfyUI does NOT expose
+// `sys.executable` over HTTP (verified on 0.29.2 — /system_stats reports
+// `embedded_python`, a BOOLEAN derived from sys.executable that throws the path
+// away). If a future ComfyUI adds it, that becomes the best source of all and
+// should be added here as tier 0 — it works for remote servers too.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import { platform } from "node:os";
+import { findPidByPort } from "./port-owner.js";
+import { logger } from "./../utils/logger.js";
+
+const IS_WIN = platform() === "win32";
+
+/** How we came to know the interpreter — surfaced to users so "we know" reads
+ *  differently from "we're guessing". */
+export type InterpreterSource = "launched-by-us" | "process-table";
+
+export interface LiveInterpreter {
+  /** Absolute path to the interpreter the running server is using. */
+  python: string;
+  source: InterpreterSource;
+  /** PID of the server process this was established for. */
+  pid: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — the interpreter WE launched ComfyUI with
+// ---------------------------------------------------------------------------
+
+let launchRecord: { pid: number; python: string } | undefined;
+
+/**
+ * Record the exact interpreter process-control just spawned ComfyUI with. Keyed by
+ * PID so it can be VALIDATED later: if the port is owned by a different process,
+ * ours died and something else took over, and the record must not be used.
+ */
+export function recordLaunchedInterpreter(pid: number, python: string): void {
+  if (!pid || !python) return;
+  launchRecord = { pid, python };
+  logger.info("Recorded the interpreter ComfyUI was launched with", { pid, python });
+}
+
+/** Forget the launch record (our child exited, or a stop was requested). */
+export function clearLaunchedInterpreter(): void {
+  launchRecord = undefined;
+}
+
+/** Test seam / introspection. */
+export function getLaunchedInterpreterRecord(): { pid: number; python: string } | undefined {
+  return launchRecord;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — the OS process table
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a command line into argv, honoring double-quoted paths. Windows launchers
+ * routinely quote the interpreter ("C:\Program Files\...\python.exe"), and a naive
+ * whitespace split would truncate it at the space.
+ */
+export function argv0FromCommandLine(cmdline: string): string | undefined {
+  const s = cmdline.trim();
+  if (!s) return undefined;
+  if (s.startsWith('"')) {
+    const end = s.indexOf('"', 1);
+    return end > 1 ? s.slice(1, end) : undefined;
+  }
+  const m = s.match(/^\S+/);
+  return m ? m[0] : undefined;
+}
+
+/**
+ * Read argv[0] of a running process from the OS.
+ *
+ * Windows: WMI's `CommandLine`, NOT `ExecutablePath`. This distinction is the whole
+ * point — for a venv, Windows reports ExecutablePath as the BASE interpreter the
+ * venv trampoline loads (e.g. …\standalone-env\python.exe) while CommandLine's
+ * argv[0] is the venv python (…\ComfyUI\.venv\Scripts\python.exe), which is what
+ * `sys.executable` reports and whose site-packages the server actually imports.
+ * Verified against a live ComfyUI Desktop instance while fixing #401.
+ *
+ * Linux: /proc/PID/cmdline (NUL-separated argv). Also avoids /proc/PID/exe, which
+ * resolves through the venv symlink to the base interpreter.
+ * macOS: `ps -o command=`.
+ */
+export function readProcessArgv0(pid: number): string | undefined {
+  try {
+    if (IS_WIN) {
+      const out = execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`,
+        ],
+        { encoding: "utf-8", timeout: 8000, windowsHide: true },
+      );
+      return argv0FromCommandLine(out);
+    }
+    if (platform() === "linux") {
+      // argv entries are NUL-separated; the first is argv[0].
+      const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      const first = raw.split("\u0000")[0];
+      return first && first.trim() ? first.trim() : undefined;
+    }
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf-8",
+      timeout: 8000,
+    });
+    return argv0FromCommandLine(out);
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The resolver
+// ---------------------------------------------------------------------------
+
+export interface ResolveOptions {
+  /** The port the connected ComfyUI listens on. */
+  port: number;
+  /** True when the server is REMOTE — no local process is it, so there is no
+   *  ground truth to be had and we must report nothing. */
+  remote: boolean;
+  /** Test seams. */
+  findPid?: (port: number) => number | null;
+  readArgv0?: (pid: number) => string | undefined;
+}
+
+/**
+ * The interpreter the running ComfyUI is ACTUALLY using, or `undefined` when we
+ * cannot observe it. Never infers from install layout.
+ *
+ * The launch record is only honored when the port is still owned by the PID we
+ * launched — otherwise our child died and a different server took the port, and
+ * reporting our old interpreter for it would be exactly the class of confident
+ * wrong answer this module exists to prevent.
+ */
+export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | undefined {
+  if (opts.remote) return undefined;
+  const findPid = opts.findPid ?? findPidByPort;
+  const readArgv0 = opts.readArgv0 ?? readProcessArgv0;
+
+  let pid: number | null = null;
+  try {
+    pid = findPid(opts.port);
+  } catch {
+    pid = null;
+  }
+  if (!pid) return undefined;
+
+  if (launchRecord && launchRecord.pid === pid && existsSync(launchRecord.python)) {
+    return { python: launchRecord.python, source: "launched-by-us", pid };
+  }
+
+  const argv0 = readArgv0(pid);
+  // A relative or bare argv[0] ("python", "./python") does not identify a file we
+  // can probe — the process's cwd is not ours. Only an absolute path that exists
+  // is usable; anything else is honestly unknown.
+  if (argv0 && isAbsolute(argv0) && existsSync(argv0)) {
+    return { python: argv0, source: "process-table", pid };
+  }
+  return undefined;
+}

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -285,10 +285,20 @@ export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | 
 
   // Tier 1 — the process we launched, confirmed by PID *and* start time.
   if (launchRecord && launchRecord.pid === pid && existsSync(launchRecord.python)) {
+    // macOS `ps lstart` is SECOND-resolution: a PID recycled within the same
+    // second compares equal. On that platform the timestamp alone is not an
+    // identity, so the observed command line must also corroborate the recorded
+    // interpreter; anywhere the stamp is sub-second (Linux ticks, Windows
+    // FileTime) equality already is proof.
+    const coarseStamp = platform() === "darwin";
+    const corroborated =
+      !coarseStamp ||
+      commandLineMatchesArgv(identity?.commandLine, [launchRecord.python]);
     if (
       launchRecord.startedAt &&
       identity?.startedAt &&
-      launchRecord.startedAt === identity.startedAt
+      launchRecord.startedAt === identity.startedAt &&
+      corroborated
     ) {
       return { python: launchRecord.python, source: "launched-by-us", pid };
     }

--- a/src/services/live-interpreter.ts
+++ b/src/services/live-interpreter.ts
@@ -50,17 +50,26 @@ export interface LiveInterpreter {
 // Tier 1 — the interpreter WE launched ComfyUI with
 // ---------------------------------------------------------------------------
 
-let launchRecord: { pid: number; python: string } | undefined;
+let launchRecord: { pid: number; python: string; startedAt?: string } | undefined;
 
 /**
- * Record the exact interpreter process-control just spawned ComfyUI with. Keyed by
- * PID so it can be VALIDATED later: if the port is owned by a different process,
- * ours died and something else took over, and the record must not be used.
+ * Record the exact interpreter process-control just spawned ComfyUI with, together
+ * with the process's CREATION TIME. A PID alone is not a process identity: PIDs are
+ * recycled, so if our child dies and an externally launched python is handed the
+ * same number before our async cleanup runs, a PID-only check would hand the stale
+ * interpreter to the replacement server. PID + start time is the standard identity
+ * and closes that (#401 round 4). If the start time cannot be read we store none,
+ * and the tier fails closed rather than trusting a bare PID match.
  */
 export function recordLaunchedInterpreter(pid: number, python: string): void {
   if (!pid || !python) return;
-  launchRecord = { pid, python };
-  logger.info("Recorded the interpreter ComfyUI was launched with", { pid, python });
+  const startedAt = readProcessIdentity(pid)?.startedAt;
+  launchRecord = { pid, python, startedAt };
+  logger.info("Recorded the interpreter ComfyUI was launched with", {
+    pid,
+    python,
+    startedAt: startedAt ?? "(unavailable)",
+  });
 }
 
 /** Forget the launch record (our child exited, or a stop was requested). */
@@ -69,7 +78,9 @@ export function clearLaunchedInterpreter(): void {
 }
 
 /** Test seam / introspection. */
-export function getLaunchedInterpreterRecord(): { pid: number; python: string } | undefined {
+export function getLaunchedInterpreterRecord():
+  | { pid: number; python: string; startedAt?: string }
+  | undefined {
   return launchRecord;
 }
 
@@ -93,8 +104,17 @@ export function argv0FromCommandLine(cmdline: string): string | undefined {
   return m ? m[0] : undefined;
 }
 
+/** What the OS can tell us about a running process. */
+export interface ProcessIdentity {
+  /** Full command line, as the OS reports it. */
+  commandLine?: string;
+  /** Process creation time, in whatever stable form the platform provides. Only ever
+   *  compared against another reading taken on the SAME platform. */
+  startedAt?: string;
+}
+
 /**
- * Read argv[0] of a running process from the OS.
+ * Read a running process's command line AND creation time from the OS.
  *
  * Windows: WMI's `CommandLine`, NOT `ExecutablePath`. This distinction is the whole
  * point — for a venv, Windows reports ExecutablePath as the BASE interpreter the
@@ -103,11 +123,12 @@ export function argv0FromCommandLine(cmdline: string): string | undefined {
  * `sys.executable` reports and whose site-packages the server actually imports.
  * Verified against a live ComfyUI Desktop instance while fixing #401.
  *
- * Linux: /proc/PID/cmdline (NUL-separated argv). Also avoids /proc/PID/exe, which
- * resolves through the venv symlink to the base interpreter.
- * macOS: `ps -o command=`.
+ * Linux: /proc/PID/cmdline ("\u0000"-separated argv) plus field 22 of /proc/PID/stat
+ * (starttime, in clock ticks since boot). Avoids /proc/PID/exe, which resolves
+ * through the venv symlink to the base interpreter.
+ * macOS: `ps -o lstart=,command=`.
  */
-export function readProcessArgv0(pid: number): string | undefined {
+export function readProcessIdentity(pid: number): ProcessIdentity | undefined {
   try {
     if (IS_WIN) {
       const out = execFileSync(
@@ -115,26 +136,80 @@ export function readProcessArgv0(pid: number): string | undefined {
         [
           "-NoProfile",
           "-Command",
-          `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}").CommandLine`,
+          `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
+            `if ($p) { "START=" + $p.CreationDate.ToFileTimeUtc(); "CMD=" + $p.CommandLine }`,
         ],
         { encoding: "utf-8", timeout: 8000, windowsHide: true },
       );
-      return argv0FromCommandLine(out);
+      const startedAt = out.match(/^START=(.+)$/m)?.[1]?.trim();
+      const commandLine = out.match(/^CMD=([\s\S]*)$/m)?.[1]?.trim();
+      if (!startedAt && !commandLine) return undefined;
+      return { commandLine: commandLine || undefined, startedAt: startedAt || undefined };
     }
     if (platform() === "linux") {
-      // argv entries are NUL-separated; the first is argv[0].
+      // argv entries are "\u0000"-separated; rejoin them as a command line.
       const raw = readFileSync(`/proc/${pid}/cmdline`, "utf-8");
-      const first = raw.split("\u0000")[0];
-      return first && first.trim() ? first.trim() : undefined;
+      const commandLine = raw.split("\u0000").filter(Boolean).join(" ").trim();
+      let startedAt: string | undefined;
+      try {
+        const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+        // Field 2 (comm) can contain spaces and parens — parse after the LAST ')'.
+        const after = stat.slice(stat.lastIndexOf(")") + 1).trim().split(/\s+/);
+        // After comm, fields run state(3)… so starttime (field 22) is index 19 here.
+        startedAt = after[19];
+      } catch {
+        /* start time unavailable → the launched-by-us tier fails closed */
+      }
+      if (!commandLine && !startedAt) return undefined;
+      return { commandLine: commandLine || undefined, startedAt };
     }
-    const out = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart=,command="], {
       encoding: "utf-8",
       timeout: 8000,
-    });
-    return argv0FromCommandLine(out);
+    }).trim();
+    if (!out) return undefined;
+    // `lstart` is a ctime-style stamp: "Fri Aug  1 12:00:00 2026".
+    const m = out.match(/^(\w{3}\s+\w{3}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+([\s\S]*)$/);
+    if (!m) return { commandLine: out };
+    return { startedAt: m[1].replace(/\s+/g, " "), commandLine: m[2].trim() };
   } catch {
     return undefined;
   }
+}
+
+/** Back-compat helper: just argv[0] of a running process. */
+export function readProcessArgv0(pid: number): string | undefined {
+  const cmd = readProcessIdentity(pid)?.commandLine;
+  return cmd ? argv0FromCommandLine(cmd) : undefined;
+}
+
+/**
+ * Is the process we found on the port the one the SERVER told us about?
+ *
+ * `/system_stats.argv` is the running server's own `sys.argv` — an observation made
+ * inside the process that answered OUR request. Requiring the command line of the
+ * process holding the port to contain every one of those tokens correlates two
+ * independent observations, instead of trusting whatever happens to hold the port.
+ *
+ * This defeats the concrete hazard: a python reverse proxy on 127.0.0.1:8188
+ * forwarding to the real ComfyUI elsewhere is a different program with a different
+ * command line, so it cannot match ComfyUI's argv — and its venv (which may well
+ * lack Triton) is never mistaken for the server's. The same applies to a
+ * tunnel/container-side forwarder, and to a second instance whose argv differs.
+ *
+ * Substring matching absorbs the quoting the OS adds around paths containing
+ * spaces; Windows comparison is case- and separator-insensitive.
+ */
+export function commandLineMatchesArgv(
+  commandLine: string | undefined,
+  argv: string[] | undefined,
+): boolean {
+  if (!commandLine || !Array.isArray(argv) || argv.length === 0) return false;
+  const norm = (s: string): string => (IS_WIN ? s.toLowerCase().replace(/\\/g, "/") : s);
+  const hay = norm(commandLine);
+  const tokens = argv.filter((t): t is string => typeof t === "string" && t.trim() !== "");
+  if (tokens.length === 0) return false;
+  return tokens.every((t) => hay.includes(norm(t.trim())));
 }
 
 // ---------------------------------------------------------------------------
@@ -144,41 +219,78 @@ export function readProcessArgv0(pid: number): string | undefined {
 export interface ResolveOptions {
   /** The port the connected ComfyUI listens on. */
   port: number;
+  /** The HOST we talk to. Binds the lookup to the right listener when several
+   *  instances share a port across different loopback/bind addresses. */
+  host?: string;
   /** True when the server is REMOTE — no local process is it, so there is no
    *  ground truth to be had and we must report nothing. */
   remote: boolean;
+  /** `/system_stats.argv` — the running server's OWN sys.argv. Tier 2 requires the
+   *  process holding the port to have a command line consistent with this, so a
+   *  proxy or forwarder on the same port can never be mistaken for ComfyUI. Without
+   *  it there is nothing to correlate against and tier 2 fails closed. */
+  serverArgv?: string[];
   /** Test seams. */
-  findPid?: (port: number) => number | null;
-  readArgv0?: (pid: number) => string | undefined;
+  findPid?: (port: number, host?: string) => number | null;
+  readIdentity?: (pid: number) => ProcessIdentity | undefined;
 }
 
 /**
  * The interpreter the running ComfyUI is ACTUALLY using, or `undefined` when we
  * cannot observe it. Never infers from install layout.
  *
- * The launch record is only honored when the port is still owned by the PID we
- * launched — otherwise our child died and a different server took the port, and
- * reporting our old interpreter for it would be exactly the class of confident
- * wrong answer this module exists to prevent.
+ * Both tiers demand a real process IDENTITY, not just a PID:
+ *  - tier 1 requires the port owner to be the process we launched — same PID AND
+ *    same creation time, because PIDs get recycled and an externally launched
+ *    python could otherwise inherit our record;
+ *  - tier 2 requires the port owner's command line to match the argv the SERVER
+ *    itself reported, so a python reverse proxy sitting on the port cannot pass its
+ *    own venv off as ComfyUI's.
+ * Any missing signal fails closed to `undefined` — unknown is always acceptable, a
+ * confidently wrong package list is the entire bug (#401).
  */
 export function resolveLiveInterpreter(opts: ResolveOptions): LiveInterpreter | undefined {
   if (opts.remote) return undefined;
   const findPid = opts.findPid ?? findPidByPort;
-  const readArgv0 = opts.readArgv0 ?? readProcessArgv0;
+  const readIdentity = opts.readIdentity ?? readProcessIdentity;
 
   let pid: number | null = null;
   try {
-    pid = findPid(opts.port);
+    pid = findPid(opts.port, opts.host);
   } catch {
     pid = null;
   }
   if (!pid) return undefined;
 
-  if (launchRecord && launchRecord.pid === pid && existsSync(launchRecord.python)) {
-    return { python: launchRecord.python, source: "launched-by-us", pid };
+  let identity: ProcessIdentity | undefined;
+  try {
+    identity = readIdentity(pid);
+  } catch {
+    identity = undefined;
   }
 
-  const argv0 = readArgv0(pid);
+  // Tier 1 — the process we launched, confirmed by PID *and* start time.
+  if (launchRecord && launchRecord.pid === pid && existsSync(launchRecord.python)) {
+    if (
+      launchRecord.startedAt &&
+      identity?.startedAt &&
+      launchRecord.startedAt === identity.startedAt
+    ) {
+      return { python: launchRecord.python, source: "launched-by-us", pid };
+    }
+    // Same PID, different (or unreadable) start time → this is NOT our process, or
+    // we cannot prove it is. Fall through to tier 2 rather than trust the record.
+    logger.info("Ignoring the launch record: process identity could not be confirmed", {
+      pid,
+      recorded: launchRecord.startedAt ?? "(unavailable)",
+      observed: identity?.startedAt ?? "(unavailable)",
+    });
+  }
+
+  // Tier 2 — the OS process table, correlated against the server's own argv.
+  if (!commandLineMatchesArgv(identity?.commandLine, opts.serverArgv)) return undefined;
+
+  const argv0 = argv0FromCommandLine(identity?.commandLine ?? "");
   // A relative or bare argv[0] ("python", "./python") does not identify a file we
   // can probe — the process's cwd is not ours. Only an absolute path that exists
   // is usable; anything else is honestly unknown.

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -23,9 +23,40 @@ const IS_WIN = platform() === "win32";
  *
  * Exported for tests: this pure function is where the bug lived.
  */
+/** Loopback spellings that all denote "this machine". */
+const LOOPBACK = new Set(["127.0.0.1", "::1", "localhost"]);
+/** Bind addresses that accept connections for EVERY local address. */
+const WILDCARD = new Set(["0.0.0.0", "::", "*", ""]);
+
+/** Split "127.0.0.1:8188" / "[::1]:8188" / "*:8188" into address + port. */
+function splitEndpoint(endpoint: string): { address: string; port: string } {
+  const idx = endpoint.lastIndexOf(":");
+  if (idx < 0) return { address: endpoint, port: "" };
+  const address = endpoint.slice(0, idx).replace(/^\[|\]$/g, "");
+  return { address, port: endpoint.slice(idx + 1) };
+}
+
+/**
+ * Does a listener bound to `address` serve the host we are actually talking to?
+ *
+ * A wildcard bind serves every local address, so it always matches. Otherwise the
+ * addresses must agree, with the loopback spellings treated as equivalent. Binding
+ * the lookup to the HOST — not just the port number — keeps two instances on
+ * different loopback addresses from being confused for one another (#401 round 4).
+ */
+export function addressServesHost(address: string, wantHost?: string): boolean {
+  const a = address.toLowerCase();
+  if (WILDCARD.has(a)) return true;
+  if (!wantHost) return true;
+  const w = wantHost.toLowerCase().replace(/^\[|\]$/g, "");
+  if (a === w) return true;
+  return LOOPBACK.has(a) && LOOPBACK.has(w);
+}
+
 export function parseListenerPidFromNetstat(
   output: string,
   port: number,
+  host?: string,
 ): number | null {
   const suffix = `:${port}`;
   for (const raw of output.split(/\r?\n/)) {
@@ -46,13 +77,48 @@ export function parseListenerPidFromNetstat(
     // local side to :PORT — killing that would take down the wrong process
     // (or none) when ComfyUI is actually down.
     if (!foreign.endsWith(":0")) continue;
+    if (!addressServesHost(splitEndpoint(local).address, host)) continue;
     const pid = parseInt(parts[parts.length - 1], 10);
     if (!Number.isNaN(pid) && pid > 0) return pid;
   }
   return null;
 }
 
-export function findPidByPort(port: number): number | null {
+/**
+ * Parse `lsof -nP -iTCP:PORT -sTCP:LISTEN -Fpn` field output. Records look like
+ *   p1234
+ *   n127.0.0.1:8188
+ * so we can bind the match to the ADDRESS as well as the port, which the plain
+ * `-t` (terse) output cannot express.
+ */
+export function parseListenerPidFromLsof(
+  output: string,
+  port: number,
+  host?: string,
+): number | null {
+  let pid: number | null = null;
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("p")) {
+      const parsed = parseInt(line.slice(1), 10);
+      pid = !Number.isNaN(parsed) && parsed > 0 ? parsed : null;
+      continue;
+    }
+    if (line.startsWith("n") && pid !== null) {
+      const endpoint = line.slice(1);
+      // Ignore a peer-qualified name ("a->b"); listeners have no peer.
+      if (endpoint.includes("->")) continue;
+      const { address, port: p } = splitEndpoint(endpoint);
+      if (p !== String(port)) continue;
+      if (!addressServesHost(address, host)) continue;
+      return pid;
+    }
+  }
+  return null;
+}
+
+export function findPidByPort(port: number, host?: string): number | null {
   if (IS_WIN) {
     // Parse `netstat -ano` ourselves instead of piping through
     // `findstr LISTENING` — that state word is localized and made detection fail
@@ -62,21 +128,27 @@ export function findPidByPort(port: number): number | null {
         encoding: "utf-8",
         timeout: 5000,
       });
-      const pid = parseListenerPidFromNetstat(out, port);
+      const pid = parseListenerPidFromNetstat(out, port, host);
       if (pid) return pid;
     } catch {
       // netstat unavailable / failed — fall through to the PowerShell probe.
     }
     // Fallback: Get-NetTCPConnection maps port→owning PID structurally, with no
     // dependence on console locale or column layout. Belt-and-suspenders for the
-    // portable/embedded-Python launch shape reported in #449.
+    // portable/embedded-Python launch shape reported in #449. LocalAddress is
+    // selected too so the host filter still applies.
     try {
       const out = execSync(
-        `powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty OwningProcess"`,
+        `powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | ForEach-Object { \\"$($_.LocalAddress) $($_.OwningProcess)\\" }"`,
         { encoding: "utf-8", timeout: 8000 },
-      ).trim();
-      const pid = parseInt(out, 10);
-      if (!Number.isNaN(pid) && pid > 0) return pid;
+      );
+      for (const raw of out.split(/\r?\n/)) {
+        const [addr, pidText] = raw.trim().split(/\s+/);
+        if (!addr || !pidText) continue;
+        if (!addressServesHost(addr.replace(/^\[|\]$/g, ""), host)) continue;
+        const pid = parseInt(pidText, 10);
+        if (!Number.isNaN(pid) && pid > 0) return pid;
+      }
     } catch {
       // PowerShell unavailable / nothing listening.
     }
@@ -84,18 +156,18 @@ export function findPidByPort(port: number): number | null {
   }
 
   try {
-    // LISTENER-ONLY, and TCP only. A bare `lsof -ti :PORT` also matches processes
-    // merely CONNECTED to that port (and UDP), so it can return a client — e.g. a
-    // browser or our own fetch — instead of the ComfyUI server. That PID is used to
-    // kill the server AND (since #401) to read the interpreter the server runs, so a
-    // client's argv[0] must never be mistaken for it. Mirrors the Windows branch,
-    // which already required a listening row (foreign endpoint :0).
-    const out = execSync(`lsof -tiTCP:${port} -sTCP:LISTEN`, {
+    // LISTENER-ONLY, TCP only, and bound to the ADDRESS we actually talk to. A bare
+    // `lsof -ti :PORT` also matches processes merely CONNECTED to that port (and
+    // UDP), so it can return a client — a browser, or our own fetch — instead of the
+    // ComfyUI server. That PID is used to kill the server AND (since #401) to read
+    // the interpreter it runs, so a client must never be mistaken for it. `-Fpn`
+    // field output carries the bind address, which terse `-t` cannot express.
+    const out = execSync(`lsof -nP -iTCP:${port} -sTCP:LISTEN -Fpn`, {
       encoding: "utf-8",
       timeout: 5000,
-    }).trim();
-    const pid = parseInt(out.split("\n")[0], 10);
-    if (!isNaN(pid) && pid > 0) return pid;
+    });
+    const pid = parseListenerPidFromLsof(out, port, host);
+    if (pid) return pid;
   } catch {
     // Command failed — no process listening on that port
   }

--- a/src/services/port-owner.ts
+++ b/src/services/port-owner.ts
@@ -1,0 +1,103 @@
+// Port → owning PID lookup.
+//
+// Extracted from process-control so the live-interpreter resolver can use it
+// WITHOUT importing process-control (which imports workspace-env, which consumes
+// the resolver — that would be an import cycle). This module is a LEAF: node
+// builtins only. process-control re-exports parseListenerPidFromNetstat so its
+// existing tests keep importing it from there.
+
+import { execSync } from "node:child_process";
+import { platform } from "node:os";
+
+const IS_WIN = platform() === "win32";
+
+/**
+ * Extract the PID that is LISTENING on `port` from `netstat -ano` output.
+ *
+ * We anchor on the local-address `:PORT` suffix rather than grepping the state
+ * word ("LISTENING"), which is TRANSLATED on non-English Windows (German
+ * "ABHÖREN", French "À L'ÉCOUTE", …). The old `findstr LISTENING` filter dropped
+ * every line on those systems, so a perfectly reachable ComfyUI looked like "no
+ * process on port". Anchoring on the local column also correctly IGNORES an
+ * outbound/established connection whose REMOTE peer happens to use `:PORT`.
+ *
+ * Exported for tests: this pure function is where the bug lived.
+ */
+export function parseListenerPidFromNetstat(
+  output: string,
+  port: number,
+): number | null {
+  const suffix = `:${port}`;
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    // Expected columns: PROTO LOCAL FOREIGN STATE PID
+    if (parts.length < 5) continue;
+    if (parts[0].toUpperCase() !== "TCP") continue;
+    const local = parts[1];
+    const foreign = parts[2];
+    // The leading colon anchors the match: "…:8188" matches but "…:81880" and
+    // "…:18188" do not (their last chars aren't ":8188").
+    if (!local.endsWith(suffix)) continue;
+    // Require a LISTENING row without depending on the localized state word: a
+    // listener's foreign endpoint is always the wildcard port 0 (0.0.0.0:0 /
+    // [::]:0). This rejects an ESTABLISHED connection that merely bound its
+    // local side to :PORT — killing that would take down the wrong process
+    // (or none) when ComfyUI is actually down.
+    if (!foreign.endsWith(":0")) continue;
+    const pid = parseInt(parts[parts.length - 1], 10);
+    if (!Number.isNaN(pid) && pid > 0) return pid;
+  }
+  return null;
+}
+
+export function findPidByPort(port: number): number | null {
+  if (IS_WIN) {
+    // Parse `netstat -ano` ourselves instead of piping through
+    // `findstr LISTENING` — that state word is localized and made detection fail
+    // on non-English Windows even when ComfyUI was reachable (issue #449).
+    try {
+      const out = execSync(`netstat -ano -p TCP`, {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const pid = parseListenerPidFromNetstat(out, port);
+      if (pid) return pid;
+    } catch {
+      // netstat unavailable / failed — fall through to the PowerShell probe.
+    }
+    // Fallback: Get-NetTCPConnection maps port→owning PID structurally, with no
+    // dependence on console locale or column layout. Belt-and-suspenders for the
+    // portable/embedded-Python launch shape reported in #449.
+    try {
+      const out = execSync(
+        `powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty OwningProcess"`,
+        { encoding: "utf-8", timeout: 8000 },
+      ).trim();
+      const pid = parseInt(out, 10);
+      if (!Number.isNaN(pid) && pid > 0) return pid;
+    } catch {
+      // PowerShell unavailable / nothing listening.
+    }
+    return null;
+  }
+
+  try {
+    // LISTENER-ONLY, and TCP only. A bare `lsof -ti :PORT` also matches processes
+    // merely CONNECTED to that port (and UDP), so it can return a client — e.g. a
+    // browser or our own fetch — instead of the ComfyUI server. That PID is used to
+    // kill the server AND (since #401) to read the interpreter the server runs, so a
+    // client's argv[0] must never be mistaken for it. Mirrors the Windows branch,
+    // which already required a listening row (foreign endpoint :0).
+    const out = execSync(`lsof -tiTCP:${port} -sTCP:LISTEN`, {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    const pid = parseInt(out.split("\n")[0], 10);
+    if (!isNaN(pid) && pid > 0) return pid;
+  } catch {
+    // Command failed — no process listening on that port
+  }
+  return null;
+}

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -9,6 +9,11 @@ import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { findComfyuiPython } from "./env-capabilities.js";
 import { resetManagerApiCache } from "./manager-api-cache.js";
+import { parseListenerPidFromNetstat, findPidByPort } from "./port-owner.js";
+import {
+  recordLaunchedInterpreter,
+  clearLaunchedInterpreter,
+} from "./live-interpreter.js";
 import {
   liveRootFromArgv,
   resolveEffectiveComfyUIBase,
@@ -115,90 +120,10 @@ let supervisorGaveUp = false;
 
 const IS_WIN = platform() === "win32";
 
-/**
- * Parse a `netstat -ano` blob and return the PID that OWNS the socket bound to
- * `port` on the LOCAL address column. Locale-independent by design (issue #449):
- * we anchor on the local-address `:PORT` suffix rather than grepping the state
- * word ("LISTENING"), which is TRANSLATED on non-English Windows (German
- * "ABHÖREN", French "À L'ÉCOUTE", …). The old `findstr LISTENING` filter dropped
- * every line on those systems, so a perfectly reachable ComfyUI looked like "no
- * process on port". Anchoring on the local column also correctly IGNORES an
- * outbound/established connection whose REMOTE peer happens to use `:PORT`.
- *
- * Exported for tests: this pure function is where the bug lived.
- */
-export function parseListenerPidFromNetstat(
-  output: string,
-  port: number,
-): number | null {
-  const suffix = `:${port}`;
-  for (const raw of output.split(/\r?\n/)) {
-    const line = raw.trim();
-    if (!line) continue;
-    const parts = line.split(/\s+/);
-    // Expected columns: PROTO LOCAL FOREIGN STATE PID
-    if (parts.length < 5) continue;
-    if (parts[0].toUpperCase() !== "TCP") continue;
-    const local = parts[1];
-    const foreign = parts[2];
-    // The leading colon anchors the match: "…:8188" matches but "…:81880" and
-    // "…:18188" do not (their last chars aren't ":8188").
-    if (!local.endsWith(suffix)) continue;
-    // Require a LISTENING row without depending on the localized state word: a
-    // listener's foreign endpoint is always the wildcard port 0 (0.0.0.0:0 /
-    // [::]:0). This rejects an ESTABLISHED connection that merely bound its
-    // local side to :PORT — killing that would take down the wrong process
-    // (or none) when ComfyUI is actually down.
-    if (!foreign.endsWith(":0")) continue;
-    const pid = parseInt(parts[parts.length - 1], 10);
-    if (!Number.isNaN(pid) && pid > 0) return pid;
-  }
-  return null;
-}
-
-function findPidByPort(port: number): number | null {
-  if (IS_WIN) {
-    // Parse `netstat -ano` ourselves instead of piping through
-    // `findstr LISTENING` — that state word is localized and made detection fail
-    // on non-English Windows even when ComfyUI was reachable (issue #449).
-    try {
-      const out = execSync(`netstat -ano -p TCP`, {
-        encoding: "utf-8",
-        timeout: 5000,
-      });
-      const pid = parseListenerPidFromNetstat(out, port);
-      if (pid) return pid;
-    } catch {
-      // netstat unavailable / failed — fall through to the PowerShell probe.
-    }
-    // Fallback: Get-NetTCPConnection maps port→owning PID structurally, with no
-    // dependence on console locale or column layout. Belt-and-suspenders for the
-    // portable/embedded-Python launch shape reported in #449.
-    try {
-      const out = execSync(
-        `powershell -NoProfile -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty OwningProcess"`,
-        { encoding: "utf-8", timeout: 8000 },
-      ).trim();
-      const pid = parseInt(out, 10);
-      if (!Number.isNaN(pid) && pid > 0) return pid;
-    } catch {
-      // PowerShell unavailable / nothing listening.
-    }
-    return null;
-  }
-
-  try {
-    const out = execSync(`lsof -ti :${port}`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    }).trim();
-    const pid = parseInt(out.split("\n")[0], 10);
-    if (!isNaN(pid) && pid > 0) return pid;
-  } catch {
-    // Command failed — no process on that port
-  }
-  return null;
-}
+// parseListenerPidFromNetstat / findPidByPort now live in port-owner.ts so the
+// live-interpreter resolver can use them without importing this module (which would
+// cycle through workspace-env). Re-exported here: this is still their public home.
+export { parseListenerPidFromNetstat, findPidByPort };
 
 /**
  * Find PIDs of the Desktop app's Electron shell — current branding
@@ -554,6 +479,9 @@ function adoptLaunchedChild(child: ChildProcess, interpreter: string | undefined
     if (recordedLaunchChild !== child) return;
     recordedLaunchChild = undefined;
     resetLocalComfyUILaunchState();
+    // Same fail-closed reasoning for the recorded interpreter: once our child is
+    // gone, a successor on that port may run a DIFFERENT python (#401).
+    clearLaunchedInterpreter();
   };
   child.once("exit", clearIfCurrent);
   child.once("error", clearIfCurrent);
@@ -573,19 +501,22 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
 
   const cmd = resolveLaunchCommand(info);
   if (!cmd) return null;
-  return {
-    child: spawn(cmd.exe, cmd.args, {
-      detached: true,
-      stdio: "ignore",
+  const child = spawn(cmd.exe, cmd.args, {
+    detached: true,
+    stdio: "ignore",
     // Prefer the cwd the command resolved against (the live process cwd for a
     // relative-script relaunch, #535); only then the configured install dir. A
     // stale/nonexistent config.comfyuiPath as cwd would ENOENT the spawn.
     cwd: cmd.cwd ?? config.comfyuiPath ?? undefined,
     shell: false,
-      windowsHide: true,
-    }),
-    interpreter: cmd.exe,
-  };
+    windowsHide: true,
+  });
+  // GROUND TRUTH for #401: we chose this interpreter, so we KNOW which python the
+  // server runs — no layout inference required. Keyed to the PID so it is discarded
+  // the moment a different process owns the port. (Desktop-app launches return
+  // above: that exe is a launcher, not an interpreter.)
+  if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
+  return { child, interpreter: cmd.exe };
 }
 
 /**
@@ -1038,8 +969,11 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   detachSupervisor();
   // The server we may have launched is going away — clear the shares-our-env flag so
   // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
+  // Forget the recorded interpreter too: a stop was requested, so the launch record
+  // must not outlive the process it describes (#401).
   recordedLaunchChild = undefined;
   resetLocalComfyUILaunchState();
+  clearLaunchedInterpreter();
 
   // Gather info before we kill it (or reuse the caller's pre-validated info so a
   // relaunch preflight in restartComfyUI is not discarded).
@@ -1171,7 +1105,7 @@ export async function startComfyUI(): Promise<StartResult> {
     // failed spawn (ERROR): a successor server that later takes the port may have a
     // DIFFERENT env, so it must NOT inherit our trust (#633 P1b stale-flag). Fail
     // closed the moment we no longer own the process (`error` covers the spawn_error
-    // path where `exit` may not fire).
+    // path where `exit` may not fire). adoptLaunchedChild wires both handlers.
   }
 
   // A NEW server instance is coming up on this port — whatever Manager dialect we

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -466,15 +466,16 @@ function rememberRestartAttempt(policy: RestartPolicy): boolean {
 
 interface SpawnedComfyUI {
   child: ChildProcess;
-  /** Defined only for the Python process we directly execute, never Desktop's shell. */
-  interpreter?: string;
 }
 
 let recordedLaunchChild: ChildProcess | undefined;
 
-function adoptLaunchedChild(child: ChildProcess, interpreter: string | undefined): void {
+function adoptLaunchedChild(child: ChildProcess): void {
   recordedLaunchChild = child;
-  markLocalComfyUILaunched(interpreter);
+  // Env-trust ONLY (#633 P1b) — the launched interpreter itself is recorded by
+  // spawnFromProcessInfo via recordLaunchedInterpreter (live-interpreter.ts), the
+  // single launch record, and trusted only after PID + creation-time validation.
+  markLocalComfyUILaunched();
   const clearIfCurrent = (): void => {
     if (recordedLaunchChild !== child) return;
     recordedLaunchChild = undefined;
@@ -516,7 +517,7 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   // the moment a different process owns the port. (Desktop-app launches return
   // above: that exe is a launcher, not an interpreter.)
   if (child.pid) recordLaunchedInterpreter(child.pid, cmd.exe);
-  return { child, interpreter: cmd.exe };
+  return { child };
 }
 
 /**
@@ -866,7 +867,7 @@ function handleSupervisedChildStop(
     return;
   }
   restarted.child.unref();
-  if (!lastProcessInfo.isDesktopApp) adoptLaunchedChild(restarted.child, restarted.interpreter);
+  if (!lastProcessInfo.isDesktopApp) adoptLaunchedChild(restarted.child);
   superviseChild(restarted.child, lastProcessInfo);
 }
 
@@ -1100,7 +1101,7 @@ export async function startComfyUI(): Promise<StartResult> {
   // expanded against process.env (#633 P1b). A Desktop-app launch's env is NOT
   // guaranteed to be ours, so it stays fail-closed (unmarked).
   if (!info.isDesktopApp) {
-    adoptLaunchedChild(launched.child, launched.interpreter);
+    adoptLaunchedChild(launched.child);
     // Revoke env-trust the instant OUR launched child goes away — on EXIT and on a
     // failed spawn (ERROR): a successor server that later takes the port may have a
     // DIFFERENT env, so it must NOT inherit our trust (#633 P1b stale-flag). Fail

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -6,6 +6,7 @@ import { basename, dirname, isAbsolute, join, resolve as pathResolve, sep } from
 import { promisify } from "node:util";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
+import { resolveLiveInterpreter } from "./live-interpreter.js";
 import { logger } from "../utils/logger.js";
 import { ValidationError } from "../utils/errors.js";
 
@@ -610,102 +611,38 @@ function isEmbeddedCandidate(candidate: string): boolean {
   return basename(dirname(candidate)).toLowerCase() === "python_embeded";
 }
 
+/**
+ * A BEST-GUESS interpreter, inferred from install layout.
+ *
+ * This is a GUESS and nothing more. It is fine for display and for probing (a
+ * package we can SEE is really installed somewhere), but it must NEVER back a
+ * negative or a "this is the server's environment" claim — that is what #401 was.
+ * Authority comes only from `resolveLiveInterpreter()` in live-interpreter.ts,
+ * which observes the actual process instead of guessing from directory layout.
+ */
 export interface ComfyuiPythonResolution {
   /** The interpreter to probe. Absolute when verified; a bare PATH name as last resort. */
   python: string | undefined;
   /** The interpreter exists on disk under a known ComfyUI root (venv/embedded). */
   verified: boolean;
-  /** That root is the LIVE running server's own install root — i.e. this is provably
-   *  the interpreter running ComfyUI. Only a `live` interpreter's negatives are
-   *  authoritative; anything else must be treated as unknown/untrusted (#401). */
-  live: boolean;
-  /** The live root was INFERRED by anchoring a RELATIVE argv `main.py` against a
-   *  configured base and confirmed by a `main.py` on disk (ComfyUI Desktop reports
-   *  `ComfyUI\main.py` with no cwd). Strong evidence, but not proof the way an
-   *  absolute argv path is — callers must corroborate with a python-version match
-   *  before treating this interpreter's answers as authoritative (#401 recurrence). */
-  anchored: boolean;
-  /** SEVERAL plausible interpreters live under the chosen root (e.g. an in-root
-   *  `.venv` AND the bundle's `python_embeded`, or `.venv` AND `standalone-env`) and
-   *  nothing tells us which one ComfyUI runs. We still probe the best guess, but its
-   *  answers are a guess — never authoritative. */
-  ambiguous: boolean;
-  /** The interpreter's LOCATION is established, not assumed: it is the sole interpreter
-   *  found INSIDE the install root the running server named in its own absolute argv —
-   *  or, for a portable bundle's sibling `python_embeded`, the server itself told us it
-   *  runs an embedded python (`embedded_python: true`), which is what makes an
-   *  outside-the-root candidate legitimate rather than a layout guess.
-   *
-   *  `proven` is NECESSARY but NOT SUFFICIENT for any authoritative claim: it says we
-   *  know WHERE the interpreter is, not that its contents agree with the running
-   *  server. Callers must still cross-check the live /system_stats fingerprint before
-   *  reporting from it, and only a `proven` probe may ever yield a definitive
-   *  "not installed" (#401). */
-  proven: boolean;
-  /** We know WHERE this interpreter is relative to the running server: it sits inside
-   *  the server's own install root, or it is the bundle's sibling `python_embeded` and
-   *  the server reported `embedded_python: true`. False means the location is a layout
-   *  guess (an unhinted `../python_embeded`), which may be probed but may never back a
-   *  report about the running server. */
-  locationEstablished: boolean;
-  /** The resolved absolute live root, when one could be determined from argv. */
+  /** The live server's install root, when argv named one. Provenance only. */
   liveRoot?: string;
 }
 
-/** Normalize a path for comparison (resolve `..`, case-fold on Windows). */
-function normalizePath(p: string): string {
-  const r = pathResolve(p);
-  return IS_WIN ? r.toLowerCase() : r;
-}
-
-/** Is `child` inside `parent`? Used to reject PARENT-RELATIVE candidates (a portable
- *  bundle's `../python_embeded`) from conferring authority: a `..` sibling is by
- *  construction NOT under the install root the server named, so finding one there
- *  proves nothing about which interpreter that server runs. */
-function isUnder(parent: string, child: string): boolean {
-  const p = normalizePath(parent);
-  const c = normalizePath(child);
-  return c === p || c.startsWith(p.endsWith(sep) ? p : p + sep);
-}
-
-/** Pick the interpreter to probe under one root, and report how sure we are.
- *  `hintMatched` is false when the server's `embedded_python` self-report rules out
- *  EVERY candidate we can see — the server's real interpreter is then demonstrably
- *  not among them, so the caller must not present our fallback as the live one.
- *  `insideRoot` is false for a parent-relative candidate (see isUnder). */
-function pickInterpreter(
-  root: string,
-  hint: boolean | undefined,
-): { python: string; ambiguous: boolean; hintMatched: boolean; insideRoot: boolean } | undefined {
-  const existing = interpreterCandidates(root).filter(safeExists);
-  if (existing.length === 0) return undefined;
-  const matching = hint === undefined ? existing : existing.filter((c) => isEmbeddedCandidate(c) === hint);
-  const pool = matching.length > 0 ? matching : existing;
-  // Count distinct ENVIRONMENTS, not filenames: `.venv/Scripts/python.exe` and
-  // `.venv/Scripts/python` are one env, `.venv` vs `standalone-env` are two.
-  const envs = new Set(pool.map((c) => normalizePath(dirname(c))));
-  return {
-    python: pool[0],
-    ambiguous: envs.size > 1,
-    hintMatched: hint === undefined || matching.length > 0,
-    insideRoot: isUnder(root, pool[0]),
-  };
-}
-
 /**
- * Resolve the python that ComfyUI actually runs on, LIVE-FIRST. The running server's
- * argv-derived install root is tried BEFORE an explicit COMFYUI_PATH, which is tried
- * before the saved default workspace (#418) — and the saved default is consulted ONLY
- * when there is neither a live argv nor an explicit path to trust. Portable/standalone
- * installs keep python under python_embeded / standalone-env (not just .venv), so all
- * are checked. Falls back to a bare PATH name (`verified:false, live:false`) when no
- * on-disk interpreter is found — a negative off THAT is untrustworthy (#401 / PR #433).
+ * BEST-GUESS interpreter for an install, from layout. Tries the running server's
+ * argv-derived root first, then an explicit COMFYUI_PATH, then the saved default
+ * workspace (#418); a relative argv `main.py` (the ComfyUI Desktop shape) is
+ * re-anchored on those bases when a `main.py` is really there, which is what gets
+ * the probe onto the server's own `ComfyUI/.venv` instead of the bundle launcher's
+ * `standalone-env`. Portable/standalone installs keep python under python_embeded /
+ * standalone-env, so those are checked too. Falls back to a bare PATH name.
  *
- * REMOTE mode (`opts.remote`): the live interpreter is on the REMOTE host and cannot be
- * probed locally, so a locally-existing argv path is NOT treated as `live` — otherwise a
- * coincident local install would have its (version-matching) negatives mis-reported as
- * authoritative for a server running elsewhere. In remote mode we do not probe the live
- * root at all; callers degrade to honest-unknown / untrusted (#401 / PR #433 round 3).
+ * THIS IS A GUESS. It decides what to PROBE, never what to CLAIM: two cloned venvs
+ * under one root, a conda env we don't enumerate, or a server started with an
+ * interpreter from elsewhere all defeat layout reasoning, and no version or torch
+ * "fingerprint" repairs that. Authority belongs to resolveLiveInterpreter(), which
+ * observes the process. Callers must treat this result as unverified (#401).
  */
 export function resolveComfyuiPython(
   comfyuiPath: string | undefined,
@@ -725,11 +662,8 @@ export function resolveComfyuiPython(
     if (saved) bases.push(saved);
   }
 
-  // ANCHORED live root — ComfyUI Desktop reports a RELATIVE `ComfyUI\main.py` with no
-  // cwd, so argvRoot is UNRESOLVED and resolution used to fall through to the bundle
-  // root and pick the launcher's `standalone-env` python instead of the server's own
-  // `ComfyUI/.venv` (#401 recurrence). Re-anchor that relative dir on each base and
-  // accept it ONLY when a main.py is really on disk there.
+  // Re-anchor a RELATIVE argv `main.py` (ComfyUI Desktop reports `ComfyUI\main.py`
+  // with no cwd) onto each base, accepted only when a main.py is really on disk.
   let anchoredRoot: string | undefined;
   if (!argvRoot && !remote) {
     const relDir = liveRelDirFromArgv(statsArgv);
@@ -746,61 +680,29 @@ export function resolveComfyuiPython(
 
   const liveRoot = argvRoot ?? anchoredRoot;
 
-  const rootsWithFlag: Array<{ root: string; live: boolean; anchored: boolean }> = [];
-  // Only a LOCAL live root is a probeable live interpreter. Skip it entirely in remote
-  // mode so we never probe a coincident local path as if it were the remote server's.
-  if (argvRoot && !remote) rootsWithFlag.push({ root: argvRoot, live: true, anchored: false });
-  if (anchoredRoot) rootsWithFlag.push({ root: anchoredRoot, live: true, anchored: true });
+  const roots: string[] = [];
+  // Skip a live root entirely in remote mode — a coincident local path of the same
+  // name is not the remote server's install.
+  if (argvRoot && !remote) roots.push(argvRoot);
+  if (anchoredRoot) roots.push(anchoredRoot);
   for (const base of bases) {
     if (base === argvRoot || base === anchoredRoot) continue;
-    rootsWithFlag.push({ root: base, live: false, anchored: false });
+    roots.push(base);
   }
 
-  // The running server's own `embedded_python` self-report tells us whether its
-  // interpreter sits in a `python_embeded` dir — the tiebreak for a bundle that has
-  // BOTH an install `.venv` and a sibling embedded python.
+  // The server's `embedded_python` self-report still ORDERS the guess (it says
+  // whether its interpreter lives in a `python_embeded` dir), which helps us probe
+  // the more likely candidate on a portable bundle. It does not confer authority.
   const hint = opts?.embeddedPython;
-  for (const { root, live, anchored } of rootsWithFlag) {
-    const pick = pickInterpreter(root, hint);
-    if (!pick) continue;
-    // A hint that rules out every candidate means the server's interpreter is NOT one
-    // of these — we return the best guess for context, but never as the live one.
-    const onLiveRoot = live && pick.hintMatched;
-    // A candidate OUTSIDE the root (a portable bundle's `../python_embeded`) can only
-    // ground authority when the server itself reports running an embedded python —
-    // otherwise "the sibling dir happened to have one" is a layout guess, not evidence.
-    const locationEstablished =
-      pick.insideRoot || (hint === true && isEmbeddedCandidate(pick.python));
-    return {
-      python: pick.python,
-      verified: true,
-      live: onLiveRoot,
-      anchored: onLiveRoot && anchored,
-      ambiguous: pick.ambiguous,
-      proven: onLiveRoot && !anchored && !pick.ambiguous && locationEstablished,
-      locationEstablished,
-      liveRoot,
-    };
+  for (const root of roots) {
+    const existing = interpreterCandidates(root).filter(safeExists);
+    if (existing.length === 0) continue;
+    const matching =
+      hint === undefined ? existing : existing.filter((c) => isEmbeddedCandidate(c) === hint);
+    const pool = matching.length > 0 ? matching : existing;
+    return { python: pool[0], verified: true, liveRoot };
   }
-  return {
-    python: names[0],
-    verified: false,
-    live: false,
-    locationEstablished: false,
-    anchored: false,
-    ambiguous: false,
-    proven: false,
-    liveRoot,
-  };
-}
-
-/** True when two python version strings share the same major.minor (3.12.11 ~ 3.12.0). */
-function pythonVersionsAgree(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  const mm = (v: string): string | undefined => v.replace(/^Python\s+/i, "").match(/^(\d+\.\d+)/)?.[1];
-  const ma = mm(a);
-  const mb = mm(b);
-  return !!ma && ma === mb;
+  return { python: names[0], verified: false, liveRoot };
 }
 
 // ---------------------------------------------------------------------------
@@ -832,42 +734,35 @@ function liveRootForInstall(argv: string[] | undefined, cwd: string | undefined,
 }
 
 /**
- * Confirm a probed interpreter really is the RUNNING server's, using the only
- * fingerprints /system_stats exposes: the python major.minor and — when the server
- * reports one — the EXACT torch version (e.g. "2.11.0.dev20260123+cu130", distinctive
- * enough that two unrelated environments rarely share it). Returns `undefined` when the
- * fingerprints check out, else the reason they don't. `requireTorch` is set when the
- * server gave us NO install root at all: with no location evidence whatsoever, a python
- * version alone is far too weak to claim identity (#401 recurrence).
+ * Do two python version strings describe the same interpreter?
+ *
+ * We probe `sys.version` — the SAME string `/system_stats` reports — so both sides
+ * carry the full banner ("3.13.12 (main, Feb 12 2026, 00:38:53) [MSC v.1944 64 bit
+ * (AMD64)]"). When both banners have build/compiler text we compare it too: a
+ * different build of the same version is a different interpreter. Otherwise we fall
+ * back to the full dotted version, at whatever precision both sides supply (so a
+ * bare "3.13" from an old probe never fails against "3.13.12").
+ *
+ * This is a CONTRADICTION check, never an identity check — two venvs cloned from one
+ * base interpreter report byte-identical banners, so agreement proves nothing. Only
+ * an OBSERVED interpreter (live-interpreter.ts) carries authority (#401).
  */
-function fingerprintMismatch(opts: {
-  probedPython: string;
-  runningPython?: string;
-  probedTorch?: string;
-  runningTorch?: string;
-  requireTorch: boolean;
-}): string | undefined {
-  if (!pythonVersionsAgree(opts.probedPython, opts.runningPython)) {
-    return (
-      `probed python ${opts.probedPython} does not match the running ComfyUI python ` +
-      `${opts.runningPython ?? "(unreported)"}`
-    );
-  }
-  if (opts.runningTorch) {
-    if (opts.probedTorch !== opts.runningTorch) {
-      return (
-        `the probed interpreter's torch (${opts.probedTorch ?? "not installed there"}) ` +
-        `does not match the running ComfyUI torch (${opts.runningTorch}) — it is a ` +
-        `different environment`
-      );
-    }
-  } else if (opts.requireTorch) {
-    return (
-      "the running server reported neither an install root (argv) nor a torch version, " +
-      "so the probed interpreter cannot be confirmed to be its own"
-    );
-  }
-  return undefined;
+export function pythonVersionsAgree(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false;
+  const norm = (v: string): string => v.replace(/^Python\s+/i, "").replace(/\s+/g, " ").trim();
+  const na = norm(a);
+  const nb = norm(b);
+  // Both carry build/compiler detail → compare the whole banner.
+  const detailed = (v: string): boolean => /[([]/.test(v);
+  if (detailed(na) && detailed(nb)) return na === nb;
+  const parts = (v: string): string[] =>
+    (v.match(/^(\d+(?:\.\d+)*)/)?.[1] ?? "").split(".").filter(Boolean);
+  const pa = parts(na);
+  const pb = parts(nb);
+  if (pa.length === 0 || pb.length === 0) return false;
+  const depth = Math.min(pa.length, pb.length);
+  for (let i = 0; i < depth; i++) if (pa[i] !== pb[i]) return false;
+  return true;
 }
 
 /** A bundle root may contain its actual server in `ComfyUI/`; do not confuse a
@@ -1019,9 +914,12 @@ export interface EnvironmentInfo {
     python_version?: string;
     embedded_python?: boolean;
     comfyui_version?: string;
-    /** torch version the RUNNING server reports (e.g. "2.11.0.dev20260123+cu130").
-     *  Used as a fingerprint to confirm a probed interpreter is really the server's. */
+    /** torch version the RUNNING server reports (e.g. "2.11.0.dev20260123+cu130"). */
     pytorch_version?: string;
+    /** ComfyUI's own label for how it was deployed, e.g. "local-desktop2-standalone".
+     *  Reported for context and used to explain WHY an interpreter could not be
+     *  observed; it identifies the LAYOUT, never which interpreter is running. */
+    deploy_environment?: string;
     devices?: Array<{
       name: string;
       type: string;
@@ -1039,6 +937,10 @@ export interface EnvironmentInfo {
      *  disagrees with the running instance — in that case `packages` is omitted
      *  rather than reporting versions from the wrong environment (#401). */
     python_probe_trusted?: boolean;
+    /** HOW the interpreter was determined — "we know" vs "we're guessing" (#401):
+     *  `launched-by-us` / `process-table` are OBSERVATIONS and are authoritative;
+     *  `layout-guess` is inferred from directory layout and never is. */
+    python_probe_source?: "launched-by-us" | "process-table" | "layout-guess";
     /** WHY the probe is (or isn't) trusted, in one sentence — so a reader can tell
      *  "we couldn't determine it" apart from "we determined it's absent" (#401). */
     python_probe_reason?: string;
@@ -1080,6 +982,8 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     running.embedded_python = stats.system.embedded_python;
     running.comfyui_version = stats.system.comfyui_version;
     running.pytorch_version = stats.system.pytorch_version;
+    running.deploy_environment = (stats.system as { deploy_environment?: string })
+      .deploy_environment;
     statsArgv = stats.system.argv;
     // ComfyUI does not currently report cwd, but tolerate it if a future/build does.
     statsCwd = (stats.system as { cwd?: string }).cwd;
@@ -1111,12 +1015,12 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   // running server's argv root wins over an explicit COMFYUI_PATH, which wins over
   // the saved default.
   const remote = isRemoteMode();
+  // GROUND TRUTH — did we launch it, or can the OS tell us? (See live-interpreter.ts.)
+  const live = resolveLiveInterpreter({ port: config.resolvedPort, remote });
   const resolved = resolveComfyuiPython(workspacePath, statsArgv, {
     cwd: statsCwd,
     remote,
-    // The server's own `embedded_python` says whether its interpreter lives in a
-    // `python_embeded` dir — the tiebreak between a bundle's embedded python and an
-    // install `.venv` when both are on disk.
+    // Orders the GUESS only (used when there is no ground truth to show instead).
     embeddedPython: running.reachable ? running.embedded_python : undefined,
   });
 
@@ -1137,117 +1041,80 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     local.note = `Using saved default workspace "${cfg.defaultWorkspace}" (COMFYUI_PATH not set).`;
   }
 
-  const version = resolved.python ? await probe(resolved.python, ["--version"]) : undefined;
-  if (resolved.python && version) {
-    const ver = version.replace(/^Python\s+/i, "");
-    local.python = { executable: resolved.python, version: ver };
+  // GROUND TRUTH first: the interpreter we LAUNCHED ComfyUI with, or the one the OS
+  // says the process on our port is running. Only these are observations; everything
+  // below is a layout guess (#401).
+  const groundTruth = live ?? undefined;
+  const probeExe = groundTruth?.python ?? resolved.python;
 
-    // "Trusted" means the probed interpreter IS the one running ComfyUI, so its
-    // package list truly describes the live environment (#401). Tiers, most certain
-    // first — anything short of a tier reports UNKNOWN (packages omitted + a stated
-    // reason), NEVER a confident answer from the wrong environment:
-    //   - REMOTE: the running server is elsewhere; NO local interpreter is its own.
-    //   - PROVEN: the sole interpreter under the server's own absolute argv root.
-    //   - INFERRED (anchored) root: NEVER trusted for package reporting. Anchoring a
-    //     relative argv against COMFYUI_PATH gets us to the right interpreter when that
-    //     path is the running install, but a stale COMFYUI_PATH pointing at a SECOND
-    //     bundle of the same shape anchors just as cleanly, and two ordinary Desktop
-    //     installs routinely share a python AND a torch build. No fingerprint available
-    //     here can tell them apart, so this caps out at unknown.
-    //   - live and AMBIGUOUS (several envs under one absolute-argv root): the LOCATION
-    //     is certain and only the env is in doubt — an exact torch match discriminates.
-    //   - server unreachable: nothing live to contradict, but only trust a REAL
-    //     workspace venv/embedded python — NOT a bare PATH fallback.
-    //   - live root KNOWN but we're not on it: a DIFFERENT environment — untrusted.
-    //   - reachable with NO resolvable install root: no location evidence at all, which
-    //     is strictly weaker than the anchored case above — untrusted, whatever the
-    //     fingerprints say. (A matching python major.minor is what let the bundle-root
-    //     `standalone-env` python pass as the server's in the #401 recurrence.)
+  // Read `sys.version` — byte-for-byte what /system_stats reports — so the
+  // contradiction check can compare build/compiler text, not just the number.
+  // `--version` is the fallback for an interpreter that can't run -c.
+  const version = probeExe
+    ? ((await probe(probeExe, ["-c", "import sys;print(sys.version)"])) ??
+      (await probe(probeExe, ["--version"])))
+    : undefined;
+  if (probeExe && version) {
+    const ver = version.replace(/^Python\s+/i, "").replace(/\s+/g, " ").trim();
+    // Display the plain number; keep the full banner for the comparison below.
+    const shortVer = ver.match(/^(\d+(?:\.\d+)*)/)?.[1] ?? ver;
+    local.python = { executable: probeExe, version: shortVer };
+
+    // THE TERMINATING RULE (#401). An interpreter is authoritative only when we
+    // OBSERVED it, never when we inferred it from install layout:
+    //   1. we launched the process and recorded the interpreter we used;
+    //   2. the OS process table reports argv[0] of the process on our port;
+    //   3. otherwise UNKNOWN — no package list, no "not installed", no trust.
+    // Everything that used to live here (sole-candidate-under-a-believed-root,
+    // python/torch "fingerprints", ambiguity corroboration) was inference dressed up
+    // as proof, and inference is what reported the wrong venv in the first place.
     const runningPy = running.python_version;
-    const runningTorch = running.pytorch_version?.trim();
     let trusted = false;
     let reason: string;
-    let pkgs: Record<string, string> | undefined;
 
     if (remote) {
       reason =
-        "the running ComfyUI is REMOTE — a locally-probed interpreter is not the remote server's environment";
-    } else if (resolved.live && (resolved.anchored || !resolved.locationEstablished)) {
-      // The interpreter's LOCATION is a guess, so no fingerprint can rescue it —
-      // matching python/torch would only show the guess is PLAUSIBLE, not that it is
-      // the running server's. Selecting it is still right (it is what makes a POSITIVE
-      // capability finding possible), but it can never back a report about the server.
-      reason = resolved.anchored
-        ? `the server root "${resolved.liveRoot}" was INFERRED by anchoring the running ` +
-          `server's relative argv main.py onto the configured path; a different install ` +
-          `of the same shape would anchor identically, so its contents cannot be ` +
-          `attributed to the running ComfyUI`
-        : `the only interpreter found sits OUTSIDE the running server's install root ` +
-          `"${resolved.liveRoot}" (a sibling bundle python), and the server did not ` +
-          `report running an embedded python, so it cannot be attributed to it`;
-    } else if (resolved.live) {
-      // The LOCATION is established (the server's own absolute argv root). Still
-      // cross-check the live fingerprint before reporting from it: `proven` says we
-      // know WHERE the interpreter is, not that it agrees with the running server —
-      // a 3.11 venv under a root whose server reports 3.13 must not be trusted.
-      const how = resolved.proven
-        ? `probed the sole interpreter under the running server's own install root "${resolved.liveRoot}"`
-        : `several interpreters live under the running server's install root "${resolved.liveRoot}"`;
-      pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
-      const mismatch = fingerprintMismatch({
-        probedPython: ver,
-        runningPython: runningPy,
-        probedTorch: pkgs.torch?.trim(),
-        runningTorch,
-        // Location alone settles a single-interpreter root; with several candidates
-        // sharing a python version, only an exact torch match can tell them apart.
-        requireTorch: !resolved.proven,
-      });
-      if (!mismatch) {
-        trusted = true;
-        reason = `${how}, and it matches the running instance's python/torch`;
-      } else {
-        pkgs = undefined;
-        reason = `${how}, but it is not the running ComfyUI's: ${mismatch}`;
-      }
-    } else if (!running.reachable) {
-      trusted = resolved.verified;
-      reason = trusted
-        ? "the server is unreachable, but the probed interpreter is the configured workspace's own venv/embedded python"
-        : "the server is unreachable and no workspace venv/embedded python was found (a bare PATH python is not authoritative)";
-    } else if (resolved.liveRoot) {
+        "the running ComfyUI is REMOTE — no local interpreter is the remote server's, " +
+        "and ComfyUI does not report its own sys.executable over HTTP";
+    } else if (!groundTruth) {
+      const deployed = running.deploy_environment
+        ? ` (ComfyUI reports deploy_environment "${running.deploy_environment}")`
+        : "";
       reason =
-        `the probe interpreter is a different workspace than the running ComfyUI ` +
-        `(the running install root is "${resolved.liveRoot}", and the probe does not ` +
-        `match the running ComfyUI python ${runningPy})`;
-    } else if (!resolved.verified) {
+        `the interpreter shown is a BEST GUESS from install layout, not an observation: ` +
+        `we did not launch this ComfyUI and could not read the interpreter of the ` +
+        `process serving port ${config.resolvedPort} from the OS${deployed}. Package ` +
+        `versions are omitted rather than attributed to the wrong environment`;
+    } else if (!pythonVersionsAgree(ver, runningPy)) {
+      // We DID observe the interpreter, yet it disagrees with the running server.
+      // Something is off (a stale PID, a wrapper); report unknown, not a wrong list.
       reason =
-        "a bare PATH python is not provably the running ComfyUI's interpreter, and the " +
-        "running server reported no install root (argv) to check it against";
+        `the observed interpreter (${groundTruth.source}) reports python ${shortVer}, which ` +
+        `does not match the running ComfyUI python ${runningPy ?? "(unreported)"} — ` +
+        `refusing to attribute its packages to the server`;
     } else {
-      // A real workspace venv, but the server reported NO install root at all — this
-      // has even less location evidence than the anchored case rejected above, and the
-      // same collision applies: a stale COMFYUI_PATH aimed at a sibling install of the
-      // same python and torch build looks identical. Fingerprints alone never establish
-      // identity, so this reports nothing rather than a confident guess.
+      trusted = true;
       reason =
-        `the running server reported no install root (argv), so the configured ` +
-        `workspace interpreter cannot be shown to be the one it is running — matching ` +
-        `python/torch would only make it plausible, not correct`;
+        groundTruth.source === "launched-by-us"
+          ? `this MCP server launched ComfyUI (PID ${groundTruth.pid}) with this exact interpreter`
+          : `the OS reports PID ${groundTruth.pid} (serving port ${config.resolvedPort}) is running this interpreter`;
     }
 
     local.python_probe_trusted = trusted;
+    local.python_probe_source = groundTruth?.source ?? "layout-guess";
     local.python_probe_reason = reason;
 
-    if (trusted) {
-      pkgs ??= await probePipPackages(resolved.python, KEY_PACKAGES);
+    let pkgs: Record<string, string> | undefined;
+
+    if (trusted && probeExe) {
+      pkgs = await probePipPackages(probeExe, KEY_PACKAGES);
       if (Object.keys(pkgs).length > 0) local.packages = pkgs;
     } else {
       local.note = [
         local.note,
         `Package versions omitted: ${reason}, so reporting them would be a false ` +
-          `capability report (#401). Point COMFYUI_PATH at the install actually ` +
-          `running ComfyUI for an accurate report.`,
+          `capability report (#401). Start ComfyUI through start_comfyui, or run it ` +
+          `locally where this process can read its command line, for an accurate report.`,
       ]
         .filter(Boolean)
         .join(" ");

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -709,7 +709,7 @@ export function resolveComfyuiPython(
 // Install interpreter resolution (#651)
 // ---------------------------------------------------------------------------
 
-export type InstallInterpreterSource = "override" | "launched" | "undetermined";
+export type InstallInterpreterSource = "override" | "launched" | "observed" | "undetermined";
 
 export interface InstallInterpreterResolution {
   python?: string;
@@ -778,11 +778,13 @@ function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefine
  * Resolve a package-install interpreter without claiming that a path-shaped guess is
  * the process that is currently serving ComfyUI.  A server that this MCP launched is
  * authoritative because we recorded its executable; an explicit COMFYUI_PYTHON is the
- * operator's own claim.  In every other case the live interpreter is UNOBSERVABLE —
- * /system_stats has no sys.executable, so even a single discovered `.venv` may be
- * unrelated (for example, the server can be using system Python).  FAIL CLOSED:
- * refuse rather than report an install into a layout-guessed env as applied when the
- * running server may not be able to import from it (#651).
+ * operator's own claim; and the OS process table is ground truth when the port owner's
+ * command line corroborates the server's own argv (#401).  In every other case the
+ * live interpreter is UNOBSERVABLE — /system_stats has no sys.executable, so even a
+ * single discovered `.venv` may be unrelated (for example, the server can be using
+ * system Python).  FAIL CLOSED: refuse rather than report an install into a
+ * layout-guessed env as applied when the running server may not be able to import
+ * from it (#651).
  */
 export async function resolveInstallInterpreter(
   root: string | undefined,
@@ -832,6 +834,34 @@ export async function resolveInstallInterpreter(
       `The running ComfyUI is a different install ("${serverRoot}") than the requested path; ` +
         "installing into the requested layout would not affect the live server.",
     );
+  }
+  // OBSERVED ground truth (#401): /system_stats cannot name the interpreter, but the
+  // OS can — the process holding our port, its command line correlated against the
+  // server's OWN argv so a proxy or forwarder can never pass its env off as
+  // ComfyUI's. This strictly ADDS a success source: every refusal above still
+  // stands, and when nothing observes the interpreter the install still refuses
+  // (#651 fail-closed).
+  let statsHost: string | undefined;
+  try {
+    statsHost = new URL(getComfyUIBaseUrl()).hostname;
+  } catch {
+    /* unparseable target → no host filter */
+  }
+  const live = resolveLiveInterpreter({
+    port: config.resolvedPort,
+    host: statsHost,
+    remote: false,
+    serverArgv: system?.argv,
+  });
+  if (live) {
+    return {
+      python: live.python,
+      source: live.source === "launched-by-us" ? "launched" : "observed",
+      reason:
+        live.source === "launched-by-us"
+          ? `Using "${live.python}", the interpreter this MCP server launched the running ComfyUI with (identity-confirmed for PID ${live.pid}).`
+          : `Using "${live.python}", the interpreter the OS reports for the running ComfyUI process (PID ${live.pid}), corroborated against the server's own argv.`,
+    };
   }
   return refuse(
     `Cannot determine which interpreter the running ComfyUI at "${serverRoot}" uses: ` +

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
-import { dirname, isAbsolute, join, resolve as pathResolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve as pathResolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
@@ -495,6 +495,25 @@ export function liveScriptFromArgv(
 }
 
 /**
+ * The RELATIVE directory of the running server's `main.py` (e.g. `"ComfyUI"` for
+ * `ComfyUI\main.py`, `"."` for a bare `main.py`). ComfyUI **Desktop** reports exactly
+ * this — a relative argv[0] with no `cwd` — so `liveRootFromArgv` cannot resolve a
+ * live root and interpreter resolution used to fall back to `COMFYUI_PATH` (the
+ * bundle root), picking the launcher's `standalone-env` python instead of the
+ * server's own `ComfyUI/.venv` (#401 recurrence). Callers anchor this against a
+ * configured base and confirm a `main.py` is really there. Shares the positional-only
+ * script extraction of `scriptTokenFromArgv` (#648 review). Returns `undefined` when
+ * argv has no main.py, or when its dir is already absolute (use `liveRootFromArgv`).
+ */
+export function liveRelDirFromArgv(argv: string[] | undefined): string | undefined {
+  const a = scriptTokenFromArgv(argv);
+  if (a === undefined) return undefined;
+  const dir = dirname(a);
+  if (isAbsolute(dir)) return undefined;
+  return dir === "" ? "." : dir;
+}
+
+/**
  * Resolve the Python interpreter that ACTUALLY belongs to a ComfyUI install
  * `root`, honoring EVERY layout ComfyUI ships with — portable Windows builds keep
  * python under `standalone-env` / `python_embeded` (NOT just `.venv`/`venv`). Used
@@ -507,32 +526,88 @@ export function liveScriptFromArgv(
 export function resolveRootInterpreter(root: string | undefined): string {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
   if (root) {
-    for (const c of interpreterCandidates(root)) {
-      if (/^\\\\/.test(c)) continue; // skip UNC (existsSync can block on dead shares)
-      try {
-        if (existsSync(c)) return c;
-      } catch {
-        // ignore and continue
-      }
+    // Candidates directly under `root` ONLY — see interpreterCandidates: this is a
+    // mutating path (pip installs) with no live server to verify a nested guess.
+    for (const c of candidatesIn(root)) {
+      if (safeExists(c)) return c;
     }
   }
   return names[0];
 }
 
-/** Platform interpreter candidates under a ComfyUI install root, most-preferred first. */
-function interpreterCandidates(root: string): string[] {
+/** existsSync that never throws and never touches UNC paths (a dead network share
+ *  can block existsSync for seconds). */
+function safeExists(p: string): boolean {
+  if (/^\\\\/.test(p)) return false;
+  try {
+    return existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+/** Does this directory hold a ComfyUI entrypoint (`main.py`/`main.pyw`)? */
+function hasMainPy(dir: string): boolean {
+  return safeExists(join(dir, "main.py")) || safeExists(join(dir, "main.pyw"));
+}
+
+/**
+ * The server roots to search under a configured/derived base, MOST SPECIFIC first.
+ *
+ * ComfyUI Desktop (and the classic Windows portable bundle) nest the actual server
+ * one level down: `<base>/ComfyUI/main.py` with its own `<base>/ComfyUI/.venv`,
+ * while `<base>` itself holds the launcher's `standalone-env` python — a DIFFERENT
+ * interpreter whose site-packages the running server never imports. Picking `<base>`
+ * is what made `get_environment` report `standalone-env/python.exe` and made pip
+ * installs land where custom nodes couldn't see them (#401 recurrence). So when the
+ * nested dir actually contains a `main.py`, it IS the server root and wins.
+ */
+function serverRootsUnder(base: string): string[] {
+  // The base IS a server root already (its own main.py) — never let a nested checkout
+  // outrank it. Otherwise an exact argv-derived root with a stray `ComfyUI/` inside it
+  // would silently lose to that nested tree's interpreter.
+  if (hasMainPy(base)) return [base];
+  const nested = join(base, "ComfyUI");
+  return hasMainPy(nested) ? [nested, base] : [base];
+}
+
+/** Platform interpreter candidates sitting DIRECTLY under one root, most-preferred
+ *  first. This order is deliberately untouched by #401: it also decides which
+ *  interpreter `resolveRootInterpreter` hands to pip installs, and reshuffling it
+ *  would silently move installs between environments. Within a root the order is only
+ *  a preference, never authority — resolveComfyuiPython marks a root holding several
+ *  environments `ambiguous` and refuses to speak for it. */
+function candidatesIn(r: string): string[] {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
   const candidates: string[] = [];
   if (IS_WIN) {
-    candidates.push(join(root, "standalone-env", "python.exe"));
-    candidates.push(join(root, "python_embeded", "python.exe"));
-    candidates.push(join(root, "..", "python_embeded", "python.exe"));
+    candidates.push(join(r, "standalone-env", "python.exe"));
+    candidates.push(join(r, "python_embeded", "python.exe"));
+    candidates.push(join(r, "..", "python_embeded", "python.exe"));
   }
   const venvBins = IS_WIN
-    ? [join(root, ".venv", "Scripts"), join(root, "venv", "Scripts")]
-    : [join(root, ".venv", "bin"), join(root, "venv", "bin")];
+    ? [join(r, ".venv", "Scripts"), join(r, "venv", "Scripts")]
+    : [join(r, ".venv", "bin"), join(r, "venv", "bin")];
   for (const bin of venvBins) for (const n of names) candidates.push(join(bin, n));
   return candidates;
+}
+
+/** Candidates for a configured base, following a NESTED server root when the base is
+ *  not one itself. Used only by resolveComfyuiPython — the live-aware reporting path,
+ *  which cross-checks whatever it picks against the running server. The install-side
+ *  `resolveRootInterpreter` deliberately does NOT follow the nesting: with no live
+ *  server to check against, preferring a nested `.venv` over the base's own
+ *  interpreter would be an unverifiable guess in a MUTATING path. */
+function interpreterCandidates(root: string): string[] {
+  return serverRootsUnder(root).flatMap(candidatesIn);
+}
+
+/** Is this candidate a portable "python_embeded" interpreter? ComfyUI's own
+ *  `/system_stats.system.embedded_python` is exactly this test applied to its
+ *  `sys.executable`, which makes it a cheap, decisive disambiguator between an
+ *  install's `.venv` and a bundle's embedded python. */
+function isEmbeddedCandidate(candidate: string): boolean {
+  return basename(dirname(candidate)).toLowerCase() === "python_embeded";
 }
 
 export interface ComfyuiPythonResolution {
@@ -544,8 +619,50 @@ export interface ComfyuiPythonResolution {
    *  the interpreter running ComfyUI. Only a `live` interpreter's negatives are
    *  authoritative; anything else must be treated as unknown/untrusted (#401). */
   live: boolean;
+  /** The live root was INFERRED by anchoring a RELATIVE argv `main.py` against a
+   *  configured base and confirmed by a `main.py` on disk (ComfyUI Desktop reports
+   *  `ComfyUI\main.py` with no cwd). Strong evidence, but not proof the way an
+   *  absolute argv path is — callers must corroborate with a python-version match
+   *  before treating this interpreter's answers as authoritative (#401 recurrence). */
+  anchored: boolean;
+  /** SEVERAL plausible interpreters live under the chosen root (e.g. an in-root
+   *  `.venv` AND the bundle's `python_embeded`, or `.venv` AND `standalone-env`) and
+   *  nothing tells us which one ComfyUI runs. We still probe the best guess, but its
+   *  answers are a guess — never authoritative. */
+  ambiguous: boolean;
+  /** The interpreter is PROVABLY the one running ComfyUI: a live, non-inferred root
+   *  with exactly one interpreter under it. ONLY a `proven` probe may yield a
+   *  definitive "not installed" or an untested-trusted package list (#401). */
+  proven: boolean;
   /** The resolved absolute live root, when one could be determined from argv. */
   liveRoot?: string;
+}
+
+/** Pick the interpreter to probe under one root, and report how sure we are.
+ *  `hintMatched` is false when the server's `embedded_python` self-report rules out
+ *  EVERY candidate we can see — the server's real interpreter is then demonstrably
+ *  not among them, so the caller must not present our fallback as the live one. */
+function pickInterpreter(
+  root: string,
+  hint: boolean | undefined,
+): { python: string; ambiguous: boolean; hintMatched: boolean } | undefined {
+  const existing = interpreterCandidates(root).filter(safeExists);
+  if (existing.length === 0) return undefined;
+  const matching = hint === undefined ? existing : existing.filter((c) => isEmbeddedCandidate(c) === hint);
+  const pool = matching.length > 0 ? matching : existing;
+  // Count distinct ENVIRONMENTS, not filenames: `.venv/Scripts/python.exe` and
+  // `.venv/Scripts/python` are one env, `.venv` vs `standalone-env` are two.
+  const envs = new Set(
+    pool.map((c) => {
+      const d = pathResolve(dirname(c));
+      return IS_WIN ? d.toLowerCase() : d;
+    }),
+  );
+  return {
+    python: pool[0],
+    ambiguous: envs.size > 1,
+    hintMatched: hint === undefined || matching.length > 0,
+  };
 }
 
 /**
@@ -566,37 +683,81 @@ export interface ComfyuiPythonResolution {
 export function resolveComfyuiPython(
   comfyuiPath: string | undefined,
   statsArgv: string[] | undefined,
-  opts?: { cwd?: string; remote?: boolean },
+  opts?: { cwd?: string; remote?: boolean; embeddedPython?: boolean },
 ): ComfyuiPythonResolution {
   const names = IS_WIN ? ["python.exe", "python"] : ["python3", "python"];
   const remote = opts?.remote ?? false;
-  const liveRoot = liveRootFromArgv(statsArgv, opts?.cwd);
+  const argvRoot = liveRootFromArgv(statsArgv, opts?.cwd);
 
-  const rootsWithFlag: Array<{ root: string; live: boolean }> = [];
-  // Only a LOCAL live root is a probeable live interpreter. Skip it entirely in remote
-  // mode so we never probe a coincident local path as if it were the remote server's.
-  if (liveRoot && !remote) rootsWithFlag.push({ root: liveRoot, live: true });
-  if (comfyuiPath && comfyuiPath !== liveRoot) {
-    rootsWithFlag.push({ root: comfyuiPath, live: false });
-  }
-  // Saved default only when we have nothing more trustworthy to go on (never remote).
-  if (!liveRoot && !comfyuiPath && !remote) {
+  // The on-disk bases we may inspect, most-trusted first: an explicit COMFYUI_PATH,
+  // else the saved default workspace (#418).
+  const bases: string[] = [];
+  if (comfyuiPath) bases.push(comfyuiPath);
+  else if (!argvRoot && !remote) {
     const saved = resolveEffectiveComfyUIBase();
-    if (saved) rootsWithFlag.push({ root: saved, live: false });
+    if (saved) bases.push(saved);
   }
 
-  for (const { root, live } of rootsWithFlag) {
-    for (const c of interpreterCandidates(root)) {
-      // Skip UNC paths — existsSync on a dead network share can block for seconds.
-      if (/^\\\\/.test(c)) continue;
-      try {
-        if (existsSync(c)) return { python: c, verified: true, live, liveRoot };
-      } catch {
-        // ignore and continue
+  // ANCHORED live root — ComfyUI Desktop reports a RELATIVE `ComfyUI\main.py` with no
+  // cwd, so argvRoot is UNRESOLVED and resolution used to fall through to the bundle
+  // root and pick the launcher's `standalone-env` python instead of the server's own
+  // `ComfyUI/.venv` (#401 recurrence). Re-anchor that relative dir on each base and
+  // accept it ONLY when a main.py is really on disk there.
+  let anchoredRoot: string | undefined;
+  if (!argvRoot && !remote) {
+    const relDir = liveRelDirFromArgv(statsArgv);
+    if (relDir !== undefined) {
+      for (const base of bases) {
+        const candidate = pathResolve(base, relDir);
+        if (hasMainPy(candidate)) {
+          anchoredRoot = candidate;
+          break;
+        }
       }
     }
   }
-  return { python: names[0], verified: false, live: false, liveRoot };
+
+  const liveRoot = argvRoot ?? anchoredRoot;
+
+  const rootsWithFlag: Array<{ root: string; live: boolean; anchored: boolean }> = [];
+  // Only a LOCAL live root is a probeable live interpreter. Skip it entirely in remote
+  // mode so we never probe a coincident local path as if it were the remote server's.
+  if (argvRoot && !remote) rootsWithFlag.push({ root: argvRoot, live: true, anchored: false });
+  if (anchoredRoot) rootsWithFlag.push({ root: anchoredRoot, live: true, anchored: true });
+  for (const base of bases) {
+    if (base === argvRoot || base === anchoredRoot) continue;
+    rootsWithFlag.push({ root: base, live: false, anchored: false });
+  }
+
+  // The running server's own `embedded_python` self-report tells us whether its
+  // interpreter sits in a `python_embeded` dir — the tiebreak for a bundle that has
+  // BOTH an install `.venv` and a sibling embedded python.
+  const hint = opts?.embeddedPython;
+  for (const { root, live, anchored } of rootsWithFlag) {
+    const pick = pickInterpreter(root, hint);
+    if (!pick) continue;
+    // A hint that rules out every candidate means the server's interpreter is NOT one
+    // of these — we return the best guess for context, but never as the live one.
+    const onLiveRoot = live && pick.hintMatched;
+    return {
+      python: pick.python,
+      verified: true,
+      live: onLiveRoot,
+      anchored: onLiveRoot && anchored,
+      ambiguous: pick.ambiguous,
+      proven: onLiveRoot && !anchored && !pick.ambiguous,
+      liveRoot,
+    };
+  }
+  return {
+    python: names[0],
+    verified: false,
+    live: false,
+    anchored: false,
+    ambiguous: false,
+    proven: false,
+    liveRoot,
+  };
 }
 
 /** True when two python version strings share the same major.minor (3.12.11 ~ 3.12.0). */
@@ -621,31 +782,56 @@ export interface InstallInterpreterResolution {
   reason: string;
 }
 
-function pathExists(path: string): boolean {
-  if (/^\\\\/.test(path)) return false;
-  try {
-    return existsSync(path);
-  } catch {
-    return false;
-  }
-}
-
-function hasMainPy(root: string): boolean {
-  return pathExists(join(root, "main.py")) || pathExists(join(root, "main.pyw"));
-}
-
 /** Desktop commonly reports `ComfyUI/main.py` without a cwd.  Anchor that only
- * against the install being modified, and only after confirming main.py exists. */
+ * against the install being modified, and only after confirming main.py exists.
+ * Shares the positional-only script extraction of `scriptTokenFromArgv` via
+ * `liveRelDirFromArgv` — a main.py-shaped flag VALUE is never the script (#648). */
 function liveRootForInstall(argv: string[] | undefined, cwd: string | undefined, root: string | undefined): string | undefined {
   const absolute = liveRootFromArgv(argv, cwd);
   if (absolute) return absolute;
-  if (!root || !Array.isArray(argv)) return undefined;
-  for (const raw of argv) {
-    if (typeof raw !== "string") continue;
-    const script = raw.trim().replace(/^["']+/, "").replace(/["']+$/, "");
-    if (!/(^|[\\/])main\.pyw?$/i.test(script) || isAbsolute(script)) continue;
-    const candidate = pathResolve(root, dirname(script));
-    if (hasMainPy(candidate)) return candidate;
+  if (!root) return undefined;
+  const relDir = liveRelDirFromArgv(argv);
+  if (relDir === undefined) return undefined;
+  const candidate = pathResolve(root, relDir);
+  if (hasMainPy(candidate)) return candidate;
+  return undefined;
+}
+
+/**
+ * Confirm a probed interpreter really is the RUNNING server's, using the only
+ * fingerprints /system_stats exposes: the python major.minor and — when the server
+ * reports one — the EXACT torch version (e.g. "2.11.0.dev20260123+cu130", distinctive
+ * enough that two unrelated environments rarely share it). Returns `undefined` when the
+ * fingerprints check out, else the reason they don't. `requireTorch` is set when the
+ * server gave us NO install root at all: with no location evidence whatsoever, a python
+ * version alone is far too weak to claim identity (#401 recurrence).
+ */
+function fingerprintMismatch(opts: {
+  probedPython: string;
+  runningPython?: string;
+  probedTorch?: string;
+  runningTorch?: string;
+  requireTorch: boolean;
+}): string | undefined {
+  if (!pythonVersionsAgree(opts.probedPython, opts.runningPython)) {
+    return (
+      `probed python ${opts.probedPython} does not match the running ComfyUI python ` +
+      `${opts.runningPython ?? "(unreported)"}`
+    );
+  }
+  if (opts.runningTorch) {
+    if (opts.probedTorch !== opts.runningTorch) {
+      return (
+        `the probed interpreter's torch (${opts.probedTorch ?? "not installed there"}) ` +
+        `does not match the running ComfyUI torch (${opts.runningTorch}) — it is a ` +
+        `different environment`
+      );
+    }
+  } else if (opts.requireTorch) {
+    return (
+      "the running server reported neither an install root (argv) nor a torch version, " +
+      "so the probed interpreter cannot be confirmed to be its own"
+    );
   }
   return undefined;
 }
@@ -799,6 +985,9 @@ export interface EnvironmentInfo {
     python_version?: string;
     embedded_python?: boolean;
     comfyui_version?: string;
+    /** torch version the RUNNING server reports (e.g. "2.11.0.dev20260123+cu130").
+     *  Used as a fingerprint to confirm a probed interpreter is really the server's. */
+    pytorch_version?: string;
     devices?: Array<{
       name: string;
       type: string;
@@ -816,6 +1005,9 @@ export interface EnvironmentInfo {
      *  disagrees with the running instance — in that case `packages` is omitted
      *  rather than reporting versions from the wrong environment (#401). */
     python_probe_trusted?: boolean;
+    /** WHY the probe is (or isn't) trusted, in one sentence — so a reader can tell
+     *  "we couldn't determine it" apart from "we determined it's absent" (#401). */
+    python_probe_reason?: string;
     git?: { rev?: string; branch?: string };
     comfyui_manager_version?: string;
     packages?: Record<string, string>;
@@ -853,6 +1045,7 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     running.python_version = stats.system.python_version;
     running.embedded_python = stats.system.embedded_python;
     running.comfyui_version = stats.system.comfyui_version;
+    running.pytorch_version = stats.system.pytorch_version;
     statsArgv = stats.system.argv;
     // ComfyUI does not currently report cwd, but tolerate it if a future/build does.
     statsCwd = (stats.system as { cwd?: string }).cwd;
@@ -884,7 +1077,14 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   // running server's argv root wins over an explicit COMFYUI_PATH, which wins over
   // the saved default.
   const remote = isRemoteMode();
-  const resolved = resolveComfyuiPython(workspacePath, statsArgv, { cwd: statsCwd, remote });
+  const resolved = resolveComfyuiPython(workspacePath, statsArgv, {
+    cwd: statsCwd,
+    remote,
+    // The server's own `embedded_python` says whether its interpreter lives in a
+    // `python_embeded` dir — the tiebreak between a bundle's embedded python and an
+    // install `.venv` when both are on disk.
+    embeddedPython: running.reachable ? running.embedded_python : undefined,
+  });
 
   // The install root we can actually inspect on disk: an explicit/saved workspace,
   // else the live server's own root (so we still report git/manager for a live
@@ -909,47 +1109,107 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     local.python = { executable: resolved.python, version: ver };
 
     // "Trusted" means the probed interpreter IS the one running ComfyUI, so its
-    // package list truly describes the live environment (#401). Order of certainty:
-    //   - REMOTE: the running server is elsewhere; NO local interpreter is its own,
-    //     so never trust a local probe (a coincident local path is not the server's).
-    //   - resolved.live: we resolved the interpreter from the live server's own
-    //     argv root — provably correct.
+    // package list truly describes the live environment (#401). Tiers, most certain
+    // first — anything short of a tier reports UNKNOWN (packages omitted + a stated
+    // reason), NEVER a confident answer from the wrong environment:
+    //   - REMOTE: the running server is elsewhere; NO local interpreter is its own.
+    //   - PROVEN: the sole interpreter under the server's own absolute argv root.
+    //   - live but INFERRED (anchored) or AMBIGUOUS (several envs under one root):
+    //     the right neighbourhood, not a certain answer — corroborate against the
+    //     running instance's python/torch fingerprints before reporting from it.
     //   - server unreachable: nothing live to contradict, but only trust a REAL
-    //     workspace venv/embedded python — NOT a bare PATH fallback (which is not
-    //     provably the configured workspace's interpreter).
-    //   - live root unknown (reachable but argv gave no resolvable root): best we
-    //     can do is a version cross-check against the running instance.
-    //   - live root KNOWN but we're not on it (a different/saved workspace): the
-    //     probe is a DIFFERENT environment — untrusted, omit packages.
+    //     workspace venv/embedded python — NOT a bare PATH fallback.
+    //   - live root KNOWN but we're not on it: a DIFFERENT environment — untrusted.
+    //   - reachable with NO resolvable install root: a matching python major.minor is
+    //     NOT proof (that is exactly how the bundle-root `standalone-env` python
+    //     passed as the server's, #401 recurrence) — require an EXACT torch match
+    //     against what the running server reports.
     const runningPy = running.python_version;
-    let trusted: boolean;
+    const runningTorch = running.pytorch_version?.trim();
+    let trusted = false;
+    let reason: string;
+    let pkgs: Record<string, string> | undefined;
+
     if (remote) {
-      trusted = false;
-    } else if (resolved.live) {
+      reason =
+        "the running ComfyUI is REMOTE — a locally-probed interpreter is not the remote server's environment";
+    } else if (resolved.proven) {
       trusted = true;
+      reason =
+        "probed the running server's own interpreter — the only one under the install " +
+        "root resolved from its /system_stats argv main.py path";
+    } else if (resolved.live) {
+      // Right neighbourhood, uncertain interpreter: either the root was INFERRED by
+      // anchoring a relative argv, or several environments sit under it. Corroborate
+      // with the running instance's fingerprints before reporting anything from it.
+      const how = resolved.ambiguous
+        ? `several interpreters live under "${resolved.liveRoot}"`
+        : `the server root "${resolved.liveRoot}" was inferred by anchoring the running server's relative argv main.py`;
+      pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
+      const mismatch = fingerprintMismatch({
+        probedPython: ver,
+        runningPython: runningPy,
+        probedTorch: pkgs.torch?.trim(),
+        runningTorch,
+        // Ambiguous siblings usually share a python version, so only an exact torch
+        // match can tell them apart.
+        requireTorch: resolved.ambiguous,
+      });
+      if (!mismatch) {
+        trusted = true;
+        reason = `${how}, and the one probed matches the running instance's python/torch`;
+      } else {
+        pkgs = undefined;
+        reason = `${how}, and the one probed is not the running ComfyUI's: ${mismatch}`;
+      }
     } else if (!running.reachable) {
       trusted = resolved.verified;
-    } else if (!resolved.liveRoot) {
-      trusted = pythonVersionsAgree(ver, runningPy);
+      reason = trusted
+        ? "the server is unreachable, but the probed interpreter is the configured workspace's own venv/embedded python"
+        : "the server is unreachable and no workspace venv/embedded python was found (a bare PATH python is not authoritative)";
+    } else if (resolved.liveRoot) {
+      reason =
+        `the probe interpreter is a different workspace than the running ComfyUI ` +
+        `(the running install root is "${resolved.liveRoot}", and the probe does not ` +
+        `match the running ComfyUI python ${runningPy})`;
+    } else if (!resolved.verified) {
+      reason =
+        "a bare PATH python is not provably the running ComfyUI's interpreter, and the " +
+        "running server reported no install root (argv) to check it against";
     } else {
-      trusted = false;
+      // A real workspace venv, but the server told us nothing about where it lives.
+      // Require the full fingerprint (python AND an exact torch match) before believing
+      // this is the same environment — a matching major.minor alone is what let a
+      // bundle-root python pass as the server's (#401 recurrence).
+      pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
+      const mismatch = fingerprintMismatch({
+        probedPython: ver,
+        runningPython: runningPy,
+        probedTorch: pkgs.torch?.trim(),
+        runningTorch,
+        requireTorch: true,
+      });
+      if (!mismatch) {
+        trusted = true;
+        reason =
+          `the running server reported no install root, but the probed workspace ` +
+          `interpreter matches it on python (${ver}) and torch (${runningTorch})`;
+      } else {
+        pkgs = undefined;
+        reason = `the running server reported no install root, and ${mismatch}`;
+      }
     }
+
     local.python_probe_trusted = trusted;
+    local.python_probe_reason = reason;
 
     if (trusted) {
-      const pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
+      pkgs ??= await probePipPackages(resolved.python, KEY_PACKAGES);
       if (Object.keys(pkgs).length > 0) local.packages = pkgs;
     } else {
-      const detail = remote
-        ? "the running ComfyUI is REMOTE — a locally-probed interpreter is not the remote server's environment"
-        : resolved.liveRoot
-          ? `the probe interpreter is a different workspace than the running ComfyUI (it does not match the running ComfyUI python ${runningPy})`
-          : !running.reachable
-            ? "the server is unreachable and no workspace venv/embedded python was found (a bare PATH python is not authoritative)"
-            : `probed python ${ver} does not match the running ComfyUI python ${runningPy}`;
       local.note = [
         local.note,
-        `Package versions omitted: ${detail}, so reporting them would be a false ` +
+        `Package versions omitted: ${reason}, so reporting them would be a false ` +
           `capability report (#401). Point COMFYUI_PATH at the install actually ` +
           `running ComfyUI for an accurate report.`,
       ]

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -630,38 +630,65 @@ export interface ComfyuiPythonResolution {
    *  nothing tells us which one ComfyUI runs. We still probe the best guess, but its
    *  answers are a guess — never authoritative. */
   ambiguous: boolean;
-  /** The interpreter is PROVABLY the one running ComfyUI: a live, non-inferred root
-   *  with exactly one interpreter under it. ONLY a `proven` probe may yield a
-   *  definitive "not installed" or an untested-trusted package list (#401). */
+  /** The interpreter's LOCATION is established, not assumed: it is the sole interpreter
+   *  found INSIDE the install root the running server named in its own absolute argv —
+   *  or, for a portable bundle's sibling `python_embeded`, the server itself told us it
+   *  runs an embedded python (`embedded_python: true`), which is what makes an
+   *  outside-the-root candidate legitimate rather than a layout guess.
+   *
+   *  `proven` is NECESSARY but NOT SUFFICIENT for any authoritative claim: it says we
+   *  know WHERE the interpreter is, not that its contents agree with the running
+   *  server. Callers must still cross-check the live /system_stats fingerprint before
+   *  reporting from it, and only a `proven` probe may ever yield a definitive
+   *  "not installed" (#401). */
   proven: boolean;
+  /** We know WHERE this interpreter is relative to the running server: it sits inside
+   *  the server's own install root, or it is the bundle's sibling `python_embeded` and
+   *  the server reported `embedded_python: true`. False means the location is a layout
+   *  guess (an unhinted `../python_embeded`), which may be probed but may never back a
+   *  report about the running server. */
+  locationEstablished: boolean;
   /** The resolved absolute live root, when one could be determined from argv. */
   liveRoot?: string;
+}
+
+/** Normalize a path for comparison (resolve `..`, case-fold on Windows). */
+function normalizePath(p: string): string {
+  const r = pathResolve(p);
+  return IS_WIN ? r.toLowerCase() : r;
+}
+
+/** Is `child` inside `parent`? Used to reject PARENT-RELATIVE candidates (a portable
+ *  bundle's `../python_embeded`) from conferring authority: a `..` sibling is by
+ *  construction NOT under the install root the server named, so finding one there
+ *  proves nothing about which interpreter that server runs. */
+function isUnder(parent: string, child: string): boolean {
+  const p = normalizePath(parent);
+  const c = normalizePath(child);
+  return c === p || c.startsWith(p.endsWith(sep) ? p : p + sep);
 }
 
 /** Pick the interpreter to probe under one root, and report how sure we are.
  *  `hintMatched` is false when the server's `embedded_python` self-report rules out
  *  EVERY candidate we can see — the server's real interpreter is then demonstrably
- *  not among them, so the caller must not present our fallback as the live one. */
+ *  not among them, so the caller must not present our fallback as the live one.
+ *  `insideRoot` is false for a parent-relative candidate (see isUnder). */
 function pickInterpreter(
   root: string,
   hint: boolean | undefined,
-): { python: string; ambiguous: boolean; hintMatched: boolean } | undefined {
+): { python: string; ambiguous: boolean; hintMatched: boolean; insideRoot: boolean } | undefined {
   const existing = interpreterCandidates(root).filter(safeExists);
   if (existing.length === 0) return undefined;
   const matching = hint === undefined ? existing : existing.filter((c) => isEmbeddedCandidate(c) === hint);
   const pool = matching.length > 0 ? matching : existing;
   // Count distinct ENVIRONMENTS, not filenames: `.venv/Scripts/python.exe` and
   // `.venv/Scripts/python` are one env, `.venv` vs `standalone-env` are two.
-  const envs = new Set(
-    pool.map((c) => {
-      const d = pathResolve(dirname(c));
-      return IS_WIN ? d.toLowerCase() : d;
-    }),
-  );
+  const envs = new Set(pool.map((c) => normalizePath(dirname(c))));
   return {
     python: pool[0],
     ambiguous: envs.size > 1,
     hintMatched: hint === undefined || matching.length > 0,
+    insideRoot: isUnder(root, pool[0]),
   };
 }
 
@@ -739,13 +766,19 @@ export function resolveComfyuiPython(
     // A hint that rules out every candidate means the server's interpreter is NOT one
     // of these — we return the best guess for context, but never as the live one.
     const onLiveRoot = live && pick.hintMatched;
+    // A candidate OUTSIDE the root (a portable bundle's `../python_embeded`) can only
+    // ground authority when the server itself reports running an embedded python —
+    // otherwise "the sibling dir happened to have one" is a layout guess, not evidence.
+    const locationEstablished =
+      pick.insideRoot || (hint === true && isEmbeddedCandidate(pick.python));
     return {
       python: pick.python,
       verified: true,
       live: onLiveRoot,
       anchored: onLiveRoot && anchored,
       ambiguous: pick.ambiguous,
-      proven: onLiveRoot && !anchored && !pick.ambiguous,
+      proven: onLiveRoot && !anchored && !pick.ambiguous && locationEstablished,
+      locationEstablished,
       liveRoot,
     };
   }
@@ -753,6 +786,7 @@ export function resolveComfyuiPython(
     python: names[0],
     verified: false,
     live: false,
+    locationEstablished: false,
     anchored: false,
     ambiguous: false,
     proven: false,
@@ -1114,16 +1148,21 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     // reason), NEVER a confident answer from the wrong environment:
     //   - REMOTE: the running server is elsewhere; NO local interpreter is its own.
     //   - PROVEN: the sole interpreter under the server's own absolute argv root.
-    //   - live but INFERRED (anchored) or AMBIGUOUS (several envs under one root):
-    //     the right neighbourhood, not a certain answer — corroborate against the
-    //     running instance's python/torch fingerprints before reporting from it.
+    //   - INFERRED (anchored) root: NEVER trusted for package reporting. Anchoring a
+    //     relative argv against COMFYUI_PATH gets us to the right interpreter when that
+    //     path is the running install, but a stale COMFYUI_PATH pointing at a SECOND
+    //     bundle of the same shape anchors just as cleanly, and two ordinary Desktop
+    //     installs routinely share a python AND a torch build. No fingerprint available
+    //     here can tell them apart, so this caps out at unknown.
+    //   - live and AMBIGUOUS (several envs under one absolute-argv root): the LOCATION
+    //     is certain and only the env is in doubt — an exact torch match discriminates.
     //   - server unreachable: nothing live to contradict, but only trust a REAL
     //     workspace venv/embedded python — NOT a bare PATH fallback.
     //   - live root KNOWN but we're not on it: a DIFFERENT environment — untrusted.
-    //   - reachable with NO resolvable install root: a matching python major.minor is
-    //     NOT proof (that is exactly how the bundle-root `standalone-env` python
-    //     passed as the server's, #401 recurrence) — require an EXACT torch match
-    //     against what the running server reports.
+    //   - reachable with NO resolvable install root: no location evidence at all, which
+    //     is strictly weaker than the anchored case above — untrusted, whatever the
+    //     fingerprints say. (A matching python major.minor is what let the bundle-root
+    //     `standalone-env` python pass as the server's in the #401 recurrence.)
     const runningPy = running.python_version;
     const runningTorch = running.pytorch_version?.trim();
     let trusted = false;
@@ -1133,34 +1172,43 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
     if (remote) {
       reason =
         "the running ComfyUI is REMOTE — a locally-probed interpreter is not the remote server's environment";
-    } else if (resolved.proven) {
-      trusted = true;
-      reason =
-        "probed the running server's own interpreter — the only one under the install " +
-        "root resolved from its /system_stats argv main.py path";
+    } else if (resolved.live && (resolved.anchored || !resolved.locationEstablished)) {
+      // The interpreter's LOCATION is a guess, so no fingerprint can rescue it —
+      // matching python/torch would only show the guess is PLAUSIBLE, not that it is
+      // the running server's. Selecting it is still right (it is what makes a POSITIVE
+      // capability finding possible), but it can never back a report about the server.
+      reason = resolved.anchored
+        ? `the server root "${resolved.liveRoot}" was INFERRED by anchoring the running ` +
+          `server's relative argv main.py onto the configured path; a different install ` +
+          `of the same shape would anchor identically, so its contents cannot be ` +
+          `attributed to the running ComfyUI`
+        : `the only interpreter found sits OUTSIDE the running server's install root ` +
+          `"${resolved.liveRoot}" (a sibling bundle python), and the server did not ` +
+          `report running an embedded python, so it cannot be attributed to it`;
     } else if (resolved.live) {
-      // Right neighbourhood, uncertain interpreter: either the root was INFERRED by
-      // anchoring a relative argv, or several environments sit under it. Corroborate
-      // with the running instance's fingerprints before reporting anything from it.
-      const how = resolved.ambiguous
-        ? `several interpreters live under "${resolved.liveRoot}"`
-        : `the server root "${resolved.liveRoot}" was inferred by anchoring the running server's relative argv main.py`;
+      // The LOCATION is established (the server's own absolute argv root). Still
+      // cross-check the live fingerprint before reporting from it: `proven` says we
+      // know WHERE the interpreter is, not that it agrees with the running server —
+      // a 3.11 venv under a root whose server reports 3.13 must not be trusted.
+      const how = resolved.proven
+        ? `probed the sole interpreter under the running server's own install root "${resolved.liveRoot}"`
+        : `several interpreters live under the running server's install root "${resolved.liveRoot}"`;
       pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
       const mismatch = fingerprintMismatch({
         probedPython: ver,
         runningPython: runningPy,
         probedTorch: pkgs.torch?.trim(),
         runningTorch,
-        // Ambiguous siblings usually share a python version, so only an exact torch
-        // match can tell them apart.
-        requireTorch: resolved.ambiguous,
+        // Location alone settles a single-interpreter root; with several candidates
+        // sharing a python version, only an exact torch match can tell them apart.
+        requireTorch: !resolved.proven,
       });
       if (!mismatch) {
         trusted = true;
-        reason = `${how}, and the one probed matches the running instance's python/torch`;
+        reason = `${how}, and it matches the running instance's python/torch`;
       } else {
         pkgs = undefined;
-        reason = `${how}, and the one probed is not the running ComfyUI's: ${mismatch}`;
+        reason = `${how}, but it is not the running ComfyUI's: ${mismatch}`;
       }
     } else if (!running.reachable) {
       trusted = resolved.verified;
@@ -1177,27 +1225,15 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
         "a bare PATH python is not provably the running ComfyUI's interpreter, and the " +
         "running server reported no install root (argv) to check it against";
     } else {
-      // A real workspace venv, but the server told us nothing about where it lives.
-      // Require the full fingerprint (python AND an exact torch match) before believing
-      // this is the same environment — a matching major.minor alone is what let a
-      // bundle-root python pass as the server's (#401 recurrence).
-      pkgs = await probePipPackages(resolved.python, KEY_PACKAGES);
-      const mismatch = fingerprintMismatch({
-        probedPython: ver,
-        runningPython: runningPy,
-        probedTorch: pkgs.torch?.trim(),
-        runningTorch,
-        requireTorch: true,
-      });
-      if (!mismatch) {
-        trusted = true;
-        reason =
-          `the running server reported no install root, but the probed workspace ` +
-          `interpreter matches it on python (${ver}) and torch (${runningTorch})`;
-      } else {
-        pkgs = undefined;
-        reason = `the running server reported no install root, and ${mismatch}`;
-      }
+      // A real workspace venv, but the server reported NO install root at all — this
+      // has even less location evidence than the anchored case rejected above, and the
+      // same collision applies: a stale COMFYUI_PATH aimed at a sibling install of the
+      // same python and torch build looks identical. Fingerprints alone never establish
+      // identity, so this reports nothing rather than a confident guess.
+      reason =
+        `the running server reported no install root (argv), so the configured ` +
+        `workspace interpreter cannot be shown to be the one it is running — matching ` +
+        `python/torch would only make it plausible, not correct`;
     }
 
     local.python_probe_trusted = trusted;

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -1016,7 +1016,20 @@ export async function getEnvironment(): Promise<EnvironmentInfo> {
   // the saved default.
   const remote = isRemoteMode();
   // GROUND TRUTH — did we launch it, or can the OS tell us? (See live-interpreter.ts.)
-  const live = resolveLiveInterpreter({ port: config.resolvedPort, remote });
+  // statsArgv is the server's OWN sys.argv: the process we find on the port must have
+  // a command line consistent with it, or it is not the server that answered us.
+  let statsHost: string | undefined;
+  try {
+    statsHost = new URL(apiTarget).hostname;
+  } catch {
+    /* unparseable target → no host filter */
+  }
+  const live = resolveLiveInterpreter({
+    port: config.resolvedPort,
+    host: statsHost,
+    remote,
+    serverArgv: statsArgv,
+  });
   const resolved = resolveComfyuiPython(workspacePath, statsArgv, {
     cwd: statsCwd,
     remote,

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -50,32 +50,28 @@ export function resetWorkspaceConfig(): void {
 // share) must NOT have its config vars expanded against our env — that could authorize
 // a wrong-place download destination (#633 P1b). Set ONLY on the env-inheriting python
 // spawn path, cleared on stop; module-scoped, so it resets each MCP process lifetime.
+//
+// This flag is ENV-TRUST ONLY. The interpreter we launched with is recorded in
+// live-interpreter.ts (recordLaunchedInterpreter) — the ONE launch record, trusted
+// only after PID + creation-time identity validation. A second, unvalidated record
+// here was the stale-record hazard: our child dies, another server takes the port
+// under the same install root, and pip/update work would have been directed into the
+// OLD interpreter while claiming to be exact (#401 re-gate).
 let localComfyUILaunchedByUs = false;
-// /system_stats intentionally does not expose sys.executable.  When this MCP
-// process starts ComfyUI, retain the executable we actually spawned: it is the
-// only non-inferred answer to where a package install belongs (#651).
-let localComfyUILaunchInterpreter: string | undefined;
 
 /** Record that this MCP process spawned the local ComfyUI (env inherited). */
-export function markLocalComfyUILaunched(interpreter?: string): void {
+export function markLocalComfyUILaunched(): void {
   localComfyUILaunchedByUs = true;
-  localComfyUILaunchInterpreter = interpreter?.trim() || undefined;
 }
 
 /** Clear the launched-by-us flag (on stop, and a test seam). */
 export function resetLocalComfyUILaunchState(): void {
   localComfyUILaunchedByUs = false;
-  localComfyUILaunchInterpreter = undefined;
 }
 
 /** True when this MCP process launched the connected local ComfyUI (shares our env). */
 export function didLaunchLocalComfyUI(): boolean {
   return localComfyUILaunchedByUs;
-}
-
-/** The exact interpreter this MCP process used to launch the live local server. */
-export function getLaunchedLocalInterpreter(): string | undefined {
-  return localComfyUILaunchedByUs ? localComfyUILaunchInterpreter : undefined;
 }
 
 function workspaceConfigPath(): string {
@@ -709,6 +705,11 @@ export function resolveComfyuiPython(
 // Install interpreter resolution (#651)
 // ---------------------------------------------------------------------------
 
+/** Where an install interpreter answer came from. "launched" and "observed" are both
+ *  OBSERVED ground truth from live-interpreter.ts: "launched" is the child this MCP
+ *  spawned, re-validated per call by PID + creation time (never a bare launch mark —
+ *  a stale record refuses); "observed" is the OS process table corroborated against
+ *  the server's own argv. "override" is the operator's COMFYUI_PYTHON. */
 export type InstallInterpreterSource = "override" | "launched" | "observed" | "undetermined";
 
 export interface InstallInterpreterResolution {
@@ -776,15 +777,18 @@ function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefine
 
 /**
  * Resolve a package-install interpreter without claiming that a path-shaped guess is
- * the process that is currently serving ComfyUI.  A server that this MCP launched is
- * authoritative because we recorded its executable; an explicit COMFYUI_PYTHON is the
- * operator's own claim; and the OS process table is ground truth when the port owner's
- * command line corroborates the server's own argv (#401).  In every other case the
- * live interpreter is UNOBSERVABLE — /system_stats has no sys.executable, so even a
- * single discovered `.venv` may be unrelated (for example, the server can be using
- * system Python).  FAIL CLOSED: refuse rather than report an install into a
- * layout-guessed env as applied when the running server may not be able to import
- * from it (#651).
+ * the process that is currently serving ComfyUI.  Success requires OBSERVED ground
+ * truth (#401): an explicit COMFYUI_PYTHON is the operator's own claim; a server this
+ * MCP launched is authoritative only while the process on the port is still that same
+ * child — PID *and* creation time, validated per-call by live-interpreter.ts tier 1,
+ * so a stale launch record (child dead, PID recycled, another server now on the same
+ * install root) is never trusted; and the OS process table is ground truth when the
+ * port owner's command line corroborates the server's own argv (tier 2).  In every
+ * other case the live interpreter is UNOBSERVABLE — /system_stats has no
+ * sys.executable, so even a single discovered `.venv` may be unrelated (for example,
+ * the server can be using system Python).  FAIL CLOSED: refuse rather than report an
+ * install into a layout-guessed env as applied when the running server may not be
+ * able to import from it (#651).
  */
 export async function resolveInstallInterpreter(
   root: string | undefined,
@@ -815,12 +819,29 @@ export async function resolveInstallInterpreter(
     );
   }
   const serverRoot = liveRootForInstall(system?.argv, system?.cwd, root);
-  const launched = getLaunchedLocalInterpreter();
-  if (launched && (!serverRoot || targetsLiveInstall(serverRoot, root))) {
+  // OBSERVED ground truth (#401): /system_stats cannot name the interpreter, but the
+  // OS can. resolveLiveInterpreter is the ONLY launch record this resolver trusts.
+  let statsHost: string | undefined;
+  try {
+    statsHost = new URL(getComfyUIBaseUrl()).hostname;
+  } catch {
+    /* unparseable target → no host filter */
+  }
+  const live = resolveLiveInterpreter({
+    port: config.resolvedPort,
+    host: statsHost,
+    remote: false,
+    serverArgv: system?.argv,
+  });
+  // A VALIDATED launched-by-us observation (tier 1) is authoritative whenever the
+  // live server is the requested install — or argv names no root to contradict it.
+  if (live?.source === "launched-by-us" && (!serverRoot || targetsLiveInstall(serverRoot, root))) {
     return {
-      python: launched,
+      python: live.python,
       source: "launched",
-      reason: `Using "${launched}", the exact interpreter this MCP server used to start the running ComfyUI.`,
+      reason:
+        `Using "${live.python}", the interpreter this MCP server launched the running ` +
+        `ComfyUI with (identity-confirmed for PID ${live.pid}).`,
     };
   }
   if (!serverRoot) {
@@ -835,32 +856,17 @@ export async function resolveInstallInterpreter(
         "installing into the requested layout would not affect the live server.",
     );
   }
-  // OBSERVED ground truth (#401): /system_stats cannot name the interpreter, but the
-  // OS can — the process holding our port, its command line correlated against the
-  // server's OWN argv so a proxy or forwarder can never pass its env off as
-  // ComfyUI's. This strictly ADDS a success source: every refusal above still
-  // stands, and when nothing observes the interpreter the install still refuses
-  // (#651 fail-closed).
-  let statsHost: string | undefined;
-  try {
-    statsHost = new URL(getComfyUIBaseUrl()).hostname;
-  } catch {
-    /* unparseable target → no host filter */
-  }
-  const live = resolveLiveInterpreter({
-    port: config.resolvedPort,
-    host: statsHost,
-    remote: false,
-    serverArgv: system?.argv,
-  });
+  // A process-table observation (tier 2) is ground truth too, but only once the
+  // guards above have tied the live server to the requested install. This strictly
+  // ADDS a success source: when nothing observes the interpreter the install still
+  // refuses (#651 fail-closed).
   if (live) {
     return {
       python: live.python,
-      source: live.source === "launched-by-us" ? "launched" : "observed",
+      source: "observed",
       reason:
-        live.source === "launched-by-us"
-          ? `Using "${live.python}", the interpreter this MCP server launched the running ComfyUI with (identity-confirmed for PID ${live.pid}).`
-          : `Using "${live.python}", the interpreter the OS reports for the running ComfyUI process (PID ${live.pid}), corroborated against the server's own argv.`,
+        `Using "${live.python}", the interpreter the OS reports for the running ComfyUI ` +
+        `process (PID ${live.pid}), corroborated against the server's own argv.`,
     };
   }
   return refuse(

--- a/src/tools/workspace-env.ts
+++ b/src/tools/workspace-env.ts
@@ -64,7 +64,7 @@ export function registerWorkspaceEnvTools(server: McpServer): void {
 
   server.tool(
     "get_environment",
-    "Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). Degrades gracefully: local probes are omitted when no local path is configured or tools are unavailable.",
+    "Report ComfyUI environment info (mirrors `comfy-cli env`): the running instance details from /system_stats (OS, Python, ComfyUI version, GPU/VRAM — works for remote targets) plus local probes when a workspace path is available (Python version, git revision, ComfyUI-Manager version, and key pip packages like torch/CUDA). The local python probe targets the interpreter the RUNNING server uses (its venv / embedded / standalone python, resolved from the live server), never a bare `python` on PATH. Degrades gracefully and NEVER guesses: when the correct interpreter can't be confirmed, `local.python_probe_trusted` is false, `local.packages` is omitted, and `local.python_probe_reason` says why — an absent package list means UNDETERMINED, never 'not installed'.",
     {},
     async () => {
       try {


### PR DESCRIPTION
## Why

`get_environment` reported `Triton: not installed` on a machine where Triton was installed and working; an agent trusted it and edited a 231-node workflow to disable real acceleration.

**PR #433 already fixed the original cause** (live-first interpreter resolution from the running server's argv, `verified`/`live` signals, `reconcileProbeState` degrading unverified negatives to `unknown`, `python_probe_trusted` on the JSON). That machinery is on `main` and this PR keeps it — it is additive, not a rework.

This PR fixes the **recurrence the reporter filed against 0.48.31** (latest comment on #401): on **ComfyUI Desktop**, `/system_stats` reports a *relative* `argv[0] = "ComfyUI\main.py"` with no `cwd`, so `liveRootFromArgv` returns UNRESOLVED, resolution falls back to `COMFYUI_PATH` = the bundle root, and picks the launcher's `standalone-env/python.exe` — while the server actually runs `<bundle>/ComfyUI/.venv/Scripts/python.exe`. It then reported `python_probe_trusted: true`, because the surviving rule *"reachable + no live root + matching python major.minor"* counted as proof. Installs made against the reported interpreter were invisible to the running server (`ModuleNotFoundError: omegaconf`).

## What changed

**Selecting the right interpreter**
- `serverRootsUnder()` — when a base is not itself a server root but `<base>/ComfyUI/main.py` exists on disk, that nested dir **is** the server root and is searched first (the Desktop and classic-portable shape). A base that has its own `main.py` is never outranked by a nested tree.
- `liveRelDirFromArgv()` + anchoring in `resolveComfyuiPython()` — a *relative* argv `main.py` dir is re-anchored on the configured base, accepted only when a `main.py` really exists there.
- The running server's own `embedded_python` self-report (ComfyUI computes it as `basename(dirname(sys.executable)) == "python_embeded"`) narrows candidates — the tiebreak between a bundle's embedded python and an install `.venv`. If it rules out every candidate we can see, the fallback is returned but never as `live`.

**Never fabricating a negative**
- `resolveComfyuiPython()` now reports `ambiguous` (several distinct environments under one root, e.g. `.venv` beside `standalone-env`) and `proven` (the sole interpreter under the install root the server named in its own absolute argv).
- `proven` is the **only** licence to state a negative: `reconcileProbeState` degrades every other `not-installed` to `unknown`. Positives always pass through untouched — a positive can't be the harmful direction here.
- `get_environment` drops *"matching major.minor ⇒ trusted"*. A live-but-unproven interpreter (inferred root, or ambiguous root) must match the running instance's python **and** — whenever ambiguous, or whenever the server reports one — its **exact** torch version before packages are reported. Otherwise `packages` is omitted and the new `local.python_probe_reason` states why, so "we couldn't determine it" is readable as distinct from "it's absent".

**Deliberately out of scope:** `resolveRootInterpreter` (which chooses the interpreter *pip installs* run under, via `manifest.ts` / `node-management.ts`) keeps its exact pre-#401 selection for every layout, guarded by a new test. With no live server to verify against, preferring a nested venv there would be an unverifiable guess in a mutating path. Making installs themselves live-first is a separate change.

## Tests

`src/__tests__/services/workspace-env.test.ts`, `src/__tests__/services/env-capabilities.test.ts`:
- Desktop relative-argv anchoring picks the **server** venv, not the bundle's launcher python (unit + end-to-end through `getEnvironment`).
- A workspace venv is always preferred over a bare PATH python.
- An argv root that is itself a server root is never overridden by a nested `ComfyUI/` tree.
- `embedded_python` tie-break both ways; a hint matching nothing drops the `live`/`proven` claim.
- Ambiguous roots (`.venv` + `venv`, `.venv` + `standalone-env`) are `ambiguous`, never `proven`.
- Inconclusive ⇒ `unknown`, never `not installed`; anchored/ambiguous probes can never emit a definitive negative.
- Anchored roots degrade to untrusted on a python **or** torch contradiction.
- `resolveRootInterpreter` does not follow the nesting.

`npm run build` clean; full suite green apart from one pre-existing, unrelated failure (`node-dev.test.ts` "builtin fallback" — asserts `engine: "builtin"` but ripgrep is installed on this machine; fails identically on `main`).

Self-gated with `codex exec -m gpt-5.6-terra` — five adversarial rounds, PASS on the last. It caught, and this diff resolves: `../python_embeded` outranking a root's own `.venv` while still claiming to be live; the nested-root preference overriding an exact argv root; version/torch matches being treated as proof of interpreter identity; and the candidate reorder leaking into the pip-install path.

Closes #401
