### PR TITLE
feat(skill): agent-driven panel node-pack sync on orchestrator update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Works on **macOS**, **Linux**, and **Windows**. Auto-detects your ComfyUI instal
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — help, model tips, and release announcements.
 
-**162 MCP tools** | **36 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
+**162 MCP tools** | **37 AI skills** (Flux · WAN · LTX 2.3 video · Qwen · Z-Image · Ideogram 4 · ERNIE · ANIMA · model registry · Civitai · node authoring · launch/perf flags) | **55 installer packs** | **11 slash commands** | **4 autonomous agents** | **3 hooks**
 
 The plugin ships **expert skills that grow with every release** — model-specific generation guides with curated download URLs, workflow recipes, troubleshooting, and custom-node authoring — so Claude knows the right sampler, CFG, resolution, and model files for each architecture without trial and error.
 

--- a/docs/local-vs-comfy-cloud.mdx
+++ b/docs/local-vs-comfy-cloud.mdx
@@ -44,7 +44,7 @@ ElevenLabs without owning a GPU.
 ## What this project offers
 
 `comfyui-mcp` is an MCP server plus a sidebar agent that drives **your** ComfyUI
-install — local, LAN, VPS, or RunPod. 162 MCP tools, 36 model-specific skills,
+install — local, LAN, VPS, or RunPod. 162 MCP tools, 37 model-specific skills,
 and a panel agent that edits your live graph in natural language.
 
 The structural difference is **where the reasoning comes from**. This project is

--- a/docs/plugin.mdx
+++ b/docs/plugin.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Claude Code Plugin"
-description: "comfyui-mcp is a full Claude Code plugin: 36 AI skills, 11 slash commands, 4 autonomous agents, and 3 hooks on top of the 162 MCP tools — expert ComfyUI knowledge that grows with every release."
+description: "comfyui-mcp is a full Claude Code plugin: 37 AI skills, 11 slash commands, 4 autonomous agents, and 3 hooks on top of the 162 MCP tools — expert ComfyUI knowledge that grows with every release."
 icon: "puzzle-piece"
 ---
 
@@ -15,7 +15,7 @@ without trial and error.
 /plugin install comfy
 ```
 
-## 36 AI skills — and growing
+## 37 AI skills — and growing
 
 Skills are curated knowledge documents Claude loads on demand. Each model
 family gets generation parameters, node graphs, curated model download URLs,
@@ -35,6 +35,7 @@ and failure-mode guidance:
 | `anima-lora-trainer` | Train custom anime LoRAs — kohya `sd-scripts` Gradio trainer, under 6 GB VRAM |
 | `ai-toolkit-trainer` | Train custom WAN 2.2 + Z-Image LoRAs (people / styles / motion) — ostris AI-Toolkit, local or RunPod |
 | `installer-packs` | Use, build, and derive one-command installer packs — and invite users to contribute new packs upstream |
+| `panel-node-pack-sync` | Keep the sidebar panel node-pack in step with the orchestrator after an update — version-mismatch detection, a version pin that is warned about rather than overridden, and a sync whose result is re-read from disk |
 | `model-compatibility` | Which VAE/CLIP/text-encoder pairs with which architecture — the #1 source of broken workflows |
 | `model-registry` | Curated download URLs + target dirs for every model the skills reference — grows each release |
 | `civitai` | Native Civitai discovery → local download/wire/generate loop via built-in `search_civitai_models` (no key, no extra server); the official [Civitai MCP](https://mcp.civitai.com/mcp) is an optional community-surface add-on, not bundled |

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -64,7 +64,7 @@ Get full details for one ComfyUI custom node pack from the public ComfyUI Regist
 
 ## install_custom_node
 
-Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required.
+Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards) and is REFUSED while the panel is version-pinned.
 
 ### Parameters
 
@@ -107,7 +107,7 @@ Install a ComfyUI custom node pack by registry id, git URL, or name. Local insta
 
 ## update_custom_node
 
-Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP.
+Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards). While the panel is version-pinned, BOTH a direct panel target and 'all' are REFUSED — 'all' would move the pinned panel too; clear the pin with install_panel(action='unpin') or update other packs individually.
 
 ### Parameters
 
@@ -141,7 +141,7 @@ Update an installed ComfyUI custom node pack, or pass 'all' to update every inst
 
 ## reinstall_custom_node
 
-Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required.
+Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards) and is REFUSED while the panel is version-pinned.
 
 ### Parameters
 

--- a/docs/tools/custom-nodes.mdx
+++ b/docs/tools/custom-nodes.mdx
@@ -178,7 +178,7 @@ Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli
 
 ## fix_custom_node
 
-Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP.
+Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP. REFUSES the comfyui-mcp sidebar panel pack — 'fix' has no verified on-disk check, so use install_panel for the panel — and refuses 'all' while the panel is version-pinned.
 
 ### Parameters
 

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -61,7 +61,7 @@ Update the ComfyUI core install: runs `git pull` in the configured ComfyUI direc
 
 ## update_all
 
-Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues update_all, then starts the queue worker). Mirrors `comfy-cli update all`. This does NOT update ComfyUI core — use update_comfyui for that. Works against the connected instance (local or remote); updates run asynchronously and a ComfyUI restart may be required afterward.
+Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues update_all, then starts the queue worker). Mirrors `comfy-cli update all`. This does NOT update ComfyUI core — use update_comfyui for that. Works against the connected instance (local or remote); updates run asynchronously and a ComfyUI restart may be required afterward. REFUSED while the comfyui-mcp sidebar panel is version-pinned, because 'all' would move the pinned panel too and ComfyUI-Manager cannot update everything-except-one-pack — clear the pin with install_panel(action='unpin'), or update the other packs individually by id.
 
 <Note>This tool takes no parameters.</Note>
 

--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -80,12 +80,18 @@ Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues updat
 
 ## install_panel
 
-Install, update, reinstall, or report status of the ComfyUI sidebar panel ('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as install_custom_node and always targets the 'nightly' (git-HEAD) channel. Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev install (a symlinked panel dir). After install/update/reinstall, ComfyUI must be RESTARTED to load the new/updated node — this tool does not auto-restart. The panel is also auto-installed-if-missing when the MCP server loads.
+Install, update, reinstall, sync, pin, or report status of the ComfyUI sidebar panel ('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as install_custom_node and always targets the 'nightly' (git-HEAD) channel. Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev install (a symlinked panel dir). After install/update/reinstall/sync, ComfyUI must be RESTARTED to load the new/updated node — this tool does not auto-restart. The panel is also auto-installed-if-missing when the MCP server loads. A version PIN (action='pin') holds the panel where it is: while a pin is set, install/update/reinstall/sync and the auto-install all refuse, and 'sync' only warns that a newer panel exists.
 
 ### Parameters
 
 <ParamField path="action" type="enum" default="status">
-  status: report installed/version/dev-symlink (never errors). install: add the panel (nightly). update: pull the latest nightly. reinstall: uninstall + reinstall (nightly). install/update/reinstall refuse on a dev symlink and require a local COMFYUI_PATH. Options: `status`, `install`, `update`, `reinstall`.
+  status: report installed/version/dev-symlink/pin plus a sync assessment (never errors). sync: bring the panel up to what this orchestrator needs — no-ops when already current, WARNS ONLY when pinned, and reports the version re-read from disk afterwards. install: add the panel (nightly). update: pull the latest nightly. reinstall: uninstall + reinstall (nightly). pin: hold the panel at a version (requires `version`). unpin: clear the pin so a sync can proceed. install/update/reinstall/sync refuse on a dev symlink or an active pin, and require a local COMFYUI_PATH. Options: `status`, `install`, `update`, `reinstall`, `sync`, `pin`, `unpin`.
+</ParamField>
+<ParamField path="version" type="string">
+  action='pin' only: the panel version to hold at, e.g. '0.11.20'. Use the installedVersion from action='status' to pin where you already are.
+</ParamField>
+<ParamField path="reason" type="string">
+  action='pin' only: why the user is pinning (stored with the pin).
 </ParamField>
 
 ### Example

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -142,8 +142,24 @@ install_panel(action='pin', version='<installedVersion from status>', reason='<w
 
 `version` is required — never invent one. Pass the `installedVersion` from
 Step 1 to pin them where they already are. A pin **records intent only**: it does
-not change what is installed. While it's set, `install`, `update`, `reinstall`,
-`sync`, and the on-load auto-install all refuse.
+not change what is installed.
+
+While it's set, everything that could move the panel refuses — not just
+`install_panel`. The panel is an ordinary custom node pack, so the generic node
+tools are a second door into the same operation, and they are guarded too:
+
+- `install_custom_node` / `update_custom_node` / `reinstall_custom_node` /
+  `fix_custom_node` targeting the panel by **any** spelling
+  (`comfyui-agent-panel`, `comfyui-mcp-panel`, or its git URL).
+- **`id="all"`, and `update_all`** — a bulk update moves the panel along with
+  everything else. ComfyUI-Manager can't update everything-except-one-pack, so
+  while pinned these refuse outright. If the user wants the rest updated, either
+  unpin first or update the other packs individually by id. Say that plainly
+  rather than quietly unpinning to make `all` work.
+
+Reaching the panel through those generic tools also **routes through the verified
+path** automatically, so the version they report is re-read from disk like
+`sync`'s. Prefer `install_panel` anyway — it's the one with `status` and `sync`.
 
 ## When to run this at all
 

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: panel-node-pack-sync
 description: Keep the ComfyUI sidebar panel node-pack (comfyui-agent-panel) in step with the orchestrator after comfyui-mcp updates. Use this whenever the orchestrator was just updated (self_update, npm i -g comfyui-mcp, a new version in the ENVIRONMENT line), when a panel/bridge command fails in a way that smells like version drift ("panel is too old", a graph_/ui_ command the panel doesn't implement, a feature that works in the docs but not in the sidebar), or when the user asks to update/pin/unpin the panel. It checks the installed panel version against what THIS orchestrator build needs, RESPECTS an explicit version pin (warn-only, never move a pinned user), offers a clear way to unset the pin, runs the sync through the verified install_panel path, and reports the version RE-READ from disk. Never claim a sync that did not happen.
-globs:
-  - "**/pyproject.toml"
 ---
 
 # Keep the panel node-pack in sync with the orchestrator
@@ -58,7 +56,7 @@ pin, shadow copies, dev symlinks, remote/cloud mode, and unreadable versions.
 | `sync` | Behind, not pinned, nothing ambiguous. | Step 3 — sync it. |
 | `pinned-warn` | Behind, **but pinned**. | Step 4 — warn only. **Do not sync.** |
 | `blocked` | A shadow copy, or a pin we couldn't read. | Step 5 — get it unblocked first. |
-| `unknown` | The installed version isn't comparable (`nightly`, `dev`, unreadable). | Report it, don't guess. Offer a deliberate `install_panel(action='update')` and let the user decide. |
+| `unknown` | The installed version isn't comparable (`nightly`, `dev`, unreadable) **and nothing is pinned**. | Report it, don't guess. Offer a deliberate `install_panel(action='update')` and let the user decide. (If they *were* pinned you'd have got `pinned-warn` instead, so `unknown` never means "quietly ignore a pin".) |
 | `dev-install` | Symlinked dev checkout. | Tell them to `git pull` their own checkout. Change nothing. |
 | `not-applicable` | Remote/cloud, or no local ComfyUI. | Explain the panel is managed on the ComfyUI host. |
 
@@ -75,8 +73,13 @@ re-reads the pack from disk afterwards. Read the result:
 - `synced: true` → it really moved. Report **`verifiedVersion`** — that is the
   version observed on disk after the op, not the one we asked for. Then tell the
   user **ComfyUI must be RESTARTED** to load it (`restartRequired: true`); this
-  never auto-restarts. If `stillBehind: true`, the update applied but did *not*
-  close the gap — say that too, don't round it up to "you're current now".
+  never auto-restarts. Now read `stillBehind`, which is **tri-state**:
+  - `false` → the panel provably meets what the orchestrator needs. Done.
+  - `true` → the update applied but did **not** close the gap. Say so; do not
+    round it up to "you're current now".
+  - **`undefined`** → it landed, but the resulting version (e.g. `nightly`)
+    can't be compared, so whether the mismatch is fixed is **unknown**. Say
+    exactly that. `undefined` is not `false` — never report it as "you're fine".
 - `synced: false` → nothing was changed. `decision` says why (`pinned-warn`,
   `up-to-date`, `blocked`, …). This is a normal outcome, not a failure.
 - **The tool errored** → the sync FAILED. The error text names the cause

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -148,18 +148,25 @@ While it's set, everything that could move the panel refuses — not just
 `install_panel`. The panel is an ordinary custom node pack, so the generic node
 tools are a second door into the same operation, and they are guarded too:
 
-- `install_custom_node` / `update_custom_node` / `reinstall_custom_node` /
-  `fix_custom_node` targeting the panel by **any** spelling
-  (`comfyui-agent-panel`, `comfyui-mcp-panel`, or its git URL).
+- `install_custom_node` / `update_custom_node` / `reinstall_custom_node`
+  targeting the panel by **any** spelling — the registry id, the repo name, or a
+  git URL including ref-carrying forms like `…/comfyui-mcp-panel.git@v0.11.28`
+  and `…/comfyui-mcp-panel/tree/main`. These also **route through the verified
+  path** automatically, so the version they report is re-read from disk like
+  `sync`'s.
 - **`id="all"`, and `update_all`** — a bulk update moves the panel along with
   everything else. ComfyUI-Manager can't update everything-except-one-pack, so
   while pinned these refuse outright. If the user wants the rest updated, either
   unpin first or update the other packs individually by id. Say that plainly
   rather than quietly unpinning to make `all` work.
+- `fix_custom_node`, `panel_install_node` and `panel_update_node` **refuse** a
+  panel target outright — pinned or not. They report success as soon as the
+  ComfyUI-Manager queue drains, which proves nothing, and there's no verified
+  equivalent to route them into. Use `install_panel` instead; don't work around
+  the refusal.
 
-Reaching the panel through those generic tools also **routes through the verified
-path** automatically, so the version they report is re-read from disk like
-`sync`'s. Prefer `install_panel` anyway — it's the one with `status` and `sync`.
+Prefer `install_panel` throughout — it's the one with `status`, `sync` and the
+pin.
 
 ## When to run this at all
 

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: panel-node-pack-sync
+description: Keep the ComfyUI sidebar panel node-pack (comfyui-agent-panel) in step with the orchestrator after comfyui-mcp updates. Use this whenever the orchestrator was just updated (self_update, npm i -g comfyui-mcp, a new version in the ENVIRONMENT line), when a panel/bridge command fails in a way that smells like version drift ("panel is too old", a graph_/ui_ command the panel doesn't implement, a feature that works in the docs but not in the sidebar), or when the user asks to update/pin/unpin the panel. It checks the installed panel version against what THIS orchestrator build needs, RESPECTS an explicit version pin (warn-only, never move a pinned user), offers a clear way to unset the pin, runs the sync through the verified install_panel path, and reports the version RE-READ from disk. Never claim a sync that did not happen.
+globs:
+  - "**/pyproject.toml"
+---
+
+# Keep the panel node-pack in sync with the orchestrator
+
+The orchestrator (`comfyui-mcp`, from npm) and the sidebar panel
+(`comfyui-agent-panel` on the Comfy Registry, repo `comfyui-mcp-panel`) ship
+**separately**. Updating one does not update the other. A new orchestrator
+driving an old panel fails in confusing ways — a bridge command the panel simply
+doesn't implement, a feature that exists in the docs but not in the sidebar — and
+those failures are hard for a user to diagnose. This skill closes that gap.
+
+## The two rules that outrank everything else here
+
+1. **Never report a sync that did not happen.** This whole feature sits on top of
+   the fabricate-success fixes (#639/#641): ComfyUI-Manager reports its queue
+   "drained" even when it never enqueued anything, and a `.bak`-style copy in
+   `custom_nodes` can shadow the real panel in the browser. So the only version
+   you may ever tell the user is the one **read back from disk after the fact**.
+   If the tool throws, the sync FAILED — say so plainly. Do not soften it, do not
+   retry it into a success, do not report the version you *intended* to install.
+
+2. **Never move a pinned user.** A pin is a promise. If the user pinned the
+   panel, you **warn and stop**. You do not unpin for them, you do not "just this
+   once", you do not sync anyway because the new version is obviously better.
+   Offer to clear the pin, and act only if they say yes.
+
+## Step 1 — Look before you touch anything
+
+```
+install_panel(action='status')
+```
+
+This never errors. Read these fields:
+
+| Field | Meaning |
+|---|---|
+| `installedVersion` | The panel version on disk (from its `pyproject.toml`). |
+| `sync.requiredPanelVersion` | The highest panel version **this** orchestrator build needs. |
+| `sync.decision` | What to do — the whole decision is made for you (Step 2). |
+| `sync.summary` | Plain-language explanation, safe to paraphrase to the user. |
+| `pin` | The active pin: `{ pinned, version, source: "env"\|"settings", reason }`. |
+| `shadows` | `.bak`-style copies that shadow the real panel in the browser. |
+| `isDevSymlink` | A developer's symlinked checkout — never ours to modify. |
+
+Do not compute the comparison yourself. `sync.decision` already accounts for the
+pin, shadow copies, dev symlinks, remote/cloud mode, and unreadable versions.
+
+## Step 2 — Act on `sync.decision`
+
+| `decision` | What it means | What you do |
+|---|---|---|
+| `up-to-date` | Panel already meets what the orchestrator needs. | Nothing. Say so in one line, or say nothing at all if the user didn't ask. |
+| `sync` | Behind, not pinned, nothing ambiguous. | Step 3 — sync it. |
+| `pinned-warn` | Behind, **but pinned**. | Step 4 — warn only. **Do not sync.** |
+| `blocked` | A shadow copy, or a pin we couldn't read. | Step 5 — get it unblocked first. |
+| `unknown` | The installed version isn't comparable (`nightly`, `dev`, unreadable). | Report it, don't guess. Offer a deliberate `install_panel(action='update')` and let the user decide. |
+| `dev-install` | Symlinked dev checkout. | Tell them to `git pull` their own checkout. Change nothing. |
+| `not-applicable` | Remote/cloud, or no local ComfyUI. | Explain the panel is managed on the ComfyUI host. |
+
+## Step 3 — Sync (`decision: "sync"`)
+
+```
+install_panel(action='sync')
+```
+
+That single call re-checks the decision at execution time (the pin may have been
+set a second ago), runs the update through the hardened, verified path, and
+re-reads the pack from disk afterwards. Read the result:
+
+- `synced: true` → it really moved. Report **`verifiedVersion`** — that is the
+  version observed on disk after the op, not the one we asked for. Then tell the
+  user **ComfyUI must be RESTARTED** to load it (`restartRequired: true`); this
+  never auto-restarts. If `stillBehind: true`, the update applied but did *not*
+  close the gap — say that too, don't round it up to "you're current now".
+- `synced: false` → nothing was changed. `decision` says why (`pinned-warn`,
+  `up-to-date`, `blocked`, …). This is a normal outcome, not a failure.
+- **The tool errored** → the sync FAILED. The error text names the cause
+  (ComfyUI-Manager's stale-3.x silent no-op, a shadow copy, an unverifiable
+  post-state) and the fix. Relay it. **Never** describe a failed sync as
+  "completed with warnings" or "probably fine after a restart".
+
+For a user who is on Comfy Desktop, restart via the Manager reboot endpoint
+rather than killing the process.
+
+## Step 4 — Pinned (`decision: "pinned-warn"`) — WARN, DO NOT SYNC
+
+The user deliberately held the panel where it is. Tell them three things and then
+**stop**:
+
+1. A newer panel that matches their orchestrator exists (`requiredPanelVersion`).
+2. They are pinned (say to what, and *where* the pin lives — `pin.source`).
+3. How to get off it, if they want to.
+
+> Your orchestrator (comfyui-mcp 0.48.32) expects panel 0.11.28+, and you're on
+> 0.11.3 — but you've pinned the panel to 0.11.3, so I haven't changed anything.
+> Want me to clear the pin and update? I'd unpin and then sync; ComfyUI needs a
+> restart afterwards.
+
+Only if they say yes:
+
+```
+install_panel(action='unpin')      # clears the persisted pin
+install_panel(action='sync')       # then Step 3
+```
+
+**If `pin.source` is `"env"`**, `unpin` cannot clear it — the pin comes from the
+`COMFYUI_MCP_PANEL_PIN` environment variable. Tell the user to unset it (or set
+it to `off`) in their environment or `~/.comfyui-mcp/.env` and restart the
+orchestrator. Do not edit their environment for them, and do not report them as
+unpinned — `install_panel(action='unpin')` returns the still-active pin in that
+case, and its `note` says exactly this.
+
+## Step 5 — Blocked
+
+- **Shadow copy** (`shadows` non-empty): a dir like
+  `.comfyui-agent-panel.bak-0.11.28` in `custom_nodes` is *also* served as a web
+  extension, and a dot-prefixed name wins by sort order — so the browser may be
+  loading the old panel no matter what the disk says. Nothing can be verified
+  until it's gone. Tell the user to move it **out of** `custom_nodes` (not just
+  rename it) and hard-refresh the ComfyUI tab, then re-run Step 1.
+- **Unreadable pin**: `~/.comfyui-mcp/panel-settings.json` exists but couldn't be
+  parsed, so we cannot prove the user *isn't* pinned — and we refuse to move them
+  on a guess. Ask them to fix or delete that file (or set
+  `COMFYUI_MCP_PANEL_PIN=off`), then re-run Step 1.
+
+## Pinning on request
+
+If the user wants to stay on their current panel (they're mid-project, a newer
+panel regressed something, they're testing):
+
+```
+install_panel(action='pin', version='<installedVersion from status>', reason='<why>')
+```
+
+`version` is required — never invent one. Pass the `installedVersion` from
+Step 1 to pin them where they already are. A pin **records intent only**: it does
+not change what is installed. While it's set, `install`, `update`, `reinstall`,
+`sync`, and the on-load auto-install all refuse.
+
+## When to run this at all
+
+- Right after the orchestrator updates (`self_update`, a fresh `npm i -g`, or a
+  version in the ENVIRONMENT line that's newer than last you saw).
+- When a panel/bridge command fails in a way that smells like version drift —
+  "panel is too old", a `graph_*`/`ui_*` command the panel doesn't implement, a
+  documented sidebar feature that isn't there.
+- Whenever the user asks to update, pin, or unpin the panel.
+
+Be proportionate: this is a one-line check. If `decision` is `up-to-date` and the
+user didn't ask, don't narrate it — just carry on with what they actually wanted.
+
+## Absolute rules
+
+- **A sync that didn't move bytes is a FAILURE.** Report the thrown error, never
+  a success.
+- **Report `verifiedVersion`** (re-read from disk), never the target version,
+  never `nightly`.
+- **A pin is never overridden**, not even "temporarily". Unpin requires the
+  user's explicit yes.
+- **Never touch a dev symlink** — it's someone's working repo.
+- **Always say a restart is required** after a sync lands; nothing here
+  auto-restarts ComfyUI.

--- a/plugin/skills/panel-node-pack-sync/SKILL.md
+++ b/plugin/skills/panel-node-pack-sync/SKILL.md
@@ -77,9 +77,9 @@ re-reads the pack from disk afterwards. Read the result:
   - `false` → the panel provably meets what the orchestrator needs. Done.
   - `true` → the update applied but did **not** close the gap. Say so; do not
     round it up to "you're current now".
-  - **`undefined`** → it landed, but the resulting version (e.g. `nightly`)
-    can't be compared, so whether the mismatch is fixed is **unknown**. Say
-    exactly that. `undefined` is not `false` — never report it as "you're fine".
+  - **`null`** → it landed, but the resulting version (e.g. `nightly`) can't be
+    compared, so whether the mismatch is fixed is **unknown**. Say exactly that.
+    `null` is not `false` — never report it as "you're fine".
 - `synced: false` → nothing was changed. `decision` says why (`pinned-warn`,
   `up-to-date`, `blocked`, …). This is a normal outcome, not a failure.
 - **The tool errored** → the sync FAILED. The error text names the cause

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as perfHooks from "node:perf_hooks";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // Regression for #646: detectManagerApi() cached the detected ComfyUI-Manager
 // wire dialect keyed ONLY by base URL, for the whole process lifetime. After the
@@ -53,7 +55,29 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
   spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
 }));
-vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+vi.mock("node:fs", async (importOriginal) => ({
+  // Keep the existsSync knob for resolveCmCliPath; delegate everything else to
+  // the REAL fs: panel-targeting mutations (id="all" below) now take the panel
+  // mutation lock (panel-pin-guard), which is a real file — a partial mock left
+  // the lock's mkdir/open/write undefined and every such op failed closed.
+  ...(await importOriginal<typeof import("node:fs")>()),
+  existsSync: vi.fn(() => true),
+}));
+
+// The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
+// so the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
+// their own lock instead of serializing on one shared file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-dialectcache-${process.pid}.lock`,
+);
+
+// The id="all" mutations below consult the panel version pin before any Manager
+// traffic. This suite is not about pinning, and its existsSync knob answers
+// true for everything, so the pin store would look present-but-unreadable and
+// fail closed (correct in production, a false positive here). Use the
+// documented env escape hatch to say plainly "no pin in this suite".
+process.env.COMFYUI_MCP_PANEL_PIN = "off";
 
 const {
   installCustomNode,

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -27,7 +27,6 @@ const execFileSyncMock = vi.hoisted(() => vi.fn());
 const installCustomNodeMock = vi.hoisted(() => vi.fn());
 const installModelViaManagerMock = vi.hoisted(() => vi.fn());
 const listInstalledNodesMock = vi.hoisted(() => vi.fn());
-const panelStatusAtMock = vi.hoisted(() => vi.fn());
 const downloadModelMock = vi.hoisted(() => vi.fn());
 const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
 const listLocalModelsMock = vi.hoisted(() => vi.fn());
@@ -74,10 +73,6 @@ vi.mock("../../services/node-management.js", () => ({
   installCustomNode: (...a: unknown[]) => installCustomNodeMock(...a),
   installModelViaManager: (...a: unknown[]) => installModelViaManagerMock(...a),
   listInstalledNodes: (...a: unknown[]) => listInstalledNodesMock(...a),
-}));
-
-vi.mock("../../services/panel-installer.js", () => ({
-  panelStatusAt: (...a: unknown[]) => panelStatusAtMock(...a),
 }));
 
 vi.mock("../../services/model-resolver.js", () => ({
@@ -179,16 +174,6 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue({ mechanism: "manager-http", message: "queued model" });
   listInstalledNodesMock.mockReset().mockResolvedValue([]);
-  panelStatusAtMock.mockReset().mockResolvedValue({
-    applicable: true,
-    installed: false,
-    isDevSymlink: false,
-    targetVersion: "nightly",
-    shadows: [],
-    shadowInspectFailed: false,
-    pin: { pinned: false, source: "none" },
-    note: "Not installed.",
-  });
   downloadModelMock.mockReset().mockResolvedValue("/fake/ComfyUI/models/checkpoints/m.safetensors");
   // Default: the model is found in NO root (multi-root resolver rejects, HTTP
   // listing is empty). Individual tests override to simulate an existing model.
@@ -360,57 +345,14 @@ describe("applyManifest", () => {
     });
   });
 
-  it("does not report the panel applied when its actual served install has a .bak shadow", async () => {
-    // The Manager's installed-list is not sufficient for the browser extension:
-    // a dot-prefixed backup can sort first and serve an older panel instead.
-    panelStatusAtMock
-      .mockResolvedValueOnce({
-        applicable: true,
-        installed: false,
-        isDevSymlink: false,
-        targetVersion: "nightly",
-        shadows: [],
-        shadowInspectFailed: false,
-        pin: { pinned: false, source: "none" },
-        note: "Not installed.",
-      })
-      .mockResolvedValueOnce({
-        applicable: true,
-        installed: true,
-        installedVersion: "0.11.32",
-        isDevSymlink: false,
-        targetVersion: "nightly",
-        shadows: [{ name: ".comfyui-agent-panel.bak-0.11.28", version: "0.11.28" }],
-        shadowInspectFailed: false,
-        pin: { pinned: false, source: "none" },
-        note: "shadow copy present",
-      });
-
-    const result = await applyManifest({
-      manifest: { custom_nodes: ["comfyui-agent-panel"] },
-    });
-
-    expect(installCustomNodeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "comfyui-agent-panel" }),
-    );
-    expect(result.summary).toMatchObject({ applied: 0, failed: 1 });
-    expect(result.results[0]?.message).toMatch(/served panel could not be verified.*shadow/i);
-  });
-
-  it("does not let a Manager installed-list skip an unverifiable existing panel", async () => {
+  it("refuses a panel manifest when Manager and local loopback targets can differ", async () => {
+    // config.comfyuiPath can point at local instance A while the current Manager
+    // client targets B. A pre/post panel scan of A cannot validate a mutation of
+    // B, even if Manager's installed list says the panel is present there.
+    mockConfig.comfyuiPath = "/fake/ComfyUI-A";
     listInstalledNodesMock.mockResolvedValueOnce([
       { module: "comfyui-agent-panel", cnrId: "comfyui-agent-panel", enabled: true },
     ]);
-    panelStatusAtMock.mockResolvedValueOnce({
-      applicable: true,
-      installed: true,
-      isDevSymlink: false,
-      targetVersion: "nightly",
-      shadows: [],
-      shadowInspectFailed: true,
-      pin: { pinned: false, source: "none" },
-      note: "could not enumerate custom_nodes",
-    });
 
     const result = await applyManifest({
       manifest: { custom_nodes: ["comfyui-agent-panel"] },
@@ -418,7 +360,7 @@ describe("applyManifest", () => {
 
     expect(installCustomNodeMock).not.toHaveBeenCalled();
     expect(result.summary).toMatchObject({ applied: 0, failed: 1 });
-    expect(result.results[0]?.message).toMatch(/not trusting the ComfyUI-Manager installed list/i);
+    expect(result.results[0]?.message).toMatch(/cannot prove.*same instance/i);
   });
 
   it("skips a model already present in an ALTERNATE model root (extra_model_paths)", async () => {

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -27,6 +27,7 @@ const execFileSyncMock = vi.hoisted(() => vi.fn());
 const installCustomNodeMock = vi.hoisted(() => vi.fn());
 const installModelViaManagerMock = vi.hoisted(() => vi.fn());
 const listInstalledNodesMock = vi.hoisted(() => vi.fn());
+const panelStatusAtMock = vi.hoisted(() => vi.fn());
 const downloadModelMock = vi.hoisted(() => vi.fn());
 const resolveExistingModelFileMock = vi.hoisted(() => vi.fn());
 const listLocalModelsMock = vi.hoisted(() => vi.fn());
@@ -73,6 +74,10 @@ vi.mock("../../services/node-management.js", () => ({
   installCustomNode: (...a: unknown[]) => installCustomNodeMock(...a),
   installModelViaManager: (...a: unknown[]) => installModelViaManagerMock(...a),
   listInstalledNodes: (...a: unknown[]) => listInstalledNodesMock(...a),
+}));
+
+vi.mock("../../services/panel-installer.js", () => ({
+  panelStatusAt: (...a: unknown[]) => panelStatusAtMock(...a),
 }));
 
 vi.mock("../../services/model-resolver.js", () => ({
@@ -174,6 +179,16 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue({ mechanism: "manager-http", message: "queued model" });
   listInstalledNodesMock.mockReset().mockResolvedValue([]);
+  panelStatusAtMock.mockReset().mockResolvedValue({
+    applicable: true,
+    installed: false,
+    isDevSymlink: false,
+    targetVersion: "nightly",
+    shadows: [],
+    shadowInspectFailed: false,
+    pin: { pinned: false, source: "none" },
+    note: "Not installed.",
+  });
   downloadModelMock.mockReset().mockResolvedValue("/fake/ComfyUI/models/checkpoints/m.safetensors");
   // Default: the model is found in NO root (multi-root resolver rejects, HTTP
   // listing is empty). Individual tests override to simulate an existing model.
@@ -343,6 +358,67 @@ describe("applyManifest", () => {
       action: "custom_node",
       status: "applied",
     });
+  });
+
+  it("does not report the panel applied when its actual served install has a .bak shadow", async () => {
+    // The Manager's installed-list is not sufficient for the browser extension:
+    // a dot-prefixed backup can sort first and serve an older panel instead.
+    panelStatusAtMock
+      .mockResolvedValueOnce({
+        applicable: true,
+        installed: false,
+        isDevSymlink: false,
+        targetVersion: "nightly",
+        shadows: [],
+        shadowInspectFailed: false,
+        pin: { pinned: false, source: "none" },
+        note: "Not installed.",
+      })
+      .mockResolvedValueOnce({
+        applicable: true,
+        installed: true,
+        installedVersion: "0.11.32",
+        isDevSymlink: false,
+        targetVersion: "nightly",
+        shadows: [{ name: ".comfyui-agent-panel.bak-0.11.28", version: "0.11.28" }],
+        shadowInspectFailed: false,
+        pin: { pinned: false, source: "none" },
+        note: "shadow copy present",
+      });
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: ["comfyui-agent-panel"] },
+    });
+
+    expect(installCustomNodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "comfyui-agent-panel" }),
+    );
+    expect(result.summary).toMatchObject({ applied: 0, failed: 1 });
+    expect(result.results[0]?.message).toMatch(/served panel could not be verified.*shadow/i);
+  });
+
+  it("does not let a Manager installed-list skip an unverifiable existing panel", async () => {
+    listInstalledNodesMock.mockResolvedValueOnce([
+      { module: "comfyui-agent-panel", cnrId: "comfyui-agent-panel", enabled: true },
+    ]);
+    panelStatusAtMock.mockResolvedValueOnce({
+      applicable: true,
+      installed: true,
+      isDevSymlink: false,
+      targetVersion: "nightly",
+      shadows: [],
+      shadowInspectFailed: true,
+      pin: { pinned: false, source: "none" },
+      note: "could not enumerate custom_nodes",
+    });
+
+    const result = await applyManifest({
+      manifest: { custom_nodes: ["comfyui-agent-panel"] },
+    });
+
+    expect(installCustomNodeMock).not.toHaveBeenCalled();
+    expect(result.summary).toMatchObject({ applied: 0, failed: 1 });
+    expect(result.results[0]?.message).toMatch(/not trusting the ComfyUI-Manager installed list/i);
   });
 
   it("skips a model already present in an ALTERNATE model root (extra_model_paths)", async () => {

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -78,6 +78,16 @@ vi.mock("node:fs", () => ({
   existsSync: vi.fn(() => true),
 }));
 
+// The mutation entry points now consult the panel version pin (panel-pin-guard),
+// because the panel is an ordinary node pack and `id="all"` would otherwise move
+// a pinned panel. This suite is not about pinning, and its `node:fs` mock is
+// deliberately partial — `existsSync` answers true for everything, so the pin
+// store would look present-but-unreadable and fail closed (correct in
+// production, a false positive here). Use the documented env escape hatch to say
+// plainly "no pin in this suite" rather than reshaping the fs mock, which
+// individual tests reconfigure for their own purposes.
+process.env.COMFYUI_MCP_PANEL_PIN = "off";
+
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -73,10 +73,22 @@ vi.mock("node:child_process", () => ({
   })),
 }));
 
-// Mock fs so resolveCmCliPath's existsSync check is controllable.
-vi.mock("node:fs", () => ({
+// Mock fs so resolveCmCliPath's existsSync check is controllable. Everything
+// else delegates to the REAL fs: panel-targeting mutations now take the panel
+// mutation lock (panel-pin-guard), which is a real file — a partial mock left
+// the lock's mkdir/open/write undefined and every id="all" op failed closed.
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
   existsSync: vi.fn(() => true),
 }));
+
+// The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
+// so the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
+// their own lock instead of serializing on one shared file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-nodemgmt-${process.pid}.lock`,
+);
 
 // The mutation entry points now consult the panel version pin (panel-pin-guard),
 // because the panel is an ordinary node pack and `id="all"` would otherwise move
@@ -89,6 +101,7 @@ vi.mock("node:fs", () => ({
 process.env.COMFYUI_MCP_PANEL_PIN = "off";
 
 import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { config } from "../../config.js";

--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // The product builds snapshot paths with node:path.join, so separators differ
 // per-platform. Mirror the exact construction here instead of hardcoding POSIX
@@ -31,7 +32,28 @@ const fsMocks = vi.hoisted(() => ({
   writeFileSync: vi.fn(),
 }));
 
-vi.mock("node:fs", () => fsMocks);
+// The three fsMocks stay per-test controllable; everything else delegates to
+// the REAL fs because restoreNodeSnapshot now takes the panel mutation lock
+// (panel-pin-guard), which is a real file — a partial mock left the lock's
+// open/write undefined and every restore failed closed.
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  ...fsMocks,
+}));
+
+// The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
+// so the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
+// their own lock instead of serializing on one shared file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-snapshots-${process.pid}.lock`,
+);
+
+// restoreNodeSnapshot now consults the panel version pin (a restore reverts
+// EVERY pack, panel included — same bulk door as update all). This suite is not
+// about pinning, so use the documented env escape hatch to say plainly "no pin
+// here" rather than reshaping the fs mocks the pin store reads through.
+process.env.COMFYUI_MCP_PANEL_PIN = "off";
 
 import {
   saveNodeSnapshot,

--- a/src/__tests__/services/node-snapshots.test.ts
+++ b/src/__tests__/services/node-snapshots.test.ts
@@ -36,10 +36,22 @@ const fsMocks = vi.hoisted(() => ({
 // the REAL fs because restoreNodeSnapshot now takes the panel mutation lock
 // (panel-pin-guard), which is a real file — a partial mock left the lock's
 // open/write undefined and every restore failed closed.
-vi.mock("node:fs", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("node:fs")>()),
-  ...fsMocks,
-}));
+vi.mock("node:fs", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...real,
+    ...fsMocks,
+    // Pending-operation markers are deliberately read back before a deferred
+    // restore starts. Keep snapshot file writes mocked, but make this one marker
+    // write real so its durability check exercises the production contract.
+    writeFileSync: (...args: Parameters<typeof import("node:fs")["writeFileSync"]>) => {
+      fsMocks.writeFileSync(...args);
+      if (String(args[0]) === process.env.COMFYUI_MCP_PANEL_PENDING) {
+        return real.writeFileSync(...args);
+      }
+    },
+  };
+});
 
 // The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
 // so the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
@@ -47,6 +59,10 @@ vi.mock("node:fs", async (importOriginal) => ({
 process.env.COMFYUI_MCP_PANEL_LOCK = join(
   tmpdir(),
   `cmcp-lock-snapshots-${process.pid}.lock`,
+);
+process.env.COMFYUI_MCP_PANEL_PENDING = join(
+  tmpdir(),
+  `cmcp-pending-snapshots-${process.pid}.json`,
 );
 
 // restoreNodeSnapshot now consults the panel version pin (a restore reverts
@@ -326,5 +342,21 @@ describe("restoreNodeSnapshot", () => {
     await expect(restoreNodeSnapshot("prod")).rejects.toBeInstanceOf(
       NodeSnapshotError,
     );
+  });
+
+  it("refuses before contacting Manager when the deferred-restore marker cannot persist", async () => {
+    // NUL is rejected by fs before a record can be read/written. The mutation
+    // must not run without the durable warning a later pin depends on.
+    const previous = process.env.COMFYUI_MCP_PANEL_PENDING;
+    process.env.COMFYUI_MCP_PANEL_PENDING = "\0";
+    try {
+      await expect(restoreNodeSnapshot("prod")).rejects.toThrow(
+        /Could not persist the pending snapshot-restore marker/i,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_MCP_PANEL_PENDING;
+      else process.env.COMFYUI_MCP_PANEL_PENDING = previous;
+    }
   });
 });

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1269,6 +1269,40 @@ describe("panel version pin — the mutation choke point", () => {
     expect(s.note).toMatch(/unpin/i);
   });
 
+  it("honours an explicit target version instead of substituting nightly", async () => {
+    // A generic call that asked for a specific version is redirected here to get
+    // the verified path; substituting `nightly` would do something other than
+    // what the caller asked while still reporting success.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const { deps, reinstalls } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.3") },
+      onReinstall: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.20");
+      },
+    });
+    const r = await runPanelAction("reinstall", deps, { version: "0.11.20" });
+    expect(reinstalls).toEqual([{ id: PANEL_REGISTRY_ID, version: "0.11.20" }]);
+    expect(r.installedVersion).toBe("0.11.20");
+  });
+
+  it("defaults to the nightly channel when no version is requested", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const { deps, reinstalls } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.3") },
+      onReinstall: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.31");
+      },
+    });
+    await runPanelAction("reinstall", deps);
+    expect(reinstalls).toEqual([{ id: PANEL_REGISTRY_ID, version: PANEL_VERSION }]);
+  });
+
   it("panelStatus flags a FAILED shadow scan structurally, not just in the note", async () => {
     // `shadows: []` from a scan that could not run means "we didn't find any",
     // not "there are none". A consumer branching on shadows.length would read

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -3,6 +3,14 @@ import { join } from "node:path";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 
+// Panel mutations take a FILE lock (panel-pin-guard). Point it at a temp path so
+// the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
+// their own lock instead of serializing on one shared file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-installer-${process.pid}.lock`,
+);
+
 // Mock config so importing panel-installer doesn't trigger real port detection.
 // (We drive comfyuiPath via the injected deps, not the mocked config, but the
 // import graph still pulls config in.)

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -26,6 +26,7 @@ import {
   PANEL_VERSION,
   type PanelInstallerDeps,
 } from "../../services/panel-installer.js";
+import type { PanelPinState } from "../../services/panel-settings.js";
 
 const COMFY = "/fake/comfy";
 const CUSTOM_NODES = join(COMFY, "custom_nodes");
@@ -51,6 +52,8 @@ function makeDeps(opts: {
   nonDirEntries?: string[]; // custom_nodes entries that are FILES, not dirs
   realPaths?: Record<string, string>; // path -> canonical realpath (else undefined)
   reachable?: boolean;
+  /** Active panel-version pin the deps report (defaults to unpinned). */
+  pin?: PanelPinState;
   /** Raw ComfyUI-Manager queue status the `update` mock returns as details. */
   updateDetails?: unknown;
   /** Queue status the `install`/`reinstall` mocks return as details. */
@@ -90,6 +93,10 @@ function makeDeps(opts: {
     readdir: (p) => (p === CUSTOM_NODES ? dirs : []),
     readFile: (p) => files[p] ?? "",
     gitRevision: (dir) => revs[dir],
+    // Default: NOT pinned. Pin behaviour has its own suite (panel-sync.test.ts);
+    // injecting it here keeps every existing case hermetic from the developer's
+    // real ~/.comfyui-mcp/panel-settings.json.
+    readPin: () => opts.pin ?? { pinned: false, source: "none" as const },
     isReachable: async () => opts.reachable ?? true,
     install: async (o) => {
       installs.push(o);
@@ -1163,6 +1170,95 @@ describe("looksLikePanelBackupName (#641)", () => {
     expect(looksLikePanelBackupName(".comfyui-agent-panel")).toBe(true);
     expect(looksLikePanelBackupName(".comfyui-mcp-panel")).toBe(true);
     expect(looksLikePanelBackupName("comfyui-agent-panel")).toBe(false);
+  });
+});
+
+describe("panel version pin — the mutation choke point", () => {
+  const PINNED: PanelPinState = { pinned: true, version: "0.11.3", source: "settings" };
+
+  function pinnedInstall(pin: PanelPinState = PINNED) {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    return makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.3") },
+      pin,
+    });
+  }
+
+  it.each(["install", "update", "reinstall"] as const)(
+    "%s refuses while a pin is in force, and queues NOTHING",
+    async (action) => {
+      const h = pinnedInstall();
+      await expect(runPanelAction(action, h.deps)).rejects.toThrow(PanelInstallError);
+      await expect(runPanelAction(action, h.deps)).rejects.toThrow(/pinned to 0\.11\.3/i);
+      // The guard runs BEFORE the ComfyUI-Manager call, so nothing was queued.
+      expect(h.installs).toEqual([]);
+      expect(h.updates).toEqual([]);
+      expect(h.reinstalls).toEqual([]);
+    },
+  );
+
+  it("an env pin refusal explains that unpin alone will not clear it", async () => {
+    const h = pinnedInstall({ pinned: true, version: "0.11.3", source: "env" });
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(
+      /COMFYUI_MCP_PANEL_PIN/,
+    );
+  });
+
+  it("an INDETERMINATE pin still refuses (unreadable is not unpinned)", async () => {
+    const h = pinnedInstall({ pinned: true, source: "settings", indeterminate: true });
+    await expect(runPanelAction("update", h.deps)).rejects.toThrow(PanelInstallError);
+    expect(h.updates).toEqual([]);
+  });
+
+  it("a readPin that THROWS is treated as pinned, not as unpinned", async () => {
+    const h = pinnedInstall();
+    const deps: PanelInstallerDeps = {
+      ...h.deps,
+      readPin: () => {
+        throw new Error("settings unreadable");
+      },
+    };
+    await expect(runPanelAction("update", deps)).rejects.toThrow(PanelInstallError);
+    expect(h.updates).toEqual([]);
+  });
+
+  it("the on-load auto-install SKIPS while pinned instead of installing nightly", async () => {
+    const { deps, installs } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: [],
+      pin: PINNED,
+    });
+    const r = await ensurePanelInstalled({ deps });
+    expect(r.action).toBe("skipped");
+    expect(r.reason).toMatch(/pin/i);
+    expect(installs).toEqual([]);
+  });
+
+  it("once the pin is cleared the very same update proceeds and verifies", async () => {
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const pyPath = join(dir, "pyproject.toml");
+    const { deps, updates } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [pyPath]: pyproject(PANEL_REGISTRY_ID, "0.11.3") },
+      // pin omitted → unpinned
+      onUpdate: ({ files }) => {
+        files[pyPath] = pyproject(PANEL_REGISTRY_ID, "0.11.30");
+      },
+    });
+    const r = await runPanelAction("update", deps);
+    expect(updates).toHaveLength(1);
+    expect(r.previousVersion).toBe("0.11.3");
+    expect(r.installedVersion).toBe("0.11.30");
+  });
+
+  it("panelStatus reports the pin and says how to clear it", async () => {
+    const h = pinnedInstall();
+    const s = await panelStatus(h.deps);
+    expect(s.pin).toMatchObject({ pinned: true, version: "0.11.3" });
+    expect(s.note).toMatch(/unpin/i);
   });
 });
 

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -1260,6 +1260,31 @@ describe("panel version pin — the mutation choke point", () => {
     expect(s.pin).toMatchObject({ pinned: true, version: "0.11.3" });
     expect(s.note).toMatch(/unpin/i);
   });
+
+  it("panelStatus flags a FAILED shadow scan structurally, not just in the note", async () => {
+    // `shadows: []` from a scan that could not run means "we didn't find any",
+    // not "there are none". A consumer branching on shadows.length would read
+    // the empty array as an all-clear, so the uncertainty must be a field.
+    const dir = join(CUSTOM_NODES, "comfyui-mcp-panel");
+    const { deps } = makeDeps({
+      comfyuiPath: COMFY,
+      dirs: ["comfyui-mcp-panel"],
+      files: { [join(dir, "pyproject.toml")]: pyproject(PANEL_REGISTRY_ID, "0.11.3") },
+    });
+    // Detection uses the fast path (direct pyproject read), so the panel still
+    // resolves; only the shadow enumeration fails.
+    const failing: PanelInstallerDeps = {
+      ...deps,
+      readdir: () => {
+        throw new Error("EACCES: permission denied, scandir");
+      },
+    };
+    const s = await panelStatus(failing);
+    expect(s.installed).toBe(true);
+    expect(s.shadows).toEqual([]);
+    expect(s.shadowInspectFailed).toBe(true);
+    expect(s.note).toMatch(/could not enumerate/i);
+  });
 });
 
 describe("panelStatus", () => {

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -118,6 +118,20 @@ describe("generic node mutations cannot walk past the panel pin", () => {
     await expect(promise).rejects.toThrow(PanelPinnedError);
   });
 
+  it.each([
+    "https://github.com/artokun/comfyui-mcp-panel.git@v0.11.28",
+    "https://github.com/artokun/comfyui-mcp-panel/tree/main",
+    "https://gitlab.com/artokun/comfyui-mcp-panel/-/commit/abc1234",
+    "comfyui-agent-panel@nightly",
+  ])("REFUSES the ref-carrying git form %j while pinned", async (id) => {
+    // These are forms parseGitUrl accepts, so they really do reach the pack —
+    // but the first matcher compared the raw last path segment and let them all
+    // through, moving a pinned panel.
+    setPanelVersionPin("0.11.3");
+    await expect(installCustomNode({ id })).rejects.toThrow(PanelPinnedError);
+    expect(managerCalls).toEqual([]);
+  });
+
   it("an UNRELATED pack is untouched by the pin", async () => {
     setPanelVersionPin("0.11.3");
     // Reaches the Manager path (and fails there on the stubbed response, not on

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -1,0 +1,139 @@
+// END-TO-END regression for the pin BYPASS.
+//
+// The pin was originally enforced only inside `runPanelAction`, which the PR
+// described as "the mutation choke point". It was not: the sidebar panel is an
+// ordinary custom node pack, so the GENERIC node mutations reach the very same
+// ComfyUI-Manager operation without touching install_panel at all. A pinned user
+// was one `update_custom_node(id="all")` away from being moved.
+//
+// These tests call the REAL exported service functions (no fs mocking, a real
+// temp settings file) and assert they REFUSE while a pin is in force — and,
+// critically, that they refuse BEFORE any Manager request is issued.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    isLocalMode: () => true,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    getComfyUIAuthHeaders: () => ({}),
+  };
+});
+
+// Any Manager traffic at all means the guard let the mutation through.
+const managerCalls: string[] = [];
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: vi.fn(async (path: string) => {
+    managerCalls.push(path);
+    return new Response("{}", { status: 200 });
+  }),
+}));
+
+import {
+  fixCustomNode,
+  installCustomNode,
+  reinstallCustomNode,
+  updateCustomNode,
+} from "../../services/node-management.js";
+import { updateAllCustomNodes } from "../../services/update-comfyui.js";
+import { PanelPinnedError } from "../../services/panel-pin-guard.js";
+import { PANEL_PIN_ENV_VAR, setPanelVersionPin } from "../../services/panel-settings.js";
+
+let dir: string;
+
+beforeEach(() => {
+  managerCalls.length = 0;
+  dir = mkdtempSync(join(tmpdir(), "cmcp-bypass-"));
+  process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
+  process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
+  delete process.env.COMFYUI_MCP_PANEL_LOCK;
+  delete process.env[PANEL_PIN_ENV_VAR];
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("generic node mutations cannot walk past the panel pin", () => {
+  it('update_custom_node(id="comfyui-agent-panel") REFUSES while pinned', async () => {
+    setPanelVersionPin("0.11.3");
+    await expect(updateCustomNode({ id: "comfyui-agent-panel" })).rejects.toThrow(
+      PanelPinnedError,
+    );
+    expect(managerCalls).toEqual([]); // refused before any Manager request
+  });
+
+  it('update_custom_node(id="all") REFUSES while pinned — the bulk door', async () => {
+    // Nothing about "all" names the panel, yet it moves it. This is the exact
+    // scenario that made the original guard placement wrong.
+    setPanelVersionPin("0.11.3");
+    await expect(updateCustomNode({ id: "all" })).rejects.toThrow(PanelPinnedError);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("update_all REFUSES while pinned — the third door, not a node tool at all", async () => {
+    setPanelVersionPin("0.11.3");
+    await expect(updateAllCustomNodes()).rejects.toThrow(PanelPinnedError);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("reinstall/install/fix of the panel REFUSE while pinned, by any spelling", async () => {
+    setPanelVersionPin("0.11.3");
+    await expect(reinstallCustomNode({ id: "comfyui-mcp-panel" })).rejects.toThrow(
+      PanelPinnedError,
+    );
+    await expect(
+      installCustomNode({ id: "https://github.com/artokun/comfyui-mcp-panel.git" }),
+    ).rejects.toThrow(PanelPinnedError);
+    await expect(fixCustomNode({ id: "all" })).rejects.toThrow(PanelPinnedError);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("REJECTS rather than throwing synchronously (callers use .then/.catch)", async () => {
+    // apply_manifest does `installCustomNode(...).then().catch()` and documents
+    // that it never rejects — a synchronous throw would walk straight past that
+    // .catch and escape as an unhandled exception.
+    setPanelVersionPin("0.11.3");
+    let sync: unknown;
+    let promise: Promise<unknown> | undefined;
+    try {
+      promise = updateCustomNode({ id: "all" });
+    } catch (err) {
+      sync = err;
+    }
+    expect(sync).toBeUndefined();
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toThrow(PanelPinnedError);
+  });
+
+  it("an UNRELATED pack is untouched by the pin", async () => {
+    setPanelVersionPin("0.11.3");
+    // Reaches the Manager path (and fails there on the stubbed response, not on
+    // the pin) — proving the guard is targeted, not a blanket freeze.
+    await expect(updateCustomNode({ id: "was-node-suite" })).rejects.not.toThrow(
+      PanelPinnedError,
+    );
+    expect(managerCalls.length).toBeGreaterThan(0);
+  });
+
+  it("everything proceeds again once the pin is cleared", async () => {
+    setPanelVersionPin("0.11.3");
+    await expect(updateCustomNode({ id: "all" })).rejects.toThrow(PanelPinnedError);
+    process.env[PANEL_PIN_ENV_VAR] = "off";
+    // No longer refused by the pin; it now reaches the Manager path.
+    await updateCustomNode({ id: "all" }).catch(() => undefined);
+    expect(managerCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -40,11 +40,38 @@ const managerCalls: string[] = [];
 // stub "{}" responses.
 let managerGate: Promise<void> | null = null;
 let managerFailAfterGate = false;
+// The update paths route through detectManagerApi (#656), and with the generic
+// "{}" answers detection THROWS — which is what most of these tests want (a
+// fast, definite failure right after the guard lets a call through). But the
+// update_all lock test needs the mutation to actually COMPLETE — enqueue +
+// worker start, no drain — so it opts into the stub answering the dialect
+// probes like a legacy 3.x Manager. (Never turn this on for a path that
+// DRAINS the Manager queue: the stub has no queue progression, so the drain
+// would hold the panel lock until the test times out, cascading into every
+// later lock-taking test.)
+let managerLegacyPersona = false;
 vi.mock("../../comfyui/fetch.js", () => ({
-  comfyuiFetch: vi.fn(async (path: string) => {
-    managerCalls.push(path);
+  comfyuiFetch: vi.fn(async (url: string) => {
+    managerCalls.push(url);
     if (managerGate) await managerGate;
     if (managerFailAfterGate) throw new Error("test: Manager went away");
+    if (managerLegacyPersona) {
+      const path = new URL(url, "http://stub.local").pathname;
+      if (path === "/manager/queue/status") {
+        return new Response(
+          JSON.stringify({
+            total_count: 1,
+            done_count: 1,
+            in_progress_count: 0,
+            is_processing: false,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (path === "/manager/version") {
+        return new Response("V3.41", { status: 200 });
+      }
+    }
     return new Response("{}", { status: 200 });
   }),
 }));
@@ -73,6 +100,7 @@ beforeEach(() => {
   managerCalls.length = 0;
   managerGate = null;
   managerFailAfterGate = false;
+  managerLegacyPersona = false;
   dir = mkdtempSync(join(tmpdir(), "cmcp-bypass-"));
   process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
   process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
@@ -212,6 +240,10 @@ describe("a pin written MID-mutation cannot slice through it", () => {
   });
 
   it("update_all holds the lock across queue + start, and still only reports 'queued'", async () => {
+    // update_all goes detectManagerApi → enqueueUpdateAll → queue/start with NO
+    // drain, so the stub can let it complete: answer the dialect probes like a
+    // legacy 3.x Manager (see the stub's comment).
+    managerLegacyPersona = true;
     let releaseManager!: () => void;
     managerGate = new Promise<void>((resolve) => {
       releaseManager = resolve;

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -33,9 +33,18 @@ vi.mock("../../config.js", () => {
 
 // Any Manager traffic at all means the guard let the mutation through.
 const managerCalls: string[] = [];
+// Test-controlled gates on the stubbed Manager. `managerGate` parks a call
+// mid-flight, so a mutation can be held BETWEEN its pin check and completion;
+// `managerFailAfterGate` then fails every later call fast, so the parked op
+// settles immediately instead of wandering the queue-dialect probes on the
+// stub "{}" responses.
+let managerGate: Promise<void> | null = null;
+let managerFailAfterGate = false;
 vi.mock("../../comfyui/fetch.js", () => ({
   comfyuiFetch: vi.fn(async (path: string) => {
     managerCalls.push(path);
+    if (managerGate) await managerGate;
+    if (managerFailAfterGate) throw new Error("test: Manager went away");
     return new Response("{}", { status: 200 });
   }),
 }));
@@ -47,13 +56,23 @@ import {
   updateCustomNode,
 } from "../../services/node-management.js";
 import { updateAllCustomNodes } from "../../services/update-comfyui.js";
-import { PanelPinnedError } from "../../services/panel-pin-guard.js";
-import { PANEL_PIN_ENV_VAR, setPanelVersionPin } from "../../services/panel-settings.js";
+import { restoreNodeSnapshot } from "../../services/node-snapshots.js";
+import {
+  PanelPinnedError,
+  withPanelMutationLock,
+} from "../../services/panel-pin-guard.js";
+import {
+  getPanelPinState,
+  PANEL_PIN_ENV_VAR,
+  setPanelVersionPin,
+} from "../../services/panel-settings.js";
 
 let dir: string;
 
 beforeEach(() => {
   managerCalls.length = 0;
+  managerGate = null;
+  managerFailAfterGate = false;
   dir = mkdtempSync(join(tmpdir(), "cmcp-bypass-"));
   process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
   process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
@@ -149,5 +168,83 @@ describe("generic node mutations cannot walk past the panel pin", () => {
     // No longer refused by the pin; it now reaches the Manager path.
     await updateCustomNode({ id: "all" }).catch(() => undefined);
     expect(managerCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("a pin written MID-mutation cannot slice through it", () => {
+  it("a bulk update holds the mutation lock across check + act, so the pin write waits", async () => {
+    // Park the update BETWEEN its pin check and completion: the first Manager
+    // request only fires once the check has passed, so an observed request
+    // means the update is inside the critical window the race used to exploit.
+    let releaseManager!: () => void;
+    managerGate = new Promise<void>((resolve) => {
+      releaseManager = resolve;
+    });
+
+    const update = updateCustomNode({ id: "all" });
+    await vi.waitFor(() => expect(managerCalls.length).toBeGreaterThan(0));
+
+    // Commit a pin exactly the way install_panel(action='pin') does — through
+    // the shared mutation lock.
+    let pinCommitted = false;
+    const pinWrite = withPanelMutationLock(async () => {
+      setPanelVersionPin("0.11.3");
+      pinCommitted = true;
+    });
+
+    // Give the pin write every chance to run. It must NOT land: the update
+    // holds the lock across check + act, so a pin commits before an op starts
+    // (and blocks it) or after it finishes — never in the middle. Before the
+    // fix, the pin committed right here and the in-flight update went on to
+    // move a by-then-pinned panel.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(pinCommitted).toBe(false);
+    expect(getPanelPinState().pinned).toBe(false);
+
+    // Let the update settle (the stub is not a real Manager — fail it fast so
+    // it ends immediately), then the pin commits and governs the NEXT op.
+    managerFailAfterGate = true;
+    releaseManager();
+    await update.catch(() => undefined);
+    await pinWrite;
+    expect(pinCommitted).toBe(true);
+    await expect(updateCustomNode({ id: "all" })).rejects.toThrow(PanelPinnedError);
+  });
+
+  it("update_all holds the lock across queue + start, and still only reports 'queued'", async () => {
+    let releaseManager!: () => void;
+    managerGate = new Promise<void>((resolve) => {
+      releaseManager = resolve;
+    });
+
+    const update = updateAllCustomNodes();
+    await vi.waitFor(() => expect(managerCalls.length).toBeGreaterThan(0));
+
+    let pinCommitted = false;
+    const pinWrite = withPanelMutationLock(async () => {
+      setPanelVersionPin("0.11.3");
+      pinCommitted = true;
+    });
+
+    await new Promise((r) => setTimeout(r, 250));
+    expect(pinCommitted).toBe(false);
+    expect(getPanelPinState().pinned).toBe(false);
+
+    // update_all is fire-and-forget by design: the lock covers the pin check +
+    // queue + worker start; the Manager-side drain afterwards is outside any
+    // process's control, which is exactly why the result must keep saying
+    // "queued" and never claim the updates landed.
+    releaseManager();
+    const result = await update;
+    await pinWrite;
+    expect(pinCommitted).toBe(true);
+    expect(result.message).toMatch(/[Qq]ueued/);
+    await expect(updateAllCustomNodes()).rejects.toThrow(PanelPinnedError);
+  });
+
+  it("restore_node_snapshot REFUSES while pinned — the snapshot door", async () => {
+    setPanelVersionPin("0.11.3");
+    await expect(restoreNodeSnapshot("prod")).rejects.toThrow(PanelPinnedError);
+    expect(managerCalls).toEqual([]); // refused before any Manager request
   });
 });

--- a/src/__tests__/services/panel-pin-bypass.test.ts
+++ b/src/__tests__/services/panel-pin-bypass.test.ts
@@ -274,7 +274,7 @@ describe("a pin written MID-mutation cannot slice through it", () => {
     await expect(updateAllCustomNodes()).rejects.toThrow(PanelPinnedError);
   });
 
-  it("restore_node_snapshot REFUSES while pinned — the snapshot door", async () => {
+  it('node_snapshot(action:"restore") REFUSES while pinned — the snapshot door', async () => {
     setPanelVersionPin("0.11.3");
     await expect(restoreNodeSnapshot("prod")).rejects.toThrow(PanelPinnedError);
     expect(managerCalls).toEqual([]); // refused before any Manager request

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -1,0 +1,198 @@
+// The pin guard at the point the PANEL PACK IS IDENTIFIED AS THE TARGET.
+//
+// The bug these tests exist for: the pin was originally enforced only inside
+// `runPanelAction`, which was described as "the mutation choke point". It wasn't
+// — the panel is an ordinary custom node pack, so `update_custom_node(id=...)`
+// and `id="all"` reached the SAME ComfyUI-Manager mutation without ever passing
+// the guard. A pinned user was one generic call away from being moved.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  assertPanelPinAllows,
+  PanelPinnedError,
+  panelLockPath,
+  targetsPanelPack,
+  targetsPanelPackExactly,
+  withPanelMutationLock,
+} from "../../services/panel-pin-guard.js";
+import { setPanelVersionPin, PANEL_PIN_ENV_VAR } from "../../services/panel-settings.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cmcp-pinguard-"));
+  process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
+  process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
+  delete process.env.COMFYUI_MCP_PANEL_LOCK;
+  delete process.env[PANEL_PIN_ENV_VAR];
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("targetsPanelPack — every spelling of the panel is the panel", () => {
+  it.each([
+    "comfyui-agent-panel", // registry id / pyproject name
+    "comfyui-mcp-panel", // repo + custom_nodes dir name
+    "ComfyUI-MCP-Panel", // case variant
+    "  comfyui-agent-panel  ", // padded
+    "https://github.com/artokun/comfyui-mcp-panel", // git URL
+    "https://github.com/artokun/comfyui-mcp-panel.git", // git URL with .git
+    "all", // bulk: moves the panel along with everything else
+    "ALL",
+  ])("matches %j", (id) => {
+    expect(targetsPanelPack(id)).toBe(true);
+  });
+
+  it.each(["comfyui-manager", "was-node-suite", "", "   ", "comfyui-panel-other"])(
+    "does not match unrelated id %j",
+    (id) => {
+      expect(targetsPanelPack(id)).toBe(false);
+    },
+  );
+
+  it("separates an exact panel target from a bulk one (only the former can be redirected)", () => {
+    expect(targetsPanelPackExactly("comfyui-agent-panel")).toBe(true);
+    // "all" targets the panel but cannot be routed through the panel-only path.
+    expect(targetsPanelPackExactly("all")).toBe(false);
+    expect(targetsPanelPack("all")).toBe(true);
+  });
+});
+
+describe("assertPanelPinAllows — the generic-tool door", () => {
+  it("permits everything when nothing is pinned", () => {
+    expect(() => assertPanelPinAllows("update", "comfyui-agent-panel")).not.toThrow();
+    expect(() => assertPanelPinAllows("update", "all")).not.toThrow();
+  });
+
+  it("permits an unrelated pack even while the panel is pinned", () => {
+    setPanelVersionPin("0.11.3");
+    expect(() => assertPanelPinAllows("update", "was-node-suite")).not.toThrow();
+  });
+
+  it.each(["install", "update", "reinstall", "fix"])(
+    "REFUSES %s of the panel by registry id while pinned",
+    (action) => {
+      setPanelVersionPin("0.11.3");
+      expect(() => assertPanelPinAllows(action, "comfyui-agent-panel")).toThrow(
+        PanelPinnedError,
+      );
+      expect(() => assertPanelPinAllows(action, "comfyui-agent-panel")).toThrow(
+        /pinned to 0\.11\.3/i,
+      );
+    },
+  );
+
+  it("REFUSES the panel by repo name and by git URL while pinned", () => {
+    setPanelVersionPin("0.11.3");
+    expect(() => assertPanelPinAllows("update", "comfyui-mcp-panel")).toThrow(
+      PanelPinnedError,
+    );
+    expect(() =>
+      assertPanelPinAllows("update", "https://github.com/artokun/comfyui-mcp-panel.git"),
+    ).toThrow(PanelPinnedError);
+  });
+
+  it('REFUSES a bulk id="all" while pinned, and says why "all" cannot be partial', () => {
+    // The scenario that made this Critical: nothing about "all" names the panel,
+    // yet it moves it.
+    setPanelVersionPin("0.11.3");
+    expect(() => assertPanelPinAllows("update", "all")).toThrow(PanelPinnedError);
+    expect(() => assertPanelPinAllows("update", "all")).toThrow(
+      /cannot update everything-except-one-pack|individually by id/i,
+    );
+  });
+
+  it("REFUSES under an ENV pin and says unpin alone will not clear it", () => {
+    process.env[PANEL_PIN_ENV_VAR] = "0.11.3";
+    expect(() => assertPanelPinAllows("update", "all")).toThrow(
+      new RegExp(PANEL_PIN_ENV_VAR),
+    );
+  });
+
+  it("REFUSES when the pin is present but unreadable (can't tell → pinned)", () => {
+    mkdirSync(dirname(process.env.COMFYUI_MCP_PANEL_SETTINGS as string), {
+      recursive: true,
+    });
+    writeFileSync(process.env.COMFYUI_MCP_PANEL_SETTINGS as string, "{ not json");
+    expect(() => assertPanelPinAllows("update", "comfyui-agent-panel")).toThrow(
+      PanelPinnedError,
+    );
+  });
+
+  it("permits again once the pin is cleared via the env escape hatch", () => {
+    setPanelVersionPin("0.11.3");
+    expect(() => assertPanelPinAllows("update", "all")).toThrow();
+    process.env[PANEL_PIN_ENV_VAR] = "off";
+    expect(() => assertPanelPinAllows("update", "all")).not.toThrow();
+  });
+});
+
+describe("withPanelMutationLock — a FILE lock, so it holds across processes", () => {
+  it("serializes overlapping operations", async () => {
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const op = async () => {
+      inFlight++;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+    };
+    await Promise.all([
+      withPanelMutationLock(op),
+      withPanelMutationLock(op),
+      withPanelMutationLock(op),
+    ]);
+    expect(maxConcurrent).toBe(1);
+  });
+
+  it("releases the lock file afterwards, including on rejection", async () => {
+    await withPanelMutationLock(async () => undefined);
+    expect(existsSync(panelLockPath())).toBe(false);
+
+    await expect(
+      withPanelMutationLock(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(existsSync(panelLockPath())).toBe(false);
+
+    // A rejection must not wedge the queue for everyone after it.
+    await expect(withPanelMutationLock(async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("is RE-ENTRANT so a guarded service can be called from inside a held lock", async () => {
+    // runPanelAction holds the lock and then calls updateCustomNode, which takes
+    // it again — a non-re-entrant lock would deadlock here.
+    const result = await withPanelMutationLock(async () =>
+      withPanelMutationLock(async () => "inner ran"),
+    );
+    expect(result).toBe("inner ran");
+  });
+
+  it("times out rather than proceeding when another process holds the lock", async () => {
+    // Simulate a live lock owned by someone else: a fresh lock file we never release.
+    writeFileSync(panelLockPath(), JSON.stringify({ pid: 999999 }));
+    await expect(
+      withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
+    ).rejects.toThrow(/Timed out .* waiting for the panel operation lock/);
+  });
+
+  it("reclaims a STALE lock so a crashed process cannot wedge pinning forever", async () => {
+    const path = panelLockPath();
+    writeFileSync(path, JSON.stringify({ pid: 999999 }));
+    // Backdate well past the stale window.
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    await expect(
+      withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
+    ).resolves.toBe("recovered");
+  });
+});

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -280,6 +280,27 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
       withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
     ).resolves.toBe("recovered");
   });
+
+  it("resolves with the action's OWN result, and only after its side effects finished", async () => {
+    // Regression coverage for the review claim that the chaining let callers
+    // resolve early (receiving undefined, racing the post-state). The caller
+    // must get the guarded action's completion value — and any code running
+    // after the returned promise resolves must observe the FINISHED
+    // post-state, including a following lock acquisition.
+    const order: string[] = [];
+    const result = await withPanelMutationLock(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      order.push("side effect committed");
+      return "the action result";
+    });
+    expect(result).toBe("the action result");
+    expect(order).toEqual(["side effect committed"]);
+
+    const observedByNextAcquisition = await withPanelMutationLock(async () =>
+      order.slice(),
+    );
+    expect(observedByNextAcquisition).toEqual(["side effect committed"]);
+  });
 });
 
 describe("assertPanelNotTargetedUnverifiable — paths that cannot verify", () => {

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -12,9 +12,12 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import {
+  activePanelPendingOps,
   assertPanelPinAllows,
   PanelPinnedError,
   panelLockPath,
+  panelPendingOpsPath,
+  recordPanelPendingOp,
   targetsPanelPack,
   targetsPanelPackExactly,
   withPanelMutationLock,
@@ -27,11 +30,13 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "cmcp-pinguard-"));
   process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
   process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+  process.env.COMFYUI_MCP_PANEL_PENDING = join(dir, "panel-pending-ops.json");
 });
 
 afterEach(() => {
   delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
   delete process.env.COMFYUI_MCP_PANEL_LOCK;
+  delete process.env.COMFYUI_MCP_PANEL_PENDING;
   delete process.env[PANEL_PIN_ENV_VAR];
   rmSync(dir, { recursive: true, force: true });
 });
@@ -243,7 +248,7 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     ).rejects.toThrow(/Timed out .* waiting for the panel operation lock/);
   });
 
-  it("reclaims a STALE lock so a crashed process cannot wedge pinning forever", async () => {
+  it("fails closed on a stale lock rather than racing a fresh replacement", async () => {
     const path = panelLockPath();
     // A pid that is old AND dead.
     writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
@@ -251,8 +256,8 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     const { utimesSync } = await import("node:fs");
     utimesSync(path, old, old);
     await expect(
-      withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
-    ).resolves.toBe("recovered");
+      withPanelMutationLock(async () => "recovered", { timeoutMs: 300 }),
+    ).rejects.toThrow(/never auto-reclaimed/i);
   });
 
   it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {
@@ -270,15 +275,15 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     ).rejects.toThrow(/Timed out/);
   });
 
-  it("reclaims an old lock with unreadable content (nobody can claim it)", async () => {
+  it("fails closed on an old unreadable lock", async () => {
     const path = panelLockPath();
     writeFileSync(path, "not json");
     const old = new Date(Date.now() - 60 * 60_000);
     const { utimesSync } = await import("node:fs");
     utimesSync(path, old, old);
     await expect(
-      withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
-    ).resolves.toBe("recovered");
+      withPanelMutationLock(async () => "recovered", { timeoutMs: 300 }),
+    ).rejects.toThrow(/never auto-reclaimed/i);
   });
 
   it("resolves with the action's OWN result, and only after its side effects finished", async () => {

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -50,12 +50,39 @@ describe("targetsPanelPack — every spelling of the panel is the panel", () => 
     expect(targetsPanelPack(id)).toBe(true);
   });
 
-  it.each(["comfyui-manager", "was-node-suite", "", "   ", "comfyui-panel-other"])(
-    "does not match unrelated id %j",
-    (id) => {
-      expect(targetsPanelPack(id)).toBe(false);
-    },
-  );
+  it.each([
+    // Every REF-CARRYING form parseGitUrl accepts. Naively taking the last path
+    // segment turned "...panel.git@v0.11.28" into itself and ".../tree/main"
+    // into "main", so both slipped past the matcher and moved a pinned panel.
+    "https://github.com/artokun/comfyui-mcp-panel.git@v0.11.28",
+    "https://github.com/artokun/comfyui-mcp-panel@nightly",
+    "comfyui-mcp-panel@0.11.20",
+    "https://github.com/artokun/comfyui-mcp-panel/tree/main",
+    "https://github.com/artokun/comfyui-mcp-panel/commit/abc1234",
+    "https://github.com/artokun/comfyui-mcp-panel/commits/main",
+    "https://github.com/artokun/comfyui-mcp-panel/releases/tag/v0.11.28",
+    "https://gitlab.com/artokun/comfyui-mcp-panel/-/tree/main",
+    "https://gitlab.com/artokun/comfyui-mcp-panel/-/commit/abc1234",
+    "https://bitbucket.org/artokun/comfyui-mcp-panel/src/main",
+    "git@github.com:artokun/comfyui-mcp-panel.git",
+    "https://github.com/artokun/comfyui-mcp-panel/",
+    "https://github.com/artokun/comfyui-mcp-panel.git?foo=1",
+    "artokun/comfyui-agent-panel", // "author/repo" form the panel tools accept
+  ])("matches the ref-carrying / URL form %j", (id) => {
+    expect(targetsPanelPack(id)).toBe(true);
+  });
+
+  it.each([
+    "comfyui-manager",
+    "was-node-suite",
+    "",
+    "   ",
+    "comfyui-panel-other",
+    "https://github.com/someone/comfyui-mcp-panel-fork",
+    "https://github.com/someone/other-pack/tree/comfyui-mcp-panel",
+  ])("does not match unrelated id %j", (id) => {
+    expect(targetsPanelPack(id)).toBe(false);
+  });
 
   it("separates an exact panel target from a bulk one (only the former can be redirected)", () => {
     expect(targetsPanelPackExactly("comfyui-agent-panel")).toBe(true);
@@ -176,6 +203,38 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
     expect(result).toBe("inner ran");
   });
 
+  it("re-entrancy is ASYNC-CONTEXT-scoped, not process-global", async () => {
+    // The bug: a process-global "held" flag let an UNRELATED concurrent caller
+    // (a pin write) sail straight through while an update held the lock —
+    // landing in the exact window between the update's final pin check and its
+    // Manager call. Only work nested INSIDE the holder may skip the lock.
+    const order: string[] = [];
+    let releaseHolder: (() => void) | undefined;
+    const holderDone = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+
+    const holder = withPanelMutationLock(async () => {
+      order.push("holder:start");
+      // Nested-inside-the-holder: exempt, runs immediately.
+      await withPanelMutationLock(async () => order.push("nested"));
+      await holderDone;
+      order.push("holder:end");
+    });
+
+    // Started from OUTSIDE the holder's async context while it is held.
+    await new Promise((r) => setTimeout(r, 20));
+    const outsider = withPanelMutationLock(async () => order.push("outsider"));
+
+    await new Promise((r) => setTimeout(r, 20));
+    // The outsider must NOT have run yet — it is queued behind the holder.
+    expect(order).toEqual(["holder:start", "nested"]);
+
+    releaseHolder?.();
+    await Promise.all([holder, outsider]);
+    expect(order).toEqual(["holder:start", "nested", "holder:end", "outsider"]);
+  });
+
   it("times out rather than proceeding when another process holds the lock", async () => {
     // Simulate a live lock owned by someone else: a fresh lock file we never release.
     writeFileSync(panelLockPath(), JSON.stringify({ pid: 999999 }));
@@ -186,13 +245,82 @@ describe("withPanelMutationLock — a FILE lock, so it holds across processes", 
 
   it("reclaims a STALE lock so a crashed process cannot wedge pinning forever", async () => {
     const path = panelLockPath();
-    writeFileSync(path, JSON.stringify({ pid: 999999 }));
-    // Backdate well past the stale window.
+    // A pid that is old AND dead.
+    writeFileSync(path, JSON.stringify({ pid: 0x7fffffff }));
     const old = new Date(Date.now() - 60 * 60_000);
     const { utimesSync } = await import("node:fs");
     utimesSync(path, old, old);
     await expect(
       withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
     ).resolves.toBe("recovered");
+  });
+
+  it("does NOT reclaim an old lock whose owner is still ALIVE", async () => {
+    // Age alone let two waiters both judge a lock stale, and the slower one
+    // could then delete the FRESH lock the faster one had just taken — two
+    // mutations in flight, the exact thing the lock prevents. A live owner's
+    // lock must never read as stale, however old it looks.
+    const path = panelLockPath();
+    writeFileSync(path, JSON.stringify({ pid: process.pid })); // definitely alive
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    await expect(
+      withPanelMutationLock(async () => "should not run", { timeoutMs: 300 }),
+    ).rejects.toThrow(/Timed out/);
+  });
+
+  it("reclaims an old lock with unreadable content (nobody can claim it)", async () => {
+    const path = panelLockPath();
+    writeFileSync(path, "not json");
+    const old = new Date(Date.now() - 60 * 60_000);
+    const { utimesSync } = await import("node:fs");
+    utimesSync(path, old, old);
+    await expect(
+      withPanelMutationLock(async () => "recovered", { timeoutMs: 1000 }),
+    ).resolves.toBe("recovered");
+  });
+});
+
+describe("assertPanelNotTargetedUnverifiable — paths that cannot verify", () => {
+  it("refuses a panel target even when NOTHING is pinned", async () => {
+    // panel_install_node / panel_update_node / fix_custom_node report success
+    // straight off the Manager queue, which a stale Manager drains without doing
+    // any work. There is no verified redirect for them, so they refuse and name
+    // install_panel rather than move the panel unverifiably.
+    const { assertPanelNotTargetedUnverifiable } = await import(
+      "../../services/panel-pin-guard.js"
+    );
+    expect(() =>
+      assertPanelNotTargetedUnverifiable("panel_update_node", "comfyui-agent-panel"),
+    ).toThrow(/install_panel/);
+    expect(() =>
+      assertPanelNotTargetedUnverifiable(
+        "panel_install_node",
+        "https://github.com/artokun/comfyui-mcp-panel.git@v1",
+      ),
+    ).toThrow(/install_panel/);
+  });
+
+  it("reports the PIN first when one is set (the more specific reason)", async () => {
+    const { assertPanelNotTargetedUnverifiable } = await import(
+      "../../services/panel-pin-guard.js"
+    );
+    setPanelVersionPin("0.11.3");
+    expect(() =>
+      assertPanelNotTargetedUnverifiable("panel_update_node", "comfyui-agent-panel"),
+    ).toThrow(/pinned to 0\.11\.3/i);
+  });
+
+  it("leaves unrelated packs and absent ids alone", async () => {
+    const { assertPanelNotTargetedUnverifiable } = await import(
+      "../../services/panel-pin-guard.js"
+    );
+    expect(() =>
+      assertPanelNotTargetedUnverifiable("panel_update_node", "ComfyUI-WanVideoWrapper"),
+    ).not.toThrow();
+    expect(() =>
+      assertPanelNotTargetedUnverifiable("panel_install_node", undefined),
+    ).not.toThrow();
   });
 });

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -215,6 +215,38 @@ describe("panel version pin", () => {
     });
   });
 
+  it.each(["[]", '["a"]', "null", '"x"', "42"])(
+    "valid JSON that isn't a plain object (%s) reads as PINNED-indeterminate",
+    (body) => {
+      // `[]` is the trap: typeof [] === "object", so a naive check accepts it,
+      // reports "no pin" on a file we never understood, AND silently drops any
+      // pin written to it (an array expando does not survive JSON.stringify).
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(settingsPath, body);
+      expect(getPanelPinState({})).toMatchObject({ pinned: true, indeterminate: true });
+    },
+  );
+
+  it("refuses to pin into a JSON-array settings file rather than silently dropping it", () => {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, "[]");
+    expect(() => setPanelVersionPin("0.11.20")).toThrow(/could not be parsed/i);
+    // Never leaves the caller believing they are pinned when they are not.
+    expect(getPanelPinState({}).version).toBeUndefined();
+    expect(readFileSync(settingsPath, "utf-8")).toBe("[]");
+  });
+
+  it("only reports a pin after re-reading it back from disk", () => {
+    // The contract set/clear verify: a returned pin has been OBSERVED on disk,
+    // so "pinned" is never claimed from a write we didn't confirm.
+    const pin = setPanelVersionPin("0.11.20");
+    const onDisk = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(onDisk.panelPin.version).toBe(pin.version);
+
+    clearPanelVersionPin();
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).panelPin).toBeUndefined();
+  });
+
   it("refuses to rewrite an unparseable settings file rather than clobber it", () => {
     mkdirSync(dirname(settingsPath), { recursive: true });
     writeFileSync(settingsPath, "{ not json");

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -188,6 +188,49 @@ describe("panel version pin", () => {
     });
   });
 
+  it.each(["   ", "\t", " \n "])(
+    "a WHITESPACE-ONLY env value (%j) reads as PINNED-indeterminate, never unpinned",
+    (value) => {
+      // The trap: trimming first made a SET variable look absent, so it fell
+      // through to the JSON store and resolved unpinned — the same
+      // present-but-unreadable fail-open as a corrupt settings file.
+      expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: value })).toMatchObject({
+        pinned: true,
+        source: "env",
+        indeterminate: true,
+      });
+    },
+  );
+
+  it.each(["not-a-version", "0.11", "??"])(
+    "a non-empty env value (%j) pins as given — the pin is a label, not a parsed version",
+    (value) => {
+      // Deliberate: pins are only ever compared for equality and shown to the
+      // user, never parsed. What matters is that a set value never resolves
+      // UNPINNED, whatever it says.
+      expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: value })).toMatchObject({
+        pinned: true,
+        source: "env",
+        version: value,
+      });
+    },
+  );
+
+  it("a whitespace-padded env pin still resolves to the trimmed version", () => {
+    expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: "  0.11.20  " })).toMatchObject({
+      pinned: true,
+      version: "0.11.20",
+      source: "env",
+    });
+  });
+
+  it("an EMPTY env value means unset, the ordinary meaning of FOO=", () => {
+    expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: "" })).toEqual({
+      pinned: false,
+      source: "none",
+    });
+  });
+
   it("an env 'off' explicitly overrides a persisted pin", () => {
     setPanelVersionPin("0.11.20");
     for (const off of ["off", "none", "0", "false", "UNPINNED"]) {

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -3,11 +3,16 @@ import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
+  clearPanelVersionPin,
+  describePanelPin,
   getAgentSettings,
   getNsfwConsent,
+  getPanelPinState,
   normalizePreferredModels,
+  PANEL_PIN_ENV_VAR,
   setAgentSettings,
   setNsfwConsent,
+  setPanelVersionPin,
 } from "../../services/panel-settings.js";
 
 let dir: string;
@@ -132,5 +137,105 @@ describe("normalizePreferredModels (#393 loop guard)", () => {
     // persisted (already-normalized) list must be equal when nothing changed.
     setAgentSettings({ preferredModels: [" x ", "x", "y"] });
     expect(getAgentSettings().preferredModels).toEqual(normalizePreferredModels([" x ", "x", "y"]));
+  });
+});
+
+describe("panel version pin", () => {
+  afterEach(() => {
+    delete process.env[PANEL_PIN_ENV_VAR];
+  });
+
+  it("defaults to unpinned and reading does not create the file", () => {
+    expect(getPanelPinState({})).toEqual({ pinned: false, source: "none" });
+    expect(existsSync(settingsPath)).toBe(false);
+  });
+
+  it("persists a pin with a timestamp and reason, and survives a reload", () => {
+    const pin = setPanelVersionPin(" 0.11.20 ", "  waiting on a node-pack fix  ");
+    expect(pin.version).toBe("0.11.20");
+    expect(typeof pin.pinnedAt).toBe("string");
+    expect(pin.reason).toBe("waiting on a node-pack fix");
+
+    expect(getPanelPinState({})).toMatchObject({
+      pinned: true,
+      version: "0.11.20",
+      source: "settings",
+      reason: "waiting on a node-pack fix",
+    });
+  });
+
+  it("clearing returns the removed pin and leaves the state unpinned", () => {
+    setPanelVersionPin("0.11.20");
+    expect(clearPanelVersionPin()?.version).toBe("0.11.20");
+    expect(getPanelPinState({})).toEqual({ pinned: false, source: "none" });
+    // Second clear is a no-op, not an error.
+    expect(clearPanelVersionPin()).toBeUndefined();
+  });
+
+  it("clearing the pin leaves the rest of the settings intact", () => {
+    setNsfwConsent(true);
+    setPanelVersionPin("0.11.20");
+    clearPanelVersionPin();
+    expect(getNsfwConsent().allowed).toBe(true);
+  });
+
+  it("an env pin wins over the persisted one (env > .env > json)", () => {
+    setPanelVersionPin("0.11.20");
+    expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: "0.9.9" })).toMatchObject({
+      pinned: true,
+      version: "0.9.9",
+      source: "env",
+    });
+  });
+
+  it("an env 'off' explicitly overrides a persisted pin", () => {
+    setPanelVersionPin("0.11.20");
+    for (const off of ["off", "none", "0", "false", "UNPINNED"]) {
+      expect(getPanelPinState({ [PANEL_PIN_ENV_VAR]: off })).toEqual({
+        pinned: false,
+        source: "none",
+      });
+    }
+  });
+
+  it("a junk persisted pin reads as PINNED-indeterminate, never as unpinned", () => {
+    // A pin key we cannot make sense of is not proof the user did not pin.
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ panelPin: { version: "   " } }));
+    expect(getPanelPinState({})).toMatchObject({ pinned: true, indeterminate: true });
+  });
+
+  it("an UNPARSEABLE settings file reads as PINNED-indeterminate", () => {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, "{ not json");
+    expect(getPanelPinState({})).toMatchObject({
+      pinned: true,
+      indeterminate: true,
+      source: "settings",
+    });
+  });
+
+  it("refuses to rewrite an unparseable settings file rather than clobber it", () => {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, "{ not json");
+    expect(() => setPanelVersionPin("0.11.20")).toThrow(/could not be parsed/i);
+    expect(() => clearPanelVersionPin()).toThrow(/could not be parsed/i);
+    // The user's file is untouched, so nothing was silently lost.
+    expect(readFileSync(settingsPath, "utf-8")).toBe("{ not json");
+  });
+
+  it("rejects a blank pin version instead of storing a meaningless pin", () => {
+    expect(() => setPanelVersionPin("   ")).toThrow(/non-empty version/i);
+    expect(getPanelPinState({})).toEqual({ pinned: false, source: "none" });
+  });
+
+  it("describePanelPin names the source so the user knows how to clear it", () => {
+    expect(describePanelPin({ pinned: false, source: "none" })).toBe("not pinned");
+    expect(describePanelPin({ pinned: true, version: "0.11.20", source: "env" })).toContain(
+      PANEL_PIN_ENV_VAR,
+    );
+    expect(
+      describePanelPin({ pinned: true, version: "0.11.20", source: "settings" }),
+    ).toContain("0.11.20");
   });
 });

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -227,6 +227,32 @@ describe("panel version pin", () => {
     },
   );
 
+  it.each([
+    ["null", null],
+    ["false", false],
+    ["zero", 0],
+    ["a bare string", "0.11.3"],
+    ["an array", ["0.11.3"]],
+  ])("a PRESENT but malformed panelPin (%s) reads as pinned, not unpinned", (_label, value) => {
+    // Only an ABSENT key means unpinned. A present key we failed to understand
+    // is somebody's hand-edit — reading it as "no pin" moves a user who
+    // believed they were protected.
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ panelPin: value }));
+    expect(getPanelPinState({})).toMatchObject({ pinned: true, indeterminate: true });
+  });
+
+  it("clearing removes a malformed FALSY pin instead of leaving the user stuck", () => {
+    // `!previous` would have skipped the delete, leaving an indeterminate pin
+    // in place forever while reporting "no pin was set".
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ panelPin: null }));
+    expect(getPanelPinState({}).pinned).toBe(true);
+    const removed = clearPanelVersionPin();
+    expect(removed?.version).toBe("(unreadable)");
+    expect(getPanelPinState({})).toEqual({ pinned: false, source: "none" });
+  });
+
   it("refuses to pin into a JSON-array settings file rather than silently dropping it", () => {
     mkdirSync(dirname(settingsPath), { recursive: true });
     writeFileSync(settingsPath, "[]");

--- a/src/__tests__/services/panel-settings.test.ts
+++ b/src/__tests__/services/panel-settings.test.ts
@@ -242,6 +242,21 @@ describe("panel version pin", () => {
     expect(getPanelPinState({})).toMatchObject({ pinned: true, indeterminate: true });
   });
 
+  it.each([
+    ["a null version", { version: null }],
+    ["a blank version", { version: "   " }],
+    ["a numeric version", { version: 11 }],
+    ["no version at all", { reason: "oops" }],
+  ])("clearing an object-shaped malformed pin (%s) reports it as unreadable", (_l, value) => {
+    // getPanelPinState calls these indeterminate; unpin must not then report
+    // "was null" / "was " — two parts of the system describing one pin differently.
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ panelPin: value }));
+    expect(getPanelPinState({})).toMatchObject({ pinned: true, indeterminate: true });
+    expect(clearPanelVersionPin()?.version).toBe("(unreadable)");
+    expect(getPanelPinState({})).toEqual({ pinned: false, source: "none" });
+  });
+
   it("clearing removes a malformed FALSY pin instead of leaving the user stuck", () => {
     // `!previous` would have skipped the delete, leaving an indeterminate pin
     // in place forever while reporting "no pin was set".

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -155,6 +155,27 @@ describe("evaluatePanelSync — a pin is honoured in every shape", () => {
     expect(a.decision).toBe("blocked");
     expect(a.decision).not.toBe("sync");
   });
+
+  it("a MISSING pin field is treated as pinned, never as unpinned", () => {
+    // A status built by a caller that predates the pin field: absence of the
+    // field is not evidence of absence of a pin.
+    const s = status({ installedVersion: "0.11.3" });
+    delete (s as Partial<PanelStatus>).pin;
+    const a = evaluatePanelSync(s, { requiredVersion: REQUIRED, orchestratorVersion: ORCH });
+    expect(a.decision).toBe("blocked");
+  });
+
+  it("a pin still WARNS when the installed version is uncomparable", () => {
+    // Must not fall through to `unknown`: that would skip the warning the user
+    // is owed and send the agent to try an update the guard will refuse.
+    const pin: PanelPinState = { pinned: true, version: "nightly", source: "settings" };
+    const a = evaluatePanelSync(status({ installedVersion: "nightly", pin }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("pinned-warn");
+    expect(a.summary).toMatch(/pinned/i);
+  });
 });
 
 describe("evaluatePanelSync — cases where we must not guess", () => {
@@ -379,6 +400,56 @@ describe("performPanelSync", () => {
     expect(r.verifiedVersion).toBe("0.11.10");
     expect(r.stillBehind).toBe(true);
     expect(r.message).toMatch(/still below/i);
+  });
+
+  it("leaves stillBehind UNDEFINED when the landed version can't be compared", async () => {
+    // "nightly" landed: the sync really happened, but whether it meets the
+    // requirement is unknown. `undefined` must NOT collapse to false — that
+    // would read as "you're fine now" on a version we never checked.
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("nightly");
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+    expect(r.synced).toBe(true);
+    expect(r.verifiedVersion).toBe("nightly");
+    expect(r.stillBehind).toBeUndefined();
+    expect(r.message).toMatch(/could NOT be confirmed/i);
+  });
+
+  it("serializes concurrent syncs instead of interleaving their before/after reads", async () => {
+    // Two overlapping ops would each read the other's half-applied state, and
+    // the #639 movement proof compares a pre-image to a post-image.
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    let n = 0;
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(`0.11.${30 + n++}`);
+      },
+    });
+    const deps: PanelInstallerDeps = {
+      ...h.deps,
+      update: async (o) => {
+        inFlight++;
+        maxConcurrent = Math.max(maxConcurrent, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        const res = await h.deps.update(o);
+        inFlight--;
+        return res;
+      },
+    };
+    const results = await Promise.allSettled([
+      performPanelSync({ deps, ...RUN }),
+      performPanelSync({ deps, ...RUN }),
+    ]);
+    expect(maxConcurrent).toBe(1);
+    // The first moves the pack; the second sees no further movement and fails
+    // closed rather than claiming a second successful sync.
+    expect(results.filter((r) => r.status === "fulfilled").length).toBeGreaterThanOrEqual(1);
   });
 
   it("refuses to sync a dev symlink", async () => {

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -1,0 +1,392 @@
+// Decision-logic tests for the node-pack auto-sync.
+//
+// Two invariants are what these tests exist to protect:
+//   1. A sync that did not move bytes is NEVER reported as a success.
+//   2. A user who pinned the panel is NEVER moved off that pin.
+// Everything else here is supporting detail.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+
+// panel-installer pulls config in transitively; stub it so importing doesn't
+// trigger real port detection (mirrors panel-installer.test.ts).
+vi.mock("../../config.js", () => ({
+  config: { comfyuiPath: undefined as string | undefined },
+  isLocalMode: () => true,
+}));
+
+import {
+  evaluatePanelSync,
+  performPanelSync,
+  requiredPanelVersion,
+  type PanelSyncDecision,
+} from "../../services/panel-sync.js";
+import {
+  PANEL_REGISTRY_ID,
+  type PanelInstallerDeps,
+  type PanelStatus,
+} from "../../services/panel-installer.js";
+import type { PanelPinState } from "../../services/panel-settings.js";
+
+const REQUIRED = "0.11.28";
+const ORCH = "0.48.32";
+const UNPINNED: PanelPinState = { pinned: false, source: "none" };
+
+function status(over: Partial<PanelStatus> = {}): PanelStatus {
+  return {
+    applicable: true,
+    installed: true,
+    dir: "/fake/comfy/custom_nodes/comfyui-mcp-panel",
+    installedVersion: "0.11.28",
+    isDevSymlink: false,
+    targetVersion: "nightly",
+    shadows: [],
+    pin: UNPINNED,
+    note: "",
+    ...over,
+  };
+}
+
+function decide(over: Partial<PanelStatus>): PanelSyncDecision {
+  return evaluatePanelSync(status(over), {
+    requiredVersion: REQUIRED,
+    orchestratorVersion: ORCH,
+  }).decision;
+}
+
+describe("requiredPanelVersion", () => {
+  it("is the maximum of the bridge baseline and every per-command minimum", () => {
+    // Derived from the orchestrator's own declared command minimums, so it can
+    // never drift from the code that needs the newer panel.
+    expect(requiredPanelVersion()).toBe(REQUIRED);
+  });
+});
+
+describe("evaluatePanelSync — the four required outcomes", () => {
+  it("mismatch + NO pin → sync", () => {
+    const a = evaluatePanelSync(status({ installedVersion: "0.11.3" }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("sync");
+    expect(a.behind).toBe(true);
+    expect(a.requiredPanelVersion).toBe(REQUIRED);
+    expect(a.installedVersion).toBe("0.11.3");
+  });
+
+  it("mismatch + pin → pinned-warn: warns a newer panel exists, syncs nothing", () => {
+    const pin: PanelPinState = { pinned: true, version: "0.11.3", source: "settings" };
+    const a = evaluatePanelSync(status({ installedVersion: "0.11.3", pin }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("pinned-warn");
+    expect(a.behind).toBe(true);
+    // The warning must actually say all three things the owner asked for.
+    expect(a.summary).toContain(REQUIRED); // a newer panel matching the orchestrator
+    expect(a.summary).toContain("0.11.3"); // what they're on
+    expect(a.summary).toMatch(/pinned/i); // that they're pinned
+    expect(a.summary).toMatch(/unpin/i); // how to get off it
+  });
+
+  it("pin cleared → the same mismatch now decides sync", () => {
+    const pinned = status({
+      installedVersion: "0.11.3",
+      pin: { pinned: true, version: "0.11.3", source: "settings" },
+    });
+    expect(
+      evaluatePanelSync(pinned, { requiredVersion: REQUIRED, orchestratorVersion: ORCH })
+        .decision,
+    ).toBe("pinned-warn");
+    // Same install, pin removed — nothing else changed.
+    const cleared = { ...pinned, pin: UNPINNED };
+    expect(
+      evaluatePanelSync(cleared, { requiredVersion: REQUIRED, orchestratorVersion: ORCH })
+        .decision,
+    ).toBe("sync");
+  });
+
+  it("versions equal → up-to-date (no-op)", () => {
+    const a = evaluatePanelSync(status({ installedVersion: REQUIRED }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("up-to-date");
+    expect(a.behind).toBe(false);
+  });
+
+  it("installed NEWER than required → up-to-date, never a downgrade", () => {
+    expect(decide({ installedVersion: "0.12.0" })).toBe("up-to-date");
+  });
+});
+
+describe("evaluatePanelSync — a pin is honoured in every shape", () => {
+  it("an env pin blocks the sync just like a settings pin", () => {
+    const pin: PanelPinState = { pinned: true, version: "0.11.3", source: "env" };
+    const a = evaluatePanelSync(status({ installedVersion: "0.11.3", pin }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("pinned-warn");
+    // Must tell the user unpin alone won't clear an env pin.
+    expect(a.summary).toContain("COMFYUI_MCP_PANEL_PIN");
+  });
+
+  it("a pin while already current is simply up-to-date (no nagging)", () => {
+    const pin: PanelPinState = { pinned: true, version: REQUIRED, source: "settings" };
+    expect(decide({ installedVersion: REQUIRED, pin })).toBe("up-to-date");
+  });
+
+  it("a pin blocks even a FRESH install of a missing panel", () => {
+    const pin: PanelPinState = { pinned: true, version: "0.11.3", source: "settings" };
+    const a = evaluatePanelSync(
+      status({ installed: false, installedVersion: undefined, pin }),
+      { requiredVersion: REQUIRED, orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("pinned-warn");
+  });
+
+  it("an UNREADABLE pin is treated as pinned, never as unpinned", () => {
+    const pin: PanelPinState = { pinned: true, source: "settings", indeterminate: true };
+    const a = evaluatePanelSync(status({ installedVersion: "0.11.3", pin }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("blocked");
+    expect(a.decision).not.toBe("sync");
+  });
+});
+
+describe("evaluatePanelSync — cases where we must not guess", () => {
+  it("missing panel + no pin → sync (install it)", () => {
+    const a = evaluatePanelSync(status({ installed: false, installedVersion: undefined }), {
+      requiredVersion: REQUIRED,
+      orchestratorVersion: ORCH,
+    });
+    expect(a.decision).toBe("sync");
+    expect(a.behind).toBe(true);
+  });
+
+  it.each(["nightly", "dev", "", "not-a-version"])(
+    "an uncomparable installed version (%j) → unknown, not a silent up-to-date",
+    (v) => {
+      // compareSemver returns 0 for junk, so an unscreened compare would report
+      // "equal" and quietly claim the panel is current. It must not.
+      expect(decide({ installedVersion: v })).toBe("unknown");
+    },
+  );
+
+  it("an unreadable installed version → unknown", () => {
+    expect(decide({ installed: true, installedVersion: undefined })).toBe("unknown");
+  });
+
+  it("a shadow copy → blocked (the served panel isn't the one on disk)", () => {
+    const a = evaluatePanelSync(
+      status({
+        installedVersion: "0.11.3",
+        shadows: [{ name: ".comfyui-agent-panel.bak-0.11.3", version: "0.11.3" }],
+      }),
+      { requiredVersion: REQUIRED, orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("blocked");
+    expect(a.summary).toContain(".comfyui-agent-panel.bak-0.11.3");
+  });
+
+  it("a dev symlink → dev-install, never touched", () => {
+    expect(decide({ isDevSymlink: true, installedVersion: "0.1.0" })).toBe("dev-install");
+  });
+
+  it("remote/cloud → not-applicable", () => {
+    expect(decide({ applicable: false, installed: false })).toBe("not-applicable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// performPanelSync — execution guards
+// ---------------------------------------------------------------------------
+
+const COMFY = "/fake/comfy";
+const CUSTOM_NODES = join(COMFY, "custom_nodes");
+const PANEL_DIR = join(CUSTOM_NODES, "comfyui-mcp-panel");
+
+function pyproject(version: string): string {
+  return `[project]\nname = "${PANEL_REGISTRY_ID}"\nversion = "${version}"\n`;
+}
+
+interface Harness {
+  deps: PanelInstallerDeps;
+  updates: number;
+  installs: number;
+}
+
+/**
+ * Minimal on-disk simulation: `files` is the live view the installer re-reads
+ * after the op, so `onUpdate` is how a test says what actually landed (or that
+ * nothing did).
+ */
+function makeDeps(opts: {
+  installedVersion?: string;
+  pin?: PanelPinState;
+  dirs?: string[];
+  /** Mutate the live files map to simulate what the Manager actually did. */
+  onUpdate?: (files: Record<string, string>) => void;
+  updateDetails?: unknown;
+}): Harness {
+  const files: Record<string, string> = {};
+  if (opts.installedVersion !== undefined) {
+    files[join(PANEL_DIR, "pyproject.toml")] = pyproject(opts.installedVersion);
+  }
+  const dirs = opts.dirs ?? (opts.installedVersion !== undefined ? ["comfyui-mcp-panel"] : []);
+  const h: Harness = { updates: 0, installs: 0, deps: undefined as never };
+
+  h.deps = {
+    isLocalMode: () => true,
+    comfyuiPath: () => COMFY,
+    env: () => ({}),
+    existsSync: (p) => p === CUSTOM_NODES || p in files,
+    probeFile: (p) => p in files,
+    isSymlink: () => false,
+    isDirectory: () => true,
+    realPath: () => undefined,
+    readdir: (p) => (p === CUSTOM_NODES ? dirs : []),
+    readFile: (p) => files[p] ?? "",
+    gitRevision: () => undefined,
+    readPin: () => opts.pin ?? UNPINNED,
+    isReachable: async () => true,
+    install: async () => {
+      h.installs++;
+      opts.onUpdate?.(files);
+      return { mechanism: "manager-http", message: "installed", details: opts.updateDetails };
+    },
+    update: async () => {
+      h.updates++;
+      opts.onUpdate?.(files);
+      return { mechanism: "manager-http", message: "updated", details: opts.updateDetails };
+    },
+    reinstall: async () => {
+      return { mechanism: "manager-http", message: "reinstalled" };
+    },
+  };
+  return h;
+}
+
+const RUN = { requiredVersion: REQUIRED, orchestratorVersion: ORCH } as const;
+
+describe("performPanelSync", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("syncs a behind, unpinned panel and reports the version RE-READ from disk", async () => {
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+    expect(h.updates).toBe(1);
+    expect(r.synced).toBe(true);
+    expect(r.previousVersion).toBe("0.11.3");
+    // The reported version is the one observed on disk afterwards.
+    expect(r.verifiedVersion).toBe("0.11.30");
+    expect(r.restartRequired).toBe(true);
+    expect(r.stillBehind).toBe(false);
+  });
+
+  it("does NOTHING and does not queue a mutation when the panel is pinned", async () => {
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      pin: { pinned: true, version: "0.11.3", source: "settings" },
+      onUpdate: (files) => {
+        // If this ever runs the guard has failed.
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+    expect(r.synced).toBe(false);
+    expect(r.decision).toBe("pinned-warn");
+    expect(h.updates).toBe(0);
+    expect(h.installs).toBe(0);
+    expect(r.verifiedVersion).toBeUndefined();
+    expect(r.message).toMatch(/pinned/i);
+  });
+
+  it("proceeds once the pin is cleared — same install, same versions", async () => {
+    const make = (pin?: PanelPinState) =>
+      makeDeps({
+        installedVersion: "0.11.3",
+        pin,
+        onUpdate: (files) => {
+          files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+        },
+      });
+
+    const pinned = make({ pinned: true, version: "0.11.3", source: "settings" });
+    expect((await performPanelSync({ deps: pinned.deps, ...RUN })).synced).toBe(false);
+    expect(pinned.updates).toBe(0);
+
+    const cleared = make(undefined);
+    const r = await performPanelSync({ deps: cleared.deps, ...RUN });
+    expect(r.synced).toBe(true);
+    expect(cleared.updates).toBe(1);
+    expect(r.verifiedVersion).toBe("0.11.30");
+  });
+
+  it("no-ops without touching anything when already current", async () => {
+    const h = makeDeps({ installedVersion: REQUIRED });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+    expect(r.synced).toBe(false);
+    expect(r.decision).toBe("up-to-date");
+    expect(h.updates).toBe(0);
+  });
+
+  it("FAILS LOUDLY when the update did not move anything on disk", async () => {
+    // The #639 silent no-op: ComfyUI-Manager drains its queue trivially and the
+    // pack is untouched. This must be an error, never "synced".
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: () => {
+        /* nothing lands */
+      },
+      updateDetails: { total_count: 0, done_count: 2 },
+    });
+    await expect(performPanelSync({ deps: h.deps, ...RUN })).rejects.toThrow(
+      /did NOT apply|NOT reporting success/i,
+    );
+    expect(h.updates).toBe(1);
+  });
+
+  it("FAILS LOUDLY when the pack disappears after the op", async () => {
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        delete files[join(PANEL_DIR, "pyproject.toml")];
+      },
+    });
+    await expect(performPanelSync({ deps: h.deps, ...RUN })).rejects.toThrow(
+      /Could not verify|NOT reporting/i,
+    );
+  });
+
+  it("reports stillBehind honestly when the sync landed but did not close the gap", async () => {
+    const h = makeDeps({
+      installedVersion: "0.11.3",
+      onUpdate: (files) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.10");
+      },
+    });
+    const r = await performPanelSync({ deps: h.deps, ...RUN });
+    expect(r.synced).toBe(true);
+    expect(r.verifiedVersion).toBe("0.11.10");
+    expect(r.stillBehind).toBe(true);
+    expect(r.message).toMatch(/still below/i);
+  });
+
+  it("refuses to sync a dev symlink", async () => {
+    const h = makeDeps({ installedVersion: "0.11.3" });
+    const deps: PanelInstallerDeps = { ...h.deps, isSymlink: (p) => p === PANEL_DIR };
+    const r = await performPanelSync({ deps, ...RUN });
+    expect(r.synced).toBe(false);
+    expect(r.decision).toBe("dev-install");
+    expect(h.updates).toBe(0);
+  });
+});

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../config.js", () => ({
 }));
 
 import {
+  classifyPinWrite,
   evaluatePanelSync,
   performPanelSync,
   requiredPanelVersion,
@@ -59,6 +60,36 @@ describe("requiredPanelVersion", () => {
     // Derived from the orchestrator's own declared command minimums, so it can
     // never drift from the code that needs the newer panel.
     expect(requiredPanelVersion()).toBe(REQUIRED);
+  });
+});
+
+describe("classifyPinWrite — writing a pin is not the same as being pinned", () => {
+  it("reports 'active' only when the pin we saved is the one in force", () => {
+    expect(
+      classifyPinWrite({ pinned: true, version: "0.11.20", source: "settings" }, "0.11.20"),
+    ).toBe("active");
+  });
+
+  it("reports the env override when a DIFFERENT pin wins — still protected, not by ours", () => {
+    expect(
+      classifyPinWrite({ pinned: true, version: "0.9.9", source: "env" }, "0.11.20"),
+    ).toBe("env-overrides-with-pin");
+  });
+
+  it("reports 'superseded' when a concurrent write replaced our pin", () => {
+    // Ours is not the pin in force, so calling it active would describe a pin
+    // that isn't there.
+    expect(
+      classifyPinWrite({ pinned: true, version: "0.11.21", source: "settings" }, "0.11.20"),
+    ).toBe("superseded");
+  });
+
+  it("reports 'not-in-force' when COMFYUI_MCP_PANEL_PIN=off leaves nothing pinned", () => {
+    // The dangerous case: the write succeeded, so a naive tool would say
+    // "pinned" while update/sync remain allowed.
+    expect(classifyPinWrite({ pinned: false, source: "none" }, "0.11.20")).toBe(
+      "not-in-force",
+    );
   });
 });
 
@@ -223,6 +254,17 @@ describe("evaluatePanelSync — cases where we must not guess", () => {
     );
     expect(a.decision).toBe("blocked");
     expect(a.summary).toContain(".comfyui-agent-panel.bak-0.11.3");
+  });
+
+  it("a FAILED shadow scan → blocked, not a clear-to-sync empty array", () => {
+    // panelStatus reports `shadows: []` when it could not enumerate custom_nodes.
+    // Reading that as "no shadows" would sync onto an install we can't verify.
+    const a = evaluatePanelSync(
+      status({ installedVersion: "0.11.3", shadows: [], shadowInspectFailed: true }),
+      { requiredVersion: REQUIRED, orchestratorVersion: ORCH },
+    );
+    expect(a.decision).toBe("blocked");
+    expect(a.summary).toMatch(/could not enumerate/i);
   });
 
   it("a dev symlink → dev-install, never touched", () => {

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -7,6 +7,14 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Panel mutations take a FILE lock (panel-pin-guard) — keep it out of
+// ~/.comfyui-mcp and off other workers' lock file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-sync-${process.pid}.lock`,
+);
 
 // panel-installer pulls config in transitively; stub it so importing doesn't
 // trigger real port detection (mirrors panel-installer.test.ts).
@@ -507,6 +515,54 @@ describe("performPanelSync", () => {
     // The first moves the pack; the second sees no further movement and fails
     // closed rather than claiming a second successful sync.
     expect(results.filter((r) => r.status === "fulfilled").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("FAILS LOUDLY when the FINAL post-sync shadow scan could not run", async () => {
+    // The mutation applied and runPanelAction's own shadow assertion passed, but
+    // custom_nodes became unreadable before performPanelSync's confirming scan.
+    // `shadows: []` from a scan that never ran is not an all-clear — reporting
+    // `synced: true` there is the same fail-open the pre-mutation assessment
+    // blocks, one step later.
+    //
+    // Self-calibrating rather than hardcoding a call index: phase 1 counts the
+    // readdir calls a clean sync makes, phase 2 replays it failing only the
+    // LAST one (necessarily the confirming scan). Survives refactors that add or
+    // remove intermediate reads.
+    const scenario = () => ({
+      installedVersion: "0.11.3",
+      onUpdate: (files: Record<string, string>) => {
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+      },
+    });
+
+    let calls = 0;
+    const probe = makeDeps(scenario());
+    const counting: PanelInstallerDeps = {
+      ...probe.deps,
+      readdir: (p) => {
+        calls++;
+        return probe.deps.readdir(p);
+      },
+    };
+    await expect(performPanelSync({ deps: counting, ...RUN })).resolves.toMatchObject({
+      synced: true,
+    });
+    const total = calls;
+    expect(total).toBeGreaterThan(1);
+
+    let n = 0;
+    const h = makeDeps(scenario());
+    const failingLast: PanelInstallerDeps = {
+      ...h.deps,
+      readdir: (p) => {
+        n++;
+        if (n >= total) throw new Error("EACCES: permission denied, scandir");
+        return h.deps.readdir(p);
+      },
+    };
+    await expect(performPanelSync({ deps: failingLast, ...RUN })).rejects.toThrow(
+      /could not be enumerated|NOT reporting a completed sync/i,
+    );
   });
 
   it("refuses to sync a dev symlink", async () => {

--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -188,7 +188,19 @@ describe("evaluatePanelSync — cases where we must not guess", () => {
     expect(a.behind).toBe(true);
   });
 
-  it.each(["nightly", "dev", "", "not-a-version"])(
+  it.each([
+    "nightly",
+    "dev",
+    "",
+    "not-a-version",
+    // Strict SemVer 2.0.0: a looser screen accepted these and compareSemver then
+    // read them as satisfying 0.11.28.
+    "01.11.28",
+    "0.11.28+.",
+    "0.11.28-",
+    "0.11.28.1",
+    "0.11.28abc",
+  ])(
     "an uncomparable installed version (%j) → unknown, not a silent up-to-date",
     (v) => {
       // compareSemver returns 0 for junk, so an unscreened compare would report
@@ -402,7 +414,7 @@ describe("performPanelSync", () => {
     expect(r.message).toMatch(/still below/i);
   });
 
-  it("leaves stillBehind UNDEFINED when the landed version can't be compared", async () => {
+  it("leaves stillBehind NULL when the landed version can't be compared", async () => {
     // "nightly" landed: the sync really happened, but whether it meets the
     // requirement is unknown. `undefined` must NOT collapse to false — that
     // would read as "you're fine now" on a version we never checked.
@@ -415,8 +427,11 @@ describe("performPanelSync", () => {
     const r = await performPanelSync({ deps: h.deps, ...RUN });
     expect(r.synced).toBe(true);
     expect(r.verifiedVersion).toBe("nightly");
-    expect(r.stillBehind).toBeUndefined();
+    expect(r.stillBehind).toBeNull();
     expect(r.message).toMatch(/could NOT be confirmed/i);
+    // `undefined` would be DROPPED by JSON.stringify on the way to the agent,
+    // so the unknown state must survive serialization as an explicit null.
+    expect(JSON.parse(JSON.stringify(r))).toHaveProperty("stillBehind", null);
   });
 
   it("serializes concurrent syncs instead of interleaving their before/after reads", async () => {

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -29,9 +29,22 @@ vi.mock("node:child_process", () => ({
   spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
 }));
 
-vi.mock("node:fs", () => ({
+vi.mock("node:fs", async (importOriginal) => ({
+  // existsSync stays mockable per-test; everything else delegates to the REAL
+  // fs because update_all now takes the panel mutation lock (panel-pin-guard),
+  // which is a real file — a partial mock left its mkdir/open/write undefined
+  // and every update_all failed closed.
+  ...(await importOriginal<typeof import("node:fs")>()),
   existsSync: vi.fn(),
 }));
+
+// The panel mutation lock is a FILE (panel-pin-guard). Point it at a temp path
+// so the suite never touches ~/.comfyui-mcp, and so parallel vitest workers get
+// their own lock instead of serializing on one shared file.
+process.env.COMFYUI_MCP_PANEL_LOCK = join(
+  tmpdir(),
+  `cmcp-lock-updatecomfyui-${process.pid}.lock`,
+);
 
 vi.mock("../../utils/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -47,6 +60,8 @@ vi.mock("../../services/workspace-env.js", () => ({
 
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   updateComfyUICore,
   updateAllCustomNodes,

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -325,7 +325,7 @@ describe("updateAllCustomNodes", () => {
     const calls = stubManager("legacy");
 
     const r = await updateAllCustomNodes();
-    expect(r.updated).toBe(true);
+    expect(r.updated).toBe(false);
     expect(r.endpoint).toBe("/manager/queue/update_all");
     expect(r.queue_started).toBe(true);
 
@@ -345,7 +345,7 @@ describe("updateAllCustomNodes", () => {
     const calls = stubManager("v4");
 
     const r = await updateAllCustomNodes();
-    expect(r.updated).toBe(true);
+    expect(r.updated).toBe(false);
     expect(r.endpoint).toBe("/v2/manager/queue/update_all");
     expect(r.queue_started).toBe(true);
 
@@ -390,7 +390,7 @@ describe("updateAllCustomNodes", () => {
     stubManager("legacy", { failStart: "error" });
 
     const r = await updateAllCustomNodes();
-    expect(r.updated).toBe(true);
+    expect(r.updated).toBe(false);
     expect(r.queue_started).toBe(false);
     expect(r.message).toMatch(/Could not confirm the queue worker started/);
   });

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -59,7 +59,7 @@ vi.mock("../../services/workspace-env.js", () => ({
 }));
 
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -384,6 +384,25 @@ describe("updateAllCustomNodes", () => {
     expect(countOf(calls, "/manager/queue/update_all")).toBe(1);
     // The queue was never started, so no half-run operation is left behind.
     expect(countOf(calls, "/manager/queue/start")).toBe(0);
+  });
+
+  it("refuses before contacting Manager when the out-of-band pin-warning marker cannot persist", async () => {
+    // A marker written after queueing can fail, then a later pin would be
+    // reported as protective even though update_all can still land. Make its
+    // parent a regular file so the preflight record is indeterminate/unwritable.
+    const blocker = join(tmpdir(), `cmcp-pending-blocker-${process.pid}-${Date.now()}`);
+    writeFileSync(blocker, "not a directory");
+    const previous = process.env.COMFYUI_MCP_PANEL_PENDING;
+    process.env.COMFYUI_MCP_PANEL_PENDING = join(blocker, "pending.json");
+    try {
+      const calls = stubManager("legacy");
+      await expect(updateAllCustomNodes()).rejects.toThrow(/Could not persist the pending update-all marker/i);
+      expect(calls).toEqual([]);
+    } finally {
+      if (previous === undefined) delete process.env.COMFYUI_MCP_PANEL_PENDING;
+      else process.env.COMFYUI_MCP_PANEL_PENDING = previous;
+      rmSync(blocker, { force: true });
+    }
   });
 
   it("still succeeds (queue_started=false) if starting the queue fails", async () => {

--- a/src/__tests__/services/workflow-deps.test.ts
+++ b/src/__tests__/services/workflow-deps.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   collectClassTypes,
   extractWorkflowDependencies,
@@ -8,6 +11,7 @@ import {
   defaultWorkflowDepsDeps,
 } from "../../services/workflow-deps.js";
 import { resetManagerApiCacheForTests } from "../../services/node-management.js";
+import { setPanelVersionPin } from "../../services/panel-settings.js";
 import type { WorkflowJSON, ObjectInfo, ComfyUINodeDef } from "../../comfyui/types.js";
 
 afterEach(() => vi.unstubAllGlobals());
@@ -225,6 +229,34 @@ describe("extractWorkflowDependencies", () => {
 });
 
 describe("installWorkflowDependencies", () => {
+  it("refuses before queuing when a workflow dependency selects the pinned panel", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cmcp-workflow-deps-pin-"));
+    process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
+    process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+    try {
+      setPanelVersionPin("0.11.3");
+      const deps = makeDeps({
+        fetchObjectInfo: vi.fn(async () => ({})),
+        fetchManagerMappings: vi.fn(async () => ({
+          "comfyui-agent-panel": [["PanelOnlyNode"], {}],
+        } as never)),
+      });
+      const panelWorkflow: WorkflowJSON = {
+        "1": { class_type: "PanelOnlyNode", inputs: {} },
+      };
+
+      await expect(installWorkflowDependencies(panelWorkflow, deps)).rejects.toThrow(/pinned/i);
+      // The guard wraps the transaction, so no Manager mutation starts.
+      expect(deps.fetchManagerList).not.toHaveBeenCalled();
+      expect(deps.resetQueue).not.toHaveBeenCalled();
+      expect(deps.queueInstall).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
+      delete process.env.COMFYUI_MCP_PANEL_LOCK;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("installs via ComfyUI-Manager regardless of any local path (server-side install)", async () => {
     // Installs run through the Manager HTTP queue on the connected instance, so
     // the absence of a local path must NOT block them.

--- a/src/__tests__/services/workflow-deps.test.ts
+++ b/src/__tests__/services/workflow-deps.test.ts
@@ -266,6 +266,28 @@ describe("installWorkflowDependencies", () => {
     expect(deps.queueInstall).toHaveBeenCalledTimes(1);
   });
 
+  it("never queues the panel through the generic direct-install/remote fallback", async () => {
+    const deps = makeDeps({
+      fetchObjectInfo: vi.fn(async () => ({})),
+      fetchManagerMappings: vi.fn(async () => ({
+        "comfyui-agent-panel": [["PanelOnlyNode"], {}],
+      } as never)),
+      fetchManagerList: vi.fn(async () => ({ directInstall: true, packs: [] })),
+    });
+    const panelWorkflow: WorkflowJSON = {
+      "1": { class_type: "PanelOnlyNode", inputs: {} },
+    };
+
+    const result = await installWorkflowDependencies(panelWorkflow, deps);
+
+    expect(result.installed).toEqual([]);
+    expect(result.unresolved).toEqual(["comfyui-agent-panel"]);
+    expect(result.panel_notes?.join(" ")).toMatch(/does not queue or mutate.*install_panel/i);
+    expect(deps.resetQueue).not.toHaveBeenCalled();
+    expect(deps.queueInstall).not.toHaveBeenCalled();
+    expect(deps.startQueue).not.toHaveBeenCalled();
+  });
+
   it("resets the queue, queues missing packs (with channel), then starts the worker", async () => {
     const deps = makeDeps();
     const order: string[] = [];

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -29,6 +29,7 @@ import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { extname, isAbsolute, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { assertPanelNotTargetedUnverifiable } from "../services/panel-pin-guard.js";
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { parse as parseYaml } from "yaml";
 import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk";
@@ -4826,11 +4827,17 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         channel: z.string().optional().describe("Manager channel (default 'default')."),
         mode: z.enum(["remote", "local", "cache"]).optional().describe("DB source (default 'remote')."),
       },
-      async (args: A, ctx) =>
-        ctx.call(
+      async (args: A, ctx) => {
+        // The panel pack is installable like any other, and this path has NO
+        // on-disk verification and never saw the version pin. Refuse both
+        // spellings (registry id and git URL) — see panel-pin-guard.
+        assertPanelNotTargetedUnverifiable("panel_install_node", args.id);
+        assertPanelNotTargetedUnverifiable("panel_install_node", args.repository);
+        return ctx.call(
           { cmd: "nodes_install", id: args.id, repository: args.repository, version: args.version, channel: args.channel, mode: args.mode },
           30000,
-        ),
+        );
+      },
     ),
     def(
       "panel_update_node",
@@ -4841,11 +4848,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         channel: z.string().optional().describe("Manager channel (default 'default')."),
         mode: z.enum(["remote", "local", "cache"]).optional().describe("DB source (default 'remote')."),
       },
-      async (args: A, ctx) =>
-        ctx.call(
+      async (args: A, ctx) => {
+        assertPanelNotTargetedUnverifiable("panel_update_node", args.id);
+        return ctx.call(
           { cmd: "graph_update_node", id: args.id, version: args.version, channel: args.channel, mode: args.mode },
           30000,
-        ),
+        );
+      },
     ),
     def(
       "panel_node_queue_status",

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -21,6 +21,8 @@ import {
   listInstalledNodes,
   type InstalledNode,
 } from "./node-management.js";
+import { targetsPanelPackExactly } from "./panel-pin-guard.js";
+import { panelStatusAt, type PanelStatus } from "./panel-installer.js";
 import {
   downloadModel,
   listLocalModels,
@@ -616,6 +618,27 @@ async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
   }
 }
 
+/**
+ * The panel is a web extension, so a Manager-installed-list entry alone proves
+ * neither which version the browser will serve nor that a dot-prefixed .bak
+ * copy is not winning registration. Only a fresh on-disk status with a readable
+ * version and a clean, completed shadow scan is safe to report as applied.
+ */
+function panelServeVerificationFailure(status: PanelStatus): string | undefined {
+  if (!status.applicable) {
+    return "the target local ComfyUI root could not be inspected";
+  }
+  if (!status.installed) return "the panel is not present on disk";
+  if (!status.installedVersion) return "the panel version could not be read from disk";
+  if (status.shadowInspectFailed) {
+    return "custom_nodes could not be inspected for .bak shadow copies";
+  }
+  if (status.shadows.length > 0) {
+    return `a served shadow copy exists (${status.shadows.map((shadow) => shadow.name).join(", ")})`;
+  }
+  return undefined;
+}
+
 export async function applyManifest(
   opts: ApplyManifestOptions,
 ): Promise<ApplyManifestResult> {
@@ -754,7 +777,55 @@ async function applyManifestSections(
   const installedNodes = initialList === BUDGET_TIMEOUT ? [] : initialList;
   if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
-    if (nodeAlreadyInstalled(id, installedNodes)) {
+    const isPanelTarget = targetsPanelPackExactly(id);
+    if (isPanelTarget && !hasLocalFs) {
+      // A remote Manager list cannot establish what the browser serves, and
+      // this process cannot inspect the remote custom_nodes for #641 shadows.
+      // Do not start a mutation we could only report from an unverified queue.
+      results.push(
+        report(
+          "custom_node",
+          id,
+          "failed",
+          "Cannot verify the sidebar panel through apply_manifest against a remote/cloud ComfyUI. " +
+            "Install it on the ComfyUI host with install_panel, which re-reads the served panel version and checks for .bak shadow copies.",
+        ),
+      );
+      continue;
+    }
+
+    let prePanelStatus: PanelStatus | undefined;
+    if (isPanelTarget) {
+      // Use `comfyuiPath`, not config.comfyuiPath: this call may have adopted a
+      // saved/default/live root specifically for the manifest.
+      prePanelStatus = await panelStatusAt(comfyuiPath!);
+      const preFailure = panelServeVerificationFailure(prePanelStatus);
+      if (!preFailure) {
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "skipped",
+            `Sidebar panel is already served from the target install (verified ${prePanelStatus.installedVersion}; no shadow copies).`,
+          ),
+        );
+        continue;
+      }
+      // A present/uninspectable panel must not be fed back through Manager: that
+      // can be a stale queue no-op or a duplicate beneath a served backup. Only
+      // a confirmed-missing panel is safe to ask Manager to install.
+      if (prePanelStatus.installed || prePanelStatus.shadowInspectFailed || prePanelStatus.shadows.length) {
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "failed",
+            `Cannot safely apply the sidebar panel: ${preFailure}. NOT trusting the ComfyUI-Manager installed list; fix the local panel/shadow state, then retry.`,
+          ),
+        );
+        continue;
+      }
+    } else if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
     }
@@ -802,6 +873,36 @@ async function applyManifestSections(
     // reboot) and confirm the node is actually present before reporting success.
     // Budget-bounded too: if the confirm can't complete in time we report pending
     // (conservative — the install itself already settled) rather than overrun.
+    if (isPanelTarget) {
+      const served = await raceDeadline(panelStatusAt(comfyuiPath!), nodeDeadline);
+      if (served === BUDGET_TIMEOUT) {
+        nodeBudgetSpent = true;
+        results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
+        continue;
+      }
+      const servedFailure = panelServeVerificationFailure(served);
+      if (servedFailure) {
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "failed",
+            `Panel Manager request settled, but the served panel could not be verified: ${servedFailure}. NOT reporting success.`,
+          ),
+        );
+      } else {
+        results.push(
+          report(
+            "custom_node",
+            id,
+            "applied",
+            `${outcome.res.message} Verified served panel ${served.installedVersion}; no shadow copies.`,
+          ),
+        );
+      }
+      continue;
+    }
+
     const verified = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
     if (verified === BUDGET_TIMEOUT) {
       nodeBudgetSpent = true;

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -22,7 +22,6 @@ import {
   type InstalledNode,
 } from "./node-management.js";
 import { targetsPanelPackExactly } from "./panel-pin-guard.js";
-import { panelStatusAt, type PanelStatus } from "./panel-installer.js";
 import {
   downloadModel,
   listLocalModels,
@@ -618,27 +617,6 @@ async function installedNodesOrEmpty(): Promise<InstalledNode[]> {
   }
 }
 
-/**
- * The panel is a web extension, so a Manager-installed-list entry alone proves
- * neither which version the browser will serve nor that a dot-prefixed .bak
- * copy is not winning registration. Only a fresh on-disk status with a readable
- * version and a clean, completed shadow scan is safe to report as applied.
- */
-function panelServeVerificationFailure(status: PanelStatus): string | undefined {
-  if (!status.applicable) {
-    return "the target local ComfyUI root could not be inspected";
-  }
-  if (!status.installed) return "the panel is not present on disk";
-  if (!status.installedVersion) return "the panel version could not be read from disk";
-  if (status.shadowInspectFailed) {
-    return "custom_nodes could not be inspected for .bak shadow copies";
-  }
-  if (status.shadows.length > 0) {
-    return `a served shadow copy exists (${status.shadows.map((shadow) => shadow.name).join(", ")})`;
-  }
-  return undefined;
-}
-
 export async function applyManifest(
   opts: ApplyManifestOptions,
 ): Promise<ApplyManifestResult> {
@@ -778,54 +756,25 @@ async function applyManifestSections(
   if (initialList === BUDGET_TIMEOUT) nodeBudgetSpent = true;
   for (const id of manifest.custom_nodes) {
     const isPanelTarget = targetsPanelPackExactly(id);
-    if (isPanelTarget && !hasLocalFs) {
-      // A remote Manager list cannot establish what the browser serves, and
-      // this process cannot inspect the remote custom_nodes for #641 shadows.
-      // Do not start a mutation we could only report from an unverified queue.
+    if (isPanelTarget) {
+      // `apply_manifest` has a Manager target but no authoritative association
+      // between that target and a local served-panel root. In particular,
+      // config.comfyuiPath may name loopback instance A while Manager targets B.
+      // Refuse rather than pre/post-scan A around a mutation of B, or report a
+      // Manager-installed-list entry as browser-visible success.
       results.push(
         report(
           "custom_node",
           id,
           "failed",
-          "Cannot verify the sidebar panel through apply_manifest against a remote/cloud ComfyUI. " +
-            "Install it on the ComfyUI host with install_panel, which re-reads the served panel version and checks for .bak shadow copies.",
+          "apply_manifest does not manage the sidebar panel because it cannot prove that its " +
+            "ComfyUI-Manager target and local served-panel filesystem are the same instance. " +
+            "Use install_panel on the selected ComfyUI host, which verifies the served version and .bak shadows.",
         ),
       );
       continue;
     }
-
-    let prePanelStatus: PanelStatus | undefined;
-    if (isPanelTarget) {
-      // Use `comfyuiPath`, not config.comfyuiPath: this call may have adopted a
-      // saved/default/live root specifically for the manifest.
-      prePanelStatus = await panelStatusAt(comfyuiPath!);
-      const preFailure = panelServeVerificationFailure(prePanelStatus);
-      if (!preFailure) {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "skipped",
-            `Sidebar panel is already served from the target install (verified ${prePanelStatus.installedVersion}; no shadow copies).`,
-          ),
-        );
-        continue;
-      }
-      // A present/uninspectable panel must not be fed back through Manager: that
-      // can be a stale queue no-op or a duplicate beneath a served backup. Only
-      // a confirmed-missing panel is safe to ask Manager to install.
-      if (prePanelStatus.installed || prePanelStatus.shadowInspectFailed || prePanelStatus.shadows.length) {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "failed",
-            `Cannot safely apply the sidebar panel: ${preFailure}. NOT trusting the ComfyUI-Manager installed list; fix the local panel/shadow state, then retry.`,
-          ),
-        );
-        continue;
-      }
-    } else if (nodeAlreadyInstalled(id, installedNodes)) {
+    if (nodeAlreadyInstalled(id, installedNodes)) {
       results.push(report("custom_node", id, "skipped", "Custom node is already installed."));
       continue;
     }
@@ -873,36 +822,6 @@ async function applyManifestSections(
     // reboot) and confirm the node is actually present before reporting success.
     // Budget-bounded too: if the confirm can't complete in time we report pending
     // (conservative — the install itself already settled) rather than overrun.
-    if (isPanelTarget) {
-      const served = await raceDeadline(panelStatusAt(comfyuiPath!), nodeDeadline);
-      if (served === BUDGET_TIMEOUT) {
-        nodeBudgetSpent = true;
-        results.push(report("custom_node", id, "pending", pendingBudgetMessage(true)));
-        continue;
-      }
-      const servedFailure = panelServeVerificationFailure(served);
-      if (servedFailure) {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "failed",
-            `Panel Manager request settled, but the served panel could not be verified: ${servedFailure}. NOT reporting success.`,
-          ),
-        );
-      } else {
-        results.push(
-          report(
-            "custom_node",
-            id,
-            "applied",
-            `${outcome.res.message} Verified served panel ${served.installedVersion}; no shadow copies.`,
-          ),
-        );
-      }
-      continue;
-    }
-
     const verified = await raceDeadline(installedNodesOrEmpty(), nodeDeadline);
     if (verified === BUDGET_TIMEOUT) {
       nodeBudgetSpent = true;

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -20,7 +20,7 @@ import {
 export type { ManagerApi } from "./manager-api-cache.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
-import { assertPanelPinAllows } from "./panel-pin-guard.js";
+import { withPanelPinGuard } from "./panel-pin-guard.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -1625,9 +1625,11 @@ export async function installCustomNode(opts: InstallOptions): Promise<NodeOpRes
   // PIN GUARD (see panel-pin-guard.ts). The panel is an ordinary node pack, so
   // these generic mutations are a second door into the same ComfyUI-Manager
   // operation that install_panel drives. Guarding here — where the TARGET is
-  // known — covers every caller, including a bulk "all".
-  assertPanelPinAllows("install", opts.id);
-  return withObjectInfoInvalidation(() => installCustomNodeImpl(opts));
+  // known — covers every caller, including a bulk "all". The check and the
+  // mutation are atomic under the panel mutation lock (withPanelPinGuard).
+  return withPanelPinGuard("install", opts.id, () =>
+    withObjectInfoInvalidation(() => installCustomNodeImpl(opts)),
+  );
 }
 
 async function installCustomNodeImpl(
@@ -1939,9 +1941,13 @@ async function enqueueUpdateAll(
 
 export async function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
   // PIN GUARD — covers id="comfyui-agent-panel", the repo-name and git-URL
-  // spellings, and id="all" (a bulk update moves the panel too).
-  assertPanelPinAllows("update", opts.id);
-  return withObjectInfoInvalidation(() => updateCustomNodeImpl(opts));
+  // spellings, and id="all" (a bulk update moves the panel too). The check and
+  // the mutation are atomic under the panel mutation lock: update_all waits on
+  // the Manager queue, and a pin written in that window must block the NEXT
+  // op, not land inside this one (withPanelPinGuard).
+  return withPanelPinGuard("update", opts.id, () =>
+    withObjectInfoInvalidation(() => updateCustomNodeImpl(opts)),
+  );
 }
 
 async function updateCustomNodeImpl(
@@ -2048,8 +2054,11 @@ export interface ReinstallOptions {
 }
 
 export async function reinstallCustomNode(opts: ReinstallOptions): Promise<NodeOpResult> {
-  assertPanelPinAllows("reinstall", opts.id); // PIN GUARD
-  return withObjectInfoInvalidation(() => reinstallCustomNodeImpl(opts));
+  // PIN GUARD — same door as install/update, and check + mutation are likewise
+  // atomic under the panel mutation lock (withPanelPinGuard).
+  return withPanelPinGuard("reinstall", opts.id, () =>
+    withObjectInfoInvalidation(() => reinstallCustomNodeImpl(opts)),
+  );
 }
 
 async function reinstallCustomNodeImpl(
@@ -2102,9 +2111,10 @@ export interface FixOptions {
 
 export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
   // `fix` reinstalls the pack's dependencies and can pull the pack itself, and
-  // it accepts "all" — same door, same guard.
-  assertPanelPinAllows("fix", opts.id);
-  return withObjectInfoInvalidation(() => fixCustomNodeImpl(opts));
+  // it accepts "all" — same door, same guard, same lock (withPanelPinGuard).
+  return withPanelPinGuard("fix", opts.id, () =>
+    withObjectInfoInvalidation(() => fixCustomNodeImpl(opts)),
+  );
 }
 
 async function fixCustomNodeImpl(opts: FixOptions): Promise<NodeOpResult> {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1970,7 +1970,7 @@ async function updateCustomNodeImpl(
   return {
     mechanism: "manager-http",
     message: all
-      ? "Queued + updated all installed node packs via ComfyUI-Manager."
+      ? "Queued update_all with ComfyUI-Manager. Completion and the sidebar panel's on-disk version are not verified yet."
       : `Queued + updated "${id}" via ComfyUI-Manager.`,
     details: status,
   };

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -20,6 +20,7 @@ import {
 export type { ManagerApi } from "./manager-api-cache.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
+import { assertPanelPinAllows } from "./panel-pin-guard.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -1615,7 +1616,17 @@ async function withObjectInfoInvalidation<T>(op: () => Promise<T>): Promise<T> {
   return result;
 }
 
-export function installCustomNode(opts: InstallOptions): Promise<NodeOpResult> {
+// NOTE on `async`: these wrappers are declared async purely so the PIN GUARD's
+// throw surfaces as a REJECTED PROMISE rather than a synchronous exception.
+// Callers rely on that — apply_manifest does `installCustomNode(...).then().catch()`
+// and documents that it never rejects, which a sync throw would walk straight past.
+
+export async function installCustomNode(opts: InstallOptions): Promise<NodeOpResult> {
+  // PIN GUARD (see panel-pin-guard.ts). The panel is an ordinary node pack, so
+  // these generic mutations are a second door into the same ComfyUI-Manager
+  // operation that install_panel drives. Guarding here — where the TARGET is
+  // known — covers every caller, including a bulk "all".
+  assertPanelPinAllows("install", opts.id);
   return withObjectInfoInvalidation(() => installCustomNodeImpl(opts));
 }
 
@@ -1926,7 +1937,10 @@ async function enqueueUpdateAll(
   return { used, response };
 }
 
-export function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
+export async function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
+  // PIN GUARD — covers id="comfyui-agent-panel", the repo-name and git-URL
+  // spellings, and id="all" (a bulk update moves the panel too).
+  assertPanelPinAllows("update", opts.id);
   return withObjectInfoInvalidation(() => updateCustomNodeImpl(opts));
 }
 
@@ -2033,7 +2047,8 @@ export interface ReinstallOptions {
   useCmCli?: boolean;
 }
 
-export function reinstallCustomNode(opts: ReinstallOptions): Promise<NodeOpResult> {
+export async function reinstallCustomNode(opts: ReinstallOptions): Promise<NodeOpResult> {
+  assertPanelPinAllows("reinstall", opts.id); // PIN GUARD
   return withObjectInfoInvalidation(() => reinstallCustomNodeImpl(opts));
 }
 
@@ -2085,7 +2100,10 @@ export interface FixOptions {
   useCmCli?: boolean;
 }
 
-export function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
+export async function fixCustomNode(opts: FixOptions): Promise<NodeOpResult> {
+  // `fix` reinstalls the pack's dependencies and can pull the pack itself, and
+  // it accepts "all" — same door, same guard.
+  assertPanelPinAllows("fix", opts.id);
   return withObjectInfoInvalidation(() => fixCustomNodeImpl(opts));
 }
 

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { withPanelPinGuard } from "./panel-pin-guard.js";
 import { NodeSnapshotError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -298,30 +299,40 @@ export async function restoreNodeSnapshot(
     throw new NodeSnapshotError("Snapshot name is required to restore.");
   }
 
-  // The Manager stores names without the .json suffix; tolerate either.
-  const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
+  // PIN GUARD. A snapshot records every pack's commit and restoring reverts them
+  // ALL, so this moves the sidebar panel exactly like an "update all" would —
+  // another door that never passes through install_panel. It is inherently bulk
+  // (there is no restore-everything-except-one-pack), so a pin refuses it
+  // outright and the message explains the two real options. The check and the
+  // restore request are atomic under the panel mutation lock (withPanelPinGuard);
+  // the Manager then applies the restore on its own schedule (the message below
+  // says "requested", never "restored").
+  return withPanelPinGuard("restore a node snapshot over", "all", async () => {
+    // The Manager stores names without the .json suffix; tolerate either.
+    const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
 
-  try {
-    await managerFetch("/snapshot/restore", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ target }),
-    });
-  } catch (err) {
-    if (isSnapshotEndpointUnsupported(err)) {
-      logger.info("Snapshot restore unsupported on this ComfyUI-Manager build");
-      return { name: target, message: SNAPSHOTS_UNSUPPORTED_MESSAGE, unsupported: true };
+    try {
+      await managerFetch("/snapshot/restore", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ target }),
+      });
+    } catch (err) {
+      if (isSnapshotEndpointUnsupported(err)) {
+        logger.info("Snapshot restore unsupported on this ComfyUI-Manager build");
+        return { name: target, message: SNAPSHOTS_UNSUPPORTED_MESSAGE, unsupported: true };
+      }
+      throw err;
     }
-    throw err;
-  }
 
-  logger.info(`Requested restore of node snapshot "${target}"`);
-  return {
-    name: target,
-    message:
-      `Restore of snapshot "${target}" requested. ComfyUI-Manager applies ` +
-      `custom-node changes on the next ComfyUI restart.`,
-  };
+    logger.info(`Requested restore of node snapshot "${target}"`);
+    return {
+      name: target,
+      message:
+        `Restore of snapshot "${target}" requested. ComfyUI-Manager applies ` +
+        `custom-node changes on the next ComfyUI restart.`,
+    };
+  });
 }
 
 /**

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -315,6 +315,20 @@ export async function restoreNodeSnapshot(
     // The Manager stores names without the .json suffix; tolerate either.
     const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
 
+    // Persist and VERIFY the warning marker BEFORE requesting the deferred
+    // restore. A pin written after Manager receives the request cannot stop the
+    // next-restart apply; refusing when the marker cannot be made durable is the
+    // only way to avoid reporting such a pin as protective. Keep the marker on a
+    // request failure because a transport error cannot prove Manager did not
+    // receive it.
+    recordPanelPendingOp(
+      "snapshot-restore",
+      `a snapshot restore ("${target}") may have been requested and reverts EVERY pack to ` +
+        `its snapshot commit — the sidebar panel included — at the next ComfyUI ` +
+        `restart`,
+      SNAPSHOT_RESTORE_PENDING_MS,
+    );
+
     try {
       await managerFetch("/snapshot/restore", {
         method: "POST",
@@ -330,19 +344,6 @@ export async function restoreNodeSnapshot(
     }
 
     logger.info(`Requested restore of node snapshot "${target}"`);
-
-    // The Manager applies the restore at the NEXT ComfyUI restart — out of
-    // band, after the lock is gone — so a pin written before that restart
-    // cannot stop it. Record a pending-op marker: a pin write while it is
-    // active gets WARNED that this restore may still land (see
-    // panel-pin-guard.ts).
-    recordPanelPendingOp(
-      "snapshot-restore",
-      `a snapshot restore ("${target}") was requested and reverts EVERY pack to ` +
-        `its snapshot commit — the sidebar panel included — at the next ComfyUI ` +
-        `restart`,
-      SNAPSHOT_RESTORE_PENDING_MS,
-    );
 
     return {
       name: target,

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -2,7 +2,11 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
-import { withPanelPinGuard } from "./panel-pin-guard.js";
+import {
+  recordPanelPendingOp,
+  SNAPSHOT_RESTORE_PENDING_MS,
+  withPanelPinGuard,
+} from "./panel-pin-guard.js";
 import { NodeSnapshotError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -326,6 +330,20 @@ export async function restoreNodeSnapshot(
     }
 
     logger.info(`Requested restore of node snapshot "${target}"`);
+
+    // The Manager applies the restore at the NEXT ComfyUI restart — out of
+    // band, after the lock is gone — so a pin written before that restart
+    // cannot stop it. Record a pending-op marker: a pin write while it is
+    // active gets WARNED that this restore may still land (see
+    // panel-pin-guard.ts).
+    recordPanelPendingOp(
+      "snapshot-restore",
+      `a snapshot restore ("${target}") was requested and reverts EVERY pack to ` +
+        `its snapshot commit — the sidebar panel included — at the next ComfyUI ` +
+        `restart`,
+      SNAPSHOT_RESTORE_PENDING_MS,
+    );
+
     return {
       name: target,
       message:

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -36,6 +36,12 @@ import {
   type NodeOpResult,
 } from "./node-management.js";
 import { getSystemStats } from "../comfyui/client.js";
+import {
+  describePanelPin,
+  getPanelPinState,
+  PANEL_PIN_ENV_VAR,
+  type PanelPinState,
+} from "./panel-settings.js";
 
 /** Comfy Registry id (also pyproject [project].name). Authoritative for detection. */
 export const PANEL_REGISTRY_ID = "comfyui-agent-panel";
@@ -112,6 +118,13 @@ export interface PanelInstallerDeps {
    * pyproject version string. Never throws.
    */
   gitRevision: (dir: string) => string | undefined;
+  /**
+   * The user's explicit panel-version pin, if any. While a pin is in force NO
+   * code path here may move the panel — install/update/reinstall refuse and the
+   * on-load ensure skips. Never throws (an unreadable pin reports
+   * `indeterminate`, which counts as pinned).
+   */
+  readPin: () => PanelPinState;
   /** Is the target ComfyUI reachable right now? Never throws. */
   isReachable: () => Promise<boolean>;
   install: (opts: { id: string; version?: string }) => Promise<NodeOpResult>;
@@ -236,6 +249,7 @@ export const defaultDeps: PanelInstallerDeps = {
   readdir: (p) => readdirSync(p),
   readFile: (p) => readFileSync(p, "utf-8"),
   gitRevision: (dir) => resolveGitRevision(dir),
+  readPin: () => getPanelPinState(),
   isReachable: async () => {
     try {
       await getSystemStats();
@@ -248,6 +262,48 @@ export const defaultDeps: PanelInstallerDeps = {
   update: (opts) => updateCustomNode(opts),
   reinstall: (opts) => reinstallCustomNode(opts),
 };
+
+// ---------------------------------------------------------------------------
+// Version pin
+//
+// A pin is the user's explicit "hold the panel here". Every mutating path in
+// this file consults it FIRST and refuses while it is in force — the on-load
+// ensure, install, update and reinstall alike. The escape hatch is to clear the
+// pin (install_panel(action='unpin'), or COMFYUI_MCP_PANEL_PIN=off), never for
+// us to decide the pin was probably fine to ignore.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the pin so that NO failure mode reads as "unpinned". A reader that throws
+ * is reported as an indeterminate pin, which counts as pinned: silently moving a
+ * user off a pin we merely failed to read is the exact bug this guards.
+ */
+function readPinSafe(deps: PanelInstallerDeps): PanelPinState {
+  try {
+    return deps.readPin();
+  } catch (err) {
+    logger.warn(
+      `[panel] could not read the panel version pin: ${
+        err instanceof Error ? err.message : String(err)
+      } — treating the panel as PINNED (refusing to move it).`,
+    );
+    return { pinned: true, source: "settings", indeterminate: true };
+  }
+}
+
+/** The refusal a pin produces for a mutating action, with the way out. */
+function pinRefusalMessage(action: string, pin: PanelPinState): string {
+  return (
+    `Refusing to ${action} the panel: it is ${describePanelPin(pin)}. ` +
+    `A pin is honoured even when a newer panel exists — clear it first with ` +
+    `install_panel(action='unpin')` +
+    (pin.source === "env"
+      ? ` (this pin comes from the ${PANEL_PIN_ENV_VAR} environment variable, so ` +
+        `it must be unset/changed in the environment — unpin cannot remove it)`
+      : ``) +
+    `, then re-run the ${action}.`
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Detection
@@ -720,6 +776,16 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
     return { action: "unavailable", reason: "ComfyUI is not reachable." };
   }
 
+  // An explicit pin outranks auto-install: installing the `nightly` channel over
+  // a pinned version is exactly the silent move the pin forbids. Skip and say so.
+  const pin = readPinSafe(deps);
+  if (pin.pinned) {
+    return {
+      action: "skipped",
+      reason: `panel version pin in force — ${describePanelPin(pin)}`,
+    };
+  }
+
   const detection = await detectPanelInstall(deps);
 
   if (detection.isDevSymlink) {
@@ -841,6 +907,11 @@ export interface PanelStatus {
    * non-empty, the SERVED panel may not match `installedVersion` on disk.
    */
   shadows: PanelShadow[];
+  /**
+   * The user's explicit version pin. While `pin.pinned` is true, install/update/
+   * reinstall refuse and the on-load ensure skips — see the pin guard above.
+   */
+  pin: PanelPinState;
   note: string;
 }
 
@@ -889,6 +960,13 @@ export async function panelStatus(
     }. Run install_panel(action='update') to pull the latest ${PANEL_VERSION}. Restart ComfyUI after updating.`;
   }
 
+  const pin = readPinSafe(deps);
+  const pinNote = pin.pinned
+    ? ` PIN: ${describePanelPin(pin)} — install/update/reinstall are refused ` +
+      `until it is cleared with install_panel(action='unpin')` +
+      (pin.source === "env" ? ` (env pins must be unset in the environment).` : `.`)
+    : "";
+
   return {
     applicable: detection.applicable,
     installed: detection.installed,
@@ -897,7 +975,8 @@ export async function panelStatus(
     isDevSymlink: detection.isDevSymlink,
     targetVersion: PANEL_VERSION,
     shadows,
-    note: note + shadowNote,
+    pin,
+    note: note + shadowNote + pinNote,
   };
 }
 
@@ -1114,6 +1193,15 @@ export async function runPanelAction(
       `Panel ${action} is local-only and requires a local ComfyUI install. ` +
         `Set COMFYUI_PATH (this is a no-op in remote/cloud mode).`,
     );
+  }
+
+  // PIN GUARD — before any Manager mutation is queued. This is the single choke
+  // point that makes "we never move a pinned user" true for every caller (the
+  // sync skill, the panel, a hand-written install_panel call), not just the ones
+  // that remembered to check.
+  const pin = readPinSafe(deps);
+  if (pin.pinned) {
+    throw new PanelInstallError(pinRefusalMessage(action, pin));
   }
 
   const detection = await detectPanelInstall(deps);

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -1270,7 +1270,7 @@ export function runPanelAction(
   return withPanelOpLock(() => runPanelActionInner(action, deps, opts));
 }
 
-async function runPanelActionInner(
+export async function runPanelActionInner(
   action: "install" | "update" | "reinstall",
   deps: PanelInstallerDeps,
   opts: PanelActionOptions = {},

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -984,6 +984,13 @@ export interface PanelStatus {
    * reinstall refuse and the on-load ensure skips — see the pin guard above.
    */
   pin: PanelPinState;
+  /**
+   * #639 — the custom_nodes enumeration itself FAILED, so `installed: false` is
+   * unreliable: a pre-existing panel may have been missed, and installing blind
+   * risks a duplicate (or clobbering a NEWER one). Consumers must not treat an
+   * unreliable "absent" as an install invitation.
+   */
+  scanReliable?: boolean;
   note: string;
 }
 
@@ -1048,6 +1055,7 @@ export async function panelStatus(
     targetVersion: PANEL_VERSION,
     shadows,
     shadowInspectFailed,
+    scanReliable: detection.scanReliable,
     pin,
     note: note + shadowNote + pinNote,
   };

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -42,6 +42,7 @@ import {
   PANEL_PIN_ENV_VAR,
   type PanelPinState,
 } from "./panel-settings.js";
+import { withPanelMutationLock } from "./panel-pin-guard.js";
 
 /** Comfy Registry id (also pyproject [project].name). Authoritative for detection. */
 export const PANEL_REGISTRY_ID = "comfyui-agent-panel";
@@ -59,6 +60,11 @@ const FAST_PATH_DIRS = ["comfyui-mcp-panel", "comfyui-agent-panel"];
 
 /** Hard cap so the on-load ensure can never block startup. */
 const ENSURE_TIMEOUT_MS = 20_000;
+
+/** How long the fire-and-forget on-load ensure will wait for the panel op lock
+ *  before giving up (well inside ENSURE_TIMEOUT_MS, so a lock held by another
+ *  orchestrator process degrades to `unavailable` rather than a timeout). */
+const ENSURE_LOCK_WAIT_MS = 3_000;
 
 export class PanelInstallError extends Error {
   constructor(message: string) {
@@ -291,35 +297,34 @@ function readPinSafe(deps: PanelInstallerDeps): PanelPinState {
   }
 }
 
-/**
- * Serializes every panel MUTATION in this process (the on-load ensure and each
+/*
+ * Serializes every panel MUTATION (the on-load ensure and each
  * install/update/reinstall). Two overlapping panel ops would each read the
  * other's half-applied disk state, and the #639 "did it move?" proof compares a
  * pre-image against a post-image — interleave them and both comparisons are
  * meaningless. One at a time makes each op's before/after its own.
  *
- * It also bounds the pin race: the final pin check (assertNotPinned, immediately
+ * It also closes the pin race: the final pin check (assertNotPinned, immediately
  * before the Manager call) and the call itself sit inside this critical section,
- * so a pin cannot be written by a concurrent op in between.
+ * so a pin cannot be written in between — by this process OR another one.
  */
-let panelOpChain: Promise<unknown> = Promise.resolve();
-
 /**
  * Exported so PIN WRITES take the same lock. Without that, a pin could be
  * committed after an in-flight update passed its final pin check but before the
- * Manager actually touched disk — the update would then land on a
- * now-pinned install and report success. Serializing both means a pin either
- * lands before an op starts (and blocks it) or after it finishes (and blocks the
- * next one); it never slices one in half.
+ * Manager actually touched disk — the update would then land on a now-pinned
+ * install and report success. Serializing both means a pin either lands before
+ * an op starts (and blocks it) or after it finishes (and blocks the next one);
+ * it never slices one in half.
+ *
+ * The underlying lock is a FILE, not module state: running more than one
+ * orchestrator process (one per MCP client) is ordinary here, and two processes
+ * do not share a promise chain. See panel-pin-guard.ts.
  */
-export function withPanelOpLock<T>(fn: () => Promise<T>): Promise<T> {
-  // Chain off settled-or-rejected so one failed op never wedges the queue.
-  const run = panelOpChain.then(fn, fn);
-  panelOpChain = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  return run;
+export function withPanelOpLock<T>(
+  fn: () => Promise<T>,
+  opts: { timeoutMs?: number } = {},
+): Promise<T> {
+  return withPanelMutationLock(fn, opts);
 }
 
 /** The refusal a pin produces for a mutating action, with the way out. */
@@ -930,9 +935,12 @@ export async function ensurePanelInstalled(
   const deps = opts.deps ?? defaultDeps;
   try {
     // Serialized with the explicit actions: the on-load ensure must not race an
-    // install_panel call the user fired at the same moment.
+    // install_panel call the user fired at the same moment. Its lock wait is
+    // SHORT — this is fire-and-forget at startup, so if another process holds
+    // the lock we give up quickly (returning `unavailable`) rather than eating
+    // the whole ensure budget waiting.
     return await withTimeout(
-      withPanelOpLock(() => ensureInner(deps)),
+      withPanelOpLock(() => ensureInner(deps), { timeoutMs: ENSURE_LOCK_WAIT_MS }),
       opts.timeoutMs ?? ENSURE_TIMEOUT_MS,
     );
   } catch (err) {

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -1053,6 +1053,24 @@ export async function panelStatus(
   };
 }
 
+/**
+ * Read the panel status for a caller-selected LOCAL ComfyUI root.
+ *
+ * `apply_manifest` may adopt a saved/default/live root for one call while
+ * `config.comfyuiPath` remains unset. Verifying through the ordinary default
+ * status in that case would inspect no directory (or a different one) and turn
+ * a Manager queue result into fabricated panel success. This narrow adapter
+ * keeps the status scan — including #641's served-shadow check — on the same
+ * root the manifest install targeted without mutating process-global config.
+ */
+export function panelStatusAt(comfyuiPath: string): Promise<PanelStatus> {
+  return panelStatus({
+    ...defaultDeps,
+    isLocalMode: () => true,
+    comfyuiPath: () => comfyuiPath,
+  });
+}
+
 export interface PanelActionResult {
   action: "install" | "update" | "reinstall";
   result: NodeOpResult;

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -964,6 +964,14 @@ export interface PanelStatus {
    */
   shadows: PanelShadow[];
   /**
+   * #641 — the shadow scan could NOT be completed (custom_nodes was not
+   * enumerable). `shadows: []` then means "we did not find any" rather than
+   * "there are none", so callers must not read the empty array as an all-clear.
+   * Structural, not just prose in `note`: a consumer branching on
+   * `shadows.length` would otherwise treat an indeterminate scan as safe.
+   */
+  shadowInspectFailed?: boolean;
+  /**
    * The user's explicit version pin. While `pin.pinned` is true, install/update/
    * reinstall refuse and the on-load ensure skips — see the pin guard above.
    */
@@ -1031,6 +1039,7 @@ export async function panelStatus(
     isDevSymlink: detection.isDevSymlink,
     targetVersion: PANEL_VERSION,
     shadows,
+    shadowInspectFailed,
     pin,
     note: note + shadowNote + pinNote,
   };

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -1242,22 +1242,40 @@ function finalizeUpdate(
   );
 }
 
+export interface PanelActionOptions {
+  /**
+   * Target version for install/reinstall, defaulting to the `nightly` channel.
+   *
+   * Exists so a caller that asked for a SPECIFIC version — e.g.
+   * `install_custom_node(id="comfyui-agent-panel", version="0.11.20")`, which is
+   * redirected here to get the verified path — actually gets the version it
+   * asked for. Redirecting and silently substituting `nightly` would do
+   * something other than what the caller requested while reporting success.
+   * (`update` has no version to honour; it always pulls the channel tip.)
+   */
+  version?: string;
+}
+
 /**
  * install/update/reinstall the panel. LOCAL-only and refuses dev symlinks.
- * Targets version "nightly". Caller must RESTART ComfyUI to load the change.
+ * Targets the "nightly" channel unless a version is given. Caller must RESTART
+ * ComfyUI to load the change.
  */
 export function runPanelAction(
   action: "install" | "update" | "reinstall",
   deps: PanelInstallerDeps = defaultDeps,
+  opts: PanelActionOptions = {},
 ): Promise<PanelActionResult> {
   // Serialized: never let two panel mutations interleave (see withPanelOpLock).
-  return withPanelOpLock(() => runPanelActionInner(action, deps));
+  return withPanelOpLock(() => runPanelActionInner(action, deps, opts));
 }
 
 async function runPanelActionInner(
   action: "install" | "update" | "reinstall",
   deps: PanelInstallerDeps,
+  opts: PanelActionOptions = {},
 ): Promise<PanelActionResult> {
+  const targetVersion = opts.version?.trim() || PANEL_VERSION;
   // P1b — truly LOCAL-only. Refuse in remote/cloud mode even when COMFYUI_PATH
   // is set: installCustomNode/reinstallCustomNode would queue Manager mutations
   // against the REMOTE host while our symlink guard inspected the LOCAL disk —
@@ -1337,8 +1355,8 @@ async function runPanelActionInner(
   assertNotPinned(action, deps);
   const result =
     action === "install"
-      ? await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION })
-      : await deps.reinstall({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
+      ? await deps.install({ id: PANEL_REGISTRY_ID, version: targetVersion })
+      : await deps.reinstall({ id: PANEL_REGISTRY_ID, version: targetVersion });
 
   // #639 — VERIFY the pack afterward. installCustomNode verifies presence
   // downstream (#232), but reinstallCustomNode does NOT — it returns as soon as

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -304,7 +304,15 @@ function readPinSafe(deps: PanelInstallerDeps): PanelPinState {
  */
 let panelOpChain: Promise<unknown> = Promise.resolve();
 
-function withPanelOpLock<T>(fn: () => Promise<T>): Promise<T> {
+/**
+ * Exported so PIN WRITES take the same lock. Without that, a pin could be
+ * committed after an in-flight update passed its final pin check but before the
+ * Manager actually touched disk — the update would then land on a
+ * now-pinned install and report success. Serializing both means a pin either
+ * lands before an op starts (and blocks it) or after it finishes (and blocks the
+ * next one); it never slices one in half.
+ */
+export function withPanelOpLock<T>(fn: () => Promise<T>): Promise<T> {
   // Chain off settled-or-rejected so one failed op never wedges the queue.
   const run = panelOpChain.then(fn, fn);
   panelOpChain = run.then(

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -291,6 +291,29 @@ function readPinSafe(deps: PanelInstallerDeps): PanelPinState {
   }
 }
 
+/**
+ * Serializes every panel MUTATION in this process (the on-load ensure and each
+ * install/update/reinstall). Two overlapping panel ops would each read the
+ * other's half-applied disk state, and the #639 "did it move?" proof compares a
+ * pre-image against a post-image — interleave them and both comparisons are
+ * meaningless. One at a time makes each op's before/after its own.
+ *
+ * It also bounds the pin race: the final pin check (assertNotPinned, immediately
+ * before the Manager call) and the call itself sit inside this critical section,
+ * so a pin cannot be written by a concurrent op in between.
+ */
+let panelOpChain: Promise<unknown> = Promise.resolve();
+
+function withPanelOpLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Chain off settled-or-rejected so one failed op never wedges the queue.
+  const run = panelOpChain.then(fn, fn);
+  panelOpChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
 /** The refusal a pin produces for a mutating action, with the way out. */
 function pinRefusalMessage(action: string, pin: PanelPinState): string {
   return (
@@ -303,6 +326,17 @@ function pinRefusalMessage(action: string, pin: PanelPinState): string {
       : ``) +
     `, then re-run the ${action}.`
   );
+}
+
+/**
+ * Throw if a pin is in force. Called BOTH on entry (fail fast with a good
+ * message before any work) and again immediately before the ComfyUI-Manager
+ * call inside the op lock — detection can take a while, and a pin set during
+ * that window must still be honoured.
+ */
+function assertNotPinned(action: string, deps: PanelInstallerDeps): void {
+  const pin = readPinSafe(deps);
+  if (pin.pinned) throw new PanelInstallError(pinRefusalMessage(action, pin));
 }
 
 // ---------------------------------------------------------------------------
@@ -810,6 +844,15 @@ async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
           "skipping auto-install to avoid a duplicate/unverified install.",
       };
     }
+    // Final pin check adjacent to the mutation (see runPanelActionInner): the
+    // reachability probe and detection above are not instantaneous.
+    const latePin = readPinSafe(deps);
+    if (latePin.pinned) {
+      return {
+        action: "skipped",
+        reason: `panel version pin in force — ${describePanelPin(latePin)}`,
+      };
+    }
     await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION });
     // #639 — VERIFY it actually landed (fresh re-read); never log "installed"
     // from the Manager result alone (a stale 3.x no-op drains the queue trivially).
@@ -878,7 +921,12 @@ export async function ensurePanelInstalled(
 ): Promise<EnsureResult> {
   const deps = opts.deps ?? defaultDeps;
   try {
-    return await withTimeout(ensureInner(deps), opts.timeoutMs ?? ENSURE_TIMEOUT_MS);
+    // Serialized with the explicit actions: the on-load ensure must not race an
+    // install_panel call the user fired at the same moment.
+    return await withTimeout(
+      withPanelOpLock(() => ensureInner(deps)),
+      opts.timeoutMs ?? ENSURE_TIMEOUT_MS,
+    );
   } catch (err) {
     logger.debug("panel: ensure failed", {
       err: err instanceof Error ? err.message : String(err),
@@ -1173,9 +1221,17 @@ function finalizeUpdate(
  * install/update/reinstall the panel. LOCAL-only and refuses dev symlinks.
  * Targets version "nightly". Caller must RESTART ComfyUI to load the change.
  */
-export async function runPanelAction(
+export function runPanelAction(
   action: "install" | "update" | "reinstall",
   deps: PanelInstallerDeps = defaultDeps,
+): Promise<PanelActionResult> {
+  // Serialized: never let two panel mutations interleave (see withPanelOpLock).
+  return withPanelOpLock(() => runPanelActionInner(action, deps));
+}
+
+async function runPanelActionInner(
+  action: "install" | "update" | "reinstall",
+  deps: PanelInstallerDeps,
 ): Promise<PanelActionResult> {
   // P1b — truly LOCAL-only. Refuse in remote/cloud mode even when COMFYUI_PATH
   // is set: installCustomNode/reinstallCustomNode would queue Manager mutations
@@ -1198,11 +1254,9 @@ export async function runPanelAction(
   // PIN GUARD — before any Manager mutation is queued. This is the single choke
   // point that makes "we never move a pinned user" true for every caller (the
   // sync skill, the panel, a hand-written install_panel call), not just the ones
-  // that remembered to check.
-  const pin = readPinSafe(deps);
-  if (pin.pinned) {
-    throw new PanelInstallError(pinRefusalMessage(action, pin));
-  }
+  // that remembered to check. It is re-checked once more immediately before the
+  // Manager call, since detection below is not instantaneous.
+  assertNotPinned(action, deps);
 
   const detection = await detectPanelInstall(deps);
   if (detection.isDevSymlink) {
@@ -1219,6 +1273,9 @@ export async function runPanelAction(
   const previousRev = detection.gitRev;
 
   if (action === "update") {
+    // Final pin check, inside the op lock and adjacent to the mutation: a pin
+    // set while detection was running must still be honoured.
+    assertNotPinned(action, deps);
     const result = await deps.update({ id: PANEL_REGISTRY_ID });
     // #639 — VERIFY the update actually advanced the pack. Re-read the installed
     // identity FRESH from disk (never trust Manager's queue-drained signal, nor
@@ -1251,7 +1308,8 @@ export async function runPanelAction(
     return finalizeUpdate(verdict, post, result);
   }
 
-  // install / reinstall.
+  // install / reinstall. Same final pin check as the update path above.
+  assertNotPinned(action, deps);
   const result =
     action === "install"
       ? await deps.install({ id: PANEL_REGISTRY_ID, version: PANEL_VERSION })

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -21,7 +21,18 @@
 // so a guard that reached back into either would create an import cycle. It
 // depends only on the pin store.
 
-import { closeSync, mkdirSync, openSync, rmSync, statSync, writeSync } from "node:fs";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { logger } from "../utils/logger.js";
@@ -56,23 +67,50 @@ function isBulkTarget(id: string): boolean {
 }
 
 /**
+ * Reduce any target spelling to a bare repo/pack name.
+ *
+ * This MUST cover every ref-carrying form `parseGitUrl` accepts, because those
+ * are the forms a caller can actually pass: naively taking the last path segment
+ * turned `…/comfyui-mcp-panel.git@v0.11.28` into `comfyui-mcp-panel.git@v0.11.28`
+ * and `…/comfyui-mcp-panel/tree/main` into `main`, so BOTH slipped past the
+ * matcher and moved a pinned panel. Kept deliberately independent of
+ * node-management's parser: panel-installer already imports node-management, so
+ * reaching back into it from here would be an import cycle.
+ */
+export function normalizePackTarget(id: string): string {
+  let s = (id ?? "").trim().toLowerCase();
+  if (!s) return "";
+  // Drop query strings / fragments first.
+  s = s.split(/[?#]/)[0] ?? "";
+  // Forge "browse at a ref" forms (GitHub/GitLab/Gitea/Bitbucket), mirroring
+  // parseGitUrl's list.
+  s = s.replace(/\/-\/(tree|commit)\/.*$/, "");
+  s = s.replace(/\/(tree|commit|commits|src)\/.*$/, "");
+  s = s.replace(/\/releases\/tag\/.*$/, "");
+  s = s.replace(/\/+$/, "");
+  // Last path segment (handles bare ids, "author/repo", and full URLs).
+  let seg = s.split(/[/\\]/).filter(Boolean).pop() ?? "";
+  // npm/pip style `repo@ref` / `repo.git@ref`. The segment can no longer contain
+  // an scp-style `git@host:` user part, since that lives before the ":".
+  seg = seg.split("@")[0] ?? "";
+  return seg.replace(/\.git$/, "");
+}
+
+/**
  * Does this mutation target cover the panel pack?
  *
- * Matches the bare aliases, and a git URL whose repo component is one of them
- * (`https://github.com/artokun/comfyui-mcp-panel.git`), case-insensitively —
- * ComfyUI-Manager resolves all of these to the same pack, so treating any of
- * them as "not the panel" would reopen the door this guard closes. `"all"` is
- * included because a bulk update moves the panel along with everything else.
+ * Matches the bare aliases and every git-URL spelling that resolves to them,
+ * case-insensitively — ComfyUI-Manager resolves all of these to the same pack,
+ * so treating any of them as "not the panel" reopens the door this guard closes.
+ * `"all"` is included because a bulk update moves the panel along with
+ * everything else.
  */
 export function targetsPanelPack(id: string): boolean {
   const raw = (id ?? "").trim().toLowerCase();
   if (!raw) return false;
   if (isBulkTarget(raw)) return true;
   if ((PANEL_PACK_ALIASES as readonly string[]).includes(raw)) return true;
-  // Git URL / path form: compare the last path segment with .git stripped.
-  const lastSegment = raw.split(/[/\\]/).filter(Boolean).pop() ?? "";
-  const repo = lastSegment.replace(/\.git$/, "");
-  return (PANEL_PACK_ALIASES as readonly string[]).includes(repo);
+  return (PANEL_PACK_ALIASES as readonly string[]).includes(normalizePackTarget(raw));
 }
 
 /** Is this an exact single-pack panel target (i.e. NOT a bulk "all")? */
@@ -131,6 +169,40 @@ export function assertPanelPinAllows(action: string, id: string): void {
   );
 }
 
+/**
+ * Refuse a panel-pack mutation on a path that has NO on-disk verification —
+ * currently the sidebar `panel_install_node` / `panel_update_node` tools (which
+ * drive the user's built-in ComfyUI Manager through the browser) and
+ * `fix_custom_node`.
+ *
+ * These cannot be redirected into the verified path: `panel_*` acts on the
+ * panel's own host through the browser Manager (which may not even be the
+ * filesystem this process can read), and `fix` has no verified equivalent. Both
+ * report success from the Manager queue alone — precisely the #639 signal that
+ * proves nothing. Rather than let the panel be moved unverifiably, or pretend we
+ * checked, they refuse and name the tool that does verify.
+ *
+ * The pin is reported FIRST when set, because that is the more specific reason.
+ */
+export function assertPanelNotTargetedUnverifiable(
+  toolName: string,
+  // `unknown` on purpose: panel-tool handlers receive loosely-typed args, and a
+  // guard that forced a cast at every call site would eventually be skipped.
+  id: unknown,
+): void {
+  if (typeof id !== "string" || !targetsPanelPack(id)) return;
+  assertPanelPinAllows(toolName, id); // pinned → the pin message wins
+  throw new PanelPinnedError(
+    `${toolName} cannot manage the comfyui-mcp sidebar panel pack ("${id}"). That ` +
+      `path reports success as soon as the ComfyUI-Manager queue drains, which a ` +
+      `stale Manager does WITHOUT doing any work (#639) and which cannot see a ` +
+      `".bak" shadow copy shadowing the real panel (#641) — so it could tell you the ` +
+      `panel updated when it did not. Use install_panel instead: ` +
+      `install_panel(action='sync') brings the panel in line with this orchestrator ` +
+      `and re-reads the installed version from disk, and action='status' reports it.`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Cross-process mutation lock
 //
@@ -170,20 +242,76 @@ const DEFAULT_ACQUIRE_MS = 60_000;
 const POLL_MS = 100;
 
 let inProcessChain: Promise<unknown> = Promise.resolve();
-/** >0 while THIS process holds the lock, making nested acquisitions re-entrant. */
-let heldDepth = 0;
+
+/**
+ * Marks the async context of the current lock HOLDER, so re-entrancy is scoped
+ * to work actually running inside it.
+ *
+ * A process-global "held" flag was wrong and dangerous: while an update held the
+ * lock, an UNRELATED concurrent request (a pin write, say) saw the flag set and
+ * sailed straight through — landing precisely in the window between the update's
+ * final pin check and its Manager call. AsyncLocalStorage makes the exemption
+ * apply only to callers nested within the holder's own execution.
+ */
+const lockHolderContext = new AsyncLocalStorage<true>();
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/** Is the process that wrote a lock still running? */
+function pidAlive(pid: unknown): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs the permission/existence check without delivering.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = the process exists but belongs to someone else — still ALIVE.
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
+
+/**
+ * A lock is stale only when it is BOTH old AND owned by a dead process.
+ *
+ * The pid check is what makes reclaiming safe. Age alone let two waiters both
+ * judge the same lock stale, and the slower one could then delete the FRESH
+ * lock the faster one had just taken — putting two mutations in flight at once,
+ * the exact thing the lock exists to prevent. A live holder's lock now never
+ * reads as stale, so that interleaving cannot arise. (pid liveness is the right
+ * test here precisely because this is a single-machine, local-first project.)
+ */
 function lockIsStale(path: string): boolean {
   try {
-    return Date.now() - statSync(path).mtimeMs > STALE_LOCK_MS;
+    if (Date.now() - statSync(path).mtimeMs <= STALE_LOCK_MS) return false;
+    let pid: unknown;
+    try {
+      pid = (JSON.parse(readFileSync(path, "utf-8")) as { pid?: unknown })?.pid;
+    } catch {
+      // Unreadable/corrupt content on an already-old lock: nobody can claim it.
+      return true;
+    }
+    return !pidAlive(pid);
   } catch {
     // Vanished between EEXIST and stat — the next create attempt will settle it.
     return false;
   }
+}
+
+/**
+ * Remove a lock judged stale, ATOMICALLY. Renaming first means only one waiter
+ * can win the reclaim (the rest get ENOENT and simply retry); deleting the path
+ * directly would let a straggler delete whatever now sits there.
+ */
+function reclaimStaleLock(path: string): void {
+  const claim = `${path}.reclaim-${randomUUID()}`;
+  try {
+    renameSync(path, claim);
+  } catch {
+    return; // someone else reclaimed it first — just retry the create
+  }
+  rmSync(claim, { force: true });
 }
 
 async function acquireFileLock(timeoutMs: number): Promise<() => void> {
@@ -225,7 +353,7 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
         );
       }
       if (lockIsStale(path)) {
-        rmSync(path, { force: true });
+        reclaimStaleLock(path);
         continue;
       }
       if (Date.now() >= deadline) {
@@ -253,15 +381,15 @@ export function withPanelMutationLock<T>(
   fn: () => Promise<T>,
   opts: { timeoutMs?: number } = {},
 ): Promise<T> {
-  if (heldDepth > 0) return fn();
+  // Only work running INSIDE the current holder is exempt — not everything that
+  // happens to overlap it in this process.
+  if (lockHolderContext.getStore()) return fn();
 
   const run = (async () => {
     const release = await acquireFileLock(opts.timeoutMs ?? DEFAULT_ACQUIRE_MS);
-    heldDepth++;
     try {
-      return await fn();
+      return await lockHolderContext.run(true, fn);
     } finally {
-      heldDepth--;
       release();
     }
   });

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -31,6 +31,7 @@ import {
   renameSync,
   rmSync,
   statSync,
+  writeFileSync,
   writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -353,14 +354,18 @@ async function acquireFileLock(timeoutMs: number): Promise<() => void> {
         );
       }
       if (lockIsStale(path)) {
-        reclaimStaleLock(path);
-        continue;
+        // Never rename/delete after a stale observation: another process can
+        // replace this path with a fresh lock between the check and reclaim.
+        // Node lacks an atomic compare-and-rename, so failing closed is the
+        // only way to avoid stealing that new holder.
       }
       if (Date.now() >= deadline) {
         throw new Error(
           `Timed out after ${timeoutMs}ms waiting for the panel operation lock ` +
             `(${path}). Another panel install/update/pin is in progress — possibly in ` +
-            `another orchestrator process. Retry shortly.`,
+            `another orchestrator process. The lock is never auto-reclaimed because that could ` +
+            `steal a fresh holder after a stale observation. Retry shortly or recover a proven ` +
+            `abandoned lock explicitly.`,
         );
       }
       await sleep(POLL_MS);
@@ -436,4 +441,156 @@ export function withPanelPinGuard<T>(
     assertPanelPinAllows(action, id);
     return op();
   });
+}
+
+// ---------------------------------------------------------------------------
+// Pending panel-affecting operations
+//
+// Some panel-moving operations are handed to ComfyUI-Manager and then applied
+// OUT OF BAND: update_all drains on the Manager's own worker after we return,
+// and a snapshot restore is deferred to the next ComfyUI restart. The mutation
+// lock cannot be held across that window (it would wedge pinning for minutes
+// to days), and no completion/apply path exists IN THIS PROCESS to re-check a
+// pin at — the Manager, not us, is the applying agent, which is exactly why
+// the window exists. What this process CAN keep truthful is the next pin
+// write: a pin set while one of these is pending must not leave the user
+// believing the panel cannot move. So each op records a marker here (with an
+// expiry), and the pin-write path warns while one is active. The lock-held
+// variants — update_custom_node(id="all"), which waits for the drain inside
+// the lock, and every install_panel mutation — need no marker: no pin can be
+// written inside their window at all.
+// ---------------------------------------------------------------------------
+
+export interface PanelPendingOp {
+  /** What is pending: "update-all" | "snapshot-restore" (unknown kinds are
+   *  tolerated when reading, so an older/newer record never reads as clear). */
+  kind: string;
+  /** When it was handed to ComfyUI-Manager (ISO). */
+  queuedAt: string;
+  /** When the warning lapses (ISO). After this the pin governs as usual — the
+   *  pending op has either landed (the pin then holds FUTURE ops) or failed. */
+  expiresAt: string;
+  /** Human-facing explanation for the pin-write warning. */
+  detail: string;
+}
+
+/** update_all drains in minutes on the Manager's worker; an hour is far beyond
+ *  a legitimate drain, so reclaiming then cannot cut a live op short. */
+export const UPDATE_ALL_PENDING_MS = 60 * 60_000;
+
+/** A snapshot restore is applied at the next ComfyUI restart, which this
+ *  process cannot observe — that could be days away. The marker cannot outlive
+ *  restarts forever, so it expires after a week and says so in its detail. */
+export const SNAPSHOT_RESTORE_PENDING_MS = 7 * 24 * 60 * 60_000;
+
+/** Marker file path. Overridable so tests never touch the real home directory. */
+export function panelPendingOpsPath(): string {
+  return (
+    process.env.COMFYUI_MCP_PANEL_PENDING ||
+    join(homedir(), ".comfyui-mcp", "panel-pending-ops.json")
+  );
+}
+
+function isPanelPendingOp(value: unknown): value is PanelPendingOp {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const op = value as Record<string, unknown>;
+  return (
+    typeof op.kind === "string" &&
+    typeof op.queuedAt === "string" &&
+    typeof op.expiresAt === "string" &&
+    typeof op.detail === "string"
+  );
+}
+
+function readPanelPendingOpsFile(): { ops: PanelPendingOp[]; unreadable: boolean } {
+  const path = panelPendingOpsPath();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    // Only ENOENT proves there is no marker. Permission/I/O errors are
+    // indeterminate and must keep a later pin from claiming clean protection.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { ops: [], unreadable: false };
+    }
+    return { ops: [], unreadable: true };
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const ops =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as { ops?: unknown }).ops
+        : undefined;
+    if (Array.isArray(ops) && ops.every(isPanelPendingOp)) {
+      return { ops, unreadable: false };
+    }
+  } catch {
+    // fall through
+  }
+  return { ops: [], unreadable: true };
+}
+
+/**
+ * Record that a panel-affecting operation was handed to ComfyUI-Manager and may
+ * still land out-of-band. Replaces any prior marker of the same kind. Best
+ * effort: the op has ALREADY been queued by the time this runs, so a write
+ * failure must not misreport it as failed — it logs and the op's own result
+ * stays truthful ("queued"/"requested").
+ */
+export function recordPanelPendingOp(
+  kind: "update-all" | "snapshot-restore",
+  detail: string,
+  ttlMs: number,
+): PanelPendingOp {
+  const now = Date.now();
+  const op: PanelPendingOp = {
+    kind,
+    queuedAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + ttlMs).toISOString(),
+    detail,
+  };
+  try {
+    const path = panelPendingOpsPath();
+    const prior = readPanelPendingOpsFile();
+    if (prior.unreadable) throw new Error("existing pending-operation record is unreadable");
+    const { ops } = prior;
+    const kept = ops.filter((o) => o.kind !== kind);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ ops: [...kept, op] }, null, 2), "utf-8");
+  } catch (err) {
+    logger.warn(
+      `[panel] could not record the pending ${kind} marker: ${
+        err instanceof Error ? err.message : String(err)
+      } — a pin written before it lands will not be warned.`,
+    );
+  }
+  return op;
+}
+
+/**
+ * The pending panel-affecting operations whose warning window is still open.
+ *
+ * Reads fail CLOSED, mirroring the pin store: a present-but-unreadable marker
+ * file means we cannot prove nothing is pending, so it yields a synthetic
+ * indeterminate op and the pin write still warns. Entries with an unparseable
+ * expiry are kept (indeterminate = still warn), never dropped.
+ */
+export function activePanelPendingOps(now: number = Date.now()): PanelPendingOp[] {
+  const { ops, unreadable } = readPanelPendingOpsFile();
+  if (unreadable) {
+    return [
+      {
+        kind: "unknown",
+        queuedAt: new Date(0).toISOString(),
+        expiresAt: new Date(0).toISOString(),
+        detail:
+          "the pending panel-operation record could not be read, so a queued " +
+          "update or deferred restore may still be outstanding",
+      },
+    ];
+  }
+  // Expiry is informational only. We have no completion signal for a Manager
+  // worker/deferred restore, so auto-expiry would falsely green a later pin.
+  void now;
+  return ops;
 }

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -532,10 +532,19 @@ function readPanelPendingOpsFile(): { ops: PanelPendingOp[]; unreadable: boolean
 
 /**
  * Record that a panel-affecting operation was handed to ComfyUI-Manager and may
- * still land out-of-band. Replaces any prior marker of the same kind. Best
- * effort: the op has ALREADY been queued by the time this runs, so a write
- * failure must not misreport it as failed — it logs and the op's own result
- * stays truthful ("queued"/"requested").
+ * still land out-of-band. Replaces any prior marker of the same kind.
+ *
+ * Call this BEFORE handing the operation to ComfyUI-Manager. A mutation whose
+ * out-of-band window cannot be durably recorded must not start: otherwise a
+ * user can set a pin immediately afterwards and be told it protects a panel
+ * which the already-queued Manager operation is still free to move. The write
+ * is read back before returning, so a successful syscall alone is not treated
+ * as proof that the warning is durable.
+ *
+ * Once this succeeds, callers deliberately leave the marker in place even if
+ * their Manager request errors. A transport error cannot prove the remote
+ * Manager did not accept the request, and retaining a conservative warning is
+ * safer than letting a later pin claim clean protection.
  */
 export function recordPanelPendingOp(
   kind: "update-all" | "snapshot-restore",
@@ -553,15 +562,31 @@ export function recordPanelPendingOp(
     const path = panelPendingOpsPath();
     const prior = readPanelPendingOpsFile();
     if (prior.unreadable) throw new Error("existing pending-operation record is unreadable");
-    const { ops } = prior;
-    const kept = ops.filter((o) => o.kind !== kind);
+    const kept = prior.ops.filter((o) => o.kind !== kind);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify({ ops: [...kept, op] }, null, 2), "utf-8");
+
+    // Verify the exact replacement record, not merely that JSON still parses.
+    // A partial/redirected write that drops this operation would recreate the
+    // same false-protection window as a write failure.
+    const confirmed = readPanelPendingOpsFile();
+    if (
+      confirmed.unreadable ||
+      !confirmed.ops.some(
+        (candidate) =>
+          candidate.kind === op.kind &&
+          candidate.queuedAt === op.queuedAt &&
+          candidate.expiresAt === op.expiresAt &&
+          candidate.detail === op.detail,
+      )
+    ) {
+      throw new Error("pending-operation record did not survive a read-back verification");
+    }
   } catch (err) {
-    logger.warn(
-      `[panel] could not record the pending ${kind} marker: ${
+    throw new Error(
+      `Could not persist the pending ${kind} marker: ${
         err instanceof Error ? err.message : String(err)
-      } — a pin written before it lands will not be warned.`,
+      }. Refusing to start an operation that could move the panel after a later pin.`,
     );
   }
   return op;

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -1,0 +1,275 @@
+// The panel version pin, enforced where the PANEL PACK IS IDENTIFIED AS THE
+// TARGET — not where the panel-specific entry point happens to be.
+//
+// WHY THIS FILE EXISTS. The first cut of the pin put its guard inside
+// `runPanelAction` and called that "the mutation choke point". It isn't one. The
+// panel IS an ordinary custom node pack, so the generic node tools are a second,
+// wider door into exactly the same ComfyUI-Manager mutation:
+//
+//     update_custom_node(id="comfyui-agent-panel")   → updateCustomNode(...)
+//     update_custom_node(id="all")                   → updateCustomNode(...)
+//     reinstall_custom_node(id="comfyui-mcp-panel")  → reinstallCustomNode(...)
+//     update_all                                     → updateAllCustomNodes()
+//
+// None of those go through `runPanelAction`, so none of them saw the pin. A
+// pinned user was one `id="all"` away from being moved. The guard therefore
+// lives at the SERVICE layer of the generic mutations, where every caller —
+// tools, apply_manifest, dependency installers, anything future — must pass.
+//
+// This module deliberately imports NOTHING from panel-installer or
+// node-management: panel-installer already imports node-management's mutations,
+// so a guard that reached back into either would create an import cycle. It
+// depends only on the pin store.
+
+import { closeSync, mkdirSync, openSync, rmSync, statSync, writeSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { logger } from "../utils/logger.js";
+import {
+  describePanelPin,
+  getPanelPinState,
+  PANEL_PIN_ENV_VAR,
+  type PanelPinState,
+} from "./panel-settings.js";
+
+/** Thrown when a pin forbids a mutation. Distinct so callers can recognise it. */
+export class PanelPinnedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PanelPinnedError";
+  }
+}
+
+/**
+ * Every spelling of "the sidebar panel pack" a caller might pass as an id. The
+ * Comfy Registry name and the repo/dir name differ, and both are accepted by
+ * ComfyUI-Manager, so both must match here.
+ */
+export const PANEL_PACK_ALIASES = [
+  "comfyui-agent-panel", // Comfy Registry id / pyproject [project].name
+  "comfyui-mcp-panel", // repo name, and the custom_nodes dir it installs to
+] as const;
+
+/** A bulk target that necessarily includes the panel. */
+function isBulkTarget(id: string): boolean {
+  return id === "all" || id === "*";
+}
+
+/**
+ * Does this mutation target cover the panel pack?
+ *
+ * Matches the bare aliases, and a git URL whose repo component is one of them
+ * (`https://github.com/artokun/comfyui-mcp-panel.git`), case-insensitively —
+ * ComfyUI-Manager resolves all of these to the same pack, so treating any of
+ * them as "not the panel" would reopen the door this guard closes. `"all"` is
+ * included because a bulk update moves the panel along with everything else.
+ */
+export function targetsPanelPack(id: string): boolean {
+  const raw = (id ?? "").trim().toLowerCase();
+  if (!raw) return false;
+  if (isBulkTarget(raw)) return true;
+  if ((PANEL_PACK_ALIASES as readonly string[]).includes(raw)) return true;
+  // Git URL / path form: compare the last path segment with .git stripped.
+  const lastSegment = raw.split(/[/\\]/).filter(Boolean).pop() ?? "";
+  const repo = lastSegment.replace(/\.git$/, "");
+  return (PANEL_PACK_ALIASES as readonly string[]).includes(repo);
+}
+
+/** Is this an exact single-pack panel target (i.e. NOT a bulk "all")? */
+export function targetsPanelPackExactly(id: string): boolean {
+  const raw = (id ?? "").trim().toLowerCase();
+  return !isBulkTarget(raw) && targetsPanelPack(id);
+}
+
+/**
+ * Read the pin so that NO failure mode reads as "unpinned" — a reader that
+ * throws is reported as an indeterminate pin, which counts as pinned.
+ */
+function readPin(): PanelPinState {
+  try {
+    return getPanelPinState();
+  } catch (err) {
+    logger.warn(
+      `[panel] could not read the panel version pin: ${
+        err instanceof Error ? err.message : String(err)
+      } — treating the panel as PINNED (refusing to move it).`,
+    );
+    return { pinned: true, source: "settings", indeterminate: true };
+  }
+}
+
+/**
+ * Refuse a generic node mutation that would move a PINNED panel.
+ *
+ * `action` and `id` are only used to build the message; the decision is the
+ * pin's. A bulk target gets its own wording because there is no way to update
+ * everything-except-the-panel through ComfyUI-Manager — the user has to unpin or
+ * update packs individually, and saying so is more useful than a generic refusal.
+ */
+export function assertPanelPinAllows(action: string, id: string): void {
+  if (!targetsPanelPack(id)) return;
+  const pin = readPin();
+  if (!pin.pinned) return;
+
+  const bulk = !targetsPanelPackExactly(id);
+  const envNote =
+    pin.source === "env"
+      ? ` (this pin comes from the ${PANEL_PIN_ENV_VAR} environment variable, so it ` +
+        `must be unset/changed in the environment — unpin cannot remove it)`
+      : ``;
+
+  throw new PanelPinnedError(
+    bulk
+      ? `Refusing to ${action} "${id}": that would also move the sidebar panel pack, ` +
+        `which is ${describePanelPin(pin)}. ComfyUI-Manager cannot update ` +
+        `everything-except-one-pack, so either clear the pin first with ` +
+        `install_panel(action='unpin')${envNote} and re-run, or update the other packs ` +
+        `individually by id.`
+      : `Refusing to ${action} the sidebar panel pack ("${id}"): it is ` +
+        `${describePanelPin(pin)}. A pin is honoured even when a newer panel exists — ` +
+        `clear it first with install_panel(action='unpin')${envNote}, then re-run.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-process mutation lock
+//
+// The first cut serialized panel mutations with a module-global promise chain.
+// That is not enough and the claim built on it was wrong: running more than one
+// orchestrator process is ordinary here (one per MCP client). Process A could
+// pass its final pin check and begin an awaited Manager update while process B
+// wrote a pin against its own, entirely separate chain — and A would then move a
+// now-pinned panel.
+//
+// So the lock is a FILE under ~/.comfyui-mcp/, which is the only thing both
+// processes share. In-process we still chain (a file lock alone would spin), and
+// the whole thing is re-entrant so `runPanelAction` can call a guarded service
+// function while already holding it.
+// ---------------------------------------------------------------------------
+
+/** Lock file path. Overridable so tests never touch the real home directory. */
+export function panelLockPath(): string {
+  return (
+    process.env.COMFYUI_MCP_PANEL_LOCK ||
+    join(homedir(), ".comfyui-mcp", "panel-op.lock")
+  );
+}
+
+/**
+ * A lock older than this is assumed abandoned by a crashed process. Panel
+ * operations are ComfyUI-Manager queue cycles measured in seconds; ten minutes
+ * is far beyond a legitimate one, so reclaiming at that point cannot cut a live
+ * op short, while still guaranteeing a crash can never wedge pinning forever.
+ */
+const STALE_LOCK_MS = 10 * 60_000;
+
+/** Default acquisition budget. Callers that must not block (the fire-and-forget
+ *  on-load ensure) pass something much shorter. */
+const DEFAULT_ACQUIRE_MS = 60_000;
+
+const POLL_MS = 100;
+
+let inProcessChain: Promise<unknown> = Promise.resolve();
+/** >0 while THIS process holds the lock, making nested acquisitions re-entrant. */
+let heldDepth = 0;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function lockIsStale(path: string): boolean {
+  try {
+    return Date.now() - statSync(path).mtimeMs > STALE_LOCK_MS;
+  } catch {
+    // Vanished between EEXIST and stat — the next create attempt will settle it.
+    return false;
+  }
+}
+
+async function acquireFileLock(timeoutMs: number): Promise<() => void> {
+  const path = panelLockPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    try {
+      // "wx" = create-exclusive: atomic across processes, which is the whole point.
+      const fd = openSync(path, "wx");
+      try {
+        writeSync(
+          fd,
+          JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }),
+        );
+      } finally {
+        closeSync(fd);
+      }
+      return () => {
+        try {
+          rmSync(path, { force: true });
+        } catch (err) {
+          logger.warn(
+            `[panel] could not remove the panel op lock at ${path}: ${
+              err instanceof Error ? err.message : String(err)
+            } (it will be reclaimed as stale).`,
+          );
+        }
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
+        // Anything other than "already held" is a real failure. FAIL CLOSED:
+        // proceeding without the lock is how a pinned user gets moved.
+        throw new Error(
+          `Could not take the panel operation lock at ${path}: ${
+            err instanceof Error ? err.message : String(err)
+          }. Refusing to mutate the panel without it.`,
+        );
+      }
+      if (lockIsStale(path)) {
+        rmSync(path, { force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out after ${timeoutMs}ms waiting for the panel operation lock ` +
+            `(${path}). Another panel install/update/pin is in progress — possibly in ` +
+            `another orchestrator process. Retry shortly.`,
+        );
+      }
+      await sleep(POLL_MS);
+    }
+  }
+}
+
+/**
+ * Run `fn` with exclusive rights to mutate the panel or its pin, across BOTH
+ * async callers in this process and other orchestrator processes.
+ *
+ * Re-entrant: a nested call while this process already holds the lock runs
+ * immediately (the in-process chain guarantees only one holder is executing, so
+ * a nested acquisition can only come from the holder itself). Rejections never
+ * wedge the chain.
+ */
+export function withPanelMutationLock<T>(
+  fn: () => Promise<T>,
+  opts: { timeoutMs?: number } = {},
+): Promise<T> {
+  if (heldDepth > 0) return fn();
+
+  const run = (async () => {
+    const release = await acquireFileLock(opts.timeoutMs ?? DEFAULT_ACQUIRE_MS);
+    heldDepth++;
+    try {
+      return await fn();
+    } finally {
+      heldDepth--;
+      release();
+    }
+  });
+
+  const started = inProcessChain.then(run, run);
+  inProcessChain = started.then(
+    () => undefined,
+    () => undefined,
+  );
+  return started;
+}

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -401,3 +401,32 @@ export function withPanelMutationLock<T>(
   );
   return started;
 }
+
+/**
+ * Run a panel-moving mutation atomically with its pin check.
+ *
+ * assertPanelPinAllows alone is a TOCTOU race: the check passes, and THEN a pin
+ * can be written before/while the ComfyUI-Manager operation runs (an update_all
+ * drain takes seconds), so the update lands on a by-then-pinned panel. The pin
+ * WRITE path takes this same lock, so checking inside it and holding it across
+ * the whole mutation means a pin either lands before the op starts (and blocks
+ * it) or after it finishes (and blocks the next one) — never in the middle.
+ *
+ * Targets that cannot move the panel skip the lock entirely: there is no pin
+ * decision to make for them, and serializing every unrelated pack mutation
+ * behind panel ops would be pointless contention.
+ *
+ * Re-entrant via withPanelMutationLock: runPanelAction already holds the lock
+ * when it calls the guarded node-management mutations, so nesting is immediate.
+ */
+export function withPanelPinGuard<T>(
+  action: string,
+  id: string,
+  op: () => Promise<T>,
+): Promise<T> {
+  if (!targetsPanelPack(id)) return op();
+  return withPanelMutationLock(() => {
+    assertPanelPinAllows(action, id);
+    return op();
+  });
+}

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -385,14 +385,21 @@ export function withPanelMutationLock<T>(
   // happens to overlap it in this process.
   if (lockHolderContext.getStore()) return fn();
 
-  const run = (async () => {
+  // `run` is the chain's settle CALLBACK — deliberately a function, NOT an
+  // invoked IIFE (note: no trailing `()`). Passing an already-started promise
+  // to .then() would resolve callers immediately with the chain's value while
+  // the guarded work floated unfinished. Written without the `(async () =>
+  // {...})` grouping parens because that shape reads as an IIFE and has been
+  // mis-reviewed as one; the semantics were and are: callers resolve only
+  // after the guarded action AND the release complete.
+  const run = async (): Promise<T> => {
     const release = await acquireFileLock(opts.timeoutMs ?? DEFAULT_ACQUIRE_MS);
     try {
       return await lockHolderContext.run(true, fn);
     } finally {
       release();
     }
-  });
+  };
 
   const started = inProcessChain.then(run, run);
   inProcessChain = started.then(

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -198,15 +198,21 @@ function normalizePinVersion(raw: unknown): string | undefined {
  */
 export function getPanelPinState(env: NodeJS.ProcessEnv = process.env): PanelPinState {
   const rawEnv = env[PANEL_PIN_ENV_VAR];
-  if (typeof rawEnv === "string" && rawEnv.trim().length > 0) {
+  // PRESENCE, not truthiness-after-trim. A whitespace-only value ("   ") is a
+  // SET variable we cannot interpret; trimming first and falling through made it
+  // resolve `unpinned` and let the mutation proceed — the same present-but-
+  // unreadable fail-open as the settings file. An EMPTY value is treated as
+  // unset, which is the ordinary meaning of `FOO=` and of an unset dotenv key.
+  if (typeof rawEnv === "string" && rawEnv.length > 0) {
     const trimmed = rawEnv.trim();
     if (PIN_ENV_OFF.has(trimmed.toLowerCase())) {
+      // The explicit no-pin escape hatch, and the ONLY way an env value clears.
       return { pinned: false, source: "none" };
     }
     const version = normalizePinVersion(trimmed);
     if (version) return { pinned: true, version, source: "env" };
-    // Present but unusable — we cannot tell what the user meant, so we do NOT
-    // fall through to "unpinned".
+    // Present but unusable (whitespace-only, or junk) — we cannot tell what the
+    // user meant, so we do NOT fall through to "unpinned".
     return { pinned: true, source: "env", indeterminate: true };
   }
 

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -213,8 +213,17 @@ export function getPanelPinState(env: NodeJS.ProcessEnv = process.env): PanelPin
   const { settings, unreadable } = readRaw();
   if (unreadable) return { pinned: true, source: "settings", indeterminate: true };
 
+  // ONLY an absent key means unpinned. A key that is PRESENT but malformed
+  // (`null`, `false`, `0`, `"0.11.3"`, `[]`) is somebody's hand-edit that we
+  // failed to understand — reading it as "no pin" would move a user who
+  // believed they were pinned. Present-but-unreadable resolves to pinned.
+  if (!("panelPin" in settings) || settings.panelPin === undefined) {
+    return { pinned: false, source: "none" };
+  }
   const raw = settings.panelPin as Partial<PanelVersionPin> | undefined;
-  if (!raw || typeof raw !== "object") return { pinned: false, source: "none" };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { pinned: true, source: "settings", indeterminate: true };
+  }
   const version = normalizePinVersion(raw.version);
   if (!version) {
     // A `panelPin` key exists but its version is junk: something pinned this
@@ -294,8 +303,17 @@ export function setPanelVersionPin(version: string, reason?: string): PanelVersi
  */
 export function clearPanelVersionPin(): PanelVersionPin | undefined {
   const settings = assertSettingsWritable();
-  const previous = settings.panelPin;
-  if (!previous) return undefined;
+  // Keyed on PRESENCE, not truthiness: a malformed falsy pin (`null`, `false`,
+  // `0`) is an active indeterminate pin, so `!previous` would have refused to
+  // delete it and left the user permanently blocked with "no pin was set".
+  if (!("panelPin" in settings) || settings.panelPin === undefined) return undefined;
+  const raw = settings.panelPin as unknown;
+  // A malformed stored pin still gets removed; describe it as unreadable rather
+  // than returning junk (or undefined, which callers render as "no pin existed").
+  const previous: PanelVersionPin =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as PanelVersionPin)
+      : { version: "(unreadable)" };
   delete settings.panelPin;
   write(settings);
   // Symmetrically verified: a "pin removed" we did not observe would leave the

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -121,11 +121,15 @@ function readRaw(): { settings: PanelSettings; unreadable: boolean } {
   if (!existsSync(p)) return { settings: {}, unreadable: false };
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
-    return parsed && typeof parsed === "object"
+    // Valid JSON but not a plain object (`null`, `"x"`, and CRUCIALLY `[]`):
+    // the file is present and structurally wrong, so a key's absence is not
+    // proven. An array is the nasty one — `typeof [] === "object"`, so an
+    // unguarded check would accept it, report "no pin" on a file we never
+    // understood, and then silently DROP a pin written to it (an expando
+    // property on an array does not survive JSON.stringify).
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
       ? { settings: parsed as PanelSettings, unreadable: false }
-      : // Valid JSON but not an object (e.g. `null`, `[]`, `"x"`): the file is
-        // present and structurally wrong, so a key's absence is not proven.
-        { settings: {}, unreadable: true };
+      : { settings: {}, unreadable: true };
   } catch (err) {
     logger.warn(`[panel-settings] could not parse ${p}: ${err instanceof Error ? err.message : String(err)}`);
     return { settings: {}, unreadable: true };
@@ -266,6 +270,19 @@ export function setPanelVersionPin(version: string, reason?: string): PanelVersi
   if (trimmedReason) pin.reason = trimmedReason;
   settings.panelPin = pin;
   write(settings);
+  // VERIFY the pin actually landed, by re-reading it. Telling a user "pinned"
+  // when nothing persisted is the same fabricated-success failure this whole
+  // feature exists to prevent — and it is the worse direction, because they
+  // would then believe they are protected. (Env is deliberately excluded here:
+  // we are confirming the FILE, not an override that would mask a failed write.)
+  const persisted = getPanelPinState({});
+  if (!persisted.pinned || persisted.version !== pin.version) {
+    throw new Error(
+      `Pin did NOT persist: after writing ${panelSettingsPath()} the stored pin reads ` +
+        `back as ${persisted.version ?? "absent/unreadable"} rather than ${pin.version}. ` +
+        `NOT reporting the panel as pinned. Check that file is writable and well-formed.`,
+    );
+  }
   return pin;
 }
 
@@ -281,6 +298,15 @@ export function clearPanelVersionPin(): PanelVersionPin | undefined {
   if (!previous) return undefined;
   delete settings.panelPin;
   write(settings);
+  // Symmetrically verified: a "pin removed" we did not observe would leave the
+  // user believing a sync can now proceed when it still cannot.
+  const persisted = getPanelPinState({});
+  if (persisted.pinned) {
+    throw new Error(
+      `Pin was NOT removed: ${panelSettingsPath()} still reads back as pinned after ` +
+        `the write. NOT reporting the pin as cleared.`,
+    );
+  }
   return previous;
 }
 

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -47,9 +47,57 @@ export interface AgentSettings {
   custom?: OllamaAgentConfig;
 }
 
+/**
+ * An EXPLICIT user pin holding the sidebar panel node-pack at one version.
+ *
+ * A pin is a promise: while it is set, nothing in this codebase may move the
+ * panel — not the auto-sync skill, not `install_panel(action='update')`, not the
+ * on-load auto-installer. The user cleared it or nothing happens. See
+ * `panel-sync.ts` for the decision logic that honours it.
+ */
+export interface PanelVersionPin {
+  /** The exact panel version the user pinned to, e.g. "0.11.20". */
+  version: string;
+  /** ISO timestamp of when the pin was set (absent for an env-var pin). */
+  pinnedAt?: string;
+  /** Optional free-text reason the user gave for pinning. */
+  reason?: string;
+}
+
+/**
+ * The resolved pin, including WHERE it came from — the caller must be able to
+ * tell the user how to clear it, and an env pin cannot be cleared by writing the
+ * settings file.
+ */
+export interface PanelPinState {
+  /** True when a pin is in force. Nothing may move the panel while true. */
+  pinned: boolean;
+  /** The pinned version (only when `pinned`). */
+  version?: string;
+  /** Where the active pin came from; "none" when unpinned. */
+  source: "env" | "settings" | "none";
+  pinnedAt?: string;
+  reason?: string;
+  /**
+   * The settings file EXISTS but could not be read/parsed, so we cannot PROVE
+   * the absence of a pin. Callers must treat this like a pin (refuse to move the
+   * panel) rather than as "unpinned" — silently moving a user off a pin we
+   * merely failed to read is exactly the failure this feature exists to prevent.
+   */
+  indeterminate?: boolean;
+}
+
+/** Env override for the pin (wins over the settings file, per env > .env > json). */
+export const PANEL_PIN_ENV_VAR = "COMFYUI_MCP_PANEL_PIN";
+
+/** Env values that explicitly assert "no pin", overriding a persisted one. */
+const PIN_ENV_OFF = new Set(["off", "none", "no", "0", "false", "unpinned"]);
+
 export interface PanelSettings {
   nsfwConsent?: NsfwConsent;
   agent?: AgentSettings;
+  /** Persisted explicit panel-version pin (see PanelVersionPin). */
+  panelPin?: PanelVersionPin;
 }
 
 /** Settings file path. Overridable for tests. */
@@ -60,16 +108,32 @@ export function panelSettingsPath(): string {
   );
 }
 
-function read(): PanelSettings {
+/**
+ * Read the settings file, reporting whether the read was CONCLUSIVE.
+ *
+ * `unreadable` is true only when the file exists but could not be read/parsed —
+ * i.e. `{}` here is NOT proof that a key is unset. Most callers don't care (a
+ * missing NSFW consent and an unreadable one both mean "not consented"), but the
+ * panel pin does: an unreadable file must not be reported as "no pin".
+ */
+function readRaw(): { settings: PanelSettings; unreadable: boolean } {
   const p = panelSettingsPath();
-  if (!existsSync(p)) return {};
+  if (!existsSync(p)) return { settings: {}, unreadable: false };
   try {
     const parsed = JSON.parse(readFileSync(p, "utf-8")) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as PanelSettings) : {};
+    return parsed && typeof parsed === "object"
+      ? { settings: parsed as PanelSettings, unreadable: false }
+      : // Valid JSON but not an object (e.g. `null`, `[]`, `"x"`): the file is
+        // present and structurally wrong, so a key's absence is not proven.
+        { settings: {}, unreadable: true };
   } catch (err) {
     logger.warn(`[panel-settings] could not parse ${p}: ${err instanceof Error ? err.message : String(err)}`);
-    return {};
+    return { settings: {}, unreadable: true };
   }
+}
+
+function read(): PanelSettings {
+  return readRaw().settings;
 }
 
 function write(settings: PanelSettings): void {
@@ -102,6 +166,122 @@ export function setNsfwConsent(allowed: boolean): NsfwConsent {
   settings.nsfwConsent = { allowed, decidedAt };
   write(settings);
   return settings.nsfwConsent;
+}
+
+// ---------------------------------------------------------------------------
+// Panel version pin
+// ---------------------------------------------------------------------------
+
+/** Normalize a pin version string; returns undefined for junk/blank. */
+function normalizePinVersion(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const v = raw.trim();
+  return v.length > 0 && v.length <= 64 ? v : undefined;
+}
+
+/**
+ * Resolve the ACTIVE panel-version pin.
+ *
+ * Precedence mirrors the rest of the project's config (env > `~/.comfyui-mcp/.env`
+ * > the JSON settings store): `~/.comfyui-mcp/.env` is loaded into `process.env`
+ * at boot, so a single `process.env` check covers both env layers.
+ * `COMFYUI_MCP_PANEL_PIN=off` (or none/no/0/false/unpinned) is an explicit
+ * "no pin" that overrides a persisted one — the env escape hatch when the
+ * settings file can't be edited.
+ *
+ * Never throws: a pin we cannot read is reported `indeterminate`, which callers
+ * MUST treat as pinned.
+ */
+export function getPanelPinState(env: NodeJS.ProcessEnv = process.env): PanelPinState {
+  const rawEnv = env[PANEL_PIN_ENV_VAR];
+  if (typeof rawEnv === "string" && rawEnv.trim().length > 0) {
+    const trimmed = rawEnv.trim();
+    if (PIN_ENV_OFF.has(trimmed.toLowerCase())) {
+      return { pinned: false, source: "none" };
+    }
+    const version = normalizePinVersion(trimmed);
+    if (version) return { pinned: true, version, source: "env" };
+    // Present but unusable — we cannot tell what the user meant, so we do NOT
+    // fall through to "unpinned".
+    return { pinned: true, source: "env", indeterminate: true };
+  }
+
+  const { settings, unreadable } = readRaw();
+  if (unreadable) return { pinned: true, source: "settings", indeterminate: true };
+
+  const raw = settings.panelPin as Partial<PanelVersionPin> | undefined;
+  if (!raw || typeof raw !== "object") return { pinned: false, source: "none" };
+  const version = normalizePinVersion(raw.version);
+  if (!version) {
+    // A `panelPin` key exists but its version is junk: something pinned this
+    // install, so refuse to move it rather than guessing it away.
+    return { pinned: true, source: "settings", indeterminate: true };
+  }
+  const state: PanelPinState = { pinned: true, version, source: "settings" };
+  if (typeof raw.pinnedAt === "string") state.pinnedAt = raw.pinnedAt;
+  if (typeof raw.reason === "string") state.reason = raw.reason;
+  return state;
+}
+
+/** Human-readable one-liner for a pin state, for messages the user reads. */
+export function describePanelPin(pin: PanelPinState): string {
+  if (!pin.pinned) return "not pinned";
+  if (pin.indeterminate) {
+    return pin.source === "env"
+      ? `pinned via ${PANEL_PIN_ENV_VAR}, but its value is unusable`
+      : `possibly pinned — ${panelSettingsPath()} could not be read`;
+  }
+  const where =
+    pin.source === "env" ? `${PANEL_PIN_ENV_VAR} env var` : panelSettingsPath();
+  return `pinned to ${pin.version} (via ${where})${pin.reason ? ` — ${pin.reason}` : ""}`;
+}
+
+function assertSettingsWritable(): PanelSettings {
+  const { settings, unreadable } = readRaw();
+  if (unreadable) {
+    throw new Error(
+      `Refusing to rewrite ${panelSettingsPath()}: it exists but could not be ` +
+        `parsed, so writing would silently discard whatever else is in it. Fix or ` +
+        `delete that file and retry (or set ${PANEL_PIN_ENV_VAR} in the environment, ` +
+        `which takes precedence).`,
+    );
+  }
+  return settings;
+}
+
+/**
+ * Persist an explicit pin. Throws on a blank version or an unparseable settings
+ * file (see assertSettingsWritable) — never silently drops the request.
+ */
+export function setPanelVersionPin(version: string, reason?: string): PanelVersionPin {
+  const normalized = normalizePinVersion(version);
+  if (!normalized) {
+    throw new Error(
+      "A panel version pin needs a non-empty version string (e.g. \"0.11.20\").",
+    );
+  }
+  const settings = assertSettingsWritable();
+  const pin: PanelVersionPin = { version: normalized, pinnedAt: new Date().toISOString() };
+  const trimmedReason = typeof reason === "string" ? reason.trim() : "";
+  if (trimmedReason) pin.reason = trimmedReason;
+  settings.panelPin = pin;
+  write(settings);
+  return pin;
+}
+
+/**
+ * Remove the persisted pin. Returns the pin that was removed, or undefined when
+ * there wasn't one. Does NOT (and cannot) clear an env-var pin — callers must
+ * report that separately so the user isn't told they're unpinned when they
+ * aren't.
+ */
+export function clearPanelVersionPin(): PanelVersionPin | undefined {
+  const settings = assertSettingsWritable();
+  const previous = settings.panelPin;
+  if (!previous) return undefined;
+  delete settings.panelPin;
+  write(settings);
+  return previous;
 }
 
 /** Persisted agent backend/model preferences ({} when never set). */

--- a/src/services/panel-settings.ts
+++ b/src/services/panel-settings.ts
@@ -310,10 +310,17 @@ export function clearPanelVersionPin(): PanelVersionPin | undefined {
   const raw = settings.panelPin as unknown;
   // A malformed stored pin still gets removed; describe it as unreadable rather
   // than returning junk (or undefined, which callers render as "no pin existed").
-  const previous: PanelVersionPin =
+  // The version is validated too, not just the container: `{ version: null }`
+  // and `{ version: " " }` are OBJECTS, and returning them verbatim made unpin
+  // report "was null" / "was " for a pin that getPanelPinState called
+  // indeterminate — two parts of the system describing the same pin differently.
+  const rawVersion =
     raw && typeof raw === "object" && !Array.isArray(raw)
-      ? (raw as PanelVersionPin)
-      : { version: "(unreadable)" };
+      ? normalizePinVersion((raw as Partial<PanelVersionPin>).version)
+      : undefined;
+  const previous: PanelVersionPin = rawVersion
+    ? (raw as PanelVersionPin)
+    : { version: "(unreadable)" };
   delete settings.panelPin;
   write(settings);
   // Symmetrically verified: a "pin removed" we did not observe would leave the

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -239,7 +239,8 @@ export function evaluatePanelSync(
       summary:
         `custom_nodes could not be enumerated, so whether the panel is present is ` +
         `UNRELIABLE — nothing will be changed (a blind install could clobber an ` +
-        `existing, possibly newer, panel). Re-run once custom_nodes is readable.`,
+        `existing, possibly newer, panel). Re-run once custom_nodes is readable.` +
+        driftNote,
     };
   }
 
@@ -269,7 +270,8 @@ export function evaluatePanelSync(
         `Could not enumerate custom_nodes to check for shadow copies of the panel, so ` +
         `it cannot be confirmed that the panel in the browser is the one on disk. NOT ` +
         `syncing on an unverified install. Check custom_nodes is readable (a stray ` +
-        `".comfyui-agent-panel.bak-*" there would shadow the real panel), then re-check.`,
+        `".comfyui-agent-panel.bak-*" there would shadow the real panel), then re-check.` +
+        driftNote,
     };
   }
 
@@ -286,7 +288,8 @@ export function evaluatePanelSync(
         `serves it too, and a dot-prefixed dir wins by sort order, so the browser may ` +
         `be loading it instead of the real panel — the installed version below cannot ` +
         `be trusted. Move the shadow copy OUT of custom_nodes and hard-refresh the ` +
-        `ComfyUI tab before syncing anything.`,
+        `ComfyUI tab before syncing anything.` +
+        driftNote,
     };
   }
 

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -1,0 +1,402 @@
+// Node-pack auto-sync: decide whether the installed sidebar panel pack
+// (comfyui-agent-panel) is behind what THIS orchestrator build needs, and — when
+// it is, and only when the user has not pinned it — run the sync through the
+// hardened, verified install_panel path.
+//
+// WHY THIS EXISTS. The orchestrator ships on npm; the panel ships on the Comfy
+// Registry. Updating one does not update the other, so users end up running a
+// new orchestrator against an old panel. The failures that produces are
+// confusing and hard to diagnose (a bridge command the panel simply doesn't
+// implement), which is exactly the report we got from the community.
+//
+// TWO RULES GOVERN EVERYTHING HERE:
+//
+//  1. NEVER REPORT A SYNC THAT DID NOT HAPPEN. This feature sits on top of the
+//     #639/#641 fabricate-success fixes, so it inherits their discipline: the
+//     mutation runs through `runPanelAction`, which fails closed unless the pack
+//     provably MOVED on disk, and the version we report afterwards is RE-READ
+//     from disk, never the version we intended to install.
+//
+//  2. NEVER MOVE A PINNED USER. A pin is a promise. `evaluatePanelSync` refuses
+//     to recommend a sync while a pin is in force, `performPanelSync` refuses to
+//     execute one, and `runPanelAction` itself refuses at the choke point. Every
+//     "can't tell" (an unreadable pin, an unreadable installed version, a shadow
+//     copy) resolves to "don't touch it", never to "probably fine".
+
+import {
+  panelStatus,
+  runPanelAction,
+  defaultDeps,
+  type PanelInstallerDeps,
+  type PanelStatus,
+} from "./panel-installer.js";
+import {
+  describePanelPin,
+  PANEL_PIN_ENV_VAR,
+  type PanelPinState,
+} from "./panel-settings.js";
+import {
+  BRIDGE_CMD_MIN_PANEL_VERSION,
+  MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
+} from "./ui-bridge.js";
+import { compareSemver, detectInstallMode } from "./self-update.js";
+
+/**
+ * Strict semver screen. `compareSemver` returns 0 for anything it cannot parse,
+ * so an unscreened "nightly" / "dev" / "" would compare EQUAL to the required
+ * version and be reported as up to date — a silent wrong answer. Everything here
+ * screens first and reports `unknown` rather than guessing.
+ */
+const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function isComparableVersion(v: string | undefined): v is string {
+  return typeof v === "string" && SEMVER_RE.test(v.trim());
+}
+
+/**
+ * The highest panel version THIS orchestrator build is known to require.
+ *
+ * Derived, not hand-maintained: it is the maximum of the bridge baseline and
+ * every per-command minimum the orchestrator declares. A release that adds a
+ * command needing a newer panel raises this automatically, so the sync advice
+ * can never drift from the code that actually needs the newer panel.
+ */
+export function requiredPanelVersion(): string {
+  let best = MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS;
+  for (const min of Object.values(BRIDGE_CMD_MIN_PANEL_VERSION)) {
+    if (!isComparableVersion(min)) continue;
+    if (!isComparableVersion(best) || compareSemver(min, best) > 0) best = min;
+  }
+  return best;
+}
+
+export type PanelSyncDecision =
+  /** Behind, nothing pinned, nothing ambiguous → sync is safe to run. */
+  | "sync"
+  /** Behind, but the user pinned the panel → WARN ONLY. Never sync. */
+  | "pinned-warn"
+  /** The installed panel already meets what this orchestrator needs. */
+  | "up-to-date"
+  /** Something must be fixed by a human first (shadow copy, unreadable pin). */
+  | "blocked"
+  /** Can't read a comparable installed version → don't guess, don't touch. */
+  | "unknown"
+  /** Symlinked dev checkout — managed by its owner, never by us. */
+  | "dev-install"
+  /** Remote/cloud, or no local ComfyUI: panel sync doesn't apply here. */
+  | "not-applicable";
+
+export interface PanelSyncAssessment {
+  decision: PanelSyncDecision;
+  /** Highest panel version this orchestrator build is known to require. */
+  requiredPanelVersion: string;
+  /** On-disk panel version; undefined when absent or unreadable. */
+  installedVersion?: string;
+  /** This orchestrator's own npm version, when it can be read. */
+  orchestratorVersion?: string;
+  /** The active pin (see panel-settings). */
+  pin: PanelPinState;
+  /**
+   * True only when we PROVED the panel is older than `requiredPanelVersion` (a
+   * comparable installed version below it, or a confirmed absent pack). An
+   * unreadable version is never "behind".
+   */
+  behind: boolean;
+  /** Plain-language explanation for the user. */
+  summary: string;
+}
+
+export interface EvaluateOptions {
+  /** Override for tests; defaults to the running package's version. */
+  orchestratorVersion?: string;
+  /** Override for tests; defaults to the derived requirement. */
+  requiredVersion?: string;
+}
+
+/**
+ * Pure decision function over a `PanelStatus` snapshot. No I/O, no mutation —
+ * every branch is directly testable, which is the point: this is the logic that
+ * decides whether we are allowed to touch a user's install.
+ */
+export function evaluatePanelSync(
+  status: PanelStatus,
+  opts: EvaluateOptions = {},
+): PanelSyncAssessment {
+  const required = opts.requiredVersion ?? requiredPanelVersion();
+  const orchestratorVersion =
+    opts.orchestratorVersion ?? detectInstallMode().currentVersion ?? undefined;
+  const pin = status.pin ?? { pinned: false, source: "none" as const };
+
+  const base = {
+    requiredPanelVersion: required,
+    installedVersion: status.installedVersion,
+    orchestratorVersion,
+    pin,
+  };
+  const orch = orchestratorVersion ? `comfyui-mcp ${orchestratorVersion}` : "this orchestrator";
+
+  if (!status.applicable) {
+    return {
+      ...base,
+      decision: "not-applicable",
+      behind: false,
+      summary:
+        `Panel sync does not apply here: ${status.note || "no local ComfyUI is configured"}. ` +
+        `The panel pack is managed on the machine that runs ComfyUI.`,
+    };
+  }
+
+  // A symlinked dev checkout belongs to whoever made it. Check this BEFORE the
+  // pin: "we don't touch dev installs" is the stronger, older promise, and
+  // telling a developer to unpin would be wrong advice.
+  if (status.isDevSymlink) {
+    return {
+      ...base,
+      decision: "dev-install",
+      behind: false,
+      summary:
+        `The panel at ${status.dir ?? "custom_nodes"} is a dev symlink — update it ` +
+        `through its own git checkout. Nothing here will modify it.`,
+    };
+  }
+
+  // Can't prove there is no pin → behave as if there is one.
+  if (pin.indeterminate) {
+    return {
+      ...base,
+      decision: "blocked",
+      behind: false,
+      summary:
+        `Cannot determine whether the panel is version-pinned (${describePanelPin(pin)}), ` +
+        `so nothing will be changed. Fix or remove the settings file, or set ` +
+        `${PANEL_PIN_ENV_VAR}=off, then re-check.`,
+    };
+  }
+
+  // A shadow copy means the SERVED panel is not the one on disk, so neither the
+  // "you are behind" reading nor any post-sync version claim would be true.
+  if (status.shadows.length > 0) {
+    const names = status.shadows.map((s) => `"${s.name}"`).join(", ");
+    return {
+      ...base,
+      decision: "blocked",
+      behind: false,
+      summary:
+        `A shadow copy of the panel is present in custom_nodes (${names}). ComfyUI ` +
+        `serves it too, and a dot-prefixed dir wins by sort order, so the browser may ` +
+        `be loading it instead of the real panel — the installed version below cannot ` +
+        `be trusted. Move the shadow copy OUT of custom_nodes and hard-refresh the ` +
+        `ComfyUI tab before syncing anything.`,
+    };
+  }
+
+  if (!status.installed) {
+    // Not installed at all. That is definitionally behind, but a pin still wins:
+    // installing the nightly channel would land some version other than the
+    // pinned one.
+    if (pin.pinned) {
+      return {
+        ...base,
+        decision: "pinned-warn",
+        behind: true,
+        summary:
+          `The panel pack is not installed, and ${orch} needs panel ${required}+. ` +
+          `You are ${describePanelPin(pin)}, so nothing will be installed automatically. ` +
+          `Clear the pin (install_panel(action='unpin')) to let the sync install it.`,
+      };
+    }
+    return {
+      ...base,
+      decision: "sync",
+      behind: true,
+      summary:
+        `The panel pack is not installed and ${orch} needs panel ${required}+. ` +
+        `Syncing will install it, then ComfyUI must be restarted.`,
+    };
+  }
+
+  if (!isComparableVersion(status.installedVersion)) {
+    return {
+      ...base,
+      decision: "unknown",
+      behind: false,
+      summary:
+        `The panel is installed at ${status.dir ?? "custom_nodes"} but its version ` +
+        `(${status.installedVersion ?? "unreadable"}) is not a comparable version ` +
+        `number, so it cannot be compared against the ${required} this orchestrator ` +
+        `needs. NOT syncing on a guess — check the pack's pyproject.toml, or run ` +
+        `install_panel(action='update') deliberately.`,
+    };
+  }
+
+  const behind = compareSemver(status.installedVersion, required) < 0;
+
+  if (pin.pinned) {
+    if (!behind) {
+      return {
+        ...base,
+        decision: "up-to-date",
+        behind: false,
+        summary:
+          `Panel ${status.installedVersion} already meets what ${orch} needs ` +
+          `(${required}+). You are ${describePanelPin(pin)}; nothing to do.`,
+      };
+    }
+    // THE WARN CASE. Say what exists, say they're pinned, change nothing.
+    return {
+      ...base,
+      decision: "pinned-warn",
+      behind: true,
+      summary:
+        `Heads up: ${orch} expects panel ${required}+, and you are on panel ` +
+        `${status.installedVersion} — a newer panel that matches your orchestrator ` +
+        `exists. You are ${describePanelPin(pin)}, so NOTHING has been changed and ` +
+        `nothing will be. If you want the newer panel, clear the pin first ` +
+        `(install_panel(action='unpin')` +
+        (pin.source === "env"
+          ? `, though this pin comes from ${PANEL_PIN_ENV_VAR} and must be unset in ` +
+            `the environment`
+          : ``) +
+        `) and then sync.`,
+    };
+  }
+
+  if (!behind) {
+    return {
+      ...base,
+      decision: "up-to-date",
+      behind: false,
+      summary:
+        `Panel ${status.installedVersion} already meets what ${orch} needs ` +
+        `(${required}+). Nothing to do.`,
+    };
+  }
+
+  return {
+    ...base,
+    decision: "sync",
+    behind: true,
+    summary:
+      `Panel ${status.installedVersion} is older than the ${required}+ that ${orch} ` +
+      `needs. Syncing will pull the latest panel via ComfyUI-Manager; ComfyUI must ` +
+      `be restarted afterwards.`,
+  };
+}
+
+export interface PanelSyncResult {
+  /** True ONLY when the pack provably moved on disk and we re-read the result. */
+  synced: boolean;
+  /** The decision that was acted on (re-evaluated at execution time). */
+  decision: PanelSyncDecision;
+  /** On-disk version before the op, when it was readable. */
+  previousVersion?: string;
+  /**
+   * The version RE-READ from disk after the op — the actual outcome, not the
+   * intended one. Only ever set when `synced` is true.
+   */
+  verifiedVersion?: string;
+  /** Highest panel version this orchestrator build needs. */
+  requiredPanelVersion: string;
+  /**
+   * True when the sync landed but the resulting version is STILL below what the
+   * orchestrator needs. The sync really happened, so `synced` is true — but the
+   * mismatch is not resolved and the user must be told so.
+   */
+  stillBehind?: boolean;
+  /** True when ComfyUI must be restarted to load what just landed. */
+  restartRequired?: boolean;
+  message: string;
+}
+
+export interface PerformSyncOptions {
+  deps?: PanelInstallerDeps;
+  orchestratorVersion?: string;
+  requiredVersion?: string;
+}
+
+/**
+ * Run the sync, honouring every guard.
+ *
+ * Contract, in order:
+ *  - Re-evaluate the decision NOW (never act on a snapshot handed in from
+ *    earlier — the pin may have been set in between).
+ *  - Any decision other than `sync` returns `synced: false` WITHOUT queueing a
+ *    mutation. In particular `pinned-warn` returns the warning and stops; this
+ *    is a policy refusal, not an error.
+ *  - `sync` delegates to `runPanelAction`, which THROWS unless the pack provably
+ *    moved on disk (#639) and no shadow copy is serving (#641). That throw
+ *    propagates: a verification failure is an explicit failure, never a
+ *    downgraded "sync completed with warnings".
+ *  - On success the installed version is RE-READ from disk and reported. If the
+ *    re-read cannot confirm a version, we throw rather than claim a version we
+ *    did not observe.
+ */
+export async function performPanelSync(
+  opts: PerformSyncOptions = {},
+): Promise<PanelSyncResult> {
+  const deps = opts.deps ?? defaultDeps;
+  const before = await panelStatus(deps);
+  const assessment = evaluatePanelSync(before, {
+    orchestratorVersion: opts.orchestratorVersion,
+    requiredVersion: opts.requiredVersion,
+  });
+
+  if (assessment.decision !== "sync") {
+    return {
+      synced: false,
+      decision: assessment.decision,
+      previousVersion: before.installedVersion,
+      requiredPanelVersion: assessment.requiredPanelVersion,
+      message: assessment.summary,
+    };
+  }
+
+  // `update` refreshes an existing pack; `install` is for a pack that isn't
+  // there. Both go through the same verified path and both fail closed.
+  const action = before.installed ? "update" : "install";
+  const result = await runPanelAction(action, deps);
+
+  // Re-read from disk. `runPanelAction` already proved movement, but the version
+  // we hand back to the user must be one we OBSERVED after the fact, not the one
+  // the installer intended or reported.
+  const after = await panelStatus(deps);
+  if (!after.installed || !after.installedVersion) {
+    throw new Error(
+      `Panel ${action} reported success, but re-reading the pack afterwards could ` +
+        `not confirm an installed version${after.dir ? ` at ${after.dir}` : ""}. NOT ` +
+        `reporting a completed sync. Check custom_nodes and re-run ` +
+        `install_panel(action='status').`,
+    );
+  }
+  if (after.shadows.length > 0) {
+    throw new Error(
+      `Panel ${action} applied on disk, but ${after.shadows.length} shadow copy/copies ` +
+        `(${after.shadows.map((s) => `"${s.name}"`).join(", ")}) are still served from ` +
+        `custom_nodes, so the browser may keep loading the OLD panel. NOT reporting a ` +
+        `completed sync: move them out of custom_nodes and hard-refresh the ComfyUI tab.`,
+    );
+  }
+
+  const stillBehind =
+    isComparableVersion(after.installedVersion) &&
+    compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0;
+
+  return {
+    synced: true,
+    decision: "sync",
+    previousVersion: result.previousVersion ?? before.installedVersion,
+    verifiedVersion: after.installedVersion,
+    requiredPanelVersion: assessment.requiredPanelVersion,
+    stillBehind,
+    restartRequired: true,
+    message:
+      `Panel synced: verified on disk as ${after.installedVersion}` +
+      (result.previousVersion ? ` (was ${result.previousVersion})` : ``) +
+      `. ` +
+      (stillBehind
+        ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
+          `orchestrator expects — the update applied but did not close the gap. `
+        : ``) +
+      `RESTART ComfyUI to load it.`,
+  };
+}

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -26,6 +26,8 @@
 import {
   panelStatus,
   runPanelAction,
+  runPanelActionInner,
+  withPanelOpLock,
   defaultDeps,
   type PanelInstallerDeps,
   type PanelStatus,
@@ -425,89 +427,96 @@ export async function performPanelSync(
   opts: PerformSyncOptions = {},
 ): Promise<PanelSyncResult> {
   const deps = opts.deps ?? defaultDeps;
-  const before = await panelStatus(deps);
-  const assessment = evaluatePanelSync(before, {
-    orchestratorVersion: opts.orchestratorVersion,
-    requiredVersion: opts.requiredVersion,
-  });
+  // The status read, the DECISION, and the mutation all run inside the op
+  // lock: a decision made outside could go stale before the lock is acquired,
+  // and a newer panel installed in that gap would be blindly overwritten by
+  // the stale decision (codex gate). runPanelAction's own wrapper would lock
+  // only the mutation half, so this calls the inner action directly.
+  return withPanelOpLock(async () => {
+    const before = await panelStatus(deps);
+    const assessment = evaluatePanelSync(before, {
+      orchestratorVersion: opts.orchestratorVersion,
+      requiredVersion: opts.requiredVersion,
+    });
 
-  if (assessment.decision !== "sync") {
+    if (assessment.decision !== "sync") {
+      return {
+        synced: false,
+        decision: assessment.decision,
+        previousVersion: before.installedVersion,
+        requiredPanelVersion: assessment.requiredPanelVersion,
+        message: assessment.summary,
+      };
+    }
+
+    // `update` refreshes an existing pack; `install` is for a pack that isn't
+    // there. Both go through the same verified path and both fail closed.
+    const action = before.installed ? "update" : "install";
+    const result = await runPanelActionInner(action, deps);
+
+    // Re-read from disk. `runPanelAction` already proved movement, but the version
+    // we hand back to the user must be one we OBSERVED after the fact, not the one
+    // the installer intended or reported.
+    const after = await panelStatus(deps);
+    if (!after.installed || !after.installedVersion) {
+      throw new Error(
+        `Panel ${action} reported success, but re-reading the pack afterwards could ` +
+          `not confirm an installed version${after.dir ? ` at ${after.dir}` : ""}. NOT ` +
+          `reporting a completed sync. Check custom_nodes and re-run ` +
+          `install_panel(action='status').`,
+      );
+    }
+    if (after.shadows.length > 0) {
+      throw new Error(
+        `Panel ${action} applied on disk, but ${after.shadows.length} shadow copy/copies ` +
+          `(${after.shadows.map((s) => `"${s.name}"`).join(", ")}) are still served from ` +
+          `custom_nodes, so the browser may keep loading the OLD panel. NOT reporting a ` +
+          `completed sync: move them out of custom_nodes and hard-refresh the ComfyUI tab.`,
+      );
+    }
+    // A shadow scan that could not RUN is not a clean scan. `shadows: []` from a
+    // failed enumeration would otherwise read as an all-clear here exactly as it
+    // did in the pre-mutation assessment — the same fail-open, one step later.
+    if (after.shadowInspectFailed) {
+      throw new Error(
+        `Panel ${action} applied on disk (now ${after.installedVersion}), but custom_nodes ` +
+          `could not be enumerated afterwards to check for shadow copies, so it cannot be ` +
+          `confirmed that the browser will load THIS panel rather than a stray ` +
+          `".comfyui-agent-panel.bak-*". NOT reporting a completed sync — re-run ` +
+          `install_panel(action='status') once custom_nodes is readable.`,
+      );
+    }
+
+    // Tri-state: `null` when the landed version can't be compared at all.
+    const stillBehind: boolean | null = isComparableVersion(after.installedVersion)
+      ? compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0
+      : null;
+
+    const gapNote =
+      stillBehind === true
+        ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
+          `orchestrator expects — the update applied but did not close the gap. `
+        : stillBehind === null
+          ? `NOTE: "${after.installedVersion}" is not a comparable version number, so ` +
+            `whether it meets the ${assessment.requiredPanelVersion} this orchestrator ` +
+            `expects could NOT be confirmed — the update applied, the version match did ` +
+            `not. `
+          : ``;
+
     return {
-      synced: false,
-      decision: assessment.decision,
-      previousVersion: before.installedVersion,
+      synced: true,
+      decision: "sync",
+      previousVersion: result.previousVersion ?? before.installedVersion,
+      verifiedVersion: after.installedVersion,
       requiredPanelVersion: assessment.requiredPanelVersion,
-      message: assessment.summary,
+      stillBehind,
+      restartRequired: true,
+      message:
+        `Panel synced: verified on disk as ${after.installedVersion}` +
+        (result.previousVersion ? ` (was ${result.previousVersion})` : ``) +
+        `. ` +
+        gapNote +
+        `RESTART ComfyUI to load it.`,
     };
-  }
-
-  // `update` refreshes an existing pack; `install` is for a pack that isn't
-  // there. Both go through the same verified path and both fail closed.
-  const action = before.installed ? "update" : "install";
-  const result = await runPanelAction(action, deps);
-
-  // Re-read from disk. `runPanelAction` already proved movement, but the version
-  // we hand back to the user must be one we OBSERVED after the fact, not the one
-  // the installer intended or reported.
-  const after = await panelStatus(deps);
-  if (!after.installed || !after.installedVersion) {
-    throw new Error(
-      `Panel ${action} reported success, but re-reading the pack afterwards could ` +
-        `not confirm an installed version${after.dir ? ` at ${after.dir}` : ""}. NOT ` +
-        `reporting a completed sync. Check custom_nodes and re-run ` +
-        `install_panel(action='status').`,
-    );
-  }
-  if (after.shadows.length > 0) {
-    throw new Error(
-      `Panel ${action} applied on disk, but ${after.shadows.length} shadow copy/copies ` +
-        `(${after.shadows.map((s) => `"${s.name}"`).join(", ")}) are still served from ` +
-        `custom_nodes, so the browser may keep loading the OLD panel. NOT reporting a ` +
-        `completed sync: move them out of custom_nodes and hard-refresh the ComfyUI tab.`,
-    );
-  }
-  // A shadow scan that could not RUN is not a clean scan. `shadows: []` from a
-  // failed enumeration would otherwise read as an all-clear here exactly as it
-  // did in the pre-mutation assessment — the same fail-open, one step later.
-  if (after.shadowInspectFailed) {
-    throw new Error(
-      `Panel ${action} applied on disk (now ${after.installedVersion}), but custom_nodes ` +
-        `could not be enumerated afterwards to check for shadow copies, so it cannot be ` +
-        `confirmed that the browser will load THIS panel rather than a stray ` +
-        `".comfyui-agent-panel.bak-*". NOT reporting a completed sync — re-run ` +
-        `install_panel(action='status') once custom_nodes is readable.`,
-    );
-  }
-
-  // Tri-state: `null` when the landed version can't be compared at all.
-  const stillBehind: boolean | null = isComparableVersion(after.installedVersion)
-    ? compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0
-    : null;
-
-  const gapNote =
-    stillBehind === true
-      ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
-        `orchestrator expects — the update applied but did not close the gap. `
-      : stillBehind === null
-        ? `NOTE: "${after.installedVersion}" is not a comparable version number, so ` +
-          `whether it meets the ${assessment.requiredPanelVersion} this orchestrator ` +
-          `expects could NOT be confirmed — the update applied, the version match did ` +
-          `not. `
-        : ``;
-
-  return {
-    synced: true,
-    decision: "sync",
-    previousVersion: result.previousVersion ?? before.installedVersion,
-    verifiedVersion: after.installedVersion,
-    requiredPanelVersion: assessment.requiredPanelVersion,
-    stillBehind,
-    restartRequired: true,
-    message:
-      `Panel synced: verified on disk as ${after.installedVersion}` +
-      (result.previousVersion ? ` (was ${result.previousVersion})` : ``) +
-      `. ` +
-      gapNote +
-      `RESTART ComfyUI to load it.`,
-  };
+  });
 }

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -38,16 +38,19 @@ import {
 import {
   BRIDGE_CMD_MIN_PANEL_VERSION,
   MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
+  SEMVER_RE,
 } from "./ui-bridge.js";
 import { compareSemver, detectInstallMode } from "./self-update.js";
 
-/**
- * Strict semver screen. `compareSemver` returns 0 for anything it cannot parse,
- * so an unscreened "nightly" / "dev" / "" would compare EQUAL to the required
- * version and be reported as up to date — a silent wrong answer. Everything here
- * screens first and reports `unknown` rather than guessing.
+/*
+ * Version screening. `compareSemver` returns 0 for anything it cannot parse, so
+ * an unscreened "nightly" / "dev" / "" would compare EQUAL to the required
+ * version and be reported as up to date — a silent wrong answer. We reuse the
+ * project's CANONICAL strict SemVer 2.0.0 grammar (ui-bridge's SEMVER_RE) rather
+ * than a hand-rolled approximation: a looser local regex admitted `01.11.28`
+ * (leading zero) and `0.11.28+.` (empty build identifier), which compareSemver
+ * then read as satisfying 0.11.28.
  */
-const SEMVER_RE = /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 function isComparableVersion(v: string | undefined): v is string {
   return typeof v === "string" && SEMVER_RE.test(v.trim());
@@ -320,17 +323,19 @@ export interface PanelSyncResult {
   /** Highest panel version this orchestrator build needs. */
   requiredPanelVersion: string;
   /**
-   * TRI-STATE, and deliberately so.
+   * TRI-STATE, and `null` rather than `undefined` ON PURPOSE: this object is
+   * JSON.stringify'd to the agent, and `undefined` keys are DROPPED — the
+   * "we couldn't check" state would vanish from the wire and read as absent.
    *  - `true`  → the sync landed but the result is STILL below what the
    *              orchestrator needs. The sync happened; the mismatch did not go
    *              away, and the user must be told.
    *  - `false` → the sync landed and the result PROVABLY meets the requirement.
-   *  - `undefined` → the sync landed but the resulting version is not a
-   *              comparable version number (e.g. "nightly"), so whether the
-   *              requirement is met is UNKNOWN. It must not collapse to `false`:
-   *              "we couldn't check" is not "you're fine".
+   *  - `null`  → the sync landed but the resulting version is not a comparable
+   *              version number (e.g. "nightly"), so whether the requirement is
+   *              met is UNKNOWN. It must not collapse to `false`: "we couldn't
+   *              check" is not "you're fine".
    */
-  stillBehind?: boolean;
+  stillBehind?: boolean | null;
   /** True when ComfyUI must be restarted to load what just landed. */
   restartRequired?: boolean;
   message: string;
@@ -405,16 +410,16 @@ export async function performPanelSync(
     );
   }
 
-  // Tri-state: `undefined` when the landed version can't be compared at all.
-  const stillBehind = isComparableVersion(after.installedVersion)
+  // Tri-state: `null` when the landed version can't be compared at all.
+  const stillBehind: boolean | null = isComparableVersion(after.installedVersion)
     ? compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0
-    : undefined;
+    : null;
 
   const gapNote =
     stillBehind === true
       ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
         `orchestrator expects — the update applied but did not close the gap. `
-      : stillBehind === undefined
+      : stillBehind === null
         ? `NOTE: "${after.installedVersion}" is not a comparable version number, so ` +
           `whether it meets the ${assessment.requiredPanelVersion} this orchestrator ` +
           `expects could NOT be confirmed — the update applied, the version match did ` +

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -186,6 +186,20 @@ export function evaluatePanelSync(
   };
   const orch = orchestratorVersion ? `comfyui-mcp ${orchestratorVersion}` : "this orchestrator";
 
+  // The skill PROMISES visible drift when a user sits on a pinned version —
+  // that warning is owed in every state, including the early-return ones
+  // (remote / dev install), not only on paths that could act.
+  const driftNote = (() => {
+    if (!pin.pinned || pin.indeterminate) return "";
+    if (!status.installedVersion || !isComparableVersion(status.installedVersion)) return "";
+    if (compareSemver(status.installedVersion, required) >= 0) return "";
+    return (
+      ` NOTE: the panel is ${describePanelPin(pin)} and BEHIND what ${orch} ` +
+        `expects (${status.installedVersion} < ${required}) — left untouched; ` +
+        `unpin with install_panel(action='unpin') to close the gap.`
+    );
+  })();
+
   if (!status.applicable) {
     return {
       ...base,
@@ -193,7 +207,8 @@ export function evaluatePanelSync(
       behind: false,
       summary:
         `Panel sync does not apply here: ${status.note || "no local ComfyUI is configured"}. ` +
-        `The panel pack is managed on the machine that runs ComfyUI.`,
+        `The panel pack is managed on the machine that runs ComfyUI.` +
+        driftNote,
     };
   }
 
@@ -207,7 +222,8 @@ export function evaluatePanelSync(
       behind: false,
       summary:
         `The panel at ${status.dir ?? "custom_nodes"} is a dev symlink — update it ` +
-        `through its own git checkout. Nothing here will modify it.`,
+        `through its own git checkout. Nothing here will modify it.` +
+        driftNote,
     };
   }
 

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -125,7 +125,13 @@ export function evaluatePanelSync(
   const required = opts.requiredVersion ?? requiredPanelVersion();
   const orchestratorVersion =
     opts.orchestratorVersion ?? detectInstallMode().currentVersion ?? undefined;
-  const pin = status.pin ?? { pinned: false, source: "none" as const };
+  // A PanelStatus without a `pin` is a caller that predates the pin (or built
+  // the object by hand). Absence of the field is not evidence of absence of a
+  // pin, so it resolves to indeterminate-pinned, not to unpinned.
+  const pin: PanelPinState =
+    status.pin && typeof status.pin === "object"
+      ? status.pin
+      : { pinned: true, source: "settings", indeterminate: true };
 
   const base = {
     requiredPanelVersion: required,
@@ -216,16 +222,32 @@ export function evaluatePanelSync(
   }
 
   if (!isComparableVersion(status.installedVersion)) {
+    const cannotCompare =
+      `The panel is installed at ${status.dir ?? "custom_nodes"} but its version ` +
+      `(${status.installedVersion ?? "unreadable"}) is not a comparable version ` +
+      `number, so it cannot be compared against the ${required} this orchestrator ` +
+      `needs.`;
+    // A pin outranks "we can't tell". Reporting `unknown` here would send the
+    // agent off to suggest a deliberate update that the mutation guard is going
+    // to refuse anyway — and would skip the warning the user is owed.
+    if (pin.pinned) {
+      return {
+        ...base,
+        decision: "pinned-warn",
+        behind: false,
+        summary:
+          `${cannotCompare} You are also ${describePanelPin(pin)}, so nothing will ` +
+          `be changed either way. Clear the pin (install_panel(action='unpin')) ` +
+          `first if you want to move the panel at all.`,
+      };
+    }
     return {
       ...base,
       decision: "unknown",
       behind: false,
       summary:
-        `The panel is installed at ${status.dir ?? "custom_nodes"} but its version ` +
-        `(${status.installedVersion ?? "unreadable"}) is not a comparable version ` +
-        `number, so it cannot be compared against the ${required} this orchestrator ` +
-        `needs. NOT syncing on a guess — check the pack's pyproject.toml, or run ` +
-        `install_panel(action='update') deliberately.`,
+        `${cannotCompare} NOT syncing on a guess — check the pack's pyproject.toml, ` +
+        `or run install_panel(action='update') deliberately.`,
     };
   }
 
@@ -298,9 +320,15 @@ export interface PanelSyncResult {
   /** Highest panel version this orchestrator build needs. */
   requiredPanelVersion: string;
   /**
-   * True when the sync landed but the resulting version is STILL below what the
-   * orchestrator needs. The sync really happened, so `synced` is true — but the
-   * mismatch is not resolved and the user must be told so.
+   * TRI-STATE, and deliberately so.
+   *  - `true`  → the sync landed but the result is STILL below what the
+   *              orchestrator needs. The sync happened; the mismatch did not go
+   *              away, and the user must be told.
+   *  - `false` → the sync landed and the result PROVABLY meets the requirement.
+   *  - `undefined` → the sync landed but the resulting version is not a
+   *              comparable version number (e.g. "nightly"), so whether the
+   *              requirement is met is UNKNOWN. It must not collapse to `false`:
+   *              "we couldn't check" is not "you're fine".
    */
   stillBehind?: boolean;
   /** True when ComfyUI must be restarted to load what just landed. */
@@ -377,9 +405,21 @@ export async function performPanelSync(
     );
   }
 
-  const stillBehind =
-    isComparableVersion(after.installedVersion) &&
-    compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0;
+  // Tri-state: `undefined` when the landed version can't be compared at all.
+  const stillBehind = isComparableVersion(after.installedVersion)
+    ? compareSemver(after.installedVersion, assessment.requiredPanelVersion) < 0
+    : undefined;
+
+  const gapNote =
+    stillBehind === true
+      ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
+        `orchestrator expects — the update applied but did not close the gap. `
+      : stillBehind === undefined
+        ? `NOTE: "${after.installedVersion}" is not a comparable version number, so ` +
+          `whether it meets the ${assessment.requiredPanelVersion} this orchestrator ` +
+          `expects could NOT be confirmed — the update applied, the version match did ` +
+          `not. `
+        : ``;
 
   return {
     synced: true,
@@ -393,10 +433,7 @@ export async function performPanelSync(
       `Panel synced: verified on disk as ${after.installedVersion}` +
       (result.previousVersion ? ` (was ${result.previousVersion})` : ``) +
       `. ` +
-      (stillBehind
-        ? `NOTE: that is still below the ${assessment.requiredPanelVersion} this ` +
-          `orchestrator expects — the update applied but did not close the gap. `
-        : ``) +
+      gapNote +
       `RESTART ComfyUI to load it.`,
   };
 }

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -227,6 +227,22 @@ export function evaluatePanelSync(
     };
   }
 
+  // Can't prove the scan saw everything → "absent" is unreliable (#639). A
+  // sync that installs blind here could clobber a NEWER panel the enumeration
+  // simply missed, exactly the loss the installer's own unreliable-scan guard
+  // refuses. Can't-tell → don't touch.
+  if (status.scanReliable === false) {
+    return {
+      ...base,
+      decision: "blocked",
+      behind: false,
+      summary:
+        `custom_nodes could not be enumerated, so whether the panel is present is ` +
+        `UNRELIABLE — nothing will be changed (a blind install could clobber an ` +
+        `existing, possibly newer, panel). Re-run once custom_nodes is readable.`,
+    };
+  }
+
   // Can't prove there is no pin → behave as if there is one.
   if (pin.indeterminate) {
     return {

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -73,6 +73,38 @@ export function requiredPanelVersion(): string {
   return best;
 }
 
+/**
+ * What a just-written persisted pin actually achieved. Writing the settings file
+ * is not the same as being pinned: `COMFYUI_MCP_PANEL_PIN` takes precedence, so
+ * the saved pin can be inert. Reporting the write as protection without checking
+ * would tell a user they are safe when they are not.
+ */
+export type PinWriteOutcome =
+  /** The pin we saved is the one in force. */
+  | "active"
+  /** An env pin wins: the panel IS pinned, but at the env pin's version. */
+  | "env-overrides-with-pin"
+  /** A concurrent write replaced ours: pinned from settings, at another version. */
+  | "superseded"
+  /** `COMFYUI_MCP_PANEL_PIN=off` (or similar): nothing is pinned at all. */
+  | "not-in-force";
+
+/**
+ * Classify what a pin WRITE achieved, given the pin state resolved immediately
+ * afterwards. `savedVersion` is required so a concurrent write that replaced
+ * ours is reported as `superseded` rather than as our pin being active — the
+ * response must describe the pin that is really in force, not the one we asked
+ * for.
+ */
+export function classifyPinWrite(
+  resolved: PanelPinState,
+  savedVersion: string,
+): PinWriteOutcome {
+  if (!resolved.pinned) return "not-in-force";
+  if (resolved.source === "env") return "env-overrides-with-pin";
+  return resolved.version === savedVersion ? "active" : "superseded";
+}
+
 export type PanelSyncDecision =
   /** Behind, nothing pinned, nothing ambiguous → sync is safe to run. */
   | "sync"
@@ -179,6 +211,23 @@ export function evaluatePanelSync(
         `Cannot determine whether the panel is version-pinned (${describePanelPin(pin)}), ` +
         `so nothing will be changed. Fix or remove the settings file, or set ` +
         `${PANEL_PIN_ENV_VAR}=off, then re-check.`,
+    };
+  }
+
+  // The shadow scan itself failed → `shadows: []` means "we didn't find any",
+  // NOT "there are none". Reading an empty array as an all-clear would let a
+  // served backup copy sit behind a "synced" claim, so an incomplete scan is
+  // blocked exactly like a found shadow.
+  if (status.shadowInspectFailed) {
+    return {
+      ...base,
+      decision: "blocked",
+      behind: false,
+      summary:
+        `Could not enumerate custom_nodes to check for shadow copies of the panel, so ` +
+        `it cannot be confirmed that the panel in the browser is the one on disk. NOT ` +
+        `syncing on an unverified install. Check custom_nodes is readable (a stray ` +
+        `".comfyui-agent-panel.bak-*" there would shadow the real panel), then re-check.`,
     };
   }
 

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -50,6 +50,14 @@ import { compareSemver, detectInstallMode } from "./self-update.js";
  * than a hand-rolled approximation: a looser local regex admitted `01.11.28`
  * (leading zero) and `0.11.28+.` (empty build identifier), which compareSemver
  * then read as satisfying 0.11.28.
+ *
+ * ONE DELIBERATE DEVIATION from the spec grammar: that regex allows an optional
+ * leading `v` (`v0.11.28`). We KEEP it rather than reject it. A `v`-prefixed
+ * version is unambiguous, `compareSemver` parses it correctly, and the panel's
+ * pyproject version is the source here — so rejecting it would call a perfectly
+ * meaningful version "unknown" and refuse a sync the user actually wants. The
+ * screen is about telling a real version from `nightly`/`dev`/garbage, and `v`
+ * does not blur that line.
  */
 
 function isComparableVersion(v: string | undefined): v is string {
@@ -456,6 +464,18 @@ export async function performPanelSync(
         `(${after.shadows.map((s) => `"${s.name}"`).join(", ")}) are still served from ` +
         `custom_nodes, so the browser may keep loading the OLD panel. NOT reporting a ` +
         `completed sync: move them out of custom_nodes and hard-refresh the ComfyUI tab.`,
+    );
+  }
+  // A shadow scan that could not RUN is not a clean scan. `shadows: []` from a
+  // failed enumeration would otherwise read as an all-clear here exactly as it
+  // did in the pre-mutation assessment — the same fail-open, one step later.
+  if (after.shadowInspectFailed) {
+    throw new Error(
+      `Panel ${action} applied on disk (now ${after.installedVersion}), but custom_nodes ` +
+        `could not be enumerated afterwards to check for shadow copies, so it cannot be ` +
+        `confirmed that the browser will load THIS panel rather than a stray ` +
+        `".comfyui-agent-panel.bak-*". NOT reporting a completed sync — re-run ` +
+        `install_panel(action='status') once custom_nodes is readable.`,
     );
   }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -240,7 +240,7 @@ export function minPanelVersionForCmd(cmd: string): string {
  *  the screen and falls through to the conservative fail-closed path (reactive rewrite;
  *  never proactively gated), keeping panelSupportsCmd and panelVersionProvesUnsupported
  *  symmetric on garbage input (codex). */
-const SEMVER_RE =
+export const SEMVER_RE =
   /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
 /** True when the panel ADVERTISED a PARSEABLE version (in its `hello`) that already

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -180,8 +180,10 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
     logger.warn(`No requirements.txt found at ${requirements}; skipping dependency install`);
   }
 
-  return {
-    updated: true,
+    return {
+      // Manager accepted/started a queue; it is not proof any pack (including
+      // the panel) moved on disk. Never fabricate completion from queue state.
+      updated: false,
     comfyui_path: comfyuiPath,
     package_manager: pm,
     steps,
@@ -212,8 +214,8 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
     queue_started: result.queueStarted,
     manager_response: result.managerResponse,
     message: result.queueStarted
-      ? "Queued updates for all custom nodes via ComfyUI-Manager and started the queue worker. " +
-        "Updates run asynchronously; a ComfyUI restart may be required afterward."
+        ? "Queued updates for all custom nodes via ComfyUI-Manager and started the queue worker. " +
+          "Completion is unverified; the sidebar panel may still change later."
       : "Queued updates for all custom nodes via ComfyUI-Manager. " +
         "Could not confirm the queue worker started — check ComfyUI-Manager.",
   };

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -7,6 +7,7 @@ import { resolveInstallInterpreter } from "./workspace-env.js";
 import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { assertPanelPinAllows } from "./panel-pin-guard.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -206,6 +207,11 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
  * then POST <same prefix>/start to kick the worker.
  */
 export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
+  // PIN GUARD — "update everything" includes the sidebar panel pack, so this is
+  // one of the doors into a pinned panel that does NOT pass through
+  // install_panel/runPanelAction. See panel-pin-guard.ts.
+  assertPanelPinAllows("update", "all");
+
   const result = await queueUpdateAllCustomNodes();
 
   return {

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -185,10 +185,8 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
     logger.warn(`No requirements.txt found at ${requirements}; skipping dependency install`);
   }
 
-    return {
-      // Manager accepted/started a queue; it is not proof any pack (including
-      // the panel) moved on disk. Never fabricate completion from queue state.
-      updated: false,
+  return {
+    updated: true,
     comfyui_path: comfyuiPath,
     package_manager: pm,
     steps,
@@ -235,13 +233,15 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
     );
 
     return {
-      updated: true,
+      // Queue acceptance is not proof a generic/bulk Manager update moved the
+      // sidebar panel on disk; keep the result explicitly unverified.
+      updated: false,
       endpoint: result.endpoint,
       queue_started: result.queueStarted,
       manager_response: result.managerResponse,
       message: result.queueStarted
         ? "Queued updates for all custom nodes via ComfyUI-Manager and started the queue worker. " +
-          "Updates run asynchronously; a ComfyUI restart may be required afterward."
+          "Completion is unverified; the sidebar panel may still change later."
         : "Queued updates for all custom nodes via ComfyUI-Manager. " +
           "Could not confirm the queue worker started — check ComfyUI-Manager.",
     };

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -218,19 +218,20 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
   // serialize — which is exactly why the result below reports "queued", never
   // "updated".
   return withPanelPinGuard("update", "all", async () => {
-    const result = await queueUpdateAllCustomNodes();
-
-    // The Manager drains this queue AFTER we return — outside the lock, outside
-    // this process entirely — so a pin written from now on cannot stop it.
-    // Record a pending-op marker: a pin write while it is active gets WARNED
-    // that this update may still land (see panel-pin-guard.ts).
+    // Persist and VERIFY the warning marker BEFORE the remote request. Once the
+    // Manager has accepted update_all, a later pin cannot stop its worker; a
+    // marker write after that point could fail and leave the later pin claiming
+    // protection it cannot provide. If the request itself fails, retain this
+    // conservative marker: a transport failure cannot prove Manager did not
+    // accept the request.
     recordPanelPendingOp(
       "update-all",
-      `an update_all was queued via ComfyUI-Manager and updates EVERY installed ` +
-        `pack — the sidebar panel included — on the Manager's own schedule ` +
+      `an update_all request may have been handed to ComfyUI-Manager and can update EVERY ` +
+        `installed pack — the sidebar panel included — on the Manager's own schedule ` +
         `(usually seconds to minutes; a ComfyUI restart then loads the result)`,
       UPDATE_ALL_PENDING_MS,
     );
+    const result = await queueUpdateAllCustomNodes();
 
     return {
       // Queue acceptance is not proof a generic/bulk Manager update moved the

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -7,7 +7,7 @@ import { resolveInstallInterpreter } from "./workspace-env.js";
 import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { assertPanelPinAllows } from "./panel-pin-guard.js";
+import { withPanelPinGuard } from "./panel-pin-guard.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -209,21 +209,26 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
 export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
   // PIN GUARD — "update everything" includes the sidebar panel pack, so this is
   // one of the doors into a pinned panel that does NOT pass through
-  // install_panel/runPanelAction. See panel-pin-guard.ts.
-  assertPanelPinAllows("update", "all");
+  // install_panel/runPanelAction. See panel-pin-guard.ts. The pin check AND the
+  // queue/start calls run inside the panel mutation lock, so a pin cannot be
+  // written between them (the pin-write path takes the same lock). The Manager
+  // then drains the queue ASYNCHRONOUSLY — outside anything this process can
+  // serialize — which is exactly why the result below reports "queued", never
+  // "updated".
+  return withPanelPinGuard("update", "all", async () => {
+    const result = await queueUpdateAllCustomNodes();
 
-  const result = await queueUpdateAllCustomNodes();
-
-  return {
-    updated: true,
-    endpoint: result.endpoint,
-    queue_started: result.queueStarted,
-    manager_response: result.managerResponse,
-    message: result.queueStarted
+    return {
+      updated: true,
+      endpoint: result.endpoint,
+      queue_started: result.queueStarted,
+      manager_response: result.managerResponse,
+      message: result.queueStarted
         ? "Queued updates for all custom nodes via ComfyUI-Manager and started the queue worker. " +
-          "Completion is unverified; the sidebar panel may still change later."
-      : "Queued updates for all custom nodes via ComfyUI-Manager. " +
-        "Could not confirm the queue worker started — check ComfyUI-Manager.",
-  };
+          "Updates run asynchronously; a ComfyUI restart may be required afterward."
+        : "Queued updates for all custom nodes via ComfyUI-Manager. " +
+          "Could not confirm the queue worker started — check ComfyUI-Manager.",
+    };
+  });
 }
 

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -7,7 +7,11 @@ import { resolveInstallInterpreter } from "./workspace-env.js";
 import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
-import { withPanelPinGuard } from "./panel-pin-guard.js";
+import {
+  recordPanelPendingOp,
+  UPDATE_ALL_PENDING_MS,
+  withPanelPinGuard,
+} from "./panel-pin-guard.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -217,6 +221,18 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
   // "updated".
   return withPanelPinGuard("update", "all", async () => {
     const result = await queueUpdateAllCustomNodes();
+
+    // The Manager drains this queue AFTER we return — outside the lock, outside
+    // this process entirely — so a pin written from now on cannot stop it.
+    // Record a pending-op marker: a pin write while it is active gets WARNED
+    // that this update may still land (see panel-pin-guard.ts).
+    recordPanelPendingOp(
+      "update-all",
+      `an update_all was queued via ComfyUI-Manager and updates EVERY installed ` +
+        `pack — the sidebar panel included — on the Manager's own schedule ` +
+        `(usually seconds to minutes; a ComfyUI restart then loads the result)`,
+      UPDATE_ALL_PENDING_MS,
+    );
 
     return {
       updated: true,

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -520,6 +520,17 @@ async function installWorkflowDependenciesForAnalysis(
       // over it (codex gate). Same pattern as performPanelSync.
       await withPanelOpLock(async () => {
         const status = await panelStatus();
+        // An unreliable scan means "not installed" proves NOTHING — installing
+        // blind could clobber a newer panel the enumeration missed (#639, the
+        // same can't-tell-don't-touch rule sync now follows).
+        if (status.scanReliable === false) {
+          panelNotes.push(
+            `"${pack}" is the sidebar panel pack: custom_nodes could not be enumerated, ` +
+              `so whether it is installed is unknown — NOT installing blind (that could ` +
+              `clobber an existing, possibly newer, panel). Re-run once readable.`,
+          );
+          return;
+        }
         if (status.installed) {
           panelNotes.push(
             `"${pack}" is the sidebar panel pack: already installed ` +

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -1,6 +1,6 @@
 import type { WorkflowJSON, ObjectInfo } from "../comfyui/types.js";
 import { getObjectInfo } from "../comfyui/client.js";
-import { getComfyUIBaseUrl } from "../config.js";
+import { getComfyUIBaseUrl, isLocalMode } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -11,6 +11,8 @@ import {
   startManagerQueueForExternal,
   type ManagerApi,
 } from "./node-management.js";
+import { assertPanelPinAllows, targetsPanelPackExactly } from "./panel-pin-guard.js";
+import { runPanelAction } from "./panel-installer.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -452,8 +454,18 @@ export async function installWorkflowDependencies(
   const toInstall: ManagerNodePack[] = [];
   const installed: string[] = [];
   const unresolved = [...analysis.unresolved];
-
+  // The sidebar panel pack NEVER goes through the generic Manager queue: that
+  // path has neither the pin guard nor on-disk verification (#639/#641 class),
+  // so a workflow naming it would silently move a pinned panel. Panel targets
+  // are peeled off here and handled by the verified path below.
+  const panelTargets: string[] = [];
+  const panelNotes: string[] = [];
   for (const pack of analysis.missingPacks) {
+    if (targetsPanelPackExactly(pack)) {
+      panelTargets.push(pack);
+      installed.push(pack);
+      continue;
+    }
     const entry = byKey.get(pack);
     if (!entry) {
       // Manager v4 removed the legacy getlist catalog endpoint. Its task API
@@ -469,6 +481,29 @@ export async function installWorkflowDependencies(
     }
     toInstall.push(entry);
     installed.push(pack);
+  }
+
+  // Resolve the panel targets: a pin REFUSES (the pin is checked before any
+  // Manager work is queued); local installs go through the verified panel
+  // path (runPanelAction re-reads the pack from disk and fails closed); on a
+  // remote host no on-disk verification exists, so the pin check is the whole
+  // guard and the pack joins the generic queue.
+  for (const pack of panelTargets) {
+    assertPanelPinAllows("install", pack);
+    if (!isLocalMode()) {
+      toInstall.push({ id: pack, version: "latest" });
+      panelNotes.push(
+        `"${pack}" is the sidebar panel pack: queued with the other packs (remote host — ` +
+          `no on-disk verification exists there; the pin check above is the whole guard).`,
+      );
+    } else {
+      const result = await runPanelAction("install");
+      panelNotes.push(
+        `"${pack}" is the sidebar panel pack: installed via the verified panel path ` +
+          `(${result.action}${result.installedVersion ? `, verified ${result.installedVersion}` : ""}). ` +
+          `RESTART ComfyUI to load it.`,
+      );
+    }
   }
 
   let queue: ManagerQueueStatus | undefined;
@@ -497,5 +532,6 @@ export async function installWorkflowDependencies(
     alreadyInstalled: analysis.requiredPacks.filter((p) => !missingSet.has(p)),
     unresolved: [...new Set(unresolved)].sort(),
     queue,
+    ...(panelNotes.length ? { panel_notes: panelNotes } : {}),
   };
 }

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -1,6 +1,6 @@
 import type { WorkflowJSON, ObjectInfo } from "../comfyui/types.js";
 import { getObjectInfo } from "../comfyui/client.js";
-import { getComfyUIBaseUrl, isLocalMode } from "../config.js";
+import { getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -12,7 +12,6 @@ import {
   type ManagerApi,
 } from "./node-management.js";
 import { targetsPanelPackExactly, withPanelPinGuard } from "./panel-pin-guard.js";
-import { runPanelActionInner, panelStatus, withPanelOpLock, defaultDeps } from "./panel-installer.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -473,16 +472,17 @@ async function installWorkflowDependenciesForAnalysis(
   const toInstall: ManagerNodePack[] = [];
   const installed: string[] = [];
   const unresolved = [...analysis.unresolved];
-  // The sidebar panel pack NEVER goes through the generic Manager queue: that
-  // path has neither the pin guard nor on-disk verification (#639/#641 class),
-  // so a workflow naming it would silently move a pinned panel. Panel targets
-  // are peeled off here and handled by the verified path below.
+  // The sidebar panel pack NEVER goes through this transaction. The Manager
+  // target resolved for a workflow dependency may differ from the local root
+  // used to establish which panel the browser serves; accepting either one as
+  // proof would permit an unverified update or fabricate success. Keep it
+  // unresolved and require install_panel on the selected ComfyUI host instead.
   const panelTargets: string[] = [];
   const panelNotes: string[] = [];
   for (const pack of analysis.missingPacks) {
     if (targetsPanelPackExactly(pack)) {
       panelTargets.push(pack);
-      installed.push(pack);
+      unresolved.push(pack);
       continue;
     }
     const entry = byKey.get(pack);
@@ -502,51 +502,16 @@ async function installWorkflowDependenciesForAnalysis(
     installed.push(pack);
   }
 
-  // Resolve the panel targets: the outer withPanelPinGuard keeps this whole
-  // transaction atomically pinned while any panel target is present; local installs go through the verified panel
-  // path (runPanelAction re-reads the pack from disk and fails closed); on a
-  // remote host no on-disk verification exists, so the pin check is the whole
-  // guard and the pack joins the generic queue.
+  // Even under the outer pin guard, this workflow transaction cannot bind its
+  // Manager target to a served-panel root. Do not re-add panel targets to the
+  // generic queue (especially in remote mode), and do not inspect/mutate the
+  // process-global panel root for a possibly different Manager target.
   for (const pack of panelTargets) {
-    if (!isLocalMode()) {
-      toInstall.push({ id: pack, version: "latest" });
-      panelNotes.push(
-        `"${pack}" is the sidebar panel pack: queued with the other packs (remote host — ` +
-          `no on-disk verification exists there; the pin check above is the whole guard).`,
-      );
-    } else {
-      // Status check AND install inside the op lock: a panel landing between
-      // the check and the mutation would otherwise have nightly installed
-      // over it (codex gate). Same pattern as performPanelSync.
-      await withPanelOpLock(async () => {
-        const status = await panelStatus();
-        // An unreliable scan means "not installed" proves NOTHING — installing
-        // blind could clobber a newer panel the enumeration missed (#639, the
-        // same can't-tell-don't-touch rule sync now follows).
-        if (status.scanReliable === false) {
-          panelNotes.push(
-            `"${pack}" is the sidebar panel pack: custom_nodes could not be enumerated, ` +
-              `so whether it is installed is unknown — NOT installing blind (that could ` +
-              `clobber an existing, possibly newer, panel). Re-run once readable.`,
-          );
-          return;
-        }
-        if (status.installed) {
-          panelNotes.push(
-            `"${pack}" is the sidebar panel pack: already installed ` +
-              `(${status.installedVersion ?? "version unreadable"}) — NOT touching it ` +
-              `(use the node-pack sync skill or install_panel to change versions).`,
-          );
-          return;
-        }
-        const result = await runPanelActionInner("install", defaultDeps);
-        panelNotes.push(
-          `"${pack}" is the sidebar panel pack: installed via the verified panel path ` +
-            `(${result.action}${result.installedVersion ? `, verified ${result.installedVersion}` : ""}). ` +
-            `RESTART ComfyUI to load it.`,
-        );
-      });
-    }
+    panelNotes.push(
+      `"${pack}" is the sidebar panel pack: workflow dependency installation does not queue or mutate it ` +
+        `because this Manager transaction cannot prove the same served-panel target. ` +
+        `Use install_panel on the selected ComfyUI host.`,
+    );
   }
 
   let queue: ManagerQueueStatus | undefined;

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -11,7 +11,7 @@ import {
   startManagerQueueForExternal,
   type ManagerApi,
 } from "./node-management.js";
-import { assertPanelPinAllows, targetsPanelPackExactly } from "./panel-pin-guard.js";
+import { targetsPanelPackExactly, withPanelPinGuard } from "./panel-pin-guard.js";
 import { runPanelActionInner, panelStatus, withPanelOpLock, defaultDeps } from "./panel-installer.js";
 
 /**
@@ -441,6 +441,25 @@ export async function installWorkflowDependencies(
     };
   }
 
+  // A dependency install can name the panel exactly like a generic node tool.
+  // Hold the shared guard across the entire queue transaction whenever that is
+  // true: a one-off assert here would reopen the same check-then-queue race the
+  // generic mutation services fixed. Non-panel workflows intentionally do not
+  // take this lock, so ordinary dependency installs do not contend with pins.
+  const panelTarget = analysis.missingPacks.find(targetsPanelPackExactly);
+  if (panelTarget) {
+    return withPanelPinGuard("install workflow dependencies including", panelTarget, () =>
+      installWorkflowDependenciesForAnalysis(analysis, deps),
+    );
+  }
+  return installWorkflowDependenciesForAnalysis(analysis, deps);
+}
+
+async function installWorkflowDependenciesForAnalysis(
+  analysis: ExtractDepsResult,
+  deps: WorkflowDepsDeps,
+): Promise<InstallDepsResult> {
+
   // Match missing packs to concrete Manager list entries for install payloads,
   // capturing the channel the list resolved against.
   const { channel = "default", packs, directInstall = false } = await deps.fetchManagerList();
@@ -483,13 +502,12 @@ export async function installWorkflowDependencies(
     installed.push(pack);
   }
 
-  // Resolve the panel targets: a pin REFUSES (the pin is checked before any
-  // Manager work is queued); local installs go through the verified panel
+  // Resolve the panel targets: the outer withPanelPinGuard keeps this whole
+  // transaction atomically pinned while any panel target is present; local installs go through the verified panel
   // path (runPanelAction re-reads the pack from disk and fails closed); on a
   // remote host no on-disk verification exists, so the pin check is the whole
   // guard and the pack joins the generic queue.
   for (const pack of panelTargets) {
-    assertPanelPinAllows("install", pack);
     if (!isLocalMode()) {
       toInstall.push({ id: pack, version: "latest" });
       panelNotes.push(

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -12,7 +12,7 @@ import {
   type ManagerApi,
 } from "./node-management.js";
 import { assertPanelPinAllows, targetsPanelPackExactly } from "./panel-pin-guard.js";
-import { runPanelAction, panelStatus } from "./panel-installer.js";
+import { runPanelActionInner, panelStatus, withPanelOpLock, defaultDeps } from "./panel-installer.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -497,25 +497,26 @@ export async function installWorkflowDependencies(
           `no on-disk verification exists there; the pin check above is the whole guard).`,
       );
     } else {
-      // Install only when MISSING: a deps install must never move an existing
-      // panel (runPanelAction("install") with no version defaults to nightly,
-      // which could replace a NEWER one). Moving panels is the sync skill's
-      // job, with its own pin/lock discipline.
-      const status = await panelStatus();
-      if (status.installed) {
+      // Status check AND install inside the op lock: a panel landing between
+      // the check and the mutation would otherwise have nightly installed
+      // over it (codex gate). Same pattern as performPanelSync.
+      await withPanelOpLock(async () => {
+        const status = await panelStatus();
+        if (status.installed) {
+          panelNotes.push(
+            `"${pack}" is the sidebar panel pack: already installed ` +
+              `(${status.installedVersion ?? "version unreadable"}) — NOT touching it ` +
+              `(use the node-pack sync skill or install_panel to change versions).`,
+          );
+          return;
+        }
+        const result = await runPanelActionInner("install", defaultDeps);
         panelNotes.push(
-          `"${pack}" is the sidebar panel pack: already installed ` +
-            `(${status.installedVersion ?? "version unreadable"}) — NOT touching it ` +
-            `(use the node-pack sync skill or install_panel to change versions).`,
+          `"${pack}" is the sidebar panel pack: installed via the verified panel path ` +
+            `(${result.action}${result.installedVersion ? `, verified ${result.installedVersion}` : ""}). ` +
+            `RESTART ComfyUI to load it.`,
         );
-        continue;
-      }
-      const result = await runPanelAction("install");
-      panelNotes.push(
-        `"${pack}" is the sidebar panel pack: installed via the verified panel path ` +
-          `(${result.action}${result.installedVersion ? `, verified ${result.installedVersion}` : ""}). ` +
-          `RESTART ComfyUI to load it.`,
-      );
+      });
     }
   }
 

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -12,7 +12,7 @@ import {
   type ManagerApi,
 } from "./node-management.js";
 import { assertPanelPinAllows, targetsPanelPackExactly } from "./panel-pin-guard.js";
-import { runPanelAction } from "./panel-installer.js";
+import { runPanelAction, panelStatus } from "./panel-installer.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -497,6 +497,19 @@ export async function installWorkflowDependencies(
           `no on-disk verification exists there; the pin check above is the whole guard).`,
       );
     } else {
+      // Install only when MISSING: a deps install must never move an existing
+      // panel (runPanelAction("install") with no version defaults to nightly,
+      // which could replace a NEWER one). Moving panels is the sync skill's
+      // job, with its own pin/lock discipline.
+      const status = await panelStatus();
+      if (status.installed) {
+        panelNotes.push(
+          `"${pack}" is the sidebar panel pack: already installed ` +
+            `(${status.installedVersion ?? "version unreadable"}) — NOT touching it ` +
+            `(use the node-pack sync skill or install_panel to change versions).`,
+        );
+        continue;
+      }
       const result = await runPanelAction("install");
       panelNotes.push(
         `"${pack}" is the sidebar panel pack: installed via the verified panel path ` +

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -4,46 +4,135 @@ import {
   panelStatus,
   runPanelAction,
 } from "../services/panel-installer.js";
+import {
+  evaluatePanelSync,
+  performPanelSync,
+  requiredPanelVersion,
+} from "../services/panel-sync.js";
+import {
+  clearPanelVersionPin,
+  getPanelPinState,
+  PANEL_PIN_ENV_VAR,
+  setPanelVersionPin,
+} from "../services/panel-settings.js";
 import { errorToToolResult } from "../utils/errors.js";
+
+function json(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
 
 export function registerInstallPanelTools(server: McpServer): void {
   server.tool(
     "install_panel",
-    "Install, update, reinstall, or report status of the ComfyUI sidebar panel " +
-      "('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in the " +
-      "LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as " +
+    "Install, update, reinstall, sync, pin, or report status of the ComfyUI sidebar " +
+      "panel ('comfyui-agent-panel' on the Comfy Registry; repo comfyui-mcp-panel) in " +
+      "the LOCAL ComfyUI's custom_nodes. Uses the same ComfyUI-Manager path as " +
       "install_custom_node and always targets the 'nightly' (git-HEAD) channel. " +
       "Local-only (no-op/refuses in remote/cloud mode) and NEVER modifies a dev " +
-      "install (a symlinked panel dir). After install/update/reinstall, ComfyUI must " +
-      "be RESTARTED to load the new/updated node — this tool does not auto-restart. " +
-      "The panel is also auto-installed-if-missing when the MCP server loads.",
+      "install (a symlinked panel dir). After install/update/reinstall/sync, ComfyUI " +
+      "must be RESTARTED to load the new/updated node — this tool does not " +
+      "auto-restart. The panel is also auto-installed-if-missing when the MCP server " +
+      "loads. A version PIN (action='pin') holds the panel where it is: while a pin " +
+      "is set, install/update/reinstall/sync and the auto-install all refuse, and " +
+      "'sync' only warns that a newer panel exists.",
     {
       action: z
-        .enum(["status", "install", "update", "reinstall"])
+        .enum([
+          "status",
+          "install",
+          "update",
+          "reinstall",
+          "sync",
+          "pin",
+          "unpin",
+        ])
         .default("status")
         .describe(
-          "status: report installed/version/dev-symlink (never errors). " +
-            "install: add the panel (nightly). update: pull the latest nightly. " +
-            "reinstall: uninstall + reinstall (nightly). install/update/reinstall " +
-            "refuse on a dev symlink and require a local COMFYUI_PATH.",
+          "status: report installed/version/dev-symlink/pin plus a sync assessment " +
+            "(never errors). sync: bring the panel up to what this orchestrator " +
+            "needs — no-ops when already current, WARNS ONLY when pinned, and " +
+            "reports the version re-read from disk afterwards. install: add the " +
+            "panel (nightly). update: pull the latest nightly. reinstall: uninstall " +
+            "+ reinstall (nightly). pin: hold the panel at a version (requires " +
+            "`version`). unpin: clear the pin so a sync can proceed. " +
+            "install/update/reinstall/sync refuse on a dev symlink or an active " +
+            "pin, and require a local COMFYUI_PATH.",
         ),
+      version: z
+        .string()
+        .optional()
+        .describe(
+          "action='pin' only: the panel version to hold at, e.g. '0.11.20'. Use the " +
+            "installedVersion from action='status' to pin where you already are.",
+        ),
+      reason: z
+        .string()
+        .optional()
+        .describe("action='pin' only: why the user is pinning (stored with the pin)."),
     },
-    async ({ action }) => {
+    async ({ action, version, reason }) => {
       try {
         if (action === "status") {
           const status = await panelStatus();
-          return {
-            content: [
-              { type: "text" as const, text: JSON.stringify(status, null, 2) },
-            ],
-          };
+          return json({ ...status, sync: evaluatePanelSync(status) });
         }
-        const result = await runPanelAction(action);
-        return {
-          content: [
-            { type: "text" as const, text: JSON.stringify(result, null, 2) },
-          ],
-        };
+
+        if (action === "sync") {
+          return json(await performPanelSync());
+        }
+
+        if (action === "pin") {
+          const target = (version ?? "").trim();
+          if (!target) {
+            // Refuse rather than guess a version for them — a pin the user did
+            // not choose is worse than no pin.
+            throw new Error(
+              "install_panel(action='pin') needs a `version` (e.g. '0.11.20'). Run " +
+                "install_panel(action='status') and pass its installedVersion to pin " +
+                "where you are now.",
+            );
+          }
+          const pin = setPanelVersionPin(target, reason);
+          const status = await panelStatus();
+          return json({
+            action: "pin",
+            pin: status.pin,
+            requestedVersion: pin.version,
+            installedVersion: status.installedVersion,
+            requiredPanelVersion: requiredPanelVersion(),
+            // A pin records intent; it does NOT move the panel. Saying so
+            // prevents "pinned to 0.11.20" being read as "now on 0.11.20".
+            note:
+              `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
+              `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
+              `install/update/reinstall/sync and the on-load auto-install will now ` +
+              `refuse until the pin is cleared with install_panel(action='unpin').`,
+          });
+        }
+
+        if (action === "unpin") {
+          const removed = clearPanelVersionPin();
+          const after = getPanelPinState();
+          return json({
+            action: "unpin",
+            removed: removed ?? null,
+            pin: after,
+            note: after.pinned
+              ? `The persisted pin was ${removed ? "removed" : "already absent"}, but a ` +
+                `pin is STILL in force via the ${PANEL_PIN_ENV_VAR} environment variable. ` +
+                `Unset ${PANEL_PIN_ENV_VAR} (or set it to 'off') in the environment / ` +
+                `~/.comfyui-mcp/.env and restart the orchestrator before syncing.`
+              : removed
+                ? `Pin removed (was ${removed.version}). install_panel(action='sync') can ` +
+                  `now proceed.`
+                : `No pin was set; nothing to clear. install_panel(action='sync') can ` +
+                  `proceed.`,
+          });
+        }
+
+        return json(await runPanelAction(action));
       } catch (err) {
         return errorToToolResult(err);
       }

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -18,6 +18,7 @@ import {
   PANEL_PIN_ENV_VAR,
   setPanelVersionPin,
 } from "../services/panel-settings.js";
+import { activePanelPendingOps } from "../services/panel-pin-guard.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 function json(value: unknown) {
@@ -102,9 +103,16 @@ export function registerInstallPanelTools(server: McpServer): void {
           // RESOLVED state is read INSIDE the same critical section — reading it
           // after releasing the lock let a concurrent pin/unpin land in between,
           // so the response could describe a pin that was no longer the real one.
-          const { pin, resolved } = await withPanelOpLock(async () => {
+          // The pending-op read is inside too: a marker recorded by an update_all
+          // or snapshot restore (both hold this lock while recording) must be
+          // seen by the very pin write that follows them.
+          const { pin, resolved, pending } = await withPanelOpLock(async () => {
             const written = setPanelVersionPin(target, reason);
-            return { pin: written, resolved: getPanelPinState() };
+            return {
+              pin: written,
+              resolved: getPanelPinState(),
+              pending: activePanelPendingOps(),
+            };
           });
           // What actually governs is NOT necessarily what we just wrote:
           // COMFYUI_MCP_PANEL_PIN takes precedence (so the saved pin can be inert,
@@ -113,6 +121,22 @@ export function registerInstallPanelTools(server: McpServer): void {
           // checking is the fabricated-success failure this feature exists to
           // prevent, so each outcome is named distinctly.
           const outcome = classifyPinWrite(resolved, pin.version);
+          // A pin cannot recall work ALREADY handed to ComfyUI-Manager (a queued
+          // update_all draining on the Manager's worker, or a snapshot restore
+          // deferred to the next ComfyUI restart). WARN rather than refuse: the
+          // pin is valid and governs every FUTURE operation — refusing it would
+          // leave the user LESS protected against the next sync, to punish them
+          // for a race they could not see. Truthful beats silent.
+          const pendingWarning = pending.length
+            ? ` WARNING — ${
+                pending.length === 1
+                  ? "a panel-affecting operation is"
+                  : `${pending.length} panel-affecting operations are`
+              } still pending and may move the panel AFTER this pin: ` +
+              `${pending.map((op) => op.detail).join("; ")}. The pin governs every ` +
+              `install/update/reinstall/sync from now on, but it cannot stop work ` +
+              `already queued — check install_panel(action='status') once it has landed.`
+            : "";
           // panelStatus is advisory here (it only supplies installedVersion for
           // the message); the authoritative pin is `resolved`, captured above.
           const status = await panelStatus();
@@ -125,6 +149,9 @@ export function registerInstallPanelTools(server: McpServer): void {
             requestedVersion: pin.version,
             installedVersion: status.installedVersion,
             requiredPanelVersion: requiredPanelVersion(),
+            /** Panel-affecting operations already handed to ComfyUI-Manager that
+             *  may still land out-of-band (absent when none are pending). */
+            pendingPanelOps: pending.length ? pending : undefined,
             // A pin records intent; it does NOT move the panel. Saying so
             // prevents "pinned to 0.11.20" being read as "now on 0.11.20".
             note:
@@ -132,24 +159,28 @@ export function registerInstallPanelTools(server: McpServer): void {
                 ? `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
                   `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
                   `install/update/reinstall/sync and the on-load auto-install will now ` +
-                  `refuse until the pin is cleared with install_panel(action='unpin').`
+                  `refuse until the pin is cleared with install_panel(action='unpin').` +
+                  pendingWarning
                 : outcome === "env-overrides-with-pin"
                   ? `Saved a pin at ${pin.version}, but it is NOT the pin in force: the ` +
                     `${PANEL_PIN_ENV_VAR} environment variable takes precedence and the ` +
                     `panel is ${describePanelPin(resolved)}. The panel IS protected — ` +
                     `just at the env pin's version, not yours. Unset ${PANEL_PIN_ENV_VAR} ` +
-                    `and restart the orchestrator for the saved ${pin.version} to govern.`
+                    `and restart the orchestrator for the saved ${pin.version} to govern.` +
+                    pendingWarning
                   : outcome === "superseded"
                     ? `Saved a pin at ${pin.version}, but another pin was written at the ` +
                       `same time and won: the panel is ${describePanelPin(resolved)}. The ` +
                       `panel IS pinned, just not at ${pin.version} — re-run the pin if you ` +
-                      `meant yours to stand.`
+                      `meant yours to stand.` +
+                      pendingWarning
                     : `WARNING — the pin was saved to disk but is NOT IN FORCE, and the ` +
                       `panel is NOT protected: ${PANEL_PIN_ENV_VAR} is set to an explicit ` +
                       `"no pin" value, which overrides the saved pin. ` +
                       `install/update/reinstall/sync will still proceed. Unset ` +
                       `${PANEL_PIN_ENV_VAR} in the environment / ~/.comfyui-mcp/.env and ` +
-                      `restart the orchestrator for the saved pin to take effect.`,
+                      `restart the orchestrator for the saved pin to take effect.` +
+                      pendingWarning,
           });
         }
 

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -6,6 +6,7 @@ import {
   withPanelOpLock,
 } from "../services/panel-installer.js";
 import {
+  classifyPinWrite,
   evaluatePanelSync,
   performPanelSync,
   requiredPanelVersion,
@@ -97,50 +98,81 @@ export function registerInstallPanelTools(server: McpServer): void {
             );
           }
           // Serialized with panel mutations: a pin must not commit halfway
-          // through an in-flight install/update (see withPanelOpLock).
-          const pin = await withPanelOpLock(async () =>
-            setPanelVersionPin(target, reason),
-          );
+          // through an in-flight install/update (see withPanelOpLock). The
+          // RESOLVED state is read INSIDE the same critical section — reading it
+          // after releasing the lock let a concurrent pin/unpin land in between,
+          // so the response could describe a pin that was no longer the real one.
+          const { pin, resolved } = await withPanelOpLock(async () => {
+            const written = setPanelVersionPin(target, reason);
+            return { pin: written, resolved: getPanelPinState() };
+          });
+          // What actually governs is NOT necessarily what we just wrote:
+          // COMFYUI_MCP_PANEL_PIN takes precedence (so the saved pin can be inert,
+          // or the panel left unpinned outright by `=off`), and a concurrent write
+          // may have superseded ours. Reporting the write as protection without
+          // checking is the fabricated-success failure this feature exists to
+          // prevent, so each outcome is named distinctly.
+          const outcome = classifyPinWrite(resolved, pin.version);
+          // panelStatus is advisory here (it only supplies installedVersion for
+          // the message); the authoritative pin is `resolved`, captured above.
           const status = await panelStatus();
-          // The RESOLVED pin is what actually governs. A persisted pin is inert
-          // while COMFYUI_MCP_PANEL_PIN overrides it (notably `=off`), and
-          // telling the user they are protected when they are not is exactly the
-          // fabricated-success failure this feature exists to prevent.
-          const active = status.pin.pinned && status.pin.source === "settings";
           return json({
             action: "pin",
-            pin: status.pin,
-            active,
+            pin: resolved,
+            outcome,
+            /** Is the pin we just SAVED the one actually in force? */
+            active: outcome === "active",
             requestedVersion: pin.version,
             installedVersion: status.installedVersion,
             requiredPanelVersion: requiredPanelVersion(),
             // A pin records intent; it does NOT move the panel. Saying so
             // prevents "pinned to 0.11.20" being read as "now on 0.11.20".
-            note: active
-              ? `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
-                `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
-                `install/update/reinstall/sync and the on-load auto-install will now ` +
-                `refuse until the pin is cleared with install_panel(action='unpin').`
-              : `WARNING — the pin was saved to disk but is NOT IN FORCE: the ` +
-                `${PANEL_PIN_ENV_VAR} environment variable overrides it (resolved state: ` +
-                `${describePanelPin(status.pin)}). You are NOT protected. Unset ` +
-                `${PANEL_PIN_ENV_VAR} in the environment / ~/.comfyui-mcp/.env and ` +
-                `restart the orchestrator for the saved pin to take effect.`,
+            note:
+              outcome === "active"
+                ? `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
+                  `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
+                  `install/update/reinstall/sync and the on-load auto-install will now ` +
+                  `refuse until the pin is cleared with install_panel(action='unpin').`
+                : outcome === "env-overrides-with-pin"
+                  ? `Saved a pin at ${pin.version}, but it is NOT the pin in force: the ` +
+                    `${PANEL_PIN_ENV_VAR} environment variable takes precedence and the ` +
+                    `panel is ${describePanelPin(resolved)}. The panel IS protected — ` +
+                    `just at the env pin's version, not yours. Unset ${PANEL_PIN_ENV_VAR} ` +
+                    `and restart the orchestrator for the saved ${pin.version} to govern.`
+                  : outcome === "superseded"
+                    ? `Saved a pin at ${pin.version}, but another pin was written at the ` +
+                      `same time and won: the panel is ${describePanelPin(resolved)}. The ` +
+                      `panel IS pinned, just not at ${pin.version} — re-run the pin if you ` +
+                      `meant yours to stand.`
+                    : `WARNING — the pin was saved to disk but is NOT IN FORCE, and the ` +
+                      `panel is NOT protected: ${PANEL_PIN_ENV_VAR} is set to an explicit ` +
+                      `"no pin" value, which overrides the saved pin. ` +
+                      `install/update/reinstall/sync will still proceed. Unset ` +
+                      `${PANEL_PIN_ENV_VAR} in the environment / ~/.comfyui-mcp/.env and ` +
+                      `restart the orchestrator for the saved pin to take effect.`,
           });
         }
 
         if (action === "unpin") {
-          const removed = await withPanelOpLock(async () => clearPanelVersionPin());
-          const after = getPanelPinState();
+          // Same critical section as the pin path: the post-state is captured
+          // WITH the write, so a concurrent pin can't be misreported as ours.
+          const { removed, after } = await withPanelOpLock(async () => {
+            const gone = clearPanelVersionPin();
+            return { removed: gone, after: getPanelPinState() };
+          });
           return json({
             action: "unpin",
             removed: removed ?? null,
             pin: after,
             note: after.pinned
-              ? `The persisted pin was ${removed ? "removed" : "already absent"}, but a ` +
-                `pin is STILL in force via the ${PANEL_PIN_ENV_VAR} environment variable. ` +
-                `Unset ${PANEL_PIN_ENV_VAR} (or set it to 'off') in the environment / ` +
-                `~/.comfyui-mcp/.env and restart the orchestrator before syncing.`
+              ? after.source === "env"
+                ? `The persisted pin was ${removed ? "removed" : "already absent"}, but a ` +
+                  `pin is STILL in force via the ${PANEL_PIN_ENV_VAR} environment variable. ` +
+                  `Unset ${PANEL_PIN_ENV_VAR} (or set it to 'off') in the environment / ` +
+                  `~/.comfyui-mcp/.env and restart the orchestrator before syncing.`
+                : `The persisted pin was ${removed ? "removed" : "already absent"}, but the ` +
+                  `panel is pinned again: ${describePanelPin(after)}. Something wrote a new ` +
+                  `pin at the same time — re-run unpin if you still want it cleared.`
               : removed
                 ? `Pin removed (was ${removed.version}). install_panel(action='sync') can ` +
                   `now proceed.`

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   panelStatus,
   runPanelAction,
+  withPanelOpLock,
 } from "../services/panel-installer.js";
 import {
   evaluatePanelSync,
@@ -11,6 +12,7 @@ import {
 } from "../services/panel-sync.js";
 import {
   clearPanelVersionPin,
+  describePanelPin,
   getPanelPinState,
   PANEL_PIN_ENV_VAR,
   setPanelVersionPin,
@@ -94,26 +96,41 @@ export function registerInstallPanelTools(server: McpServer): void {
                 "where you are now.",
             );
           }
-          const pin = setPanelVersionPin(target, reason);
+          // Serialized with panel mutations: a pin must not commit halfway
+          // through an in-flight install/update (see withPanelOpLock).
+          const pin = await withPanelOpLock(async () =>
+            setPanelVersionPin(target, reason),
+          );
           const status = await panelStatus();
+          // The RESOLVED pin is what actually governs. A persisted pin is inert
+          // while COMFYUI_MCP_PANEL_PIN overrides it (notably `=off`), and
+          // telling the user they are protected when they are not is exactly the
+          // fabricated-success failure this feature exists to prevent.
+          const active = status.pin.pinned && status.pin.source === "settings";
           return json({
             action: "pin",
             pin: status.pin,
+            active,
             requestedVersion: pin.version,
             installedVersion: status.installedVersion,
             requiredPanelVersion: requiredPanelVersion(),
             // A pin records intent; it does NOT move the panel. Saying so
             // prevents "pinned to 0.11.20" being read as "now on 0.11.20".
-            note:
-              `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
-              `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
-              `install/update/reinstall/sync and the on-load auto-install will now ` +
-              `refuse until the pin is cleared with install_panel(action='unpin').`,
+            note: active
+              ? `Pinned to ${pin.version}. This records intent only — it does NOT change ` +
+                `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
+                `install/update/reinstall/sync and the on-load auto-install will now ` +
+                `refuse until the pin is cleared with install_panel(action='unpin').`
+              : `WARNING — the pin was saved to disk but is NOT IN FORCE: the ` +
+                `${PANEL_PIN_ENV_VAR} environment variable overrides it (resolved state: ` +
+                `${describePanelPin(status.pin)}). You are NOT protected. Unset ` +
+                `${PANEL_PIN_ENV_VAR} in the environment / ~/.comfyui-mcp/.env and ` +
+                `restart the orchestrator for the saved pin to take effect.`,
           });
         }
 
         if (action === "unpin") {
-          const removed = clearPanelVersionPin();
+          const removed = await withPanelOpLock(async () => clearPanelVersionPin());
           const after = getPanelPinState();
           return json({
             action: "unpin",

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -8,6 +8,7 @@ import {
   fixCustomNode,
   listInstalledNodes,
   syncNodeDependencies,
+  parseGitUrl,
   type InstalledNode,
 } from "../services/node-management.js";
 import { errorToToolResult } from "../utils/errors.js";
@@ -17,6 +18,7 @@ import {
   targetsPanelPackExactly,
 } from "../services/panel-pin-guard.js";
 import { runPanelAction } from "../services/panel-installer.js";
+import { SEMVER_RE } from "../services/ui-bridge.js";
 
 /**
  * The sidebar panel pack is an ordinary custom node pack, so `install_custom_node`
@@ -31,6 +33,21 @@ import { runPanelAction } from "../services/panel-installer.js";
  * is enforced deeper still, in the services themselves — see panel-pin-guard.ts —
  * so bulk targets like "all" are covered even though they cannot be redirected.)
  */
+/**
+ * Can the verified panel path honour this git ref as a registry version?
+ *
+ * The verified path installs from the Comfy Registry, so the only refs it can
+ * honour are the ones that ARE registry versions: the channel names, or a
+ * strict semver (ui-bridge's canonical grammar; a leading-"v" tag means the
+ * same version, and the registry spelling is the bare form). Anything else — a
+ * branch, a sha — would silently become something other than what was asked.
+ */
+function registryInstallableRef(ref: string): string | undefined {
+  if (ref === "nightly" || ref === "latest") return ref;
+  if (!SEMVER_RE.test(ref)) return undefined;
+  return ref.replace(/^v(?=\d)/, "");
+}
+
 async function runVerifiedPanelAction(
   action: "install" | "update" | "reinstall",
   id: string,
@@ -51,7 +68,42 @@ async function runVerifiedPanelAction(
         `never touched by these tools).`,
     );
   }
-  const result = await runPanelAction(action, undefined, { version: opts.version });
+
+  // A ref EMBEDDED in the id itself ("...comfyui-mcp-panel.git@v0.11.28",
+  // ".../tree/v0.11.28") is just as much a requested version as the `version`
+  // option — and it used to DIE here: targetsPanelPackExactly matched the URL,
+  // the redirect threaded only `version`, and the user got NIGHTLY while the
+  // response implied success. Honour the refs the registry path can honour;
+  // refuse the rest, exactly like the git options above.
+  const embeddedRef = parseGitUrl(id).ref;
+  let version = opts.version;
+  if (embeddedRef) {
+    const registryVersion = registryInstallableRef(embeddedRef);
+    if (!registryVersion) {
+      throw new Error(
+        `"${id}" embeds git ref "${embeddedRef}", which the verified panel path ` +
+          `cannot honour: it installs the comfyui-mcp sidebar panel pack from the ` +
+          `Comfy Registry, where only a strict semver (e.g. v0.11.28), "nightly" or ` +
+          `"latest" names a version. Use a release tag, or pass \`version\` instead.`,
+      );
+    }
+    if (version && version !== registryVersion) {
+      throw new Error(
+        `Conflicting panel versions: the id embeds "@${embeddedRef}" but ` +
+          `\`version\` says "${version}". Pick one — this tool will not guess.`,
+      );
+    }
+    if (action === "update") {
+      throw new Error(
+        `"${id}" embeds git ref "${embeddedRef}", but update always pulls the ` +
+          `channel tip — a ref cannot be honoured. Use install/reinstall with the ` +
+          `ref to get a specific panel version.`,
+      );
+    }
+    version = registryVersion;
+  }
+
+  const result = await runPanelAction(action, undefined, { version });
   return {
     content: [
       {
@@ -65,8 +117,11 @@ async function runVerifiedPanelAction(
               `through the verified panel path: the version above was RE-READ from ` +
               `disk after the operation, and a Manager no-op or a shadow copy would ` +
               `have failed instead of reporting success. ` +
-              (opts.version
-                ? `Your requested version (${opts.version}) was used as the target. `
+              (version
+                ? embeddedRef
+                  ? `The ref embedded in the URL (@${embeddedRef}) was honoured as ` +
+                    `the target version (${version}). `
+                  : `Your requested version (${version}) was used as the target. `
                 : `It targets the 'nightly' channel. `) +
               `The mode/channel/useCmCli options do not apply on this path. Use ` +
               `install_panel directly for status/sync/pin.`,

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -12,7 +12,10 @@ import {
 } from "../services/node-management.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { getComfyCliVersion, resolveComfyCliExecutable, shouldUseComfyCli } from "../services/comfy-cli.js";
-import { targetsPanelPackExactly } from "../services/panel-pin-guard.js";
+import {
+  assertPanelNotTargetedUnverifiable,
+  targetsPanelPackExactly,
+} from "../services/panel-pin-guard.js";
 import { runPanelAction } from "../services/panel-installer.js";
 
 /**
@@ -31,8 +34,24 @@ import { runPanelAction } from "../services/panel-installer.js";
 async function runVerifiedPanelAction(
   action: "install" | "update" | "reinstall",
   id: string,
+  opts: { version?: string; ref?: string; source?: string } = {},
 ) {
-  const result = await runPanelAction(action);
+  // Options the verified path cannot honour are REFUSED, not dropped. Silently
+  // ignoring a caller's `ref` and then reporting success would be doing
+  // something other than what was asked — a smaller cousin of the exact lie this
+  // whole feature guards against. (`version` IS honoured; it is threaded through.)
+  if (opts.ref || opts.source === "git") {
+    throw new Error(
+      `"${id}" is the comfyui-mcp sidebar panel pack, which is managed through the ` +
+        `verified panel path (it re-reads the pack from disk afterwards and fails ` +
+        `closed on a ComfyUI-Manager no-op or a shadow copy). That path installs from ` +
+        `the Comfy Registry, so a git \`ref\`/\`source: "git"\` cannot be honoured and ` +
+        `will NOT be silently ignored. Drop the git options to install it normally, ` +
+        `or manage a git checkout of the panel yourself (a symlinked dev install is ` +
+        `never touched by these tools).`,
+    );
+  }
+  const result = await runPanelAction(action, undefined, { version: opts.version });
   return {
     content: [
       {
@@ -45,8 +64,12 @@ async function runVerifiedPanelAction(
               `"${id}" is the comfyui-mcp sidebar panel pack, so this ${action} ran ` +
               `through the verified panel path: the version above was RE-READ from ` +
               `disk after the operation, and a Manager no-op or a shadow copy would ` +
-              `have failed instead of reporting success. Use install_panel directly ` +
-              `for status/sync/pin.`,
+              `have failed instead of reporting success. ` +
+              (opts.version
+                ? `Your requested version (${opts.version}) was used as the target. `
+                : `It targets the 'nightly' channel. `) +
+              `The mode/channel/useCmCli options do not apply on this path. Use ` +
+              `install_panel directly for status/sync/pin.`,
           },
           null,
           2,
@@ -144,7 +167,11 @@ export function registerNodeManagementTools(server: McpServer): void {
     async (args) => {
       try {
         if (targetsPanelPackExactly(args.id)) {
-          return await runVerifiedPanelAction("install", args.id);
+          return await runVerifiedPanelAction("install", args.id, {
+            version: args.version,
+            ref: args.ref,
+            source: args.source,
+          });
         }
         const result = await installCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
@@ -198,7 +225,9 @@ export function registerNodeManagementTools(server: McpServer): void {
     async (args) => {
       try {
         if (targetsPanelPackExactly(args.id)) {
-          return await runVerifiedPanelAction("reinstall", args.id);
+          return await runVerifiedPanelAction("reinstall", args.id, {
+            version: args.version,
+          });
         }
         const result = await reinstallCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
@@ -212,7 +241,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "fix_custom_node",
-    "Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP.",
+    "Repair a ComfyUI custom node pack's install and Python dependencies, or pass 'all' to repair every pack. Local operations prefer official comfy-cli; remote single-pack repairs use Manager HTTP. REFUSES the comfyui-mcp sidebar panel pack — 'fix' has no verified on-disk check, so use install_panel for the panel — and refuses 'all' while the panel is version-pinned.",
     {
       id: z
         .string()
@@ -234,6 +263,13 @@ export function registerNodeManagementTools(server: McpServer): void {
         );
       }
       try {
+        // `fix` has no verified equivalent (it reports success off the Manager
+        // queue, which proves nothing — #639), so a panel target is refused
+        // rather than redirected. Bulk "all" is handled by the pin guard inside
+        // the service.
+        if (targetsPanelPackExactly(args.id)) {
+          assertPanelNotTargetedUnverifiable("fix_custom_node", args.id);
+        }
         const result = await fixCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],

--- a/src/tools/node-management.ts
+++ b/src/tools/node-management.ts
@@ -12,6 +12,49 @@ import {
 } from "../services/node-management.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { getComfyCliVersion, resolveComfyCliExecutable, shouldUseComfyCli } from "../services/comfy-cli.js";
+import { targetsPanelPackExactly } from "../services/panel-pin-guard.js";
+import { runPanelAction } from "../services/panel-installer.js";
+
+/**
+ * The sidebar panel pack is an ordinary custom node pack, so `install_custom_node`
+ * / `update_custom_node` / `reinstall_custom_node` can target it by id. The
+ * generic services report success straight off the ComfyUI-Manager queue result,
+ * which a stale Manager 3.x drains WITHOUT doing any work (#639) — and they know
+ * nothing about `.bak` shadow copies (#641). Reaching the panel through them
+ * would therefore reintroduce both bugs through a side door.
+ *
+ * So a call that names the panel is REDIRECTED into the verified path, which
+ * re-reads the pack from disk and fails closed unless it provably moved. (The pin
+ * is enforced deeper still, in the services themselves — see panel-pin-guard.ts —
+ * so bulk targets like "all" are covered even though they cannot be redirected.)
+ */
+async function runVerifiedPanelAction(
+  action: "install" | "update" | "reinstall",
+  id: string,
+) {
+  const result = await runPanelAction(action);
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            ...result,
+            routedVia: "install_panel",
+            note:
+              `"${id}" is the comfyui-mcp sidebar panel pack, so this ${action} ran ` +
+              `through the verified panel path: the version above was RE-READ from ` +
+              `disk after the operation, and a Manager no-op or a shadow copy would ` +
+              `have failed instead of reporting success. Use install_panel directly ` +
+              `for status/sync/pin.`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
 
 /** Graceful "not supported remotely" tool result (no isError), matching the
  *  degrade-don't-throw pattern list_local_models uses. */
@@ -71,7 +114,7 @@ function formatInstalledNodes(nodes: InstalledNode[]): string {
 export function registerNodeManagementTools(server: McpServer): void {
   server.tool(
     "install_custom_node",
-    "Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required.",
+    "Install a ComfyUI custom node pack by registry id, git URL, or name. Local installs prefer official comfy-cli when available; remote or CLI-unavailable installs use the ComfyUI-Manager HTTP API. A ComfyUI restart may be required. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards) and is REFUSED while the panel is version-pinned.",
     {
       id: z
         .string()
@@ -100,6 +143,9 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
+        if (targetsPanelPackExactly(args.id)) {
+          return await runVerifiedPanelAction("install", args.id);
+        }
         const result = await installCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
@@ -112,7 +158,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "update_custom_node",
-    "Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP.",
+    "Update an installed ComfyUI custom node pack, or pass 'all' to update every installed pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards). While the panel is version-pinned, BOTH a direct panel target and 'all' are REFUSED — 'all' would move the pinned panel too; clear the pin with install_panel(action='unpin') or update other packs individually.",
     {
       id: z
         .string()
@@ -123,6 +169,9 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
+        if (targetsPanelPackExactly(args.id)) {
+          return await runVerifiedPanelAction("update", args.id);
+        }
         const result = await updateCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
@@ -135,7 +184,7 @@ export function registerNodeManagementTools(server: McpServer): void {
 
   server.tool(
     "reinstall_custom_node",
-    "Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required.",
+    "Reinstall a ComfyUI custom node pack. Local operations prefer official comfy-cli; remote operations use Manager HTTP. A ComfyUI restart may be required. Targeting the comfyui-mcp sidebar panel pack ('comfyui-agent-panel' / 'comfyui-mcp-panel') is routed through the verified install_panel path (the version is re-read from disk afterwards) and is REFUSED while the panel is version-pinned.",
     {
       id: z.string().describe("Registry id / module name to reinstall."),
       version: z
@@ -148,6 +197,9 @@ export function registerNodeManagementTools(server: McpServer): void {
     },
     async (args) => {
       try {
+        if (targetsPanelPackExactly(args.id)) {
+          return await runVerifiedPanelAction("reinstall", args.id);
+        }
         const result = await reinstallCustomNode({ ...args, useCmCli: preferLocalComfyCli(args.useCmCli) });
         return {
           content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],

--- a/src/tools/update-comfyui.ts
+++ b/src/tools/update-comfyui.ts
@@ -24,7 +24,7 @@ export function registerUpdateComfyUITools(server: McpServer): void {
 
   server.tool(
     "update_all",
-    "Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues update_all, then starts the queue worker). Mirrors `comfy-cli update all`. This does NOT update ComfyUI core — use update_comfyui for that. Works against the connected instance (local or remote); updates run asynchronously and a ComfyUI restart may be required afterward.",
+    "Update ALL installed custom nodes via the ComfyUI-Manager HTTP API (queues update_all, then starts the queue worker). Mirrors `comfy-cli update all`. This does NOT update ComfyUI core — use update_comfyui for that. Works against the connected instance (local or remote); updates run asynchronously and a ComfyUI restart may be required afterward. REFUSED while the comfyui-mcp sidebar panel is version-pinned, because 'all' would move the pinned panel too and ComfyUI-Manager cannot update everything-except-one-pack — clear the pin with install_panel(action='unpin'), or update the other packs individually by id.",
     {},
     async () => {
       try {


### PR DESCRIPTION
## Why

The orchestrator ships on npm; the sidebar panel node-pack (`comfyui-agent-panel`) ships on the Comfy Registry. **Updating one does not update the other**, so users end up running a new orchestrator against an old panel — and the failures that produces (a bridge command the panel simply doesn't implement, a documented sidebar feature that isn't there) are confusing and hard to self-diagnose.

Community request: **Discord `#help`, from `seanmcmagic`** — "orchestrator updated, panel didn't; can it offer to sync?" No issue number for this one.

Unblocked by the hardened install/update-verify path that just landed (`0a4d98b`, `00df2c3`, `4c3aed3`, closing #639/#641). This feature is built **on top of** that verified path and inherits its discipline.

## What

A new skill, **`plugin/skills/panel-node-pack-sync/SKILL.md`** (36 → 37 skills), that walks an agent through: detect the version mismatch → check for a pin → warn-or-sync → report the **verified** outcome.

Supporting logic, all behind the existing `install_panel` tool — **no new tool** (`TOOL_NAMES`, `MAX_TOOLS`, the baseline SHA and `tool-vocabulary.json` are untouched, so this doesn't collide with the in-flight consolidation).

### Version pin — new, minimal

There was no pin mechanism in the codebase, so this adds one, following the existing `panel-settings.ts` accessor pattern:

- Stored as `panelPin` in `~/.comfyui-mcp/panel-settings.json`, with a `COMFYUI_MCP_PANEL_PIN` env override (**env > `.env` > json**, matching the rest of the config since `.env` is loaded into `process.env` at boot). `COMFYUI_MCP_PANEL_PIN=off` is an explicit "no pin" escape hatch.
- **Enforced at the mutation choke point** (`runPanelAction`), not in the skill — so `install`/`update`/`reinstall`/`sync` *and* the on-load auto-installer all refuse for every caller, not just the ones that remembered to check.

Owner's three constraints, and where each lives:

| Constraint | Implementation |
|---|---|
| **Respect an explicit pin** | `runPanelAction` throws before queuing anything; `ensurePanelInstalled` skips; `performPanelSync` refuses without calling the mutation at all. |
| **Warn when pinned** | `decision: "pinned-warn"` — names the newer version the orchestrator needs, says they're pinned and *where* the pin lives, and changes nothing. |
| **Allow unset/reset** | `install_panel(action='unpin')` clears it and reports whether a sync can now proceed. An env pin is reported as still in force rather than falsely cleared. |

### The two invariants

1. **Never report a sync that didn't happen.** The mutation goes through `runPanelAction`, which fails closed unless the pack provably moved on disk (#639) and no shadow copy is serving (#641). `performPanelSync` then **re-reads the pack from disk** and reports `verifiedVersion` — the version *observed*, never the one intended. `stillBehind` is tri-state (`null` = the landed version isn't comparable, so the match could **not** be confirmed — deliberately `null` and not `undefined`, which `JSON.stringify` would drop).
2. **Never move a pinned user.** Every "can't tell" resolves to *pinned*: an unparseable settings file, a present-but-malformed pin key, or a pin reader that throws all refuse to move the panel.

### `install_panel` surface

`action` gains `sync`, `pin`, `unpin` (plus optional `version`/`reason`); `status` additionally returns the pin and a `sync` assessment. Existing actions behave as before when nothing is pinned.

## Self-gate

`codex exec -s read-only -m gpt-5.6-terra`, scoped to *"can this ever report a sync that didn't happen, and can it move a pinned user off their pin?"* — **4 rounds, FAIL → FAIL → FAIL → PASS**, 12 findings fixed. The ones worth knowing about:

- **Critical:** `typeof [] === "object"`, so a settings file containing `[]` parsed as valid → read as *unpinned*, **and** a pin written to it was silently dropped (an array expando doesn't survive `JSON.stringify`) while the tool reported "Pinned to X". A user would have believed they were protected and weren't. Arrays/null/scalars are now `unreadable` (= pinned), and set/clear **verify by re-reading**.
- **High:** pin writes and panel mutations weren't serialized, so a pin could commit after an op's final pin check but before ComfyUI-Manager touched disk. Both now share one in-process lock (which independently stops two concurrent ops each reading the other's half-applied state — that would break the #639 before/after proof).
- **High:** `action='pin'` claimed protection even when `COMFYUI_MCP_PANEL_PIN` overrode it. Four resolved outcomes are now reported distinctly, and only the genuine `=off` case says the panel is unprotected.
- **Medium:** a *present but malformed* `panelPin` (`null`, `false`, `0`, a bare string) read as unpinned, and clear keyed on truthiness so a falsy one could never be removed.
- **Medium:** a **failed** shadow scan returned `shadows: []` with the caveat only in prose, so the sync assessment read it as an all-clear. It's now structural (`shadowInspectFailed`) and decides `blocked`.
- **Medium:** the hand-rolled semver screen accepted `01.11.28` / `0.11.28+.`; it now reuses ui-bridge's canonical strict SemVer 2.0.0 grammar, which existed for exactly this reason.

Round 4 verdict: *"No remaining path found that reports a completed sync/update/install without verified disk movement… No remaining path found that moves a currently pinned user."*

## Tests

`src/__tests__/services/panel-sync.test.ts` (new) plus additions to the panel-installer and panel-settings suites — the required decision matrix (mismatch+no pin → sync; mismatch+pin → warn only, **zero** mutations queued; pin cleared → sync proceeds; equal → no-op; verification failure → throws, never a success claim), the choke-point guard, pin-store precedence and every fail-closed path.

## Verification

`npm run build`, `npm run lint`, `npm test` (green — the one `node-dev` failure is pre-existing on this machine: it asserts the builtin search fallback while ripgrep is on `PATH`, and fails identically on `main`), `asset-counts --check`, `check:vocabulary`, `vocab:export --check`, `docs:gen` (no-op), and `smoke-install.mjs`.

Not live-tested against a real ComfyUI-Manager update — the verified path it delegates to was live-tested in #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
