### PR TITLE
fix(install): target the live ComfyUI interpreter

### DIFF
--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -42,7 +42,7 @@ Install ComfyUI locally: git-clone it into a target directory, create a dedicate
 
 ## update_comfyui
 
-Update the ComfyUI core install: runs `git pull` in the configured ComfyUI directory and reinstalls its Python requirements (auto-detecting uv vs pip). Requires a local install (COMFYUI_PATH); returns a clear error when targeting a remote instance via --comfyui-url.
+Update the ComfyUI core install: runs `git pull` in the configured ComfyUI directory and reinstalls its Python requirements (auto-detecting uv vs pip). Requires a local install (COMFYUI_PATH); returns a clear error when targeting a remote instance via --comfyui-url. The requirements install targets the running server's own interpreter (recorded when this server launched ComfyUI, or an explicit COMFYUI_PYTHON); when that interpreter cannot be verified the update refuses rather than install into a guessed environment — start ComfyUI or connect first.
 
 <Note>This tool takes no parameters.</Note>
 

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -34,6 +34,17 @@ const savedWorkspaceMock = vi.hoisted(() => vi.fn(() => undefined as string | un
 const liveComfyBaseMock = vi.hoisted(() =>
   vi.fn(async () => undefined as string | undefined),
 );
+// Overridable per-test: default mirrors a VERIFIED install-root interpreter (the
+// fail-closed resolver only returns a python it can account for, #651).
+const installInterpreterMock = vi.hoisted(() =>
+  vi.fn(
+    async (root: string | undefined): Promise<{ python?: string; source: string; reason: string }> => ({
+      python: root ? `${root}/python` : "python",
+      source: "launched",
+      reason: "test interpreter",
+    }),
+  ),
+);
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
@@ -124,11 +135,8 @@ vi.mock("../../services/workspace-env.js", () => ({
   // Mirrors the real resolver enough for the pip tests: an install-root python.
   resolveRootInterpreter: (root: string | undefined) =>
     root ? `${root}/python` : "python",
-  resolveInstallInterpreter: async (root: string | undefined) => ({
-    python: root ? `${root}/python` : "python",
-    source: "unverified",
-    reason: "test interpreter",
-  }),
+  resolveInstallInterpreter: (...a: unknown[]) =>
+    installInterpreterMock(...(a as [string | undefined])),
 }));
 
 // resolveLocalModelPath now roots local_path validation at the SAME live write
@@ -173,6 +181,13 @@ beforeEach(() => {
   listLocalModelsMock.mockReset().mockResolvedValue([]);
   savedWorkspaceMock.mockReset().mockReturnValue(undefined);
   liveComfyBaseMock.mockReset().mockResolvedValue(undefined);
+  installInterpreterMock.mockReset().mockImplementation(
+    async (root: string | undefined) => ({
+      python: root ? `${root}/python` : "python",
+      source: "launched",
+      reason: "test interpreter",
+    }),
+  );
   modelsDirMock.mockReset().mockResolvedValue("/fake/ComfyUI/models");
 });
 
@@ -539,6 +554,29 @@ describe("applyManifest", () => {
       ["-m", "pip", "install", "imageio-ffmpeg"],
       expect.objectContaining({ cwd: COMFY }),
     );
+  });
+
+  it("reports pip as failed — never applied — when the server interpreter cannot be verified (#651)", async () => {
+    installInterpreterMock.mockResolvedValue({
+      source: "undetermined",
+      reason:
+        "Cannot verify the running server's interpreter: no local ComfyUI is reachable. " +
+        "Start ComfyUI or connect to it first.",
+    });
+
+    const result = await applyManifest({ manifest: { pip: ["omegaconf"] } });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toMatchObject([
+      { action: "pip", item: "omegaconf", status: "failed" },
+    ]);
+    expect(result.results[0].message).toContain("Cannot verify the running server's interpreter");
+    // No pip/uv subprocess ran for the refused package.
+    expect(
+      execFileSyncMock.mock.calls.some(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).includes("omegaconf"),
+      ),
+    ).toBe(false);
   });
 
   it("adopts the saved default workspace as the local path when COMFYUI_PATH is unset (#390)", async () => {

--- a/src/__tests__/services/manifest.test.ts
+++ b/src/__tests__/services/manifest.test.ts
@@ -124,6 +124,11 @@ vi.mock("../../services/workspace-env.js", () => ({
   // Mirrors the real resolver enough for the pip tests: an install-root python.
   resolveRootInterpreter: (root: string | undefined) =>
     root ? `${root}/python` : "python",
+  resolveInstallInterpreter: async (root: string | undefined) => ({
+    python: root ? `${root}/python` : "python",
+    source: "unverified",
+    reason: "test interpreter",
+  }),
 }));
 
 // resolveLocalModelPath now roots local_path validation at the SAME live write

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -205,6 +205,7 @@ describe("node-management service", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    delete process.env.COMFYUI_PYTHON;
   });
 
   // ---- install -----------------------------------------------------------
@@ -534,6 +535,10 @@ describe("node-management service", () => {
         IS_WIN ? "python.exe" : "python",
       );
       const nodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      // The install resolver is fail-closed (#651): it only hands out an
+      // interpreter it can account for. Pin the explicit override so the deps
+      // install targets the adopted venv python.
+      process.env.COMFYUI_PYTHON = venvPy;
       const requirements = join(nodeDir, "requirements.txt");
       stubFetch({ installedBody: {} });
       let cloned = false;
@@ -565,6 +570,46 @@ describe("node-management service", () => {
       expect(pipCall).toBeDefined();
       // The deps install ran under the ADOPTED venv python, not bare "python".
       expect(pipCall![0]).toBe(venvPy);
+    });
+
+    it("warns and skips the deps install when the server's interpreter cannot be verified (#651)", async () => {
+      // No override, no launched record, no reachable live server → fail CLOSED:
+      // the clone still succeeds, but requirements are NOT installed into a guess.
+      config.comfyuiPath = undefined;
+      const adopted = "/adopted/ComfyUI";
+      const nodeDir = resolve(adopted, "custom_nodes", "comfyui-teskors-utils");
+      const requirements = join(nodeDir, "requirements.txt");
+      stubFetch({ installedBody: {} });
+      let cloned = false;
+      mockedExists.mockImplementation((p: unknown) => {
+        const s = String(p);
+        if (s === requirements) return true; // node ships requirements.txt
+        if (s.includes("install.py") || s.includes("cm-cli.py")) return false;
+        if (s.includes(".venv")) return false;
+        if (s.includes("comfyui-teskors-utils")) return cloned;
+        return false;
+      });
+      mockedExec.mockImplementation(((bin: string, args: string[]) => {
+        if (bin === "git" && args[0] === "clone") cloned = true;
+        return "";
+      }) as never);
+
+      const res = await installCustomNode({
+        id: "https://github.com/teskor-hub/comfyui-teskors-utils",
+        comfyuiPath: adopted,
+      });
+
+      expect(res.mechanism).toBe("git-clone");
+      // The deps install was REFUSED and the reason is surfaced in the message…
+      expect(res.message).toContain("Python dependencies were NOT installed");
+      // …and no pip subprocess ran against any interpreter.
+      const pipCall = mockedExec.mock.calls.find(
+        (c) =>
+          Array.isArray(c[1]) &&
+          (c[1] as string[]).includes("-r") &&
+          (c[1] as string[]).includes(requirements),
+      );
+      expect(pipCall).toBeUndefined();
     });
 
     it("full-clones (no --depth) and checks out an explicit ref on fallback", async () => {

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -26,6 +26,14 @@ vi.mock("../../utils/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+// The requirements install now resolves its interpreter through the shared
+// fail-closed live-interpreter resolver (#651) — stub it per-test.
+const mockResolveInstallInterpreter = vi.hoisted(() => vi.fn());
+
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveInstallInterpreter: mockResolveInstallInterpreter,
+}));
+
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import {
@@ -56,6 +64,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   mockConfig.comfyuiPath = "/fake/ComfyUI";
+  // Default: the resolver has verified an interpreter; refusal tests override.
+  mockResolveInstallInterpreter.mockResolvedValue({
+    python: "/fake/ComfyUI/.venv/bin/python",
+    source: "launched",
+    reason: "test interpreter",
+  });
 });
 
 // --- updateComfyUICore --------------------------------------------------
@@ -110,8 +124,8 @@ describe("updateComfyUICore", () => {
     expect(r.package_manager).toBe("uv");
     const uvCall = mockedExec.mock.calls.find((c) => c[0] === "uv");
     expect(uvCall).toBeDefined();
-    // uv must be pinned to the workspace venv via --python (no venv exists in
-    // this mock, so it resolves to the PATH python fallback).
+    // uv must be pinned via --python to the interpreter the resolver verified
+    // (never an ambient env).
     expect(uvCall![1]).toEqual([
       "pip",
       "install",
@@ -163,6 +177,47 @@ describe("updateComfyUICore", () => {
       throw new Error("no uv");
     });
     await expect(updateComfyUICore()).rejects.toThrow(/Command failed: git pull/);
+  });
+
+  it("refuses before git pull when the running server's interpreter cannot be verified (#651)", async () => {
+    mockedExists.mockImplementation((p: string) => {
+      if (p === "/fake/ComfyUI") return true;
+      if (p.endsWith("requirements.txt")) return true;
+      return false;
+    });
+    mockedExec.mockImplementation((file: string) => {
+      if (file === "uv" || file === "uv.exe") throw new Error("uv not found");
+      return "ok";
+    });
+    mockResolveInstallInterpreter.mockResolvedValue({
+      source: "undetermined",
+      reason:
+        "Cannot verify the running server's interpreter: no local ComfyUI is reachable. " +
+        "Start ComfyUI or connect to it first.",
+    });
+
+    await expect(updateComfyUICore()).rejects.toThrow(/Cannot update ComfyUI core/);
+    await expect(updateComfyUICore()).rejects.toThrow(/Cannot verify the running server's interpreter/);
+    // Fail CLOSED means no mutation at all: git pull never ran.
+    expect(mockedExec.mock.calls.find((c) => c[0] === "git")).toBeUndefined();
+  });
+
+  it("still runs git pull alone when requirements.txt is absent, even if the interpreter is unverifiable", async () => {
+    mockedExists.mockImplementation((p: string) => p === "/fake/ComfyUI");
+    mockedExec.mockImplementation((file: string) => {
+      if (file === "uv" || file === "uv.exe") throw new Error("no uv");
+      return "ok";
+    });
+    mockResolveInstallInterpreter.mockResolvedValue({
+      source: "undetermined",
+      reason: "Cannot verify the running server's interpreter.",
+    });
+
+    const r = await updateComfyUICore();
+    expect(r.steps.length).toBe(1);
+    expect(r.steps[0].command).toContain("git pull");
+    // No requirements install was due, so the resolver was never consulted.
+    expect(mockResolveInstallInterpreter).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -74,6 +74,8 @@ function setExecFileResponder(
 
 import {
   configureWorkspace,
+  markLocalComfyUILaunched,
+  resetLocalComfyUILaunchState,
   resetWorkspaceConfig,
   getWorkspace,
   setDefaultWorkspace,
@@ -81,6 +83,7 @@ import {
   getEnvironment,
   liveRootFromArgv,
   resolveComfyuiPython,
+  resolveInstallInterpreter,
   resolveLiveComfyUIBase,
   resolveRootInterpreter,
 } from "../../services/workspace-env.js";
@@ -101,6 +104,98 @@ beforeEach(() => {
 
 afterEach(() => {
   resetWorkspaceConfig();
+  resetLocalComfyUILaunchState();
+});
+
+describe("resolveInstallInterpreter (#651)", () => {
+  it("refuses a live Desktop-style bundle with two possible environments", async () => {
+    const base = await tmpDir();
+    try {
+      const serverRoot = join(base, "ComfyUI");
+      await mkdir(serverRoot, { recursive: true });
+      await writeFile(join(serverRoot, "main.py"), "", "utf-8");
+      await makeVenvPython(base);
+      await makeVenvPython(serverRoot);
+      mockGetSystemStats.mockResolvedValue({
+        system: { argv: [join("ComfyUI", "main.py")] },
+      });
+
+      const result = await resolveInstallInterpreter(base);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("sys.executable");
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the prior layout result when no server is reachable", async () => {
+    const root = await tmpDir();
+    try {
+      const python = await makeVenvPython(root);
+      mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result).toMatchObject({ python, source: "unverified" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat a single discovered venv as the externally launched server", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
+
+      const result = await resolveInstallInterpreter(root);
+      expect(result.source).toBe("undetermined");
+      expect(result).not.toHaveProperty("python");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses rather than falling back to the requested path when live ComfyUI is another install", async () => {
+    const parent = await tmpDir();
+    try {
+      const requested = join(parent, "requested");
+      const live = join(parent, "live");
+      await mkdir(live, { recursive: true });
+      await writeFile(join(live, "main.py"), "", "utf-8");
+      await makeVenvPython(requested);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(live, "main.py")] } });
+
+      const result = await resolveInstallInterpreter(requested);
+
+      expect(result.source).toBe("undetermined");
+      expect(result).not.toHaveProperty("python");
+      expect(result.reason).toContain("different install");
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the exact interpreter recorded when MCP launched the live server", async () => {
+    const root = await tmpDir();
+    try {
+      await writeFile(join(root, "main.py"), "", "utf-8");
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: [join(root, "main.py")] } });
+      markLocalComfyUILaunched("C:/ComfyUI/.venv/Scripts/python.exe");
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: "C:/ComfyUI/.venv/Scripts/python.exe",
+        source: "launched",
+      });
+    } finally {
+      resetLocalComfyUILaunchState();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/services/workspace-env.test.ts
+++ b/src/__tests__/services/workspace-env.test.ts
@@ -130,15 +130,17 @@ describe("resolveInstallInterpreter (#651)", () => {
     }
   });
 
-  it("keeps the prior layout result when no server is reachable", async () => {
+  it("refuses when no server is reachable rather than installing into a layout guess", async () => {
     const root = await tmpDir();
     try {
-      const python = await makeVenvPython(root);
+      await makeVenvPython(root);
       mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
 
       const result = await resolveInstallInterpreter(root);
 
-      expect(result).toMatchObject({ python, source: "unverified" });
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("Cannot verify the running server's interpreter");
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -193,6 +195,54 @@ describe("resolveInstallInterpreter (#651)", () => {
       });
     } finally {
       resetLocalComfyUILaunchState();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses in remote mode: a local install would not affect the remote server", async () => {
+    const root = await tmpDir();
+    try {
+      await makeVenvPython(root);
+      h.remoteMode.value = true;
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("remote");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses when the running server does not report a resolvable main.py location", async () => {
+    const root = await tmpDir();
+    try {
+      await makeVenvPython(root);
+      mockGetSystemStats.mockResolvedValue({ system: { argv: ["--port", "8188"] } });
+
+      const result = await resolveInstallInterpreter(root);
+
+      expect(result.source).toBe("undetermined");
+      expect(result.python).toBeUndefined();
+      expect(result.reason).toContain("main.py");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("honors an explicit COMFYUI_PYTHON override even when nothing is reachable", async () => {
+    const root = await tmpDir();
+    try {
+      process.env.COMFYUI_PYTHON = "C:/explicit/python.exe";
+      mockGetSystemStats.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(resolveInstallInterpreter(root)).resolves.toMatchObject({
+        python: "C:/explicit/python.exe",
+        source: "override",
+      });
+    } finally {
+      delete process.env.COMFYUI_PYTHON;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/src/services/manifest.ts
+++ b/src/services/manifest.ts
@@ -33,8 +33,9 @@ import { startDownloadJob, type DownloadJob } from "./download-jobs.js";
 import { resolveModelsDir } from "./output-dir.js";
 import {
   getSavedDefaultWorkspaceSync,
+  resolveInstallInterpreter,
   resolveLiveComfyUIBase,
-  resolveRootInterpreter,
+  type InstallInterpreterResolution,
 } from "./workspace-env.js";
 import { ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -198,12 +199,8 @@ function commandExists(cmd: string): boolean {
   }
 }
 
-function resolveWorkspacePython(comfyuiPath: string): string {
-  if (process.env.COMFYUI_PYTHON) return process.env.COMFYUI_PYTHON;
-  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
-  // so a manifest pip install targets the install's OWN interpreter, never a bare
-  // system python that would contaminate the host env (#463 codex review).
-  return resolveRootInterpreter(comfyuiPath);
+async function resolveWorkspacePython(comfyuiPath: string): Promise<InstallInterpreterResolution> {
+  return resolveInstallInterpreter(comfyuiPath);
 }
 
 function validatePipPackageSpec(pkg: string): void {
@@ -239,14 +236,24 @@ function isUvNonVenvError(text: string): boolean {
   );
 }
 
-function installPipPackage(pkg: string, comfyuiPath: string): string {
+async function installPipPackage(
+  pkg: string,
+  comfyuiPath: string,
+): Promise<InstallInterpreterResolution> {
   validatePipPackageSpec(pkg);
-  const python = resolveWorkspacePython(comfyuiPath);
+  const resolved = await resolveWorkspacePython(comfyuiPath);
+  if (!resolved.python) {
+    throw new ValidationError(
+      `Refusing to install "${pkg}". ${resolved.reason} Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.`,
+    );
+  }
+  const python = resolved.python;
   const useUv = commandExists("uv");
 
   if (!useUv) {
     logger.info("Installing manifest Python package", { package: pkg, installer: "pip" });
-    return runPythonPipInstall(python, pkg, comfyuiPath);
+    runPythonPipInstall(python, pkg, comfyuiPath);
+    return resolved;
   }
 
   logger.info("Installing manifest Python package", { package: pkg, installer: "uv" });
@@ -257,7 +264,8 @@ function installPipPackage(pkg: string, comfyuiPath: string): string {
       timeout: 600_000,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return (out ?? "").trim();
+    void out;
+    return resolved;
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; stderr?: Buffer | string };
     const detail = `${e.stderr?.toString() ?? ""}\n${e.stdout?.toString() ?? ""}\n${e.message ?? ""}`;
@@ -269,7 +277,8 @@ function installPipPackage(pkg: string, comfyuiPath: string): string {
         "uv rejected the non-venv ComfyUI interpreter; falling back to `python -m pip install`",
         { package: pkg },
       );
-      return runPythonPipInstall(python, pkg, comfyuiPath);
+      runPythonPipInstall(python, pkg, comfyuiPath);
+      return resolved;
     }
     throw err;
   }
@@ -704,8 +713,8 @@ async function applyManifestSections(
       continue;
     }
     try {
-      installPipPackage(pkg, comfyuiPath!);
-      results.push(report("pip", pkg, "applied", "Python package installed."));
+      const resolved = await installPipPackage(pkg, comfyuiPath!);
+      results.push(report("pip", pkg, "applied", `Python package installed. ${resolved.reason}`));
     } catch (err) {
       results.push(
         report(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -17,7 +17,7 @@ import {
   setManagerApiCacheForTests,
   suppressDialectRecheck,
 } from "./manager-api-cache.js";
-import { resolveRootInterpreter } from "./workspace-env.js";
+import { resolveInstallInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
@@ -1353,11 +1353,8 @@ function nodeInstalledMatches(
  * for an adopted workspace, corrupting/ missing the real ComfyUI environment while
  * the node is still reported installed (#463 codex review).
  */
-function resolveVenvPython(basePath?: string): string {
-  // Honors .venv/venv AND portable Windows layouts (python_embeded/standalone-env)
-  // via the shared resolver, so a cloned node's deps target the install's OWN
-  // interpreter rather than a bare system python (#463 codex review).
-  return resolveRootInterpreter(basePath ?? config.comfyuiPath);
+async function resolveVenvPython(basePath?: string) {
+  return resolveInstallInterpreter(basePath ?? config.comfyuiPath);
 }
 
 /**
@@ -1412,13 +1409,13 @@ export function assertSafeRepoName(repoName: string): void {
  * Dep failures DON'T fail the install (clone succeeded) — they're surfaced as
  * warnings. A clone failure throws NodeManagementError.
  */
-function cloneCustomNodeFallback(
+async function cloneCustomNodeFallback(
   gitId: string,
   repoName: string,
   gitRef: string | undefined,
   managerStatus: unknown,
   basePath?: string,
-): NodeOpResult {
+): Promise<NodeOpResult> {
   // basePath is the CALL-SCOPED local ComfyUI root (apply_manifest threads an
   // adopted saved-default/live root here WITHOUT mutating global config, so a
   // panel-connected local session with no COMFYUI_PATH can still clone an
@@ -1494,8 +1491,13 @@ function cloneCustomNodeFallback(
   const requirements = join(nodeDir, "requirements.txt");
   const installScript = join(nodeDir, "install.py");
   if (existsSync(requirements) || existsSync(installScript)) {
-    const python = resolveVenvPython(comfyuiBase);
-    if (existsSync(requirements)) {
+    const resolved = await resolveVenvPython(comfyuiBase);
+    if (!resolved.python) {
+      warnings.push(
+        `Python dependencies were NOT installed. ${resolved.reason} Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.`,
+      );
+    } else if (existsSync(requirements)) {
+      const python = resolved.python;
       try {
         execFileSync(python, ["-m", "pip", "install", "-r", requirements], {
           cwd: nodeDir,
@@ -1509,7 +1511,8 @@ function cloneCustomNodeFallback(
         );
       }
     }
-    if (existsSync(installScript)) {
+    if (resolved.python && existsSync(installScript)) {
+      const python = resolved.python;
       try {
         execFileSync(python, [installScript], {
           cwd: nodeDir,
@@ -1678,7 +1681,7 @@ async function installCustomNodeImpl(
         details: status,
       };
     }
-    return cloneCustomNodeFallback(gitId, repoName, gitRef, status, basePath);
+    return await cloneCustomNodeFallback(gitId, repoName, gitRef, status, basePath);
   }
 
   // Registry (plain CNR id). Keep the prior defaults channel "default" /

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -539,37 +539,53 @@ function rememberRestartAttempt(policy: RestartPolicy): boolean {
   return true;
 }
 
-function spawnFromProcessInfo(info: ProcessInfo): ChildProcess | null {
+interface SpawnedComfyUI {
+  child: ChildProcess;
+  /** Defined only for the Python process we directly execute, never Desktop's shell. */
+  interpreter?: string;
+}
+
+let recordedLaunchChild: ChildProcess | undefined;
+
+function adoptLaunchedChild(child: ChildProcess, interpreter: string | undefined): void {
+  recordedLaunchChild = child;
+  markLocalComfyUILaunched(interpreter);
+  const clearIfCurrent = (): void => {
+    if (recordedLaunchChild !== child) return;
+    recordedLaunchChild = undefined;
+    resetLocalComfyUILaunchState();
+  };
+  child.once("exit", clearIfCurrent);
+  child.once("error", clearIfCurrent);
+}
+
+function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   if (info.isDesktopApp) {
     if (IS_WIN) {
       const exe = info.desktopExePath;
       if (!exe) return null;
-      return spawn(exe, [], {
-        detached: true,
-        stdio: "ignore",
-        shell: false,
-      });
+      return { child: spawn(exe, [], { detached: true, stdio: "ignore", shell: false }) };
     }
 
     const appPath = info.desktopExePath ?? "ComfyUI";
-    return spawn("open", ["-a", appPath], {
-      detached: true,
-      stdio: "ignore",
-    });
+    return { child: spawn("open", ["-a", appPath], { detached: true, stdio: "ignore" }) };
   }
 
   const cmd = resolveLaunchCommand(info);
   if (!cmd) return null;
-  return spawn(cmd.exe, cmd.args, {
-    detached: true,
-    stdio: "ignore",
+  return {
+    child: spawn(cmd.exe, cmd.args, {
+      detached: true,
+      stdio: "ignore",
     // Prefer the cwd the command resolved against (the live process cwd for a
     // relative-script relaunch, #535); only then the configured install dir. A
     // stale/nonexistent config.comfyuiPath as cwd would ENOENT the spawn.
     cwd: cmd.cwd ?? config.comfyuiPath ?? undefined,
     shell: false,
-    windowsHide: true,
-  });
+      windowsHide: true,
+    }),
+    interpreter: cmd.exe,
+  };
 }
 
 /**
@@ -918,8 +934,9 @@ function handleSupervisedChildStop(
     logger.warn("Could not auto-restart ComfyUI because launch info was incomplete");
     return;
   }
-  restarted.unref();
-  superviseChild(restarted, lastProcessInfo);
+  restarted.child.unref();
+  if (!lastProcessInfo.isDesktopApp) adoptLaunchedChild(restarted.child, restarted.interpreter);
+  superviseChild(restarted.child, lastProcessInfo);
 }
 
 function captureChildProcessError(
@@ -1021,6 +1038,7 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   detachSupervisor();
   // The server we may have launched is going away — clear the shares-our-env flag so
   // a differently-launched successor doesn't inherit env-trust it shouldn't (#633 P1b).
+  recordedLaunchChild = undefined;
   resetLocalComfyUILaunchState();
 
   // Gather info before we kill it (or reuse the caller's pre-validated info so a
@@ -1139,24 +1157,21 @@ export async function startComfyUI(): Promise<StartResult> {
       auto_restart: supervisorResult(info),
     };
   }
-  const spawnError = captureChildProcessError(launched);
-  launched.unref();
+  const spawnError = captureChildProcessError(launched.child);
+  launched.child.unref();
   lastProcessInfo = info;
-  superviseChild(launched, info);
+  superviseChild(launched.child, info);
   // A python `spawn` inherits our process.env, so this local server shares our
   // environment — mark it so its live extra_model_paths $VAR references may be
   // expanded against process.env (#633 P1b). A Desktop-app launch's env is NOT
   // guaranteed to be ours, so it stays fail-closed (unmarked).
   if (!info.isDesktopApp) {
-    markLocalComfyUILaunched();
+    adoptLaunchedChild(launched.child, launched.interpreter);
     // Revoke env-trust the instant OUR launched child goes away — on EXIT and on a
     // failed spawn (ERROR): a successor server that later takes the port may have a
     // DIFFERENT env, so it must NOT inherit our trust (#633 P1b stale-flag). Fail
     // closed the moment we no longer own the process (`error` covers the spawn_error
     // path where `exit` may not fire).
-    const revokeEnvTrust = (): void => resetLocalComfyUILaunchState();
-    launched.once("exit", revokeEnvTrust);
-    launched.once("error", revokeEnvTrust);
   }
 
   // A NEW server instance is coming up on this port — whatever Manager dialect we

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { platform } from "node:os";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
+import { resolveInstallInterpreter } from "./workspace-env.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -98,21 +99,6 @@ function detectPackageManager(comfyuiPath: string): "uv" | "pip" {
 }
 
 /**
- * Resolve the ComfyUI workspace's own Python interpreter — its `.venv`/`venv`
- * if present — so dependency installs target the workspace env, NOT the Python
- * running this MCP server. Falls back to PATH python when no venv exists.
- */
-function resolveWorkspacePython(comfyuiPath: string): string {
-  for (const venv of [".venv", "venv"]) {
-    const py = IS_WIN
-      ? join(comfyuiPath, venv, "Scripts", "python.exe")
-      : join(comfyuiPath, venv, "bin", "python");
-    if (existsSync(py)) return py;
-  }
-  return IS_WIN ? "python" : "python3";
-}
-
-/**
  * Resolve the ComfyUI install path or throw a clear error explaining that core
  * updates require a local install (not available in remote --comfyui-url mode).
  */
@@ -192,16 +178,33 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
   const pm = detectPackageManager(comfyuiPath);
   const steps: CommandResult[] = [];
 
+  // Resolve the requirements install's interpreter BEFORE `git pull` mutates the
+  // checkout: it must be the interpreter the RUNNING server imports from, never a
+  // configured-workspace venv/PATH guess the server may not see (#651). Fail
+  // closed when the live interpreter cannot be verified.
+  const requirements = join(comfyuiPath, "requirements.txt");
+  let venvPython: string | undefined;
+  let pythonReason = "";
+  if (existsSync(requirements)) {
+    const resolved = await resolveInstallInterpreter(comfyuiPath);
+    if (!resolved.python) {
+      throw new ProcessControlError(
+        `Cannot update ComfyUI core. ${resolved.reason} ` +
+          "Set COMFYUI_PYTHON to the interpreter ComfyUI runs with, or restart ComfyUI through this MCP server and retry.",
+      );
+    }
+    venvPython = resolved.python;
+    pythonReason = ` ${resolved.reason}`;
+  }
+
   // 1. git pull the core repo.
   steps.push(runCommand("git", ["pull"], comfyuiPath));
 
-  // 2. Reinstall requirements into the WORKSPACE venv (never this server's
-  //    Python). requirements.txt lives in the repo root.
-  const requirements = join(comfyuiPath, "requirements.txt");
-  if (existsSync(requirements)) {
-    const venvPython = resolveWorkspacePython(comfyuiPath);
+  // 2. Reinstall requirements into the resolved interpreter's env (never this
+  //    server's Python). requirements.txt lives in the repo root.
+  if (venvPython) {
     if (pm === "uv") {
-      // `--python` pins uv to the workspace venv rather than an ambient env.
+      // `--python` pins uv to the resolved interpreter rather than an ambient env.
       steps.push(
         runCommand(
           "uv",
@@ -227,7 +230,7 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
     comfyui_path: comfyuiPath,
     package_manager: pm,
     steps,
-    message: `ComfyUI core updated in ${comfyuiPath} using ${pm}.`,
+    message: `ComfyUI core updated in ${comfyuiPath} using ${pm}.${pythonReason}`,
   };
 }
 

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -531,7 +531,7 @@ function pythonVersionsAgree(a: string | undefined, b: string | undefined): bool
 // Install interpreter resolution (#651)
 // ---------------------------------------------------------------------------
 
-export type InstallInterpreterSource = "override" | "launched" | "unverified" | "undetermined";
+export type InstallInterpreterSource = "override" | "launched" | "undetermined";
 
 export interface InstallInterpreterResolution {
   python?: string;
@@ -581,10 +581,12 @@ function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefine
 /**
  * Resolve a package-install interpreter without claiming that a path-shaped guess is
  * the process that is currently serving ComfyUI.  A server that this MCP launched is
- * authoritative because we recorded its executable.  For a separately launched live
- * server, /system_stats has no sys.executable, so even a single discovered `.venv`
- * may be unrelated (for example, the server can be using system Python). Refuse rather
- * than create an invisible successful-looking install.
+ * authoritative because we recorded its executable; an explicit COMFYUI_PYTHON is the
+ * operator's own claim.  In every other case the live interpreter is UNOBSERVABLE —
+ * /system_stats has no sys.executable, so even a single discovered `.venv` may be
+ * unrelated (for example, the server can be using system Python).  FAIL CLOSED:
+ * refuse rather than report an install into a layout-guessed env as applied when the
+ * running server may not be able to import from it (#651).
  */
 export async function resolveInstallInterpreter(
   root: string | undefined,
@@ -594,19 +596,25 @@ export async function resolveInstallInterpreter(
     return { python: override, source: "override", reason: `Using "${override}" because COMFYUI_PYTHON is set.` };
   }
 
-  const fallback = resolveRootInterpreter(root);
-  const fallbackResult = (why: string): InstallInterpreterResolution => ({
-    python: fallback,
-    source: "unverified",
-    reason: `Using "${fallback}" selected by install layout; ${why}. It is not confirmed as the running server's interpreter.`,
+  const refuse = (reason: string): InstallInterpreterResolution => ({
+    source: "undetermined",
+    reason,
   });
-  if (isRemoteMode()) return fallbackResult("the connected ComfyUI is remote");
+  if (isRemoteMode()) {
+    return refuse(
+      "Cannot verify the running server's interpreter: the connected ComfyUI is remote, " +
+        "so a package installed locally would not affect it.",
+    );
+  }
 
   let system: { argv?: string[]; cwd?: string } | undefined;
   try {
     system = (await getSystemStats()).system as { argv?: string[]; cwd?: string };
   } catch {
-    return fallbackResult("no local running ComfyUI was reachable");
+    return refuse(
+      "Cannot verify the running server's interpreter: no local ComfyUI is reachable. " +
+        "Start ComfyUI or connect to it first.",
+    );
   }
   const serverRoot = liveRootForInstall(system?.argv, system?.cwd, root);
   const launched = getLaunchedLocalInterpreter();
@@ -617,21 +625,22 @@ export async function resolveInstallInterpreter(
       reason: `Using "${launched}", the exact interpreter this MCP server used to start the running ComfyUI.`,
     };
   }
-  if (!serverRoot) return fallbackResult("the running ComfyUI did not report a resolvable main.py location");
-  if (!targetsLiveInstall(serverRoot, root)) {
-    return {
-      source: "undetermined",
-      reason:
-        `Refusing to install: the running ComfyUI is a different install ("${serverRoot}") ` +
-        `than the requested path. Installing into the requested layout would not affect the live server.`,
-    };
+  if (!serverRoot) {
+    return refuse(
+      "Cannot verify the running server's interpreter: the running ComfyUI did not report " +
+        "a resolvable main.py location.",
+    );
   }
-  return {
-    source: "undetermined",
-    reason:
-      `Cannot determine which interpreter the running ComfyUI at "${serverRoot}" uses: ` +
-      `/system_stats does not expose sys.executable, so an interpreter discovered from its layout is unconfirmed.`,
-  };
+  if (!targetsLiveInstall(serverRoot, root)) {
+    return refuse(
+      `The running ComfyUI is a different install ("${serverRoot}") than the requested path; ` +
+        "installing into the requested layout would not affect the live server.",
+    );
+  }
+  return refuse(
+    `Cannot determine which interpreter the running ComfyUI at "${serverRoot}" uses: ` +
+      "/system_stats does not expose sys.executable, so an interpreter discovered from its layout is unconfirmed.",
+  );
 }
 
 async function probePipPackages(

--- a/src/services/workspace-env.ts
+++ b/src/services/workspace-env.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir, platform } from "node:os";
-import { dirname, isAbsolute, join, resolve as pathResolve } from "node:path";
+import { dirname, isAbsolute, join, resolve as pathResolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { config, getComfyUIBaseUrl, isRemoteMode } from "../config.js";
 import { getSystemStats } from "../comfyui/client.js";
@@ -50,20 +50,31 @@ export function resetWorkspaceConfig(): void {
 // a wrong-place download destination (#633 P1b). Set ONLY on the env-inheriting python
 // spawn path, cleared on stop; module-scoped, so it resets each MCP process lifetime.
 let localComfyUILaunchedByUs = false;
+// /system_stats intentionally does not expose sys.executable.  When this MCP
+// process starts ComfyUI, retain the executable we actually spawned: it is the
+// only non-inferred answer to where a package install belongs (#651).
+let localComfyUILaunchInterpreter: string | undefined;
 
 /** Record that this MCP process spawned the local ComfyUI (env inherited). */
-export function markLocalComfyUILaunched(): void {
+export function markLocalComfyUILaunched(interpreter?: string): void {
   localComfyUILaunchedByUs = true;
+  localComfyUILaunchInterpreter = interpreter?.trim() || undefined;
 }
 
 /** Clear the launched-by-us flag (on stop, and a test seam). */
 export function resetLocalComfyUILaunchState(): void {
   localComfyUILaunchedByUs = false;
+  localComfyUILaunchInterpreter = undefined;
 }
 
 /** True when this MCP process launched the connected local ComfyUI (shares our env). */
 export function didLaunchLocalComfyUI(): boolean {
   return localComfyUILaunchedByUs;
+}
+
+/** The exact interpreter this MCP process used to launch the live local server. */
+export function getLaunchedLocalInterpreter(): string | undefined {
+  return localComfyUILaunchedByUs ? localComfyUILaunchInterpreter : undefined;
 }
 
 function workspaceConfigPath(): string {
@@ -514,6 +525,113 @@ function pythonVersionsAgree(a: string | undefined, b: string | undefined): bool
   const ma = mm(a);
   const mb = mm(b);
   return !!ma && ma === mb;
+}
+
+// ---------------------------------------------------------------------------
+// Install interpreter resolution (#651)
+// ---------------------------------------------------------------------------
+
+export type InstallInterpreterSource = "override" | "launched" | "unverified" | "undetermined";
+
+export interface InstallInterpreterResolution {
+  python?: string;
+  source: InstallInterpreterSource;
+  /** An operator-facing explanation: mutation must never be a silent layout guess. */
+  reason: string;
+}
+
+function pathExists(path: string): boolean {
+  if (/^\\\\/.test(path)) return false;
+  try {
+    return existsSync(path);
+  } catch {
+    return false;
+  }
+}
+
+function hasMainPy(root: string): boolean {
+  return pathExists(join(root, "main.py")) || pathExists(join(root, "main.pyw"));
+}
+
+/** Desktop commonly reports `ComfyUI/main.py` without a cwd.  Anchor that only
+ * against the install being modified, and only after confirming main.py exists. */
+function liveRootForInstall(argv: string[] | undefined, cwd: string | undefined, root: string | undefined): string | undefined {
+  const absolute = liveRootFromArgv(argv, cwd);
+  if (absolute) return absolute;
+  if (!root || !Array.isArray(argv)) return undefined;
+  for (const raw of argv) {
+    if (typeof raw !== "string") continue;
+    const script = raw.trim().replace(/^["']+/, "").replace(/["']+$/, "");
+    if (!/(^|[\\/])main\.pyw?$/i.test(script) || isAbsolute(script)) continue;
+    const candidate = pathResolve(root, dirname(script));
+    if (hasMainPy(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** A bundle root may contain its actual server in `ComfyUI/`; do not confuse a
+ * nested independent checkout with that bundle layout. */
+function targetsLiveInstall(serverRoot: string, requestedRoot: string | undefined): boolean {
+  if (!requestedRoot) return true;
+  const server = pathResolve(serverRoot);
+  const requested = pathResolve(requestedRoot);
+  return server === requested || (server.startsWith(requested + sep) && !hasMainPy(requested));
+}
+
+/**
+ * Resolve a package-install interpreter without claiming that a path-shaped guess is
+ * the process that is currently serving ComfyUI.  A server that this MCP launched is
+ * authoritative because we recorded its executable.  For a separately launched live
+ * server, /system_stats has no sys.executable, so even a single discovered `.venv`
+ * may be unrelated (for example, the server can be using system Python). Refuse rather
+ * than create an invisible successful-looking install.
+ */
+export async function resolveInstallInterpreter(
+  root: string | undefined,
+): Promise<InstallInterpreterResolution> {
+  const override = process.env.COMFYUI_PYTHON?.trim();
+  if (override) {
+    return { python: override, source: "override", reason: `Using "${override}" because COMFYUI_PYTHON is set.` };
+  }
+
+  const fallback = resolveRootInterpreter(root);
+  const fallbackResult = (why: string): InstallInterpreterResolution => ({
+    python: fallback,
+    source: "unverified",
+    reason: `Using "${fallback}" selected by install layout; ${why}. It is not confirmed as the running server's interpreter.`,
+  });
+  if (isRemoteMode()) return fallbackResult("the connected ComfyUI is remote");
+
+  let system: { argv?: string[]; cwd?: string } | undefined;
+  try {
+    system = (await getSystemStats()).system as { argv?: string[]; cwd?: string };
+  } catch {
+    return fallbackResult("no local running ComfyUI was reachable");
+  }
+  const serverRoot = liveRootForInstall(system?.argv, system?.cwd, root);
+  const launched = getLaunchedLocalInterpreter();
+  if (launched && (!serverRoot || targetsLiveInstall(serverRoot, root))) {
+    return {
+      python: launched,
+      source: "launched",
+      reason: `Using "${launched}", the exact interpreter this MCP server used to start the running ComfyUI.`,
+    };
+  }
+  if (!serverRoot) return fallbackResult("the running ComfyUI did not report a resolvable main.py location");
+  if (!targetsLiveInstall(serverRoot, root)) {
+    return {
+      source: "undetermined",
+      reason:
+        `Refusing to install: the running ComfyUI is a different install ("${serverRoot}") ` +
+        `than the requested path. Installing into the requested layout would not affect the live server.`,
+    };
+  }
+  return {
+    source: "undetermined",
+    reason:
+      `Cannot determine which interpreter the running ComfyUI at "${serverRoot}" uses: ` +
+      `/system_stats does not expose sys.executable, so an interpreter discovered from its layout is unconfirmed.`,
+  };
 }
 
 async function probePipPackages(

--- a/src/tools/update-comfyui.ts
+++ b/src/tools/update-comfyui.ts
@@ -8,7 +8,7 @@ import { errorToToolResult } from "../utils/errors.js";
 export function registerUpdateComfyUITools(server: McpServer): void {
   server.tool(
     "update_comfyui",
-    "Update the ComfyUI core install: runs `git pull` in the configured ComfyUI directory and reinstalls its Python requirements (auto-detecting uv vs pip). Requires a local install (COMFYUI_PATH); returns a clear error when targeting a remote instance via --comfyui-url.",
+    "Update the ComfyUI core install: runs `git pull` in the configured ComfyUI directory and reinstalls its Python requirements (auto-detecting uv vs pip). Requires a local install (COMFYUI_PATH); returns a clear error when targeting a remote instance via --comfyui-url. The requirements install targets the running server's own interpreter (recorded when this server launched ComfyUI, or an explicit COMFYUI_PYTHON); when that interpreter cannot be verified the update refuses rather than install into a guessed environment — start ComfyUI or connect first.",
     {},
     async () => {
       try {


### PR DESCRIPTION
Closes #651.\n\nPackage installs now use the exact executable recorded when this MCP instance starts ComfyUI. For an externally launched live install, it preserves offline fallback behavior but refuses when several distinct local environments make the target unknowable, instead of reporting a successful install into a guessed interpreter.\n\nValidation:\n- npm.cmd test -- --run src/__tests__/services/workspace-env.test.ts src/__tests__/services/manifest.test.ts src/__tests__/services/node-management.test.ts src/__tests__/services/process-control.test.ts (165 passed)\n- npm.cmd run lint