### PR TITLE
fix(manager): pin dialect retries to original target

### DIFF
--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -408,19 +408,37 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(getCachedManagerApi(BASE)).toBe("v2-batch");
   });
 
-  it("a slower concurrent detection cannot overwrite a fresher verdict", async () => {
-    // Both probes start after the window lapsed, with NO reset involved (an
-    // out-of-band restart lands between them), so the epoch alone can't order
-    // them: probe A reads the OLD server, probe B reads the new one and commits
-    // first, then A resolves last.
-    const stampA = managerApiCacheStamp();
-    cacheManagerApi(BASE, "v2", managerApiCacheStamp()); // probe B, fresher
-    cacheManagerApi(BASE, "v2-batch", stampA); // probe A, stale, resolves last
+  it("orders concurrent detections by START, so the newest reading wins either way", async () => {
+    // Both probes start after the window lapsed with NO reset involved (an
+    // out-of-band restart lands between them), so the epoch can't order them and
+    // completion order says nothing about which reading is newer. A starts first
+    // and reads the OLD server; B starts second and reads the NEW one.
+
+    // Case 1 — the newer probe finishes FIRST, the older resolves last.
+    let stampA = managerApiCacheStamp();
+    let stampB = managerApiCacheStamp();
+    cacheManagerApi(BASE, "v2", stampB);
+    cacheManagerApi(BASE, "v2-batch", stampA); // stale, must be dropped
     expect(getCachedManagerApi(BASE)).toBe("v2");
 
-    // A verdict backed by a SUCCEEDED enqueue (the #464 demotion) is still
-    // allowed to supersede a probe-derived one — it guards on the epoch only.
+    // Case 2 — the OLDER probe finishes first: its verdict lands, and the
+    // later-started probe must still be able to replace it (this is the order a
+    // write-counter guard gets wrong: it would drop the fresher reading).
+    resetManagerApiCache("test");
+    stampA = managerApiCacheStamp();
+    stampB = managerApiCacheStamp();
+    cacheManagerApi(BASE, "legacy", stampA);
+    expect(getCachedManagerApi(BASE)).toBe("legacy");
+    cacheManagerApi(BASE, "v2", stampB);
+    expect(getCachedManagerApi(BASE)).toBe("v2");
+
+    // A verdict backed by a SUCCEEDED enqueue (the #464 demotion) supersedes a
+    // probe-derived one — it guards on the epoch only …
     cacheManagerApi(BASE, "v2-batch", { epoch: managerApiEpoch() });
+    expect(getCachedManagerApi(BASE)).toBe("v2-batch");
+    // … and it takes a fresh ticket, so a detection that started BEFORE it can
+    // no longer clobber it.
+    cacheManagerApi(BASE, "legacy", stampA);
     expect(getCachedManagerApi(BASE)).toBe("v2-batch");
   });
 
@@ -448,10 +466,11 @@ describe("#646 Manager API dialect cache invalidation", () => {
 
     // The parked detection concluded AFTER the invalidation, so its verdict
     // described a server that may no longer be there and must NOT be pinned over
-    // the reset. The very next detection inside this same operation (the queue
-    // drain resolves the route prefix) therefore has to probe again: two
-    // detections, not one. Without the epoch guard the stale verdict would have
-    // been re-pinned and the second detection served from cache.
-    expect(detections(calls)).toBe(2);
+    // the reset — it left the cache EMPTY. The next operation therefore probes
+    // again; without the epoch guard the stale verdict would have been re-pinned
+    // and this call served from cache with no probe at all.
+    calls.length = 0;
+    await downloadAModel();
+    expect(detections(calls)).toBe(1);
   });
 });

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -131,8 +131,12 @@ function stubServer(opts: {
     if (path === "/v2/manager/queue/start") return new Response("", { status: 200 });
     if (path === "/v2/manager/queue/update_all") return new Response("", { status: 200 });
     if (path === "/v2/manager/is_legacy_manager_ui") {
+      // Read the persona BEFORE parking on the gate, so a gated probe answers
+      // with the reading it took when the request was issued — that is what makes
+      // "the server changed while a probe was in flight" testable.
+      const body = { is_legacy_manager_ui: opts.persona() === "v2-batch" };
       if (opts.legacyUiGate) await opts.legacyUiGate();
-      return jsonResponse({ is_legacy_manager_ui: opts.persona() === "v2-batch" });
+      return jsonResponse(body);
     }
 
     if (opts.persona() === "v2-batch") {
@@ -297,7 +301,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(getCachedManagerApi(BASE)).toBeUndefined();
   });
 
-  it("self-heals a stale entry: one re-detect, one retry, no duplicate enqueue", async () => {
+  it("on a 400 it re-detects but REFUSES to re-send the mutation", async () => {
     let persona: Persona = "v2-batch";
     const calls = stubServer({ persona: () => persona });
 
@@ -307,14 +311,33 @@ describe("#646 Manager API dialect cache invalidation", () => {
     persona = "v4";
     calls.length = 0;
 
-    await expect(downloadAModel()).resolves.toMatchObject({ mechanism: "manager-http" });
+    // A 400 does NOT prove the server left the request unexecuted (it can come
+    // from a handler that already acted, or from a proxy on the response path),
+    // and Manager has no idempotency key — so the model install must NOT be
+    // re-sent, however confident we are that the dialect moved.
+    const err = (await downloadAModel().catch((e: unknown) => e)) as Error;
+    expect(err).toBeInstanceOf(Error);
+    // The refusal is actionable: it names the dialect we spoke and the one the
+    // server now answers as, says the classification is already corrected, and
+    // tells the user to verify before reissuing.
+    expect(err.message).toMatch(/dialect CHANGED/);
+    expect(err.message).toMatch(/"v2-batch"/);
+    expect(err.message).toMatch(/"v2"/);
+    expect(err.message).toMatch(/NOT retried automatically/);
+    expect(err.message).toMatch(/VERIFY/);
 
-    // Attempt 1 spoke the stale dialect and was rejected 400 BEFORE anything was
-    // enqueued; one re-probe proved the dialect changed; attempt 2 succeeded.
     expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
     expect(detections(calls)).toBe(1);
-    // Exactly ONE task enqueued — the retry must not double-submit the install.
+    // NOTHING was re-sent in the newly-detected dialect.
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(0);
+    // The queue was never started, so no half-run operation is left behind.
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(0);
+
+    // …and the reissue now routes correctly on the FIRST attempt.
+    calls.length = 0;
+    await expect(downloadAModel()).resolves.toMatchObject({ mechanism: "manager-http" });
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(0);
   });
 
   it("rebuilds a dialect-specific body on retry (git install), not just the route", async () => {
@@ -379,22 +402,190 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
   });
 
-  it("re-detects at most once on a genuine 400, and does NOT retry when the dialect is unchanged", async () => {
+  it("a persistently-400ing endpoint cannot buy a probe per call (re-check cooldown)", async () => {
     const calls = stubServer({ persona: () => "v4", taskStatus: () => 400 });
 
     await expect(downloadAModel()).rejects.toThrow(/400/);
 
-    // The 400 could have been a stale dialect, so one re-probe is spent proving
-    // otherwise — but the dialect is unchanged, so the enqueue is NOT repeated
-    // and the caller's original error surfaces.
+    // The 400 could have been a stale dialect, so ONE re-probe is spent proving
+    // otherwise — the dialect is unchanged, so the enqueue is not repeated and the
+    // caller's original error surfaces unwrapped.
     expect(detections(calls)).toBe(2);
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
 
-    // The re-probe re-populated the cache, so a second failing call costs one
-    // more re-probe at most — it never degrades into per-call re-detection.
+    // Every subsequent identical failure is now free: the "unchanged" verdict
+    // armed a cooldown, so the cache is NOT reset-and-re-probed per call.
+    for (let i = 0; i < 3; i++) {
+      calls.length = 0;
+      await expect(downloadAModel()).rejects.toThrow(/400/);
+      expect(detections(calls)).toBe(0);
+      expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+    }
+
+    // A real lifecycle event is new information and clears the cooldown, so the
+    // very next failure re-checks again rather than trusting the stale verdict.
+    resetManagerApiCache("comfyui restarted");
     calls.length = 0;
     await expect(downloadAModel()).rejects.toThrow(/400/);
+    expect(detections(calls)).toBe(2);
+  });
+
+  it("shares ONE detection between concurrent callers (no probe storm)", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = true;
+    const calls = stubServer({
+      persona: () => "v4",
+      legacyUiGate: async () => {
+        if (gated) await gate;
+      },
+    });
+
+    // Five operations arrive together on a cold cache (exactly what happens just
+    // after the window lapses). They must not each fire their own probe round.
+    const ops = [downloadAModel(), downloadAModel(), downloadAModel(), downloadAModel(), downloadAModel()];
+    while (!calls.some((c) => c.path === "/v2/manager/is_legacy_manager_ui")) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    gated = false;
+    release();
+    await Promise.all(ops);
+
+    // One shared detection for all five …
     expect(detections(calls)).toBe(1);
+    // … and all five operations still went through.
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(5);
+  });
+
+  it("shares ONE reset+re-detect between concurrent failing calls", async () => {
+    const calls = stubServer({ persona: () => "v4", taskStatus: () => 400 });
+
+    // Warm the cache so the failures — not the cold start — drive the re-checks.
+    await expect(downloadAModel()).rejects.toThrow(/400/);
+    resetManagerApiCache("test: clear the cooldown armed by the warm-up");
+    calls.length = 0;
+
+    // Four operations fail concurrently with the ambiguous status. Each re-check
+    // RESETS the cache (bumping the epoch), so without a shared transaction they
+    // would invalidate each other's probe and run four full detection rounds.
+    const results = await Promise.allSettled([
+      downloadAModel(),
+      downloadAModel(),
+      downloadAModel(),
+      downloadAModel(),
+    ]);
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+
+    // One cold-start detection plus ONE shared re-check for all four.
+    expect(detections(calls)).toBe(2);
+    // Every operation attempted its own enqueue exactly once, and none was re-sent.
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(4);
+  });
+
+  it("does not enqueue with a reading taken before a restart landed mid-detection", async () => {
+    let persona: Persona = "v2-batch";
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = true;
+    const calls = stubServer({
+      persona: () => persona,
+      legacyUiGate: async () => {
+        if (gated) await gate;
+      },
+    });
+
+    // A detection is parked holding the PRE-restart reading (legacy-UI) …
+    const inflight = downloadAModel();
+    while (!calls.some((c) => c.path === "/v2/manager/is_legacy_manager_ui")) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    // … while ComfyUI restarts with the upgraded Manager and the lifecycle fires.
+    persona = "v4";
+    resetManagerApiCache("comfyui restarted mid-detection");
+    gated = false;
+    release();
+    await expect(inflight).resolves.toMatchObject({ mechanism: "manager-http" });
+
+    // Dropping only the CACHE write is not enough: the parked reading must not be
+    // handed back to the caller either, or the mutation goes out on the dead
+    // dialect. The operation re-probed and enqueued on the live v4 route, and the
+    // stale 3.x route was never touched.
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(0);
+  });
+
+  it("refuses to send anything when every detection is invalidated (restart storm)", async () => {
+    // ComfyUI is cycling: each probe is invalidated before it can answer, so every
+    // reading describes a server that is already gone. Handing the last one back
+    // would route a MUTATION on a dialect we know is stale — nothing has been sent
+    // yet at that point, so refusing costs nothing and is the only safe outcome.
+    const calls = stubServer({
+      persona: () => "v2-batch",
+      legacyUiGate: async () => {
+        resetManagerApiCache("comfyui restarted again");
+      },
+    });
+
+    await expect(downloadAModel()).rejects.toThrow(/kept being restarted[\s\S]*NOTHING was sent/i);
+
+    // It gave up after a bounded number of probes rather than spinning …
+    expect(detections(calls)).toBe(3);
+    // … and no enqueue was attempted on any dialect.
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(0);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(0);
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(0);
+  });
+
+  it("still pins the #464 v2-batch demotion when a restart landed during detection", async () => {
+    // A build that serves the bundled 3.x server under /v2 but whose
+    // is_legacy_manager_ui probe does NOT identify it: detection says "v2", the
+    // unified task route 405s, and the batch fallback succeeds — that success is
+    // what pins "v2-batch" (#464). If the demotion is guarded on an epoch captured
+    // before DETECTION, a restart landing mid-probe vetoes it and every later op
+    // pays the dead /queue/task round trip again.
+    const calls: Call[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        const path = new URL(url).pathname;
+        calls.push({ path, method, body });
+        if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
+        if (path === "/v2/manager/is_legacy_manager_ui") {
+          if (gated) await gate;
+          // Unregistered → ComfyUI's SPA catchall, so the sub-dialect is unknown.
+          return new Response("<!doctype html><html>frontend</html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        if (path === "/v2/manager/queue/task") return new Response("405", { status: 405 });
+        if (path === "/v2/manager/queue/batch") return jsonResponse({ failed: [] });
+        return new Response("", { status: 200 });
+      }),
+    );
+
+    const inflight = updateCustomNode({ id: "pack-a" });
+    while (!calls.some((c) => c.path === "/v2/manager/is_legacy_manager_ui")) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    resetManagerApiCache("comfyui restarted mid-detection");
+    gated = false;
+    release();
+    await expect(inflight).resolves.toMatchObject({ mechanism: "manager-http" });
+
+    // The batch enqueue SUCCEEDED, so the corrected dialect must be pinned even
+    // though a reset landed while the detection was probing …
+    expect(getCachedManagerApi(BASE)).toBe("v2-batch");
+    // … and the next operation therefore skips the dead task route entirely.
+    calls.length = 0;
+    await updateCustomNode({ id: "pack-b" });
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(0);
+    expect(countOf(calls, "/v2/manager/queue/batch")).toBe(1);
   });
 
   it("drops a detection that completed across an invalidation (in-flight restart)", async () => {
@@ -465,12 +656,16 @@ describe("#646 Manager API dialect cache invalidation", () => {
     await inflight;
 
     // The parked detection concluded AFTER the invalidation, so its verdict
-    // described a server that may no longer be there and must NOT be pinned over
-    // the reset — it left the cache EMPTY. The next operation therefore probes
-    // again; without the epoch guard the stale verdict would have been re-pinned
-    // and this call served from cache with no probe at all.
+    // described a server that may no longer be there: it is neither pinned nor
+    // returned. The operation therefore probed a SECOND time before enqueueing —
+    // without the epoch guard the stale verdict would have been kept and one
+    // detection would have sufficed.
+    expect(detections(calls)).toBe(2);
+
+    // The second (post-reset) reading IS pinned, so the next call is served from
+    // cache rather than probing forever.
     calls.length = 0;
     await downloadAModel();
-    expect(detections(calls)).toBe(1);
+    expect(detections(calls)).toBe(0);
   });
 });

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as perfHooks from "node:perf_hooks";
 
 // Regression for #646: detectManagerApi() cached the detected ComfyUI-Manager
 // wire dialect keyed ONLY by base URL, for the whole process lifetime. After the
@@ -159,16 +160,29 @@ const downloadAModel = () =>
     type: "checkpoints",
   });
 
-// A controllable clock: the TTL and the queue-drain loop both read Date.now(),
-// and real timers must keep working (the drain sleeps), so shift Date.now by an
-// offset instead of switching to fake timers.
-let clockOffset = 0;
+// Controllable clocks. The freshness window is measured on the MONOTONIC clock
+// (performance.now) while the queue-drain loop reads the wall clock (Date.now),
+// and real timers must keep working (the drain sleeps) — so shift both sources by
+// their own offset rather than switching to fake timers. Keeping them separate is
+// what lets a test step the WALL clock backward while real time keeps elapsing.
+let monotonicOffset = 0;
+let wallOffset = 0;
 const realNow = Date.now;
+const realPerfNow = perfHooks.performance.now.bind(perfHooks.performance);
+/** Real time passes (both clocks advance together). */
+const elapse = (ms: number): void => {
+  monotonicOffset += ms;
+  wallOffset += ms;
+};
 
 describe("#646 Manager API dialect cache invalidation", () => {
   beforeEach(() => {
-    clockOffset = 0;
-    vi.spyOn(Date, "now").mockImplementation(() => realNow() + clockOffset);
+    monotonicOffset = 0;
+    wallOffset = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + wallOffset);
+    vi.spyOn(perfHooks.performance, "now").mockImplementation(
+      () => realPerfNow() + monotonicOffset,
+    );
     resetManagerApiCacheForTests();
     setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5000 });
   });
@@ -211,7 +225,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
     await downloadAModel();
     expect(detections(calls)).toBe(1);
 
-    clockOffset += 4_000; // still inside the 5 s window
+    elapse(4_000); // still inside the 5 s window
     await downloadAModel();
     expect(detections(calls)).toBe(1);
   });
@@ -226,7 +240,7 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // The user restarts ComfyUI themselves after upgrading Manager: nothing in
     // this process observed it, so no explicit invalidation ever fires.
     persona = "v4";
-    clockOffset += 6_000; // > the 5 s TTL
+    elapse(6_000); // > the 5 s TTL
 
     await downloadAModel();
     // Re-probed and routed to the unified v4 envelope on the FIRST attempt —
@@ -236,20 +250,39 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
   });
 
-  it("treats a backward clock jump as expired (a rollback can't extend the window)", async () => {
+  it("a backward wall-clock step neither extends nor resurrects the window", async () => {
     let persona: Persona = "v2-batch";
     const calls = stubServer({ persona: () => persona });
 
     await downloadAModel();
     expect(detections(calls)).toBe(1);
 
+    // The wall clock is stepped BACK an hour (NTP step / VM snapshot restore)
+    // while real time keeps running. Wall-clock arithmetic would read the age as
+    // hugely negative here and, worse, read it as ~0 ("fresh") again once wall
+    // time caught back up — so a Date.now()-based window could serve the
+    // pre-restart dialect for another full TTL after a real restart.
+    wallOffset -= 3_600_000;
     persona = "v4";
-    clockOffset -= 3_600_000; // NTP step / VM snapshot restore, an hour backward
 
+    // Only 4 s of REAL time has passed: still inside the window, still cached.
+    elapse(4_000);
+    expect(getCachedManagerApi(BASE)).toBe("v2-batch");
+
+    // Past the window in REAL time — expired regardless of where the wall clock
+    // sits, and the next call re-probes and speaks the live dialect.
+    elapse(2_000);
+    expect(getCachedManagerApi(BASE)).toBeUndefined();
     await downloadAModel();
-    // A raw Date.now() age would go negative and read "fresh" for an hour.
     expect(detections(calls)).toBe(2);
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+
+    // And the wall clock catching back up cannot revive the (already re-stamped)
+    // entry: freshness never depends on wall-clock arithmetic.
+    wallOffset += 3_600_000;
+    expect(getCachedManagerApi(BASE)).toBe("v2");
+    elapse(6_000);
+    expect(getCachedManagerApi(BASE)).toBeUndefined();
   });
 
   it("self-heals a stale entry: one re-detect, one retry, no duplicate enqueue", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -58,6 +58,7 @@ vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
 const {
   installCustomNode,
   installModelViaManager,
+  reinstallCustomNode,
   updateCustomNode,
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
@@ -430,6 +431,38 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/install")).toBe(true);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/start")).toBe(true);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path.startsWith("/customnode/installed"))).toBe(true);
+  });
+
+  it("keeps BOTH halves of a reinstall on its original target after retarget", async () => {
+    const targetA = BASE;
+    const targetB = "http://127.0.0.1:8282";
+    let retargeted = false;
+    const calls = stubServer({
+      persona: () => "v4",
+      // Retarget while the UNINSTALL half is draining. A reinstall is uninstall
+      // + install as two queue cycles; if each cycle pins its own target, the
+      // install half lands on B — leaving A uninstalled while reporting success.
+      onCall: (url, path, method) => {
+        if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/start" && method === "POST") {
+          retargeted = true;
+          target.base = targetB;
+          resetManagerApiCache("panel retargeted while Manager request was in flight");
+        }
+      },
+    });
+
+    await expect(reinstallCustomNode({ id: "comfyui-foo" })).resolves.toMatchObject({
+      mechanism: "manager-http",
+    });
+
+    // Nothing reached B: the install half re-used the target captured before the
+    // uninstall began, not the target selected mid-operation.
+    expect(calls.filter((call) => call.url.startsWith(targetB))).toHaveLength(0);
+    const kinds = calls
+      .filter((c) => c.url.startsWith(targetA) && c.path === "/v2/manager/queue/task" && c.method === "POST")
+      .map((c) => (c.body as { kind: string }).kind);
+    expect(kinds).toEqual(["uninstall", "install"]);
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(2);
   });
 
   it("does NOT re-detect or retry on an unrelated failure (403 security gating)", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression for #646: detectManagerApi() cached the detected ComfyUI-Manager
+// wire dialect keyed ONLY by base URL, for the whole process lifetime. After the
+// user upgraded Manager 3.x → pip comfyui_manager 4.2.2 and restarted ComfyUI at
+// the SAME URL, every later Manager call kept speaking the PRE-restart dialect:
+// download_model routed through the v2-batch/legacy-UI path and failed with
+// "400 Bad Request for /v2/manager/queue/install_model … LEGACY-UI mode" against
+// a server that was demonstrably a normal Manager 4.2.2.
+//
+// Three self-healing mechanisms are asserted here:
+//   1. explicit invalidation on the restart lifecycle (resetManagerApiCache(),
+//      which process-control / the panel restart tools call alongside
+//      resetObjectInfoCache());
+//   2. a TTL backstop for an OUT-OF-BAND restart that no mcp tool observed
+//      (mirrors the /object_info TTL added for the same class of bug in #528);
+//   3. per-call self-heal — a pre-execution rejection re-probes ONCE and retries
+//      the enqueue only when the live dialect actually changed.
+
+// The TTL is read once at module load, so it must be set BEFORE the imports.
+process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = "5000";
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: "/fake/comfy",
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    getComfyUIAuthHeaders: () => ({}),
+  };
+});
+
+// node-management pulls in comfy-cli → workspace-env, which calls
+// promisify(execFile) at module load; keep the subprocess surface inert.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
+}));
+vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
+
+const { installModelViaManager, setQueueTimingForTests, resetManagerApiCacheForTests } =
+  await import("../../services/node-management.js");
+const { resetManagerApiCache, cacheManagerApi, getCachedManagerApi, managerApiEpoch } =
+  await import("../../services/manager-api-cache.js");
+
+const BASE = "http://127.0.0.1:8188";
+
+interface Call {
+  path: string;
+  method: string;
+  body: unknown;
+}
+
+/** Which Manager the (single, unchanging) URL is currently serving. */
+type Persona = "v2-batch" | "v4";
+
+const DRAINED = { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false };
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * One ComfyUI at ONE URL whose Manager persona can be swapped mid-test — exactly
+ * what an in-place Manager upgrade + restart looks like from our side.
+ *
+ *   "v2-batch" = pip Manager in legacy-UI mode: is_legacy_manager_ui true, the
+ *                3.x routes (queue/batch, queue/install_model) answer, and the
+ *                unified task route does not exist.
+ *   "v4"       = normal pip Manager 4.2.2: is_legacy_manager_ui false, the
+ *                unified task route answers, and the 3.x-shaped install_model
+ *                body is rejected 400 by Pydantic validation (the #646 report),
+ *                while the unregistered batch route 405s via ComfyUI's catchall.
+ */
+function stubServer(opts: {
+  persona: () => Persona;
+  /** Gate resolution of the is_legacy_manager_ui probe (in-flight-race tests). */
+  legacyUiGate?: () => Promise<void>;
+  /** Override the response for the unified task route. */
+  taskStatus?: () => number;
+}) {
+  const calls: Call[] = [];
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const path = new URL(url).pathname;
+    calls.push({ path, method, body });
+
+    if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
+    if (path === "/v2/manager/queue/start") return new Response("", { status: 200 });
+    if (path === "/v2/manager/is_legacy_manager_ui") {
+      if (opts.legacyUiGate) await opts.legacyUiGate();
+      return jsonResponse({ is_legacy_manager_ui: opts.persona() === "v2-batch" });
+    }
+
+    if (opts.persona() === "v2-batch") {
+      if (path === "/v2/manager/queue/install_model") return new Response("", { status: 200 });
+      if (path === "/v2/manager/queue/batch") return jsonResponse({ failed: [] });
+      // The unified task route does not exist on the bundled 3.x server.
+      if (path === "/v2/manager/queue/task") return new Response("405", { status: 405 });
+    } else {
+      if (path === "/v2/manager/queue/task") {
+        const status = opts.taskStatus?.() ?? 200;
+        return new Response(status === 200 ? "" : String(status), { status });
+      }
+      // v4 registers install_model but validates a ModelMetadata envelope — the
+      // 3.x-shaped body the v2-batch dialect sends is rejected 400 (#646).
+      if (path === "/v2/manager/queue/install_model") {
+        return new Response("400: Bad Request", { status: 400 });
+      }
+      if (path === "/v2/manager/queue/batch") return new Response("405", { status: 405 });
+    }
+    return new Response("", { status: 200 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+}
+
+const countOf = (calls: Call[], path: string, method = "POST"): number =>
+  calls.filter((c) => c.path === path && c.method === method).length;
+/** Each completed detection probes is_legacy_manager_ui exactly once. */
+const detections = (calls: Call[]): number =>
+  calls.filter((c) => c.path === "/v2/manager/is_legacy_manager_ui").length;
+
+const downloadAModel = () =>
+  installModelViaManager({
+    name: "model.safetensors",
+    url: "https://huggingface.co/foo/model.safetensors",
+    filename: "model.safetensors",
+    type: "checkpoints",
+  });
+
+// A controllable clock: the TTL and the queue-drain loop both read Date.now(),
+// and real timers must keep working (the drain sleeps), so shift Date.now by an
+// offset instead of switching to fake timers.
+let clockOffset = 0;
+const realNow = Date.now;
+
+describe("#646 Manager API dialect cache invalidation", () => {
+  beforeEach(() => {
+    clockOffset = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + clockOffset);
+    resetManagerApiCacheForTests();
+    setQueueTimingForTests({ pollIntervalMs: 1, startupGraceMs: 0, timeoutMs: 5000 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("re-detects after a restart at the SAME url (explicit invalidation)", async () => {
+    let persona: Persona = "v2-batch";
+    const calls = stubServer({ persona: () => persona });
+
+    // 1. Legacy-UI Manager: the model install goes through the 3.x route.
+    await downloadAModel();
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(0);
+
+    // 2. The user upgrades Manager and restarts ComfyUI on the SAME url. The
+    //    restart lifecycle (process-control / the panel restart tools) drops the
+    //    live-derived caches, the dialect among them.
+    persona = "v4";
+    resetManagerApiCache("comfyui restarted");
+
+    // 3. The next Manager call re-probes and speaks v4 — no stale legacy-UI
+    //    routing, no arbitrary-URL rejection.
+    await downloadAModel();
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+    // The stale 3.x route was NOT attempted again.
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
+  });
+
+  it("serves the cached dialect within the freshness window (no per-call re-probe)", async () => {
+    const calls = stubServer({ persona: () => "v2-batch" });
+    await downloadAModel();
+    expect(detections(calls)).toBe(1);
+
+    clockOffset += 4_000; // still inside the 5 s window
+    await downloadAModel();
+    expect(detections(calls)).toBe(1);
+  });
+
+  it("re-detects once the TTL lapses (OUT-OF-BAND restart, no mcp tool involved)", async () => {
+    let persona: Persona = "v2-batch";
+    const calls = stubServer({ persona: () => persona });
+
+    await downloadAModel();
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
+
+    // The user restarts ComfyUI themselves after upgrading Manager: nothing in
+    // this process observed it, so no explicit invalidation ever fires.
+    persona = "v4";
+    clockOffset += 6_000; // > the 5 s TTL
+
+    await downloadAModel();
+    // Re-probed and routed to the unified v4 envelope on the FIRST attempt —
+    // the stale 3.x route was never touched again.
+    expect(detections(calls)).toBe(2);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
+  });
+
+  it("treats a backward clock jump as expired (a rollback can't extend the window)", async () => {
+    let persona: Persona = "v2-batch";
+    const calls = stubServer({ persona: () => persona });
+
+    await downloadAModel();
+    expect(detections(calls)).toBe(1);
+
+    persona = "v4";
+    clockOffset -= 3_600_000; // NTP step / VM snapshot restore, an hour backward
+
+    await downloadAModel();
+    // A raw Date.now() age would go negative and read "fresh" for an hour.
+    expect(detections(calls)).toBe(2);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+  });
+
+  it("self-heals a stale entry: one re-detect, one retry, no duplicate enqueue", async () => {
+    let persona: Persona = "v2-batch";
+    const calls = stubServer({ persona: () => persona });
+
+    // Pin the legacy-UI dialect, then swap the server underneath it WITHOUT any
+    // restart signal and INSIDE the freshness window — the wedge from #646.
+    await downloadAModel();
+    persona = "v4";
+    calls.length = 0;
+
+    await expect(downloadAModel()).resolves.toMatchObject({ mechanism: "manager-http" });
+
+    // Attempt 1 spoke the stale dialect and was rejected 400 BEFORE anything was
+    // enqueued; one re-probe proved the dialect changed; attempt 2 succeeded.
+    expect(countOf(calls, "/v2/manager/queue/install_model")).toBe(1);
+    expect(detections(calls)).toBe(1);
+    // Exactly ONE task enqueued — the retry must not double-submit the install.
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+  });
+
+  it("does NOT re-detect or retry on an unrelated failure (403 security gating)", async () => {
+    const calls = stubServer({ persona: () => "v4", taskStatus: () => 403 });
+
+    await expect(downloadAModel()).rejects.toThrow(/403/);
+
+    // A 403 is a permission verdict from a route that exists — not a dialect
+    // signal. No re-probe storm, no retry of the mutation.
+    expect(detections(calls)).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+  });
+
+  it("re-detects at most once on a genuine 400, and does NOT retry when the dialect is unchanged", async () => {
+    const calls = stubServer({ persona: () => "v4", taskStatus: () => 400 });
+
+    await expect(downloadAModel()).rejects.toThrow(/400/);
+
+    // The 400 could have been a stale dialect, so one re-probe is spent proving
+    // otherwise — but the dialect is unchanged, so the enqueue is NOT repeated
+    // and the caller's original error surfaces.
+    expect(detections(calls)).toBe(2);
+    expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+
+    // The re-probe re-populated the cache, so a second failing call costs one
+    // more re-probe at most — it never degrades into per-call re-detection.
+    calls.length = 0;
+    await expect(downloadAModel()).rejects.toThrow(/400/);
+    expect(detections(calls)).toBe(1);
+  });
+
+  it("drops a detection that completed across an invalidation (in-flight restart)", async () => {
+    // Direct check of the epoch guard the async detection path relies on.
+    const startEpoch = managerApiEpoch();
+    resetManagerApiCache("comfyui restarted mid-detection");
+    cacheManagerApi(BASE, "v2-batch", startEpoch);
+    expect(getCachedManagerApi(BASE)).toBeUndefined();
+    // A detection that started AFTER the reset still pins normally.
+    cacheManagerApi(BASE, "v2-batch", managerApiEpoch());
+    expect(getCachedManagerApi(BASE)).toBe("v2-batch");
+  });
+
+  it("a restart during an in-flight detection does not re-pin the pre-restart dialect", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let gated = true;
+    const calls = stubServer({
+      persona: () => "v2-batch",
+      legacyUiGate: async () => {
+        if (gated) await gate;
+      },
+    });
+
+    // Park the detection mid-probe …
+    const inflight = downloadAModel();
+    while (!calls.some((c) => c.path === "/v2/manager/is_legacy_manager_ui")) {
+      await new Promise((r) => setTimeout(r, 1));
+    }
+    // … then restart ComfyUI underneath it and let the probe answer.
+    resetManagerApiCache("comfyui restarted mid-detection");
+    gated = false;
+    release();
+    await inflight;
+
+    // The parked detection concluded AFTER the invalidation, so its verdict
+    // described a server that may no longer be there and must NOT be pinned over
+    // the reset. The very next detection inside this same operation (the queue
+    // drain resolves the route prefix) therefore has to probe again: two
+    // detections, not one. Without the epoch guard the stale verdict would have
+    // been re-pinned and the second detection served from cache.
+    expect(detections(calls)).toBe(2);
+  });
+});

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Regression for #646: detectManagerApi() cached the detected ComfyUI-Manager
 // wire dialect keyed ONLY by base URL, for the whole process lifetime. After the
@@ -18,6 +18,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 //      the enqueue only when the live dialect actually changed.
 
 // The TTL is read once at module load, so it must be set BEFORE the imports.
+// Stash the caller's value and restore it after the suite: the variable is
+// process-wide, and a worker that later loads another suite must not inherit it.
+const PRIOR_TTL_ENV = process.env.COMFYUI_MCP_MANAGER_API_TTL_MS;
 process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = "5000";
 
 vi.mock("../../config.js", () => {
@@ -32,6 +35,9 @@ vi.mock("../../config.js", () => {
     config,
     getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
     getComfyUIAuthHeaders: () => ({}),
+    // node-management's Manager self-update path (#424) imports this; the mock
+    // must provide it or the named import fails at load.
+    isLoopbackHost: (host?: string) => host === "127.0.0.1" || host === "localhost",
   };
 });
 
@@ -44,8 +50,12 @@ vi.mock("node:child_process", () => ({
 }));
 vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
 
-const { installModelViaManager, setQueueTimingForTests, resetManagerApiCacheForTests } =
-  await import("../../services/node-management.js");
+const {
+  installModelViaManager,
+  updateCustomNode,
+  setQueueTimingForTests,
+  resetManagerApiCacheForTests,
+} = await import("../../services/node-management.js");
 const { resetManagerApiCache, cacheManagerApi, getCachedManagerApi, managerApiEpoch } =
   await import("../../services/manager-api-cache.js");
 
@@ -58,7 +68,7 @@ interface Call {
 }
 
 /** Which Manager the (single, unchanging) URL is currently serving. */
-type Persona = "v2-batch" | "v4";
+type Persona = "v2-batch" | "v4" | "legacy";
 
 const DRAINED = { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false };
 
@@ -95,8 +105,18 @@ function stubServer(opts: {
     const path = new URL(url).pathname;
     calls.push({ path, method, body });
 
+    if (opts.persona() === "legacy") {
+      // The 3.x custom-node Manager: no /v2/* at all (ComfyUI's frontend catchall
+      // 405s an unregistered POST), per-operation routes under /manager/*.
+      if (path === "/manager/queue/status") return jsonResponse(DRAINED);
+      if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+      if (path.startsWith("/manager/queue/")) return new Response("", { status: 200 });
+      return new Response("404: Not Found", { status: 404 });
+    }
+
     if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
     if (path === "/v2/manager/queue/start") return new Response("", { status: 200 });
+    if (path === "/v2/manager/queue/update_all") return new Response("", { status: 200 });
     if (path === "/v2/manager/is_legacy_manager_ui") {
       if (opts.legacyUiGate) await opts.legacyUiGate();
       return jsonResponse({ is_legacy_manager_ui: opts.persona() === "v2-batch" });
@@ -156,6 +176,11 @@ describe("#646 Manager API dialect cache invalidation", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (PRIOR_TTL_ENV === undefined) delete process.env.COMFYUI_MCP_MANAGER_API_TTL_MS;
+    else process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = PRIOR_TTL_ENV;
   });
 
   it("re-detects after a restart at the SAME url (explicit invalidation)", async () => {
@@ -245,6 +270,29 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(detections(calls)).toBe(1);
     // Exactly ONE task enqueued — the retry must not double-submit the install.
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+  });
+
+  it("heals update_all too (its dedicated route bypasses queueManagerTask)", async () => {
+    let persona: Persona = "v4";
+    const calls = stubServer({ persona: () => persona });
+
+    await updateCustomNode({ id: "all" });
+    expect(countOf(calls, "/v2/manager/queue/update_all")).toBe(1);
+
+    // Same URL, now serving the 3.x custom-node Manager (a downgrade/rollback is
+    // the mirror of the reported upgrade), still inside the freshness window.
+    persona = "legacy";
+    calls.length = 0;
+
+    await expect(updateCustomNode({ id: "all" })).resolves.toMatchObject({
+      mechanism: "manager-http",
+    });
+    // One rejected attempt on the stale prefix, one retry on the live one …
+    expect(countOf(calls, "/v2/manager/queue/update_all")).toBe(1);
+    expect(countOf(calls, "/manager/queue/update_all")).toBe(1);
+    // … and the queue is started (drained) exactly once, on the live prefix.
+    expect(countOf(calls, "/manager/queue/start")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(0);
   });
 
   it("does NOT re-detect or retry on an unrelated failure (403 security gating)", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -58,8 +58,13 @@ const {
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
 } = await import("../../services/node-management.js");
-const { resetManagerApiCache, cacheManagerApi, getCachedManagerApi, managerApiEpoch } =
-  await import("../../services/manager-api-cache.js");
+const {
+  resetManagerApiCache,
+  cacheManagerApi,
+  getCachedManagerApi,
+  managerApiCacheStamp,
+  managerApiEpoch,
+} = await import("../../services/manager-api-cache.js");
 
 const BASE = "http://127.0.0.1:8188";
 
@@ -394,12 +399,28 @@ describe("#646 Manager API dialect cache invalidation", () => {
 
   it("drops a detection that completed across an invalidation (in-flight restart)", async () => {
     // Direct check of the epoch guard the async detection path relies on.
-    const startEpoch = managerApiEpoch();
+    const stamp = managerApiCacheStamp();
     resetManagerApiCache("comfyui restarted mid-detection");
-    cacheManagerApi(BASE, "v2-batch", startEpoch);
+    cacheManagerApi(BASE, "v2-batch", stamp);
     expect(getCachedManagerApi(BASE)).toBeUndefined();
     // A detection that started AFTER the reset still pins normally.
-    cacheManagerApi(BASE, "v2-batch", managerApiEpoch());
+    cacheManagerApi(BASE, "v2-batch", managerApiCacheStamp());
+    expect(getCachedManagerApi(BASE)).toBe("v2-batch");
+  });
+
+  it("a slower concurrent detection cannot overwrite a fresher verdict", async () => {
+    // Both probes start after the window lapsed, with NO reset involved (an
+    // out-of-band restart lands between them), so the epoch alone can't order
+    // them: probe A reads the OLD server, probe B reads the new one and commits
+    // first, then A resolves last.
+    const stampA = managerApiCacheStamp();
+    cacheManagerApi(BASE, "v2", managerApiCacheStamp()); // probe B, fresher
+    cacheManagerApi(BASE, "v2-batch", stampA); // probe A, stale, resolves last
+    expect(getCachedManagerApi(BASE)).toBe("v2");
+
+    // A verdict backed by a SUCCEEDED enqueue (the #464 demotion) is still
+    // allowed to supersede a probe-derived one — it guards on the epoch only.
+    cacheManagerApi(BASE, "v2-batch", { epoch: managerApiEpoch() });
     expect(getCachedManagerApi(BASE)).toBe("v2-batch");
   });
 

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -24,6 +24,10 @@ import * as perfHooks from "node:perf_hooks";
 const PRIOR_TTL_ENV = process.env.COMFYUI_MCP_MANAGER_API_TTL_MS;
 process.env.COMFYUI_MCP_MANAGER_API_TTL_MS = "5000";
 
+// Kept mutable to model the runtime target change that the panel applies while a
+// Manager operation is in flight. vi.hoisted makes it available to the mock factory.
+const target = vi.hoisted(() => ({ base: "http://127.0.0.1:8188" }));
+
 vi.mock("../../config.js", () => {
   const config = {
     comfyuiPath: "/fake/comfy",
@@ -34,7 +38,7 @@ vi.mock("../../config.js", () => {
   };
   return {
     config,
-    getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
+    getComfyUIBaseUrl: () => target.base,
     getComfyUIAuthHeaders: () => ({}),
     // node-management's Manager self-update path (#424) imports this; the mock
     // must provide it or the named import fails at load.
@@ -69,6 +73,7 @@ const {
 const BASE = "http://127.0.0.1:8188";
 
 interface Call {
+  url: string;
   path: string;
   method: string;
   body: unknown;
@@ -99,26 +104,29 @@ function jsonResponse(obj: unknown): Response {
  *                while the unregistered batch route 405s via ComfyUI's catchall.
  */
 function stubServer(opts: {
-  persona: () => Persona;
+  persona: (url: string) => Persona;
   /** Gate resolution of the is_legacy_manager_ui probe (in-flight-race tests). */
   legacyUiGate?: () => Promise<void>;
   /** Override the response for the unified task route. */
-  taskStatus?: () => number;
+  taskStatus?: (url: string) => number;
+  /** Run after recording a request but before this fake Manager replies. */
+  onCall?: (url: string, path: string, method: string) => void | Promise<void>;
 }) {
   const calls: Call[] = [];
   const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(init.body as string) : undefined;
     const path = new URL(url).pathname;
-    calls.push({ path, method, body });
+    calls.push({ url, path, method, body });
+    await opts.onCall?.(url, path, method);
 
     // The install VERIFY step: report the pack as present so installCustomNode
     // never reaches its clone fallback.
-    if (path.startsWith("/v2/customnode/installed")) {
+    if (path.startsWith("/v2/customnode/installed") || path.startsWith("/customnode/installed")) {
       return jsonResponse({ "comfyui-foo": { ver: "1.0", cnr_id: "comfyui-foo", enabled: true } });
     }
 
-    if (opts.persona() === "legacy") {
+    if (opts.persona(url) === "legacy") {
       // The 3.x custom-node Manager: no /v2/* at all (ComfyUI's frontend catchall
       // 405s an unregistered POST), per-operation routes under /manager/*.
       if (path === "/manager/queue/status") return jsonResponse(DRAINED);
@@ -134,19 +142,19 @@ function stubServer(opts: {
       // Read the persona BEFORE parking on the gate, so a gated probe answers
       // with the reading it took when the request was issued — that is what makes
       // "the server changed while a probe was in flight" testable.
-      const body = { is_legacy_manager_ui: opts.persona() === "v2-batch" };
+      const body = { is_legacy_manager_ui: opts.persona(url) === "v2-batch" };
       if (opts.legacyUiGate) await opts.legacyUiGate();
       return jsonResponse(body);
     }
 
-    if (opts.persona() === "v2-batch") {
+    if (opts.persona(url) === "v2-batch") {
       if (path === "/v2/manager/queue/install_model") return new Response("", { status: 200 });
       if (path === "/v2/manager/queue/batch") return jsonResponse({ failed: [] });
       // The unified task route does not exist on the bundled 3.x server.
       if (path === "/v2/manager/queue/task") return new Response("405", { status: 405 });
     } else {
       if (path === "/v2/manager/queue/task") {
-        const status = opts.taskStatus?.() ?? 200;
+        const status = opts.taskStatus?.(url) ?? 200;
         return new Response(status === 200 ? "" : String(status), { status });
       }
       // v4 registers install_model but validates a ModelMetadata envelope — the
@@ -193,6 +201,7 @@ const elapse = (ms: number): void => {
 
 describe("#646 Manager API dialect cache invalidation", () => {
   beforeEach(() => {
+    target.base = BASE;
     monotonicOffset = 0;
     wallOffset = 0;
     vi.spyOn(Date, "now").mockImplementation(() => realNow() + wallOffset);
@@ -389,6 +398,38 @@ describe("#646 Manager API dialect cache invalidation", () => {
     // … and the queue is started (drained) exactly once, on the live prefix.
     expect(countOf(calls, "/manager/queue/start")).toBe(1);
     expect(countOf(calls, "/v2/manager/queue/start")).toBe(0);
+  });
+
+  it("keeps a dialect self-heal retry and drain on its original target after retarget", async () => {
+    const targetA = BASE;
+    const targetB = "http://127.0.0.1:8282";
+    let retargeted = false;
+    const calls = stubServer({
+      // A is a legacy Manager even though its stale cache says v2; B is normal
+      // v4. Before the fix, the failed A request re-read the mutable target,
+      // detected B, then retried and drained B's queue instead of A's.
+      persona: (url) => (url.startsWith(targetA) ? "legacy" : "v4"),
+      onCall: (url, path) => {
+        if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/task") {
+          retargeted = true;
+          target.base = targetB;
+          resetManagerApiCache("panel retargeted while Manager request was in flight");
+        }
+      },
+    });
+    resetManagerApiCacheForTests("v2");
+
+    await expect(installCustomNode({ id: "comfyui-foo" })).resolves.toMatchObject({
+      mechanism: "manager-http",
+    });
+
+    // The mutation began at A, so its retry, queue start, and drain are all
+    // pinned to A. B is now the target for subsequent calls, but receives none
+    // from this already-started transaction.
+    expect(calls.filter((call) => call.url.startsWith(targetB))).toHaveLength(0);
+    expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/install")).toBe(true);
+    expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/start")).toBe(true);
+    expect(calls.some((call) => call.url.startsWith(targetA) && call.path.startsWith("/customnode/installed"))).toBe(true);
   });
 
   it("does NOT re-detect or retry on an unrelated failure (403 security gating)", async () => {

--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -52,6 +52,7 @@ vi.mock("node:child_process", () => ({
 vi.mock("node:fs", () => ({ existsSync: vi.fn(() => true) }));
 
 const {
+  installCustomNode,
   installModelViaManager,
   updateCustomNode,
   setQueueTimingForTests,
@@ -105,6 +106,12 @@ function stubServer(opts: {
     const body = init?.body ? JSON.parse(init.body as string) : undefined;
     const path = new URL(url).pathname;
     calls.push({ path, method, body });
+
+    // The install VERIFY step: report the pack as present so installCustomNode
+    // never reaches its clone fallback.
+    if (path.startsWith("/v2/customnode/installed")) {
+      return jsonResponse({ "comfyui-foo": { ver: "1.0", cnr_id: "comfyui-foo", enabled: true } });
+    }
 
     if (opts.persona() === "legacy") {
       // The 3.x custom-node Manager: no /v2/* at all (ComfyUI's frontend catchall
@@ -303,6 +310,34 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(detections(calls)).toBe(1);
     // Exactly ONE task enqueued — the retry must not double-submit the install.
     expect(countOf(calls, "/v2/manager/queue/task")).toBe(1);
+  });
+
+  it("rebuilds a dialect-specific body on retry (git install), not just the route", async () => {
+    let persona: Persona = "v2-batch";
+    const calls = stubServer({ persona: () => persona });
+
+    // Pin the legacy-UI dialect, then swap the server to a normal v4 underneath.
+    await downloadAModel();
+    persona = "v4";
+    calls.length = 0;
+
+    await installCustomNode({ id: "https://github.com/bar/comfyui-foo" });
+
+    // Attempt 1 spoke 3.x: a real git URL in `files`, version "unknown".
+    const batch = calls.find((c) => c.path === "/v2/manager/queue/batch");
+    expect(batch).toBeDefined();
+    const sent = (batch!.body as Record<string, Array<Record<string, unknown>>>).install[0];
+    expect(sent.files).toEqual(["https://github.com/bar/comfyui-foo"]);
+
+    // The retry must speak v4 SEMANTICS, not merely the v4 route: repo name +
+    // "nightly" and NO `files` (v4 resolves by registry id, so a 3.x body would
+    // silently install nothing).
+    const task = calls.find((c) => c.path === "/v2/manager/queue/task");
+    expect(task).toBeDefined();
+    const params = (task!.body as { params: Record<string, unknown> }).params;
+    expect(params.id).toBe("comfyui-foo");
+    expect(params.selected_version).toBe("nightly");
+    expect(params.files).toBeUndefined();
   });
 
   it("heals update_all too (its dedicated route bypasses queueManagerTask)", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { chmodSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSy
 import { homedir } from "node:os";
 import { isIP } from "node:net";
 import { parseComfyUIUrl, type ComfyUITarget } from "./transport/comfyui-url.js";
+import { resetManagerApiCache } from "./services/manager-api-cache.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -766,6 +767,13 @@ export function setComfyuiTarget(url: string): boolean {
   // from COMFYUI_URL, and a runtime retarget must not leave them pinning the
   // process-start host (codex finding).
   process.env.COMFYUI_URL = url;
+  // We are pointed at a DIFFERENT ComfyUI now, so the detected ComfyUI-Manager
+  // dialect describes the previous one. It is normally keyed by base URL and
+  // would simply miss — but a round trip (local → pod → local) can land back on
+  // an identical base string whose server was restarted meanwhile, which is
+  // exactly the stale-dialect case #646 is about. Drop it at the canonical
+  // retarget choke point rather than relying on the key.
+  resetManagerApiCache("comfyui target changed");
   // Tell the control panels where renders run now (local ⇄ pod).
   emitComfyuiTargetChanged();
   return true;

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -62,6 +62,7 @@ import {
 } from "../comfyui/client.js";
 import { convertUiToApi, collectNodeTypes } from "../services/workflow-converter.js";
 import { restartComfyUI } from "../services/process-control.js";
+import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import {
   isRemoteMode,
   isCloudMode,
@@ -4975,6 +4976,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // Manager-reboot / preflight no-op) is honestly couldn't-confirm (coordinator P1).
             resetClient();
             resetObjectInfoCache();
+            resetManagerApiCache("panel managed restart");
             // The observation window spans the ~40s blocking sync + a full cold-start
             // window. (Under a test timing override, use the injected budget instead so the
             // never-certify cases don't wait the real ~140s.)
@@ -5048,9 +5050,12 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         }
 
         // ACCEPTED. A reboot restarts ComfyUI out-of-band, so the orchestrator's cached WS
-        // client + /object_info go stale (#353/#357/#378/#394) — drop both caches.
+        // client + /object_info go stale (#353/#357/#378/#394) — drop both caches. The
+        // detected ComfyUI-Manager dialect is live-derived too and a reboot can bring back
+        // a different Manager generation on the same URL (#646), so drop that as well.
         resetClient();
         resetObjectInfoCache();
+        resetManagerApiCache("panel Manager reboot");
 
         // Observe recovery. There is exactly ONE sound proof that THIS ComfyUI instance
         // actually cycled: a directly OBSERVED down→up on the server-authorized, immutable,

--- a/src/services/manager-api-cache.ts
+++ b/src/services/manager-api-cache.ts
@@ -1,0 +1,145 @@
+import { logger } from "../utils/logger.js";
+
+// ---------------------------------------------------------------------------
+// ComfyUI-Manager API dialect cache (issue #646)
+//
+// detectManagerApi() (services/node-management.ts) probes the connected ComfyUI
+// once and classifies its Manager into one of three wire dialects. Probing on
+// every operation would add 1-3 round trips to every Manager call, so the result
+// is cached — but it used to be cached for the WHOLE PROCESS LIFETIME, keyed
+// only by the base URL.
+//
+// A ComfyUI restart at the SAME base URL can change the dialect underneath us:
+// upgrading the 3.x custom-node Manager to pip comfyui_manager 4.x, or dropping
+// --enable-manager-legacy-ui, keeps the URL identical while flipping which
+// endpoints exist. The URL-keyed lifetime cache then routes every subsequent
+// Manager call through the PREVIOUS server's endpoints — download_model kept
+// speaking the v2-batch/legacy-UI dialect to a normal Manager 4.2.2 and failed
+// with a legacy-UI arbitrary-URL rejection forever (#646).
+//
+// This module is the single owner of that cached classification, so the two
+// self-healing mechanisms live in one place:
+//
+//   1. EXPLICIT INVALIDATION on the restart lifecycle the repo already has.
+//      Every place that drops the memoized /object_info because ComfyUI is
+//      being restarted (services/process-control.ts stop/restart/Manager-reboot,
+//      the panel's restart tools) also drops the dialect — same signal, same
+//      reason: what the live server exposes may have just changed.
+//
+//   2. A TTL BACKSTOP for the OUT-OF-BAND restart — the #646 report's actual
+//      path: the user upgraded Manager and restarted ComfyUI themselves, so no
+//      mcp tool ever ran and no explicit invalidation fired. This mirrors the
+//      /object_info TTL added for the same class of bug in #528: within the
+//      window calls are served from cache (no extra probes on the hot path), and
+//      the first call after the window re-probes and picks up whatever the live
+//      server now is. Manager exposes no boot id / generation counter, so a TTL
+//      is the lightest self-healing mechanism available.
+//
+// Deliberately kept in its own leaf module (logger-only imports) so the restart
+// paths can invalidate the dialect without importing the heavyweight
+// node-management unit (comfy-cli subprocesses, git helpers, …).
+// ---------------------------------------------------------------------------
+
+/**
+ * The three Manager wire dialects found in the wild (issue #116 found the
+ * second; #235 the third) — see detectManagerApi() for how each is recognized.
+ *   "v2"       pip comfyui_manager (Manager v4) in NORMAL mode — the unified
+ *              POST /v2/manager/queue/task envelope.
+ *   "v2-batch" pip comfyui_manager started with --enable-manager-legacy-ui: the
+ *              bundled 3.x server under the /v2 prefix (POST .../queue/batch).
+ *   "legacy"   the 3.x custom-node Manager: per-operation /manager/queue/*.
+ */
+export type ManagerApi = "v2" | "v2-batch" | "legacy";
+
+/**
+ * Freshness window for a detected dialect. 60s keeps the probe off the hot path
+ * for any realistic burst of Manager operations while bounding how long an
+ * out-of-band Manager upgrade + restart can be mis-routed. Override with
+ * COMFYUI_MCP_MANAGER_API_TTL_MS (0 re-probes on every call; a large value
+ * restores the old lifetime-cache behavior).
+ */
+const MANAGER_API_TTL_MS = (() => {
+  const raw = process.env.COMFYUI_MCP_MANAGER_API_TTL_MS;
+  if (raw === undefined || raw.trim() === "") return 60_000;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : 60_000;
+})();
+
+let cache: { base: string; api: ManagerApi; at: number } | null = null;
+
+/**
+ * Invalidation epoch. resetManagerApiCache() bumps it; a detection that STARTED
+ * under an older epoch must not commit its result, otherwise a probe already in
+ * flight when ComfyUI restarted would re-pin the PRE-restart dialect right after
+ * the restart cleared it (the same guard /object_info carries — #528).
+ */
+let epoch = 0;
+
+/** Current invalidation epoch — capture it before an async detection/operation
+ *  and pass it back to the commit helpers so a concurrent reset wins. */
+export function managerApiEpoch(): number {
+  return epoch;
+}
+
+/**
+ * The cached dialect for `base`, or undefined when there is none, it was
+ * detected against a different base URL, or it has aged out of the freshness
+ * window.
+ *
+ * A NEGATIVE age (the system clock stepped backward: NTP correction, VM
+ * snapshot restore) counts as EXPIRED rather than fresh — otherwise a one-hour
+ * rollback would silently extend a 60s TTL by an hour and keep a stale dialect
+ * pinned well past the intended window (#528 review). The re-detect that follows
+ * re-stamps `at` against the corrected clock, so normal caching resumes at once.
+ */
+export function getCachedManagerApi(base: string): ManagerApi | undefined {
+  if (!cache || cache.base !== base) return undefined;
+  const age = Date.now() - cache.at;
+  if (age >= 0 && age < MANAGER_API_TTL_MS) return cache.api;
+  logger.debug("Manager API dialect cache expired — re-probing", {
+    base,
+    was: cache.api,
+    age_ms: age,
+  });
+  return undefined;
+}
+
+/**
+ * Record a detected dialect. When `startEpoch` is supplied and no longer matches
+ * the current epoch, the write is DROPPED: something invalidated the cache while
+ * this detection was in flight (a restart), so its conclusion describes a server
+ * that may no longer be there. The caller still gets the value it detected — it
+ * simply isn't pinned for later callers.
+ */
+export function cacheManagerApi(base: string, api: ManagerApi, startEpoch?: number): void {
+  if (startEpoch !== undefined && startEpoch !== epoch) {
+    logger.debug("Dropping Manager API dialect detected across an invalidation", {
+      base,
+      api,
+      startEpoch,
+      epoch,
+    });
+    return;
+  }
+  cache = { base, api, at: Date.now() };
+}
+
+/**
+ * Forget the detected dialect so the next Manager call re-probes the live
+ * server. Call this whenever the connected ComfyUI is (or may have been)
+ * restarted — a restart is exactly when the Manager generation can change under
+ * a stable URL (#646) — and when a Manager response proves the cached dialect
+ * wrong.
+ */
+export function resetManagerApiCache(reason?: string): void {
+  const was = cache?.api;
+  cache = null;
+  epoch++;
+  logger.debug("Manager API dialect cache reset", { reason, was, epoch });
+}
+
+/** @internal — test hook: pin a dialect for `base`, or clear the cache. */
+export function setManagerApiCacheForTests(base: string, api?: ManagerApi): void {
+  resetManagerApiCache("test");
+  if (api) cacheManagerApi(base, api);
+}

--- a/src/services/manager-api-cache.ts
+++ b/src/services/manager-api-cache.ts
@@ -118,6 +118,46 @@ export function managerApiCacheStamp(): ManagerApiCacheStamp {
   return { epoch, seq: ++seqCounter };
 }
 
+// ---------------------------------------------------------------------------
+// Negative-result cooldown for the per-call dialect re-check
+// ---------------------------------------------------------------------------
+
+/**
+ * When a Manager call fails with a status that COULD mean a stale dialect, the
+ * caller re-probes to find out. If the probe says the dialect is unchanged, the
+ * failure had nothing to do with the dialect — and an endpoint that keeps failing
+ * that way (a persistently-400ing route, a pack Manager always refuses) would
+ * otherwise buy a fresh probe on EVERY call, since each re-check resets the entry
+ * the previous one just repopulated.
+ *
+ * So a confirmed-unchanged (or unreachable) verdict arms a cooldown for that base
+ * URL: re-checks are suppressed until it lapses, capping the cost of a repeatedly
+ * failing operation at one probe per window instead of one per call. Any genuine
+ * new information — a restart, a stop, any resetManagerApiCache() — clears it, so
+ * the cooldown can never delay reacting to a real dialect change.
+ */
+let recheckCooldown: { base: string; until: number } | null = null;
+
+/** Is a dialect re-check for `base` still inside its cooldown window? */
+export function dialectRecheckSuppressed(base: string): boolean {
+  if (!recheckCooldown || recheckCooldown.base !== base) return false;
+  if (monotonicNow() >= recheckCooldown.until) {
+    recheckCooldown = null;
+    return false;
+  }
+  return true;
+}
+
+/** Arm the cooldown after a re-check that produced no new dialect. */
+export function suppressDialectRecheck(base: string, reason: string): void {
+  recheckCooldown = { base, until: monotonicNow() + MANAGER_API_TTL_MS };
+  logger.debug("Suppressing Manager dialect re-checks for this base", {
+    base,
+    reason,
+    for_ms: MANAGER_API_TTL_MS,
+  });
+}
+
 /**
  * The cached dialect for `base`, or undefined when there is none, it was
  * detected against a different base URL, or it has aged out of the freshness
@@ -195,6 +235,9 @@ export function cacheManagerApi(
 export function resetManagerApiCache(reason?: string): void {
   const was = cache?.api;
   cache = null;
+  // A reset is new information about the server, so the re-check cooldown (a
+  // "nothing changed" verdict about the PREVIOUS state) no longer applies.
+  recheckCooldown = null;
   epoch++;
   logger.debug("Manager API dialect cache reset", { reason, was, epoch });
 }

--- a/src/services/manager-api-cache.ts
+++ b/src/services/manager-api-cache.ts
@@ -88,10 +88,33 @@ let cache: { base: string; api: ManagerApi; at: number } | null = null;
  */
 let epoch = 0;
 
-/** Current invalidation epoch — capture it before an async detection/operation
- *  and pass it back to the commit helpers so a concurrent reset wins. */
+/**
+ * Commit counter, bumped by every accepted cache write. A reset is not the only
+ * way a detection can be overtaken: after the TTL lapses, two operations can
+ * probe CONCURRENTLY, and if the slower probe (which read the PRE-restart server)
+ * resolves last it would overwrite the fresher verdict and re-pin the stale
+ * dialect for another window — with no reset involved, so the epoch alone
+ * wouldn't catch it. A detection therefore also refuses to commit when any other
+ * write landed while it was in flight; the fresher verdict stands and the loser
+ * simply returns its own value to its caller.
+ */
+let writes = 0;
+
+/** Current invalidation epoch — capture it before an async operation and pass it
+ *  back to the commit helpers so a concurrent RESET wins. */
 export function managerApiEpoch(): number {
   return epoch;
+}
+
+/** Full cache state stamp for a DETECTION: loses to a concurrent reset AND to a
+ *  concurrent detection that committed first. */
+export interface ManagerApiCacheStamp {
+  epoch: number;
+  writes: number;
+}
+
+export function managerApiCacheStamp(): ManagerApiCacheStamp {
+  return { epoch, writes };
 }
 
 /**
@@ -118,23 +141,34 @@ export function getCachedManagerApi(base: string): ManagerApi | undefined {
 }
 
 /**
- * Record a detected dialect. When `startEpoch` is supplied and no longer matches
- * the current epoch, the write is DROPPED: something invalidated the cache while
- * this detection was in flight (a restart), so its conclusion describes a server
- * that may no longer be there. The caller still gets the value it detected — it
- * simply isn't pinned for later callers.
+ * Record a detected dialect, subject to an optional `guard` captured before the
+ * work that produced it:
+ *   • `epoch` mismatch → something INVALIDATED the cache while this was in
+ *     flight (a restart), so the conclusion may describe a server that is gone.
+ *   • `writes` mismatch (detections only) → another probe already committed a
+ *     FRESHER verdict; ours is the older read and must not overwrite it.
+ * A dropped write is not an error: the caller still gets the value it derived,
+ * it simply isn't pinned for later callers.
  */
-export function cacheManagerApi(base: string, api: ManagerApi, startEpoch?: number): void {
-  if (startEpoch !== undefined && startEpoch !== epoch) {
-    logger.debug("Dropping Manager API dialect detected across an invalidation", {
-      base,
-      api,
-      startEpoch,
-      epoch,
-    });
-    return;
+export function cacheManagerApi(
+  base: string,
+  api: ManagerApi,
+  guard?: { epoch: number; writes?: number },
+): void {
+  if (guard) {
+    const reason =
+      guard.epoch !== epoch
+        ? "invalidated in flight"
+        : guard.writes !== undefined && guard.writes !== writes
+          ? "overtaken by a fresher detection"
+          : undefined;
+    if (reason) {
+      logger.debug("Dropping a Manager API dialect commit", { base, api, reason, guard, epoch, writes });
+      return;
+    }
   }
   cache = { base, api, at: monotonicNow() };
+  writes++;
 }
 
 /**

--- a/src/services/manager-api-cache.ts
+++ b/src/services/manager-api-cache.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { logger } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
@@ -65,6 +66,18 @@ const MANAGER_API_TTL_MS = (() => {
   return Number.isFinite(n) && n >= 0 ? n : 60_000;
 })();
 
+/**
+ * Elapsed-time source for the freshness window. MONOTONIC on purpose: a wall
+ * clock can be stepped in either direction (NTP correction, VM snapshot restore,
+ * a manual fix), and Date.now() arithmetic then misreports how much real time has
+ * passed — a backward step can make an already-expired entry read as fresh again
+ * once wall time catches back up to the stamp. performance.now() only ever moves
+ * forward, so the window always measures actual elapsed time.
+ */
+function monotonicNow(): number {
+  return performance.now();
+}
+
 let cache: { base: string; api: ManagerApi; at: number } | null = null;
 
 /**
@@ -86,15 +99,15 @@ export function managerApiEpoch(): number {
  * detected against a different base URL, or it has aged out of the freshness
  * window.
  *
- * A NEGATIVE age (the system clock stepped backward: NTP correction, VM
- * snapshot restore) counts as EXPIRED rather than fresh — otherwise a one-hour
- * rollback would silently extend a 60s TTL by an hour and keep a stale dialect
- * pinned well past the intended window (#528 review). The re-detect that follows
- * re-stamps `at` against the corrected clock, so normal caching resumes at once.
+ * Age is measured on the MONOTONIC clock (see monotonicNow), so stepping the
+ * system clock — in either direction — can neither extend the window nor
+ * resurrect an entry that has already aged out. The `age >= 0` check is kept as a
+ * defensive floor: a monotonic source cannot produce a negative age, and if one
+ * ever appeared the safe reading is EXPIRED, not fresh (#528 review).
  */
 export function getCachedManagerApi(base: string): ManagerApi | undefined {
   if (!cache || cache.base !== base) return undefined;
-  const age = Date.now() - cache.at;
+  const age = monotonicNow() - cache.at;
   if (age >= 0 && age < MANAGER_API_TTL_MS) return cache.api;
   logger.debug("Manager API dialect cache expired — re-probing", {
     base,
@@ -121,7 +134,7 @@ export function cacheManagerApi(base: string, api: ManagerApi, startEpoch?: numb
     });
     return;
   }
-  cache = { base, api, at: Date.now() };
+  cache = { base, api, at: monotonicNow() };
 }
 
 /**

--- a/src/services/manager-api-cache.ts
+++ b/src/services/manager-api-cache.ts
@@ -89,16 +89,17 @@ let cache: { base: string; api: ManagerApi; at: number } | null = null;
 let epoch = 0;
 
 /**
- * Commit counter, bumped by every accepted cache write. A reset is not the only
- * way a detection can be overtaken: after the TTL lapses, two operations can
- * probe CONCURRENTLY, and if the slower probe (which read the PRE-restart server)
- * resolves last it would overwrite the fresher verdict and re-pin the stale
- * dialect for another window — with no reset involved, so the epoch alone
- * wouldn't catch it. A detection therefore also refuses to commit when any other
- * write landed while it was in flight; the fresher verdict stands and the loser
- * simply returns its own value to its caller.
+ * Ordering ticket for concurrent detections. A reset is not the only way a
+ * detection can be overtaken: once the TTL lapses, two operations can probe
+ * CONCURRENTLY, and if a restart lands between them the two probes read DIFFERENT
+ * servers. Completion order says nothing about which reading is newer, so writes
+ * are ordered by when the detection STARTED: each takes a ticket up front, and a
+ * commit is accepted only when no LATER-STARTED detection has already committed.
+ * The newest reading therefore always ends up pinned, whichever probe finishes
+ * first, and the loser simply returns its own value to its own caller.
  */
-let writes = 0;
+let seqCounter = 0;
+let lastCommittedSeq = 0;
 
 /** Current invalidation epoch — capture it before an async operation and pass it
  *  back to the commit helpers so a concurrent RESET wins. */
@@ -106,15 +107,15 @@ export function managerApiEpoch(): number {
   return epoch;
 }
 
-/** Full cache state stamp for a DETECTION: loses to a concurrent reset AND to a
- *  concurrent detection that committed first. */
+/** Ordering stamp for a DETECTION, taken BEFORE it probes. It loses to a
+ *  concurrent reset and to any later-started detection that already committed. */
 export interface ManagerApiCacheStamp {
   epoch: number;
-  writes: number;
+  seq: number;
 }
 
 export function managerApiCacheStamp(): ManagerApiCacheStamp {
-  return { epoch, writes };
+  return { epoch, seq: ++seqCounter };
 }
 
 /**
@@ -145,30 +146,43 @@ export function getCachedManagerApi(base: string): ManagerApi | undefined {
  * work that produced it:
  *   • `epoch` mismatch → something INVALIDATED the cache while this was in
  *     flight (a restart), so the conclusion may describe a server that is gone.
- *   • `writes` mismatch (detections only) → another probe already committed a
- *     FRESHER verdict; ours is the older read and must not overwrite it.
+ *   • `seq` older than the last accepted commit (detections only) → a
+ *     LATER-STARTED detection has already committed, so this is the older
+ *     reading and must not overwrite it.
+ * A guard WITHOUT a `seq` is a barrier write: it is not a probe reading but a
+ * conclusion proven by an operation that actually succeeded (the #464 v2-batch
+ * demotion), so it supersedes probe verdicts and takes a fresh ticket, which in
+ * turn keeps any still-in-flight older detection from clobbering it.
+ *
  * A dropped write is not an error: the caller still gets the value it derived,
  * it simply isn't pinned for later callers.
  */
 export function cacheManagerApi(
   base: string,
   api: ManagerApi,
-  guard?: { epoch: number; writes?: number },
+  guard?: { epoch: number; seq?: number },
 ): void {
   if (guard) {
     const reason =
       guard.epoch !== epoch
         ? "invalidated in flight"
-        : guard.writes !== undefined && guard.writes !== writes
-          ? "overtaken by a fresher detection"
+        : guard.seq !== undefined && guard.seq < lastCommittedSeq
+          ? "overtaken by a later-started detection"
           : undefined;
     if (reason) {
-      logger.debug("Dropping a Manager API dialect commit", { base, api, reason, guard, epoch, writes });
+      logger.debug("Dropping a Manager API dialect commit", {
+        base,
+        api,
+        reason,
+        guard,
+        epoch,
+        lastCommittedSeq,
+      });
       return;
     }
   }
   cache = { base, api, at: monotonicNow() };
-  writes++;
+  lastCommittedSeq = guard?.seq ?? ++seqCounter;
 }
 
 /**

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -6,6 +6,14 @@ import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { resetObjectInfoCache } from "../comfyui/client.js";
 import { progressEnabled, reportDownloadProgress } from "./download-progress.js";
+import {
+  type ManagerApi,
+  cacheManagerApi,
+  getCachedManagerApi,
+  managerApiEpoch,
+  resetManagerApiCache,
+  setManagerApiCacheForTests,
+} from "./manager-api-cache.js";
 import { resolveRootInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
@@ -259,13 +267,15 @@ async function managerQueueControl(path: string): Promise<void> {
 //              an unregistered POST returns 405 (never 404) — the exact
 //              symptom of #235.
 //   "legacy"   the 3.x custom-node Manager: per-operation /manager/queue/*.
-type ManagerApi = "v2" | "v2-batch" | "legacy";
-
-let managerApiCache: { base: string; api: ManagerApi } | null = null;
+//
+// The detected dialect is cached by ./manager-api-cache.ts — URL-keyed AND
+// TTL-bounded, and invalidated by the restart lifecycle, so a ComfyUI restart at
+// the SAME URL (a Manager 3.x→4.x upgrade, dropping --enable-manager-legacy-ui)
+// can no longer pin the pre-restart dialect forever (#646).
 
 /** @internal — test hook so suites can pin/clear the detected generation. */
 export function resetManagerApiCacheForTests(api?: ManagerApi): void {
-  managerApiCache = api ? { base: managerBaseUrl(), api } : null;
+  setManagerApiCacheForTests(managerBaseUrl(), api);
 }
 
 /**
@@ -276,9 +286,13 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
  * didn't identify it (#464). Pin the corrected dialect so subsequent operations
  * skip the dead task route. Caller must only invoke this once the batch enqueue
  * has actually succeeded, so a transient/proxy 405 can't poison the cache.
+ *
+ * `startEpoch` is the invalidation epoch from before the operation began: if
+ * ComfyUI restarted while the enqueue was in flight, this conclusion describes
+ * the OLD server and must not be pinned over the fresh invalidation (#646).
  */
-function demoteManagerApiToV2Batch(): void {
-  managerApiCache = { base: managerBaseUrl(), api: "v2-batch" };
+function demoteManagerApiToV2Batch(startEpoch: number): void {
+  cacheManagerApi(managerBaseUrl(), "v2-batch", startEpoch);
 }
 
 /** A real queue/status payload — guards detection against servers that answer
@@ -350,11 +364,16 @@ async function resolveV2SubDialect(): Promise<ManagerApi> {
 
 async function detectManagerApi(): Promise<ManagerApi> {
   const base = managerBaseUrl();
-  if (managerApiCache?.base === base) return managerApiCache.api;
+  const cached = getCachedManagerApi(base);
+  if (cached !== undefined) return cached;
+  // Capture the invalidation epoch BEFORE probing: if ComfyUI is restarted while
+  // these probes are in flight, the conclusion describes the pre-restart server
+  // and must not be pinned over that invalidation (#646).
+  const startEpoch = managerApiEpoch();
   const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { soft: true });
   if (looksLikeQueueStatus(v2)) {
     const api = await resolveV2SubDialect();
-    managerApiCache = { base, api };
+    cacheManagerApi(base, api, startEpoch);
     return api;
   }
   const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { soft: true });
@@ -379,11 +398,11 @@ async function detectManagerApi(): Promise<ManagerApi> {
       });
       if (looksLikeQueueStatus(v2Retry)) {
         const api = await resolveV2SubDialect();
-        managerApiCache = { base, api };
+        cacheManagerApi(base, api, startEpoch);
         return api;
       }
     }
-    managerApiCache = { base, api: "legacy" };
+    cacheManagerApi(base, "legacy", startEpoch);
     return "legacy";
   }
   throw new NodeManagementError(
@@ -584,10 +603,97 @@ async function queueManagerTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
 ): Promise<QueueStatus> {
-  const uiId = randomUUID();
+  // Epoch snapshot for the whole operation: any dialect conclusion reached
+  // during it is only pinned if nothing invalidated the cache meanwhile (#646).
+  const startEpoch = managerApiEpoch();
   const api = await detectManagerApi();
-  if (api === "legacy") return runLegacyTask(kind, params, uiId);
-  if (api === "v2-batch") return runV2BatchTask(kind, params, uiId);
+  try {
+    await enqueueManagerTask(api, kind, params, randomUUID(), startEpoch);
+  } catch (err) {
+    const fresh = await redetectAfterDialectMismatch(api, kind, err);
+    if (fresh === undefined) throw err;
+    // The live server speaks a DIFFERENT dialect than the one we routed with, and
+    // the failure was a pre-execution rejection (see redetectAfterDialectMismatch),
+    // so nothing was enqueued — re-enqueue ONCE in the correct dialect. This calls
+    // the dispatcher directly rather than recursing, so there is exactly one retry.
+    await enqueueManagerTask(fresh, kind, params, randomUUID(), managerApiEpoch());
+  }
+  return runManagerQueue();
+}
+
+/**
+ * Manager statuses that mean "your request was rejected BEFORE any work ran":
+ *   404/405 — the route doesn't exist for this build (ComfyUI's frontend catchall
+ *             answers an unregistered POST with 405, never 404), so no handler ran.
+ *   400     — the handler exists but refused the body during validation, which is
+ *             exactly what a v4 Manager does to a 3.x-shaped install_model payload
+ *             (the #646 report: "400 Bad Request for /v2/manager/queue/install_model"
+ *             while the live server was a normal Manager 4.2.2). Manager validates
+ *             before enqueuing, so a 400 likewise means nothing was queued.
+ * Everything else (403 security_level gating, 5xx, transport failures, queue-drain
+ * timeouts) is NOT a dialect signal and must never trigger a re-probe or a retry.
+ */
+const DIALECT_MISMATCH_STATUSES = new Set([400, 404, 405]);
+
+/**
+ * Decide whether a failed enqueue was the CACHED DIALECT being stale, and if so
+ * return the dialect the live server actually speaks now.
+ *
+ * A restart at the same URL can swap the Manager generation underneath a cached
+ * classification (#646). The explicit restart-lifecycle invalidation and the TTL
+ * cover the common paths; this is the per-call backstop so ONE stale entry heals
+ * itself instead of failing every subsequent Manager operation.
+ *
+ * Two guards keep this from looping or double-executing a mutation:
+ *   • only pre-execution rejections (DIALECT_MISMATCH_STATUSES) qualify, so the
+ *     failed attempt provably enqueued nothing;
+ *   • the caller only retries when a FRESH probe reports a DIFFERENT dialect. A
+ *     genuine 400 (bad params, a 3.x whitelist rejection) re-detects the same
+ *     dialect → undefined → the original error surfaces, and the re-probe has
+ *     already re-populated the cache, so a failing call costs at most one extra
+ *     detection rather than re-probing on every subsequent call.
+ */
+async function redetectAfterDialectMismatch(
+  used: ManagerApi,
+  kind: ManagerTaskKind,
+  err: unknown,
+): Promise<ManagerApi | undefined> {
+  const status = errorStatus(err);
+  if (status === undefined || !DIALECT_MISMATCH_STATUSES.has(status)) return undefined;
+  resetManagerApiCache(`manager ${kind} enqueue failed ${status} on the "${used}" dialect`);
+  let fresh: ManagerApi;
+  try {
+    fresh = await detectManagerApi();
+  } catch {
+    // Manager isn't answering at all — that's not a dialect mismatch; surface the
+    // caller's original (more informative) failure.
+    return undefined;
+  }
+  if (fresh === used) return undefined;
+  logger.info("Manager API dialect changed under a cached classification — retrying once", {
+    kind,
+    was: used,
+    now: fresh,
+    status,
+  });
+  return fresh;
+}
+
+/**
+ * ENQUEUE one operation in the given dialect. Deliberately does NOT drain the
+ * queue: queueManagerTask retries this step (and only this step) after a dialect
+ * mismatch, and a retry is only sound while nothing has been queued yet. Draining
+ * happens once, afterwards, in queueManagerTask.
+ */
+async function enqueueManagerTask(
+  api: ManagerApi,
+  kind: ManagerTaskKind,
+  params: Record<string, unknown>,
+  uiId: string,
+  startEpoch: number,
+): Promise<void> {
+  if (api === "legacy") return enqueueLegacyTask(kind, params, uiId);
+  if (api === "v2-batch") return enqueueV2BatchTask(kind, params, uiId);
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
     await managerFetch("/v2/manager/queue/task", {
@@ -615,36 +721,34 @@ async function queueManagerTask(
         "Manager /v2/manager/queue/task 405 — retrying via the v2-batch envelope",
         { kind },
       );
-      const status = await runV2BatchTask(kind, params, uiId);
+      await enqueueV2BatchTask(kind, params, uiId);
       // Pin the corrected dialect ONLY after the batch enqueue actually
       // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
-      // batch also unavailable) never poisons the cache: runV2BatchTask throws
-      // on a batch failure, leaving the cache as "v2" so the next op re-probes
-      // the unified task route (codex review).
-      demoteManagerApiToV2Batch();
-      return status;
+      // batch also unavailable) never poisons the cache: enqueueV2BatchTask
+      // throws on a batch failure, leaving the cache as "v2" so the next op
+      // re-probes the unified task route (codex review).
+      demoteManagerApiToV2Batch(startEpoch);
+      return;
     }
     throw err;
   }
-  return runManagerQueue();
 }
 
 /**
  * Enqueue one operation on the released Manager 3.x per-operation routes
- * (issue #116 — the unified /v2 task route 405s there) and drain the queue.
+ * (issue #116 — the unified /v2 task route 405s there).
  */
-async function runLegacyTask(
+async function enqueueLegacyTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
-): Promise<QueueStatus> {
+): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     await managerFetch(path, { method: "POST", body });
   } catch (err) {
     throw annotateLegacyError(err, kind);
   }
-  return runManagerQueue();
 }
 
 /**
@@ -656,11 +760,11 @@ async function runLegacyTask(
  * install-model keeps its dedicated route (same path as v4, 3.x whitelist
  * semantics).
  */
-async function runV2BatchTask(
+async function enqueueV2BatchTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
-): Promise<QueueStatus> {
+): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     if (kind === "install-model") {
@@ -685,7 +789,6 @@ async function runV2BatchTask(
   } catch (err) {
     throw annotateLegacyError(err, kind, MANAGER_LEGACY_UI_HINT);
   }
-  return runManagerQueue();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1588,15 +1588,20 @@ async function updateManagerSelf(id: string): Promise<NodeOpResult> {
   // be flatly wrong. Only a 405 that survives a re-probe — the route really is
   // unregistered on the live dialect — reaches the unsupported verdict.
   let used: ManagerApi;
+  // The verdict must name the dialect of the attempt that ACTUALLY 405'd — after a
+  // re-probe that can differ from the dialect detected on entry, and the message is
+  // dialect-specific ("the LEGACY 3.x queue API" vs the legacy-UI one).
+  let lastTried = api;
   try {
-    used = await enqueueWithDialectSelfHeal("update", (dialect, epoch) =>
-      enqueueManagerTask(dialect, "update", () => ({ node_name: id }), randomUUID(), epoch),
-    );
+    used = await enqueueWithDialectSelfHeal("update", (dialect, epoch) => {
+      lastTried = dialect;
+      return enqueueManagerTask(dialect, "update", () => ({ node_name: id }), randomUUID(), epoch);
+    });
   } catch (err) {
     if (errorStatus(err) !== 405) throw err;
     // 405 = the update route is not registered on this build (#424).
-    logger.debug("Manager self-update route 405 — reporting unsupported", { api });
-    throw managerSelfUpdateUnsupported(api, err);
+    logger.debug("Manager self-update route 405 — reporting unsupported", { api: lastTried });
+    throw managerSelfUpdateUnsupported(lastTried, err);
   }
   const status = await runManagerQueue(used);
   return {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -601,13 +601,23 @@ async function runManagerQueue(): Promise<QueueStatus> {
  */
 async function queueManagerTask(
   kind: ManagerTaskKind,
-  params: Record<string, unknown>,
+  params: ManagerTaskParams,
 ): Promise<QueueStatus> {
+  // Normalize to a resolver so every attempt builds its body for the dialect it
+  // is about to speak — a few operations (git installs) have dialect-specific
+  // params, and a self-heal retry must rebuild them, not just re-route them.
+  const resolve: ManagerParamsResolver =
+    typeof params === "function" ? params : () => params;
   await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
-    enqueueManagerTask(api, kind, params, randomUUID(), epoch),
+    enqueueManagerTask(api, kind, resolve, randomUUID(), epoch),
   );
   return runManagerQueue();
 }
+
+/** Params for a Manager task: a fixed body, or a resolver invoked with the
+ *  dialect the request is about to be sent in (for dialect-specific bodies). */
+type ManagerParamsResolver = (api: ManagerApi) => Record<string, unknown>;
+type ManagerTaskParams = Record<string, unknown> | ManagerParamsResolver;
 
 /**
  * Run ONE enqueue against the detected Manager dialect, healing a stale
@@ -703,12 +713,12 @@ async function redetectAfterDialectMismatch(
 async function enqueueManagerTask(
   api: ManagerApi,
   kind: ManagerTaskKind,
-  params: Record<string, unknown>,
+  resolveParams: ManagerParamsResolver,
   uiId: string,
   startEpoch: number,
 ): Promise<void> {
-  if (api === "legacy") return enqueueLegacyTask(kind, params, uiId);
-  if (api === "v2-batch") return enqueueV2BatchTask(kind, params, uiId);
+  if (api === "legacy") return enqueueLegacyTask(kind, resolveParams("legacy"), uiId);
+  if (api === "v2-batch") return enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
     await managerFetch("/v2/manager/queue/task", {
@@ -717,7 +727,7 @@ async function enqueueManagerTask(
         ui_id: uiId,
         client_id: MANAGER_CLIENT_ID,
         kind,
-        params: { ...params, ui_id: uiId },
+        params: { ...resolveParams("v2"), ui_id: uiId },
       },
     });
   } catch (err) {
@@ -736,7 +746,10 @@ async function enqueueManagerTask(
         "Manager /v2/manager/queue/task 405 — retrying via the v2-batch envelope",
         { kind },
       );
-      await enqueueV2BatchTask(kind, params, uiId);
+      // Rebuild the body for the dialect we are downgrading TO: this build runs
+      // the 3.x handlers under /v2, so a dialect-specific body (a git install)
+      // must be its 3.x shape, not the v2 one we just tried.
+      await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
       // Pin the corrected dialect ONLY after the batch enqueue actually
       // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
       // batch also unavailable) never poisons the cache: enqueueV2BatchTask
@@ -1372,39 +1385,42 @@ async function installCustomNodeImpl(
 
   if (source === "git") {
     const repoName = gitCheckoutDir(gitId);
-    let status: QueueStatus;
-    if ((await detectManagerApi()) !== "v2") {
-      // 3.x SEMANTICS (both the custom-node Manager AND pip Manager in
-      // legacy-UI mode, whose /v2 batch runs the same 3.x handlers — codex
-      // review on #235): a REAL git URL installs natively via
-      // { version:'unknown', files:[url] }, cloning it as an unregistered
-      // pack. (Gated server-side by security_level + allow_git_url_install
-      // config — a rejection surfaces as a 403/404 from the queue route.)
-      status = await queueManagerTask("install", {
-        id: repoName,
-        version: "unknown",
-        selected_version: "unknown",
-        files: [gitId],
-        channel: opts.channel ?? "default",
-        mode: opts.mode ?? "cache",
-      });
-    } else {
-      // Manager v4: REGISTRY-FIRST, CLONE FALLBACK. The v4 backend resolves an
-      // install by the pack's REPO NAME / CNR id — NOT a full git URL
-      // (do_install splits `${id}@${selected_version}` and looks the result up
-      // in its DB; a full URL matches nothing and the queue silently marks the
-      // task "done"). So we mirror the frontend UI: id = repo name,
-      // selected_version = ref or "nightly" (the git-HEAD channel for unclaimed
-      // packs), channel "dev", mode "cache".
-      const selected = gitRef ?? "nightly";
-      status = await queueManagerTask("install", {
-        id: repoName,
-        version: selected,
-        selected_version: selected,
-        channel: opts.channel ?? "dev",
-        mode: opts.mode ?? "cache",
-      });
-    }
+    // A git install's PARAMS are dialect-specific, not just its route, so they
+    // are built per-attempt from the dialect actually being spoken. Precomputing
+    // them from the cached dialect would let a self-heal retry (#646) resend
+    // 3.x-shaped params to a v4 server (or the reverse) and install the wrong
+    // thing — the retry has to rebuild the body, not just re-route it.
+    const status = await queueManagerTask("install", (api) =>
+      api !== "v2"
+        ? // 3.x SEMANTICS (both the custom-node Manager AND pip Manager in
+          // legacy-UI mode, whose /v2 batch runs the same 3.x handlers — codex
+          // review on #235): a REAL git URL installs natively via
+          // { version:'unknown', files:[url] }, cloning it as an unregistered
+          // pack. (Gated server-side by security_level + allow_git_url_install
+          // config — a rejection surfaces as a 403/404 from the queue route.)
+          {
+            id: repoName,
+            version: "unknown",
+            selected_version: "unknown",
+            files: [gitId],
+            channel: opts.channel ?? "default",
+            mode: opts.mode ?? "cache",
+          }
+        : // Manager v4: REGISTRY-FIRST, CLONE FALLBACK. The v4 backend resolves
+          // an install by the pack's REPO NAME / CNR id — NOT a full git URL
+          // (do_install splits `${id}@${selected_version}` and looks the result
+          // up in its DB; a full URL matches nothing and the queue silently
+          // marks the task "done"). So we mirror the frontend UI: id = repo
+          // name, selected_version = ref or "nightly" (the git-HEAD channel for
+          // unclaimed packs), channel "dev", mode "cache".
+          {
+            id: repoName,
+            version: gitRef ?? "nightly",
+            selected_version: gitRef ?? "nightly",
+            channel: opts.channel ?? "dev",
+            mode: opts.mode ?? "cache",
+          },
+    );
 
     // VERIFY: /v2/customnode/installed reflects on-disk custom_nodes, so a
     // freshly-cloned pack shows up even before a reboot. If the Manager actually

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -141,6 +141,12 @@ function managerBaseUrl(): string {
 interface ManagerFetchOptions {
   method?: "GET" | "POST";
   body?: unknown;
+  /**
+   * Call-scoped ComfyUI target. Manager mutations capture this before their first
+   * await so a concurrent panel retarget cannot send a retry/drain to a different
+   * ComfyUI instance.
+   */
+  base?: string;
   /** Treat a non-2xx response as a soft failure (return undefined) instead of throwing. */
   soft?: boolean;
 }
@@ -149,8 +155,8 @@ async function managerFetch<T>(
   path: string,
   options: ManagerFetchOptions = {},
 ): Promise<T | undefined> {
-  const { method = "GET", body, soft = false } = options;
-  const url = `${managerBaseUrl()}${path}`;
+  const { method = "GET", body, base = managerBaseUrl(), soft = false } = options;
+  const url = `${base}${path}`;
   logger.debug("Manager API request", { url, method });
 
   const headers: Record<string, string> = {};
@@ -232,14 +238,14 @@ function looksLikeHtml(body: unknown): boolean {
  * request — surface the original method error. Any non-405 error, or a
  * non-2xx GET, propagates unchanged.
  */
-async function managerQueueControl(path: string): Promise<void> {
+async function managerQueueControl(path: string, base: string): Promise<void> {
   try {
-    await managerFetch(path, { method: "POST" });
+    await managerFetch(path, { method: "POST", base });
   } catch (err) {
     if (errorStatus(err) === 405) {
       // GET-only legacy build — negotiate the method rather than declare failure.
       logger.debug("Manager queue control 405 on POST; retrying as GET", { path });
-      const body = await managerFetch<unknown>(path); // throws on a non-2xx GET
+      const body = await managerFetch<unknown>(path, { base }); // throws on a non-2xx GET
       if (looksLikeHtml(body)) throw err; // catchall page — not a real GET-only start
       return;
     }
@@ -294,11 +300,11 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
  * ComfyUI restarted while the enqueue was in flight, this conclusion describes
  * the OLD server and must not be pinned over the fresh invalidation (#646).
  */
-function demoteManagerApiToV2Batch(startEpoch: number): void {
+function demoteManagerApiToV2Batch(base: string, startEpoch: number): void {
   // Guarded on the invalidation epoch ONLY (not the write counter): this verdict
   // is backed by an enqueue that actually SUCCEEDED, so it legitimately
   // supersedes a probe-derived classification that landed during the operation.
-  cacheManagerApi(managerBaseUrl(), "v2-batch", { epoch: startEpoch });
+  cacheManagerApi(base, "v2-batch", { epoch: startEpoch });
 }
 
 /** A real queue/status payload — guards detection against servers that answer
@@ -341,14 +347,14 @@ function parseManagerMajor(raw: unknown): number | undefined {
   return m ? Number(m[1]) : undefined;
 }
 
-async function probeManagerMajor(): Promise<number | undefined> {
+async function probeManagerMajor(base: string): Promise<number | undefined> {
   // v4's /v2/manager/version is the strongest signal; check it first.
   const v4 = parseManagerMajor(
-    await managerFetch<string>("/v2/manager/version", { soft: true }),
+    await managerFetch<string>("/v2/manager/version", { base, soft: true }),
   );
   if (v4 !== undefined) return v4;
   return parseManagerMajor(
-    await managerFetch<string>("/manager/version", { soft: true }),
+    await managerFetch<string>("/manager/version", { base, soft: true }),
   );
 }
 
@@ -358,10 +364,10 @@ async function probeManagerMajor(): Promise<number | undefined> {
  * GET /v2/manager/is_legacy_manager_ui and answer truthfully; a missing route
  * (older pip) means the normal v4 server → unified task dialect.
  */
-async function resolveV2SubDialect(): Promise<ManagerApi> {
+async function resolveV2SubDialect(base: string): Promise<ManagerApi> {
   const legacyUi = await managerFetch<{ is_legacy_manager_ui?: boolean }>(
     "/v2/manager/is_legacy_manager_ui",
-    { soft: true },
+    { base, soft: true },
   );
   return legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
     ? "v2-batch"
@@ -385,8 +391,7 @@ let detectInflight: { base: string; epoch: number; promise: Promise<ManagerApi> 
  *  spin here; three readings is far past any real restart. */
 const DETECT_INVALIDATION_RETRIES = 2;
 
-async function detectManagerApi(): Promise<ManagerApi> {
-  const base = managerBaseUrl();
+async function detectManagerApi(base = managerBaseUrl()): Promise<ManagerApi> {
   for (let attempt = 0; ; attempt++) {
     const cached = getCachedManagerApi(base);
     if (cached !== undefined) return cached;
@@ -440,13 +445,13 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
   // conclusion describes a server that may be gone and must not be pinned over
   // the newer state (#646).
   const stamp = managerApiCacheStamp();
-  const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { soft: true });
+  const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { base, soft: true });
   if (looksLikeQueueStatus(v2)) {
-    const api = await resolveV2SubDialect();
+    const api = await resolveV2SubDialect(base);
     cacheManagerApi(base, api, stamp);
     return api;
   }
-  const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { soft: true });
+  const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { base, soft: true });
   if (looksLikeQueueStatus(legacy)) {
     // /manager/queue/status answering ALMOST always means the released 3.x
     // custom-node Manager — but do NOT brand it "legacy 3.x" (and speak 3.x
@@ -455,7 +460,7 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
     // here; CONFIRM the generation with the authoritative version string first.
     // A 405/route-shape is NEVER the version signal — /v2/manager/version ("V4.x")
     // vs /manager/version ("V3.x") is.
-    const major = await probeManagerMajor();
+    const major = await probeManagerMajor(base);
     if (major !== undefined && major >= 4) {
       // Version says v4 — but only speak v4 if its queue surface ACTUALLY
       // validates now (re-probe): routing to v2 when /v2/manager/queue/status is
@@ -464,10 +469,11 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
       // keep the proven, WORKING legacy classification (we hold a validated
       // /manager queue endpoint) rather than route to a dead v4 surface.
       const v2Retry = await managerFetch<QueueStatus>("/v2/manager/queue/status", {
+        base,
         soft: true,
       });
       if (looksLikeQueueStatus(v2Retry)) {
-        const api = await resolveV2SubDialect();
+        const api = await resolveV2SubDialect(base);
         cacheManagerApi(base, api, stamp);
         return api;
       }
@@ -635,19 +641,20 @@ export function setQueueTimingForTests(
  * work that is really running — and inviting a caller retry that double-executes
  * it (#646).
  */
-async function runManagerQueue(api: ManagerApi): Promise<QueueStatus> {
+async function runManagerQueue(api: ManagerApi, base: string): Promise<QueueStatus> {
   const prefix = managerQueuePrefixFor(api);
   // queue/start returns 200 (worker started) or 201 (already running) — both
   // are 2xx, so managerFetch accepts either. Same on both generations. Some
   // legacy 3.x builds expose start as GET-only, so negotiate POST→GET on a 405
   // (#551) rather than failing the queue on a method mismatch.
-  await managerQueueControl(`${prefix}/start`);
+  await managerQueueControl(`${prefix}/start`, base);
 
   const start = Date.now();
   let lastStatus: QueueStatus | undefined;
   while (Date.now() - start < queueTiming.timeoutMs) {
     await sleep(queueTiming.pollIntervalMs);
     const status = await managerFetch<QueueStatus>(`${prefix}/status`, {
+      base,
       soft: true,
     });
     if (status) {
@@ -679,16 +686,21 @@ async function runManagerQueue(api: ManagerApi): Promise<QueueStatus> {
 async function queueManagerTask(
   kind: ManagerTaskKind,
   params: ManagerTaskParams,
+  base = managerBaseUrl(),
 ): Promise<QueueStatus> {
   // Normalize to a resolver so every attempt builds its body for the dialect it
   // is about to speak — a few operations (git installs) have dialect-specific
   // params, and a self-heal retry must rebuild them, not just re-route them.
   const resolve: ManagerParamsResolver =
     typeof params === "function" ? params : () => params;
+  // This is a mutation transaction, so freeze its target before the first await.
+  // A later setComfyuiTarget() selects where NEW calls go; it must not redirect a
+  // retry, queue start, or verification of a request the user already made.
   const used = await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
-    enqueueManagerTask(api, kind, resolve, randomUUID(), epoch),
+    enqueueManagerTask(api, kind, resolve, randomUUID(), base, epoch),
+    base,
   );
-  return runManagerQueue(used);
+  return runManagerQueue(used, base);
 }
 
 /** Params for a Manager task: a fixed body, or a resolver invoked with the
@@ -717,8 +729,9 @@ type ManagerTaskParams = Record<string, unknown> | ManagerParamsResolver;
 async function enqueueWithDialectSelfHeal(
   label: string,
   enqueue: (api: ManagerApi, startEpoch: number) => Promise<ManagerApi | void>,
+  base = managerBaseUrl(),
 ): Promise<ManagerApi> {
-  const api = await detectManagerApi();
+  const api = await detectManagerApi(base);
   // Epoch snapshot taken AFTER detection, i.e. spanning exactly the enqueue whose
   // outcome a conclusion would be based on. Taking it earlier would also cover the
   // detection — and since a detection invalidated mid-probe now re-probes and
@@ -729,7 +742,7 @@ async function enqueueWithDialectSelfHeal(
   try {
     return (await enqueue(api, startEpoch)) ?? api;
   } catch (err) {
-    const fresh = await redetectAfterDialectMismatch(api, label, err);
+    const fresh = await redetectAfterDialectMismatch(api, label, err, base);
     if (fresh === undefined) throw err;
     if (!ROUTE_MISMATCH_STATUSES.has(errorStatus(err) as number)) {
       // The dialect DID change, but this failure doesn't prove the request went
@@ -843,7 +856,7 @@ async function sharedDialectRecheck(
     resetManagerApiCache(`manager ${label} enqueue failed ${status} on the "${used}" dialect`);
     const epoch = managerApiEpoch();
     try {
-      return { fresh: await detectManagerApi(), epoch };
+      return { fresh: await detectManagerApi(base), epoch };
     } catch {
       // Manager isn't answering at all — that's not a dialect mismatch; the
       // caller surfaces its own (more informative) failure. Don't re-probe on
@@ -869,6 +882,7 @@ async function redetectAfterDialectMismatch(
   used: ManagerApi,
   label: string,
   err: unknown,
+  base = managerBaseUrl(),
 ): Promise<ManagerApi | undefined> {
   const status = errorStatus(err);
   if (
@@ -877,7 +891,6 @@ async function redetectAfterDialectMismatch(
   ) {
     return undefined;
   }
-  const base = managerBaseUrl();
   if (dialectRecheckSuppressed(base)) {
     logger.debug("Skipping Manager dialect re-check (cooldown)", { op: label, status });
     return undefined;
@@ -925,20 +938,22 @@ async function enqueueManagerTask(
   kind: ManagerTaskKind,
   resolveParams: ManagerParamsResolver,
   uiId: string,
+  base: string,
   startEpoch: number,
 ): Promise<ManagerApi> {
   if (api === "legacy") {
-    await enqueueLegacyTask(kind, resolveParams("legacy"), uiId);
+    await enqueueLegacyTask(kind, resolveParams("legacy"), uiId, base);
     return "legacy";
   }
   if (api === "v2-batch") {
-    await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
+    await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
     return "v2-batch";
   }
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
     await managerFetch("/v2/manager/queue/task", {
       method: "POST",
+      base,
       body: {
         ui_id: uiId,
         client_id: MANAGER_CLIENT_ID,
@@ -965,13 +980,13 @@ async function enqueueManagerTask(
       // Rebuild the body for the dialect we are downgrading TO: this build runs
       // the 3.x handlers under /v2, so a dialect-specific body (a git install)
       // must be its 3.x shape, not the v2 one we just tried.
-      await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
+      await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId, base);
       // Pin the corrected dialect ONLY after the batch enqueue actually
       // succeeded, so a transient/proxy 405 on a genuine v4 host (task 405 but
       // batch also unavailable) never poisons the cache: enqueueV2BatchTask
       // throws on a batch failure, leaving the cache as "v2" so the next op
       // re-probes the unified task route (codex review).
-      demoteManagerApiToV2Batch(startEpoch);
+      demoteManagerApiToV2Batch(base, startEpoch);
       return "v2-batch";
     }
     throw err;
@@ -987,10 +1002,11 @@ async function enqueueLegacyTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
+  base: string,
 ): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
-    await managerFetch(path, { method: "POST", body });
+    await managerFetch(path, { method: "POST", body, base });
   } catch (err) {
     throw annotateLegacyError(err, kind);
   }
@@ -1009,11 +1025,12 @@ async function enqueueV2BatchTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
   uiId: string,
+  base: string,
 ): Promise<void> {
   const { path, body } = legacyTaskRequest(kind, params, uiId);
   try {
     if (kind === "install-model") {
-      await managerFetch("/v2/manager/queue/install_model", { method: "POST", body });
+      await managerFetch("/v2/manager/queue/install_model", { method: "POST", body, base });
     } else {
       // legacyTaskRequest's path is "/manager/queue/<op>"; the batch key is
       // that trailing op ("enable" maps to an install body → key "install").
@@ -1021,6 +1038,7 @@ async function enqueueV2BatchTask(
       const res = await managerFetch<{ failed?: unknown[] }>("/v2/manager/queue/batch", {
         method: "POST",
         body: { [op]: [body] },
+        base,
       });
       const failed = Array.isArray(res?.failed) ? res.failed : [];
       if (failed.length && (body.id === undefined || failed.includes(body.id))) {
@@ -1586,6 +1604,11 @@ async function installCustomNodeImpl(
   // actually used (runGitCheckout, cloneCustomNodeFallback).
   if (source === "git") assertSafeGitUrl(gitId);
 
+  // Keep both the mutation and its post-queue on-disk verification on the
+  // target selected for this invocation. Otherwise a panel retarget between
+  // them can turn an A-side install into a B-side fabricated success/fallback.
+  const managerBase = managerBaseUrl();
+
   if (opts.useCmCli) {
     // cm-cli install accepts registry ids and git urls alike.
     const installId = source === "git" ? gitId : id;
@@ -1607,8 +1630,10 @@ async function installCustomNodeImpl(
     // them from the cached dialect would let a self-heal retry (#646) resend
     // 3.x-shaped params to a v4 server (or the reverse) and install the wrong
     // thing — the retry has to rebuild the body, not just re-route it.
-    const status = await queueManagerTask("install", (api) =>
-      api !== "v2"
+    const status = await queueManagerTask(
+      "install",
+      (api) =>
+        api !== "v2"
         ? // 3.x SEMANTICS (both the custom-node Manager AND pip Manager in
           // legacy-UI mode, whose /v2 batch runs the same 3.x handlers — codex
           // review on #235): a REAL git URL installs natively via
@@ -1637,12 +1662,13 @@ async function installCustomNodeImpl(
             channel: opts.channel ?? "dev",
             mode: opts.mode ?? "cache",
           },
+      managerBase,
     );
 
     // VERIFY: /v2/customnode/installed reflects on-disk custom_nodes, so a
     // freshly-cloned pack shows up even before a reboot. If the Manager actually
     // installed it, we're done; otherwise it's unregistered → clone it directly.
-    const installed = await listInstalledNodes().catch(
+    const installed = await listInstalledNodesAt(managerBase).catch(
       () => [] as InstalledNode[],
     );
     if (nodeInstalledMatches(gitId, installed)) {
@@ -1667,8 +1693,8 @@ async function installCustomNodeImpl(
     selected_version: version ?? "latest",
     channel,
     mode,
-  });
-  const installed = await listInstalledNodes().catch(
+  }, managerBase);
+  const installed = await listInstalledNodesAt(managerBase).catch(
     () => [] as InstalledNode[],
   );
   if (!nodeInstalledMatches(id, installed)) {
@@ -1766,7 +1792,10 @@ function managerSelfUpdateUnsupported(api: ManagerApi, cause?: unknown): NodeMan
  * registers the route, so this branch is for builds that genuinely lack it.)
  */
 async function updateManagerSelf(id: string): Promise<NodeOpResult> {
-  const api = await detectManagerApi();
+  // Keep this self-update on the ComfyUI instance selected at invocation. A
+  // panel retarget during the dialect recheck must not update another instance.
+  const base = managerBaseUrl();
+  const api = await detectManagerApi(base);
   // ONLY the enqueue is inspected for the 405 signal. A 405 raised later, while
   // draining (e.g. `${prefix}/start`), says nothing about whether the update route
   // exists, so it must propagate as itself rather than be reported as "unsupported"
@@ -1785,15 +1814,22 @@ async function updateManagerSelf(id: string): Promise<NodeOpResult> {
   try {
     used = await enqueueWithDialectSelfHeal("update", (dialect, epoch) => {
       lastTried = dialect;
-      return enqueueManagerTask(dialect, "update", () => ({ node_name: id }), randomUUID(), epoch);
-    });
+      return enqueueManagerTask(
+        dialect,
+        "update",
+        () => ({ node_name: id }),
+        randomUUID(),
+        base,
+        epoch,
+      );
+    }, base);
   } catch (err) {
     if (errorStatus(err) !== 405) throw err;
     // 405 = the update route is not registered on this build (#424).
     logger.debug("Manager self-update route 405 — reporting unsupported", { api: lastTried });
     throw managerSelfUpdateUnsupported(lastTried, err);
   }
-  const status = await runManagerQueue(used);
+  const status = await runManagerQueue(used, base);
   return {
     mechanism: "manager-http",
     message:
@@ -1839,6 +1875,7 @@ async function updateCustomNodeImpl(
     // queueManagerTask), but it is just as dialect-dependent — route it through
     // the same enqueue-only self-heal so a stale classification can't wedge it
     // either (#646). Enqueue here, drain once below.
+    const base = managerBaseUrl();
     const used = await enqueueWithDialectSelfHeal("update-all", async (api) => {
       // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
       // (manager_server.py), NOT the JSON body — a body-only request leaves mode
@@ -1850,6 +1887,7 @@ async function updateCustomNodeImpl(
         await managerFetch("/manager/queue/update_all", {
           method: "POST",
           body: { mode, ui_id: uiId },
+          base,
         });
       } else {
         const query = new URLSearchParams({
@@ -1859,10 +1897,11 @@ async function updateCustomNodeImpl(
         }).toString();
         await managerFetch(`/v2/manager/queue/update_all?${query}`, {
           method: "POST",
+          base,
         });
       }
-    });
-    status = await runManagerQueue(used);
+    }, base);
+    status = await runManagerQueue(used, base);
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
     status = await queueManagerTask("update", { node_name: id });
@@ -1974,7 +2013,8 @@ export interface ListInstalledOptions {
   useCmCli?: boolean;
 }
 
-export async function listInstalledNodes(
+async function listInstalledNodesAt(
+  base: string,
   opts: ListInstalledOptions = {},
 ): Promise<InstalledNode[]> {
   const { mode = "default" } = opts;
@@ -1996,11 +2036,18 @@ export async function listInstalledNodes(
 
   // Both pip-Manager modes serve /v2/customnode/installed (the legacy-UI
   // module registers it too); only the 3.x custom-node Manager lacks /v2.
-  const prefix = (await detectManagerApi()) === "legacy" ? "" : "/v2";
+  const prefix = (await detectManagerApi(base)) === "legacy" ? "" : "/v2";
   const raw = await managerFetch<unknown>(
     `${prefix}/customnode/installed?mode=${encodeURIComponent(mode)}`,
+    { base },
   );
   return parseInstalled(raw);
+}
+
+export async function listInstalledNodes(
+  opts: ListInstalledOptions = {},
+): Promise<InstalledNode[]> {
+  return listInstalledNodesAt(managerBaseUrl(), opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1946,15 +1946,20 @@ async function reinstallCustomNodeImpl(
   }
 
   // The unified queue has no `reinstall` kind, so model it as uninstall + a
-  // fresh install of the same target. Each is its own drained queue cycle.
-  await queueManagerTask("uninstall", { node_name: id });
+  // fresh install of the same target. Each is its own drained queue cycle, but
+  // the TWO cycles are one logical operation and must share ONE pinned target:
+  // captured once, up front, so a panel retarget after the uninstall drains
+  // cannot send the install to a different ComfyUI — which would leave the
+  // user's server uninstalled while reporting success for another.
+  const base = managerBaseUrl();
+  await queueManagerTask("uninstall", { node_name: id }, base);
   const status = await queueManagerTask("install", {
     id,
     version: version ?? "latest",
     selected_version: version ?? "latest",
     channel,
     mode,
-  });
+  }, base);
   return {
     mechanism: "manager-http",
     message: `Queued + reinstalled "${id}" (uninstall + install) via ComfyUI-Manager. A restart may be required.`,
@@ -2144,11 +2149,17 @@ const REMOTE_LANDING_TIMEOUT_MS = 4 * 60 * 60 * 1000; // generous: multi-GB on s
  * if it never shows within the timeout. Fire-and-forget: the tool call returns
  * at dispatch; this keeps the tray honest afterwards. No-op outside the panel
  * (progress channel disabled).
+ *
+ * `base` is the ComfyUI the download was DISPATCHED to: the file lands there,
+ * so the poll must stay there even if the panel retargets mid-download —
+ * following the new target would watch a server the file never lands on and
+ * eventually report a false "error".
  */
 export function watchRemoteModelLanding(
   category: string,
   filename: string,
   url: string,
+  base = getComfyUIBaseUrl(),
 ): void {
   if (!progressEnabled()) return;
   const id = createHash("sha256").update(url).digest("hex").slice(0, 16);
@@ -2160,7 +2171,7 @@ export function watchRemoteModelLanding(
       let listed = false;
       try {
         const res = await comfyuiFetch(
-          `${getComfyUIBaseUrl()}/models/${encodeURIComponent(category)}`,
+          `${base}/models/${encodeURIComponent(category)}`,
         );
         if (res.ok) {
           const names = (await res.json()) as unknown;
@@ -2217,7 +2228,11 @@ export async function installModelViaManager(
     type: params.type,
     save_path,
   };
-  const status = await queueManagerTask("install-model", taskParams);
+  // One pinned target for the whole operation — the dispatch, its self-heal
+  // retry/drain, AND the landing watcher (the file lands on the server the task
+  // was dispatched to, so that is the only server worth polling).
+  const base = managerBaseUrl();
+  const status = await queueManagerTask("install-model", taskParams, base);
   // NOTE: the Manager queue reports the task "done" once it DRAINS, even when
   // the underlying OperationResult failed (e.g. a 404 download, or Manager's
   // security gate rejecting a network fetch) — and with an aria2 sidecar
@@ -2231,7 +2246,7 @@ export async function installModelViaManager(
   // in network_mode=personal_cloud (or loopback) with permissive security; a
   // stricter security_level rejects the server-side download.
   if (params.trayCategory) {
-    watchRemoteModelLanding(params.trayCategory, params.filename, params.url);
+    watchRemoteModelLanding(params.trayCategory, params.filename, params.url, base);
   }
   return {
     mechanism: "manager-http",

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -9,11 +9,13 @@ import { progressEnabled, reportDownloadProgress } from "./download-progress.js"
 import {
   type ManagerApi,
   cacheManagerApi,
+  dialectRecheckSuppressed,
   getCachedManagerApi,
   managerApiCacheStamp,
   managerApiEpoch,
   resetManagerApiCache,
   setManagerApiCacheForTests,
+  suppressDialectRecheck,
 } from "./manager-api-cache.js";
 import { resolveRootInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
@@ -366,10 +368,73 @@ async function resolveV2SubDialect(): Promise<ManagerApi> {
     : "v2";
 }
 
+/**
+ * In-flight detection, shared by every caller that misses the cache for the same
+ * base under the same epoch. Without this, N operations arriving just after the
+ * window lapses each fire their own probe round — a thundering herd against a
+ * server that is often exactly the one that just restarted (#646 review).
+ *
+ * The EPOCH is part of the join key: a detection that started before an
+ * invalidation is probing the pre-restart server, so a caller arriving after the
+ * reset must start its own rather than inherit that reading.
+ */
+let detectInflight: { base: string; epoch: number; promise: Promise<ManagerApi> } | null = null;
+
+/** How many times a detection will re-probe when it is invalidated mid-probe
+ *  before giving the caller its latest reading anyway. A restart storm must not
+ *  spin here; three readings is far past any real restart. */
+const DETECT_INVALIDATION_RETRIES = 2;
+
 async function detectManagerApi(): Promise<ManagerApi> {
   const base = managerBaseUrl();
-  const cached = getCachedManagerApi(base);
-  if (cached !== undefined) return cached;
+  for (let attempt = 0; ; attempt++) {
+    const cached = getCachedManagerApi(base);
+    if (cached !== undefined) return cached;
+
+    const epochAtStart = managerApiEpoch();
+    let entry = detectInflight;
+    let created = false;
+    if (!(entry && entry.base === base && entry.epoch === epochAtStart)) {
+      entry = { base, epoch: epochAtStart, promise: probeManagerApi(base) };
+      detectInflight = entry;
+      created = true;
+    }
+    let api: ManagerApi;
+    try {
+      api = await entry.promise;
+    } finally {
+      // Only the caller that STARTED this probe clears the slot, and only if it
+      // is still ours — a joiner finishing early must not free the slot out from
+      // under a probe others could still share.
+      if (created && detectInflight === entry) detectInflight = null;
+    }
+
+    // The commit was already dropped if something invalidated the cache while we
+    // probed — but the VALUE is just as stale, and returning it would route the
+    // caller's mutation at the server that just went away (#646 review). Probe
+    // again against whatever is there now.
+    if (managerApiEpoch() === epochAtStart) return api;
+    if (attempt >= DETECT_INVALIDATION_RETRIES) {
+      // Every reading so far described a server that was already gone. Handing
+      // the last one back would send a mutation on a dialect we KNOW is stale, so
+      // refuse instead — nothing has been sent at this point, which makes this the
+      // one moment where failing is completely free.
+      throw new NodeManagementError(
+        "ComfyUI-Manager's API generation could not be determined: the connected ComfyUI kept " +
+          "being restarted (or retargeted) while comfyui-mcp was probing it, so every reading " +
+          "described a server that was already gone. NOTHING was sent to the Manager. Wait for " +
+          "ComfyUI to settle, then retry.",
+      );
+    }
+    logger.debug("Manager dialect detection invalidated mid-probe — re-probing", {
+      base,
+      dropped: api,
+      attempt,
+    });
+  }
+}
+
+async function probeManagerApi(base: string): Promise<ManagerApi> {
   // Stamp the cache state BEFORE probing: if ComfyUI is restarted — or another
   // probe commits a fresher verdict — while these probes are in flight, this
   // conclusion describes a server that may be gone and must not be pinned over
@@ -634,84 +699,209 @@ type ManagerTaskParams = Record<string, unknown> | ManagerParamsResolver;
 /**
  * Run ONE enqueue against the detected Manager dialect, healing a stale
  * classification (#646). `enqueue` must only ENQUEUE — never drain — because a
- * retry is sound only while nothing has been queued yet; it is handed the dialect
- * to speak and the invalidation epoch the operation started under, and is called
- * at most twice (never recursively, so the retry is structurally bounded to one).
+ * re-send is sound only while nothing has been queued yet; it is handed the
+ * dialect to speak and the invalidation epoch the operation started under.
+ *
+ * EVERY operation routed through here is a MUTATION (install, uninstall, update,
+ * fix, enable/disable, install-model, update_all, Manager self-update) and Manager
+ * has no idempotency key, so a re-sent request is a genuinely second operation.
+ * The enqueue is therefore re-sent ONLY when the failure PROVES nothing ran — a
+ * 404/405 route rejection — and only when a fresh probe shows the dialect really
+ * changed. It is called at most twice, never recursively.
+ *
+ * On an AMBIGUOUS failure that also indicates a dialect change (a 400: possibly a
+ * validation rejection, possibly a handler that already acted) the classification
+ * is still refreshed, but the operation is NOT re-sent — the caller gets an
+ * actionable error and decides. See AMBIGUOUS_MISMATCH_STATUSES.
  */
 async function enqueueWithDialectSelfHeal(
   label: string,
   enqueue: (api: ManagerApi, startEpoch: number) => Promise<ManagerApi | void>,
 ): Promise<ManagerApi> {
-  // Epoch snapshot for the whole operation: any dialect conclusion reached
-  // during it is only pinned if nothing invalidated the cache meanwhile.
-  const startEpoch = managerApiEpoch();
   const api = await detectManagerApi();
+  // Epoch snapshot taken AFTER detection, i.e. spanning exactly the enqueue whose
+  // outcome a conclusion would be based on. Taking it earlier would also cover the
+  // detection — and since a detection invalidated mid-probe now re-probes and
+  // returns a POST-restart dialect, that stale epoch would then veto a perfectly
+  // good conclusion drawn from it (the #464 v2→v2-batch demotion would never
+  // re-pin, leaving every later op to 405 on /queue/task first — #646 review).
+  const startEpoch = managerApiEpoch();
   try {
     return (await enqueue(api, startEpoch)) ?? api;
   } catch (err) {
     const fresh = await redetectAfterDialectMismatch(api, label, err);
     if (fresh === undefined) throw err;
-    // The live server speaks a DIFFERENT dialect than the one we routed with, and
-    // the failure was a pre-execution rejection (see redetectAfterDialectMismatch),
-    // so nothing was enqueued — re-enqueue ONCE in the correct dialect.
+    if (!ROUTE_MISMATCH_STATUSES.has(errorStatus(err) as number)) {
+      // The dialect DID change, but this failure doesn't prove the request went
+      // unexecuted, so re-sending it could run the mutation twice. Refuse, and
+      // hand the user everything needed to decide (#646 review).
+      throw dialectChangedError(label, api, fresh, err);
+    }
+    // A route-level rejection: no handler ran, so nothing was enqueued —
+    // re-enqueue ONCE in the dialect the live server actually speaks.
     return (await enqueue(fresh, managerApiEpoch())) ?? fresh;
   }
 }
 
 /**
- * Manager statuses that mean "your request was rejected BEFORE any work ran":
- *   404/405 — the route doesn't exist for this build (ComfyUI's frontend catchall
- *             answers an unregistered POST with 405, never 404), so no handler ran.
- *   400     — the handler exists but refused the body during validation, which is
- *             exactly what a v4 Manager does to a 3.x-shaped install_model payload
- *             (the #646 report: "400 Bad Request for /v2/manager/queue/install_model"
- *             while the live server was a normal Manager 4.2.2). Manager validates
- *             before enqueuing, so a 400 likewise means nothing was queued.
- * Everything else (403 security_level gating, 5xx, transport failures, queue-drain
- * timeouts) is NOT a dialect signal and must never trigger a re-probe or a retry.
+ * The classification was stale AND the failure can't be proven pre-execution, so
+ * the operation was deliberately not re-sent. Say exactly that: which dialect we
+ * spoke, which one the server actually speaks now, that the classification is
+ * already corrected, and that the previous attempt's effect is UNKNOWN — so the
+ * user verifies before reissuing rather than blindly repeating a mutation.
  */
-const DIALECT_MISMATCH_STATUSES = new Set([400, 404, 405]);
+function dialectChangedError(
+  label: string,
+  was: ManagerApi,
+  now: ManagerApi,
+  cause: unknown,
+): NodeManagementError {
+  const base = cause instanceof Error ? cause.message : String(cause);
+  return new NodeManagementError(
+    `${base}\nThe ComfyUI-Manager API dialect CHANGED under this connection: the request ` +
+      `was sent as "${was}", but the live server now answers as "${now}" (ComfyUI was ` +
+      `restarted with a different Manager generation at the same URL). comfyui-mcp has ` +
+      `re-detected the dialect, so the next call routes correctly. The "${label}" request ` +
+      `was NOT retried automatically: this failure does not prove the server left it ` +
+      `unexecuted, and Manager offers no idempotency key, so an automatic retry could run ` +
+      `it TWICE. VERIFY whether it took effect (list_installed_nodes / list_local_models, ` +
+      `or the ComfyUI server log), then reissue it if it did not.`,
+    cause instanceof NodeManagementError ? cause.details : undefined,
+  );
+}
+
+/**
+ * ROUTE-level rejections: the request never reached a handler, so the operation
+ * PROVABLY did not run and re-sending it cannot double-execute anything. On a
+ * Manager route this is exactly 404/405 — ComfyUI's frontend catchall answers an
+ * unregistered POST with 405 (never 404), and both mean "no such route on this
+ * build", never "the Manager is unreachable". These are the ONLY statuses that
+ * may trigger an automatic re-enqueue.
+ */
+const ROUTE_MISMATCH_STATUSES = new Set([404, 405]);
+
+/**
+ * A 400 is AMBIGUOUS. It can mean a stale dialect — a v4 Manager rejecting a
+ * 3.x-shaped install_model body is the #646 report itself — but it can equally
+ * come from a handler that already did the work and failed afterwards, or from a
+ * proxy on the response path. Manager exposes no idempotency key, so a re-sent
+ * mutation is a genuinely SECOND operation; there is no way to make that safe.
+ *
+ * So a 400 refreshes the CLASSIFICATION but never re-sends the request: if the
+ * re-probe shows the dialect really did change, the caller gets an actionable
+ * error naming both dialects and is left to decide whether to reissue. Refusing
+ * is always correct here; guessing is not.
+ *
+ * Everything else (403 security_level gating, 5xx, transport failures, queue-drain
+ * timeouts) is not a dialect signal at all and triggers neither.
+ */
+const AMBIGUOUS_MISMATCH_STATUSES = new Set([400]);
 
 /**
  * Decide whether a failed enqueue was the CACHED DIALECT being stale, and if so
- * return the dialect the live server actually speaks now.
+ * return the dialect the live server actually speaks now (undefined = no dialect
+ * news; the caller surfaces its original failure).
  *
  * A restart at the same URL can swap the Manager generation underneath a cached
  * classification (#646). The explicit restart-lifecycle invalidation and the TTL
  * cover the common paths; this is the per-call backstop so ONE stale entry heals
- * itself instead of failing every subsequent Manager operation.
+ * itself instead of failing every subsequent Manager operation. It only reports
+ * the change — whether the operation may be re-sent is the caller's decision,
+ * made from the STATUS (see ROUTE_MISMATCH_STATUSES vs AMBIGUOUS_*).
  *
- * Two guards keep this from looping or double-executing a mutation:
- *   • only pre-execution rejections (DIALECT_MISMATCH_STATUSES) qualify, so the
- *     failed attempt provably enqueued nothing;
- *   • the caller only retries when a FRESH probe reports a DIFFERENT dialect. A
- *     genuine 400 (bad params, a 3.x whitelist rejection) re-detects the same
- *     dialect → undefined → the original error surfaces, and the re-probe has
- *     already re-populated the cache, so a failing call costs at most one extra
- *     detection rather than re-probing on every subsequent call.
+ * Three guards keep this cheap and non-looping:
+ *   • only the two mismatch-capable status classes get here at all; 403/5xx and
+ *     transport failures never cost a probe;
+ *   • a verdict of "unchanged" (or an unreachable Manager) ARMS A COOLDOWN, so an
+ *     endpoint that fails the same way on every call cannot buy a probe per call —
+ *     without it, each re-check resets the entry the previous one repopulated;
+ *   • the cooldown is cleared by any resetManagerApiCache(), i.e. by every real
+ *     lifecycle event, so it can never delay reacting to an actual restart.
  */
+/**
+ * In-flight "reset + re-detect" transaction, shared per base URL. The re-check is
+ * NOT just a detection: it resets the cache first, which bumps the epoch — so
+ * without sharing, N concurrent failures would each reset (invalidating each
+ * other's in-flight probe, since the detector joins only on a matching epoch) and
+ * each run a full probe round. One transaction serves them all (#646 review).
+ */
+let recheckInflight: {
+  base: string;
+  promise: Promise<{ fresh: ManagerApi | undefined; epoch: number }>;
+} | null = null;
+
+async function sharedDialectRecheck(
+  base: string,
+  label: string,
+  status: number,
+  used: ManagerApi,
+): Promise<{ fresh: ManagerApi | undefined; epoch: number }> {
+  const joined = recheckInflight;
+  if (joined?.base === base) return joined.promise;
+
+  const run = async (): Promise<{ fresh: ManagerApi | undefined; epoch: number }> => {
+    resetManagerApiCache(`manager ${label} enqueue failed ${status} on the "${used}" dialect`);
+    const epoch = managerApiEpoch();
+    try {
+      return { fresh: await detectManagerApi(), epoch };
+    } catch {
+      // Manager isn't answering at all — that's not a dialect mismatch; the
+      // caller surfaces its own (more informative) failure. Don't re-probe on
+      // every subsequent call while it stays down, unless a lifecycle event has
+      // since told us something new.
+      if (managerApiEpoch() === epoch) {
+        suppressDialectRecheck(base, "manager unreachable during re-check");
+      }
+      return { fresh: undefined, epoch };
+    }
+  };
+
+  const entry = { base, promise: run() };
+  recheckInflight = entry;
+  try {
+    return await entry.promise;
+  } finally {
+    if (recheckInflight === entry) recheckInflight = null;
+  }
+}
+
 async function redetectAfterDialectMismatch(
   used: ManagerApi,
   label: string,
   err: unknown,
 ): Promise<ManagerApi | undefined> {
   const status = errorStatus(err);
-  if (status === undefined || !DIALECT_MISMATCH_STATUSES.has(status)) return undefined;
-  resetManagerApiCache(`manager ${label} enqueue failed ${status} on the "${used}" dialect`);
-  let fresh: ManagerApi;
-  try {
-    fresh = await detectManagerApi();
-  } catch {
-    // Manager isn't answering at all — that's not a dialect mismatch; surface the
-    // caller's original (more informative) failure.
+  if (
+    status === undefined ||
+    !(ROUTE_MISMATCH_STATUSES.has(status) || AMBIGUOUS_MISMATCH_STATUSES.has(status))
+  ) {
     return undefined;
   }
-  if (fresh === used) return undefined;
-  logger.info("Manager API dialect changed under a cached classification — retrying once", {
+  const base = managerBaseUrl();
+  if (dialectRecheckSuppressed(base)) {
+    logger.debug("Skipping Manager dialect re-check (cooldown)", { op: label, status });
+    return undefined;
+  }
+  const { fresh, epoch: epochAfterReset } = await sharedDialectRecheck(base, label, status, used);
+  if (fresh === undefined) return undefined;
+  if (fresh === used) {
+    // Nothing changed, so this failure was never about the dialect. Arm the
+    // cooldown — but only if no lifecycle event landed since the re-check began,
+    // otherwise a stale continuation would suppress re-checks against a server
+    // we now know nothing about (#646 review).
+    if (managerApiEpoch() === epochAfterReset) {
+      suppressDialectRecheck(base, `dialect confirmed unchanged ("${used}") after a ${status}`);
+    }
+    return undefined;
+  }
+  logger.info("Manager API dialect changed under a cached classification", {
     op: label,
     was: used,
     now: fresh,
     status,
+    // A route-level rejection proves nothing ran, so the caller re-sends once;
+    // anything else is refused rather than risking a double-execute.
+    resend: ROUTE_MISMATCH_STATUSES.has(status),
   });
   return fresh;
 }

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -418,10 +418,15 @@ async function detectManagerApi(): Promise<ManagerApi> {
   );
 }
 
-/** Queue route prefix for the detected generation ("v2-batch" serves
- *  status/start under the /v2 prefix too — only the mutation routes differ). */
+/** Queue route prefix for a dialect ("v2-batch" serves status/start under the
+ *  /v2 prefix too — only the mutation routes differ). */
+function managerQueuePrefixFor(api: ManagerApi): string {
+  return api === "legacy" ? "/manager/queue" : "/v2/manager/queue";
+}
+
+/** Queue route prefix for the currently detected generation. */
 async function managerQueuePrefix(): Promise<string> {
-  return (await detectManagerApi()) === "legacy" ? "/manager/queue" : "/v2/manager/queue";
+  return managerQueuePrefixFor(await detectManagerApi());
 }
 
 /** Appended to every legacy-Manager operation failure so users know they're on
@@ -562,9 +567,16 @@ export function setQueueTimingForTests(
 /**
  * Kick off the Manager queue worker and poll until it drains.
  * Returns the final queue status.
+ *
+ * Callers that just enqueued something pass the dialect they ACTUALLY enqueued
+ * with: re-deriving the prefix from the cache here could start and poll a
+ * different generation's queue than the one holding our task (a self-heal retry,
+ * or a concurrent detection landing mid-operation), which reports a false failure
+ * for work that is really running (#646). Only callers with nothing in flight
+ * fall back to the currently detected dialect.
  */
-async function runManagerQueue(): Promise<QueueStatus> {
-  const prefix = await managerQueuePrefix();
+async function runManagerQueue(api?: ManagerApi): Promise<QueueStatus> {
+  const prefix = api ? managerQueuePrefixFor(api) : await managerQueuePrefix();
   // queue/start returns 200 (worker started) or 201 (already running) — both
   // are 2xx, so managerFetch accepts either. Same on both generations. Some
   // legacy 3.x builds expose start as GET-only, so negotiate POST→GET on a 405
@@ -613,10 +625,10 @@ async function queueManagerTask(
   // params, and a self-heal retry must rebuild them, not just re-route them.
   const resolve: ManagerParamsResolver =
     typeof params === "function" ? params : () => params;
-  await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
+  const used = await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
     enqueueManagerTask(api, kind, resolve, randomUUID(), epoch),
   );
-  return runManagerQueue();
+  return runManagerQueue(used);
 }
 
 /** Params for a Manager task: a fixed body, or a resolver invoked with the
@@ -633,21 +645,21 @@ type ManagerTaskParams = Record<string, unknown> | ManagerParamsResolver;
  */
 async function enqueueWithDialectSelfHeal(
   label: string,
-  enqueue: (api: ManagerApi, startEpoch: number) => Promise<void>,
-): Promise<void> {
+  enqueue: (api: ManagerApi, startEpoch: number) => Promise<ManagerApi | void>,
+): Promise<ManagerApi> {
   // Epoch snapshot for the whole operation: any dialect conclusion reached
   // during it is only pinned if nothing invalidated the cache meanwhile.
   const startEpoch = managerApiEpoch();
   const api = await detectManagerApi();
   try {
-    await enqueue(api, startEpoch);
+    return (await enqueue(api, startEpoch)) ?? api;
   } catch (err) {
     const fresh = await redetectAfterDialectMismatch(api, label, err);
     if (fresh === undefined) throw err;
     // The live server speaks a DIFFERENT dialect than the one we routed with, and
     // the failure was a pre-execution rejection (see redetectAfterDialectMismatch),
     // so nothing was enqueued — re-enqueue ONCE in the correct dialect.
-    await enqueue(fresh, managerApiEpoch());
+    return (await enqueue(fresh, managerApiEpoch())) ?? fresh;
   }
 }
 
@@ -721,9 +733,15 @@ async function enqueueManagerTask(
   resolveParams: ManagerParamsResolver,
   uiId: string,
   startEpoch: number,
-): Promise<void> {
-  if (api === "legacy") return enqueueLegacyTask(kind, resolveParams("legacy"), uiId);
-  if (api === "v2-batch") return enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
+): Promise<ManagerApi> {
+  if (api === "legacy") {
+    await enqueueLegacyTask(kind, resolveParams("legacy"), uiId);
+    return "legacy";
+  }
+  if (api === "v2-batch") {
+    await enqueueV2BatchTask(kind, resolveParams("v2-batch"), uiId);
+    return "v2-batch";
+  }
   // v2 unified task envelope (normal-mode pip Manager v4).
   try {
     await managerFetch("/v2/manager/queue/task", {
@@ -761,10 +779,11 @@ async function enqueueManagerTask(
       // throws on a batch failure, leaving the cache as "v2" so the next op
       // re-probes the unified task route (codex review).
       demoteManagerApiToV2Batch(startEpoch);
-      return;
+      return "v2-batch";
     }
     throw err;
   }
+  return "v2";
 }
 
 /**
@@ -1578,7 +1597,7 @@ async function updateCustomNodeImpl(
     // queueManagerTask), but it is just as dialect-dependent — route it through
     // the same enqueue-only self-heal so a stale classification can't wedge it
     // either (#646). Enqueue here, drain once below.
-    await enqueueWithDialectSelfHeal("update-all", async (api) => {
+    const used = await enqueueWithDialectSelfHeal("update-all", async (api) => {
       // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
       // (manager_server.py), NOT the JSON body — a body-only request leaves mode
       // defaulting to 'remote' and drops client_id/ui_id. Send them as URL query
@@ -1601,7 +1620,7 @@ async function updateCustomNodeImpl(
         });
       }
     });
-    status = await runManagerQueue();
+    status = await runManagerQueue(used);
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
     status = await queueManagerTask("update", { node_name: id });

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -10,6 +10,7 @@ import {
   type ManagerApi,
   cacheManagerApi,
   getCachedManagerApi,
+  managerApiCacheStamp,
   managerApiEpoch,
   resetManagerApiCache,
   setManagerApiCacheForTests,
@@ -292,7 +293,10 @@ export function resetManagerApiCacheForTests(api?: ManagerApi): void {
  * the OLD server and must not be pinned over the fresh invalidation (#646).
  */
 function demoteManagerApiToV2Batch(startEpoch: number): void {
-  cacheManagerApi(managerBaseUrl(), "v2-batch", startEpoch);
+  // Guarded on the invalidation epoch ONLY (not the write counter): this verdict
+  // is backed by an enqueue that actually SUCCEEDED, so it legitimately
+  // supersedes a probe-derived classification that landed during the operation.
+  cacheManagerApi(managerBaseUrl(), "v2-batch", { epoch: startEpoch });
 }
 
 /** A real queue/status payload — guards detection against servers that answer
@@ -366,14 +370,15 @@ async function detectManagerApi(): Promise<ManagerApi> {
   const base = managerBaseUrl();
   const cached = getCachedManagerApi(base);
   if (cached !== undefined) return cached;
-  // Capture the invalidation epoch BEFORE probing: if ComfyUI is restarted while
-  // these probes are in flight, the conclusion describes the pre-restart server
-  // and must not be pinned over that invalidation (#646).
-  const startEpoch = managerApiEpoch();
+  // Stamp the cache state BEFORE probing: if ComfyUI is restarted — or another
+  // probe commits a fresher verdict — while these probes are in flight, this
+  // conclusion describes a server that may be gone and must not be pinned over
+  // the newer state (#646).
+  const stamp = managerApiCacheStamp();
   const v2 = await managerFetch<QueueStatus>("/v2/manager/queue/status", { soft: true });
   if (looksLikeQueueStatus(v2)) {
     const api = await resolveV2SubDialect();
-    cacheManagerApi(base, api, startEpoch);
+    cacheManagerApi(base, api, stamp);
     return api;
   }
   const legacy = await managerFetch<QueueStatus>("/manager/queue/status", { soft: true });
@@ -398,11 +403,11 @@ async function detectManagerApi(): Promise<ManagerApi> {
       });
       if (looksLikeQueueStatus(v2Retry)) {
         const api = await resolveV2SubDialect();
-        cacheManagerApi(base, api, startEpoch);
+        cacheManagerApi(base, api, stamp);
         return api;
       }
     }
-    cacheManagerApi(base, "legacy", startEpoch);
+    cacheManagerApi(base, "legacy", stamp);
     return "legacy";
   }
   throw new NodeManagementError(

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -603,22 +603,37 @@ async function queueManagerTask(
   kind: ManagerTaskKind,
   params: Record<string, unknown>,
 ): Promise<QueueStatus> {
+  await enqueueWithDialectSelfHeal(kind, (api, epoch) =>
+    enqueueManagerTask(api, kind, params, randomUUID(), epoch),
+  );
+  return runManagerQueue();
+}
+
+/**
+ * Run ONE enqueue against the detected Manager dialect, healing a stale
+ * classification (#646). `enqueue` must only ENQUEUE — never drain — because a
+ * retry is sound only while nothing has been queued yet; it is handed the dialect
+ * to speak and the invalidation epoch the operation started under, and is called
+ * at most twice (never recursively, so the retry is structurally bounded to one).
+ */
+async function enqueueWithDialectSelfHeal(
+  label: string,
+  enqueue: (api: ManagerApi, startEpoch: number) => Promise<void>,
+): Promise<void> {
   // Epoch snapshot for the whole operation: any dialect conclusion reached
-  // during it is only pinned if nothing invalidated the cache meanwhile (#646).
+  // during it is only pinned if nothing invalidated the cache meanwhile.
   const startEpoch = managerApiEpoch();
   const api = await detectManagerApi();
   try {
-    await enqueueManagerTask(api, kind, params, randomUUID(), startEpoch);
+    await enqueue(api, startEpoch);
   } catch (err) {
-    const fresh = await redetectAfterDialectMismatch(api, kind, err);
+    const fresh = await redetectAfterDialectMismatch(api, label, err);
     if (fresh === undefined) throw err;
     // The live server speaks a DIFFERENT dialect than the one we routed with, and
     // the failure was a pre-execution rejection (see redetectAfterDialectMismatch),
-    // so nothing was enqueued — re-enqueue ONCE in the correct dialect. This calls
-    // the dispatcher directly rather than recursing, so there is exactly one retry.
-    await enqueueManagerTask(fresh, kind, params, randomUUID(), managerApiEpoch());
+    // so nothing was enqueued — re-enqueue ONCE in the correct dialect.
+    await enqueue(fresh, managerApiEpoch());
   }
-  return runManagerQueue();
 }
 
 /**
@@ -655,12 +670,12 @@ const DIALECT_MISMATCH_STATUSES = new Set([400, 404, 405]);
  */
 async function redetectAfterDialectMismatch(
   used: ManagerApi,
-  kind: ManagerTaskKind,
+  label: string,
   err: unknown,
 ): Promise<ManagerApi | undefined> {
   const status = errorStatus(err);
   if (status === undefined || !DIALECT_MISMATCH_STATUSES.has(status)) return undefined;
-  resetManagerApiCache(`manager ${kind} enqueue failed ${status} on the "${used}" dialect`);
+  resetManagerApiCache(`manager ${label} enqueue failed ${status} on the "${used}" dialect`);
   let fresh: ManagerApi;
   try {
     fresh = await detectManagerApi();
@@ -671,7 +686,7 @@ async function redetectAfterDialectMismatch(
   }
   if (fresh === used) return undefined;
   logger.info("Manager API dialect changed under a cached classification — retrying once", {
-    kind,
+    op: label,
     was: used,
     now: fresh,
     status,
@@ -1538,27 +1553,33 @@ async function updateCustomNodeImpl(
 
   let status: QueueStatus;
   if (all) {
-    // update_all keeps its own dedicated route. The backend reads
-    // UpdateAllQueryParams from the QUERY STRING (manager_server.py), NOT the
-    // JSON body — a body-only request leaves mode defaulting to 'remote' and
-    // drops client_id/ui_id. Send them as URL query params.
-    const uiId = randomUUID();
-    if ((await detectManagerApi()) === "legacy") {
-      // 3.x reads {mode} from the JSON BODY (and ignores client_id/ui_id).
-      await managerFetch("/manager/queue/update_all", {
-        method: "POST",
-        body: { mode, ui_id: uiId },
-      });
-    } else {
-      const query = new URLSearchParams({
-        mode,
-        client_id: MANAGER_CLIENT_ID,
-        ui_id: uiId,
-      }).toString();
-      await managerFetch(`/v2/manager/queue/update_all?${query}`, {
-        method: "POST",
-      });
-    }
+    // update_all keeps its own dedicated route (so it does NOT go through
+    // queueManagerTask), but it is just as dialect-dependent — route it through
+    // the same enqueue-only self-heal so a stale classification can't wedge it
+    // either (#646). Enqueue here, drain once below.
+    await enqueueWithDialectSelfHeal("update-all", async (api) => {
+      // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
+      // (manager_server.py), NOT the JSON body — a body-only request leaves mode
+      // defaulting to 'remote' and drops client_id/ui_id. Send them as URL query
+      // params. A fresh ui_id per attempt keeps the two attempts distinguishable.
+      const uiId = randomUUID();
+      if (api === "legacy") {
+        // 3.x reads {mode} from the JSON BODY (and ignores client_id/ui_id).
+        await managerFetch("/manager/queue/update_all", {
+          method: "POST",
+          body: { mode, ui_id: uiId },
+        });
+      } else {
+        const query = new URLSearchParams({
+          mode,
+          client_id: MANAGER_CLIENT_ID,
+          ui_id: uiId,
+        }).toString();
+        await managerFetch(`/v2/manager/queue/update_all?${query}`, {
+          method: "POST",
+        });
+      }
+    });
     status = await runManagerQueue();
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -424,11 +424,6 @@ function managerQueuePrefixFor(api: ManagerApi): string {
   return api === "legacy" ? "/manager/queue" : "/v2/manager/queue";
 }
 
-/** Queue route prefix for the currently detected generation. */
-async function managerQueuePrefix(): Promise<string> {
-  return managerQueuePrefixFor(await detectManagerApi());
-}
-
 /** Appended to every legacy-Manager operation failure so users know they're on
  *  the partial feature set and how to get off it. */
 const MANAGER_UPGRADE_HINT =
@@ -568,15 +563,15 @@ export function setQueueTimingForTests(
  * Kick off the Manager queue worker and poll until it drains.
  * Returns the final queue status.
  *
- * Callers that just enqueued something pass the dialect they ACTUALLY enqueued
- * with: re-deriving the prefix from the cache here could start and poll a
- * different generation's queue than the one holding our task (a self-heal retry,
- * or a concurrent detection landing mid-operation), which reports a false failure
- * for work that is really running (#646). Only callers with nothing in flight
- * fall back to the currently detected dialect.
+ * `api` is REQUIRED and must be the dialect the caller ACTUALLY enqueued with.
+ * Re-deriving the prefix from the cache here could start and poll a different
+ * generation's queue than the one holding our task (after a self-heal retry, or
+ * when a concurrent detection lands mid-operation), reporting a false failure for
+ * work that is really running — and inviting a caller retry that double-executes
+ * it (#646).
  */
-async function runManagerQueue(api?: ManagerApi): Promise<QueueStatus> {
-  const prefix = api ? managerQueuePrefixFor(api) : await managerQueuePrefix();
+async function runManagerQueue(api: ManagerApi): Promise<QueueStatus> {
+  const prefix = managerQueuePrefixFor(api);
   // queue/start returns 200 (worker started) or 201 (already running) — both
   // are 2xx, so managerFetch accepts either. Same on both generations. Some
   // legacy 3.x builds expose start as GET-only, so negotiate POST→GET on a 405

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -8,6 +8,7 @@ import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { findComfyuiPython } from "./env-capabilities.js";
+import { resetManagerApiCache } from "./manager-api-cache.js";
 import {
   liveRootFromArgv,
   resolveEffectiveComfyUIBase,
@@ -1052,9 +1053,14 @@ export async function stopComfyUI(preInfo?: ProcessInfo): Promise<StopResult> {
   }
 
   // Reset the WebSocket client singleton + the memoized /object_info —
-  // a restart is exactly when the node set may have changed.
+  // a restart is exactly when the node set may have changed. The detected
+  // ComfyUI-Manager API dialect is live-derived the same way: the instance that
+  // comes back on this port can be a different Manager generation (a 3.x→4.x
+  // upgrade, or dropping --enable-manager-legacy-ui) at an unchanged URL, and a
+  // stale dialect misroutes every later Manager call (#646).
   resetClient();
   resetObjectInfoCache();
+  resetManagerApiCache("comfyui stopped");
 
   // Wait for port to actually free
   try {
@@ -1146,6 +1152,12 @@ export async function startComfyUI(): Promise<StartResult> {
     launched.once("exit", revokeEnvTrust);
     launched.once("error", revokeEnvTrust);
   }
+
+  // A NEW server instance is coming up on this port — whatever Manager dialect we
+  // classified belonged to whatever ran here before (start_comfyui is also
+  // reachable without a preceding stopComfyUI, e.g. after an external kill or a
+  // Manager upgrade), so re-probe rather than trust it (#646).
+  resetManagerApiCache("comfyui started");
 
   // Wait for API to become ready
   const startupResult = await Promise.race([
@@ -1418,10 +1430,12 @@ async function restartViaManagerReboot(context: {
     };
   }
 
-  // Back and ready — refresh the WS client singleton + memoized /object_info,
-  // since a reboot is exactly when the node set may have changed.
+  // Back and ready — refresh the WS client singleton + memoized /object_info +
+  // the detected Manager dialect, since a reboot is exactly when the node set
+  // and the Manager generation may have changed (#646).
   resetClient();
   resetObjectInfoCache();
+  resetManagerApiCache("comfyui rebooted via Manager");
 
   return {
     stopped: true,

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -884,6 +884,12 @@ function handleSupervisedChildStop(
   if (supervisedChild !== child) return;
   detachSupervisor();
 
+  // The supervised ComfyUI is GONE (crash/exit), whether or not we go on to
+  // respawn it. Whatever Manager dialect we classified belonged to that dead
+  // instance, and a respawn can come back as a different Manager generation on
+  // the same URL — re-probe rather than trust it (#646).
+  resetManagerApiCache("supervised comfyui exited");
+
   if (!lastProcessInfo) return;
   const currentPolicy = getRestartPolicy();
   if (!currentPolicy.enabled) return;
@@ -1408,6 +1414,12 @@ async function restartViaManagerReboot(context: {
     note: reboot.note,
   });
 
+  // The reboot HAS been accepted — the server is going down regardless of what
+  // the readiness poll below concludes. Drop the detected dialect now so the
+  // timed-out branch (which returns early) can't leave the pre-reboot dialect
+  // pinned for the instance that eventually comes back (#646).
+  resetManagerApiCache("comfyui reboot fired via Manager");
+
   const timing = getRemoteRebootTiming();
   if (timing.settleMs > 0) await sleep(timing.settleMs);
 
@@ -1432,7 +1444,9 @@ async function restartViaManagerReboot(context: {
 
   // Back and ready — refresh the WS client singleton + memoized /object_info +
   // the detected Manager dialect, since a reboot is exactly when the node set
-  // and the Manager generation may have changed (#646).
+  // and the Manager generation may have changed (#646). The dialect is dropped a
+  // SECOND time here on purpose: a probe that ran against the half-booted server
+  // during the readiness wait must not stay pinned.
   resetClient();
   resetObjectInfoCache();
   resetManagerApiCache("comfyui rebooted via Manager");

--- a/src/tools/comfy-cli.ts
+++ b/src/tools/comfy-cli.ts
@@ -11,6 +11,7 @@ import {
   isLocalModelsListAction,
   listLocalModelsFallback,
 } from "../services/local-models-fallback.js";
+import { resetManagerApiCache } from "../services/manager-api-cache.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 const whereSchema = z.enum(["local", "cloud"]).optional();
@@ -60,12 +61,20 @@ export function registerComfyCliTools(server: McpServer): void {
       try {
         const options = { workspace: args.workspace, timeoutMs: 120_000 };
         let stopped: Awaited<ReturnType<typeof runComfyCli>> | undefined;
-        if (args.action !== "start") stopped = await runComfyCli(["stop"], options);
+        if (args.action !== "start") {
+          stopped = await runComfyCli(["stop"], options);
+          // This is a ComfyUI lifecycle transition like any other: the instance
+          // that comes back on the same URL can be a different ComfyUI-Manager
+          // generation, so the detected dialect must not carry over (#646).
+          resetManagerApiCache("comfy-cli server stop");
+        }
         if (args.action === "stop") return textEnvelope(stopped);
         if (stopped && !stopped.ok) return textEnvelope(stopped);
         const launch = ["launch", "--background"];
         if (args.launchArgs?.length) launch.push("--", ...args.launchArgs);
         const started = await runComfyCli(launch, options);
+        // A launch may have replaced the server behind the same URL — re-probe.
+        resetManagerApiCache("comfy-cli server launch");
         return textEnvelope(args.action === "restart" ? { stopped, started } : started);
       } catch (error) {
         return errorToToolResult(error);


### PR DESCRIPTION
## Summary\n- pin Manager dialect probe, recheck, retry, queue drain, and install verification to the ComfyUI target selected at invocation\n- prevent a concurrent panel retarget from sending an in-flight operation to a different ComfyUI\n- add regression coverage for stale-dialect self-heal plus retarget\n\n## Validation\n- 
px tsc --noEmit --pretty false\n- 
pm test -- src/__tests__/services/manager-dialect-cache.test.ts\n- 
pm test (one unrelated baseline failure: 
ode-dev.test.ts > builtin fallback finds matches and skips binary files expects uiltin, received ipgrep)\n\nStacked on #653 (ix/manager-dialect-cache-646); merge this after #653.