### PR TITLE
chore(deps): add @comfyorg/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@comfyorg/sdk": "^0.1.5",
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@stable-canvas/comfyui-client": "^1.5.9",
         "better-sqlite3": "^12.6.2",
@@ -1062,6 +1063,20 @@
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@comfyorg/sdk": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@comfyorg/sdk/-/sdk-0.1.5.tgz",
+      "integrity": "sha512-ByZ7FhC14wFkDzQ45xXTgjPSM7UyRenNjnodcJrFjU0MZ22r9j9JsJn8o97Ny7XD/F47C43iArGOzH+z156bow==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.0",
+        "hash-wasm": "^4.11.0",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@emnapi/core": {
@@ -3783,6 +3798,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prepare": "tsc"
   },
   "dependencies": {
+    "@comfyorg/sdk": "^0.1.5",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@stable-canvas/comfyui-client": "^1.5.9",
     "better-sqlite3": "^12.6.2",
@@ -67,13 +68,13 @@
     "zod": "^4.0.0"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
-    "@openai/codex": "0.145.0-alpha.24",
     "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/google": "^3.0.79",
     "@ai-sdk/openai": "^3.0.65",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
     "@aws-sdk/client-s3": "^3.1053.0",
     "@azure/storage-blob": "^12.31.0",
+    "@openai/codex": "0.145.0-alpha.24",
     "ai": "^6.0.191",
     "cloudflared": "^0.7.1"
   },


### PR DESCRIPTION
Owner directive (Discord DM 2026-08-02): add the official TypeScript SDK for the Comfy API v2 (`@comfyorg/sdk@^0.1.5`) as a runtime dependency. No code uses it yet — wiring to follow.