### PR TITLE
fix(tools): get_image saves valid MP4 assets to disk (#663)

### DIFF
--- a/docs/tools/assets-images.mdx
+++ b/docs/tools/assets-images.mdx
@@ -33,7 +33,7 @@ Fetch a registered asset's bytes and return them as an inline image so the agent
 
 ## get_image
 
-Fetch a generated image from ComfyUI and return it as an inline image. Works with remote ComfyUI instances — does not require COMFYUI_PATH. Use get_history first to obtain the filename.
+Fetch a generated image from ComfyUI and return it as an inline image. Video/audio outputs (e.g. a VHS_VideoCombine .mp4) are saved to save_dir with their original extension instead of being rendered inline. Works with remote ComfyUI instances — does not require COMFYUI_PATH. Use get_history first to obtain the filename.
 
 ### Parameters
 

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -187,6 +187,52 @@ describe("getOutputImage — non-image /view payloads (issue #385)", () => {
   });
 });
 
+describe("getOutputImage — video/audio media (issue #663)", () => {
+  // /view returns raw bytes for any media type, and video nodes like
+  // VHS_VideoCombine legitimately produce .mp4 outputs that get_image must be
+  // able to save to disk. allowMedia opts the caller into video/*/audio/*
+  // payloads; the junk-body guards (empty / JSON / HTML) still apply.
+
+  it("rejects a video/mp4 payload by default (inline callers stay image-only)", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("fake-mp4").toString("base64"),
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video"),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("resolves a video/mp4 payload when allowMedia is set", async () => {
+    const base64 = Buffer.from("fake-mp4").toString("base64");
+    fetchImageMock.mockResolvedValue({ base64, mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).resolves.toMatchObject({
+      base64,
+      mimeType: "video/mp4",
+      filename: "clip_00001_.mp4",
+    });
+  });
+
+  it("still rejects a JSON error body even when allowMedia is set", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"error":"not found"}').toString("base64"),
+      mimeType: "application/json",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("still rejects an empty body even when allowMedia is set", async () => {
+    fetchImageMock.mockResolvedValue({ base64: "", mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+});
+
 describe("listOutputImages — remote mode keyed off isRemoteMode (issue #2 regression)", () => {
   it("uses /history (not a local-FS scan) when remote even though COMFYUI_PATH is set", async () => {
     // A remote target coexists with an unrelated local COMFYUI_PATH. Scanning the

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -583,6 +583,30 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
   });
 
+  it("rejects octet-stream WAV bytes requested as .mp4 (extension is the only claim)", async () => {
+    // Under the generic label the FILENAME is the last format claim: WAV bytes
+    // saved as clip.mp4 would be a corrupt asset with a fabricated success.
+    fetchImageMock.mockResolvedValue({
+      base64: WAV_BASE64,
+      mimeType: "application/octet-stream",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("passes octet-stream media whose extension is unmapped (fail-open for exotic assets)", async () => {
+    // An extension we can't classify declares nothing checkable — the bytes
+    // still proved themselves via the structural sniff, so they pass.
+    fetchImageMock.mockResolvedValue({
+      base64: MP4_BASE64,
+      mimeType: "application/octet-stream",
+    });
+    await expect(
+      getOutputImage("clip_00001_.m2ts", "output", "video", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
+  });
+
   it("resolves an m4a payload labeled audio/mp4 (audio-brand ftyp)", async () => {
     // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is the
     // audio/mp4 format, so it must not trip the cross-format guard.

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -193,7 +193,8 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
   // able to save to disk. allowMedia opts the caller into video/*/audio/*
   // payloads; the junk-body guards (empty / JSON / HTML) still apply — and the
   // declared media content-type is only accepted when the payload actually
-  // sniffs as media (magic bytes).
+  // sniffs as that media FORMAT (structural magic-byte checks, not just the
+  // leading signature).
 
   // Realistic MP4 header: 24-byte ftyp box, isom major brand.
   const MP4_BASE64 = Buffer.from([
@@ -201,10 +202,36 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // isom....
     0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32, // isomiso2
   ]).toString("base64");
-  // WAV header: RIFF chunk with WAVE form type.
+  // WAV header: RIFF chunk whose declared size (8) is consistent with the
+  // 16-byte body (chunk size + 8 header bytes == body length).
   const WAV_BASE64 = Buffer.from([
-    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, // RIFF$...
+    0x52, 0x49, 0x46, 0x46, 0x08, 0x00, 0x00, 0x00, // RIFF....
     0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20, // WAVEfmt␠
+  ]).toString("base64");
+  // MP3 frame sync (0xFFFB = MPEG-1 Layer III) padded to a plausible file
+  // size — the sync alone is only 2 bytes, so size is the structure here.
+  const MP3_BASE64 = Buffer.from([0xff, 0xfb, ...new Array(254).fill(0)]).toString("base64");
+  // AAC: ADTS frame sync (MPEG layer bits 00), padded to a plausible size.
+  const AAC_BASE64 = Buffer.from([0xff, 0xf1, ...new Array(254).fill(0)]).toString("base64");
+  // WebM: EBML magic, padded to a plausible file size.
+  const WEBM_BASE64 = Buffer.from([0x1a, 0x45, 0xdf, 0xa3, ...new Array(252).fill(0)]).toString("base64");
+  // FLAC: magic + the mandatory first metadata block (a STREAMINFO block
+  // header: type 0, length exactly 34) — 42 bytes total.
+  const FLAC_BASE64 = Buffer.from([
+    0x66, 0x4c, 0x61, 0x43, 0x80, 0x00, 0x00, 0x22, // fLaC, STREAMINFO hdr
+    ...new Array(34).fill(0),
+  ]).toString("base64");
+  // Ogg: capture pattern + version-0 page header; 1 segment of size 0.
+  const OGG_BASE64 = Buffer.from([
+    0x4f, 0x67, 0x67, 0x53, 0x00, 0x02, // OggS, version 0, header type
+    ...new Array(20).fill(0), // granule/serial/seq/crc
+    0x01, 0x00, // 1 page segment, size 0
+  ]).toString("base64");
+  // m4a: 24-byte ftyp box with the audio-only M4A major brand.
+  const M4A_BASE64 = Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, // ....ftyp
+    0x4d, 0x34, 0x41, 0x20, 0x00, 0x00, 0x00, 0x00, // M4A␠....
+    0x4d, 0x34, 0x41, 0x20, 0x6d, 0x70, 0x34, 0x32, // M4A␠mp42
   ]).toString("base64");
 
   it("rejects a video/mp4 payload by default (inline callers stay image-only)", async () => {
@@ -286,6 +313,205 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
   });
 
+  // ── Cross-FORMAT mislabels (#663 round 4): same family, wrong subtype ──
+
+  it("rejects MP3 bytes mislabeled as audio/wav (cross-format within a family)", async () => {
+    // Both are audio — but the sniffed format (MPEG sync) is not the declared
+    // subtype (wav), so this must not be saved/reported as a .wav.
+    fetchImageMock.mockResolvedValue({ base64: MP3_BASE64, mimeType: "audio/wav" });
+    await expect(
+      getOutputImage("audio_00001_.wav", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects WAV bytes mislabeled as audio/mpeg", async () => {
+    fetchImageMock.mockResolvedValue({ base64: WAV_BASE64, mimeType: "audio/mpeg" });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects WebM bytes mislabeled as video/mp4", async () => {
+    fetchImageMock.mockResolvedValue({ base64: WEBM_BASE64, mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects MP4 bytes mislabeled as video/webm", async () => {
+    fetchImageMock.mockResolvedValue({ base64: MP4_BASE64, mimeType: "video/webm" });
+    await expect(
+      getOutputImage("clip_00001_.webm", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects WAV bytes mislabeled as audio/ogg", async () => {
+    fetchImageMock.mockResolvedValue({ base64: WAV_BASE64, mimeType: "audio/ogg" });
+    await expect(
+      getOutputImage("audio_00001_.ogg", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects Ogg bytes mislabeled as audio/flac", async () => {
+    fetchImageMock.mockResolvedValue({ base64: OGG_BASE64, mimeType: "audio/flac" });
+    await expect(
+      getOutputImage("audio_00001_.flac", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a video-brand MP4 mislabeled as audio/mp4", async () => {
+    // Same container family, wrong brand: isom is a VIDEO ftyp — audio/mp4
+    // requires an audio brand (M4A/M4B).
+    fetchImageMock.mockResolvedValue({ base64: MP4_BASE64, mimeType: "audio/mp4" });
+    await expect(
+      getOutputImage("audio_00001_.m4a", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an m4a (audio-brand ftyp) mislabeled as video/mp4", async () => {
+    fetchImageMock.mockResolvedValue({ base64: M4A_BASE64, mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects MP3 bytes mislabeled as audio/aac (frame-sync formats are distinct)", async () => {
+    // ADTS frames have MPEG layer bits 00; mp3 frames have them set.
+    fetchImageMock.mockResolvedValue({ base64: MP3_BASE64, mimeType: "audio/aac" });
+    await expect(
+      getOutputImage("audio_00001_.aac", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  // ── Positive controls: declared subtype matches sniffed format ──
+
+  it("resolves MP3 bytes labeled audio/mpeg", async () => {
+    fetchImageMock.mockResolvedValue({ base64: MP3_BASE64, mimeType: "audio/mpeg" });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/mpeg" });
+  });
+
+  it("resolves WebM bytes labeled video/webm", async () => {
+    fetchImageMock.mockResolvedValue({ base64: WEBM_BASE64, mimeType: "video/webm" });
+    await expect(
+      getOutputImage("clip_00001_.webm", "output", "video", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "video/webm" });
+  });
+
+  it("resolves FLAC bytes labeled audio/flac (STREAMINFO structure)", async () => {
+    fetchImageMock.mockResolvedValue({ base64: FLAC_BASE64, mimeType: "audio/flac" });
+    await expect(
+      getOutputImage("audio_00001_.flac", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/flac" });
+  });
+
+  it("resolves Ogg bytes labeled audio/ogg (page-header structure)", async () => {
+    fetchImageMock.mockResolvedValue({ base64: OGG_BASE64, mimeType: "audio/ogg" });
+    await expect(
+      getOutputImage("audio_00001_.ogg", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/ogg" });
+  });
+
+  it("resolves AAC (ADTS sync) bytes labeled audio/aac", async () => {
+    fetchImageMock.mockResolvedValue({ base64: AAC_BASE64, mimeType: "audio/aac" });
+    await expect(
+      getOutputImage("audio_00001_.aac", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/aac" });
+  });
+
+  // ── Truncated prefixes (#663 round 4): structure, not just signature ──
+
+  it("rejects a 2-byte MPEG sync prefix labeled audio/mpeg", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0xff, 0xfb]).toString("base64"),
+      mimeType: "audio/mpeg",
+    });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an undersized frame-sync body labeled audio/mpeg", async () => {
+    // 102 bytes — above the bare sync, still below a plausible media file.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0xff, 0xfb, ...new Array(100).fill(0)]).toString("base64"),
+      mimeType: "audio/mpeg",
+    });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a bare 3-byte 'ID3' prefix labeled audio/mpeg", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0x49, 0x44, 0x33]).toString("base64"), // ID3
+      mimeType: "audio/mpeg",
+    });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an ID3 header whose size bytes are not syncsafe", async () => {
+    // Full-size body, but a tag-size byte has the high bit set — malformed.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([
+        0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x80, 0x00, 0x00, 0x10,
+        ...new Array(246).fill(0),
+      ]).toString("base64"),
+      mimeType: "audio/mpeg",
+    });
+    await expect(
+      getOutputImage("audio_00001_.mp3", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a RIFF/WAVE header claiming more bytes than the body holds", async () => {
+    // Chunk size 36 but only 16 delivered — a truncated/fabricated prefix.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, // RIFF$...
+        0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20, // WAVEfmt␠
+      ]).toString("base64"),
+      mimeType: "audio/wav",
+    });
+    await expect(
+      getOutputImage("audio_00001_.wav", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a bare 4-byte 'OggS' prefix labeled audio/ogg", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0x4f, 0x67, 0x67, 0x53]).toString("base64"),
+      mimeType: "audio/ogg",
+    });
+    await expect(
+      getOutputImage("audio_00001_.ogg", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a 'fLaC' magic with no STREAMINFO block labeled audio/flac", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0x66, 0x4c, 0x61, 0x43, 0xff, 0xff, 0xff, 0xff]).toString("base64"),
+      mimeType: "audio/flac",
+    });
+    await expect(
+      getOutputImage("audio_00001_.flac", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an undersized EBML prefix labeled video/webm", async () => {
+    // 4-byte EBML magic + 100 zero bytes — below the plausible-size floor.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([0x1a, 0x45, 0xdf, 0xa3, ...new Array(100).fill(0)]).toString("base64"),
+      mimeType: "video/webm",
+    });
+    await expect(
+      getOutputImage("clip_00001_.webm", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
   it("rejects a truncated 8-byte body that is only '....ftyp' (no box behind it)", async () => {
     // The four bytes "ftyp" at offset 4 alone are not an MP4 — a valid ftyp
     // box needs the major brand and minor version too (>= 16 bytes), so a
@@ -358,13 +584,8 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
   });
 
   it("resolves an m4a payload labeled audio/mp4 (audio-brand ftyp)", async () => {
-    // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is an
-    // AUDIO signature, so it must not trip the cross-family guard.
-    const M4A_BASE64 = Buffer.from([
-      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, // ....ftyp
-      0x4d, 0x34, 0x41, 0x20, 0x00, 0x00, 0x00, 0x00, // M4A␠....
-      0x4d, 0x34, 0x41, 0x20, 0x6d, 0x70, 0x34, 0x32, // M4A␠mp42
-    ]).toString("base64");
+    // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is the
+    // audio/mp4 format, so it must not trip the cross-format guard.
     fetchImageMock.mockResolvedValue({ base64: M4A_BASE64, mimeType: "audio/mp4" });
     await expect(
       getOutputImage("audio_00001_.m4a", "output", "", { allowMedia: true }),

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -607,6 +607,15 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
   });
 
+  it("rejects genuinely-declared audio/wav bytes requested as .mp4", async () => {
+    // mime↔sniff agrees (wav is wav), but the filename claims video — every
+    // claim must hold, or the save fabricates a corrupt asset.
+    fetchImageMock.mockResolvedValue({ base64: WAV_BASE64, mimeType: "audio/wav" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
   it("resolves an m4a payload labeled audio/mp4 (audio-brand ftyp)", async () => {
     // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is the
     // audio/mp4 format, so it must not trip the cross-format guard.

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -270,6 +270,52 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
   });
 
+  it("rejects a truncated 8-byte body that is only '....ftyp' (no box behind it)", async () => {
+    // The four bytes "ftyp" at offset 4 alone are not an MP4 — a valid ftyp
+    // box needs the major brand and minor version too (>= 16 bytes), so a
+    // truncated body must not sniff as media even labeled video/mp4.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([
+        0x00, 0x00, 0x00, 0x08, 0x66, 0x74, 0x79, 0x70, // ....ftyp
+      ]).toString("base64"),
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an ftyp whose box size exceeds the actual body length", async () => {
+    // 16-byte body, but the box header claims 32 bytes — an inconsistent,
+    // fabricated header.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, // box claims 32 bytes
+        0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // isom....
+      ]).toString("base64"),
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("accepts a minimal 16-byte ftyp box (box size exactly covers the body)", async () => {
+    // Boundary of the box-size check: size == body length == 16, printable
+    // major brand, minor version present — the smallest well-formed ftyp.
+    const MINIMAL_MP4_BASE64 = Buffer.from([
+      0x00, 0x00, 0x00, 0x10, 0x66, 0x74, 0x79, 0x70, // box = 16 bytes
+      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x00, 0x00, // isom, minor 0
+    ]).toString("base64");
+    fetchImageMock.mockResolvedValue({
+      base64: MINIMAL_MP4_BASE64,
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "video/mp4" });
+  });
+
   it("resolves genuine MP4 bytes served as application/octet-stream (generic proxy label)", async () => {
     // ComfyUI itself reports video/mp4 (aiohttp mimetypes), but a proxy or a
     // signed URL hop can serve the same real bytes under the generic type —

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -270,6 +270,22 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
   });
 
+  it("rejects a WAV body mislabeled as video/mp4 (cross-family mismatch)", async () => {
+    // Bytes AND label are both "media", but the families disagree — saving the
+    // WAV under the requested .mp4 would report a corrupt video as a success.
+    fetchImageMock.mockResolvedValue({ base64: WAV_BASE64, mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an MP4 body mislabeled as audio/wav (cross-family mismatch)", async () => {
+    fetchImageMock.mockResolvedValue({ base64: MP4_BASE64, mimeType: "audio/wav" });
+    await expect(
+      getOutputImage("audio_00001_.wav", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
   it("rejects a truncated 8-byte body that is only '....ftyp' (no box behind it)", async () => {
     // The four bytes "ftyp" at offset 4 alone are not an MP4 — a valid ftyp
     // box needs the major brand and minor version too (>= 16 bytes), so a
@@ -327,6 +343,32 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     await expect(
       getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
     ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
+  });
+
+  it("resolves genuine WAV bytes served as application/octet-stream", async () => {
+    // The generic label declares no family, so any genuine media signature
+    // passes — video OR audio.
+    fetchImageMock.mockResolvedValue({
+      base64: WAV_BASE64,
+      mimeType: "application/octet-stream",
+    });
+    await expect(
+      getOutputImage("audio_00001_.wav", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
+  });
+
+  it("resolves an m4a payload labeled audio/mp4 (audio-brand ftyp)", async () => {
+    // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is an
+    // AUDIO signature, so it must not trip the cross-family guard.
+    const M4A_BASE64 = Buffer.from([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, // ....ftyp
+      0x4d, 0x34, 0x41, 0x20, 0x00, 0x00, 0x00, 0x00, // M4A␠....
+      0x4d, 0x34, 0x41, 0x20, 0x6d, 0x70, 0x34, 0x32, // M4A␠mp42
+    ]).toString("base64");
+    fetchImageMock.mockResolvedValue({ base64: M4A_BASE64, mimeType: "audio/mp4" });
+    await expect(
+      getOutputImage("audio_00001_.m4a", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/mp4" });
   });
 
   it("rejects a non-media body served as application/octet-stream", async () => {

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -191,11 +191,27 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
   // /view returns raw bytes for any media type, and video nodes like
   // VHS_VideoCombine legitimately produce .mp4 outputs that get_image must be
   // able to save to disk. allowMedia opts the caller into video/*/audio/*
-  // payloads; the junk-body guards (empty / JSON / HTML) still apply.
+  // payloads; the junk-body guards (empty / JSON / HTML) still apply — and the
+  // declared media content-type is only accepted when the payload actually
+  // sniffs as media (magic bytes).
+
+  // Realistic MP4 header: 24-byte ftyp box, isom major brand.
+  const MP4_BASE64 = Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, // ....ftyp
+    0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // isom....
+    0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32, // isomiso2
+  ]).toString("base64");
+  // WAV header: RIFF chunk with WAVE form type.
+  const WAV_BASE64 = Buffer.from([
+    0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, // RIFF$...
+    0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20, // WAVEfmt␠
+  ]).toString("base64");
 
   it("rejects a video/mp4 payload by default (inline callers stay image-only)", async () => {
+    // Genuine MP4 bytes — the rejection must come from the missing allowMedia
+    // opt-in, not from the payload sniff.
     fetchImageMock.mockResolvedValue({
-      base64: Buffer.from("fake-mp4").toString("base64"),
+      base64: MP4_BASE64,
       mimeType: "video/mp4",
     });
     await expect(
@@ -204,21 +220,73 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
   });
 
   it("resolves a video/mp4 payload when allowMedia is set", async () => {
-    const base64 = Buffer.from("fake-mp4").toString("base64");
-    fetchImageMock.mockResolvedValue({ base64, mimeType: "video/mp4" });
+    fetchImageMock.mockResolvedValue({ base64: MP4_BASE64, mimeType: "video/mp4" });
     await expect(
       getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
     ).resolves.toMatchObject({
-      base64,
+      base64: MP4_BASE64,
       mimeType: "video/mp4",
       filename: "clip_00001_.mp4",
     });
+  });
+
+  it("resolves an audio/wav payload when allowMedia is set", async () => {
+    fetchImageMock.mockResolvedValue({ base64: WAV_BASE64, mimeType: "audio/wav" });
+    await expect(
+      getOutputImage("audio_00001_.wav", "output", "", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "audio/wav" });
   });
 
   it("still rejects a JSON error body even when allowMedia is set", async () => {
     fetchImageMock.mockResolvedValue({
       base64: Buffer.from('{"error":"not found"}').toString("base64"),
       mimeType: "application/json",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects a JSON error body MISLABELED as video/mp4 (declared type is no proof)", async () => {
+    // A proxy can answer /view with a 200 whose body is a JSON error page but
+    // whose content-type says video/mp4 — saving those bytes would fabricate a
+    // successful media save. The payload must sniff as media, not just declare it.
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"error":"not found"}').toString("base64"),
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("rejects an HTML error page mislabeled as video/mp4", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from("<!DOCTYPE html><html><body>404</body></html>").toString("base64"),
+      mimeType: "video/mp4",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
+  it("resolves genuine MP4 bytes served as application/octet-stream (generic proxy label)", async () => {
+    // ComfyUI itself reports video/mp4 (aiohttp mimetypes), but a proxy or a
+    // signed URL hop can serve the same real bytes under the generic type —
+    // the magic-byte sniff must still let them through.
+    fetchImageMock.mockResolvedValue({
+      base64: MP4_BASE64,
+      mimeType: "application/octet-stream",
+    });
+    await expect(
+      getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),
+    ).resolves.toMatchObject({ mimeType: "application/octet-stream" });
+  });
+
+  it("rejects a non-media body served as application/octet-stream", async () => {
+    fetchImageMock.mockResolvedValue({
+      base64: Buffer.from('{"error":"not found"}').toString("base64"),
+      mimeType: "application/octet-stream",
     });
     await expect(
       getOutputImage("clip_00001_.mp4", "output", "video", { allowMedia: true }),

--- a/src/__tests__/services/image-management-traversal.test.ts
+++ b/src/__tests__/services/image-management-traversal.test.ts
@@ -616,6 +616,13 @@ describe("getOutputImage — video/audio media (issue #663)", () => {
     ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
   });
 
+  it("rejects video/mp4 bytes requested as .png (image extension claims a still)", async () => {
+    fetchImageMock.mockResolvedValue({ base64: MP4_BASE64, mimeType: "video/mp4" });
+    await expect(
+      getOutputImage("frame_00001_.png", "output", "", { allowMedia: true }),
+    ).rejects.toMatchObject({ code: "IMAGE_NOT_FOUND" });
+  });
+
   it("resolves an m4a payload labeled audio/mp4 (audio-brand ftyp)", async () => {
     // .m4a is audio in an mp4 container — its ftyp major brand (M4A ) is the
     // audio/mp4 format, so it must not trip the cross-format guard.

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { ComfyUIError } from "../../utils/errors.js";
 
 // #483: get_image for a valid `type:"input"` image must return the binary
@@ -77,5 +79,44 @@ describe("get_image — binary-safe (#483)", () => {
     // structured error), not free-form prose the caller then fails to parse.
     const parsed = JSON.parse(text) as { error?: string };
     expect(parsed.error).toBe("IMAGE_NOT_FOUND");
+  });
+});
+
+describe("get_image — video/audio save-to-disk (#663)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("saves a video/mp4 asset to disk and returns text only (no inline image)", async () => {
+    const base64 = Buffer.from("fake-mp4-bytes").toString("base64");
+    getOutputImageMock.mockResolvedValue({
+      base64,
+      mimeType: "video/mp4",
+      filename: "I2V_HD_FaceLock_00036-audio.mp4",
+    });
+
+    const out = await getHandler("get_image")({
+      filename: "I2V_HD_FaceLock_00036-audio.mp4",
+      type: "output",
+      subfolder: "Eros",
+      save_dir: "/tmp/x",
+    });
+
+    expect(out.isError).toBeUndefined();
+    // The handler must opt into media payloads so the service doesn't reject
+    // the mp4 as IMAGE_NOT_FOUND.
+    expect(getOutputImageMock).toHaveBeenCalledWith(
+      "I2V_HD_FaceLock_00036-audio.mp4",
+      "output",
+      "Eros",
+      { allowMedia: true },
+    );
+    // Saved under the original filename/extension in the requested save_dir.
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      join("/tmp/x", "I2V_HD_FaceLock_00036-audio.mp4"),
+      Buffer.from(base64, "base64"),
+    );
+    expect(out.content.find((c) => c.type === "image")).toBeUndefined();
+    const text = out.content.map((c) => c.text ?? "").join("");
+    expect(text).toContain("I2V_HD_FaceLock_00036-audio.mp4");
+    expect(text).toContain("video/mp4");
   });
 });

--- a/src/__tests__/tools/get-image-binary-safe.test.ts
+++ b/src/__tests__/tools/get-image-binary-safe.test.ts
@@ -86,7 +86,13 @@ describe("get_image — video/audio save-to-disk (#663)", () => {
   afterEach(() => vi.clearAllMocks());
 
   it("saves a video/mp4 asset to disk and returns text only (no inline image)", async () => {
-    const base64 = Buffer.from("fake-mp4-bytes").toString("base64");
+    // Realistic MP4 header (24-byte ftyp box, isom brand) — the service's
+    // magic-byte sniff accepts this shape; junk bytes would be rejected there.
+    const base64 = Buffer.from([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, // ....ftyp
+      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // isom....
+      0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32, // isomiso2
+    ]).toString("base64");
     getOutputImageMock.mockResolvedValue({
       base64,
       mimeType: "video/mp4",
@@ -118,5 +124,32 @@ describe("get_image — video/audio save-to-disk (#663)", () => {
     const text = out.content.map((c) => c.text ?? "").join("");
     expect(text).toContain("I2V_HD_FaceLock_00036-audio.mp4");
     expect(text).toContain("video/mp4");
+  });
+
+  it("writes NOTHING to disk when the service rejects a mislabeled media body", async () => {
+    // A JSON/HTML error body mislabeled video/mp4 is rejected inside
+    // getOutputImage (magic-byte sniff, see image-management-traversal.test.ts).
+    // The tool must surface that structured error and must NOT save a
+    // fabricated .mp4 from the junk bytes.
+    getOutputImageMock.mockRejectedValue(
+      new ComfyUIError(
+        'ComfyUI /view did not return an image for "clip_00001_.mp4" (output/video); got content-type "video/mp4".',
+        "IMAGE_NOT_FOUND",
+      ),
+    );
+
+    const out = await getHandler("get_image")({
+      filename: "clip_00001_.mp4",
+      type: "output",
+      subfolder: "video",
+      save_dir: "/tmp/x",
+    });
+
+    expect(out.isError).toBe(true);
+    const parsed = JSON.parse(
+      out.content.map((c) => c.text ?? "").join(""),
+    ) as { error?: string };
+    expect(parsed.error).toBe("IMAGE_NOT_FOUND");
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
   });
 });

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -445,12 +445,46 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
 }
 
 /**
+ * Magic-byte sniff for the video/audio formats get_image can save (#663).
+ * Every container ComfyUI's media nodes emit has a fixed leading signature:
+ * MP4/MOV/M4V/M4A carry an "ftyp" box at offset 4, WebM/MKV start with the
+ * EBML header, WAV/AVI are RIFF containers, FLAC/Ogg have ASCII magic, and
+ * MP3/AAC start with an ID3 tag or an MPEG/ADTS frame sync. A textual junk
+ * body (JSON/HTML error page) matches none of these.
+ */
+function sniffsAsMedia(base64: string): boolean {
+  // 24 base64 chars decode to the first 18 bytes — the deepest signature
+  // below (the RIFF form type at bytes 8–11) fits comfortably.
+  const head = Buffer.from(base64.slice(0, 24), "base64");
+  const ascii = (start: number, end: number) =>
+    head.subarray(start, end).toString("ascii");
+  if (head.length >= 8 && ascii(4, 8) === "ftyp") return true; // mp4/mov/m4v/m4a
+  if (head.length >= 4) {
+    if (head.readUInt32BE(0) === 0x1a45dfa3) return true; // webm/mkv (EBML)
+    if (ascii(0, 4) === "fLaC" || ascii(0, 4) === "OggS") return true; // flac/ogg
+  }
+  if (head.length >= 12 && ascii(0, 4) === "RIFF") {
+    const form = ascii(8, 12);
+    if (form === "WAVE" || form === "AVI ") return true; // wav/avi
+  }
+  if (head.length >= 3 && ascii(0, 3) === "ID3") return true; // mp3 (tagged)
+  if (head.length >= 2 && head[0] === 0xff && (head[1] & 0xe0) === 0xe0) {
+    return true; // mp3 / aac frame sync
+  }
+  return false;
+}
+
+/**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
  * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
  *
  * By default only image/* payloads are accepted. Pass `allowMedia: true` to
  * also accept video/* and audio/* (e.g. a VHS_VideoCombine .mp4) so the caller
- * can save them to disk — /view returns raw bytes for any media type.
+ * can save them to disk — /view returns raw bytes for any media type. Media
+ * acceptance sniffs the payload's magic bytes instead of trusting the declared
+ * content-type, so a JSON/HTML error body mislabeled as video/mp4 is still
+ * rejected — and genuine media a proxy serves as application/octet-stream
+ * (ComfyUI itself reports video/mp4 via mimetypes) still passes.
  */
 export async function getOutputImage(
   filename: string,
@@ -469,10 +503,20 @@ export async function getOutputImage(
   // returned them as an inline image block, so the MCP client then choked trying
   // to decode them ("Unexpected end of JSON input"). Fail loudly and structured
   // instead, so get_image surfaces a clean not-found rather than a corrupt image.
+  //
+  // Under allowMedia the same junk body can arrive labeled video/mp4 — the
+  // declared content-type alone is no proof, and get_image would save the junk
+  // bytes as a working .mp4. So media payloads must also SNIFF as media (magic
+  // bytes), which doubles as acceptance for genuine media a proxy serves under
+  // the generic application/octet-stream type.
   const mime = result.mimeType.toLowerCase();
   const isImage = mime.startsWith("image/");
   const isMedia =
-    allowMedia && (mime.startsWith("video/") || mime.startsWith("audio/"));
+    allowMedia &&
+    (mime.startsWith("video/") ||
+      mime.startsWith("audio/") ||
+      mime === "application/octet-stream") &&
+    sniffsAsMedia(result.base64);
   if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -447,18 +447,32 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
 /**
  * Magic-byte sniff for the video/audio formats get_image can save (#663).
  * Every container ComfyUI's media nodes emit has a fixed leading signature:
- * MP4/MOV/M4V/M4A carry an "ftyp" box at offset 4, WebM/MKV start with the
- * EBML header, WAV/AVI are RIFF containers, FLAC/Ogg have ASCII magic, and
- * MP3/AAC start with an ID3 tag or an MPEG/ADTS frame sync. A textual junk
- * body (JSON/HTML error page) matches none of these.
+ * MP4/MOV/M4V/M4A open with a well-formed "ftyp" box, WebM/MKV start with
+ * the EBML header, WAV/AVI are RIFF containers, FLAC/Ogg have ASCII magic,
+ * and MP3/AAC start with an ID3 tag or an MPEG/ADTS frame sync. A textual
+ * junk body (JSON/HTML error page) matches none of these.
  */
 function sniffsAsMedia(base64: string): boolean {
   // 24 base64 chars decode to the first 18 bytes — the deepest signature
-  // below (the RIFF form type at bytes 8–11) fits comfortably.
+  // below (the ftyp minor version at bytes 12–15) fits comfortably.
   const head = Buffer.from(base64.slice(0, 24), "base64");
   const ascii = (start: number, end: number) =>
     head.subarray(start, end).toString("ascii");
-  if (head.length >= 8 && ascii(4, 8) === "ftyp") return true; // mp4/mov/m4v/m4a
+  if (head.length >= 16 && ascii(4, 8) === "ftyp") {
+    // mp4/mov/m4v/m4a — require a well-formed ftyp BOX, not just the four
+    // bytes "ftyp": the box size (big-endian uint32) must cover the header +
+    // major brand + minor version (>= 16) and not exceed the actual body
+    // length, and the major brand must be printable ASCII. An 8-byte
+    // truncated body ending in "ftyp" fails every one of these.
+    const boxSize = head.readUInt32BE(0);
+    const bodyLength =
+      Math.floor((base64.length * 3) / 4) -
+      (base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0);
+    const printableBrand = head
+      .subarray(8, 12)
+      .every((b) => b >= 0x20 && b <= 0x7e);
+    if (boxSize >= 16 && boxSize <= bodyLength && printableBrand) return true;
+  }
   if (head.length >= 4) {
     if (head.readUInt32BE(0) === 0x1a45dfa3) return true; // webm/mkv (EBML)
     if (ascii(0, 4) === "fLaC" || ascii(0, 4) === "OggS") return true; // flac/ogg

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -447,11 +447,16 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
 /**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
  * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
+ *
+ * By default only image/* payloads are accepted. Pass `allowMedia: true` to
+ * also accept video/* and audio/* (e.g. a VHS_VideoCombine .mp4) so the caller
+ * can save them to disk — /view returns raw bytes for any media type.
  */
 export async function getOutputImage(
   filename: string,
   type: "output" | "input" | "temp" = "output",
   subfolder = "",
+  { allowMedia = false }: { allowMedia?: boolean } = {},
 ): Promise<{ base64: string; mimeType: string; filename: string }> {
   assertSafeViewRef(filename, subfolder);
   const result = await fetchImage(filename, type, subfolder);
@@ -466,7 +471,9 @@ export async function getOutputImage(
   // instead, so get_image surfaces a clean not-found rather than a corrupt image.
   const mime = result.mimeType.toLowerCase();
   const isImage = mime.startsWith("image/");
-  if (!isImage || result.base64.length === 0) {
+  const isMedia =
+    allowMedia && (mime.startsWith("video/") || mime.startsWith("audio/"));
+  if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(
       `ComfyUI /view did not return an image for "${filename}" (${where}); ` +

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -587,6 +587,31 @@ const MEDIA_FORMAT_BY_MIME: Record<string, MediaFormat> = {
 };
 
 /**
+ * Filename extension → the media format its payload must sniff as (#663).
+ * application/octet-stream declares nothing, so the requested FILENAME is the
+ * only remaining claim: a WAV body returned as "clip.mp4" would otherwise be
+ * saved under a video extension it isn't. Unlisted extensions declare nothing
+ * we can check and pass any valid media format (fail-open for exotic-but-real
+ * assets — the bytes still have to prove themselves via the structural sniff).
+ */
+const MEDIA_FORMAT_BY_EXTENSION: Record<string, MediaFormat> = {
+  ".mp4": "mp4-video",
+  ".mov": "mp4-video",
+  ".m4v": "mp4-video",
+  ".m4a": "mp4-audio",
+  ".m4b": "mp4-audio",
+  ".webm": "ebml",
+  ".mkv": "ebml",
+  ".avi": "avi",
+  ".wav": "wav",
+  ".mp3": "mpegaudio",
+  ".aac": "aac",
+  ".flac": "flac",
+  ".ogg": "ogg",
+  ".oga": "ogg",
+};
+
+/**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
  * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
  *
@@ -629,10 +654,12 @@ export async function getOutputImage(
   const mime = result.mimeType.toLowerCase();
   const isImage = mime.startsWith("image/");
   const sniffedFormat = allowMedia ? sniffMediaFormat(result.base64) : null;
+  const ext = extname(filename).toLowerCase();
   const isMedia =
     sniffedFormat !== null &&
-    (mime === "application/octet-stream" ||
-      MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
+    (mime === "application/octet-stream"
+      ? (MEDIA_FORMAT_BY_EXTENSION[ext] ?? sniffedFormat) === sniffedFormat
+      : MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
   if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -655,11 +655,17 @@ export async function getOutputImage(
   const isImage = mime.startsWith("image/");
   const sniffedFormat = allowMedia ? sniffMediaFormat(result.base64) : null;
   const ext = extname(filename).toLowerCase();
+  // The sniffed format must satisfy EVERY claim present: the declared
+  // content-type (exact subtype match), and the requested filename's
+  // extension whenever we can classify it — audio/wav bytes requested as
+  // clip.mp4 pass mime↔sniff yet would still land on disk as a corrupt .mp4.
+  const extOk =
+    !MEDIA_FORMAT_BY_EXTENSION[ext] || MEDIA_FORMAT_BY_EXTENSION[ext] === sniffedFormat;
   const isMedia =
     sniffedFormat !== null &&
-    (mime === "application/octet-stream"
-      ? (MEDIA_FORMAT_BY_EXTENSION[ext] ?? sniffedFormat) === sniffedFormat
-      : MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
+    extOk &&
+    (mime === "application/octet-stream" ||
+      MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
   if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -444,24 +444,45 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
   }
 }
 
-type MediaFamily = "video" | "audio";
+/**
+ * Media formats get_image can save, identified by magic-byte sniff (#663).
+ * Format — not just family — so a cross-format mislabel (MP3 bytes declared
+ * audio/wav) is rejected even when both byte streams are genuine media.
+ */
+type MediaFormat =
+  | "mp4-video"
+  | "mp4-audio"
+  | "ebml"
+  | "avi"
+  | "wav"
+  | "flac"
+  | "ogg"
+  | "mpegaudio"
+  | "aac";
+
+// EBML magic and MPEG/ADTS frame syncs are only 2–4 bytes — short enough for
+// a truncated error-prefix to satisfy them — so formats with no cheap local
+// structure to validate require a plausible minimum file size instead.
+const MIN_MEDIA_BYTES = 256;
 
 /**
  * Magic-byte sniff for the video/audio formats get_image can save (#663).
- * Returns the media FAMILY the payload's leading signature belongs to, or
- * null when it matches none of them. Every container ComfyUI's media nodes
- * emit has a fixed leading signature: MP4/MOV/M4V/M4A open with a well-formed
- * "ftyp" box, WebM/MKV start with the EBML header, WAV/AVI are RIFF
- * containers, FLAC/Ogg have ASCII magic, and MP3/AAC start with an ID3 tag or
- * an MPEG/ADTS frame sync. A textual junk body (JSON/HTML error page) matches
- * none of these. The family lets the caller reject cross-family mislabels —
- * a WAV body declared video/mp4, or an MP4 declared audio/wav — even though
- * both byte streams are genuine media.
+ * Returns the media FORMAT the payload proves itself to be, or null when it
+ * matches none of them. Each check validates STRUCTURE, not just a leading
+ * signature: MP4/MOV/M4V/M4A need a well-formed "ftyp" box, RIFF containers
+ * (WAV/AVI) a chunk size consistent with the delivered body, FLAC the
+ * mandatory STREAMINFO first block, Ogg a version-0 page header whose
+ * segment table fits inside the body, and ID3 a syncsafe tag size that fits.
+ * A textual junk body (JSON/HTML error page) or a truncated prefix matches
+ * none of these.
  */
-function sniffMediaFamily(base64: string): MediaFamily | null {
-  // 24 base64 chars decode to the first 18 bytes — the deepest signature
-  // below (the ftyp minor version at bytes 12–15) fits comfortably.
-  const head = Buffer.from(base64.slice(0, 24), "base64");
+function sniffMediaFormat(base64: string): MediaFormat | null {
+  // 40 base64 chars decode to the first 30 bytes — enough for the deepest
+  // header below (the 27-byte Ogg page header).
+  const head = Buffer.from(base64.slice(0, 40), "base64");
+  const bodyLength =
+    Math.floor((base64.length * 3) / 4) -
+    (base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0);
   const ascii = (start: number, end: number) =>
     head.subarray(start, end).toString("ascii");
   if (head.length >= 16 && ascii(4, 8) === "ftyp") {
@@ -471,9 +492,6 @@ function sniffMediaFamily(base64: string): MediaFamily | null {
     // length, and the major brand must be printable ASCII. An 8-byte
     // truncated body ending in "ftyp" fails every one of these.
     const boxSize = head.readUInt32BE(0);
-    const bodyLength =
-      Math.floor((base64.length * 3) / 4) -
-      (base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0);
     const printableBrand = head
       .subarray(8, 12)
       .every((b) => b >= 0x20 && b <= 0x7e);
@@ -481,24 +499,92 @@ function sniffMediaFamily(base64: string): MediaFamily | null {
       // M4A/M4B are audio-only brands (m4a audio in an mp4 container); the
       // rest (isom/mp41/mp42/avc1/qt/M4V…) are video.
       const brand = ascii(8, 12);
-      return brand === "M4A " || brand === "M4B " ? "audio" : "video";
+      return brand === "M4A " || brand === "M4B " ? "mp4-audio" : "mp4-video";
     }
   }
-  if (head.length >= 4) {
-    if (head.readUInt32BE(0) === 0x1a45dfa3) return "video"; // webm/mkv (EBML)
-    if (ascii(0, 4) === "fLaC" || ascii(0, 4) === "OggS") return "audio"; // flac/ogg
+  if (head.length >= 4 && head.readUInt32BE(0) === 0x1a45dfa3) {
+    // webm/mkv — EBML magic is only 4 bytes; require a plausible file size.
+    if (bodyLength >= MIN_MEDIA_BYTES) return "ebml";
+  }
+  if (head.length >= 8 && ascii(0, 4) === "fLaC") {
+    // flac — the magic must be followed by the mandatory first metadata
+    // block: a STREAMINFO block header (type 0, length exactly 34).
+    if (
+      (head[4] & 0x7f) === 0 &&
+      head.readUIntBE(5, 3) === 34 &&
+      bodyLength >= 42
+    ) {
+      return "flac";
+    }
+  }
+  if (head.length >= 27 && ascii(0, 4) === "OggS") {
+    // ogg — the page version byte must be 0 and the segment table must fit
+    // inside the body (27-byte page header + page_segments bytes).
+    if (head[4] === 0 && 27 + head[26] <= bodyLength) return "ogg";
   }
   if (head.length >= 12 && ascii(0, 4) === "RIFF") {
-    const form = ascii(8, 12);
-    if (form === "WAVE") return "audio"; // wav
-    if (form === "AVI ") return "video"; // avi
+    // wav/avi — the RIFF chunk size (file size − 8) must be consistent with
+    // the body actually delivered: at least the 4-byte form type, and never
+    // claiming more bytes than we have (a truncated/fabricated prefix).
+    const riffSize = head.readUInt32LE(4);
+    if (riffSize >= 4 && riffSize + 8 <= bodyLength) {
+      const form = ascii(8, 12);
+      if (form === "WAVE") return "wav";
+      if (form === "AVI ") return "avi";
+    }
   }
-  if (head.length >= 3 && ascii(0, 3) === "ID3") return "audio"; // mp3 (tagged)
+  if (head.length >= 10 && ascii(0, 3) === "ID3") {
+    // mp3 with an ID3v2 tag — the 4 tag-size bytes must be syncsafe (7-bit)
+    // and the declared tag must fit inside the body; a bare "ID3" prefix
+    // fails both, and the floor rejects a tag with no audio behind it.
+    if (head.subarray(6, 10).every((b) => (b & 0x80) === 0)) {
+      const tagSize =
+        (head[6] << 21) | (head[7] << 14) | (head[8] << 7) | head[9];
+      if (tagSize + 10 <= bodyLength && bodyLength >= MIN_MEDIA_BYTES) {
+        return "mpegaudio";
+      }
+    }
+  }
   if (head.length >= 2 && head[0] === 0xff && (head[1] & 0xe0) === 0xe0) {
-    return "audio"; // mp3 / aac frame sync
+    // mp3 / aac frame sync — 2 bytes is an error-prefix-sized signature, so
+    // require a plausible file size. ADTS (aac) frames always have the MPEG
+    // layer bits 00; mp3/mp2 frames have them set.
+    if (bodyLength >= MIN_MEDIA_BYTES) {
+      return (head[1] & 0x06) === 0 ? "aac" : "mpegaudio";
+    }
   }
   return null;
 }
+
+/**
+ * Declared content-type → the media format its payload must sniff as (#663).
+ * Cross-format mislabels within a family (MP3 bytes labeled audio/wav) are
+ * rejected just like cross-family ones. Unlisted media types fail closed;
+ * application/octet-stream is handled separately and accepts any format.
+ */
+const MEDIA_FORMAT_BY_MIME: Record<string, MediaFormat> = {
+  "video/mp4": "mp4-video",
+  "video/quicktime": "mp4-video",
+  "video/x-m4v": "mp4-video",
+  "video/webm": "ebml",
+  "video/x-matroska": "ebml",
+  "video/x-msvideo": "avi",
+  "video/avi": "avi",
+  "video/msvideo": "avi",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/wave": "wav",
+  "audio/vnd.wave": "wav",
+  "audio/mpeg": "mpegaudio",
+  "audio/mp3": "mpegaudio",
+  "audio/aac": "aac",
+  "audio/x-aac": "aac",
+  "audio/flac": "flac",
+  "audio/x-flac": "flac",
+  "audio/ogg": "ogg",
+  "audio/mp4": "mp4-audio",
+  "audio/x-m4a": "mp4-audio",
+};
 
 /**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
@@ -511,8 +597,8 @@ function sniffMediaFamily(base64: string): MediaFamily | null {
  * content-type, so a JSON/HTML error body mislabeled as video/mp4 is still
  * rejected — and genuine media a proxy serves as application/octet-stream
  * (ComfyUI itself reports video/mp4 via mimetypes) still passes. The sniffed
- * media family must also match the declared top-level type (a WAV labeled
- * video/mp4 is rejected).
+ * media format must also match the declared subtype (MP3 bytes labeled
+ * audio/wav are rejected).
  */
 export async function getOutputImage(
   filename: string,
@@ -534,28 +620,19 @@ export async function getOutputImage(
   //
   // Under allowMedia the same junk body can arrive labeled video/mp4 — the
   // declared content-type alone is no proof, and get_image would save the junk
-  // bytes as a working .mp4. So media payloads must also SNIFF as media (magic
-  // bytes), which doubles as acceptance for genuine media a proxy serves under
-  // the generic application/octet-stream type. The sniffed media FAMILY must
-  // also match the declared top-level type: video/* requires a video signature
-  // and audio/* an audio one, so a cross-family mismatch (WAV labeled
-  // video/mp4, MP4 labeled audio/wav) is rejected like other junk instead of
-  // being saved under a corrupt extension.
+  // bytes as a working .mp4. So media payloads must also SNIFF as media, and
+  // the sniffed FORMAT must match the declared subtype exactly: MP3 bytes
+  // labeled audio/wav are rejected even though both are audio, otherwise the
+  // asset is saved under a corrupt extension. The generic
+  // application/octet-stream label declares no format, so any genuine media
+  // signature passes.
   const mime = result.mimeType.toLowerCase();
   const isImage = mime.startsWith("image/");
-  const declaredFamily: MediaFamily | null = mime.startsWith("video/")
-    ? "video"
-    : mime.startsWith("audio/")
-      ? "audio"
-      : null;
-  const sniffedFamily =
-    allowMedia &&
-    (declaredFamily !== null || mime === "application/octet-stream")
-      ? sniffMediaFamily(result.base64)
-      : null;
+  const sniffedFormat = allowMedia ? sniffMediaFormat(result.base64) : null;
   const isMedia =
-    sniffedFamily !== null &&
-    (declaredFamily === null || sniffedFamily === declaredFamily);
+    sniffedFormat !== null &&
+    (mime === "application/octet-stream" ||
+      MEDIA_FORMAT_BY_MIME[mime] === sniffedFormat);
   if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -611,6 +611,20 @@ const MEDIA_FORMAT_BY_EXTENSION: Record<string, MediaFormat> = {
   ".oga": "ogg",
 };
 
+/** Image extensions claim a still image — never consistent with a sniffed
+ *  video/audio payload (an MP4 saved as clip.png is the same corruption). */
+const IMAGE_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+  ".bmp",
+  ".tif",
+  ".tiff",
+  ".avif",
+]);
+
 /**
  * Fetch a generated image from ComfyUI via HTTP /view endpoint.
  * Does NOT require COMFYUI_PATH — works with remote ComfyUI instances.
@@ -660,7 +674,8 @@ export async function getOutputImage(
   // extension whenever we can classify it — audio/wav bytes requested as
   // clip.mp4 pass mime↔sniff yet would still land on disk as a corrupt .mp4.
   const extOk =
-    !MEDIA_FORMAT_BY_EXTENSION[ext] || MEDIA_FORMAT_BY_EXTENSION[ext] === sniffedFormat;
+    !IMAGE_EXTENSIONS.has(ext) &&
+    (!MEDIA_FORMAT_BY_EXTENSION[ext] || MEDIA_FORMAT_BY_EXTENSION[ext] === sniffedFormat);
   const isMedia =
     sniffedFormat !== null &&
     extOk &&

--- a/src/services/image-management.ts
+++ b/src/services/image-management.ts
@@ -444,15 +444,21 @@ function assertSafeViewRef(filename: string, subfolder: string): void {
   }
 }
 
+type MediaFamily = "video" | "audio";
+
 /**
  * Magic-byte sniff for the video/audio formats get_image can save (#663).
- * Every container ComfyUI's media nodes emit has a fixed leading signature:
- * MP4/MOV/M4V/M4A open with a well-formed "ftyp" box, WebM/MKV start with
- * the EBML header, WAV/AVI are RIFF containers, FLAC/Ogg have ASCII magic,
- * and MP3/AAC start with an ID3 tag or an MPEG/ADTS frame sync. A textual
- * junk body (JSON/HTML error page) matches none of these.
+ * Returns the media FAMILY the payload's leading signature belongs to, or
+ * null when it matches none of them. Every container ComfyUI's media nodes
+ * emit has a fixed leading signature: MP4/MOV/M4V/M4A open with a well-formed
+ * "ftyp" box, WebM/MKV start with the EBML header, WAV/AVI are RIFF
+ * containers, FLAC/Ogg have ASCII magic, and MP3/AAC start with an ID3 tag or
+ * an MPEG/ADTS frame sync. A textual junk body (JSON/HTML error page) matches
+ * none of these. The family lets the caller reject cross-family mislabels —
+ * a WAV body declared video/mp4, or an MP4 declared audio/wav — even though
+ * both byte streams are genuine media.
  */
-function sniffsAsMedia(base64: string): boolean {
+function sniffMediaFamily(base64: string): MediaFamily | null {
   // 24 base64 chars decode to the first 18 bytes — the deepest signature
   // below (the ftyp minor version at bytes 12–15) fits comfortably.
   const head = Buffer.from(base64.slice(0, 24), "base64");
@@ -471,21 +477,27 @@ function sniffsAsMedia(base64: string): boolean {
     const printableBrand = head
       .subarray(8, 12)
       .every((b) => b >= 0x20 && b <= 0x7e);
-    if (boxSize >= 16 && boxSize <= bodyLength && printableBrand) return true;
+    if (boxSize >= 16 && boxSize <= bodyLength && printableBrand) {
+      // M4A/M4B are audio-only brands (m4a audio in an mp4 container); the
+      // rest (isom/mp41/mp42/avc1/qt/M4V…) are video.
+      const brand = ascii(8, 12);
+      return brand === "M4A " || brand === "M4B " ? "audio" : "video";
+    }
   }
   if (head.length >= 4) {
-    if (head.readUInt32BE(0) === 0x1a45dfa3) return true; // webm/mkv (EBML)
-    if (ascii(0, 4) === "fLaC" || ascii(0, 4) === "OggS") return true; // flac/ogg
+    if (head.readUInt32BE(0) === 0x1a45dfa3) return "video"; // webm/mkv (EBML)
+    if (ascii(0, 4) === "fLaC" || ascii(0, 4) === "OggS") return "audio"; // flac/ogg
   }
   if (head.length >= 12 && ascii(0, 4) === "RIFF") {
     const form = ascii(8, 12);
-    if (form === "WAVE" || form === "AVI ") return true; // wav/avi
+    if (form === "WAVE") return "audio"; // wav
+    if (form === "AVI ") return "video"; // avi
   }
-  if (head.length >= 3 && ascii(0, 3) === "ID3") return true; // mp3 (tagged)
+  if (head.length >= 3 && ascii(0, 3) === "ID3") return "audio"; // mp3 (tagged)
   if (head.length >= 2 && head[0] === 0xff && (head[1] & 0xe0) === 0xe0) {
-    return true; // mp3 / aac frame sync
+    return "audio"; // mp3 / aac frame sync
   }
-  return false;
+  return null;
 }
 
 /**
@@ -498,7 +510,9 @@ function sniffsAsMedia(base64: string): boolean {
  * acceptance sniffs the payload's magic bytes instead of trusting the declared
  * content-type, so a JSON/HTML error body mislabeled as video/mp4 is still
  * rejected — and genuine media a proxy serves as application/octet-stream
- * (ComfyUI itself reports video/mp4 via mimetypes) still passes.
+ * (ComfyUI itself reports video/mp4 via mimetypes) still passes. The sniffed
+ * media family must also match the declared top-level type (a WAV labeled
+ * video/mp4 is rejected).
  */
 export async function getOutputImage(
   filename: string,
@@ -522,15 +536,26 @@ export async function getOutputImage(
   // declared content-type alone is no proof, and get_image would save the junk
   // bytes as a working .mp4. So media payloads must also SNIFF as media (magic
   // bytes), which doubles as acceptance for genuine media a proxy serves under
-  // the generic application/octet-stream type.
+  // the generic application/octet-stream type. The sniffed media FAMILY must
+  // also match the declared top-level type: video/* requires a video signature
+  // and audio/* an audio one, so a cross-family mismatch (WAV labeled
+  // video/mp4, MP4 labeled audio/wav) is rejected like other junk instead of
+  // being saved under a corrupt extension.
   const mime = result.mimeType.toLowerCase();
   const isImage = mime.startsWith("image/");
-  const isMedia =
+  const declaredFamily: MediaFamily | null = mime.startsWith("video/")
+    ? "video"
+    : mime.startsWith("audio/")
+      ? "audio"
+      : null;
+  const sniffedFamily =
     allowMedia &&
-    (mime.startsWith("video/") ||
-      mime.startsWith("audio/") ||
-      mime === "application/octet-stream") &&
-    sniffsAsMedia(result.base64);
+    (declaredFamily !== null || mime === "application/octet-stream")
+      ? sniffMediaFamily(result.base64)
+      : null;
+  const isMedia =
+    sniffedFamily !== null &&
+    (declaredFamily === null || sniffedFamily === declaredFamily);
   if ((!isImage && !isMedia) || result.base64.length === 0) {
     const where = subfolder ? `${type}/${subfolder}` : type;
     throw new ComfyUIError(

--- a/src/tools/image-management.ts
+++ b/src/tools/image-management.ts
@@ -20,6 +20,8 @@ export function registerImageManagementTools(server: McpServer): void {
   server.tool(
     "get_image",
     "Fetch a generated image from ComfyUI and return it as an inline image. " +
+      "Video/audio outputs (e.g. a VHS_VideoCombine .mp4) are saved to save_dir " +
+      "with their original extension instead of being rendered inline. " +
       "Works with remote ComfyUI instances — does not require COMFYUI_PATH. " +
       "Use get_history first to obtain the filename.",
     {
@@ -49,6 +51,7 @@ export function registerImageManagementTools(server: McpServer): void {
           args.filename,
           args.type ?? "output",
           args.subfolder ?? "",
+          { allowMedia: true },
         );
 
         // Save to local file
@@ -57,6 +60,18 @@ export function registerImageManagementTools(server: McpServer): void {
         const localFilename = basename(args.filename);
         const savePath = join(saveDir, localFilename);
         await writeFile(savePath, Buffer.from(base64, "base64"));
+
+        // Only images render inline; video/audio are save-to-disk only (#663).
+        if (!mimeType.toLowerCase().startsWith("image/")) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Saved to: ${savePath} (${mimeType}; not rendered inline)`,
+              },
+            ],
+          };
+        }
 
         return {
           content: [


### PR DESCRIPTION
Refs #663

## Problem
`get_image` rejected any non-image /view payload as `IMAGE_NOT_FOUND`, so a valid MP4 produced by e.g. VHS_VideoCombine (content-type `video/mp4`) could not be saved to disk — blocking last-frame-extraction workflows and forcing an exact-path filesystem workaround.

## Fix
- `getOutputImage` (src/services/image-management.ts) gains an opt-in `{ allowMedia }` flag that also accepts `video/*` and `audio/*` payloads. The junk-body guards from #385/#483 (empty body, JSON/HTML error pages) still apply, and the default stays image-only so the other consumers (`view_image`, color-analysis, image-convert, storage-upload) are unchanged.
- `get_image` (src/tools/image-management.ts) passes `allowMedia: true`, saves the bytes to `save_dir` under the original filename/extension as before, and only renders the inline image block for `image/*` payloads — video/audio return a text-only result with the saved path and mime type. No new path restrictions.
- Tool description updated; `npm run docs:gen` output committed (docs/tools/assets-images.mdx).

## Tests
- Service (image-management-traversal.test.ts): mp4 rejected by default, resolved with `allowMedia`, JSON error body and empty body still rejected with `allowMedia`.
- Tool (get-image-binary-safe.test.ts): mp4 saved to the requested save_dir under the original name, text-only response (no inline image), handler passes `{ allowMedia: true }`.
- `npx tsc --noEmit` clean; full `npx vitest run` green except the known pre-existing node-dev builtin-fallback/ripgrep environment failure.