### PR TITLE
docs: docker-compose example + stdio-is-not-a-service documentation (#660)

### DIFF
--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -1,0 +1,63 @@
+# docker-compose example — ComfyUI as a service
+
+A minimal compose setup for running **ComfyUI** in a container and driving it
+with `comfyui-mcp`. Full explanation:
+[docs → Docker & Compose](https://comfyui-mcp.artokun.io/docs/docker).
+
+## The one thing to understand
+
+**`comfyui-mcp` is not in the compose file — on purpose.** It is a *stdio* MCP
+server: it has no port, and the MCP client (Claude Code, Cursor, a bridge, …)
+spawns it as a child process over stdin/stdout. A `comfyui-mcp` compose service
+would have nothing to talk to and exit. What goes in compose is **ComfyUI**;
+the MCP server runs wherever your MCP client runs and connects to ComfyUI over
+HTTP via `COMFYUI_URL`.
+
+## Usage
+
+```bash
+docker compose up -d
+```
+
+Then add the MCP server to your client config (e.g. `~/.claude/settings.json`
+for Claude Code — requires **Node.js >= 22** on that machine):
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "command": "npx",
+      "args": ["-y", "comfyui-mcp@latest"],
+      "env": {
+        "COMFYUI_URL": "http://localhost:8188"
+      }
+    }
+  }
+}
+```
+
+If the MCP client runs **inside another compose service** on the same network
+(e.g. an MCP bridge for Open WebUI), use the service name instead of
+localhost:
+
+```
+COMFYUI_URL=http://comfyui:8188
+```
+
+## GPU variants
+
+The compose file defaults to NVIDIA (`yanwk/comfyui-boot:cu130-slim-v2`, a
+third-party community image). For **AMD/ROCm**, switch the image to
+`yanwk/comfyui-boot:rocm` and uncomment the ROCm passthrough block
+(`devices`, `group_add`, `security_opt`) — comments in
+[`docker-compose.yml`](./docker-compose.yml) walk through it. `comfyui-mcp`
+itself has no GPU/CUDA dependency.
+
+> `docker/runpod` in this repo is a **CUDA-oriented RunPod cloud image**, not a
+> general-purpose ComfyUI image — don't start from it for a local or AMD setup.
+
+## Volumes
+
+Bind mounts under `./storage/` persist models, custom nodes, outputs, and user
+workflows on the host across container rebuilds. Layout follows the image's
+docs (`/root/ComfyUI`).

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,0 +1,92 @@
+# ComfyUI as a docker-compose service, driven by comfyui-mcp.
+#
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ IMPORTANT: comfyui-mcp itself is NOT in this file — on purpose.         │
+# │                                                                         │
+# │ comfyui-mcp is a *stdio* MCP server. It has no port and nothing to      │
+# │ expose: the MCP client (Claude Code, Cursor, a bridge, …) spawns it as  │
+# │ a child process and talks to it over stdin/stdout. So it CANNOT be its  │
+# │ own compose service — a `comfyui-mcp:` service here would start, have   │
+# │ no one to talk to, and exit. Don't add it.                              │
+# │                                                                         │
+# │ Instead, point your MCP client at the ComfyUI service below via         │
+# │ COMFYUI_URL. Client config (e.g. ~/.claude/settings.json on the host):  │
+# │                                                                         │
+# │   {                                                                     │
+# │     "mcpServers": {                                                     │
+# │       "comfyui": {                                                      │
+# │         "command": "npx",                                               │
+# │         "args": ["-y", "comfyui-mcp@latest"],                           │
+# │         "env": {                                                        │
+# │           "COMFYUI_URL": "http://localhost:8188"                        │
+# │         }                                                               │
+# │       }                                                                 │
+# │     }                                                                   │
+# │   }                                                                     │
+# │                                                                         │
+# │ Requires Node.js >= 22 on whatever machine runs the npx command.        │
+# │ If your MCP client itself runs INSIDE another compose service on this   │
+# │ network (e.g. an MCP bridge), use the service name instead:             │
+# │   COMFYUI_URL=http://comfyui:8188    # service name, not localhost      │
+# └─────────────────────────────────────────────────────────────────────────┘
+#
+# Usage:  docker compose up -d        (from this directory)
+# Then open http://localhost:8188 to confirm ComfyUI is up.
+
+services:
+  comfyui:
+    # Third-party community image (https://github.com/YanWenKun/ComfyUI-Docker).
+    # NVIDIA: pick the tag matching your GPU generation (see that repo's table):
+    #   cu130-slim-v2  — CUDA 13.0, recommended (Ada/Blackwell: RTX 40xx/50xx)
+    #   cu126-slim     — CUDA 12.6 (Ampere and older: RTX 30xx and back)
+    image: yanwk/comfyui-boot:cu130-slim-v2
+    # AMD (ROCm) instead: swap the image and uncomment the passthrough below —
+    #   image: yanwk/comfyui-boot:rocm
+    # and remove the `deploy:` NVIDIA reservation. comfyui-mcp itself has no
+    # GPU/CUDA dependency, so ROCm hosts are fully supported.
+    ports:
+      - "8188:8188"
+    environment:
+      # Extra ComfyUI launch args, e.g. CLI_ARGS=--lowvram
+      CLI_ARGS: ""
+    volumes:
+      # Layout per the image docs (workdir /root/ComfyUI). Bind mounts keep
+      # models/workflows/outputs on the host across container rebuilds.
+      - ./storage/models:/root/ComfyUI/models
+      - ./storage/custom_nodes:/root/ComfyUI/custom_nodes
+      - ./storage/input:/root/ComfyUI/input
+      - ./storage/output:/root/ComfyUI/output
+      - ./storage/user:/root/ComfyUI/user
+    restart: unless-stopped
+    # NVIDIA GPU reservation (requires the NVIDIA Container Toolkit).
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    # AMD (ROCm) passthrough — commonly missed; uncomment with the rocm image:
+    # devices:
+    #   - /dev/kfd
+    #   - /dev/dri
+    # group_add:
+    #   - video
+    # security_opt:
+    #   - seccomp:unconfined
+
+  # ── External front ends (Open WebUI, etc.) ──────────────────────────────
+  # If your MCP client lives in a container (e.g. an MCP-to-HTTP bridge for
+  # Open WebUI), THAT service is what spawns comfyui-mcp — so comfyui-mcp must
+  # be installed inside the bridge's image (Node >= 22), with
+  # COMFYUI_URL=http://comfyui:8188 in its environment. A bridge is
+  # third-party software; configure it per its own docs. Sketch:
+  #
+  # bridge:
+  #   image: <your-mcp-bridge-image>          # must contain Node >= 22
+  #   environment:
+  #     # whatever your bridge uses to launch MCP servers, e.g.:
+  #     MCP_COMFYUI_COMMAND: "npx -y comfyui-mcp@latest"
+  #     COMFYUI_URL: "http://comfyui:8188"
+  #   depends_on:
+  #     - comfyui

--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -1,0 +1,112 @@
+---
+title: "Docker & Compose"
+description: "Run ComfyUI as a docker-compose service and connect comfyui-mcp to it — and why comfyui-mcp itself is never a compose service."
+icon: "docker"
+---
+
+## comfyui-mcp is stdio — it cannot be a compose service
+
+`comfyui-mcp` is a **stdio MCP server**. It has no port and exposes nothing
+over the network: the MCP client (Claude Code, Cursor, an MCP bridge, …)
+**spawns it as a child process** and talks to it over stdin/stdout.
+
+So in a `docker-compose.yml`, a `comfyui-mcp` service is a dead end — it would
+start, have no one to talk to, and exit. This trips up almost everyone wiring
+ComfyUI into compose, because a correct compose file looks like it's "missing"
+a service. It isn't: what you compose is **ComfyUI**, and the MCP server runs
+wherever your MCP client runs, reaching ComfyUI over plain HTTP via
+`COMFYUI_URL`.
+
+<Note>
+  The `npx` command that launches the server requires **Node.js >= 22** on the
+  machine (or container) that runs it — the main gotcha for slim base images.
+</Note>
+
+## The two deployment shapes
+
+<CardGroup cols={2}>
+  <Card title="Local npx + local ComfyUI" icon="laptop">
+    The default. ComfyUI runs directly on your machine; the MCP client spawns
+    `npx -y comfyui-mcp@latest`, which auto-detects the local install and its
+    port. No config needed. See [Installation](/installation).
+  </Card>
+  <Card title="Local npx + dockerized / remote ComfyUI" icon="docker">
+    ComfyUI runs in a container (or on another host); the MCP client still
+    spawns `comfyui-mcp` locally, pointed at it with `COMFYUI_URL` (or
+    `--comfyui-url`). A non-loopback URL puts the server in **remote mode**:
+    all HTTP tools work, and local-only tools (installing custom nodes,
+    reading logs, removing model files) return a clear error.
+  </Card>
+</CardGroup>
+
+## Example: ComfyUI in docker-compose
+
+A ready-to-use example lives in the repo at
+[`docker/compose/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/compose)
+— ComfyUI as a service (NVIDIA default, AMD/ROCm variant commented in), bind
+mounts for models and outputs, and the client config in the header comments:
+
+```yaml
+services:
+  comfyui:
+    image: yanwk/comfyui-boot:cu130-slim-v2   # community image; :rocm for AMD
+    ports:
+      - "8188:8188"
+    volumes:
+      - ./storage/models:/root/ComfyUI/models
+      - ./storage/custom_nodes:/root/ComfyUI/custom_nodes
+      - ./storage/input:/root/ComfyUI/input
+      - ./storage/output:/root/ComfyUI/output
+      - ./storage/user:/root/ComfyUI/user
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+```
+
+Then point your MCP client at the container. On the **host** (the common case —
+Claude Code on the same machine), use the published port:
+
+```json
+{
+  "mcpServers": {
+    "comfyui": {
+      "command": "npx",
+      "args": ["-y", "comfyui-mcp@latest"],
+      "env": {
+        "COMFYUI_URL": "http://localhost:8188"
+      }
+    }
+  }
+}
+```
+
+If the MCP client runs **inside another compose service** on the same network
+(e.g. an MCP-to-HTTP bridge fronting Open WebUI), use the **compose service
+name**, not `localhost`:
+
+```
+COMFYUI_URL=http://comfyui:8188
+```
+
+In that layout the bridge service is what spawns `comfyui-mcp`, so its image
+must contain Node.js >= 22 with the server launchable via
+`npx -y comfyui-mcp@latest`. Bridges are third-party software — configure
+yours per its own docs; the example compose file has a commented sketch.
+
+## AMD / ROCm notes
+
+- Use the `yanwk/comfyui-boot:rocm` image tag and uncomment the ROCm
+  passthrough in the example — the bits people miss:
+  `devices: [/dev/kfd, /dev/dri]`, `group_add: [video]`,
+  `security_opt: [seccomp:unconfined]`.
+- `comfyui-mcp` itself has **no GPU/CUDA dependency** — ROCm hosts are fully
+  supported. The [Agent Panel](/panel) is a **ComfyUI extension**, not a
+  service, and is optional when an external front end is your surface.
+- [`docker/runpod/`](https://github.com/artokun/comfyui-mcp/tree/main/docker/runpod)
+  in this repo is a **CUDA-oriented RunPod cloud image** (see
+  [Cloud deployment](/cloud-deployment)), not a general-purpose ComfyUI image —
+  AMD users should not start there.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -55,6 +55,7 @@
               "configuration",
               "remote-connector",
               "cloud-deployment",
+              "docker",
               "self-hosted-relay",
               "concepts",
               "plugin",


### PR DESCRIPTION
## What

Fixes the documentation gap behind #660 (Discord user gave up after ~10 exchanges asking for a compose file).

**1. `docker/compose/` — committed compose example**
- ComfyUI as a service (`yanwk/comfyui-boot` community image, NVIDIA `cu130-slim-v2` default, `:rocm` variant commented in with the easily-missed passthrough: `devices: [/dev/kfd, /dev/dri]`, `group_add: [video]`, `security_opt: [seccomp:unconfined]`)
- Header comment block stating explicitly that **comfyui-mcp is a stdio MCP server and is NOT composed** — the MCP client spawns it (`npx -y comfyui-mcp@latest`); a compose service for it would start, have no one to talk to, and exit
- Client config snippet pointing `COMFYUI_URL` at the composed ComfyUI (`http://localhost:8188` from the host, `http://comfyui:8188` — service name — from an in-network client/bridge)
- Commented sketch for a third-party MCP bridge service (left unconfigured per the issue — untested by us)

**2. `docs/docker.mdx` — new "Docker & Compose" docs page** (registered in `docs/docs.json` under Configuration)
- The stdio-is-not-a-service constraint, stated explicitly
- The two deployment shapes: local npx + local ComfyUI (default, auto-detected) vs. local npx + dockerized/remote ComfyUI (`COMFYUI_URL` → remote mode)
- Node >= 22 requirement (`engines`), ROCm notes, and a pointer that `docker/runpod` is a CUDA-oriented RunPod image, not a general-purpose one; the Agent Panel is a ComfyUI extension, not a service

## Verified

- `COMFYUI_URL` / `--comfyui-url` against `src/config.ts`; URL parsing against `src/transport/comfyui-url.ts`
- `engines: node >= 22.0.0` in `package.json`
- Image tags `cu130-slim-v2` / `rocm` exist on Docker Hub (`yanwk/comfyui-boot`); volume layout (`/root/ComfyUI`) matches the image's docs
- `docker compose config` validates the example; `docs.json` parses

Ref #660