### PR TITLE
fix(tests): deterministic node-dev builtin-search + load-proof landing-timeout watcher (#655)

### DIFF
--- a/src/__tests__/services/node-dev.test.ts
+++ b/src/__tests__/services/node-dev.test.ts
@@ -250,7 +250,9 @@ describe("searchNodePacks", () => {
     mkdirSync(pack, { recursive: true });
     writeFileSync(join(pack, "nodes.py"), "class FooNode:\n    pass\n");
     writeFileSync(join(pack, "bin.dat"), Buffer.from([0, 1, 2, 0, 70, 111, 111]));
-    const res = searchNodePacks({ query: "FooNode" });
+    // Force the builtin path regardless of whether rg exists on this host (#655).
+    const { deps } = makeDeps();
+    const res = searchNodePacks({ query: "FooNode" }, deps);
     expect(res.engine).toBe("builtin");
     expect(res.matches.length).toBe(1);
     // Default path "." searches the whole jail root, so file is root-relative.

--- a/src/__tests__/services/remote-model-landing.test.ts
+++ b/src/__tests__/services/remote-model-landing.test.ts
@@ -76,12 +76,16 @@ describe("watchRemoteModelLanding", () => {
     expect(trayRows()[0].status).toBe("downloading");
   });
 
-  // Fake-advancing 4h steps ~2,880 async poll iterations — wall-clock sits right
-  // at vitest's default 5s on a loaded machine, so give it explicit headroom.
-  it("writes a terminal error row when the file never lands within the timeout", { timeout: 20_000 }, async () => {
+  // The timeout check reads Date.now(), so jump the fake clock past 4h instead of
+  // iterating ~2,880 async polls — same state machine, no load-sensitive
+  // wall-clock cost (#655).
+  it("writes a terminal error row when the file never lands within the timeout", async () => {
     fetchMock.mockResolvedValue(listingResponse([]));
     watchRemoteModelLanding("checkpoints", "never.safetensors", "https://x/never");
-    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000 + 10_000);
+    await vi.advanceTimersByTimeAsync(5_100); // poll 1 → still downloading
+    expect(trayRows()[0].status).toBe("downloading");
+    vi.setSystemTime(Date.now() + 4 * 60 * 60 * 1000 + 10_000);
+    await vi.advanceTimersByTimeAsync(5_100); // poll 2 → past timeout → error
     const rows = trayRows();
     expect(rows[0].status).toBe("error");
     const calls = fetchMock.mock.calls.length;


### PR DESCRIPTION
Refs #655.

Two test-environment robustness fixes, test-only — no production or tool-surface changes.

## node-dev: builtin fallback fails wherever ripgrep is installed

`builtin fallback finds matches and skips binary files` called `searchNodePacks()` with `defaultDeps`, whose `hasRipgrep()` spawns `rg --version` — so on any dev machine/CI with ripgrep on PATH the test routed to the ripgrep engine and failed its `engine === "builtin"` assertion.

Fix: pass the file's existing `makeDeps()` seam (default `hasRipgrep: () => false`) into the test, exactly as the neighboring ripgrep-seam test already does. The builtin walker still runs against a real tmpdir via `defaultDeps` fs — same assertions, now deterministic.

## remote-model-landing: 20s watcher test is load-sensitive

The timeout test fake-advanced 4h, which steps through ~2,880 async poll iterations, each writing a real heartbeat row to disk — wall-clock sits right at vitest's limit on a loaded machine.

Fix: the watcher's timeout check reads `Date.now()`, so the test now jumps the fake clock past the 4h timeout with `vi.setSystemTime` and lets one more poll trip it. Same state machine asserted (heartbeat → terminal error row → polling stops), plus a new intermediate assertion that the row is still `downloading` before the jump (proves the error comes from the timeout, not an instant failure). The 20s test-timeout override is dropped — the test now runs in single-digit ms.

## Verification

- `node-dev.test.ts`: 35/35 passed, 3 consecutive runs
- `remote-model-landing.test.ts`: 4/4 passed, 3 consecutive runs (~60ms per run)
- `npx tsc --noEmit`: clean
- Full suite (`npm test`) on a machine with rg installed: **219 files, 3158 passed, 1 skipped, 0 failed** — no other failures seen