### PR TITLE
fix(tools): retired-name error from the DEAD_NAMES ledger on call_tool (#659)

### DIFF
--- a/scripts/check-tool-vocabulary.mts
+++ b/scripts/check-tool-vocabulary.mts
@@ -104,6 +104,11 @@ const SELF = new Set([
   "src/__tests__/tools/node-snapshots-tool.test.ts",
   "src/__tests__/tools/batches.test.ts",
   "src/__tests__/tools/apps.test.ts",
+  // Same, for the #659 retired-name error: these pass dead names to call_tool /
+  // the ollama dispatch as FIXTURES and assert the error quotes the ledger's
+  // replacement — the names are call arguments under test, not live guidance.
+  "src/__tests__/tools/compact.test.ts",
+  "src/__tests__/orchestrator/ollama-backend.test.ts",
   // Generated FROM the ledger by scripts/export-vocabulary.mts, so it reproduces
   // the dead names as data for the panel to consume. Caught this gate out a second
   // time, in the same way as the first: green while untracked, red once committed.

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -343,6 +343,25 @@ describe("OllamaBackend", () => {
     expect(events.filter((e) => e.type === "result")).toEqual([{ type: "result", ok: true, usage: expect.anything() }]);
   });
 
+  it("a retired comfy tool name gets the ledger's specific error, not the bare Available list (#659)", async () => {
+    // No call_tool meta on the comfy client, so the forgiving direct dispatch
+    // falls through to the backend's own unknown-tool fallback — the path that
+    // used to answer with the full Available list.
+    const { client } = fakeMcpClient([{ name: "get_queue", description: "x" }]);
+    const backend = new OllamaBackend({ model: "gemma4:e4b", connectToolClients: async () => ({ comfyui: client }) });
+    chatScript.push(
+      [{ message: { content: "", tool_calls: [{ function: { name: "apps_list", arguments: {} } }] }, done: true }],
+      [{ message: { content: "done" }, done: true }],
+    );
+
+    await collect(backend, turnsOf({ text: "list my apps" }));
+    const toolMsg = chatRequests[1].messages.find((m) => m.role === "tool");
+    const content = String(toolMsg?.content);
+    expect(content).toContain("removed in 0.49.0");
+    expect(content).toContain('apps (action:"list")');
+    expect(content).not.toContain("Available:");
+  });
+
   it("synthesizes panel meta-tools over the panel MCP client", async () => {
     const { client: comfy } = fakeMcpClient(COMFY_META);
     const { client: panel, callTool: panelCall } = fakeMcpClient([

--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -198,6 +198,51 @@ describe("compact mode over a real MCP client/server pair", () => {
     expect(textOf(res as never)).toContain("gen_image");
   });
 
+  it("call_tool names the replacement for a RETIRED name (#659)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "apps_list" },
+    })) as { isError?: boolean };
+    expect(res.isError).toBe(true);
+    const text = textOf(res as never);
+    expect(text).toContain("removed in 0.49.0");
+    expect(text).toContain('apps (action:"list")');
+    expect(text).not.toContain("Did you mean");
+  });
+
+  it("call_tool resolves a retired name through the mcp__<server>__ prefix (#659)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "mcp__comfyui__apps_run" },
+    })) as { isError?: boolean };
+    expect(res.isError).toBe(true);
+    expect(textOf(res as never)).toContain('apps (action:"run")');
+  });
+
+  it("describe_tool gives a retired name the same specific error (#659)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "describe_tool",
+      arguments: { name: "submit_batch" },
+    })) as { isError?: boolean };
+    expect(res.isError).toBe(true);
+    expect(textOf(res as never)).toContain('batch (action:"submit")');
+  });
+
+  it("a merely-similar name still gets the fuzzy path, not the retired error (#659)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "apps_list_v2" },
+    })) as { isError?: boolean };
+    expect(res.isError).toBe(true);
+    const text = textOf(res as never);
+    expect(text).toContain("Unknown tool 'apps_list_v2'.");
+    expect(text).not.toContain("removed in");
+  });
+
   it("call_tool converts handler throws into isError results", async () => {
     const client = await compactPair(fakeCatalog());
     const res = (await client.callTool({

--- a/src/__tests__/tools/vocabulary.test.ts
+++ b/src/__tests__/tools/vocabulary.test.ts
@@ -7,6 +7,8 @@ import {
   TOOL_NAMES,
   baselineIntegrity,
   deadNameRe,
+  findDeadName,
+  retiredToolMessage,
 } from "../../tools/vocabulary.js";
 
 /**
@@ -133,5 +135,59 @@ describe("DEAD_NAMES ledger", () => {
       (d.allowedIn ?? []).filter((a) => !a.why.trim()).map((a) => `${d.name} → ${a.path}`),
     );
     expect(unjustified).toEqual([]);
+  });
+});
+
+/**
+ * The call_tool side of the ledger (#659): an EXACT retired name — bare or
+ * behind an mcp__<server>__ prefix — resolves to its entry so the caller can be
+ * told what replaced it, and nothing else does. The anchoring cases mirror
+ * deadNameRe's: the same names that must not match in prose must not resolve
+ * here either, or the fuzzy unknown-tool path would be shadowed for them.
+ */
+describe("findDeadName", () => {
+  it("resolves a bare retired name", () => {
+    expect(findDeadName("apps_list")?.replacement).toBe('apps (action:"list")');
+  });
+
+  it("resolves through an mcp__<server>__ prefix", () => {
+    expect(findDeadName("mcp__comfyui__apps_run")?.name).toBe("apps_run");
+  });
+
+  it("rejects a name embedded in a longer identifier", () => {
+    expect(findDeadName("my_apps_list")).toBeUndefined();
+    expect(findDeadName("retarget_image")).toBeUndefined();
+  });
+
+  it("rejects a retired name that is only a prefix of the called name", () => {
+    expect(findDeadName("apps_list_v2")).toBeUndefined();
+    expect(findDeadName("panel_get_graph_outline")).toBeUndefined();
+  });
+
+  it("rejects live and unknown names", () => {
+    expect(findDeadName("apps")).toBeUndefined();
+    expect(findDeadName("definitely_not_a_tool")).toBeUndefined();
+  });
+});
+
+describe("retiredToolMessage", () => {
+  it("quotes the removing version and the replacement", () => {
+    expect(retiredToolMessage("apps_run")).toBe(
+      `Unknown tool 'apps_run' — removed in 0.49.0. Call apps (action:"run") instead.`,
+    );
+  });
+
+  it("resolves the prefixed form to the same message", () => {
+    expect(retiredToolMessage("mcp__comfyui__apps_import")).toContain('Call apps (action:"import") instead.');
+  });
+
+  it("stays grammatical for a clause-shaped since (pre-baseline entries)", () => {
+    const message = retiredToolMessage("panel_get_graph");
+    expect(message).toContain("removed upstream before 0.48.0");
+    expect(message).not.toContain("removed in removed");
+  });
+
+  it("returns undefined for a genuinely unknown name", () => {
+    expect(retiredToolMessage("definitely_not_a_tool")).toBeUndefined();
   });
 });

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -29,6 +29,7 @@ import type { ImageRef } from "./panel-agent.js";
 import { OLLAMA_CAPABILITIES } from "./agent-backend.js";
 import type { GeminiMcpServerSpec } from "./gemini-backend.js";
 import { resolvePrompt } from "../services/prompt-overrides.js";
+import { retiredToolMessage } from "../tools/vocabulary.js";
 
 type McpToolInfo = { name: string; description?: string; inputSchema?: unknown };
 type McpCallResult = { isError?: boolean; content?: Array<{ type: string; text?: string }> };
@@ -512,6 +513,12 @@ export class OllamaBackend implements AgentBackend {
         const res = await this.comfy.callTool({ name: "call_tool", arguments: { name, args } });
         return { text: textOf(res), isError: !!res.isError };
       }
+      // Same retired-name courtesy as the compact server's call_tool (#659):
+      // with no call_tool meta to delegate to, this fallback is the last word
+      // the model gets, so a ledger name must name its replacement rather than
+      // drown in the full Available list.
+      const retired = retiredToolMessage(name);
+      if (retired) return { text: retired, isError: true };
       const known = [...this.comfyTools.map((t) => t.name), "panel_list_tools", "panel_describe_tool", "panel_call_tool"];
       return { text: `Unknown tool '${name}'. Available: ${known.join(", ")}.`, isError: true };
     } catch (err) {

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { errorToToolResult } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import type { CatalogedTool, ToolCatalog } from "./catalog.js";
+import { retiredToolMessage } from "./vocabulary.js";
 
 /** First sentence of a tool description, hard-capped so the manifest stays token-light. */
 export function summarize(description: string, maxLen = 160): string {
@@ -227,6 +228,11 @@ export function registerCompactTools(
 }
 
 function unknownToolMessage(catalog: ToolCatalog, name: string): string {
+  // A name in the retirement ledger gets a specific answer — which version
+  // removed it and what to call instead (#659). Exact matches only: partial
+  // names still get the fuzzy suggestions below.
+  const retired = retiredToolMessage(name);
+  if (retired) return retired;
   const needle = name.toLowerCase();
   const close = [...catalog.tools.keys()]
     .filter((n) => n.includes(needle) || needle.includes(n))

--- a/src/tools/vocabulary.ts
+++ b/src/tools/vocabulary.ts
@@ -523,3 +523,42 @@ export const DEAD_NAMES: readonly DeadName[] = [
     ],
   },
 ];
+
+/**
+ * deadNameRe's contract anchored to the WHOLE string — it answers "is this
+ * exact name retired?", the question call_tool has to answer when a client
+ * invokes a name that no longer exists (#659), where deadNameRe answers "does
+ * this prose mention one?".
+ *
+ * The `mcp__<server>__` prefix rides along because that is the form names take
+ * in MCP clients that namespace tools, so `apps_list` and
+ * `mcp__comfyui__apps_list` resolve to the same entry. Anchoring is the safety
+ * property: a merely-similar name (`apps_list_v2`, `my_apps_list`) returns
+ * undefined and falls through to the fuzzy unknown-tool path, so a ledger entry
+ * can never shadow the suggestions for a partial name.
+ */
+export function findDeadName(name: string): DeadName | undefined {
+  return DEAD_NAMES.find((d) => {
+    const escaped = d.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^(?:mcp__[A-Za-z0-9_]+__)?${escaped}$`).test(name);
+  });
+}
+
+/**
+ * The error a caller gets for invoking a RETIRED name: which version removed it
+ * and what to call instead, straight from the ledger — turning every
+ * consolidation from a silent break into a self-explaining one (#659). Undefined
+ * for names the ledger does not know, so callers fall through to their ordinary
+ * unknown-tool handling.
+ *
+ * `since` is usually a bare version ("0.49.0") but the pre-baseline entries carry
+ * a clause ("removed upstream before 0.48.0"), so only the version form is
+ * conjugated — "removed in ${since}" would mangle the clause into "removed in
+ * removed upstream before 0.48.0".
+ */
+export function retiredToolMessage(name: string): string | undefined {
+  const dead = findDeadName(name);
+  if (!dead) return undefined;
+  const removed = dead.since.startsWith("removed") ? dead.since : `removed in ${dead.since}`;
+  return `Unknown tool '${name}' — ${removed}. Call ${dead.replacement} instead.`;
+}


### PR DESCRIPTION
## What

Implements the actionable half of #659: a client calling a **retired** tool name through `call_tool` now gets a specific error quoting the `DEAD_NAMES` ledger — which version removed the name and what to call instead — instead of the generic fuzzy `Unknown tool '<name>'. Did you mean: ...?`.

\`\`\`
Unknown tool 'apps_list' — removed in 0.49.0. Call apps (action:"list") instead.
\`\`\`

This is the self-explaining break the issue asked for: every future consolidation (the remaining 0.49.0 slices, panel slices, #572) retires names the same way, and each lands in the ledger as part of the retirement — so from now on any external consumer calling a dead name gets pointed at its replacement, not just mobile.

## How

- **`src/tools/vocabulary.ts`** — two exports keyed off the existing ledger:
  - `findDeadName(name)` — `deadNameRe`'s matching contract (optional `mcp__<server>__` prefix) **anchored to the whole string**. Exact-match only: `apps_list_v2` / `my_apps_list` return `undefined` and fall through, so a ledger entry can never shadow the fuzzy path for partial names.
  - `retiredToolMessage(name)` — formats the error from `since` + `replacement`. `since` is conjugated as `removed in <version>` only for bare versions; the pre-baseline clause entries (`removed upstream before 0.48.0`) are quoted as-is so the sentence stays grammatical.
- **`src/tools/compact.ts`** — `unknownToolMessage` consults the helper first, so both `call_tool` and `describe_tool` return the retired-name error; genuinely unknown names get the unchanged fuzzy message.
- **`src/orchestrator/ollama-backend.ts`** — the last-resort dispatch fallback (only reached when the comfy session exposes no `call_tool` meta to delegate to) shares the helper instead of answering with the bare `Available: ...` list.

## Tests

- `vocabulary.test.ts` — `findDeadName` bare/prefixed/embedded/prefix-of/live-name cases; `retiredToolMessage` message shape, prefixed form, clause-shaped `since`, unknown name.
- `compact.test.ts` — retired name via `call_tool` (quotes since + replacement, no "Did you mean"), `mcp__comfyui__apps_run` prefixed form, `describe_tool` path, and `apps_list_v2` still taking the fuzzy path.
- `ollama-backend.test.ts` — retired name through the dispatch fallback yields the ledger error, not the `Available:` list.
- The two test files now spelling dead names as fixtures join the checker's `SELF` list, same convention as the slice-1/2 fixture tests.

## Verification

- Full suite: 220 files, 3196 passed / 1 skipped, 0 failures
- `npx tsc --noEmit` clean
- `npm run check:vocabulary` green (run after staging, per the checker's own note)

No tool-surface change (error text only) → no `docs:gen`. Refs #659 — the mobile-client `call_tool` migration half of the issue stays open.