### PR TITLE
fix(manager): route update_all tool through detectManagerApi (#656)

### DIFF
--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -60,6 +60,7 @@ const {
   installModelViaManager,
   reinstallCustomNode,
   updateCustomNode,
+  queueUpdateAllCustomNodes,
   setQueueTimingForTests,
   resetManagerApiCacheForTests,
 } = await import("../../services/node-management.js");
@@ -431,6 +432,40 @@ describe("#646 Manager API dialect cache invalidation", () => {
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/install")).toBe(true);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path === "/manager/queue/start")).toBe(true);
     expect(calls.some((call) => call.url.startsWith(targetA) && call.path.startsWith("/customnode/installed"))).toBe(true);
+  });
+
+  it("keeps the update_all tool's enqueue + start on its original target after retarget (#656)", async () => {
+    const targetA = BASE;
+    const targetB = "http://127.0.0.1:8282";
+    let retargeted = false;
+    const calls = stubServer({
+      // A serves the 3.x Manager even though the cache pinned v2; B is normal
+      // v4. The update_all tool (queueUpdateAllCustomNodes) pins ONE base for
+      // the whole operation, so the panel retarget must not redirect its
+      // self-heal retry or queue start to B.
+      persona: (url) => (url.startsWith(targetA) ? "legacy" : "v4"),
+      onCall: (url, path) => {
+        if (!retargeted && url.startsWith(targetA) && path === "/v2/manager/queue/update_all") {
+          retargeted = true;
+          target.base = targetB;
+          resetManagerApiCache("panel retargeted while Manager request was in flight");
+        }
+      },
+    });
+    resetManagerApiCacheForTests("v2");
+
+    await expect(queueUpdateAllCustomNodes()).resolves.toMatchObject({
+      endpoint: "/manager/queue/update_all",
+      queueStarted: true,
+    });
+
+    // The stale-dialect attempt, its self-heal retry, and the queue start are
+    // all pinned to A. B is now the target for subsequent calls, but receives
+    // nothing from this already-started operation.
+    expect(calls.filter((call) => call.url.startsWith(targetB))).toHaveLength(0);
+    expect(countOf(calls, "/v2/manager/queue/update_all")).toBe(1);
+    expect(countOf(calls, "/manager/queue/update_all")).toBe(1);
+    expect(countOf(calls, "/manager/queue/start")).toBe(1);
   });
 
   it("keeps BOTH halves of a reinstall on its original target after retarget", async () => {

--- a/src/__tests__/services/update-comfyui.test.ts
+++ b/src/__tests__/services/update-comfyui.test.ts
@@ -6,16 +6,27 @@ import { describe, expect, it, beforeEach, vi, type Mock } from "vitest";
 // Created with vi.hoisted so it exists before the hoisted vi.mock factory runs.
 const mockConfig = vi.hoisted(() => ({
   comfyuiPath: "/fake/ComfyUI" as string | undefined,
+  resolvedPort: 8188,
+  comfyuiHost: "127.0.0.1",
+  comfyuiSsl: false,
+  githubToken: undefined as string | undefined,
 }));
 
 vi.mock("../../config.js", () => ({
   config: mockConfig,
   getComfyUIBaseUrl: () => "http://127.0.0.1:8188",
   getComfyUIAuthHeaders: () => ({}),
+  // node-management (the update_all dialect path, #656) transitively imports
+  // this; the mock must provide it or the named import fails at load.
+  isLoopbackHost: (host?: string) => host === "127.0.0.1" || host === "localhost",
 }));
 
+// node-management pulls in comfy-cli → workspace-env, which calls
+// promisify(execFile) at module load; keep the subprocess surface inert.
 vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
+  spawnSync: vi.fn(() => ({ status: 0, stdout: "{}", stderr: "" })),
 }));
 
 vi.mock("node:fs", () => ({
@@ -40,25 +51,93 @@ import {
   updateComfyUICore,
   updateAllCustomNodes,
 } from "../../services/update-comfyui.js";
+import { resetManagerApiCacheForTests } from "../../services/node-management.js";
 
 const mockedExec = execFileSync as unknown as Mock;
 const mockedExists = existsSync as unknown as Mock;
 
-function mockFetchOnce(responses: Array<{ ok: boolean; status: number; body: unknown }>) {
-  let i = 0;
-  const fn = vi.fn(async () => {
-    const r = responses[Math.min(i, responses.length - 1)];
-    i++;
-    return {
-      ok: r.ok,
-      status: r.status,
-      text: async () =>
-        typeof r.body === "string" ? r.body : JSON.stringify(r.body),
-    } as unknown as Response;
+const BASE = "http://127.0.0.1:8188";
+
+interface Call {
+  url: string;
+  path: string;
+  method: string;
+  body: unknown;
+}
+
+/** Which Manager generation the (single) URL is serving. */
+type Persona = "legacy" | "v4" | "v2-batch";
+
+const DRAINED = { total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false };
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * One ComfyUI whose Manager answers the dialect-detection probes according to
+ * its persona, so updateAllCustomNodes exercises the SAME detectManagerApi
+ * path as the other Manager operations (#656):
+ *   "legacy"   = the 3.x custom-node Manager: no /v2/* at all, per-operation
+ *                routes under /manager/*.
+ *   "v4"       = normal pip Manager: the /v2 surface answers, is_legacy_manager_ui
+ *                false, and NO bare /manager/* (an unregistered POST there is
+ *                answered 405 by ComfyUI's frontend catchall — the misroute the
+ *                old hardcoded-legacy update_all hit).
+ *   "v2-batch" = pip Manager in legacy-UI mode: /v2 surface, is_legacy_manager_ui
+ *                true.
+ */
+function stubManager(
+  persona: Persona,
+  opts: { updateAllStatus?: number; failStart?: "error" } = {},
+) {
+  const calls: Call[] = [];
+  const fn = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    const path = new URL(url).pathname;
+    calls.push({ url, path, method, body });
+
+    if (persona === "legacy") {
+      if (path === "/manager/queue/status") return jsonResponse(DRAINED);
+      if (path === "/manager/version") return new Response("V3.41", { status: 200 });
+      if (path === "/manager/queue/update_all" && method === "POST") {
+        const status = opts.updateAllStatus ?? 200;
+        return new Response(status === 200 ? "" : String(status), { status });
+      }
+      if (path === "/manager/queue/start") {
+        if (opts.failStart === "error") throw new Error("connection reset");
+        return new Response("", { status: 200 });
+      }
+      // The 3.x custom-node Manager registers no /v2/* at all.
+      return new Response("404: Not Found", { status: 404 });
+    }
+
+    // pip comfyui_manager (v4 lineage): the /v2 surface answers.
+    if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
+    if (path === "/v2/manager/is_legacy_manager_ui") {
+      return jsonResponse({ is_legacy_manager_ui: persona === "v2-batch" });
+    }
+    if (path === "/v2/manager/queue/update_all" && method === "POST") {
+      return new Response("", { status: 200 });
+    }
+    if (path === "/v2/manager/queue/start") {
+      if (opts.failStart === "error") throw new Error("connection reset");
+      return new Response("", { status: 200 });
+    }
+    // A v4 host registers NO bare /manager/* route.
+    if (path.startsWith("/manager/")) return new Response("405", { status: 405 });
+    return new Response("404: Not Found", { status: 404 });
   });
   vi.stubGlobal("fetch", fn);
-  return fn;
+  return calls;
 }
+
+const countOf = (calls: Call[], path: string, method = "POST"): number =>
+  calls.filter((c) => c.path === path && c.method === method).length;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -70,6 +149,9 @@ beforeEach(() => {
     source: "launched",
     reason: "test interpreter",
   });
+  // The detected dialect is cached across calls — drop it so each test's
+  // persona is probed fresh.
+  resetManagerApiCacheForTests();
 });
 
 // --- updateComfyUICore --------------------------------------------------
@@ -224,51 +306,78 @@ describe("updateComfyUICore", () => {
 // --- updateAllCustomNodes ----------------------------------------------
 
 describe("updateAllCustomNodes", () => {
-  it("POSTs update_all then starts the queue", async () => {
-    const fetchFn = mockFetchOnce([
-      { ok: true, status: 200, body: { result: "queued" } },
-      { ok: true, status: 200, body: { started: true } },
-    ]);
+  it("on a legacy 3.x host: POSTs /manager/queue/update_all then starts the queue", async () => {
+    const calls = stubManager("legacy");
 
     const r = await updateAllCustomNodes();
     expect(r.updated).toBe(true);
     expect(r.endpoint).toBe("/manager/queue/update_all");
     expect(r.queue_started).toBe(true);
 
-    expect(fetchFn).toHaveBeenCalledTimes(2);
-    const [updateUrl, updateInit] = fetchFn.mock.calls[0];
-    expect(updateUrl).toBe("http://127.0.0.1:8188/manager/queue/update_all");
-    expect(updateInit.method).toBe("POST");
-    expect(JSON.parse(updateInit.body)).toEqual({ mode: "default" });
-
-    const [startUrl, startInit] = fetchFn.mock.calls[1];
-    expect(startUrl).toBe("http://127.0.0.1:8188/manager/queue/start");
-    expect(startInit.method).toBe("POST");
+    const update = calls.find((c) => c.path === "/manager/queue/update_all");
+    expect(update?.method).toBe("POST");
+    expect(update?.url).toBe(`${BASE}/manager/queue/update_all`);
+    // 3.x reads {mode} from the JSON body; no query string.
+    expect(update?.body).toMatchObject({ mode: "remote" });
+    expect(typeof (update?.body as { ui_id?: unknown }).ui_id).toBe("string");
+    expect(countOf(calls, "/manager/queue/start")).toBe(1);
   });
 
-  it("throws when Manager returns a non-OK status for update_all", async () => {
-    mockFetchOnce([{ ok: false, status: 404, body: "not found" }]);
-    await expect(updateAllCustomNodes()).rejects.toThrow(/returned 404/);
+  // #656: the old implementation hardcoded POST /manager/queue/update_all,
+  // which a v4 host answers 405 (ComfyUI's frontend catchall) — the tool must
+  // detect the dialect and speak v4 instead.
+  it("on a v4 host: detects the dialect and POSTs /v2/manager/queue/update_all (never the legacy route)", async () => {
+    const calls = stubManager("v4");
+
+    const r = await updateAllCustomNodes();
+    expect(r.updated).toBe(true);
+    expect(r.endpoint).toBe("/v2/manager/queue/update_all");
+    expect(r.queue_started).toBe(true);
+
+    // The hardcoded-legacy misroute was never attempted.
+    expect(countOf(calls, "/manager/queue/update_all")).toBe(0);
+    expect(countOf(calls, "/manager/queue/start")).toBe(0);
+
+    // v4 reads UpdateAllQueryParams from the QUERY string, not the body.
+    const update = calls.find((c) => c.path === "/v2/manager/queue/update_all");
+    expect(update?.method).toBe("POST");
+    const u = new URL(update!.url);
+    expect(u.searchParams.get("mode")).toBe("remote");
+    expect(u.searchParams.get("client_id")).toBe("comfyui-mcp");
+    expect(u.searchParams.get("ui_id")).toBeTruthy();
+    expect(update?.body).toBeUndefined();
+
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(1);
+  });
+
+  it("on a v2-batch host (pip Manager in legacy-UI mode): also routes at the /v2 update_all route", async () => {
+    const calls = stubManager("v2-batch");
+
+    const r = await updateAllCustomNodes();
+    expect(r.endpoint).toBe("/v2/manager/queue/update_all");
+    expect(countOf(calls, "/manager/queue/update_all")).toBe(0);
+    expect(countOf(calls, "/v2/manager/queue/update_all")).toBe(1);
+    expect(countOf(calls, "/v2/manager/queue/start")).toBe(1);
+  });
+
+  it("throws when Manager rejects update_all — and does NOT re-send the mutation", async () => {
+    // A 404 is a route-level rejection: the dialect self-heal re-probes, finds
+    // the dialect UNCHANGED (still legacy), and surfaces the original failure
+    // instead of retrying — update_all must never execute twice (#656 caution).
+    const calls = stubManager("legacy", { updateAllStatus: 404 });
+    await expect(updateAllCustomNodes()).rejects.toThrow(/ComfyUI-Manager API 404/);
+    expect(countOf(calls, "/manager/queue/update_all")).toBe(1);
+    // The queue was never started, so no half-run operation is left behind.
+    expect(countOf(calls, "/manager/queue/start")).toBe(0);
   });
 
   it("still succeeds (queue_started=false) if starting the queue fails", async () => {
-    let call = 0;
-    const fn = vi.fn(async () => {
-      call++;
-      if (call === 1) {
-        return {
-          ok: true,
-          status: 200,
-          text: async () => JSON.stringify({ result: "queued" }),
-        } as unknown as Response;
-      }
-      throw new Error("connection reset");
-    });
-    vi.stubGlobal("fetch", fn);
+    stubManager("legacy", { failStart: "error" });
 
     const r = await updateAllCustomNodes();
     expect(r.updated).toBe(true);
     expect(r.queue_started).toBe(false);
+    expect(r.message).toMatch(/Could not confirm the queue worker started/);
   });
 
   it("throws a clear error when ComfyUI-Manager is unreachable", async () => {
@@ -276,7 +385,7 @@ describe("updateAllCustomNodes", () => {
       throw new Error("ECONNREFUSED");
     });
     vi.stubGlobal("fetch", fn);
-    await expect(updateAllCustomNodes()).rejects.toThrow(/Failed to reach ComfyUI-Manager/);
+    await expect(updateAllCustomNodes()).rejects.toThrow(/queue API is not reachable/);
   });
 });
 
@@ -284,10 +393,7 @@ describe("updateAllCustomNodes", () => {
 
 describe("update_all is custom-nodes-only", () => {
   it("runs no git/pip core-update commands (mirrors comfy-cli `update all`)", async () => {
-    mockFetchOnce([
-      { ok: true, status: 200, body: { result: "queued" } },
-      { ok: true, status: 200, body: { started: true } },
-    ]);
+    stubManager("legacy");
     await updateAllCustomNodes();
     // update_all touches ONLY the ComfyUI-Manager HTTP API — it must never
     // git pull / pip install ComfyUI core.

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1844,6 +1844,50 @@ async function updateManagerSelf(id: string): Promise<NodeOpResult> {
   };
 }
 
+/**
+ * ENQUEUE update_all on its dedicated route in the detected dialect, WITHOUT
+ * draining the queue. Shared by updateCustomNode({id:"all"}) (which drains) and
+ * the update_all tool's fire-and-forget path (queueUpdateAllCustomNodes), so
+ * both inherit dialect selection, cache invalidation, and the 404/405-only
+ * re-send discipline from enqueueWithDialectSelfHeal — a 400 re-detects but is
+ * never re-sent, so update_all can never run twice (#656).
+ *
+ * Returns the dialect the enqueue ACTUALLY spoke (so the caller starts/polls
+ * the queue holding the task) and the route's raw response body.
+ */
+async function enqueueUpdateAll(
+  mode: string,
+  base: string,
+): Promise<{ used: ManagerApi; response: unknown }> {
+  let response: unknown;
+  const used = await enqueueWithDialectSelfHeal("update-all", async (api) => {
+    // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
+    // (manager_server.py), NOT the JSON body — a body-only request leaves mode
+    // defaulting to 'remote' and drops client_id/ui_id. Send them as URL query
+    // params. A fresh ui_id per attempt keeps the two attempts distinguishable.
+    const uiId = randomUUID();
+    if (api === "legacy") {
+      // 3.x reads {mode} from the JSON BODY (and ignores client_id/ui_id).
+      response = await managerFetch("/manager/queue/update_all", {
+        method: "POST",
+        body: { mode, ui_id: uiId },
+        base,
+      });
+    } else {
+      const query = new URLSearchParams({
+        mode,
+        client_id: MANAGER_CLIENT_ID,
+        ui_id: uiId,
+      }).toString();
+      response = await managerFetch(`/v2/manager/queue/update_all?${query}`, {
+        method: "POST",
+        base,
+      });
+    }
+  }, base);
+  return { used, response };
+}
+
 export function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
   return withObjectInfoInvalidation(() => updateCustomNodeImpl(opts));
 }
@@ -1879,31 +1923,7 @@ async function updateCustomNodeImpl(
     // the same enqueue-only self-heal so a stale classification can't wedge it
     // either (#646). Enqueue here, drain once below.
     const base = managerBaseUrl();
-    const used = await enqueueWithDialectSelfHeal("update-all", async (api) => {
-      // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
-      // (manager_server.py), NOT the JSON body — a body-only request leaves mode
-      // defaulting to 'remote' and drops client_id/ui_id. Send them as URL query
-      // params. A fresh ui_id per attempt keeps the two attempts distinguishable.
-      const uiId = randomUUID();
-      if (api === "legacy") {
-        // 3.x reads {mode} from the JSON BODY (and ignores client_id/ui_id).
-        await managerFetch("/manager/queue/update_all", {
-          method: "POST",
-          body: { mode, ui_id: uiId },
-          base,
-        });
-      } else {
-        const query = new URLSearchParams({
-          mode,
-          client_id: MANAGER_CLIENT_ID,
-          ui_id: uiId,
-        }).toString();
-        await managerFetch(`/v2/manager/queue/update_all?${query}`, {
-          method: "POST",
-          base,
-        });
-      }
-    }, base);
+    const { used } = await enqueueUpdateAll(mode, base);
     status = await runManagerQueue(used, base);
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
@@ -1916,6 +1936,51 @@ async function updateCustomNodeImpl(
       : `Queued + updated "${id}" via ComfyUI-Manager.`,
     details: status,
   };
+}
+
+/**
+ * Result of the update_all tool's fire-and-forget path (queueUpdateAllCustomNodes).
+ */
+export interface QueueUpdateAllResult {
+  /** The update_all route the enqueue actually used (dialect-dependent). */
+  endpoint: string;
+  /** Whether the queue worker was confirmed started. */
+  queueStarted: boolean;
+  /** Raw update_all response body, when the route produced one. */
+  managerResponse?: unknown;
+}
+
+/**
+ * The update_all MCP tool's path (#656): enqueue update_all in the DETECTED
+ * dialect and kick the queue worker, then return WITHOUT draining — the tool
+ * reports "queued + started" and the updates run asynchronously (unlike
+ * updateCustomNode({id:"all"}), which drains the queue). Routed through the
+ * same detectManagerApi + enqueue-with-self-heal machinery as every other
+ * Manager mutation, so it inherits dialect selection, cache invalidation, and
+ * the no-double-execute discipline rather than assuming the legacy 3.x route.
+ *
+ * No object_info invalidation here: the queued updates only take effect after
+ * a ComfyUI RESTART, and the restart lifecycle already drops that cache.
+ */
+export async function queueUpdateAllCustomNodes(): Promise<QueueUpdateAllResult> {
+  // One pinned target for the whole operation — detection, the enqueue, any
+  // self-heal retry, and the queue start all stay on the instance selected at
+  // invocation, even if the panel retargets mid-call.
+  const base = managerBaseUrl();
+  const { used, response } = await enqueueUpdateAll("remote", base);
+  const prefix = managerQueuePrefixFor(used);
+  let queueStarted = true;
+  try {
+    await managerQueueControl(`${prefix}/start`, base);
+  } catch (err) {
+    // The update_all IS queued — a start failure must not fail the whole call;
+    // report it so the user can kick the queue manually.
+    queueStarted = false;
+    logger.warn("Queued update_all but failed to start the queue worker", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return { endpoint: `${prefix}/update_all`, queueStarted, managerResponse: response };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -2,9 +2,9 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { platform } from "node:os";
-import { config, getComfyUIBaseUrl } from "../config.js";
-import { comfyuiFetch } from "../comfyui/fetch.js";
+import { config } from "../config.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
+import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 
@@ -121,51 +121,6 @@ function requireComfyUIPath(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Manager HTTP client (local helper — no shared module)
-// ---------------------------------------------------------------------------
-
-function managerBaseUrl(): string {
-  return getComfyUIBaseUrl();
-}
-
-interface ManagerFetchResult {
-  ok: boolean;
-  status: number;
-  body: unknown;
-}
-
-async function managerFetch(
-  path: string,
-  init?: RequestInit,
-  timeoutMs = 30_000,
-): Promise<ManagerFetchResult> {
-  const url = `${managerBaseUrl()}${path}`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await comfyuiFetch(url, { ...init, signal: controller.signal });
-    let body: unknown = null;
-    const text = await res.text();
-    if (text) {
-      try {
-        body = JSON.parse(text);
-      } catch {
-        body = text;
-      }
-    }
-    return { ok: res.ok, status: res.status, body };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    throw new ProcessControlError(
-      `Failed to reach ComfyUI-Manager at ${url}: ${msg}. ` +
-        "Is ComfyUI running with ComfyUI-Manager installed?",
-    );
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -236,45 +191,27 @@ export async function updateComfyUICore(): Promise<UpdateCoreResult> {
 
 /**
  * Update all installed custom nodes via the ComfyUI-Manager HTTP API.
- * Queues the update_all task then starts the queue worker.
+ * Queues the update_all task then starts the queue worker (fire-and-forget —
+ * the updates run asynchronously; unlike update_node with id "all", which
+ * drains the queue).
  *
- * Endpoints (confirmed against Comfy-Org/ComfyUI-Manager):
- *   POST /manager/queue/update_all   — queue update of all nodes
- *   POST /manager/queue/start        — start processing the queue
+ * Routed through the Manager dialect machinery in node-management.ts (#656),
+ * so the route follows the detected dialect instead of a hardcoded legacy
+ * assumption:
+ *   legacy 3.x:     POST /manager/queue/update_all      (mode in the JSON body)
+ *   v4 / v2-batch:  POST /v2/manager/queue/update_all   (mode/client_id/ui_id
+ *                                                      as query params)
+ * then POST <same prefix>/start to kick the worker.
  */
 export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
-  const endpoint = "/manager/queue/update_all";
-
-  const queued = await managerFetch(endpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ mode: "default" }),
-  });
-
-  if (!queued.ok) {
-    throw new ProcessControlError(
-      `ComfyUI-Manager returned ${queued.status} for ${endpoint}: ` +
-        `${typeof queued.body === "string" ? queued.body : JSON.stringify(queued.body)}`,
-    );
-  }
-
-  // Kick off the worker that drains the queue.
-  let queueStarted = false;
-  try {
-    const started = await managerFetch("/manager/queue/start", { method: "POST" });
-    queueStarted = started.ok;
-  } catch (err) {
-    logger.warn("Queued node updates but failed to start the queue worker", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
+  const result = await queueUpdateAllCustomNodes();
 
   return {
     updated: true,
-    endpoint,
-    queue_started: queueStarted,
-    manager_response: queued.body,
-    message: queueStarted
+    endpoint: result.endpoint,
+    queue_started: result.queueStarted,
+    manager_response: result.managerResponse,
+    message: result.queueStarted
       ? "Queued updates for all custom nodes via ComfyUI-Manager and started the queue worker. " +
         "Updates run asynchronously; a ComfyUI restart may be required afterward."
       : "Queued updates for all custom nodes via ComfyUI-Manager. " +


### PR DESCRIPTION
## What

The `update_all` MCP tool (`src/services/update-comfyui.ts` → `updateAllCustomNodes()`) was the last Manager call site that bypassed `detectManagerApi()` entirely: it POSTed the hardcoded legacy route `/manager/queue/update_all` unconditionally, then `/manager/queue/start`. On a Manager v4 host those routes don't exist — ComfyUI's frontend catchall answers the unregistered POST with 405, the exact wrong-dialect symptom reported in #646/#424.

Tracked in #656 (left deliberately out of scope for #653).

## How

- Extracted the dialect-aware update_all enqueue from `updateCustomNode({id:"all"})` into a shared `enqueueUpdateAll()` in `node-management.ts`, and added `queueUpdateAllCustomNodes()` — the tool's fire-and-forget path (enqueue + queue start, **no drain**; `update_node` with `id: "all"` still drains). No parallel dialect logic: both callers share the one enqueue.
- `updateAllCustomNodes()` is now a thin adapter over it; the tool result shape, messages, and registration are unchanged (no tool-surface change, no docs:gen). The dead local `managerFetch` helper in `update-comfyui.ts` is removed.
- It inherits the full #646/#670 machinery:
  - dialect selection (`legacy` → body `{mode, ui_id}` on `/manager/queue/update_all`; `v2`/`v2-batch` → query params on `/v2/manager/queue/update_all`),
  - cache invalidation + TTL + per-call self-heal,
  - the no-double-execute discipline: a re-send happens **only** on a route-level 404/405 (which proves nothing ran); an ambiguous 400 re-detects and surfaces the `dialectChangedError` — per the #656 caution, update_all can never be replayed,
  - retarget-pin: one `base` captured per operation, so a panel retarget mid-call cannot redirect the retry or the queue start.
- Wire note: the legacy-route body now sends `mode: "remote"` (Manager's own default, and what `update_node` `id=all` sends) instead of `"default"`, which is a channel name, not an update mode.

## Sweep result (per #656)

Three other call sites still carry their own local `managerFetch` + hardcoded legacy routes and bypass `detectManagerApi()`: `workflow-deps.ts` (`/manager/queue/install|start|reset`), `node-bisect.ts` (`/manager/queue/disable|install|start`), `manager-config.ts` (`/manager/queue/reset`). Left untouched here to keep this PR minimal — worth a follow-up issue if they should get the same treatment.

## Tests

- `update-comfyui.test.ts`: reworked the `updateAllCustomNodes` block to persona-stubbed servers mirroring the manager-dialect-cache style — legacy 3.x (body shape, no query string), **v4 host (the #656 regression: asserts `/manager/queue/update_all` is never attempted and the v4 query-param route is used)**, v2-batch, update_all rejection (asserts the mutation is NOT re-sent and the queue never starts), queue-start failure (`queue_started=false`), unreachable Manager.
- `manager-dialect-cache.test.ts`: added a retarget-pin test for `queueUpdateAllCustomNodes` mirroring the install retarget test (stale v2 cache, A serves legacy, retarget to B mid-call → retry + start stay on A, nothing reaches B).
- Verified: the 4 affected files (155 tests) pass; full suite 3184 passed / 1 skipped; `npx tsc --noEmit` clean. (Rebased onto `origin/main` including the #655 test fix, so the previously-failing `node-dev` builtin-fallback test passes too.)