### PR TITLE
fix(tools): compact tool mode is the default; --full opts back in (#667)

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,10 +669,11 @@ doesn't work). Thinking and vision are strongly recommended — without
 thinking, multi-step tool chains degrade; without vision the agent can
 generate but can't see its own outputs.
 
-For small/local models, **compact tool mode** (`--compact` /
-`COMFYUI_MCP_TOOL_MODE=compact`) registers 3 meta-tools
+**Compact tool mode is the default**: the server registers 3 meta-tools
 (`list_tools` → `describe_tool` → `call_tool`) instead of the full ~200-schema
-surface, pulling schemas into context one tool at a time. **Run it locally
+surface (~200 KB / ~50k tokens per `tools/list`), pulling schemas into context
+one tool at a time. Frontier-model harnesses opt back into the full surface
+with `--full` / `COMFYUI_MCP_TOOL_MODE=full`. **Run it locally
 for free with our fine-tuned models**: `ollama pull artokun/gemma4-comfyui-mcp:e4b`
 (also `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB) — Gemma 4 QLoRA-trained on 1,055
 server-verified trajectories over the full comfyui-mcp tool surface, and the
@@ -685,7 +686,7 @@ per-harness setup, troubleshooting:
 | Flag | Env | Default | Description |
 |------|-----|---------|-------------|
 | `setup <agent>` | | | Write the comfyui entry into hermes / openclaw / copilot config, then exit |
-| `--compact` / `--tool-mode compact` | `COMFYUI_MCP_TOOL_MODE=compact` | `full` | Register 3 meta-tools instead of the full ~200-schema surface |
+| `--full` / `--tool-mode full` | `COMFYUI_MCP_TOOL_MODE=full` | `compact` | Opt into the full ~200-schema surface; the default compact mode registers 3 meta-tools instead |
 
 ### Other agents & local LLMs (Hermes, OpenClaw, Copilot CLI, Ollama)
 
@@ -705,10 +706,11 @@ doesn't work). Thinking and vision are strongly recommended — without
 thinking, multi-step tool chains degrade; without vision the agent can
 generate but can't see its own outputs.
 
-For small/local models, **compact tool mode** (`--compact` /
-`COMFYUI_MCP_TOOL_MODE=compact`) registers 3 meta-tools
+**Compact tool mode is the default**: the server registers 3 meta-tools
 (`list_tools` → `describe_tool` → `call_tool`) instead of the full ~200-schema
-surface, pulling schemas into context one tool at a time. **Run it locally
+surface (~200 KB / ~50k tokens per `tools/list`), pulling schemas into context
+one tool at a time. Frontier-model harnesses opt back into the full surface
+with `--full` / `COMFYUI_MCP_TOOL_MODE=full`. **Run it locally
 for free with our fine-tuned models**: `ollama pull artokun/gemma4-comfyui-mcp:e4b`
 (also `:e2b` for ~2 GB VRAM, `:12b` for ~8 GB) — Gemma 4 QLoRA-trained on 1,055
 server-verified trajectories over the full comfyui-mcp tool surface, and the
@@ -721,7 +723,7 @@ per-harness setup, troubleshooting:
 | Flag | Env | Default | Description |
 |------|-----|---------|-------------|
 | `setup <agent>` | | | Write the comfyui entry into hermes / openclaw / copilot config, then exit |
-| `--compact` / `--tool-mode compact` | `COMFYUI_MCP_TOOL_MODE=compact` | `full` | Register 3 meta-tools instead of the full ~200-schema surface |
+| `--full` / `--tool-mode full` | `COMFYUI_MCP_TOOL_MODE=full` | `compact` | Opt into the full ~200-schema surface; the default compact mode registers 3 meta-tools instead |
 
 ### Remote ComfyUI
 

--- a/docs/local-llms.mdx
+++ b/docs/local-llms.mdx
@@ -29,10 +29,11 @@ models (below) generally keep tool calling and drop the rest.
 
 ## Compact tool mode
 
-The full surface is 169 tools with rich JSON schemas. Most non-Claude
-harnesses inject every registered schema straight into the model's context —
-fine for frontier models, fatal for a 4B local one. **Compact tool mode**
-registers exactly **three meta-tools** and keeps the real catalog behind them:
+The full surface is 169 tools with rich JSON schemas (~200 KB, roughly 50k
+tokens, per `tools/list`). Most non-Claude harnesses inject every registered
+schema straight into the model's context — fine for frontier models, fatal
+for a 4B local one. **Compact tool mode** registers exactly **three
+meta-tools** and keeps the real catalog behind them:
 
 | Meta-tool | What it does |
 | --- | --- |
@@ -47,7 +48,8 @@ string, common field aliases (`tool_name`, `arguments`) are accepted, and
 validation errors come back with the expected schema so the model can
 self-correct instead of dying on an opaque protocol error.
 
-Enable it with either (the flag wins):
+Compact is the **default** — no flags needed. The opt-ins below are only
+needed to force a mode explicitly (the flag wins over the env var):
 
 ```bash
 npx -y comfyui-mcp --compact
@@ -55,8 +57,10 @@ npx -y comfyui-mcp --compact
 COMFYUI_MCP_TOOL_MODE=compact npx -y comfyui-mcp
 ```
 
-`--full` / `--tool-mode full` (default) keeps the classic full-schema surface —
-nothing changes for Claude Code / Cursor / Claude Desktop users.
+`--full` / `--tool-mode full` / `COMFYUI_MCP_TOOL_MODE=full` opts back into
+the classic full-schema surface — right for frontier-model harnesses
+(Claude Code / Cursor / Claude Desktop) whose clients handle large tool
+lists well.
 
 ## One-command setup
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -176,9 +176,10 @@ stdio mode (the default, what MCP clients use) needs none of this.
   arena; `:e4b` remains the sweet spot).
 - **gemma3 has no native tool calling in Ollama** — unsupported; use
   our fine-tune above, stock `gemma4` (e4b+), `qwen3`, or `llama3.1+`.
-- Make sure [compact tool mode](/local-llms) is on for small models
-  (`--compact`) — ~200 full schemas overflow small contexts and the model
-  starts hallucinating tool names.
+- Make sure [compact tool mode](/local-llms) is on for small models —
+  it's the default, so this only bites if you opted into `--full`: ~200 full
+  schemas overflow small contexts and the model starts hallucinating tool
+  names.
 - Cold model loads can take 30s+ before the first token — the panel's
   watchdog accounts for this, but a request that dies instantly usually
   means the model tag isn't pulled (`ollama pull <tag>`).

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -3,7 +3,8 @@
     "command": "npx",
     "args": [
       "-y",
-      "comfyui-mcp"
+      "comfyui-mcp",
+      "--full"
     ],
     "env": {
       "CIVITAI_API_TOKEN": ""

--- a/src/__tests__/orchestrator/ollama-backend.test.ts
+++ b/src/__tests__/orchestrator/ollama-backend.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { OllamaBackend, isOllamaModel, type McpToolClient } from "../../orchestrator/ollama-backend.js";
+import { OllamaBackend, comfyuiSpawnEnv, isOllamaModel, type McpToolClient } from "../../orchestrator/ollama-backend.js";
 import type { AgentEvent, NeutralTurn } from "../../orchestrator/agent-backend.js";
 
 // ---------------------------------------------------------------------------
@@ -577,5 +577,33 @@ describe("inline image delivery (per-model vision, graceful degradation)", () =>
     await collect(backend, turnsOf({ text: "hello" }));
     const user = chatRequests[0].messages.find((m) => m.role === "user") as { images?: string[] };
     expect(user.images).toBeUndefined();
+  });
+});
+
+describe("comfyuiSpawnEnv (#667)", () => {
+  // The ollama path spawns the headless comfyui MCP COMPACT by default (small
+  // local models choke on the full ~200-schema list), but an EXPLICIT user
+  // choice must win over that default — the pre-#667 force overwrote even an
+  // explicit COMFYUI_MCP_TOOL_MODE=full.
+  it("an explicit COMFYUI_MCP_TOOL_MODE=full in the user env survives the ollama path", () => {
+    const env = comfyuiSpawnEnv(undefined, { COMFYUI_MCP_TOOL_MODE: "full", PATH: "/bin" });
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("full");
+    expect(env.PATH).toBe("/bin");
+  });
+
+  it("an explicit COMFYUI_MCP_TOOL_MODE=compact in the user env is honored (not just defaulted)", () => {
+    const env = comfyuiSpawnEnv(undefined, { COMFYUI_MCP_TOOL_MODE: "compact" });
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("compact");
+  });
+
+  it("the spec's resolved lane mode wins over an unset user env (orchestrator → child channel)", () => {
+    const env = comfyuiSpawnEnv({ COMFYUI_MCP_TOOL_MODE: "full", CIVITAI_API_TOKEN: "tok" }, {});
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("full");
+    expect(env.CIVITAI_API_TOKEN).toBe("tok");
+  });
+
+  it("unset env AND no spec mode gets the documented compact default", () => {
+    const env = comfyuiSpawnEnv(undefined, {});
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("compact");
   });
 });

--- a/src/__tests__/services/agent-setup.test.ts
+++ b/src/__tests__/services/agent-setup.test.ts
@@ -69,10 +69,12 @@ describe("setupAgent", () => {
     const res = await setupAgent({ agent: "copilot", configPath });
     expect(res.compact).toBe(false);
     const parsed = JSON.parse(await fs.readFile(configPath, "utf8"));
+    // --full is pinned explicitly: bare `npx comfyui-mcp` means compact since
+    // #667, so an unpinned entry would silently flip modes on upgrade.
     expect(parsed.mcpServers.comfyui).toEqual({
       type: "stdio",
       command: "npx",
-      args: ["-y", "comfyui-mcp"],
+      args: ["-y", "comfyui-mcp", "--full"],
       env: {},
       tools: ["*"],
     });
@@ -83,6 +85,7 @@ describe("setupAgent", () => {
     expect(JSON.parse(copilot.content).mcpServers.comfyui.args).toContain("--compact");
     const hermes = await setupAgent({ agent: "hermes", configPath: join(dir, "h.yaml"), compact: false });
     expect(hermes.content).not.toContain("--compact");
+    expect(hermes.content).toContain("--full");
   });
 
   it("is idempotent: running twice leaves one comfyui entry", async () => {
@@ -91,7 +94,7 @@ describe("setupAgent", () => {
     await setupAgent({ agent: "openclaw", configPath, compact: false });
     const parsed = JSON.parse(await fs.readFile(configPath, "utf8"));
     expect(Object.keys(parsed.mcpServers)).toEqual(["comfyui"]);
-    expect(parsed.mcpServers.comfyui.args).toEqual(["-y", "comfyui-mcp"]);
+    expect(parsed.mcpServers.comfyui.args).toEqual(["-y", "comfyui-mcp", "--full"]);
   });
 
   it("dry run returns content without touching disk", async () => {

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseCliArgs, validateConnectUrl } from "../../transport/cli.js";
+import { exportExplicitToolMode, parseCliArgs, validateConnectUrl } from "../../transport/cli.js";
 
 const base = ["node", "comfyui-mcp"];
 
@@ -167,6 +167,33 @@ describe("parseCliArgs", () => {
   it("explicit flags override env values", () => {
     const o = parseCliArgs([...base, "--port", "7000"], { MCP_PORT: "5000" });
     expect(o.port).toBe(7000);
+  });
+});
+
+describe("exportExplicitToolMode (#667)", () => {
+  // The panel orchestrator's spawned MCP children read the tool mode from the
+  // ENV, so an explicit CLI choice must be exported before they spawn —
+  // otherwise `--full --panel-orchestrator` silently ran compact downstream.
+  it("exports an explicit --full so orchestrator children spawn the full surface", () => {
+    const cli = parseCliArgs([...base, "--full", "--panel-orchestrator"], {});
+    const env: NodeJS.ProcessEnv = {};
+    exportExplicitToolMode(cli, env);
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("full");
+  });
+
+  it("exports an explicit --compact (and an explicit env mode survives parsing)", () => {
+    const env: NodeJS.ProcessEnv = {};
+    exportExplicitToolMode(parseCliArgs([...base, "--compact"], {}), env);
+    expect(env.COMFYUI_MCP_TOOL_MODE).toBe("compact");
+    const env2: NodeJS.ProcessEnv = {};
+    exportExplicitToolMode(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }), env2);
+    expect(env2.COMFYUI_MCP_TOOL_MODE).toBe("full");
+  });
+
+  it("leaves the env UNSET when the mode was only defaulted (children apply their documented default)", () => {
+    const env: NodeJS.ProcessEnv = {};
+    exportExplicitToolMode(parseCliArgs(base, {}), env);
+    expect("COMFYUI_MCP_TOOL_MODE" in env).toBe(false);
   });
 });
 

--- a/src/__tests__/transport/cli.test.ts
+++ b/src/__tests__/transport/cli.test.ts
@@ -7,7 +7,7 @@ describe("parseCliArgs", () => {
   it("defaults to stdio on 127.0.0.1:9100 with no args/env", () => {
     expect(parseCliArgs(base, {})).toEqual({
       transport: "stdio",
-      toolMode: "full",
+      toolMode: "compact",
       toolModeExplicit: false,
       host: "127.0.0.1",
       port: 9100,
@@ -31,33 +31,42 @@ describe("parseCliArgs", () => {
 
   it("supports --port value and --host value", () => {
     const o = parseCliArgs([...base, "--http", "--host", "0.0.0.0", "--port", "8080"], {});
-    expect(o).toEqual({ transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 8080, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("supports --flag=value form", () => {
     const o = parseCliArgs([...base, "--transport=http", "--port=3000", "--host=0.0.0.0"], {});
-    expect(o).toEqual({ transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 3000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
   it("reads env defaults", () => {
     const o = parseCliArgs(base, { MCP_TRANSPORT: "http", MCP_HOST: "0.0.0.0", MCP_PORT: "5000" });
-    expect(o).toEqual({ transport: "http", toolMode: "full", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
+    expect(o).toEqual({ transport: "http", toolMode: "compact", toolModeExplicit: false, host: "0.0.0.0", port: 5000, panelOrchestrator: false, token: undefined, tunnel: false, allowUnauthenticated: false, insecureBridge: false, setupAgent: undefined, setupDryRun: false });
   });
 
-  it("--compact / --tool-mode / COMFYUI_MCP_TOOL_MODE select the compact tool mode", () => {
-    expect(parseCliArgs(base, {}).toolMode).toBe("full");
+  it("compact is the DEFAULT tool mode; --full / COMFYUI_MCP_TOOL_MODE=full opts out (#667)", () => {
+    expect(parseCliArgs(base, {}).toolMode).toBe("compact");
     expect(parseCliArgs([...base, "--compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs([...base, "--tool-mode", "compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs([...base, "--tool-mode=compact"], {}).toolMode).toBe("compact");
     expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode).toBe("compact");
-    // explicit --tool-mode full / --full overrides the env opt-in
+    // the full surface is still available, explicitly
+    expect(parseCliArgs([...base, "--full"], {}).toolMode).toBe("full");
+    expect(parseCliArgs([...base, "--tool-mode", "full"], {}).toolMode).toBe("full");
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }).toolMode).toBe("full");
+    // explicit CLI wins over env, in both directions
     expect(
       parseCliArgs([...base, "--tool-mode", "full"], { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode,
     ).toBe("full");
     expect(parseCliArgs([...base, "--full"], { COMFYUI_MCP_TOOL_MODE: "compact" }).toolMode).toBe("full");
-    // unknown values fall back to full
-    expect(parseCliArgs([...base, "--tool-mode", "bogus"], {}).toolMode).toBe("full");
-    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "bogus" }).toolMode).toBe("full");
+    expect(parseCliArgs([...base, "--compact"], { COMFYUI_MCP_TOOL_MODE: "full" }).toolMode).toBe("compact");
+    // unknown values fall back to the compact default
+    expect(parseCliArgs([...base, "--tool-mode", "bogus"], {}).toolMode).toBe("compact");
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "bogus" }).toolMode).toBe("compact");
+    // either explicit env mode counts as an explicit choice (for `setup`)
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "compact" }).toolModeExplicit).toBe(true);
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "full" }).toolModeExplicit).toBe(true);
+    expect(parseCliArgs(base, { COMFYUI_MCP_TOOL_MODE: "bogus" }).toolModeExplicit).toBe(false);
   });
 
   it("`setup <agent>` captures the agent, --dry-run, --comfyui-url, and explicit tool mode", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { collectToolCatalog, registerFullTools } from "./tools/index.js";
 import { registerCompactTools } from "./tools/compact.js";
 import { logger } from "./utils/logger.js";
 import { JobWatcher } from "./services/job-watcher.js";
-import { parseCliArgs, validateConnectUrl, type ToolMode } from "./transport/cli.js";
+import { parseCliArgs, validateConnectUrl, exportExplicitToolMode, type ToolMode } from "./transport/cli.js";
 import { startHttpServer } from "./transport/http.js";
 import { isLocalMode } from "./config.js";
 import { ensurePanelInstalled } from "./services/panel-installer.js";
@@ -294,6 +294,10 @@ async function main() {
     // the pod's HTTPS panel can reach the bridge (a plain ws:// from https is
     // browser-blocked); --insecure-bridge forces the plain loopback bridge.
     if (cli.insecureBridge) process.env.COMFYUI_MCP_INSECURE_BRIDGE = "1";
+    // #667: an explicit --full/--compact must reach the orchestrator's spawned
+    // MCP children, which read the mode from the ENV — the flag alone never
+    // made it downstream, silently running compact when full was requested.
+    exportExplicitToolMode(cli);
     if (cli.comfyuiUrl) {
       // Hard-fail on a bad `connect <url>` instead of silently falling back to the
       // local ComfyUI (which would make the banner below lie about what it drives).

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ function selfUpdateOnLoad(): void {
     .catch(() => {});
 }
 
-async function createConfiguredServer(toolMode: ToolMode = "full"): Promise<McpServer> {
+async function createConfiguredServer(toolMode: ToolMode = "compact"): Promise<McpServer> {
   const server = new McpServer(
     {
       name: "comfyui-mcp",
@@ -118,20 +118,25 @@ async function createConfiguredServer(toolMode: ToolMode = "full"): Promise<McpS
     },
   );
   if (toolMode === "compact") {
-    // Compact tool mode for small/local LLMs (Hermes Agent, Ollama — issue #97):
-    // capture the whole tool surface into a catalog and expose only the
-    // list_tools/describe_tool/call_tool meta-tools, keeping the client's
-    // context cost near-zero until a tool is actually needed.
+    // Compact tool mode (DEFAULT since #667): capture the whole tool surface
+    // into a catalog and expose only the list_tools/describe_tool/call_tool
+    // meta-tools, keeping the client's context cost near-zero until a tool is
+    // actually needed. Built for small/local LLMs (Hermes Agent, Ollama —
+    // issue #97), but the right default for every harness that injects
+    // tools/list into context: the full surface is ~200KB (~50k tokens) per
+    // read. --full / COMFYUI_MCP_TOOL_MODE=full opts back into the classic
+    // direct surface below.
     const catalog = await collectToolCatalog();
     registerCompactTools(server, catalog);
     logger.info(
       `Compact tool mode: ${catalog.tools.size} tools available via list_tools/describe_tool/call_tool`,
     );
   } else {
-    // Full direct surface PLUS the compact facade (list_tools/describe_tool/
-    // call_tool) as a stable reconnect escape hatch — see registerFullTools and
-    // issue #616. One atomic registration pass, completed before the transport
-    // connects below. Opt out of the facade with COMFYUI_MCP_NO_FACADE=1.
+    // Full direct surface (opt-in via --full) PLUS the compact facade
+    // (list_tools/describe_tool/call_tool) as a stable reconnect escape hatch —
+    // see registerFullTools and issue #616. One atomic registration pass,
+    // completed before the transport connects below. Opt out of the facade
+    // with COMFYUI_MCP_NO_FACADE=1.
     await registerFullTools(server);
   }
 

--- a/src/orchestrator/ollama-backend.ts
+++ b/src/orchestrator/ollama-backend.ts
@@ -55,8 +55,9 @@ export interface OllamaBackendDeps {
   apiKey?: string;
   comfyuiUrl?: string;
   /** Same spec shape the Codex/Gemini backends take: the headless comfyui stdio
-   *  MCP + the panel HTTP MCP. The comfyui spawn env is overridden with
-   *  COMFYUI_MCP_TOOL_MODE=compact so it exposes the 3 meta-tools directly. */
+   *  MCP + the panel HTTP MCP. The comfyui child spawns COMPACT by default (see
+   *  comfyuiSpawnEnv) — an explicit COMFYUI_MCP_TOOL_MODE in the spec or the
+   *  user's own env wins (#667). */
   mcpServers?: Record<string, GeminiMcpServerSpec>;
   /** Panel system prompt (persona), prepended to the system message. */
   systemAppend?: string;
@@ -73,6 +74,30 @@ export interface OllamaBackendDeps {
   connectToolClients?: () => Promise<{ comfyui?: McpToolClient; panel?: McpToolClient }>;
   /** Panel backend id when reusing this driver for GLM/Kimi/Ollama (default ollama). */
   backendId?: BackendId;
+}
+
+/**
+ * Spawn env for the headless comfyui MCP child (#667).
+ *
+ * Compact is the default on this path because the backend feeds the advertised
+ * tool defs straight into a small local model's context — the full ~200-schema
+ * list can fill most of a 16k num_ctx before the conversation starts, so the
+ * child must expose the 3 meta-tools unless the user asked otherwise.
+ *
+ * Precedence: an explicit COMFYUI_MCP_TOOL_MODE — the spec's (the
+ * orchestrator's resolved lane mode, see resolveHttpLaneComfyToolMode) or the
+ * user's own env — WINS; the compact default applies only when neither sets it.
+ */
+export function comfyuiSpawnEnv(
+  specEnv: Record<string, string> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  return {
+    ...env,
+    ...specEnv,
+    COMFYUI_MCP_TOOL_MODE:
+      specEnv?.COMFYUI_MCP_TOOL_MODE ?? env.COMFYUI_MCP_TOOL_MODE ?? "compact",
+  };
 }
 
 type ChatMessage = {
@@ -355,8 +380,7 @@ export class OllamaBackend implements AgentBackend {
               new StdioClientTransport({
                 command: spec.command,
                 args: spec.args ?? [],
-                // Compact mode: the subprocess itself exposes the 3 meta-tools.
-                env: { ...process.env, ...spec.env, COMFYUI_MCP_TOOL_MODE: "compact" },
+                env: comfyuiSpawnEnv(spec.env),
               }),
             );
             this.comfy = client as unknown as McpToolClient;

--- a/src/services/agent-setup.ts
+++ b/src/services/agent-setup.ts
@@ -58,7 +58,9 @@ export function defaultCompact(agent: AgentName): boolean {
 }
 
 function serverArgs(compact: boolean): string[] {
-  return compact ? ["-y", "comfyui-mcp", "--compact"] : ["-y", "comfyui-mcp"];
+  // Explicit on BOTH sides: bare `npx comfyui-mcp` means compact since #667,
+  // so a full-mode entry must pin --full to survive the default flip.
+  return compact ? ["-y", "comfyui-mcp", "--compact"] : ["-y", "comfyui-mcp", "--full"];
 }
 
 function buildEntry(agent: AgentName, compact: boolean, comfyuiUrl?: string): Record<string, unknown> {

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -73,11 +73,13 @@ export function buildManifest(
 }
 
 /**
- * Compact tool mode (COMFYUI_MCP_TOOL_MODE=compact / --compact): registers
- * exactly three meta-tools backed by the captured catalog, instead of the full
- * ~200-tool surface. Built for small/local models (Hermes Agent, Ollama, any
- * MCP client on a non-frontier LLM) where 200 JSON schemas blow the context
- * budget — see issue #97.
+ * Compact tool mode — the DEFAULT registration (since #667; --full /
+ * COMFYUI_MCP_TOOL_MODE=full opts out): registers exactly three meta-tools
+ * backed by the captured catalog, instead of the full ~200-tool surface.
+ * Built for small/local models (Hermes Agent, Ollama, any MCP client on a
+ * non-frontier LLM) where 200 JSON schemas blow the context budget — see
+ * issue #97 — and the right default everywhere: the full surface costs a
+ * client ~200KB (~50k tokens) per tools/list.
  */
 export function registerCompactTools(
   server: McpServer,

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -5,10 +5,12 @@ export type ToolMode = "full" | "compact";
 
 export interface CliOptions {
   transport: TransportMode;
-  /** --compact / --tool-mode compact / COMFYUI_MCP_TOOL_MODE=compact: register
-   *  only the list_tools/describe_tool/call_tool meta-tools instead of the full
-   *  ~200-schema surface — for small/local LLMs (Hermes Agent, Ollama). "full"
-   *  (default) keeps the existing behavior. */
+  /** --compact / --tool-mode compact / COMFYUI_MCP_TOOL_MODE=compact (DEFAULT,
+   *  #667): register only the list_tools/describe_tool/call_tool meta-tools
+   *  instead of the full ~200-schema surface — the full surface costs a client
+   *  ~200KB (~50k tokens) per tools/list, which harnesses that inject schemas
+   *  into context pay on every read. --full / COMFYUI_MCP_TOOL_MODE=full opts
+   *  back into the classic surface (frontier-model harnesses). */
   toolMode: ToolMode;
   host: string;
   port: number;
@@ -67,7 +69,7 @@ export function parseCliArgs(
   const args = argv.slice(2);
 
   let transport: TransportMode = env.MCP_TRANSPORT === "http" ? "http" : "stdio";
-  let toolMode: ToolMode = env.COMFYUI_MCP_TOOL_MODE === "compact" ? "compact" : "full";
+  let toolMode: ToolMode = env.COMFYUI_MCP_TOOL_MODE === "full" ? "full" : "compact";
   let host = env.MCP_HOST ?? DEFAULT_HOST;
   let port = env.MCP_PORT ? Number(env.MCP_PORT) : DEFAULT_PORT;
   let panelOrchestrator =
@@ -82,7 +84,8 @@ export function parseCliArgs(
   let comfyuiUrl: string | undefined;
   let setupAgent: string | undefined;
   let setupDryRun = false;
-  let toolModeExplicit = env.COMFYUI_MCP_TOOL_MODE === "compact";
+  let toolModeExplicit =
+    env.COMFYUI_MCP_TOOL_MODE === "compact" || env.COMFYUI_MCP_TOOL_MODE === "full";
 
   const valueOf = (current: string, inline: string, i: number): [string, number] => {
     if (current.includes("=")) return [current.slice(current.indexOf("=") + 1), i];
@@ -139,7 +142,7 @@ export function parseCliArgs(
       toolModeExplicit = true;
     } else if (a === "--tool-mode" || a.startsWith("--tool-mode=")) {
       const [v, ni] = valueOf(a, "--tool-mode", i);
-      toolMode = v === "compact" ? "compact" : "full";
+      toolMode = v === "full" ? "full" : "compact";
       toolModeExplicit = true;
       i = ni;
     } else if (a === "setup") {

--- a/src/transport/cli.ts
+++ b/src/transport/cli.ts
@@ -189,6 +189,23 @@ export function parseCliArgs(
 }
 
 /**
+ * Propagate an explicitly-chosen tool mode into the process environment so the
+ * panel orchestrator's spawned MCP children inherit it (#667). Children read
+ * the mode from the ENV (resolveHttpLaneComfyToolMode for the HTTP lane,
+ * comfyuiSpawnEnv for the Ollama family) — a bare --full/--compact flag
+ * otherwise never reaches them, so `--full --panel-orchestrator` silently ran
+ * compact downstream. A DEFAULTED mode is deliberately NOT exported: unset env
+ * is how children tell "user chose nothing" from "user chose compact", and
+ * unset resolves to the documented compact default on its own.
+ */
+export function exportExplicitToolMode(
+  cli: Pick<CliOptions, "toolMode" | "toolModeExplicit">,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (cli.toolModeExplicit) env.COMFYUI_MCP_TOOL_MODE = cli.toolMode;
+}
+
+/**
  * Validate the `connect <comfyui-url>` positional before the orchestrator starts.
  * The URL is exported as COMFYUI_URL and used to drive a (possibly remote)
  * ComfyUI, so a bad value (e.g. `connect not-a-url`) must hard-fail instead of


### PR DESCRIPTION
## Problem

Refs #667 — a default (no-flags) comfyui-mcp server answers `tools/list` with the full direct surface: **172 tools ≈ 196,876 bytes (~49k tokens)** of JSON, split roughly evenly between descriptions (~85KB) and input schemas (~95KB). Harnesses that inject the advertised schemas into the model's context (Open WebUI via mcp-app-bridge, Hermes, most non-Claude clients) pay that on **every read** — the reporter measured ~70k tokens added per list.

## Fix

The repo already has the compaction machinery built for #97: compact mode registers exactly three meta-tools (`list_tools` / `describe_tool` / `call_tool`) over the same captured catalog and handlers, pulling full per-tool schemas into context one at a time via `describe_tool`. This PR makes it **the default** and keeps the classic surface available opt-in:

- `--full` / `--tool-mode full` / `COMFYUI_MCP_TOOL_MODE=full` → classic full direct surface (+ the #616 facade).
- No flags → compact: **3 tools, 1,748 bytes (~440 tokens)** per `tools/list` — a **99% reduction** (~197KB → ~1.7KB).

This aligns the bare server with what the panel orchestrator's HTTP lane (`resolveHttpLaneComfyToolMode`) and the Ollama backend already did — both default to compact with `COMFYUI_MCP_TOOL_MODE=full` as the opt-back-in — and with the 0.49.0 surface-shrink direction (`TOOL_BUDGET_TARGET = 30`).

## Consumer impact (pinned so nothing silently flips)

- **`setup <agent>`**: full-mode entries (copilot) now write an explicit `--full` — bare `npx comfyui-mcp` means compact now, so an unpinned entry would have changed meaning on upgrade.
- **Claude Code plugin** (`plugin/.mcp.json`): pins `--full`, preserving today's direct surface for Claude Code's frontier models (it can opt into compact deliberately later).
- **Orchestrator/panel, arena, local-llm scripts**: unchanged — they already set the mode explicitly.
- Existing saved configs without a mode flag switch to the compact surface on upgrade; every tool remains reachable via `call_tool`, and adding `--full` restores the previous behavior.

## Verification

- End-to-end probe of the built server, no flags: 3 tools / 1,748 B (~440 tok); `--full` still yields the full surface.
- `npm test`: **220 files, 3204 passed, 1 skipped** (cli + agent-setup + compact + registry-surface + http-backend-tools updated/extended).
- `npx tsc --noEmit`: clean.
- `npm run check:vocabulary`: OK. `node scripts/asset-counts.mjs --check`: OK. `npm run docs:gen`: no diff (registered surface unchanged).