### PR TITLE
fix(ui-bridge): reuse the original rid on mutation retry + surface late completions (#517)

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2593,4 +2593,197 @@ describe("UiBridge (mutation retry dedupe — #517)", () => {
     await expect(promise).resolves.toMatchObject({ errors: [] });
     a2.close();
   });
+
+  // Gate finding 1 — the fingerprint must match the frame's ACTUAL JSON wire
+  // semantics: a key JSON drops (undefined value) is absent from the frame and
+  // must not differentiate the fingerprint, while an explicit null IS on the
+  // wire and must stay distinct (a different command, never an rid adoption).
+  it("fingerprint follows JSON wire semantics: undefined ≡ missing key, explicit null stays distinct", async () => {
+    const sock = await connectPanel("tab-dedupe-8");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-8")).toBe(true));
+    const frames = collectFrames(sock);
+    // Attempt 1 carries an undefined-valued arg — JSON.stringify DROPS it from the
+    // frame, so the wire command is exactly {cmd, type}.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", extra: undefined },
+        { tabId: "tab-dedupe-8", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    expect(frames[0]).not.toHaveProperty("extra"); // confirm the key never hit the wire
+    // The retry WITHOUT the key sends the SAME frame → it must correlate.
+    const retry = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler" },
+      { tabId: "tab-dedupe-8", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).toBe(rid1);
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 1 } }));
+    await expect(retry).resolves.toMatchObject({ node_id: 1 });
+    // Now an attempt whose arg is EXPLICITLY null times out — a DIFFERENT wire
+    // frame ({…, "extra":null}) than the missing-key command above.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", extra: null },
+        { tabId: "tab-dedupe-8", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const ridNull = frames[2].rid as string;
+    // A missing-key retry must NOT adopt the null-command's rid (and vice versa
+    // would be just as wrong): distinct command → fresh rid → own dispatch.
+    const missingRetry = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler" },
+      { tabId: "tab-dedupe-8", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(4));
+    expect(frames[3].rid).not.toBe(ridNull);
+    sock.send(JSON.stringify({ rid: frames[3].rid, ok: true, result: { node_id: 2 } }));
+    await expect(missingRetry).resolves.toMatchObject({ node_id: 2 });
+    sock.close();
+  });
+
+  // Gate finding 2 — overlapping retries of one timed-out mutation must not
+  // overwrite each other's sole `pending` slot: the later one waits for the
+  // in-flight attempt's terminal state and shares it (never a wrong resolve).
+  it("overlapping retries of one timed-out mutation SHARE the in-flight attempt — one frame, both resolve", async () => {
+    const sock = await connectPanel("tab-dedupe-9");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-9")).toBe(true));
+    const frames = collectFrames(sock);
+    const cmd = { cmd: "graph_add_node", type: "KSampler" };
+    await expect(
+      bridge.send(cmd, { tabId: "tab-dedupe-9", timeoutMs: 60 }),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    // Retry A adopts rid1 and stays in flight; retry B arrives while A is pending.
+    const retryA = bridge.send(cmd, { tabId: "tab-dedupe-9", timeoutMs: 5000 });
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    const retryB = bridge.send(cmd, { tabId: "tab-dedupe-9", timeoutMs: 5000 });
+    // B must NOT dispatch a concurrent frame with the same rid (which would
+    // overwrite A's pending entry) — it shares A's outcome instead.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(frames).toHaveLength(2);
+    // The panel's single (deduped) reply resolves BOTH callers with the true
+    // outcome — never a wrong or displaced resolve.
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 3 } }));
+    await expect(retryA).resolves.toMatchObject({ node_id: 3 });
+    await expect(retryB).resolves.toMatchObject({ node_id: 3 });
+    sock.close();
+  });
+
+  it("a retry joining an in-flight retry that TIMES OUT shares the timeout; the next retry still adopts the rid", async () => {
+    const sock = await connectPanel("tab-dedupe-9b");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-9b")).toBe(true));
+    const frames = collectFrames(sock);
+    const cmd = { cmd: "graph_add_node", type: "KSampler" };
+    await expect(
+      bridge.send(cmd, { tabId: "tab-dedupe-9b", timeoutMs: 60 }),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    const retryA = bridge.send(cmd, { tabId: "tab-dedupe-9b", timeoutMs: 80 });
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    const retryB = bridge.send(cmd, { tabId: "tab-dedupe-9b", timeoutMs: 5000 }); // joins A
+    // A times out again; B shares that terminal state honestly (no frame of its
+    // own, no fabricated success).
+    await expect(retryA).rejects.toThrow(/did not reply/);
+    await expect(retryB).rejects.toThrow(/did not reply/);
+    expect(frames).toHaveLength(2);
+    // A's timeout re-recorded the ambiguous outcome → retry C adopts rid1 and
+    // dispatches once more.
+    const retryC = bridge.send(cmd, { tabId: "tab-dedupe-9b", timeoutMs: 2000 });
+    await vi.waitFor(() => expect(frames).toHaveLength(3));
+    expect(frames[2].rid).toBe(rid1);
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 4 } }));
+    await expect(retryC).resolves.toMatchObject({ node_id: 4 });
+    sock.close();
+  });
+
+  // Gate finding 3 — TTL/capacity eviction must skip a record whose adopted
+  // retry is still in flight, or a later identical retry could mint a fresh rid
+  // and re-apply after the original applied-but-unacknowledged.
+  it("capacity eviction skips a record whose adopted retry is still in flight", async () => {
+    const sock = await connectPanel("tab-dedupe-10");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-10")).toBe(true));
+    const frames = collectFrames(sock);
+    const cmd = { cmd: "graph_add_node", type: "FloodTarget" };
+    await expect(
+      bridge.send(cmd, { tabId: "tab-dedupe-10", timeoutMs: 60 }),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    // The adopted retry A goes in flight and STAYS pending through the flood.
+    const retryA = bridge.send(cmd, { tabId: "tab-dedupe-10", timeoutMs: 10000 });
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    // Flood the ledger past its 64-record capacity with DISTINCT timed-out
+    // mutations — X's record is the oldest and would be evicted first if the
+    // in-flight skip didn't protect it.
+    for (let i = 0; i < 70; i++) {
+      await expect(
+        bridge.send(
+          { cmd: "graph_add_node", type: `Flood${i}` },
+          { tabId: "tab-dedupe-10", timeoutMs: 15 },
+        ),
+      ).rejects.toThrow(/did not reply/);
+    }
+    expect(frames).toHaveLength(72);
+    // A later identical retry arriving while A is still pending must find the
+    // record intact and JOIN A — not mint a fresh rid and dispatch a second
+    // application.
+    const retryB = bridge.send(cmd, { tabId: "tab-dedupe-10", timeoutMs: 5000 });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(frames).toHaveLength(72); // no fresh-rid dispatch
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 11 } }));
+    await expect(retryA).resolves.toMatchObject({ node_id: 11 });
+    await expect(retryB).resolves.toMatchObject({ node_id: 11 });
+    sock.close();
+  }, 20000);
+
+  // Gate finding 4 — a proven same-workflow tab-id migration (tmp:→wf:) changes
+  // conn.tabId; the fingerprint must follow the migration-aware workflow
+  // identity (#570 tabStableIdentity), so the retry still correlates.
+  it("a proven same-workflow tab-id migration still correlates the retry onto the original rid", async () => {
+    const WF = "22222222-2222-4222-8222-222222222222";
+    // Mimic the orchestrator's tabStableIdentity: keyed under the CURRENT tab id,
+    // re-keyed (old key deleted) on a proven migration, uuid stable throughout.
+    const identities = new Map<string, string>([["tab-mig-old", WF]]);
+    bridge.setTabWorkflowUuidResolver((id) => identities.get(id));
+    const sock = await connectPanel("tab-mig-old");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-mig-old")).toBe(true));
+    const frames = collectFrames(sock);
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler" },
+        { tabId: "tab-mig-old", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    // Same socket re-hellos under the workflow's deterministic id — a PROVEN
+    // same-workflow migration; the identity store is re-keyed to the new id.
+    sock.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "wf:migrated.json",
+        title: "wf",
+        enforces_workflow_stamp: true,
+      }),
+    );
+    identities.delete("tab-mig-old");
+    identities.set("wf:migrated.json", WF);
+    await vi.waitFor(() =>
+      expect(bridge.tabs().some((t) => t.tab_id === "wf:migrated.json")).toBe(true),
+    );
+    // The retry — addressed to the NEW canonical id, as a rebound session would
+    // issue it — must adopt the original rid even though conn.tabId changed
+    // underneath it: the fingerprint follows the workflow identity, which
+    // survived the migration. (The #570 stamp gate passes: the identity store
+    // serves the uuid under the new id.)
+    const retry = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler" },
+      { tabId: "wf:migrated.json", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).toBe(rid1);
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 8 } }));
+    await expect(retry).resolves.toMatchObject({ node_id: 8 });
+    sock.close();
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2786,4 +2786,50 @@ describe("UiBridge (mutation retry dedupe — #517)", () => {
     await expect(retry).resolves.toMatchObject({ node_id: 8 });
     sock.close();
   });
+
+  // Gate finding (final round) — canonicalization must apply JSON.stringify's
+  // OWN toJSON semantics: a toJSON-bearing value (e.g. Date) fingerprints as the
+  // serialized form the wire frame carries, NOT the raw object shell (which for
+  // a Date is `{}` regardless of the instant — two different Dates would
+  // collide, and the later, distinct mutation would adopt the stale rid and be
+  // suppressed with the original's result).
+  it("toJSON-bearing values fingerprint as their serialized form: Date A ≠ Date B, identical instants correlate", async () => {
+    const sock = await connectPanel("tab-dedupe-11");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-11")).toBe(true));
+    const frames = collectFrames(sock);
+    const DATE_A = new Date("2026-01-01T00:00:00.000Z");
+    const DATE_B = new Date("2026-02-02T00:00:00.000Z");
+    // Attempt with Date A times out and is recorded.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", stamp: DATE_A },
+        { tabId: "tab-dedupe-11", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const ridA = frames[0].rid as string;
+    // The wire frame carried the ISO string — the fingerprint must hash THAT.
+    expect(frames[0].stamp).toBe("2026-01-01T00:00:00.000Z");
+    // A command differing ONLY in the toJSON-bearing field (Date B) is a
+    // DIFFERENT mutation: fresh rid, its own dispatch — never suppressed with
+    // A's outcome.
+    const retryB = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler", stamp: DATE_B },
+      { tabId: "tab-dedupe-11", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).not.toBe(ridA);
+    sock.send(JSON.stringify({ rid: frames[1].rid, ok: true, result: { node_id: 21 } }));
+    await expect(retryB).resolves.toMatchObject({ node_id: 21 });
+    // An IDENTICAL toJSON value (same instant, a different Date instance)
+    // produces the same serialized form → the retry correlates and adopts ridA.
+    const retryA = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler", stamp: new Date("2026-01-01T00:00:00.000Z") },
+      { tabId: "tab-dedupe-11", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(3));
+    expect(frames[2].rid).toBe(ridA);
+    sock.send(JSON.stringify({ rid: ridA, ok: true, result: { node_id: 20 } }));
+    await expect(retryA).resolves.toMatchObject({ node_id: 20 });
+    sock.close();
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -2832,4 +2832,79 @@ describe("UiBridge (mutation retry dedupe — #517)", () => {
     await expect(retryA).resolves.toMatchObject({ node_id: 20 });
     sock.close();
   });
+
+  it("a sparse array NEVER collides with its dense prefix (holes are null on the wire)", async () => {
+    const sock = await connectPanel("tab-dedupe-12");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-12")).toBe(true));
+    const frames = collectFrames(sock);
+    const sparse = [1, , 3]; // eslint-disable-line no-sparse-arrays
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", inputs: sparse },
+        { tabId: "tab-dedupe-12", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    expect(JSON.parse(JSON.stringify({ inputs: sparse })).inputs).toEqual([1, null, 3]);
+    // [1] differs from [1, null, 3] on the wire — a dense-prefix retry must be
+    // a DIFFERENT command: fresh rid, its own dispatch.
+    const dense = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler", inputs: [1] },
+      { tabId: "tab-dedupe-12", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).not.toBe(frames[0].rid);
+    sock.send(JSON.stringify({ rid: frames[1].rid, ok: true, result: { node_id: 22 } }));
+    await expect(dense).resolves.toMatchObject({ node_id: 22 });
+    sock.close();
+  });
+
+  it("a caller-supplied rid can NEVER override the frame's rid (dedupe can't be bypassed)", async () => {
+    const sock = await connectPanel("tab-dedupe-13");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-13")).toBe(true));
+    const frames = collectFrames(sock);
+    const send = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler", rid: "caller-forged-rid" },
+      { tabId: "tab-dedupe-13", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(1));
+    expect(frames[0].rid).not.toBe("caller-forged-rid");
+    sock.send(JSON.stringify({ rid: frames[0].rid, ok: true, result: { node_id: 23 } }));
+    await expect(send).resolves.toMatchObject({ node_id: 23 });
+    sock.close();
+  });
+
+  it("a consumed late reply keeps answering later identical retries (no re-dispatch)", async () => {
+    const sock = await connectPanel("tab-dedupe-14");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-14")).toBe(true));
+    const frames = collectFrames(sock);
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", seed: 7 },
+        { tabId: "tab-dedupe-14", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const ridA = frames[0].rid as string;
+    // The original's late reply lands.
+    sock.send(JSON.stringify({ rid: ridA, ok: true, result: { node_id: 24 } }));
+    // Let the bridge's reply handler buffer it before any retry fires.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(frames).toHaveLength(1); // nothing re-sent
+    // First retry: answered from the buffer, no new frame.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", seed: 7 },
+        { tabId: "tab-dedupe-14", timeoutMs: 2000 },
+      ),
+    ).resolves.toMatchObject({ node_id: 24 });
+    // Second identical retry: STILL answered from the buffer — a consumed
+    // record must never free a fresh dispatch of an already-applied mutation.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler", seed: 7 },
+        { tabId: "tab-dedupe-14", timeoutMs: 2000 },
+      ),
+    ).resolves.toMatchObject({ node_id: 24 });
+    expect(frames).toHaveLength(1);
+    sock.close();
+  });
 });

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -17,6 +17,7 @@ import {
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
 } from "../../services/ui-bridge.js";
+import { logger } from "../../utils/logger.js";
 
 // #570 P0c — classifier that decides which commands must pass the enforcement+stamp gate.
 describe("requiresWorkflowStampEnforcement (#570 P0c)", () => {
@@ -2401,5 +2402,195 @@ describe("UiBridge (late ask_user answer buffer — #486)", () => {
     // Give the late reply time to land; it must NOT be buffered under any ask id.
     await new Promise((r) => setTimeout(r, 120));
     expect(bridge.takeLateAskReply("tab-plain")).toBeUndefined();
+  });
+});
+
+
+// #517 — the orchestrator half of the duplicate-mutation fix. The panel (PR #521)
+// dedupes inbound command frames purely by `rid`: a re-delivered rid is answered
+// with the ORIGINAL reply instead of re-executing. The bridge must therefore (a)
+// REUSE the original rid when a caller retries a mutation whose earlier attempt
+// ended ambiguously (reply-timeout / OUTCOME-UNKNOWN drop), and (b) never let a
+// late completion vanish — buffer it so the retry is answered truthfully.
+describe("UiBridge (mutation retry dedupe — #517)", () => {
+  /** Collect the command frames the bridge writes to this panel socket. */
+  function collectFrames(sock: WebSocket): Array<Record<string, unknown>> {
+    const frames: Array<Record<string, unknown>> = [];
+    sock.on("message", (buf) => {
+      const msg = JSON.parse(buf.toString());
+      if (msg.rid && msg.cmd) frames.push(msg);
+    });
+    return frames;
+  }
+
+  it("a mutation retried after a reply-timeout REUSES the original rid, and resolves with the deduped reply", async () => {
+    const sock = await connectPanel("tab-dedupe-1");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-1")).toBe(true));
+    const frames = collectFrames(sock);
+    // The tab never replies → the first attempt times out.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler" },
+        { tabId: "tab-dedupe-1", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    expect(frames).toHaveLength(1);
+    const rid1 = frames[0].rid as string;
+    // The agent re-issues the SAME logical mutation: it must go out under the
+    // ORIGINAL rid — never a fresh one — so the panel ledger answers with the
+    // original reply instead of applying a second node.
+    const retry = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler" },
+      { tabId: "tab-dedupe-1", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).toBe(rid1);
+    // The (ledger-deduped) original reply resolves the retry truthfully.
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 5 } }));
+    await expect(retry).resolves.toMatchObject({ node_id: 5 });
+    // Once a reply reached a caller the ambiguity is resolved: a THIRD identical
+    // command is genuinely new and must mint a FRESH rid.
+    const third = bridge.send(
+      { cmd: "graph_add_node", type: "KSampler" },
+      { tabId: "tab-dedupe-1", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(3));
+    expect(frames[2].rid).not.toBe(rid1);
+    sock.send(JSON.stringify({ rid: frames[2].rid, ok: true, result: { node_id: 6 } }));
+    await expect(third).resolves.toMatchObject({ node_id: 6 });
+    sock.close();
+  });
+
+  it("a late reply to a timed-out mutation is surfaced (log) and buffered — the retry is answered with NO re-dispatch", async () => {
+    const sock = await connectPanel("tab-dedupe-2");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-2")).toBe(true));
+    const frames = collectFrames(sock);
+    const infoSpy = vi.spyOn(logger, "info");
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler" },
+        { tabId: "tab-dedupe-2", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    // The panel DID apply it — the completion merely arrived after the caller was
+    // failed. It must not vanish: it is logged and buffered against the record.
+    sock.send(JSON.stringify({ rid: rid1, ok: true, result: { node_id: 7 } }));
+    await vi.waitFor(() =>
+      expect(
+        infoSpy.mock.calls.some(([m]) => String(m).includes('late reply for timed-out "graph_add_node"')),
+      ).toBe(true),
+    );
+    // The retry is answered with the truthful late outcome ("applied after
+    // timeout") WITHOUT any frame going back out — no second execution is possible.
+    await expect(
+      bridge.send(
+        { cmd: "graph_add_node", type: "KSampler" },
+        { tabId: "tab-dedupe-2", timeoutMs: 2000 },
+      ),
+    ).resolves.toMatchObject({ node_id: 7 });
+    expect(frames).toHaveLength(1);
+    sock.close();
+  });
+
+  it("a late ERROR reply for a timed-out mutation answers the retry with the same error, without re-executing", async () => {
+    const sock = await connectPanel("tab-dedupe-3");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-3")).toBe(true));
+    const frames = collectFrames(sock);
+    await expect(
+      bridge.send(
+        { cmd: "graph_remove_node", node_id: 4 },
+        { tabId: "tab-dedupe-3", timeoutMs: 60 },
+      ),
+    ).rejects.toThrow(/did not reply/);
+    const rid1 = frames[0].rid as string;
+    sock.send(JSON.stringify({ rid: rid1, ok: false, error: "workflow instance mismatch" }));
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(
+      bridge.send(
+        { cmd: "graph_remove_node", node_id: 4 },
+        { tabId: "tab-dedupe-3", timeoutMs: 2000 },
+      ),
+    ).rejects.toThrow(/workflow instance mismatch/);
+    expect(frames).toHaveLength(1);
+    sock.close();
+  });
+
+  it("genuinely new commands still get fresh rids (no correlation after a SUCCESS)", async () => {
+    const sock = await connectPanel("tab-dedupe-4");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-4")).toBe(true));
+    autoReply(sock, "D4");
+    const frames = collectFrames(sock);
+    // Two identical mutations, the first one SUCCESSFUL — the second is a real,
+    // separate command (the agent may genuinely want two identical nodes).
+    await bridge.send({ cmd: "graph_add_node", type: "A" }, { tabId: "tab-dedupe-4" });
+    await bridge.send({ cmd: "graph_add_node", type: "A" }, { tabId: "tab-dedupe-4" });
+    expect(frames).toHaveLength(2);
+    expect(frames[0].rid).not.toBe(frames[1].rid);
+    sock.close();
+  });
+
+  it("a retry with DIFFERENT args does NOT correlate with the timed-out attempt", async () => {
+    const sock = await connectPanel("tab-dedupe-5");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-5")).toBe(true));
+    const frames = collectFrames(sock);
+    await expect(
+      bridge.send({ cmd: "graph_add_node", type: "A" }, { tabId: "tab-dedupe-5", timeoutMs: 60 }),
+    ).rejects.toThrow(/did not reply/);
+    // Different args = a different logical command → fresh rid, dispatched anew.
+    const retry = bridge.send(
+      { cmd: "graph_add_node", type: "B" },
+      { tabId: "tab-dedupe-5", timeoutMs: 2000 },
+    );
+    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    expect(frames[1].rid).not.toBe(frames[0].rid);
+    sock.send(JSON.stringify({ rid: frames[1].rid, ok: true, result: { node_id: 9 } }));
+    await expect(retry).resolves.toMatchObject({ node_id: 9 });
+    sock.close();
+  });
+
+  it("a mutation dropped mid-command (OUTCOME UNKNOWN) correlates its post-reconnect retry onto the original rid", async () => {
+    const a1 = await connectPanel("tab-dedupe-6");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-6")).toBe(true));
+    const frames1 = collectFrames(a1);
+    const promise = bridge.send({ cmd: "graph_run" }, { tabId: "tab-dedupe-6", timeoutMs: 5000 });
+    await vi.waitFor(() => expect(frames1).toHaveLength(1));
+    const rid1 = frames1[0].rid as string;
+    a1.close();
+    await expect(promise).rejects.toThrow(/OUTCOME UNKNOWN/);
+    // The tab reconnects; the caller (told to verify, then retry) re-issues the
+    // SAME command — it must adopt the original rid so the panel ledger (which
+    // survives a socket supersede) can dedupe it.
+    const a2 = await connectPanel("tab-dedupe-6");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-6")).toBe(true));
+    const frames2 = collectFrames(a2);
+    const retry = bridge.send({ cmd: "graph_run" }, { tabId: "tab-dedupe-6", timeoutMs: 2000 });
+    await vi.waitFor(() => expect(frames2).toHaveLength(1));
+    expect(frames2[0].rid).toBe(rid1);
+    a2.send(JSON.stringify({ rid: rid1, ok: true, result: { prompt_id: "p1" } }));
+    await expect(retry).resolves.toMatchObject({ prompt_id: "p1" });
+    a2.close();
+  });
+
+  it("the idempotent read-resume path is unchanged — it still resolves the caller, replaying the SAME rid", async () => {
+    const a1 = await connectPanel("tab-dedupe-7");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tab-dedupe-7")).toBe(true));
+    const frames1 = collectFrames(a1);
+    // No autoReply on a1 → the read stays in-flight (un-acked) when the socket drops.
+    const promise = bridge.send(
+      { cmd: "graph_get_errors" },
+      { tabId: "tab-dedupe-7", timeoutMs: 5000 },
+    );
+    await vi.waitFor(() => expect(frames1).toHaveLength(1));
+    a1.close();
+    // Same tab reconnects within the grace window → the parked read is resumed onto
+    // the fresh socket, as one replay of the SAME logical command (same rid).
+    const a2 = await connectPanel("tab-dedupe-7");
+    const frames2 = collectFrames(a2);
+    await vi.waitFor(() => expect(frames2.some((f) => f.cmd === "graph_get_errors")).toBe(true));
+    expect(frames2.find((f) => f.cmd === "graph_get_errors")?.rid).toBe(frames1[0].rid);
+    a2.send(JSON.stringify({ rid: frames1[0].rid, ok: true, result: { errors: [] } }));
+    await expect(promise).resolves.toMatchObject({ errors: [] });
+    a2.close();
   });
 });

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -15,7 +15,7 @@
 // or `{ rid, ok: false, error }`. Frames WITHOUT a rid are panel-initiated
 // events (`hello`, `user_message`) and flow to `onPanelMessage`.
 
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
 import { logger } from "../utils/logger.js";
 import { compareSemver } from "./self-update.js";
@@ -77,6 +77,18 @@ type SendCtx = {
    *  EXECUTE it against a DIFFERENT workflow it has since switched to. Undefined for a tab
    *  with no established workflow identity (old panel / relay) → no client-side fence. */
   workflowUuid?: string;
+  /** #517 — the request id stamped on EVERY attempt frame of this logical command.
+   *  Minted once per send() — or ADOPTED from a prior attempt of the same logical
+   *  mutation that ended ambiguously (reply-timeout / outcome-unknown drop) — and
+   *  REUSED verbatim by every re-dispatch (reconnect resume), so the panel's rid
+   *  dedupe ledger (panel #521) answers a replay with the ORIGINAL reply instead of
+   *  re-executing it. Genuinely new commands always mint a fresh rid. */
+  rid: string;
+  /** #517 — canonical fingerprint of this logical command (canonical tabId + cmd
+   *  args), set only for MUTATING commands. Keys `timedOutMutations`, so a caller
+   *  retrying a mutation whose earlier attempt ended ambiguously can adopt the
+   *  original rid (or be answered from its buffered late reply). */
+  dedupeKey?: string;
 };
 
 type Pending = {
@@ -496,6 +508,19 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
+/** Deterministic serialization for fingerprinting a logical command (#517):
+ *  object keys sorted recursively, so two calls carrying identical args in a
+ *  different key order still correlate to the same fingerprint. */
+function stableStringify(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`)
+    .join(",")}}`;
+}
+
 /** Normalize a WebSocket handshake `Origin` header into a canonical scheme://host:port
  *  string, or undefined when it is absent, the opaque literal `"null"` (a sandboxed /
  *  file:// / data: origin, which proves nothing), or unparseable. The browser sets this
@@ -697,6 +722,33 @@ export class UiBridge {
    *  enough to cover a slow human pick within the MCP tools/call budget, short
    *  enough that abandoned entries don't accumulate. */
   private static readonly LATE_ASK_TTL_MS = 5 * 60 * 1000;
+  /** #517 — recent AMBIGUOUS-outcome MUTATING dispatches (reply-timeout, or a
+   *  mid-command drop surfaced as OUTCOME UNKNOWN), keyed by the logical-command
+   *  fingerprint ({@link commandDedupeKey}). Lets a caller's RETRY of the same
+   *  mutation adopt the original rid — so the panel's rid dedupe ledger (panel
+   *  #521) answers it with the ORIGINAL reply instead of applying the mutation a
+   *  second time (duplicate nodes) — and holds the original's LATE reply, when one
+   *  arrives, so the retry can be answered truthfully with no re-dispatch at all.
+   *  Cleared as soon as any reply for the rid reaches a caller (the ambiguity is
+   *  resolved; a later identical command is genuinely new); TTL-pruned otherwise.
+   *  Eviction/expiry fails OPEN: an untracked retry just re-executes under a fresh
+   *  rid — exactly the pre-#517 behavior, never a new failure mode. */
+  private timedOutMutations = new Map<
+    string,
+    {
+      rid: string;
+      tabId: string;
+      cmd: string;
+      ts: number;
+      reply?: { ok: boolean; result?: unknown; error?: string };
+    }
+  >();
+  /** How long a timed-out mutation stays correlatable — long enough to cover an
+   *  agent's "see the timeout error → re-issue the same edit" turnaround. */
+  private static readonly TIMED_OUT_MUTATION_TTL_MS = 5 * 60 * 1000;
+  /** Cardinality cap (oldest-first eviction) so a flapping session can't grow the
+   *  ledger without limit. */
+  private static readonly TIMED_OUT_MUTATION_MAX = 64;
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
@@ -1243,12 +1295,25 @@ export class UiBridge {
               this.pruneLateAsk();
               this.lateAskReplies.set(entry.askId, { result: msg.result, ts: Date.now() });
             }
+            return;
           }
+          // #517 — a late reply for a timed-out MUTATION must not vanish either:
+          // buffer it against the recorded dispatch so the caller's retry of the
+          // same logical command is answered with the true outcome (and so the
+          // completion is at least surfaced in the log when no retry ever comes).
+          if (this.bufferLateMutationReply(rid, msg)) return;
+          logger.debug(
+            `[ui-bridge] dropping a late reply for a timed-out/unknown rid (${rid.slice(0, 8)})`,
+          );
           return;
         }
         clearTimeout(p.timer);
         this.pending.delete(rid);
         this.askRidToId.delete(rid);
+        // #517 — a definitive reply is reaching a caller for this rid: any
+        // timed-out-mutation record for it is resolved, so a LATER identical
+        // command mints a fresh rid and executes as genuinely new.
+        this.clearTimedOutMutation(rid);
         if (msg.ok) {
           // #422 — the panel DEMONSTRABLY served this command. Record it on the LIVE
           // connection (following a same-socket tmp:→wf: migration whose reply landed
@@ -1549,6 +1614,89 @@ export class UiBridge {
     return e.result;
   }
 
+  /** #517 — canonical fingerprint of a logical command: the canonical tab id plus
+   *  the command with bridge-owned frame metadata (`rid`, `workflow_uuid` — both
+   *  stripped/overwritten at dispatch) excluded. Two sends of the same command with
+   *  identical args to the same tab produce the same key; any real difference (a
+   *  genuinely new command) produces a different one. Hashed so a command carrying
+   *  a large payload (e.g. an embedded workflow) doesn't turn into a giant map key. */
+  private commandDedupeKey(tabId: string, cmd: BridgeCommand): string {
+    const args: Record<string, unknown> = { ...cmd };
+    delete args.rid;
+    delete args.workflow_uuid;
+    return createHash("sha256").update(tabId).update("\n").update(stableStringify(args)).digest("hex");
+  }
+
+  /** Drop expired timed-out-mutation records and cap the ledger oldest-first. */
+  private pruneTimedOutMutations(): void {
+    const now = Date.now();
+    for (const [key, e] of this.timedOutMutations) {
+      if (now - e.ts > UiBridge.TIMED_OUT_MUTATION_TTL_MS) this.timedOutMutations.delete(key);
+    }
+    while (this.timedOutMutations.size > UiBridge.TIMED_OUT_MUTATION_MAX) {
+      const oldest = this.timedOutMutations.keys().next().value;
+      if (oldest === undefined) break;
+      this.timedOutMutations.delete(oldest);
+    }
+  }
+
+  /** #517 — record a MUTATING command whose outcome just became ambiguous (the
+   *  frame was written but no reply will reach the caller: a reply-timeout, or an
+   *  OUTCOME-UNKNOWN mid-command drop). The next send() of the SAME logical command
+   *  adopts this rid so the panel dedupes the replay (panel #521) — and so its late
+   *  reply, if one arrives, is buffered for that retry instead of vanishing. No-op
+   *  for reads (they have no dedupeKey): re-running a read is always safe. */
+  private recordTimedOutMutation(ctx: SendCtx): void {
+    if (!ctx.mutating || !ctx.dedupeKey) return;
+    this.pruneTimedOutMutations();
+    const prev = this.timedOutMutations.get(ctx.dedupeKey);
+    // Re-set (not just update) so a repeat record moves newest for eviction; a
+    // retry that adopted this rid and timed out AGAIN keeps the same rid/key.
+    this.timedOutMutations.delete(ctx.dedupeKey);
+    this.timedOutMutations.set(ctx.dedupeKey, {
+      rid: ctx.rid,
+      tabId: ctx.tabId,
+      cmd: ctx.command.cmd,
+      ts: Date.now(),
+      reply: prev?.rid === ctx.rid ? prev.reply : undefined,
+    });
+  }
+
+  /** #517 — a reply for `rid` is about to reach a caller: the ambiguity around any
+   *  timed-out attempt with this rid is resolved, so drop its record. A later
+   *  identical command must mint a FRESH rid and execute as genuinely new. */
+  private clearTimedOutMutation(rid: string): void {
+    for (const [key, e] of this.timedOutMutations) {
+      if (e.rid === rid) this.timedOutMutations.delete(key);
+    }
+  }
+
+  /** #517 — TRUTHFUL LATE COMPLETION: a reply arrived for a rid with no pending
+   *  waiter. If it belongs to a recorded timed-out mutation, BUFFER the outcome so
+   *  the caller's retry (same logical command, within the TTL) is answered with it
+   *  instead of blindly re-executing, and surface it in the log. Returns true when
+   *  the reply was claimed; false for anything else (dropped with a debug log by
+   *  the caller, exactly as before). */
+  private bufferLateMutationReply(rid: string, msg: Record<string, unknown>): boolean {
+    for (const [key, e] of this.timedOutMutations) {
+      if (e.rid !== rid) continue;
+      e.reply = msg.ok
+        ? { ok: true, result: msg.result }
+        : { ok: false, error: String(msg.error ?? "panel reported an error") };
+      e.ts = Date.now();
+      // LRU touch — a reply that just landed is by definition still relevant.
+      this.timedOutMutations.delete(key);
+      this.timedOutMutations.set(key, e);
+      logger.info(
+        `[ui-bridge] late reply for timed-out "${e.cmd}" arrived after the caller was failed ` +
+          `(tab ${e.tabId.slice(0, 8)}) — buffered so a retry of the same command is answered ` +
+          `truthfully instead of re-executing (#517)`,
+      );
+      return true;
+    }
+    return false;
+  }
+
   /** All currently connected tabs, most recent hello last. */
   tabs(): PanelTab[] {
     return Array.from(this.conns.values()).map((c) => ({
@@ -1712,6 +1860,12 @@ export class UiBridge {
   dropQueuedDeliveries(tabId: string): void {
     this.missedFrames.delete(tabId);
     this.mailbox.delete(tabId);
+    // #517 — purge timed-out-mutation records for this tab too: a retry must not
+    // adopt a rid (or be answered from a buffered late reply) that belongs to the
+    // PRIOR workflow's ambiguous dispatch.
+    for (const [key, e] of this.timedOutMutations) {
+      if (e.tabId === tabId) this.timedOutMutations.delete(key);
+    }
     // MIRROR teardown (see above): a viewer must not auto-follow an unproven workflow switch.
     for (const [s, drivenTab] of this.mirrorViewers) {
       if (drivenTab === tabId) this.mirrorViewers.delete(s);
@@ -1889,6 +2043,44 @@ export class UiBridge {
         markDispatched(new Error(`Panel tab ${conn.tabId.slice(0, 8)} is not open`), false),
       );
     }
+    // #517 — a caller RETRYING a mutation whose earlier attempt ended ambiguously
+    // (reply-timeout / OUTCOME-UNKNOWN drop) must not blindly re-execute under a
+    // fresh rid. Correlate it with the recorded dispatch: if the original's LATE
+    // reply already arrived, answer the retry from it directly — no frame is
+    // re-sent at all ("applied after timeout", exactly the panel #521 ledger's
+    // replay semantics, one hop earlier). Otherwise ADOPT the original rid so the
+    // panel's dedupe ledger answers the replay with the ORIGINAL reply instead of
+    // applying the mutation a second time. A genuinely new command (no record)
+    // mints a fresh rid as before.
+    const mutating = !UiBridge.READONLY_CMDS.has(cmd.cmd);
+    let dedupeKey: string | undefined;
+    let rid: string | undefined;
+    if (mutating) {
+      dedupeKey = this.commandDedupeKey(conn.tabId, cmd);
+      this.pruneTimedOutMutations();
+      const prior = this.timedOutMutations.get(dedupeKey);
+      if (prior?.reply) {
+        this.timedOutMutations.delete(dedupeKey);
+        logger.info(
+          `[ui-bridge] answering the retry of "${cmd.cmd}" (tab ${conn.tabId.slice(0, 8)}) with the ` +
+            `late reply of its original dispatch — applied after timeout, NOT re-executed (#517)`,
+        );
+        return prior.reply.ok
+          ? Promise.resolve(prior.reply.result)
+          : Promise.reject(new Error(prior.reply.error ?? "panel reported an error"));
+      }
+      if (prior) {
+        // LRU touch — the command is still being retried within the window.
+        this.timedOutMutations.delete(dedupeKey);
+        prior.ts = Date.now();
+        this.timedOutMutations.set(dedupeKey, prior);
+        rid = prior.rid;
+        logger.info(
+          `[ui-bridge] retry of timed-out "${cmd.cmd}" (tab ${conn.tabId.slice(0, 8)}) reuses the ` +
+            `original request id so the panel dedupes it instead of re-applying (#517)`,
+        );
+      }
+    }
     return new Promise((resolve, reject) => {
       const ctx: SendCtx = {
         resolve,
@@ -1899,13 +2091,15 @@ export class UiBridge {
         // or migration-alias tabId) — the key the reconnect hello will use, so a
         // parked read is found and resumed.
         tabId: conn.tabId,
-        mutating: !UiBridge.READONLY_CMDS.has(cmd.cmd),
+        mutating,
         deadline: Date.now() + timeoutMs,
         // #570 — resolve from the CALLER'S intended tab (opts.tabId), NOT the canonical
         // conn.tabId: after a same-socket switch the two differ, and we must stamp the
         // workflow the command was ISSUED FOR (so the panel, now showing a different one,
         // declines it) — never the workflow it happens to have landed on.
         workflowUuid: this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId) ?? undefined,
+        rid: rid ?? randomUUID(),
+        dedupeKey,
       };
       this.dispatch(conn, ctx);
     });
@@ -1914,7 +2108,10 @@ export class UiBridge {
   /** Write one attempt of a command to a live socket and arm its reply timer.
    *  Reused verbatim when an idempotent read is re-dispatched onto a fresh socket
    *  after a mid-command reconnect (so resume runs the exact same path as a first
-   *  send). Rejections/resolutions go through the shared SendCtx. */
+   *  send). Rejections/resolutions go through the shared SendCtx. Every attempt
+   *  carries the SAME `ctx.rid` (#517): a re-dispatch is a replay of one logical
+   *  command, and the panel's rid dedupe ledger (panel #521) answers a replay with
+   *  the ORIGINAL reply instead of re-executing it. */
   private dispatch(conn: Conn, ctx: SendCtx): void {
     const cmd = ctx.command;
     // Never let a re-dispatch (reconnect resume) extend the caller's original
@@ -1931,7 +2128,11 @@ export class UiBridge {
       return;
     }
     const replyTimeoutMs = Math.min(ctx.timeoutMs, remaining);
-    const rid = randomUUID();
+    // #517 — the rid is STABLE across attempts of this logical command (minted
+    // once in send(), reused on every re-dispatch). Only one attempt is ever in
+    // `pending` at a time: a resume/re-dispatch happens strictly after the prior
+    // attempt's entry was removed (reply timer fired or the socket died).
+    const rid = ctx.rid;
     // Track an ask_user card's stable ask_id against this attempt's rid so a reply
     // that validates AFTER the reply timer fires (and drops out of `pending`) can
     // still be buffered for the caller by rid, not discarded (#486 late answer).
@@ -1977,6 +2178,10 @@ export class UiBridge {
       // dispatched:true so a mutating caller (e.g. comfy_reboot readiness) treats it as an
       // accepted-but-unacked dispatch and verifies by observation, rather than mistaking a
       // genuinely-sent command for one that never went out (#509).
+      // #517 — and for a MUTATION, record the ambiguous outcome so a caller's retry
+      // of the same logical command adopts this rid (panel-ledger dedupe) and its
+      // late reply is buffered instead of vanishing.
+      this.recordTimedOutMutation(ctx);
       ctx.reject(
         markReplyTimeout(
           markDispatched(
@@ -2081,6 +2286,13 @@ export class UiBridge {
     // bare failure invites a blind retry that double-applies the action (e.g. a
     // second render). Say the outcome is UNKNOWN so the caller verifies first.
     if (ctx.mutating) {
+      // #517 — record the ambiguous outcome: if the caller DOES retry the same
+      // logical command (e.g. after verifying), the retry adopts this rid so the
+      // panel's dedupe ledger answers it with the original reply instead of
+      // applying the mutation a second time (the ledger survives a socket
+      // supersede; a full page reload wipes it and the retry fails open into the
+      // pre-#517 behavior).
+      this.recordTimedOutMutation(ctx);
       ctx.reject(
         markDispatched(
           new Error(
@@ -2254,6 +2466,7 @@ export class UiBridge {
       }
       this.awaitingReconnect.delete(tabId);
     }
+    this.timedOutMutations.clear();
     for (const conn of this.conns.values()) {
       try {
         conn.sock.close();

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -508,14 +508,23 @@ export interface BridgeCommand {
   [key: string]: unknown;
 }
 
-/** Deterministic serialization for fingerprinting a logical command (#517):
- *  object keys sorted recursively, so two calls carrying identical args in a
- *  different key order still correlate to the same fingerprint. */
+/** Deterministic serialization for fingerprinting a logical command (#517),
+ *  matching the frame's ACTUAL JSON wire semantics: an object key whose value
+ *  JSON.stringify would OMIT (undefined / function / symbol) is dropped — it never
+ *  reaches the panel, so it must not differentiate the fingerprint either — while
+ *  an explicit `null` stays DISTINCT from a missing key (it IS on the wire, and a
+ *  mutation carrying it is a different command that must never adopt the
+ *  missing-key command's rid). Object keys sorted recursively, so two calls
+ *  carrying identical args in a different key order still correlate. */
 function stableStringify(v: unknown): string {
-  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (v === null || typeof v !== "object") {
+    // In an ARRAY position JSON serializes undefined/function/symbol as null.
+    return JSON.stringify(v) ?? "null";
+  }
   if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
   const o = v as Record<string, unknown>;
   return `{${Object.keys(o)
+    .filter((k) => JSON.stringify(o[k]) !== undefined) // keys JSON would drop from the frame
     .sort()
     .map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`)
     .join(",")}}`;
@@ -749,6 +758,21 @@ export class UiBridge {
   /** Cardinality cap (oldest-first eviction) so a flapping session can't grow the
    *  ledger without limit. */
   private static readonly TIMED_OUT_MUTATION_MAX = 64;
+  /** #517 — dedupeKey → the promise of an ADOPTED retry that is currently IN
+   *  FLIGHT. `pending` is a single slot per rid, so a second retry of the same
+   *  timed-out mutation arriving while the first adopted retry is still pending
+   *  must NOT dispatch a concurrent frame with the same rid: it would overwrite
+   *  the live `pending` entry, and the displaced attempt's timer could then delete
+   *  (and re-record) the LIVE retry — a real panel reply landing on the wrong
+   *  caller. Instead the later retry SHARES this promise (waits for the first's
+   *  terminal state and mirrors it) — exactly the panel ledger's in-flight rule
+   *  (#521: a duplicate delivery awaits the first execution and shares its
+   *  reply). A key's presence also VETOES TTL/capacity eviction of the timed-out
+   *  record: evicting it would let a later identical retry mint a fresh rid and
+   *  re-apply after the original applied-but-unacknowledged. Entries are removed
+   *  when the tracked promise settles (every dispatch path settles it), so this
+   *  can't leak; cleared on stop(). */
+  private inFlightMutationRetries = new Map<string, Promise<unknown>>();
   /** In-flight IDEMPOTENT reads whose socket dropped mid-command, parked per tabId
    *  waiting a bounded grace for that tab to reconnect so we can re-dispatch them
    *  (resume) instead of hard-failing. Never holds mutating commands. */
@@ -1614,29 +1638,44 @@ export class UiBridge {
     return e.result;
   }
 
-  /** #517 — canonical fingerprint of a logical command: the canonical tab id plus
-   *  the command with bridge-owned frame metadata (`rid`, `workflow_uuid` — both
-   *  stripped/overwritten at dispatch) excluded. Two sends of the same command with
-   *  identical args to the same tab produce the same key; any real difference (a
-   *  genuinely new command) produces a different one. Hashed so a command carrying
-   *  a large payload (e.g. an embedded workflow) doesn't turn into a giant map key. */
-  private commandDedupeKey(tabId: string, cmd: BridgeCommand): string {
+  /** #517 — canonical fingerprint of a logical command: a stable tab/workflow
+   *  IDENTITY (the migration-aware trusted workflow uuid when one resolves,
+   *  else the canonical tab id) plus the command with bridge-owned frame metadata
+   *  (`rid`, `workflow_uuid` — both stripped/overwritten at dispatch) excluded.
+   *  Two sends of the same command with identical args to the same workflow
+   *  produce the same key — across a proven tab-id migration too; any real
+   *  difference (a genuinely new command, or a different workflow after an
+   *  unproven switch) produces a different one. Hashed so a command carrying a
+   *  large payload (e.g. an embedded workflow) doesn't turn into a giant map key. */
+  private commandDedupeKey(identity: string, cmd: BridgeCommand): string {
     const args: Record<string, unknown> = { ...cmd };
     delete args.rid;
     delete args.workflow_uuid;
-    return createHash("sha256").update(tabId).update("\n").update(stableStringify(args)).digest("hex");
+    return createHash("sha256").update(identity).update("\n").update(stableStringify(args)).digest("hex");
   }
 
-  /** Drop expired timed-out-mutation records and cap the ledger oldest-first. */
+  /** Drop expired timed-out-mutation records and cap the ledger oldest-first.
+   *  Both TTL and capacity eviction SKIP a record whose adopted retry is still in
+   *  flight (#517): evicting it would let a later identical retry mint a fresh rid
+   *  and re-apply after the original applied-but-unacknowledged — the panel
+   *  ledger's in-flight rule (#521), mirrored bridge-side. */
   private pruneTimedOutMutations(): void {
     const now = Date.now();
     for (const [key, e] of this.timedOutMutations) {
+      if (this.inFlightMutationRetries.has(key)) continue; // in flight — never evict
       if (now - e.ts > UiBridge.TIMED_OUT_MUTATION_TTL_MS) this.timedOutMutations.delete(key);
     }
     while (this.timedOutMutations.size > UiBridge.TIMED_OUT_MUTATION_MAX) {
-      const oldest = this.timedOutMutations.keys().next().value;
-      if (oldest === undefined) break;
-      this.timedOutMutations.delete(oldest);
+      let evicted = false;
+      for (const key of this.timedOutMutations.keys()) {
+        if (this.inFlightMutationRetries.has(key)) continue; // in flight — never evict
+        this.timedOutMutations.delete(key);
+        evicted = true;
+        break;
+      }
+      // Every record is in flight — let the ledger exceed the cap temporarily
+      // rather than drop one of them.
+      if (!evicted) break;
     }
   }
 
@@ -2056,7 +2095,19 @@ export class UiBridge {
     let dedupeKey: string | undefined;
     let rid: string | undefined;
     if (mutating) {
-      dedupeKey = this.commandDedupeKey(conn.tabId, cmd);
+      // #517 gate — fingerprint the tab by its MIGRATION-AWARE workflow identity,
+      // not the raw mutable tabId: a proven same-workflow tab-id migration
+      // (tmp:<uuid> → wf:<hash>) changes conn.tabId, and keying on it would strand
+      // the ambiguous record under the old id — the retry would mint a fresh rid
+      // and double-apply. The trusted per-instance workflow uuid (#570,
+      // tabStableIdentity) is re-keyed to the CURRENT canonical tab id on a proven
+      // migration and is stable for the workflow's lifetime, so resolving it via
+      // the RESOLVED conn's id (not the caller's possibly-retired opts.tabId)
+      // yields the same identity before and after the migration; on an unproven
+      // switch the uuid CHANGES, correctly breaking correlation. Fall back to the
+      // tabId only when no workflow identity resolves (old panel / relay).
+      const identity = this.resolveTabWorkflowUuid?.(conn.tabId) ?? conn.tabId;
+      dedupeKey = this.commandDedupeKey(identity, cmd);
       this.pruneTimedOutMutations();
       const prior = this.timedOutMutations.get(dedupeKey);
       if (prior?.reply) {
@@ -2070,6 +2121,20 @@ export class UiBridge {
           : Promise.reject(new Error(prior.reply.error ?? "panel reported an error"));
       }
       if (prior) {
+        // #517 gate — a retry is ALREADY in flight for this exact timed-out
+        // mutation. `pending` is a single slot per rid: dispatching a concurrent
+        // frame with the same rid would overwrite the live entry and let the
+        // displaced timer delete/re-record it (a real reply landing on the wrong
+        // caller). Wait for the in-flight attempt's terminal state and SHARE it —
+        // the panel ledger's in-flight rule (#521), one hop earlier.
+        const inFlight = this.inFlightMutationRetries.get(dedupeKey);
+        if (inFlight) {
+          logger.info(
+            `[ui-bridge] retry of timed-out "${cmd.cmd}" (tab ${conn.tabId.slice(0, 8)}) joins the ` +
+              `retry already in flight — sharing its outcome, not dispatching a concurrent duplicate (#517)`,
+          );
+          return inFlight;
+        }
         // LRU touch — the command is still being retried within the window.
         this.timedOutMutations.delete(dedupeKey);
         prior.ts = Date.now();
@@ -2081,7 +2146,7 @@ export class UiBridge {
         );
       }
     }
-    return new Promise((resolve, reject) => {
+    const attempt = new Promise((resolve, reject) => {
       const ctx: SendCtx = {
         resolve,
         reject,
@@ -2103,6 +2168,19 @@ export class UiBridge {
       };
       this.dispatch(conn, ctx);
     });
+    if (rid !== undefined && dedupeKey !== undefined) {
+      // Track the ADOPTED retry while it is in flight so an overlapping retry of
+      // the same mutation shares it (above) and TTL/capacity eviction skips its
+      // record. Removed on settlement — every dispatch path settles the promise.
+      this.inFlightMutationRetries.set(dedupeKey, attempt);
+      const settled = () => {
+        if (this.inFlightMutationRetries.get(dedupeKey) === attempt) {
+          this.inFlightMutationRetries.delete(dedupeKey);
+        }
+      };
+      attempt.then(settled, settled);
+    }
+    return attempt;
   }
 
   /** Write one attempt of a command to a live socket and arm its reply timer.
@@ -2129,9 +2207,12 @@ export class UiBridge {
     }
     const replyTimeoutMs = Math.min(ctx.timeoutMs, remaining);
     // #517 — the rid is STABLE across attempts of this logical command (minted
-    // once in send(), reused on every re-dispatch). Only one attempt is ever in
-    // `pending` at a time: a resume/re-dispatch happens strictly after the prior
-    // attempt's entry was removed (reply timer fired or the socket died).
+    // once in send(), reused on every re-dispatch). Only one attempt of a rid is
+    // ever in `pending` at a time: a resume/re-dispatch happens strictly after the
+    // prior attempt's entry was removed (reply timer fired or the socket died),
+    // and send() SERIALIZES overlapping retries of a timed-out mutation (the
+    // later one shares the in-flight attempt's outcome rather than dispatching a
+    // concurrent frame that would overwrite this slot).
     const rid = ctx.rid;
     // Track an ask_user card's stable ask_id against this attempt's rid so a reply
     // that validates AFTER the reply timer fires (and drops out of `pending`) can
@@ -2467,6 +2548,7 @@ export class UiBridge {
       this.awaitingReconnect.delete(tabId);
     }
     this.timedOutMutations.clear();
+    this.inFlightMutationRetries.clear();
     for (const conn of this.conns.values()) {
       try {
         conn.sock.close();

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -536,12 +536,30 @@ function stableStringify(v: unknown, key = ""): string {
     // In an ARRAY position JSON serializes undefined/function/symbol as null.
     return JSON.stringify(v) ?? "null";
   }
-  if (Array.isArray(v)) return `[${v.map((e, i) => stableStringify(e, String(i))).join(",")}]`;
+  if (Array.isArray(v)) {
+    // .map skips HOLES; the wire writes them as null. Array.from visits them
+    // (as undefined → "null" above), so [] and [<hole>] can never collide.
+    return `[${Array.from(v, (e, i) => stableStringify(e, String(i))).join(",")}]`;
+  }
   const o = v as Record<string, unknown>;
   return `{${Object.keys(o)
-    .filter((k) => JSON.stringify(o[k]) !== undefined) // keys JSON would drop from the frame
-    .sort()
-    .map((k) => `${JSON.stringify(k)}:${stableStringify(o[k], k)}`)
+    .map((k) => {
+      // Apply toJSON with THIS property key before testing omission: the frame
+      // does the same, so a key-sensitive toJSON can't make distinct wire
+      // commands fingerprint alike (#517 gate).
+      let val = o[k];
+      if (val !== null && (typeof val === "object" || typeof val === "bigint")) {
+        const toJSON = (val as { toJSON?: unknown }).toJSON;
+        if (typeof toJSON === "function") {
+          val = (toJSON as (this: unknown, k2: string) => unknown).call(val, k);
+        }
+      }
+      return [k, val] as const;
+    })
+    // JSON omits object properties whose value is undefined/function/symbol.
+    .filter(([, val]) => val !== undefined && typeof val !== "function" && typeof val !== "symbol")
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, val]) => `${JSON.stringify(k)}:${stableStringify(val, k)}`)
     .join(",")}}`;
 }
 
@@ -2126,7 +2144,11 @@ export class UiBridge {
       this.pruneTimedOutMutations();
       const prior = this.timedOutMutations.get(dedupeKey);
       if (prior?.reply) {
-        this.timedOutMutations.delete(dedupeKey);
+        // Do NOT delete the record here: a simultaneous identical retry arriving
+        // after a delete would find nothing, mint a fresh rid, and re-execute an
+        // already-applied mutation (#517 gate). The buffered reply stays
+        // answerable until TTL/capacity prunes it — every later identical retry
+        // inside the window learns the same truthful "applied after timeout".
         logger.info(
           `[ui-bridge] answering the retry of "${cmd.cmd}" (tab ${conn.tabId.slice(0, 8)}) with the ` +
             `late reply of its original dispatch — applied after timeout, NOT re-executed (#517)`,
@@ -2309,7 +2331,11 @@ export class UiBridge {
       // (ctx.workflowUuid), and STRIP any caller-supplied value entirely when we have no trusted
       // one — an identity-less tab / old panel ships unstamped (mutations are already refused by
       // the requiresWorkflowStampEnforcement gate above; reads execute, reply still server-fenced).
-      const frame: Record<string, unknown> = { rid, ...cmd };
+      // rid is BRIDGE-OWNED for the same reason workflow_uuid is (below): a
+      // caller-supplied rid on retry would replace the ledger/pending ctx.rid,
+      // bypass the panel's dedupe, and allow a double-apply (#517 gate). Spread
+      // first so the trusted rid always wins over anything cmd carries.
+      const frame: Record<string, unknown> = { ...cmd, rid };
       if (ctx.workflowUuid) frame.workflow_uuid = ctx.workflowUuid;
       else delete frame.workflow_uuid;
       conn.sock.send(JSON.stringify(frame));

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -509,24 +509,39 @@ export interface BridgeCommand {
 }
 
 /** Deterministic serialization for fingerprinting a logical command (#517),
- *  matching the frame's ACTUAL JSON wire semantics: an object key whose value
- *  JSON.stringify would OMIT (undefined / function / symbol) is dropped — it never
- *  reaches the panel, so it must not differentiate the fingerprint either — while
- *  an explicit `null` stays DISTINCT from a missing key (it IS on the wire, and a
- *  mutation carrying it is a different command that must never adopt the
- *  missing-key command's rid). Object keys sorted recursively, so two calls
- *  carrying identical args in a different key order still correlate. */
-function stableStringify(v: unknown): string {
+ *  matching the frame's ACTUAL JSON wire semantics:
+ *   - a value's own `toJSON()` is applied BEFORE serializing (Date → ISO string),
+ *     because that is what the wire frame carries — the raw object shell is NOT
+ *     (a Date serializes as `{}` there regardless of the instant, so two
+ *     mutations differing only in a Date field would collide on the fingerprint
+ *     while their frames differ, and the later, distinct command would adopt the
+ *     stale rid and be suppressed with the original's result — a lost action);
+ *   - an object key whose value JSON.stringify would OMIT (undefined / function /
+ *     symbol) is dropped — it never reaches the panel, so it must not
+ *     differentiate the fingerprint either — while an explicit `null` stays
+ *     DISTINCT from a missing key (it IS on the wire, and a mutation carrying it
+ *     is a different command that must never adopt the missing-key command's rid).
+ *  Object keys sorted recursively, so two calls carrying identical args in a
+ *  different key order still correlate. */
+function stableStringify(v: unknown, key = ""): string {
+  // JSON.stringify calls a value's toJSON(key) once per position before
+  // serializing it; substitute the result and canonicalize THAT instead.
+  if (v !== null && (typeof v === "object" || typeof v === "bigint")) {
+    const toJSON = (v as { toJSON?: unknown }).toJSON;
+    if (typeof toJSON === "function") {
+      v = (toJSON as (this: unknown, k: string) => unknown).call(v, key);
+    }
+  }
   if (v === null || typeof v !== "object") {
     // In an ARRAY position JSON serializes undefined/function/symbol as null.
     return JSON.stringify(v) ?? "null";
   }
-  if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
+  if (Array.isArray(v)) return `[${v.map((e, i) => stableStringify(e, String(i))).join(",")}]`;
   const o = v as Record<string, unknown>;
   return `{${Object.keys(o)
     .filter((k) => JSON.stringify(o[k]) !== undefined) // keys JSON would drop from the frame
     .sort()
-    .map((k) => `${JSON.stringify(k)}:${stableStringify(o[k])}`)
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(o[k], k)}`)
     .join(",")}}`;
 }
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -532,6 +532,12 @@ function stableStringify(v: unknown, key = ""): string {
       v = (toJSON as (this: unknown, k: string) => unknown).call(v, key);
     }
   }
+  // Boxed primitives (new Number/String/Boolean) carry no enumerable keys, so
+  // the object branch below would fingerprint them all as {} while the wire
+  // writes the primitive — unwrap to the primitive first (#517 gate).
+  if (v instanceof Number || v instanceof String || v instanceof Boolean) {
+    v = v.valueOf();
+  }
   if (v === null || typeof v !== "object") {
     // In an ARRAY position JSON serializes undefined/function/symbol as null.
     return JSON.stringify(v) ?? "null";


### PR DESCRIPTION
Orchestrator half of the duplicate-mutation fix for #517, complementing the panel-side command ledger in artokun/comfyui-mcp-panel#521.

## Problem

`dispatch()` minted a **fresh `randomUUID()` rid per attempt**, and a late reply to a timed-out rid was silently dropped (`pending.get(rid)` miss, except the #486 ask_user buffer). So: bridge reply-timeout → the agent re-issues the same mutation → the panel applies it **twice** (duplicate/orphan nodes), and the first attempt's late completion vanishes.

## Fix (correlation only — no timeout/ack budgets touched)

- **Stable rid per logical command.** `SendCtx` now carries `rid`, minted once in `send()` and reused verbatim by every re-dispatch (the existing idempotent read-resume path included). Genuinely new commands still mint fresh rids.
- **Rid reuse on mutation retry.** A mutating command whose attempt ends ambiguously (reply-timeout, or an OUTCOME-UNKNOWN mid-command drop) is recorded in a bounded (64), TTL'd (5 min) ledger keyed by a canonical fingerprint of the logical command (canonical tab id + cmd args; bridge-owned `rid`/`workflow_uuid` excluded). A retry of the same mutation **adopts the original rid**, so the panel's #521 ledger answers it with the ORIGINAL reply instead of applying the mutation a second time. Miss/expiry fails open into the pre-#517 behavior.
- **Truthful late completion.** A late reply for a timed-out mutation is logged and buffered; a retry within the TTL is answered with that outcome directly — *"applied after timeout"*, no frame re-sent at all (the panel ledger's replay semantics, one hop earlier; also covers pre-#521 panels when the reply did arrive). ask_user buffering (#486) is untouched and still runs first.
- Records are cleared once any reply for the rid reaches a caller (a later identical command is genuinely new), purged by `dropQueuedDeliveries` on an unproven workflow replacement, and cleared on `stop()`.

## Panel-ledger contract assumptions

- The panel dedupes purely on `rid` (all commands, not just mutations) and answers a duplicate with the ORIGINAL reply, awaiting it if the first execution is still in flight — including `ok:false` replies (a failed command's replay re-sends the same error without re-executing; mirrored bridge-side by the buffered-error path).
- The ledger is module-scoped, so it survives a socket supersede; a full page reload wipes it. In the wipe case a correlated retry simply re-executes — identical to today's behavior (fail-open).
- Replaying the same rid on a reconnected socket is valid and reaches the same ledger.

## Tests

`src/__tests__/services/ui-bridge.test.ts` (+7): retried mutation reuses the original rid and resolves with the deduped reply; late success **and** late error replies answer the retry with no re-dispatch (and are surfaced via `logger.info`); fresh rids after a success and for different args; OUTCOME-UNKNOWN disconnect correlates the post-reconnect retry; the idempotent read-resume path still resolves the caller, replaying the same rid.

- `npx vitest run src/__tests__/services/ui-bridge.test.ts` — 128/128 pass
- Full suite `npm test` — 221 files, 3335 passed / 2 skipped
- `npx tsc --noEmit` — clean