### PR TITLE
fix(manager): route remaining callers through detected dialect (#681)

### DIFF
--- a/src/__tests__/services/manager-config.test.ts
+++ b/src/__tests__/services/manager-config.test.ts
@@ -21,6 +21,7 @@ import {
   configureManager,
   MANAGER_CONFIG_ACTIONS,
 } from "../../services/manager-config.js";
+import { resetManagerApiCacheForTests } from "../../services/node-management.js";
 
 const mockedExistsSync = vi.mocked(existsSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
@@ -45,6 +46,7 @@ function fetchSequence(responses: Array<Partial<Response> & { __text?: string; _
 describe("configureManager (HTTP API actions)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    resetManagerApiCacheForTests("legacy");
     config.comfyuiPath = "/fake/ComfyUI";
   });
   afterEach(() => {
@@ -75,6 +77,33 @@ describe("configureManager (HTTP API actions)", () => {
     const res = await configureManager("set_db_mode", "remote");
     expect(f.mock.calls[0][0]).toBe("http://127.0.0.1:8188/manager/db_mode");
     expect(res.state).toBe("remote");
+  });
+
+  it("uses the v4-prefixed db_mode route instead of the legacy catchall", async () => {
+    resetManagerApiCacheForTests("v2");
+    const f = fetchSequence([{ ok: true }, { ok: true, __text: "remote" }]);
+    vi.stubGlobal("fetch", f);
+    await configureManager("set_db_mode", "remote");
+    expect(f.mock.calls.map((call) => call[0])).toEqual([
+      "http://127.0.0.1:8188/v2/manager/db_mode",
+      "http://127.0.0.1:8188/v2/manager/db_mode",
+    ]);
+  });
+
+  it("does not misroute legacy-only preview settings to v4", async () => {
+    resetManagerApiCacheForTests("v2");
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    await expect(configureManager("set_preview_method", "taesd")).rejects.toThrow(/does not expose/i);
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it("does not misroute legacy-only preview settings to v2 batch mode", async () => {
+    resetManagerApiCacheForTests("v2-batch");
+    const f = vi.fn();
+    vi.stubGlobal("fetch", f);
+    await expect(configureManager("set_preview_method", "taesd")).rejects.toThrow(/does not expose/i);
+    expect(f).not.toHaveBeenCalled();
   });
 
   it("set_component_policy hits /manager/policy/component", async () => {
@@ -145,6 +174,7 @@ describe("configureManager (config.ini fallback actions)", () => {
     // previous test's leftover.
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    resetManagerApiCacheForTests("legacy");
     config.comfyuiPath = "/fake/ComfyUI";
     // No HTTP fetch should be needed for these.
     vi.stubGlobal("fetch", vi.fn(async () => {
@@ -229,6 +259,7 @@ describe("configureManager (config.ini fallback actions)", () => {
 describe("configureManager validation", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    resetManagerApiCacheForTests("legacy");
     config.comfyuiPath = "/fake/ComfyUI";
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, text: async () => "" }) as unknown as Response));
   });

--- a/src/__tests__/services/node-bisect.test.ts
+++ b/src/__tests__/services/node-bisect.test.ts
@@ -13,6 +13,7 @@ import {
   type BisectState,
   type NodeController,
 } from "../../services/node-bisect.js";
+import { resetManagerApiCacheForTests } from "../../services/node-management.js";
 
 // ---------------------------------------------------------------------------
 // In-memory controller — records enable/disable calls, no real side effects.
@@ -297,6 +298,7 @@ describe("bisectStatus", () => {
 describe("managerController (mocked fetch)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    resetManagerApiCacheForTests("legacy");
   });
 
   it("lists nodes from /customnode/installed and starts a run when toggling", async () => {
@@ -357,6 +359,34 @@ describe("managerController (mocked fetch)", () => {
     await managerController.setEnabledStates([], []);
     expect(fetchMock).not.toHaveBeenCalled();
 
+    vi.unstubAllGlobals();
+  });
+
+  it("uses v4 task envelopes and /v2 queue start, never legacy mutation routes", async () => {
+    resetManagerApiCacheForTests("v2");
+    const { managerController } = await import("../../services/node-bisect.js");
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/v2/customnode/installed")) {
+        return new Response(JSON.stringify({
+          "a-node": { ver: "1.0", cnr_id: "a-cnr", enabled: true },
+          "b-node": { ver: "1.0", cnr_id: "b-cnr", enabled: true },
+        }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await managerController.listNodes();
+    await managerController.setEnabledStates(["a-node"], ["b-node"]);
+
+    const urls = fetchMock.mock.calls.map((call) => call[0] as string);
+    expect(urls).toContain("http://127.0.0.1:8188/v2/manager/queue/task");
+    expect(urls).toContain("http://127.0.0.1:8188/v2/manager/queue/start");
+    expect(urls.some((url) => url.includes("/manager/queue/disable"))).toBe(false);
+    const taskBodies = fetchMock.mock.calls
+      .filter((call) => (call[0] as string).endsWith("/queue/task"))
+      .map((call) => JSON.parse((call[1] as RequestInit).body as string));
+    expect(taskBodies.map((body) => body.kind)).toEqual(["disable", "enable"]);
     vi.unstubAllGlobals();
   });
 

--- a/src/__tests__/services/workflow-deps.test.ts
+++ b/src/__tests__/services/workflow-deps.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import {
   collectClassTypes,
   extractWorkflowDependencies,
   installWorkflowDependencies,
   type WorkflowDepsDeps,
   type ManagerNodePack,
+  defaultWorkflowDepsDeps,
 } from "../../services/workflow-deps.js";
+import { resetManagerApiCacheForTests } from "../../services/node-management.js";
 import type { WorkflowJSON, ObjectInfo, ComfyUINodeDef } from "../../comfyui/types.js";
+
+afterEach(() => vi.unstubAllGlobals());
 
 /** Build a minimal ObjectInfo node def with a given python_module. */
 function def(name: string, pythonModule: string): ComfyUINodeDef {
@@ -84,6 +88,18 @@ function makeDeps(overrides: Partial<WorkflowDepsDeps> = {}): WorkflowDepsDeps {
     ...overrides,
   };
 }
+
+describe("default WorkflowDeps Manager dialect routing", () => {
+  it("uses the v4-prefixed customnode mapping route", async () => {
+    resetManagerApiCacheForTests("v2");
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await defaultWorkflowDepsDeps().fetchManagerMappings();
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:8188/v2/customnode/getmappings?mode=nickname",
+    );
+  });
+});
 
 describe("collectClassTypes", () => {
   it("returns distinct, sorted class_types", () => {

--- a/src/services/manager-config.ts
+++ b/src/services/manager-config.ts
@@ -4,6 +4,7 @@ import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError, ValidationError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import { detectManagerApi, managerApiPrefixFor } from "./node-management.js";
 
 /**
  * ComfyUI-Manager configuration, mirroring `comfy-cli manager` capabilities.
@@ -30,8 +31,9 @@ export class ManagerConfigError extends ComfyUIError {
 async function managerFetch(
   path: string,
   init?: RequestInit,
+  base = getComfyUIBaseUrl(),
 ): Promise<Response> {
-  const url = `${getComfyUIBaseUrl()}${path}`;
+  const url = `${base}${path}`;
   logger.debug("ComfyUI-Manager API request", { url, method: init?.method ?? "GET" });
   let res: Response;
   try {
@@ -105,14 +107,25 @@ async function setViaApi(
   postPath: string,
   value: string,
   getPath: string = postPath,
+  options: { v4Supported?: boolean } = {},
 ): Promise<string> {
-  await managerFetch(postPath, {
+  // Capture one target for both the mutation and its read-back.  A panel
+  // retarget must never make this call set A then report B's state (#670).
+  const base = getComfyUIBaseUrl();
+  const api = await detectManagerApi(base);
+  if (api !== "legacy" && options.v4Supported === false) {
+    throw new ManagerConfigError(
+      `ComfyUI-Manager v4 does not expose ${postPath}; this setting is only available on the legacy Manager API.`,
+    );
+  }
+  const prefix = managerApiPrefixFor(api);
+  await managerFetch(`${prefix}${postPath}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ value }),
-  });
+  }, base);
   // Read back the resulting state (these GET endpoints return text/plain).
-  const res = await managerFetch(getPath, { method: "GET" });
+  const res = await managerFetch(`${prefix}${getPath}`, { method: "GET" }, base);
   return (await res.text()).trim();
 }
 
@@ -120,7 +133,7 @@ export async function setPreviewMethod(
   value: string,
 ): Promise<ManagerConfigResult> {
   const v = assertOneOf(value, VALID_PREVIEW_METHODS, "preview method");
-  const state = await setViaApi("/manager/preview_method", v);
+  const state = await setViaApi("/manager/preview_method", v, undefined, { v4Supported: false });
   return {
     message: `Set ComfyUI-Manager preview method to "${v}".`,
     via: "api",
@@ -142,7 +155,7 @@ export async function setComponentPolicy(
   value: string,
 ): Promise<ManagerConfigResult> {
   const v = assertOneOf(value, VALID_COMPONENT_POLICIES, "component policy");
-  const state = await setViaApi("/manager/policy/component", v);
+  const state = await setViaApi("/manager/policy/component", v, undefined, { v4Supported: false });
   return {
     message: `Set ComfyUI-Manager component policy to "${v}".`,
     via: "api",
@@ -172,12 +185,15 @@ export async function setChannel(value: string): Promise<ManagerConfigResult> {
     throw new ValidationError("Channel name must be a non-empty string.");
   }
   const name = value.trim();
-  await managerFetch("/manager/channel_url_list", {
+  const base = getComfyUIBaseUrl();
+  const api = await detectManagerApi(base);
+  const path = `${managerApiPrefixFor(api)}/manager/channel_url_list`;
+  await managerFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ value: name }),
-  });
-  const res = await managerFetch("/manager/channel_url_list", { method: "GET" });
+  }, base);
+  const res = await managerFetch(path, { method: "GET" }, base);
   const data = (await res.json()) as { selected?: string };
   const selected = data.selected ?? "custom";
   // Manager silently ignores unknown channel names, leaving selection unchanged.
@@ -199,7 +215,9 @@ export async function setChannel(value: string): Promise<ManagerConfigResult> {
  * `comfy-cli manager clear` (which clears reserved startup actions locally).
  */
 export async function resetQueue(): Promise<ManagerConfigResult> {
-  await managerFetch("/manager/queue/reset", { method: "POST" });
+  const base = getComfyUIBaseUrl();
+  const api = await detectManagerApi(base);
+  await managerFetch(`${managerApiPrefixFor(api)}/manager/queue/reset`, { method: "POST" }, base);
   return {
     message: "Reset the ComfyUI-Manager task queue (cleared pending actions).",
     via: "api",

--- a/src/services/node-bisect.ts
+++ b/src/services/node-bisect.ts
@@ -4,6 +4,13 @@ import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { NodeBisectError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import {
+  detectManagerApi,
+  enqueueManagerTaskForExternal,
+  managerApiPrefixFor,
+  startManagerQueueForExternal,
+  type ManagerApi,
+} from "./node-management.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -154,11 +161,12 @@ async function managerFetch(
   path: string,
   init?: RequestInit,
   timeoutMs = 15000,
+  base = managerBase(),
 ): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await comfyuiFetch(`${managerBase()}${path}`, {
+    const res = await comfyuiFetch(`${base}${path}`, {
       ...init,
       signal: controller.signal,
       headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
@@ -180,10 +188,13 @@ async function managerFetch(
  */
 export async function isManagerAvailable(): Promise<boolean> {
   try {
+    const base = managerBase();
+    const api = await detectManagerApi(base);
     const res = await managerFetch(
-      "/customnode/installed?mode=default",
+      `${managerApiPrefixFor(api)}/customnode/installed?mode=default`,
       { method: "GET" },
       4000,
+      base,
     );
     return res.ok;
   } catch {
@@ -220,9 +231,11 @@ const managerDescriptors = new Map<string, ManagerNodeDescriptor>();
  */
 export const managerController: NodeController = {
   async listNodes(): Promise<InstalledNodeInfo[]> {
-    const res = await managerFetch("/customnode/installed?mode=default", {
+    const base = managerBase();
+    const api = await detectManagerApi(base);
+    const res = await managerFetch(`${managerApiPrefixFor(api)}/customnode/installed?mode=default`, {
       method: "GET",
-    });
+    }, 15000, base);
     if (!res.ok) {
       throw new NodeBisectError(
         `ComfyUI-Manager /customnode/installed returned HTTP ${res.status}`,
@@ -262,49 +275,31 @@ export const managerController: NodeController = {
       };
     };
 
+    const base = managerBase();
     let queued = 0;
+    let used: ManagerApi | undefined;
     for (const id of disabled) {
-      const res = await managerFetch("/manager/queue/disable", {
-        method: "POST",
-        body: JSON.stringify(payloadFor(id)),
-      });
-      if (!res.ok) {
-        throw new NodeBisectError(
-          `Failed to queue disable for "${id}": HTTP ${res.status}`,
-        );
-      }
+      const p = payloadFor(id);
+      used = await enqueueManagerTaskForExternal("disable", (api) =>
+        api === "v2"
+          ? { node_name: id, is_unknown: false }
+          : { node_name: id, node_ver: p.version },
+      base);
       queued++;
     }
     for (const id of enabled) {
       const p = payloadFor(id);
-      const res = await managerFetch("/manager/queue/install", {
-        method: "POST",
-        // skip_post_install routes Manager to the synchronous unified_enable
-        // path: it moves the pack out of .disabled/ without reinstalling.
-        body: JSON.stringify({
-          ...p,
-          selected_version: p.version,
-          skip_post_install: true,
-        }),
-      });
-      if (!res.ok) {
-        throw new NodeBisectError(
-          `Failed to queue enable for "${id}": HTTP ${res.status}`,
-        );
-      }
+      used = await enqueueManagerTaskForExternal("enable", (api) =>
+        api === "v2"
+          ? { cnr_id: managerDescriptors.get(id)?.cnrId ?? id }
+          : {
+              node_name: id,
+              node_ver: p.version,
+            },
+      base);
       queued++;
     }
-    if (queued > 0) {
-      const res = await managerFetch("/manager/queue/start", {
-        method: "POST",
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) {
-        throw new NodeBisectError(
-          `Failed to start ComfyUI-Manager task queue: HTTP ${res.status}`,
-        );
-      }
-    }
+    if (queued > 0 && used) await startManagerQueueForExternal(used, base);
   },
 };
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -17,6 +17,7 @@ import {
   setManagerApiCacheForTests,
   suppressDialectRecheck,
 } from "./manager-api-cache.js";
+export type { ManagerApi } from "./manager-api-cache.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
 import { assertComfyCliOk, runComfyCliSync } from "./comfy-cli.js";
 import { ComfyUIError, ProcessControlError, ValidationError } from "../utils/errors.js";
@@ -121,7 +122,7 @@ interface QueueStatus {
 }
 
 /** OperationType values accepted by /v2/manager/queue/task. */
-type ManagerTaskKind =
+export type ManagerTaskKind =
   | "install"
   | "uninstall"
   | "update"
@@ -391,7 +392,7 @@ let detectInflight: { base: string; epoch: number; promise: Promise<ManagerApi> 
  *  spin here; three readings is far past any real restart. */
 const DETECT_INVALIDATION_RETRIES = 2;
 
-async function detectManagerApi(base = managerBaseUrl()): Promise<ManagerApi> {
+export async function detectManagerApi(base = managerBaseUrl()): Promise<ManagerApi> {
   for (let attempt = 0; ; attempt++) {
     const cached = getCachedManagerApi(base);
     if (cached !== undefined) return cached;
@@ -493,6 +494,13 @@ async function probeManagerApi(base: string): Promise<ManagerApi> {
  *  /v2 prefix too — only the mutation routes differ). */
 function managerQueuePrefixFor(api: ManagerApi): string {
   return api === "legacy" ? "/manager/queue" : "/v2/manager/queue";
+}
+
+/** Prefix for non-queue Manager routes.  The two pip-Manager dialects both
+ * serve their custom-node/config surface under /v2; only the standalone 3.x
+ * Manager uses unprefixed paths. */
+export function managerApiPrefixFor(api: ManagerApi): string {
+  return api === "legacy" ? "" : "/v2";
 }
 
 /** Appended to every legacy-Manager operation failure so users know they're on
@@ -754,6 +762,36 @@ async function enqueueWithDialectSelfHeal(
     // re-enqueue ONCE in the dialect the live server actually speaks.
     return (await enqueue(fresh, managerApiEpoch())) ?? fresh;
   }
+}
+
+/**
+ * Enqueue a task without draining the Manager queue.  This is the small shared
+ * seam for tools that deliberately batch several mutations before starting the
+ * worker.  It retains the same cached-dialect self-heal as queueManagerTask:
+ * only a 404/405 route rejection is re-sent, never an ambiguous handler error.
+ */
+export async function enqueueManagerTaskForExternal(
+  kind: ManagerTaskKind,
+  params: Record<string, unknown> | ((api: ManagerApi) => Record<string, unknown>),
+  base = managerBaseUrl(),
+): Promise<ManagerApi> {
+  return enqueueWithDialectSelfHeal(
+    kind,
+    (api, epoch) => enqueueManagerTask(
+      api,
+      kind,
+      typeof params === "function" ? params : () => params,
+      randomUUID(),
+      base,
+      epoch,
+    ),
+    base,
+  );
+}
+
+/** Start the queue that received an externally enqueued task. */
+export async function startManagerQueueForExternal(api: ManagerApi, base = managerBaseUrl()): Promise<void> {
+  await managerQueueControl(`${managerQueuePrefixFor(api)}/start`, base);
 }
 
 /**

--- a/src/services/workflow-deps.ts
+++ b/src/services/workflow-deps.ts
@@ -4,6 +4,13 @@ import { getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
 import { ComfyUIError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
+import {
+  detectManagerApi,
+  enqueueManagerTaskForExternal,
+  managerApiPrefixFor,
+  startManagerQueueForExternal,
+  type ManagerApi,
+} from "./node-management.js";
 
 /**
  * Workflow dependency analysis & installation.
@@ -107,7 +114,7 @@ export interface WorkflowDepsDeps {
    * in the Manager response) alongside pack metadata, so installs are queued
    * against the same channel the list came from.
    */
-  fetchManagerList: () => Promise<{ channel?: string; packs: ManagerNodePack[] }>;
+  fetchManagerList: () => Promise<{ channel?: string; packs: ManagerNodePack[]; directInstall?: boolean }>;
   /** POST a single pack install task to the Manager queue (against `channel`). */
   queueInstall: (pack: ManagerNodePack, channel: string) => Promise<void>;
   /** POST to reset the Manager queue (clears stale pending tasks before a run). */
@@ -127,8 +134,9 @@ const managerBase = (): string => getComfyUIBaseUrl();
 async function managerFetch(
   path: string,
   init?: RequestInit,
+  base = managerBase(),
 ): Promise<Response> {
-  const url = `${managerBase()}${path}`;
+  const url = `${base}${path}`;
   logger.debug("Manager API request", { url, method: init?.method ?? "GET" });
   let res: Response;
   try {
@@ -153,15 +161,28 @@ async function managerFetch(
 
 /** Default dependency wiring backed by live HTTP + the ComfyUI client. */
 export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
+  // installWorkflowDependencies invokes reset → N enqueues → start → status as
+  // one Manager transaction. Keep that entire sequence on the target selected
+  // by reset, including a dialect self-heal, so a panel retarget cannot split
+  // a queue across two ComfyUI instances (#670).
+  let queueOperation: { base: string; api?: ManagerApi } | undefined;
   return {
     fetchObjectInfo: () => getObjectInfo(),
     fetchManagerMappings: async () => {
-      const res = await managerFetch("/customnode/getmappings?mode=nickname");
+      const base = managerBase();
+      const api = await detectManagerApi(base);
+      const res = await managerFetch(`${managerApiPrefixFor(api)}/customnode/getmappings?mode=nickname`, undefined, base);
       return (await res.json()) as ManagerMappings;
     },
     fetchManagerList: async () => {
       // skip_update=true avoids slow per-pack git checks; we only need metadata.
-      const res = await managerFetch("/customnode/getlist?mode=cache&skip_update=true");
+      const base = managerBase();
+      const api = await detectManagerApi(base);
+      // v4 deliberately dropped getlist; its registry-first install task does
+      // not need the legacy catalog descriptor.  Keep the legacy list path for
+      // 3.x and let callers resolve against Manager mappings on v4.
+      if (api !== "legacy") return { packs: [], directInstall: true };
+      const res = await managerFetch("/customnode/getlist?mode=cache&skip_update=true", undefined, base);
       const data = (await res.json()) as ManagerListResponse | ManagerNodePack[];
       if (Array.isArray(data)) return { packs: data };
       const packs = data.node_packs ?? {};
@@ -175,10 +196,8 @@ export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
       // A plain/non-registry pack (git URL, no registry version) must route on
       // version === "unknown"; a registry pack installs its catalog version.
       const isUnknown = !pack.version || pack.version === "unknown";
-      await managerFetch("/manager/queue/install", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      const base = queueOperation?.base ?? managerBase();
+      const used = await enqueueManagerTaskForExternal("install", {
           id: pack.id,
           version: isUnknown ? "unknown" : pack.version,
           selected_version:
@@ -188,13 +207,18 @@ export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
           channel: pack.channel ?? channel,
           mode: pack.mode ?? "cache",
           ui_id: pack.id ?? pack.title ?? pack.reference,
-        }),
-      });
+      }, base);
+      if (queueOperation) queueOperation.api = used;
     },
     resetQueue: async () => {
-      await managerFetch("/manager/queue/reset", { method: "POST" });
+      const base = managerBase();
+      const api = await detectManagerApi(base);
+      await managerFetch(`${managerApiPrefixFor(api)}/manager/queue/reset`, { method: "POST" }, base);
+      queueOperation = { base, api };
     },
     startQueue: async () => {
+      const base = queueOperation?.base ?? managerBase();
+      const api = queueOperation?.api ?? await detectManagerApi(base);
       // Some legacy Manager 3.x builds expose /manager/queue/start as GET-only,
       // returning HTTP 405 to our POST (#551). A 405 on a Manager route is a
       // METHOD mismatch for this endpoint, not an unreachable Manager — retry the
@@ -202,21 +226,17 @@ export function defaultWorkflowDepsDeps(): WorkflowDepsDeps {
       // the GET against ComfyUI's frontend catchall, which 200s an UNREGISTERED
       // GET with a page of HTML: that HTML is NOT a real queue start (codex
       // review), so treat it as the route not accepting our request.
-      try {
-        await managerFetch("/manager/queue/start", { method: "POST" });
-      } catch (err) {
-        if (err instanceof ComfyUIError && (err.details as { status?: number } | undefined)?.status === 405) {
-          const res = await managerFetch("/manager/queue/start", { method: "GET" });
-          const body = await res.text().catch(() => "");
-          if (/^\s*<(?:!doctype\b|html\b|!--)/i.test(body)) throw err;
-          return;
-        }
-        throw err;
-      }
+      await startManagerQueueForExternal(api, base);
     },
     queueStatus: async () => {
-      const res = await managerFetch("/manager/queue/status");
-      return (await res.json()) as ManagerQueueStatus;
+      const base = queueOperation?.base ?? managerBase();
+      const api = queueOperation?.api ?? await detectManagerApi(base);
+      try {
+        const res = await managerFetch(`${managerApiPrefixFor(api)}/manager/queue/status`, undefined, base);
+        return (await res.json()) as ManagerQueueStatus;
+      } finally {
+        queueOperation = undefined;
+      }
     },
   };
 }
@@ -421,7 +441,7 @@ export async function installWorkflowDependencies(
 
   // Match missing packs to concrete Manager list entries for install payloads,
   // capturing the channel the list resolved against.
-  const { channel = "default", packs } = await deps.fetchManagerList();
+  const { channel = "default", packs, directInstall = false } = await deps.fetchManagerList();
   const byKey = new Map<string, ManagerNodePack>();
   for (const p of packs) {
     for (const key of [p.id, p.title, p.reference]) {
@@ -436,6 +456,14 @@ export async function installWorkflowDependencies(
   for (const pack of analysis.missingPacks) {
     const entry = byKey.get(pack);
     if (!entry) {
+      // Manager v4 removed the legacy getlist catalog endpoint. Its task API
+      // resolves a registry/repository id directly, so an empty catalog is the
+      // v4 signal to enqueue that id rather than falsely claim it is unresolved.
+      if (directInstall) {
+        toInstall.push({ id: pack, version: "latest" });
+        installed.push(pack);
+        continue;
+      }
       unresolved.push(pack);
       continue;
     }


### PR DESCRIPTION
Fixes #681.\n\nRoutes workflow dependency installs, node bisect, and manager settings through the cached Manager dialect with target snapshots and 404/405-only queue self-heal. Adds v4/v2-batch regressions.\n\nVerified: focused 77 tests, npm run lint, git diff --check.