### PR TITLE
fix(civitai): unclassified versions are never vouched in SFW search (#664 gate)

### DIFF
--- a/src/__tests__/services/civitai-resolver.test.ts
+++ b/src/__tests__/services/civitai-resolver.test.ts
@@ -327,6 +327,9 @@ describe("searchCivitaiModels", () => {
             baseModel: "Flux.1 D",
             trainedWords: ["Jeddtlv3"],
             files: [{ name: "flux-detailer.safetensors", primary: true, sizeKB: 300000 }],
+            // SFW mode vouches trained_words only for a PROVEN-clean version
+            // (#664 gate) — give the fixture explicit clean previews.
+            images: [{ url: "p1", nsfwLevel: 1 }],
           },
         ],
       },
@@ -404,6 +407,66 @@ describe("searchCivitaiModels", () => {
     expect(hits[0].version_id).toBe(1599906);
     expect(hits[0].version_name).toBe("v2");
     expect(hits[0].trained_words).toEqual(["subtle camera motion"]);
+  });
+
+  it("nsfw:false treats an image-less version as UNCLASSIFIED, never vouched (#664 gate)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            id: 2,
+            name: "No Previews",
+            nsfw: false,
+            modelVersions: [
+              {
+                id: 200,
+                name: "v1",
+                trainedWords: ["unverified phrase"],
+                images: [], // no previews → unclassified, not "clean"
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const { hits } = await searchCivitaiModels("no previews", { nsfw: false });
+    // Download handoff preserved…
+    expect(hits[0].version_id).toBe(200);
+    // …but an unverified version's words are never serialized in SFW mode.
+    expect(hits[0].trained_words).toBeUndefined();
+  });
+
+  it("nsfw:false uses the version-level nsfwLevel when present, previews or not (#664 gate)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            id: 3,
+            name: "Rated Versions",
+            nsfw: false,
+            modelVersions: [
+              {
+                id: 301,
+                name: "v2 (latest, explicit rating)",
+                nsfwLevel: 8,
+                trainedWords: ["adult phrase"],
+                images: [],
+              },
+              {
+                id: 300,
+                name: "v1 (clean rating, no previews)",
+                nsfwLevel: 1,
+                trainedWords: ["safe phrase"],
+                images: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const { hits } = await searchCivitaiModels("rated", { nsfw: false });
+    expect(hits[0].version_id).toBe(300);
+    expect(hits[0].trained_words).toEqual(["safe phrase"]);
   });
 
   it("nsfw:false never serializes trained words when NO version is clean (#664)", async () => {

--- a/src/services/civitai-resolver.ts
+++ b/src/services/civitai-resolver.ts
@@ -38,6 +38,8 @@ interface CivitaiModelVersion {
   downloadUrl?: string;
   files?: CivitaiFile[];
   images?: CivitaiImage[];
+  /** Version-level maturity rating (newer API responses). */
+  nsfwLevel?: number;
   // Present on GET /model-versions/{id} (not on the nested versions of /models/{id}).
   model?: { name?: string; type?: string };
 }
@@ -534,11 +536,22 @@ export interface CivitaiSearchResult {
  */
 const MAX_SFW_NSFW_LEVEL = 2;
 
-/** True when every preview of this version is at/below PG-13 (or it has none). */
-function versionIsSfw(version: CivitaiModelVersion): boolean {
-  return (version.images ?? []).every(
-    (img) => (img.nsfwLevel ?? 1) <= MAX_SFW_NSFW_LEVEL,
-  );
+/**
+ * SFW classification of one version — "clean" requires POSITIVE evidence:
+ * a version-level rating at/below PG-13, or at least one preview image all of
+ * which are at/below PG-13. A version with NO rating and NO previews is
+ * UNCLASSIFIED, not clean: treating an empty `images` array as safe let SFW
+ * search vouch an explicit version's trigger words (#664 gate).
+ */
+function versionSfwClass(v: CivitaiModelVersion): "clean" | "explicit" | "unclassified" {
+  if (typeof v.nsfwLevel === "number") {
+    return v.nsfwLevel <= MAX_SFW_NSFW_LEVEL ? "clean" : "explicit";
+  }
+  const imgs = v.images ?? [];
+  if (imgs.length === 0) return "unclassified";
+  return imgs.every((img) => (img.nsfwLevel ?? 1) <= MAX_SFW_NSFW_LEVEL)
+    ? "clean"
+    : "explicit";
 }
 
 function toSearchHit(
@@ -548,10 +561,11 @@ function toSearchHit(
   const versions = m.modelVersions ?? [];
   // The API gates only the MODEL-level nsfw flag — a model flagged SFW can
   // still front a version with mature/explicit previews and adult trigger
-  // words (#664). In SFW mode prefer the newest version whose previews stay
-  // at/below PG-13; when none qualifies, keep the latest version for the
-  // download handoff but don't vouch for its trigger words.
-  const clean = opts.nsfw ? undefined : versions.find(versionIsSfw);
+  // words (#664). In SFW mode prefer the newest version PROVEN clean; an
+  // unclassified version (no rating, no previews) is never vouched, and when
+  // nothing is proven clean the latest version still goes out for the
+  // download handoff but its trigger words are omitted.
+  const clean = opts.nsfw ? undefined : versions.find((v) => versionSfwClass(v) === "clean");
   const v = clean ?? versions[0];
   const file = v ? pickFile(v) : undefined;
   const sizeKb = (file as { sizeKB?: number } | undefined)?.sizeKB;


### PR DESCRIPTION
The merged #664 fix (#688) treated a version with **no previews** as clean (vacuous `every()`), so SFW search could still serialize an unverified version's trigger words.

'Clean' now requires positive evidence: a version-level `nsfwLevel` at/below PG-13, or previews all at/below PG-13. No rating + no previews = **unclassified** — the download handoff is preserved but `trained_words` is omitted. Regression tests for both new cases; the pre-existing field-mapping fixture gained explicit clean previews (its assertion is unchanged).