### PR TITLE
fix(tools): route describe facade through call_tool

### DIFF
--- a/src/__tests__/tools/compact.test.ts
+++ b/src/__tests__/tools/compact.test.ts
@@ -151,6 +151,19 @@ describe("compact mode over a real MCP client/server pair", () => {
     expect(text).toContain('"required"');
   });
 
+  it("routes describe_tool through the stable call_tool facade when its direct binding is stale (#693)", async () => {
+    const client = await compactPair(fakeCatalog());
+    const res = (await client.callTool({
+      name: "call_tool",
+      arguments: { name: "describe_tool", args: { name: "gen_image" } },
+    })) as { isError?: boolean };
+    const text = textOf(res as never);
+    expect(res.isError).not.toBe(true);
+    expect(text).toContain("# gen_image");
+    expect(text).toContain("Long tail of details");
+    expect(text).toContain('"prompt"');
+  });
+
   it("call_tool dispatches to the underlying handler", async () => {
     const client = await compactPair(fakeCatalog());
     const res = await client.callTool({

--- a/src/tools/compact.ts
+++ b/src/tools/compact.ts
@@ -112,48 +112,51 @@ export function registerCompactTools(
       return undefined as unknown as ReturnType<McpServer["tool"]>;
     }
   }) as McpServer["tool"];
+  const listToolsSchema = {
+    category: z
+      .string()
+      .optional()
+      .describe("Only list this category (as shown in the catalog headings)."),
+    search: z
+      .string()
+      .optional()
+      .describe("Case-insensitive substring filter over tool names and descriptions."),
+  };
+  const describeToolSchema = {
+    name: z.string().optional().describe("Exact tool name from list_tools."),
+    tool_name: z.string().optional().describe("Alias for name."),
+  };
+  const describeTool = (params: { name?: string; tool_name?: string }): CallToolResult => {
+    const name = params.name ?? params.tool_name;
+    if (!name) return errorText('Missing tool name. Call as: describe_tool {"name": "<tool>"}');
+    const tool = catalog.get(name);
+    if (!tool) return errorText(unknownToolMessage(catalog, name));
+    const schema = inputJsonSchema(tool);
+    const sections = [
+      `# ${tool.name}  (category: ${tool.category})`,
+      "",
+      tool.description,
+      "",
+      schema
+        ? `Parameters (JSON Schema):\n${JSON.stringify(schema, null, 1)}`
+        : "Parameters: none.",
+      "",
+      `Run it with: call_tool {"name": "${tool.name}", "args": ${schema ? "{...}" : "{}"}}`,
+    ];
+    return text(sections.join("\n"));
+  };
   register(
     "list_tools",
     "List every comfyui-mcp capability as a token-light catalog: tool names with one-line summaries, grouped by category. Start here. Then use describe_tool to get a tool's parameters and call_tool to run it.",
-    {
-      category: z
-        .string()
-        .optional()
-        .describe("Only list this category (as shown in the catalog headings)."),
-      search: z
-        .string()
-        .optional()
-        .describe("Case-insensitive substring filter over tool names and descriptions."),
-    },
+    listToolsSchema,
     async (args) => text(buildManifest(catalog, args)),
   );
 
   register(
     "describe_tool",
     "Get the full description and JSON Schema of one tool from the catalog. Always call this before the first call_tool of a tool you haven't used in this session.",
-    {
-      name: z.string().optional().describe("Exact tool name from list_tools."),
-      tool_name: z.string().optional().describe("Alias for name."),
-    },
-    async (params) => {
-      const name = params.name ?? params.tool_name;
-      if (!name) return errorText('Missing tool name. Call as: describe_tool {"name": "<tool>"}');
-      const tool = catalog.get(name);
-      if (!tool) return errorText(unknownToolMessage(catalog, name));
-      const schema = inputJsonSchema(tool);
-      const sections = [
-        `# ${tool.name}  (category: ${tool.category})`,
-        "",
-        tool.description,
-        "",
-        schema
-          ? `Parameters (JSON Schema):\n${JSON.stringify(schema, null, 1)}`
-          : "Parameters: none.",
-        "",
-        `Run it with: call_tool {"name": "${tool.name}", "args": ${schema ? "{...}" : "{}"}}`,
-      ];
-      return text(sections.join("\n"));
-    },
+    describeToolSchema,
+    async (params) => describeTool(params),
   );
 
   register(
@@ -180,7 +183,14 @@ export function registerCompactTools(
         return errorText('Missing tool name. Call as: call_tool {"name": "<tool>", "args": {...}}');
       }
       const tool = catalog.get(name);
-      if (!tool) return errorText(unknownToolMessage(catalog, name));
+      // #693 — a client can retain the stable call_tool binding while its direct
+      // describe_tool/list_tools bindings are stale after a reconnect. The manifest
+      // itself tells that client to describe a tool before calling it, so route those
+      // two facade control-plane operations through call_tool too. Do this ONLY when
+      // the catalog has no direct tool under the same name: in full mode a user
+      // workflow may legitimately claim a reserved name and win the direct registry.
+      const facadeMeta = !tool && (name === "list_tools" || name === "describe_tool") ? name : null;
+      if (!tool && !facadeMeta) return errorText(unknownToolMessage(catalog, name));
 
       const args = params.args ?? params.arguments;
       let rawArgs: Record<string, unknown> = {};
@@ -208,6 +218,21 @@ export function registerCompactTools(
         }
         rawArgs = args as Record<string, unknown>;
       }
+
+      if (facadeMeta === "list_tools") {
+        const parsed = z.object(listToolsSchema).safeParse(rawArgs);
+        if (!parsed.success) return errorText(`Invalid arguments for list_tools: ${parsed.error.message}`);
+        return text(buildManifest(catalog, parsed.data));
+      }
+      if (facadeMeta === "describe_tool") {
+        const parsed = z.object(describeToolSchema).safeParse(rawArgs);
+        if (!parsed.success) return errorText(`Invalid arguments for describe_tool: ${parsed.error.message}`);
+        return describeTool(parsed.data);
+      }
+
+      // The only catalog-less names above returned through facadeMeta, so the
+      // remaining branch always has a concrete application tool to validate.
+      if (!tool) return errorText(unknownToolMessage(catalog, name));
 
       const validated = z.object(tool.schema ?? {}).safeParse(rawArgs);
       if (!validated.success) {


### PR DESCRIPTION
## Summary

- route catalog `describe_tool` through the stable `call_tool` facade when its direct binding is stale
- also preserve `list_tools` through the same fallback path
- keep a direct catalog tool with either reserved name authoritative, preserving the existing collision rule

## Root cause

`call_tool` dispatched only tools captured in the application catalog. The compact facade itself is registered after that catalog is captured, so a reconnecting client that retained only `call_tool` could not follow the catalog's `describe_tool` instruction.

## Validation

- `npm.cmd run build`
- `npm.cmd test` (227 files, 3699 passed, 2 skipped)
- focused regression covering `call_tool({name:"describe_tool", args:{name:"gen_image"}})`
