### PR TITLE
fix(panel): pin write cancels pending update_all / snapshot restore (#689)

### DIFF
--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -484,8 +484,38 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
   });
 
-  it("partial: the dropped count is DERIVED from before/after reads, never asserted", async () => {
-    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
+  it("partial with a concurrent RE-FILL (pending 2 → 3): drop UNPROVEN, never a 'dropped' claim", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5b" });
+    const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
+    v4Persona(
+      { pending: 2, inProgress: 0, done: 3 },
+      {
+        mine,
+        onReset: () => {
+          mine.inProgress = 1; // a task dequeued mid-reset…
+          mine.pending = 3; // …and a concurrent enqueue added MORE than was dropped
+        },
+      },
+    );
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(1);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("partially-cancelled");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.pendingBefore).toBe(2);
+    expect(cancel.pendingAfter).toBe(3);
+    // mineAfter.pending > mine.pending: a "dropped" count would be zero or
+    // negative, i.e. fabricated. The report names the movement and stops there.
+    expect(cancel.detail).not.toMatch(/dropped \d/);
+    expect(cancel.detail).toMatch(/UNPROVEN/);
+    expect(cancel.detail).toMatch(/2 → 3/);
+    expect(cancel.detail).toMatch(/RUNNING/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
+  it("partial: the dropped count is DERIVED from before/after reads, never asserted", async () => {    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
     const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
     v4Persona(
       { pending: 2, inProgress: 0, done: 3 },

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -14,7 +14,14 @@
 // only); remote reports "cannot cancel — remote host" truthfully.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -66,6 +73,7 @@ import {
   resetManagerApiCacheForTests,
 } from "../../services/node-management.js";
 import { updateAllCustomNodes } from "../../services/update-comfyui.js";
+import { restoreNodeSnapshot } from "../../services/node-snapshots.js";
 import { registerInstallPanelTools } from "../../tools/install-panel.js";
 
 let dir: string;
@@ -133,23 +141,50 @@ interface QueueState {
   done: number;
 }
 
-/** A Manager v4 host whose queue state the test controls; POST reset wipes pending. */
-function v4Persona(state: QueueState, opts: { resetFails?: boolean } = {}) {
+interface V4PersonaOpts {
+  resetFails?: boolean;
+  /** Completed task ui_ids the Manager reports in its queue history. */
+  history?: Set<string>;
+  /** Counts for THIS orchestrator (the client_id=comfyui-mcp filter).
+   *  Defaults to the shared state object. */
+  mine?: QueueState;
+  /** Race injection run when the reset lands (e.g. dequeue a task first). */
+  onReset?: () => void;
+}
+
+/**
+ * A Manager v4 host whose queue state the test controls: shared counts,
+ * client-filtered counts (?client_id=comfyui-mcp), a queue-history lookup
+ * (?ui_id=), and a reset that wipes PENDING only (running survives).
+ */
+function v4Persona(state: QueueState, opts: V4PersonaOpts = {}) {
+  const mine = opts.mine ?? state;
+  const history = opts.history ?? new Set<string>();
   managerHandler = (url, init) => {
-    const path = new URL(url).pathname;
+    const u = new URL(url);
+    const path = u.pathname;
     const method = init?.method ?? "GET";
     if (path === "/v2/manager/queue/status" && method === "GET") {
+      const s = u.searchParams.get("client_id") === "comfyui-mcp" ? mine : state;
       return jsonRes({
-        total_count: state.done + state.inProgress + state.pending,
-        done_count: state.done,
-        in_progress_count: state.inProgress,
-        pending_count: state.pending,
-        is_processing: state.inProgress > 0,
+        total_count: s.done + s.inProgress + s.pending,
+        done_count: s.done,
+        in_progress_count: s.inProgress,
+        pending_count: s.pending,
+        is_processing: s.inProgress > 0,
       });
+    }
+    if (path === "/v2/manager/queue/history" && method === "GET") {
+      const uiId = u.searchParams.get("ui_id") ?? "";
+      return history.has(uiId)
+        ? jsonRes({ history: { ui_id: uiId, kind: "update", result: "done" } })
+        : jsonRes({ history: {} });
     }
     if (path === "/v2/manager/queue/reset" && method === "POST") {
       if (opts.resetFails) return new Response("boom", { status: 500 });
       state.pending = 0; // wipe_queue() clears PENDING only — running survives
+      mine.pending = 0;
+      opts.onReset?.();
       return new Response("", { status: 200 });
     }
     return new Response("not found", { status: 404 });
@@ -180,7 +215,7 @@ function legacyPersona(state: QueueState) {
   };
 }
 
-function recordUpdateAllMarker(extra: { base?: string } = { base: ORIG }) {
+function recordUpdateAllMarker(extra: { base?: string; uiId?: string } = { base: ORIG }) {
   return recordPanelPendingOp(
     "update-all",
     "an update_all request may have been handed to ComfyUI-Manager",
@@ -206,11 +241,16 @@ function cancelReports(report: Record<string, unknown>): CancellationReport[] {
 const resetPosts = () =>
   managerCalls.filter((c) => c.method === "POST" && c.url.includes("/manager/queue/reset"));
 
+const clientStatusGets = () => managerCalls.filter((c) => c.url.includes("client_id=comfyui-mcp"));
+
+const historyGets = () => managerCalls.filter((c) => c.url.includes("/manager/queue/history"));
+
 describe("pin write cancels a pending update_all (#689)", () => {
-  it("proven cancel: resets the queue ON THE MARKER'S SERVER, names the dropped counts, clears the marker", async () => {
-    recordUpdateAllMarker({ base: ORIG });
-    v4Persona({ pending: 2, inProgress: 0, done: 3 });
-    // Retarget AFTER the marker was recorded: the reset must still hit ORIG.
+  it("proven cancel (v4 + ui_id): resets ON THE MARKER'S SERVER after proving our tasks pending, names the counts, clears the marker", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-1" });
+    // Shared queue has OTHER clients' work too — the report must name it.
+    v4Persona({ pending: 5, inProgress: 0, done: 3 }, { mine: { pending: 2, inProgress: 0, done: 1 } });
+    // Retarget AFTER the marker was recorded: everything must still hit ORIG.
     currentBase = "http://new:8188";
 
     const report = await writePin();
@@ -222,16 +262,23 @@ describe("pin write cancels a pending update_all (#689)", () => {
     // Every Manager call went to the marker's server — none to the new target.
     expect(managerCalls.length).toBeGreaterThan(0);
     expect(managerCalls.every((c) => c.url.startsWith(ORIG))).toBe(true);
+    // Proof came first: the panel's per-pack task ids were checked against the
+    // queue history, and OUR tasks were counted via the client filter — only
+    // then the reset.
+    expect(historyGets().some((c) => c.url.includes("ui_id=ui-1_comfyui-agent-panel"))).toBe(true);
+    expect(historyGets().some((c) => c.url.includes("ui_id=ui-1_comfyui-mcp-panel"))).toBe(true);
+    expect(clientStatusGets().length).toBeGreaterThanOrEqual(2); // before + after
     expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
 
-    // The report names the before/after pending counts — never "saved".
+    // The report names OUR dropped count AND the shared blast radius — never "saved".
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("cancelled");
     expect(cancel.markerCleared).toBe(true);
     expect(cancel.pendingBefore).toBe(2);
     expect(cancel.pendingAfter).toBe(0);
     expect(cancel.inProgress).toBe(0);
-    expect(cancel.detail).toMatch(/dropped 2 pending task/);
+    expect(cancel.detail).toMatch(/dropped 2 of this orchestrator's pending task/);
+    expect(cancel.detail).toMatch(/Queue-wide pending went 5 → 0/);
 
     // Marker provably cleared; no residue warning in the note.
     expect(activePanelPendingOps()).toEqual([]);
@@ -240,23 +287,87 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/Pending-op handling:/);
   });
 
-  it("base-less marker: best-effort reset on the current target, but UNVERIFIED — marker KEPT, never 'cancelled'", async () => {
+  it("shared pending from OTHER clients never triggers a reset — nothing of ours ⇒ already-drained", async () => {
+    // THE finding-1 case: our update_all already drained; only unrelated
+    // tasks are pending. A reset would clear THOSE (collateral) while
+    // claiming the panel was saved.
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-2" });
+    v4Persona({ pending: 5, inProgress: 1, done: 3 }, { mine: { pending: 0, inProgress: 0, done: 1 } });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0); // no collateral damage
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.detail).toMatch(/not pending, not running, and not in the Manager's/);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("panel's task in the v4 queue history ⇒ already RAN — already-drained, NO reset", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-9" });
+    v4Persona(
+      { pending: 4, inProgress: 0, done: 3 },
+      { mine: { pending: 2, inProgress: 0, done: 1 }, history: new Set(["ui-9_comfyui-agent-panel"]) },
+    );
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.detail).toMatch(/queue history/);
+    expect(cancel.detail).toMatch(/already RAN/);
+    expect(cancel.detail).toMatch(/may ALREADY have been moved/);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("v4 marker WITHOUT a ui_id: our pending work is ambiguous — NO reset, could-not-verify", async () => {
+    recordUpdateAllMarker({ base: ORIG }); // has base, no uiId
+    v4Persona({ pending: 3, inProgress: 0, done: 1 }, { mine: { pending: 2, inProgress: 0, done: 1 } });
+
+    const report = await writePin();
+
+    expect(clientStatusGets().length).toBe(1); // it looked…
+    expect(resetPosts()).toHaveLength(0); // …but could not prove, so no blind reset
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/recorded no ui_id/);
+    expect(cancel.detail).toMatch(/NO reset was sent/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING/);
+  });
+
+  it("v4 marker without a ui_id, nothing of ours in flight: already-drained", async () => {
+    recordUpdateAllMarker({ base: ORIG });
+    v4Persona({ pending: 4, inProgress: 0, done: 1 }, { mine: { pending: 0, inProgress: 0, done: 1 } });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("base-less marker: NO blind reset even with pending work on the current target — UNVERIFIED, marker kept", async () => {
     recordUpdateAllMarker({}); // no base captured (older marker shape)
     v4Persona({ pending: 1, inProgress: 0, done: 0 });
 
     const report = await writePin();
 
-    // The reset IS attempted on the current target (the likely server)...
-    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
-    // ...but it proves nothing about the real server, so no proven outcome is
-    // reported and the marker + warning stay.
+    // Round 3: a reset here could wipe an innocent server's queue, so none is
+    // sent at all — the outcome can never be proven from the wrong server.
+    expect(resetPosts()).toHaveLength(0);
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
     expect(cancel.detail).toMatch(/recorded NO server/);
-    expect(cancel.detail).toMatch(/UNVERIFIED/);
-    expect(cancel.detail).toMatch(/best-effort/);
-    expect(cancel.detail).not.toMatch(/cancelled the queued update_all/);
+    expect(cancel.detail).toMatch(/NO reset was sent/);
+    expect(cancel.detail).not.toMatch(/cancelled the queued update_all|best-effort/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.pendingPanelOps).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
@@ -278,7 +389,7 @@ describe("pin write cancels a pending update_all (#689)", () => {
   });
 
   it("reset failure: marker KEPT, warning preserved, nothing claimed", async () => {
-    recordUpdateAllMarker();
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-3" });
     v4Persona({ pending: 2, inProgress: 0, done: 3 }, { resetFails: true });
 
     const report = await writePin();
@@ -287,7 +398,7 @@ describe("pin write cancels a pending update_all (#689)", () => {
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/reset FAILED/);
+    expect(cancel.detail).toMatch(/queue reset on .* FAILED/);
     // The marker and today's warning survive.
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.pendingPanelOps).toHaveLength(1);
@@ -310,8 +421,8 @@ describe("pin write cancels a pending update_all (#689)", () => {
   });
 
   it("in-flight (already dequeued): cannot cancel, NO reset sent, never 'saved'", async () => {
-    recordUpdateAllMarker();
-    v4Persona({ pending: 0, inProgress: 1, done: 3 });
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-4" });
+    v4Persona({ pending: 0, inProgress: 1, done: 3 }, { mine: { pending: 0, inProgress: 1, done: 1 } });
 
     const report = await writePin();
 
@@ -327,9 +438,13 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
   });
 
-  it("partial: pending dropped but a task is running — marker KEPT, both halves reported", async () => {
-    recordUpdateAllMarker();
-    v4Persona({ pending: 2, inProgress: 1, done: 3 });
+  it("partial: pending dropped but a task started running in the race — marker KEPT, both halves reported", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
+    const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
+    v4Persona(
+      { pending: 2, inProgress: 0, done: 3 },
+      { mine, onReset: () => { mine.inProgress = 1; } }, // dequeued mid-reset
+    );
 
     const report = await writePin();
 
@@ -340,14 +455,14 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(cancel.pendingBefore).toBe(2);
     expect(cancel.pendingAfter).toBe(0);
     expect(cancel.inProgress).toBe(1);
-    expect(cancel.detail).toMatch(/dropped 2 pending task/);
+    expect(cancel.detail).toMatch(/dropped 2 of this orchestrator's pending task/);
     expect(cancel.detail).toMatch(/already RUNNING and in-flight work cannot be cancelled/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING/);
   });
 
-  it("already drained: nothing left to cancel — marker cleared, panel may ALREADY have moved", async () => {
-    recordUpdateAllMarker();
+  it("already drained (no trace of the panel's task): marker cleared, truthfully not a cancel", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-6" });
     v4Persona({ pending: 0, inProgress: 0, done: 3 });
 
     const report = await writePin();
@@ -356,23 +471,37 @@ describe("pin write cancels a pending update_all (#689)", () => {
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("already-drained");
     expect(cancel.markerCleared).toBe(true);
-    expect(cancel.detail).toMatch(/NOTHING left to cancel/);
-    expect(cancel.detail).toMatch(/may ALREADY have been moved/);
-    expect(cancel.detail).not.toMatch(/cancelled|dropped/);
+    expect(cancel.detail).toMatch(/NOTHING remains that can move the panel/);
+    expect(cancel.detail).not.toMatch(/cancelled the queued|dropped \d/);
     expect(activePanelPendingOps()).toEqual([]);
   });
 
-  it("legacy 3.x: pending derived by total−done−in_progress, reset on the unprefixed route", async () => {
-    recordUpdateAllMarker();
+  it("legacy 3.x: pending work can never be attributed — NO blind reset, could-not-verify", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-7" }); // uiId is useless on 3.x
     legacyPersona({ pending: 2, inProgress: 0, done: 2 });
 
     const report = await writePin();
 
-    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/manager/queue/reset`]);
+    expect(resetPosts()).toHaveLength(0); // 3.x has no task history — never reset
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("cancelled");
-    expect(cancel.pendingBefore).toBe(2);
-    expect(cancel.pendingAfter).toBe(0);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.pendingBefore).toBe(2); // still measured via total−done−in_progress
+    expect(cancel.detail).toMatch(/no task history/);
+    expect(cancel.detail).toMatch(/NO reset was sent/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
+  it("legacy 3.x, empty and idle: already-drained via the arithmetic counts", async () => {
+    recordUpdateAllMarker({ base: ORIG });
+    legacyPersona({ pending: 0, inProgress: 0, done: 3 });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
     expect(activePanelPendingOps()).toEqual([]);
   });
 
@@ -557,6 +686,33 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
   });
 });
 
+describe("the snapshot restore marker follows the POST's actual target (#689 round 3)", () => {
+  it("a mid-call retarget cannot split the marker and the restore POST across servers", async () => {
+    managerHandler = (url, init) => {
+      const path = new URL(url).pathname;
+      if (path === "/snapshot/restore" && init?.method === "POST") {
+        // Retarget DURING the call: anything resolving the base afterwards
+        // would get the new server — but the POST and its marker were pinned
+        // to the target captured at the start of the operation.
+        currentBase = "http://new:8188";
+        return new Response("", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const result = await restoreNodeSnapshot("prod");
+
+    expect(result.message).toMatch(/requested/i);
+    // The POST went to the target pinned at the start…
+    const posts = managerCalls.filter((c) => c.url.includes("/snapshot/restore"));
+    expect(posts.map((c) => c.url)).toEqual([`${ORIG}/snapshot/restore`]);
+    // …and the marker names THAT server, not the new one.
+    const ops = activePanelPendingOps();
+    expect(ops).toHaveLength(1);
+    expect(ops[0].base).toBe(ORIG);
+  });
+});
+
 describe("pin write with no pending markers", () => {
   it("makes NO Manager calls at all", async () => {
     const report = await writePin();
@@ -601,6 +757,88 @@ describe("the update_all marker captures base + ui_id at enqueue (#689)", () => 
     expect(ops[0].kind).toBe("update-all");
     expect(ops[0].base).toBe(ORIG);
     expect(ops[0].uiId).toBe(enqueuedUiId);
+  });
+
+  it("the marker is BASE-UNKNOWN until the enqueue proves the target — no stale base can survive (#689 round 3)", async () => {
+    let markerDuringEnqueue: { ops: Array<{ base?: string; uiId?: string }> } | undefined;
+    managerHandler = (url, init) => {
+      const u = new URL(url);
+      const method = init?.method ?? "GET";
+      if (u.pathname === "/v2/manager/queue/status" && method === "GET") {
+        return jsonRes({
+          total_count: 0,
+          done_count: 0,
+          in_progress_count: 0,
+          pending_count: 0,
+          is_processing: false,
+        });
+      }
+      if (u.pathname === "/v2/manager/queue/update_all" && method === "POST") {
+        // What the marker on disk says DURING the enqueue: it must not name a
+        // server yet — a retarget before this point could have made it stale.
+        markerDuringEnqueue = JSON.parse(
+          readFileSync(process.env.COMFYUI_MCP_PANEL_PENDING as string, "utf-8"),
+        ) as typeof markerDuringEnqueue;
+        return jsonRes({});
+      }
+      if (u.pathname === "/v2/manager/queue/start" && method === "POST") {
+        return new Response("", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    await updateAllCustomNodes();
+
+    expect(markerDuringEnqueue?.ops).toHaveLength(1);
+    expect(markerDuringEnqueue?.ops[0].base).toBeUndefined();
+    expect(markerDuringEnqueue?.ops[0].uiId).toBeUndefined();
+    // …and after the enqueue it is enriched with the proven base + ui_id
+    // (asserted by the previous test).
+  });
+
+  it("enrichment failure never leaves a stale base — the marker reads as unverifiable (#689 round 3)", async () => {
+    managerHandler = (url, init) => {
+      const u = new URL(url);
+      const method = init?.method ?? "GET";
+      if (u.pathname === "/v2/manager/queue/status" && method === "GET") {
+        return jsonRes({
+          total_count: 0,
+          done_count: 0,
+          in_progress_count: 0,
+          pending_count: 0,
+          is_processing: false,
+        });
+      }
+      if (u.pathname === "/v2/manager/queue/update_all" && method === "POST") {
+        // Break the marker store between the initial record and the enrichment.
+        writeFileSync(process.env.COMFYUI_MCP_PANEL_PENDING as string, "{ not json");
+        return jsonRes({});
+      }
+      if (u.pathname === "/v2/manager/queue/start" && method === "POST") {
+        return new Response("", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    // The update still reports "queued" (a marker problem must not punish a
+    // success)…
+    const result = await updateAllCustomNodes();
+    expect(result.message).toMatch(/[Qq]ueued/);
+    // …and the corrupt record reads as a synthetic UNKNOWN marker (fail
+    // closed) — never as a stale base the pin path could trust.
+    const ops = activePanelPendingOps();
+    expect(ops).toHaveLength(1);
+    expect(ops[0].kind).toBe("unknown");
+
+    // A pin afterwards cannot prove anything, sends NOTHING, and keeps the
+    // warning.
+    managerHandler = () => new Response("not found", { status: 404 });
+    const report = await writePin();
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cannot-cancel");
+    expect(cancel.markerCleared).toBe(false);
+    expect(report.note as string).toMatch(/WARNING/);
   });
 });
 

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -240,16 +240,41 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/Pending-op handling:/);
   });
 
-  it("falls back to the CURRENT target when the marker recorded no base — and says so", async () => {
+  it("base-less marker: best-effort reset on the current target, but UNVERIFIED — marker KEPT, never 'cancelled'", async () => {
     recordUpdateAllMarker({}); // no base captured (older marker shape)
     v4Persona({ pending: 1, inProgress: 0, done: 0 });
 
     const report = await writePin();
 
+    // The reset IS attempted on the current target (the likely server)...
     expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
+    // ...but it proves nothing about the real server, so no proven outcome is
+    // reported and the marker + warning stay.
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("cancelled");
-    expect(cancel.detail).toMatch(/recorded no server/);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/recorded NO server/);
+    expect(cancel.detail).toMatch(/UNVERIFIED/);
+    expect(cancel.detail).toMatch(/best-effort/);
+    expect(cancel.detail).not.toMatch(/cancelled the queued update_all/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.pendingPanelOps).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
+  });
+
+  it("base-less marker with an idle current target: NO reset sent, still unverified, marker kept", async () => {
+    recordUpdateAllMarker({});
+    v4Persona({ pending: 0, inProgress: 0, done: 3 });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/recorded NO server/);
+    expect(cancel.detail).toMatch(/proves NOTHING/);
+    expect(activePanelPendingOps()).toHaveLength(1);
   });
 
   it("reset failure: marker KEPT, warning preserved, nothing claimed", async () => {
@@ -440,6 +465,94 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.pendingPanelOps).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("marker recorded for a DIFFERENT server (remote→local retarget): cannot cancel from here, local file UNTOUCHED, marker kept", async () => {
+    const comfyRoot = join(dir, "ComfyUI");
+    config.comfyuiPath = comfyRoot;
+    const restoreFile = join(
+      comfyRoot,
+      "user",
+      "__manager",
+      "startup-scripts",
+      "restore-snapshot.json",
+    );
+    mkdirSync(dirname(restoreFile), { recursive: true });
+    writeFileSync(restoreFile, "{}");
+    // The restore was requested against a remote host; the orchestrator was
+    // then retargeted to this local install. Local evidence must never clear
+    // the remote marker.
+    recordPanelPendingOp(
+      "snapshot-restore",
+      'a snapshot restore ("prod") may have been requested',
+      SNAPSHOT_RESTORE_PENDING_MS,
+      { base: "http://other:8188" },
+    );
+
+    const report = await writePin();
+
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cannot-cancel");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/cannot cancel from here/);
+    expect(cancel.detail).toContain("http://other:8188");
+    // The local file is NOT touched — deleting it would prove nothing about
+    // the remote host (and could cancel an unrelated LOCAL restore).
+    expect(existsSync(restoreFile)).toBe(true);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.pendingPanelOps).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING/);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("base-less restore marker with a local restore file: best-effort delete, but UNVERIFIED — marker kept", async () => {
+    const comfyRoot = join(dir, "ComfyUI");
+    config.comfyuiPath = comfyRoot;
+    const restoreFile = join(
+      comfyRoot,
+      "user",
+      "__manager",
+      "startup-scripts",
+      "restore-snapshot.json",
+    );
+    mkdirSync(dirname(restoreFile), { recursive: true });
+    writeFileSync(restoreFile, "{}");
+    recordPanelPendingOp(
+      "snapshot-restore",
+      'a snapshot restore ("prod") may have been requested',
+      SNAPSHOT_RESTORE_PENDING_MS,
+    ); // no base — older marker shape
+
+    const report = await writePin();
+
+    // The local file WILL run at the next local restart, so deleting it is
+    // protective — but it proves nothing about which host the marker is for.
+    expect(existsSync(restoreFile)).toBe(false);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/UNVERIFIED/);
+    expect(cancel.detail).toMatch(/recorded no server/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("base-less restore marker with NO local restore file: not provably drained — marker kept", async () => {
+    config.comfyuiPath = join(dir, "ComfyUI"); // nothing scheduled locally
+    recordPanelPendingOp(
+      "snapshot-restore",
+      'a snapshot restore ("prod") may have been requested',
+      SNAPSHOT_RESTORE_PENDING_MS,
+    ); // no base
+
+    const report = await writePin();
+
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/recorded no server/);
+    expect(activePanelPendingOps()).toHaveLength(1);
     expect(managerCalls).toEqual([]);
   });
 });

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -1,0 +1,499 @@
+// #689 — a pin written during a pending update_all / snapshot-restore window
+// must CANCEL the queued panel-affecting work, not just warn about it.
+//
+// These tests drive the REAL install_panel(action='pin') tool handler with a
+// stubbed ComfyUI-Manager and a real temp-dir marker/lock/settings file, and
+// assert the four honesty cases:
+//   1. proven cancel      → resetQueue called ON THE MARKER'S SERVER, pending
+//                           counts named before/after, marker cleared;
+//   2. reset failure /    → marker KEPT and today's warning preserved;
+//      unverifiable state
+//   3. in-flight work     → "cannot cancel", never "saved";
+//   4. no markers         → no Manager calls at all.
+// Snapshot restores cancel by deleting Manager's deferred-restore file (local
+// only); remote reports "cannot cancel — remote host" truthfully.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+// The marker records the server the op was queued on; the cancel must target
+// THAT server even after the orchestrator is retargeted (#689).
+const ORIG = "http://orig:8188";
+let currentBase = ORIG;
+
+vi.mock("../../config.js", () => {
+  const config = {
+    comfyuiPath: undefined as string | undefined,
+    resolvedPort: 8188,
+    comfyuiHost: "127.0.0.1",
+    comfyuiSsl: false,
+    githubToken: undefined as string | undefined,
+  };
+  return {
+    config,
+    isLocalMode: () => true,
+    isRemoteMode: () => false,
+    getComfyUIBaseUrl: () => currentBase,
+    getComfyUIAuthHeaders: () => ({}),
+  };
+});
+
+// Any Manager traffic is recorded and answered by the per-test persona.
+const managerCalls: Array<{ url: string; method: string }> = [];
+let managerHandler: (url: string, init?: RequestInit) => Response = () =>
+  new Response("not found", { status: 404 });
+
+vi.mock("../../comfyui/fetch.js", () => ({
+  comfyuiFetch: vi.fn(async (url: string, init?: RequestInit) => {
+    managerCalls.push({ url, method: init?.method ?? "GET" });
+    return managerHandler(url, init);
+  }),
+}));
+
+import { config } from "../../config.js";
+import {
+  activePanelPendingOps,
+  recordPanelPendingOp,
+  SNAPSHOT_RESTORE_PENDING_MS,
+  UPDATE_ALL_PENDING_MS,
+} from "../../services/panel-pin-guard.js";
+import { getPanelPinState, PANEL_PIN_ENV_VAR } from "../../services/panel-settings.js";
+import {
+  fetchManagerQueueCounts,
+  resetManagerApiCacheForTests,
+} from "../../services/node-management.js";
+import { updateAllCustomNodes } from "../../services/update-comfyui.js";
+import { registerInstallPanelTools } from "../../tools/install-panel.js";
+
+let dir: string;
+
+beforeEach(() => {
+  managerCalls.length = 0;
+  managerHandler = () => new Response("not found", { status: 404 });
+  currentBase = ORIG;
+  resetManagerApiCacheForTests();
+  dir = mkdtempSync(join(tmpdir(), "cmcp-pincancel-"));
+  process.env.COMFYUI_MCP_PANEL_SETTINGS = join(dir, "panel-settings.json");
+  process.env.COMFYUI_MCP_PANEL_LOCK = join(dir, "panel-op.lock");
+  process.env.COMFYUI_MCP_PANEL_PENDING = join(dir, "panel-pending-ops.json");
+  config.comfyuiPath = undefined;
+});
+
+afterEach(() => {
+  delete process.env.COMFYUI_MCP_PANEL_SETTINGS;
+  delete process.env.COMFYUI_MCP_PANEL_LOCK;
+  delete process.env.COMFYUI_MCP_PANEL_PENDING;
+  delete process.env[PANEL_PIN_ENV_VAR];
+  config.comfyuiPath = undefined;
+  resetManagerApiCacheForTests();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// ── Tool-handler capture (mirrors __tests__/tools/batches.test.ts) ──────────
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}>;
+
+function pinHandler(): ToolHandler {
+  const tools: Array<{ name: string; handler: ToolHandler }> = [];
+  const server = {
+    tool: (_name: string, _desc: string, _shape: unknown, handler: ToolHandler) => {
+      tools.push({ name: _name, handler });
+    },
+  } as unknown as McpServer;
+  registerInstallPanelTools(server);
+  const tool = tools.find((t) => t.name === "install_panel");
+  if (!tool) throw new Error("install_panel was not registered");
+  return tool.handler;
+}
+
+async function writePin(): Promise<Record<string, unknown>> {
+  const result = await pinHandler()({ action: "pin", version: "0.11.3" });
+  expect(result.isError ?? false).toBe(false);
+  return JSON.parse(result.content[0].text ?? "{}") as Record<string, unknown>;
+}
+
+// ── Stub Manager personas ────────────────────────────────────────────────────
+
+function jsonRes(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface QueueState {
+  pending: number;
+  inProgress: number;
+  done: number;
+}
+
+/** A Manager v4 host whose queue state the test controls; POST reset wipes pending. */
+function v4Persona(state: QueueState, opts: { resetFails?: boolean } = {}) {
+  managerHandler = (url, init) => {
+    const path = new URL(url).pathname;
+    const method = init?.method ?? "GET";
+    if (path === "/v2/manager/queue/status" && method === "GET") {
+      return jsonRes({
+        total_count: state.done + state.inProgress + state.pending,
+        done_count: state.done,
+        in_progress_count: state.inProgress,
+        pending_count: state.pending,
+        is_processing: state.inProgress > 0,
+      });
+    }
+    if (path === "/v2/manager/queue/reset" && method === "POST") {
+      if (opts.resetFails) return new Response("boom", { status: 500 });
+      state.pending = 0; // wipe_queue() clears PENDING only — running survives
+      return new Response("", { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+/** A legacy 3.x host: no /v2 surface, no pending_count — the arithmetic path. */
+function legacyPersona(state: QueueState) {
+  managerHandler = (url, init) => {
+    const path = new URL(url).pathname;
+    const method = init?.method ?? "GET";
+    if (path === "/manager/queue/status" && method === "GET") {
+      return jsonRes({
+        total_count: state.done + state.inProgress + state.pending,
+        done_count: state.done,
+        in_progress_count: state.inProgress,
+        is_processing: state.inProgress > 0,
+      });
+    }
+    if (path === "/manager/version" && method === "GET") {
+      return new Response("V3.41", { status: 200 });
+    }
+    if (path === "/manager/queue/reset" && method === "POST") {
+      state.pending = 0;
+      return new Response("", { status: 200 });
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+function recordUpdateAllMarker(extra: { base?: string } = { base: ORIG }) {
+  return recordPanelPendingOp(
+    "update-all",
+    "an update_all request may have been handed to ComfyUI-Manager",
+    UPDATE_ALL_PENDING_MS,
+    extra,
+  );
+}
+
+interface CancellationReport {
+  kind: string;
+  outcome: string;
+  markerCleared: boolean;
+  pendingBefore?: number;
+  pendingAfter?: number;
+  inProgress?: number;
+  detail: string;
+}
+
+function cancelReports(report: Record<string, unknown>): CancellationReport[] {
+  return (report.pendingOpCancellations ?? []) as CancellationReport[];
+}
+
+const resetPosts = () =>
+  managerCalls.filter((c) => c.method === "POST" && c.url.includes("/manager/queue/reset"));
+
+describe("pin write cancels a pending update_all (#689)", () => {
+  it("proven cancel: resets the queue ON THE MARKER'S SERVER, names the dropped counts, clears the marker", async () => {
+    recordUpdateAllMarker({ base: ORIG });
+    v4Persona({ pending: 2, inProgress: 0, done: 3 });
+    // Retarget AFTER the marker was recorded: the reset must still hit ORIG.
+    currentBase = "http://new:8188";
+
+    const report = await writePin();
+
+    // The pin itself always lands.
+    expect(report.outcome).toBe("active");
+    expect(getPanelPinState().pinned).toBe(true);
+
+    // Every Manager call went to the marker's server — none to the new target.
+    expect(managerCalls.length).toBeGreaterThan(0);
+    expect(managerCalls.every((c) => c.url.startsWith(ORIG))).toBe(true);
+    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
+
+    // The report names the before/after pending counts — never "saved".
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cancelled");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.pendingBefore).toBe(2);
+    expect(cancel.pendingAfter).toBe(0);
+    expect(cancel.inProgress).toBe(0);
+    expect(cancel.detail).toMatch(/dropped 2 pending task/);
+
+    // Marker provably cleared; no residue warning in the note.
+    expect(activePanelPendingOps()).toEqual([]);
+    expect(report.pendingPanelOps).toBeUndefined();
+    expect(report.note as string).not.toMatch(/WARNING — a panel-affecting operation/);
+    expect(report.note as string).toMatch(/Pending-op handling:/);
+  });
+
+  it("falls back to the CURRENT target when the marker recorded no base — and says so", async () => {
+    recordUpdateAllMarker({}); // no base captured (older marker shape)
+    v4Persona({ pending: 1, inProgress: 0, done: 0 });
+
+    const report = await writePin();
+
+    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cancelled");
+    expect(cancel.detail).toMatch(/recorded no server/);
+  });
+
+  it("reset failure: marker KEPT, warning preserved, nothing claimed", async () => {
+    recordUpdateAllMarker();
+    v4Persona({ pending: 2, inProgress: 0, done: 3 }, { resetFails: true });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(1); // the reset WAS attempted
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/reset FAILED/);
+    // The marker and today's warning survive.
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.pendingPanelOps).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
+    expect(report.note as string).not.toMatch(/cancelled the queued update_all/);
+  });
+
+  it("unverifiable pre-reset state: NOTHING is sent, marker KEPT", async () => {
+    recordUpdateAllMarker();
+    managerHandler = () => new Response("not found", { status: 404 }); // Manager gone
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0); // fail closed — no blind reset
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.detail).toMatch(/NOTHING was sent/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING/);
+  });
+
+  it("in-flight (already dequeued): cannot cancel, NO reset sent, never 'saved'", async () => {
+    recordUpdateAllMarker();
+    v4Persona({ pending: 0, inProgress: 1, done: 3 });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0); // pointless — reset only drops pending
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-running");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.inProgress).toBe(1);
+    expect(cancel.detail).toMatch(/cannot cancel/i);
+    expect(cancel.detail).toMatch(/RUNNING/);
+    expect(cancel.detail).not.toMatch(/dropped|cancelled the queued/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
+  });
+
+  it("partial: pending dropped but a task is running — marker KEPT, both halves reported", async () => {
+    recordUpdateAllMarker();
+    v4Persona({ pending: 2, inProgress: 1, done: 3 });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(1);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("partially-cancelled");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.pendingBefore).toBe(2);
+    expect(cancel.pendingAfter).toBe(0);
+    expect(cancel.inProgress).toBe(1);
+    expect(cancel.detail).toMatch(/dropped 2 pending task/);
+    expect(cancel.detail).toMatch(/already RUNNING and in-flight work cannot be cancelled/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING/);
+  });
+
+  it("already drained: nothing left to cancel — marker cleared, panel may ALREADY have moved", async () => {
+    recordUpdateAllMarker();
+    v4Persona({ pending: 0, inProgress: 0, done: 3 });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.detail).toMatch(/NOTHING left to cancel/);
+    expect(cancel.detail).toMatch(/may ALREADY have been moved/);
+    expect(cancel.detail).not.toMatch(/cancelled|dropped/);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("legacy 3.x: pending derived by total−done−in_progress, reset on the unprefixed route", async () => {
+    recordUpdateAllMarker();
+    legacyPersona({ pending: 2, inProgress: 0, done: 2 });
+
+    const report = await writePin();
+
+    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/manager/queue/reset`]);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cancelled");
+    expect(cancel.pendingBefore).toBe(2);
+    expect(cancel.pendingAfter).toBe(0);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("incoherent 3.x counts (the #639 stale signature) read as could-not-verify", async () => {
+    recordUpdateAllMarker();
+    // total < done + in_progress: the stale-3.x no-op shape. Nothing may be
+    // concluded from it — and a blind reset must NOT be sent on it either.
+    managerHandler = (url, init) => {
+      const path = new URL(url).pathname;
+      const method = init?.method ?? "GET";
+      if (path === "/manager/queue/status" && method === "GET") {
+        return jsonRes({ total_count: 0, done_count: 2, in_progress_count: 0, is_processing: false });
+      }
+      if (path === "/manager/version" && method === "GET") return new Response("V3.41", { status: 200 });
+      return new Response("not found", { status: 404 });
+    };
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+});
+
+describe("pin write cancels a deferred snapshot restore (#689)", () => {
+  function recordSnapshotMarker() {
+    return recordPanelPendingOp(
+      "snapshot-restore",
+      'a snapshot restore ("prod") may have been requested',
+      SNAPSHOT_RESTORE_PENDING_MS,
+      { base: ORIG },
+    );
+  }
+
+  it("local: deletes restore-snapshot.json from the live Manager files dir, clears the marker, no Manager calls", async () => {
+    const comfyRoot = join(dir, "ComfyUI");
+    config.comfyuiPath = comfyRoot;
+    const restoreFile = join(
+      comfyRoot,
+      "user",
+      "__manager",
+      "startup-scripts",
+      "restore-snapshot.json",
+    );
+    mkdirSync(dirname(restoreFile), { recursive: true });
+    writeFileSync(restoreFile, "{}");
+    recordSnapshotMarker();
+
+    const report = await writePin();
+
+    expect(existsSync(restoreFile)).toBe(false);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cancelled");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.detail).toMatch(/deleted the deferred restore file/);
+    expect(cancel.detail).toContain(restoreFile);
+    expect(activePanelPendingOps()).toEqual([]);
+    // The cancel is filesystem-local — the Manager was never contacted.
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("local, no restore file: already applied or never scheduled — marker cleared, truthfully not a cancel", async () => {
+    config.comfyuiPath = join(dir, "ComfyUI"); // nothing scheduled
+    recordSnapshotMarker();
+
+    const report = await writePin();
+
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-drained");
+    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.detail).toMatch(/NOTHING left to cancel/);
+    expect(cancel.detail).toMatch(/may ALREADY have been reverted/);
+    expect(activePanelPendingOps()).toEqual([]);
+    expect(managerCalls).toEqual([]);
+  });
+
+  it("remote: truthful 'cannot cancel — remote host', marker KEPT, no Manager calls", async () => {
+    config.comfyuiPath = undefined; // remote mode — the file lives on the host
+    recordSnapshotMarker();
+
+    const report = await writePin();
+
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("cannot-cancel-remote");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/cannot cancel — remote host/);
+    expect(cancel.detail).toMatch(/BEFORE the next ComfyUI restart/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.pendingPanelOps).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
+    expect(managerCalls).toEqual([]);
+  });
+});
+
+describe("pin write with no pending markers", () => {
+  it("makes NO Manager calls at all", async () => {
+    const report = await writePin();
+
+    expect(report.outcome).toBe("active");
+    expect(report.pendingPanelOps).toBeUndefined();
+    expect(report.pendingOpCancellations).toBeUndefined();
+    expect(managerCalls).toEqual([]);
+  });
+});
+
+describe("the update_all marker captures base + ui_id at enqueue (#689)", () => {
+  it("records the server it queued on and the ui_id of the attempt that landed", async () => {
+    let enqueuedUiId: string | undefined;
+    managerHandler = (url, init) => {
+      const u = new URL(url);
+      const method = init?.method ?? "GET";
+      if (u.pathname === "/v2/manager/queue/status" && method === "GET") {
+        return jsonRes({
+          total_count: 0,
+          done_count: 0,
+          in_progress_count: 0,
+          pending_count: 0,
+          is_processing: false,
+        });
+      }
+      if (u.pathname === "/v2/manager/queue/update_all" && method === "POST") {
+        enqueuedUiId = u.searchParams.get("ui_id") ?? undefined;
+        return jsonRes({});
+      }
+      if (u.pathname === "/v2/manager/queue/start" && method === "POST") {
+        return new Response("", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    await updateAllCustomNodes();
+
+    expect(enqueuedUiId).toBeTruthy();
+    const ops = activePanelPendingOps();
+    expect(ops).toHaveLength(1);
+    expect(ops[0].kind).toBe("update-all");
+    expect(ops[0].base).toBe(ORIG);
+    expect(ops[0].uiId).toBe(enqueuedUiId);
+  });
+});
+
+describe("fetchManagerQueueCounts", () => {
+  it("returns undefined (could-not-verify) when the Manager is unreachable", async () => {
+    managerHandler = () => new Response("not found", { status: 404 });
+    await expect(fetchManagerQueueCounts(ORIG)).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -70,6 +70,7 @@ import {
 import { getPanelPinState, PANEL_PIN_ENV_VAR } from "../../services/panel-settings.js";
 import {
   fetchManagerQueueCounts,
+  fetchManagerTaskHistoryEntry,
   resetManagerApiCacheForTests,
 } from "../../services/node-management.js";
 import { updateAllCustomNodes } from "../../services/update-comfyui.js";
@@ -145,11 +146,16 @@ interface V4PersonaOpts {
   resetFails?: boolean;
   /** Completed task ui_ids the Manager reports in its queue history. */
   history?: Set<string>;
+  /** Override the history response entirely (e.g. a mismatched ui_id). */
+  historyResponder?: (uiId: string) => unknown;
   /** Counts for THIS orchestrator (the client_id=comfyui-mcp filter).
    *  Defaults to the shared state object. */
   mine?: QueueState;
   /** Race injection run when the reset lands (e.g. dequeue a task first). */
   onReset?: () => void;
+  /** After a reset fires, the client-filtered status 404s (post-reset state
+   *  unreadable). */
+  clientStatusFailsAfterReset?: boolean;
 }
 
 /**
@@ -160,12 +166,17 @@ interface V4PersonaOpts {
 function v4Persona(state: QueueState, opts: V4PersonaOpts = {}) {
   const mine = opts.mine ?? state;
   const history = opts.history ?? new Set<string>();
+  let resetDone = false;
   managerHandler = (url, init) => {
     const u = new URL(url);
     const path = u.pathname;
     const method = init?.method ?? "GET";
     if (path === "/v2/manager/queue/status" && method === "GET") {
-      const s = u.searchParams.get("client_id") === "comfyui-mcp" ? mine : state;
+      const isMine = u.searchParams.get("client_id") === "comfyui-mcp";
+      if (isMine && resetDone && opts.clientStatusFailsAfterReset) {
+        return new Response("gone", { status: 404 });
+      }
+      const s = isMine ? mine : state;
       return jsonRes({
         total_count: s.done + s.inProgress + s.pending,
         done_count: s.done,
@@ -176,12 +187,14 @@ function v4Persona(state: QueueState, opts: V4PersonaOpts = {}) {
     }
     if (path === "/v2/manager/queue/history" && method === "GET") {
       const uiId = u.searchParams.get("ui_id") ?? "";
+      if (opts.historyResponder) return jsonRes(opts.historyResponder(uiId));
       return history.has(uiId)
         ? jsonRes({ history: { ui_id: uiId, kind: "update", result: "done" } })
         : jsonRes({ history: {} });
     }
     if (path === "/v2/manager/queue/reset" && method === "POST") {
       if (opts.resetFails) return new Response("boom", { status: 500 });
+      resetDone = true;
       state.pending = 0; // wipe_queue() clears PENDING only — running survives
       mine.pending = 0;
       opts.onReset?.();
@@ -420,6 +433,39 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/WARNING/);
   });
 
+  it("in-flight detected FIRST: our work running AND pending — already-running, NO reset sent", async () => {
+    // Round-4 finding: pending > 0 must not fall through to the reset path
+    // while a task of ours is in flight.
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-r1" });
+    v4Persona({ pending: 2, inProgress: 1, done: 1 }, { mine: { pending: 2, inProgress: 1, done: 1 } });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-running");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.pendingBefore).toBe(2);
+    expect(cancel.inProgress).toBe(1);
+    expect(cancel.detail).toMatch(/cannot cancel/i);
+    expect(cancel.detail).toMatch(/RUNNING/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
+  it("v4 marker without a ui_id, our work running AND pending: already-running — NO reset", async () => {
+    recordUpdateAllMarker({ base: ORIG }); // no uiId
+    v4Persona({ pending: 2, inProgress: 1, done: 1 }, { mine: { pending: 2, inProgress: 1, done: 1 } });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("already-running");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.inProgress).toBe(1);
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
   it("in-flight (already dequeued): cannot cancel, NO reset sent, never 'saved'", async () => {
     recordUpdateAllMarker({ base: ORIG, uiId: "ui-4" });
     v4Persona({ pending: 0, inProgress: 1, done: 3 }, { mine: { pending: 0, inProgress: 1, done: 1 } });
@@ -438,12 +484,18 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
   });
 
-  it("partial: pending dropped but a task started running in the race — marker KEPT, both halves reported", async () => {
+  it("partial: the dropped count is DERIVED from before/after reads, never asserted", async () => {
     recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
     const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
     v4Persona(
       { pending: 2, inProgress: 0, done: 3 },
-      { mine, onReset: () => { mine.inProgress = 1; } }, // dequeued mid-reset
+      {
+        mine,
+        onReset: () => {
+          mine.inProgress = 1; // a task was dequeued mid-reset…
+          mine.pending = 1; // …and a concurrent enqueue re-filled one slot
+        },
+      },
     );
 
     const report = await writePin();
@@ -453,15 +505,56 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(cancel.outcome).toBe("partially-cancelled");
     expect(cancel.markerCleared).toBe(false);
     expect(cancel.pendingBefore).toBe(2);
-    expect(cancel.pendingAfter).toBe(0);
+    expect(cancel.pendingAfter).toBe(1);
     expect(cancel.inProgress).toBe(1);
-    expect(cancel.detail).toMatch(/dropped 2 of this orchestrator's pending task/);
-    expect(cancel.detail).toMatch(/already RUNNING and in-flight work cannot be cancelled/);
+    // 2 → 1 is a drop of ONE: the report must not claim both were dropped.
+    expect(cancel.detail).toMatch(/dropped 1 of this orchestrator's pending task/);
+    expect(cancel.detail).toMatch(/\(2 → 1\)/);
+    expect(cancel.detail).not.toMatch(/dropped 2/);
+    expect(cancel.detail).toMatch(/Queue-wide pending went/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING/);
   });
 
-  it("already drained (no trace of the panel's task): marker cleared, truthfully not a cancel", async () => {
+  it("post-reset state unreadable: UNVERIFIED claims NO drop and names the blast radius", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-8" });
+    v4Persona({ pending: 2, inProgress: 0, done: 1 }, { clientStatusFailsAfterReset: true });
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(1); // the reset DID fire
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/what was dropped is UNVERIFIED/);
+    expect(cancel.detail).toMatch(/Queue-wide pending went 2 → 0/);
+    expect(cancel.detail).not.toMatch(/dropped \d/); // no unmeasured claim
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
+  it("a history entry with a DIFFERENT ui_id proves nothing — could-not-verify, marker kept", async () => {
+    recordUpdateAllMarker({ base: ORIG, uiId: "ui-x" });
+    v4Persona(
+      { pending: 0, inProgress: 0, done: 1 },
+      {
+        // A proxy/variant answering with somebody else's history entry.
+        historyResponder: () => ({
+          history: { ui_id: "someone-elses-task", kind: "update", result: "done" },
+        }),
+      },
+    );
+
+    const report = await writePin();
+
+    expect(resetPosts()).toHaveLength(0);
+    const [cancel] = cancelReports(report);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/queue history on .* could not be read/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+  });
+
+  it("already drained (no trace of the panel's task): marker cleared, truthfully not a cancel — and says the panel may ALREADY have moved", async () => {
     recordUpdateAllMarker({ base: ORIG, uiId: "ui-6" });
     v4Persona({ pending: 0, inProgress: 0, done: 3 });
 
@@ -471,7 +564,11 @@ describe("pin write cancels a pending update_all (#689)", () => {
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("already-drained");
     expect(cancel.markerCleared).toBe(true);
-    expect(cancel.detail).toMatch(/NOTHING remains that can move the panel/);
+    expect(cancel.detail).toMatch(/NOTHING left to cancel/);
+    // Finding 4: "already finished" alone is not enough — the report must
+    // name the possibility that the update already landed.
+    expect(cancel.detail).toMatch(/may ALREADY have been moved/);
+    expect(cancel.detail).toMatch(/install_panel\(action='status'\)/);
     expect(cancel.detail).not.toMatch(/cancelled the queued|dropped \d/);
     expect(activePanelPendingOps()).toEqual([]);
   });
@@ -846,5 +943,30 @@ describe("fetchManagerQueueCounts", () => {
   it("returns undefined (could-not-verify) when the Manager is unreachable", async () => {
     managerHandler = () => new Response("not found", { status: 404 });
     await expect(fetchManagerQueueCounts(ORIG)).resolves.toBeUndefined();
+  });
+});
+
+describe("fetchManagerTaskHistoryEntry (#689 round 4)", () => {
+  it("returns the entry ONLY when the ui_id matches; {} is provably absent", async () => {
+    v4Persona(
+      { pending: 0, inProgress: 0, done: 0 },
+      { history: new Set(["ui-a_comfyui-agent-panel"]) },
+    );
+    await expect(
+      fetchManagerTaskHistoryEntry("ui-a_comfyui-agent-panel", ORIG),
+    ).resolves.toMatchObject({ uiId: "ui-a_comfyui-agent-panel", kind: "update" });
+    await expect(
+      fetchManagerTaskHistoryEntry("ui-b_comfyui-agent-panel", ORIG),
+    ).resolves.toBeNull();
+  });
+
+  it("a mismatched ui_id in the response is UNTRUSTED (undefined), never proof", async () => {
+    v4Persona(
+      { pending: 0, inProgress: 0, done: 0 },
+      { historyResponder: () => ({ history: { ui_id: "other-task", kind: "update" } }) },
+    );
+    await expect(
+      fetchManagerTaskHistoryEntry("ui-a_comfyui-agent-panel", ORIG),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/__tests__/services/panel-pin-guard.test.ts
+++ b/src/__tests__/services/panel-pin-guard.test.ts
@@ -14,6 +14,7 @@ import { dirname, join } from "node:path";
 import {
   activePanelPendingOps,
   assertPanelPinAllows,
+  clearPanelPendingOp,
   PanelPinnedError,
   panelLockPath,
   panelPendingOpsPath,
@@ -348,5 +349,58 @@ describe("assertPanelNotTargetedUnverifiable — paths that cannot verify", () =
     expect(() =>
       assertPanelNotTargetedUnverifiable("panel_install_node", undefined),
     ).not.toThrow();
+  });
+});
+
+describe("pending-op markers — record, read, and clear (#689)", () => {
+  it("round-trips the optional base/uiId capture fields", () => {
+    const op = recordPanelPendingOp("update-all", "test marker", 60_000, {
+      base: "http://orig:8188",
+      uiId: "ui-123",
+    });
+    const active = activePanelPendingOps();
+    expect(active).toHaveLength(1);
+    expect(active[0].base).toBe("http://orig:8188");
+    expect(active[0].uiId).toBe("ui-123");
+    expect(active[0].queuedAt).toBe(op.queuedAt);
+  });
+
+  it("markers without the optional fields still read fine (older shape)", () => {
+    recordPanelPendingOp("update-all", "bare marker", 60_000);
+    const active = activePanelPendingOps();
+    expect(active).toHaveLength(1);
+    expect(active[0].base).toBeUndefined();
+    expect(active[0].uiId).toBeUndefined();
+  });
+
+  it("clearPanelPendingOp removes ONLY the exact record handed in", () => {
+    const first = recordPanelPendingOp("update-all", "first", 60_000);
+    // A newer marker of the same kind REPLACES the old one on record...
+    const second = recordPanelPendingOp("update-all", "second", 60_000);
+    expect(activePanelPendingOps().map((o) => o.detail)).toEqual(["second"]);
+
+    // ...so clearing the STALE one is a no-op that must not touch the new one.
+    expect(clearPanelPendingOp(first)).toBe(true);
+    expect(activePanelPendingOps().map((o) => o.detail)).toEqual(["second"]);
+
+    // Clearing the live one removes exactly it.
+    expect(clearPanelPendingOp(second)).toBe(true);
+    expect(activePanelPendingOps()).toEqual([]);
+  });
+
+  it("clearPanelPendingOp leaves other kinds alone", () => {
+    const update = recordPanelPendingOp("update-all", "u", 60_000);
+    recordPanelPendingOp("snapshot-restore", "s", 60_000);
+    expect(clearPanelPendingOp(update)).toBe(true);
+    expect(activePanelPendingOps().map((o) => o.kind)).toEqual(["snapshot-restore"]);
+  });
+
+  it("clearPanelPendingOp fails CLOSED on an unreadable marker file", () => {
+    const op = recordPanelPendingOp("update-all", "u", 60_000);
+    writeFileSync(panelPendingOpsPath(), "{ not json"); // corrupt it afterwards
+    expect(clearPanelPendingOp(op)).toBe(false);
+    // ...and the unreadable record still reads as a (synthetic) pending op.
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(activePanelPendingOps()[0].kind).toBe("unknown");
   });
 });

--- a/src/services/manager-config.ts
+++ b/src/services/manager-config.ts
@@ -213,9 +213,20 @@ export async function setChannel(value: string): Promise<ManagerConfigResult> {
 /**
  * Reset the Manager task queue. This is the runtime, HTTP-reachable analog of
  * `comfy-cli manager clear` (which clears reserved startup actions locally).
+ *
+ * NOTE on blast radius: the reset drops EVERY pending task in the Manager
+ * queue (Manager has no per-task cancel), while a task already dequeued by
+ * the worker keeps running — callers reporting a cancel must say both halves.
+ *
+ * `base` pins the target for this call (the ManagerFetchOptions.base
+ * convention): the pin-write cancellation path (#689) passes the server its
+ * pending-op marker was recorded against, so the reset lands on the ORIGINAL
+ * ComfyUI even if the orchestrator has been retargeted since. Defaults to the
+ * current target.
  */
-export async function resetQueue(): Promise<ManagerConfigResult> {
-  const base = getComfyUIBaseUrl();
+export async function resetQueue(
+  base = getComfyUIBaseUrl(),
+): Promise<ManagerConfigResult> {
   const api = await detectManagerApi(base);
   await managerFetch(`${managerApiPrefixFor(api)}/manager/queue/reset`, { method: "POST" }, base);
   return {

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -776,6 +776,11 @@ export async function fetchManagerTaskHistoryEntry(
     // shaped wrong is not an answer we can act on.
     return Object.keys(h).length === 0 ? null : undefined;
   }
+  // STRICT id check: an entry for a DIFFERENT task (a rewriting proxy, a
+  // Manager variant that ignores ui_id and answers with something else's
+  // history) must never prove anything about OUR task — least of all clear
+  // its marker as already-drained (#689 round 4).
+  if (h.ui_id !== uiId) return undefined;
   return {
     uiId: h.ui_id,
     kind: typeof h.kind === "string" ? h.kind : undefined,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -651,15 +651,48 @@ export interface ManagerQueueCounts {
 }
 
 /**
+ * Extract counts from a queue/status payload. Returns undefined when required
+ * fields are missing or the counts are incoherent (negative pending — the
+ * #639 stale-3.x signature), so callers report "could not verify" instead of
+ * guessing.
+ */
+function countsFromStatus(status: unknown): ManagerQueueCounts | undefined {
+  if (!status || typeof status !== "object") return undefined;
+  const s = status as QueueStatus;
+  const inProgress = typeof s.in_progress_count === "number" ? s.in_progress_count : undefined;
+  if (inProgress === undefined) return undefined;
+  let pending: number;
+  if (typeof s.pending_count === "number") {
+    pending = s.pending_count; // v4 reports it directly
+  } else {
+    // 3.x: total_count = done + in_progress + queued exactly.
+    if (typeof s.total_count !== "number" || typeof s.done_count !== "number") {
+      return undefined;
+    }
+    pending = s.total_count - s.done_count - inProgress;
+    if (pending < 0) return undefined; // incoherent counts — cannot verify anything
+  }
+  return {
+    pending,
+    inProgress,
+    processing: typeof s.is_processing === "boolean" ? s.is_processing : inProgress > 0,
+  };
+}
+
+/**
  * Read the Manager queue counts ONCE, in the detected dialect — the measuring
  * stick for the pin-write cancellation path (#689), which must report what a
  * queue reset actually dropped rather than claim the panel was saved.
  *
+ * These are SHARED, queue-wide counts: they can never say whether OUR task is
+ * among the pending ones (that needs fetchManagerClientQueueCounts /
+ * fetchManagerTaskHistoryEntry on v4).
+ *
  * Returns undefined whenever the state cannot be PROVEN: detection failed,
  * the status endpoint did not answer with queue counts, required fields are
- * missing, or the counts are incoherent (negative pending — the #639 stale-3.x
- * signature). The caller reports "could not verify" and keeps the pending-op
- * marker rather than guessing in either direction.
+ * missing, or the counts are incoherent. The caller reports "could not
+ * verify" and keeps the pending-op marker rather than guessing in either
+ * direction.
  */
 export async function fetchManagerQueueCounts(
   base = managerBaseUrl(),
@@ -674,26 +707,79 @@ export async function fetchManagerQueueCounts(
     base,
     soft: true,
   });
-  if (!status || typeof status !== "object") return undefined;
-  const inProgress =
-    typeof status.in_progress_count === "number" ? status.in_progress_count : undefined;
-  if (inProgress === undefined) return undefined;
-  let pending: number;
-  if (typeof status.pending_count === "number") {
-    pending = status.pending_count; // v4 reports it directly
-  } else {
-    // 3.x: total_count = done + in_progress + queued exactly.
-    if (typeof status.total_count !== "number" || typeof status.done_count !== "number") {
-      return undefined;
-    }
-    pending = status.total_count - status.done_count - inProgress;
-    if (pending < 0) return undefined; // incoherent counts — cannot verify anything
+  return countsFromStatus(status);
+}
+
+/**
+ * v4-only: queue counts for tasks THIS orchestrator enqueued (every enqueue
+ * carries client_id "comfyui-mcp"). This is what separates "the update_all is
+ * still queued" from "UNRELATED tasks are queued" on a shared Manager — the
+ * distinction a proven cancel needs (#689 round 3).
+ *
+ * Returns undefined on any non-v4 dialect: the 3.x and legacy-UI (v2-batch)
+ * status handlers IGNORE the client_id parameter and answer GLOBAL counts,
+ * which would impersonate our tasks. Also undefined when unreadable or
+ * incoherent.
+ */
+export async function fetchManagerClientQueueCounts(
+  base = managerBaseUrl(),
+): Promise<ManagerQueueCounts | undefined> {
+  let api: ManagerApi;
+  try {
+    api = await detectManagerApi(base);
+  } catch {
+    return undefined;
+  }
+  if (api !== "v2") return undefined;
+  const status = await managerFetch<QueueStatus>(
+    `/v2/manager/queue/status?client_id=${encodeURIComponent(MANAGER_CLIENT_ID)}`,
+    { base, soft: true },
+  );
+  return countsFromStatus(status);
+}
+
+export interface ManagerTaskHistoryEntry {
+  uiId: string;
+  kind?: string;
+  result?: string;
+}
+
+/**
+ * v4-only: look up ONE completed task in the Manager's queue history by exact
+ * ui_id (GET /v2/manager/queue/history?ui_id=…). Returns the entry when found,
+ * null when the Manager provably has NO such completed task ({}), and
+ * undefined when the answer cannot be trusted — non-v4 dialect (the legacy-UI
+ * history route knows only the file-based ?id= form, so it would not answer
+ * the question asked) or an unreadable response.
+ */
+export async function fetchManagerTaskHistoryEntry(
+  uiId: string,
+  base = managerBaseUrl(),
+): Promise<ManagerTaskHistoryEntry | null | undefined> {
+  let api: ManagerApi;
+  try {
+    api = await detectManagerApi(base);
+  } catch {
+    return undefined;
+  }
+  if (api !== "v2") return undefined;
+  const res = await managerFetch<{ history?: unknown }>(
+    `/v2/manager/queue/history?ui_id=${encodeURIComponent(uiId)}`,
+    { base, soft: true },
+  );
+  if (!res || typeof res !== "object" || !("history" in res)) return undefined;
+  const history = (res as { history: unknown }).history;
+  if (!history || typeof history !== "object" || Array.isArray(history)) return undefined;
+  const h = history as Record<string, unknown>;
+  if (typeof h.ui_id !== "string") {
+    // {"history": {}} is the provable "no such completed task". Anything else
+    // shaped wrong is not an answer we can act on.
+    return Object.keys(h).length === 0 ? null : undefined;
   }
   return {
-    pending,
-    inProgress,
-    processing:
-      typeof status.is_processing === "boolean" ? status.is_processing : inProgress > 0,
+    uiId: h.ui_id,
+    kind: typeof h.kind === "string" ? h.kind : undefined,
+    result: typeof h.result === "string" ? h.result : undefined,
   };
 }
 

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -639,6 +639,64 @@ export function setQueueTimingForTests(
   Object.assign(queueTiming, overrides);
 }
 
+/** Queue counts for honest before/after reporting around a queue reset. */
+export interface ManagerQueueCounts {
+  /** Tasks still WAITING to run — v4's `pending_count` directly, else the 3.x
+   *  arithmetic total−done−in_progress (3.x defines total that way exactly). */
+  pending: number;
+  /** Tasks already dequeued by the worker — these a queue reset CANNOT stop. */
+  inProgress: number;
+  /** Manager's worker-alive flag (falls back to inProgress > 0 when absent). */
+  processing: boolean;
+}
+
+/**
+ * Read the Manager queue counts ONCE, in the detected dialect — the measuring
+ * stick for the pin-write cancellation path (#689), which must report what a
+ * queue reset actually dropped rather than claim the panel was saved.
+ *
+ * Returns undefined whenever the state cannot be PROVEN: detection failed,
+ * the status endpoint did not answer with queue counts, required fields are
+ * missing, or the counts are incoherent (negative pending — the #639 stale-3.x
+ * signature). The caller reports "could not verify" and keeps the pending-op
+ * marker rather than guessing in either direction.
+ */
+export async function fetchManagerQueueCounts(
+  base = managerBaseUrl(),
+): Promise<ManagerQueueCounts | undefined> {
+  let api: ManagerApi;
+  try {
+    api = await detectManagerApi(base);
+  } catch {
+    return undefined;
+  }
+  const status = await managerFetch<QueueStatus>(`${managerQueuePrefixFor(api)}/status`, {
+    base,
+    soft: true,
+  });
+  if (!status || typeof status !== "object") return undefined;
+  const inProgress =
+    typeof status.in_progress_count === "number" ? status.in_progress_count : undefined;
+  if (inProgress === undefined) return undefined;
+  let pending: number;
+  if (typeof status.pending_count === "number") {
+    pending = status.pending_count; // v4 reports it directly
+  } else {
+    // 3.x: total_count = done + in_progress + queued exactly.
+    if (typeof status.total_count !== "number" || typeof status.done_count !== "number") {
+      return undefined;
+    }
+    pending = status.total_count - status.done_count - inProgress;
+    if (pending < 0) return undefined; // incoherent counts — cannot verify anything
+  }
+  return {
+    pending,
+    inProgress,
+    processing:
+      typeof status.is_processing === "boolean" ? status.is_processing : inProgress > 0,
+  };
+}
+
 /**
  * Kick off the Manager queue worker and poll until it drains.
  * Returns the final queue status.
@@ -1904,39 +1962,45 @@ async function updateManagerSelf(id: string): Promise<NodeOpResult> {
  * never re-sent, so update_all can never run twice (#656).
  *
  * Returns the dialect the enqueue ACTUALLY spoke (so the caller starts/polls
- * the queue holding the task) and the route's raw response body.
+ * the queue holding the task), the route's raw response body, and the ui_id
+ * of the attempt that LANDED (a self-heal retry mints a fresh one — only the
+ * last one's tasks exist, so only it correlates with v4 queue history, #689).
  */
 async function enqueueUpdateAll(
   mode: string,
   base: string,
-): Promise<{ used: ManagerApi; response: unknown }> {
+): Promise<{ used: ManagerApi; response: unknown; uiId: string }> {
   let response: unknown;
+  let uiId = "";
   const used = await enqueueWithDialectSelfHeal("update-all", async (api) => {
     // The v4 backend reads UpdateAllQueryParams from the QUERY STRING
     // (manager_server.py), NOT the JSON body — a body-only request leaves mode
     // defaulting to 'remote' and drops client_id/ui_id. Send them as URL query
     // params. A fresh ui_id per attempt keeps the two attempts distinguishable.
-    const uiId = randomUUID();
+    const attemptUiId = randomUUID();
     if (api === "legacy") {
       // 3.x reads {mode} from the JSON BODY (and ignores client_id/ui_id).
       response = await managerFetch("/manager/queue/update_all", {
         method: "POST",
-        body: { mode, ui_id: uiId },
+        body: { mode, ui_id: attemptUiId },
         base,
       });
     } else {
       const query = new URLSearchParams({
         mode,
         client_id: MANAGER_CLIENT_ID,
-        ui_id: uiId,
+        ui_id: attemptUiId,
       }).toString();
       response = await managerFetch(`/v2/manager/queue/update_all?${query}`, {
         method: "POST",
         base,
       });
     }
+    // Only reached when the enqueue did NOT throw — this attempt's id is the
+    // one whose tasks are actually on the queue.
+    uiId = attemptUiId;
   }, base);
-  return { used, response };
+  return { used, response, uiId };
 }
 
 export async function updateCustomNode(opts: UpdateOptions): Promise<NodeOpResult> {
@@ -2006,6 +2070,12 @@ export interface QueueUpdateAllResult {
   queueStarted: boolean;
   /** Raw update_all response body, when the route produced one. */
   managerResponse?: unknown;
+  /** The ComfyUI base the enqueue actually targeted (captured at invocation,
+   *  so a later cancel can aim at the same server — #689). */
+  base: string;
+  /** The ui_id of the enqueue attempt that landed; v4 derives each per-pack
+   *  task id as `${uiId}_${pack}`, so this correlates with queue history. */
+  uiId: string;
 }
 
 /**
@@ -2025,7 +2095,7 @@ export async function queueUpdateAllCustomNodes(): Promise<QueueUpdateAllResult>
   // self-heal retry, and the queue start all stay on the instance selected at
   // invocation, even if the panel retargets mid-call.
   const base = managerBaseUrl();
-  const { used, response } = await enqueueUpdateAll("remote", base);
+  const { used, response, uiId } = await enqueueUpdateAll("remote", base);
   const prefix = managerQueuePrefixFor(used);
   let queueStarted = true;
   try {
@@ -2038,7 +2108,13 @@ export async function queueUpdateAllCustomNodes(): Promise<QueueUpdateAllResult>
       error: err instanceof Error ? err.message : String(err),
     });
   }
-  return { endpoint: `${prefix}/update_all`, queueStarted, managerResponse: response };
+  return {
+    endpoint: `${prefix}/update_all`,
+    queueStarted,
+    managerResponse: response,
+    base,
+    uiId,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -70,12 +70,18 @@ function managerBaseUrl(): string {
 /**
  * Fetch a ComfyUI-Manager endpoint. Throws NodeSnapshotError on non-2xx or
  * network failure so callers can route through errorToToolResult.
+ *
+ * `base` pins the target for this call (the ManagerFetchOptions.base
+ * convention): callers that record a pending-op marker must pass the SAME
+ * base they recorded, so marker and request can never name different servers
+ * (#689 round 3).
  */
 async function managerFetch(
   path: string,
   init?: RequestInit,
+  base = managerBaseUrl(),
 ): Promise<Response> {
-  const url = `${managerBaseUrl()}${path}`;
+  const url = `${base}${path}`;
   logger.debug("Manager API request", { url, method: init?.method ?? "GET" });
 
   let res: Response;
@@ -326,28 +332,38 @@ export async function restoreNodeSnapshot(
     // The Manager stores names without the .json suffix; tolerate either.
     const target = trimmed.endsWith(".json") ? trimmed.slice(0, -5) : trimmed;
 
+    // Pin the target ONCE and use it for BOTH the marker and the request: a
+    // retarget between the record and the POST must never leave the marker
+    // naming server A while the restore is scheduled on server B — a later
+    // pin-write cancellation trusts the marker's base (#689 round 3).
+    const base = managerBaseUrl();
+
     // Persist and VERIFY the warning marker BEFORE requesting the deferred
     // restore. A pin written after Manager receives the request cannot stop the
     // next-restart apply; refusing when the marker cannot be made durable is the
     // only way to avoid reporting such a pin as protective. Keep the marker on a
     // request failure because a transport error cannot prove Manager did not
-    // receive it. The base is recorded so a later pin-write cancellation report
-    // can name the host the restore was scheduled on (#689).
+    // receive it. The base is recorded so the pin-write cancellation path aims
+    // at the host the restore is actually scheduled on (#689).
     recordPanelPendingOp(
       "snapshot-restore",
       `a snapshot restore ("${target}") may have been requested and reverts EVERY pack to ` +
         `its snapshot commit — the sidebar panel included — at the next ComfyUI ` +
         `restart`,
       SNAPSHOT_RESTORE_PENDING_MS,
-      { base: managerBaseUrl() },
+      { base },
     );
 
     try {
-      await managerFetch("/snapshot/restore", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ target }),
-      });
+      await managerFetch(
+        "/snapshot/restore",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ target }),
+        },
+        base,
+      );
     } catch (err) {
       if (isSnapshotEndpointUnsupported(err)) {
         logger.info("Snapshot restore unsupported on this ComfyUI-Manager build");

--- a/src/services/node-snapshots.ts
+++ b/src/services/node-snapshots.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { config, getComfyUIBaseUrl } from "../config.js";
 import { comfyuiFetch } from "../comfyui/fetch.js";
@@ -101,15 +101,26 @@ async function managerFetch(
 }
 
 /**
+ * Candidate ComfyUI-Manager FILES directories under a local install, newest
+ * layout first. Mirrors manager_migration.get_manager_path() (user/__manager
+ * when ComfyUI has the system-user API, user/default/ComfyUI-Manager
+ * otherwise) plus the legacy git-clone layout, which keeps everything inside
+ * the extension dir.
+ */
+function managerFilesDirCandidates(comfyuiPath: string): string[] {
+  return [
+    join(comfyuiPath, "user", "__manager"),
+    join(comfyuiPath, "user", "default", "ComfyUI-Manager"),
+    join(comfyuiPath, "custom_nodes", "ComfyUI-Manager"),
+  ];
+}
+
+/**
  * Candidate ComfyUI-Manager snapshot directories under a local install,
- * newest layout first. Mirrors manager_migration.get_manager_path().
+ * newest layout first.
  */
 function snapshotDirCandidates(comfyuiPath: string): string[] {
-  return [
-    join(comfyuiPath, "user", "__manager", "snapshots"),
-    join(comfyuiPath, "user", "default", "ComfyUI-Manager", "snapshots"),
-    join(comfyuiPath, "custom_nodes", "ComfyUI-Manager", "snapshots"),
-  ];
+  return managerFilesDirCandidates(comfyuiPath).map((dir) => join(dir, "snapshots"));
 }
 
 /**
@@ -320,13 +331,15 @@ export async function restoreNodeSnapshot(
     // next-restart apply; refusing when the marker cannot be made durable is the
     // only way to avoid reporting such a pin as protective. Keep the marker on a
     // request failure because a transport error cannot prove Manager did not
-    // receive it.
+    // receive it. The base is recorded so a later pin-write cancellation report
+    // can name the host the restore was scheduled on (#689).
     recordPanelPendingOp(
       "snapshot-restore",
       `a snapshot restore ("${target}") may have been requested and reverts EVERY pack to ` +
         `its snapshot commit — the sidebar panel included — at the next ComfyUI ` +
         `restart`,
       SNAPSHOT_RESTORE_PENDING_MS,
+      { base: managerBaseUrl() },
     );
 
     try {
@@ -352,6 +365,113 @@ export async function restoreNodeSnapshot(
         `custom-node changes on the next ComfyUI restart.`,
     };
   });
+}
+
+/**
+ * The deferred-restore file Manager's POST /snapshot/restore leaves behind:
+ * nothing happens at request time beyond copying the chosen snapshot to
+ * `<manager files>/startup-scripts/restore-snapshot.json`, and
+ * prestartup_script.py applies it at the next ComfyUI start only
+ * `if os.path.exists(...)`, then deletes it. Deleting the file before that
+ * restart is therefore a PROVABLE cancel, and its absence proves nothing is
+ * scheduled. (Verified against Comfy-Org/ComfyUI-Manager main AND the
+ * manager-v4 pip package — both use the same path.)
+ */
+const RESTORE_SNAPSHOT_FILE = join("startup-scripts", "restore-snapshot.json");
+
+export interface CancelSnapshotRestoreResult {
+  outcome:
+    | "cancelled" // the deferred-restore file was found and is now gone
+    | "not-scheduled" // no deferred-restore file exists anywhere — nothing to cancel
+    | "remote" // no local install path: the file lives on the ComfyUI host
+    | "failed"; // a delete was attempted and failed
+  /** The restore file(s) deleted (outcome "cancelled"). */
+  deletedPaths: string[];
+  /** Every location checked (local mode only). */
+  checkedPaths: string[];
+  /** Human-facing explanation for the pin-write report. */
+  detail: string;
+}
+
+/**
+ * Cancel a DEFERRED snapshot restore by deleting Manager's deferred-restore
+ * file before the next ComfyUI restart consumes it (#689).
+ *
+ * Local installs only: in remote mode the file lives on the ComfyUI host,
+ * which this process cannot reach — reported truthfully as "cannot cancel",
+ * never as a cancel. Every candidate Manager files dir is checked (a stale
+ * copy in a legacy layout is deleted too: Manager's prestartup reads exactly
+ * one of these, and leaving any of them in place risks the restore running).
+ */
+export function cancelPendingSnapshotRestore(): CancelSnapshotRestoreResult {
+  if (!config.comfyuiPath) {
+    return {
+      outcome: "remote",
+      deletedPaths: [],
+      checkedPaths: [],
+      detail:
+        "cannot cancel — remote host: the deferred restore file " +
+        "(<ComfyUI>/user/**/startup-scripts/restore-snapshot.json) lives on the " +
+        "ComfyUI host and this orchestrator has no local install path to delete " +
+        "it through. Delete it on the host BEFORE the next ComfyUI restart, or " +
+        "the restore will run.",
+    };
+  }
+  const checkedPaths = managerFilesDirCandidates(config.comfyuiPath).map((dir) =>
+    join(dir, RESTORE_SNAPSHOT_FILE),
+  );
+  const found = checkedPaths.filter((p) => existsSync(p));
+  if (found.length === 0) {
+    return {
+      outcome: "not-scheduled",
+      deletedPaths: [],
+      checkedPaths,
+      detail:
+        "no deferred restore file exists in any ComfyUI-Manager files dir, so " +
+        "there was NOTHING left to cancel — the restore already ran at a ComfyUI " +
+        "restart (or was never scheduled). The panel may ALREADY have been " +
+        "reverted to its snapshot commit — check install_panel(action='status').",
+    };
+  }
+  const deletedPaths: string[] = [];
+  for (const p of found) {
+    try {
+      rmSync(p, { force: true });
+    } catch (err) {
+      return {
+        outcome: "failed",
+        deletedPaths,
+        checkedPaths,
+        detail:
+          `could not delete the deferred restore file at ${p}: ${
+            err instanceof Error ? err.message : String(err)
+          }. The restore may still run at the next ComfyUI restart — delete that ` +
+          `file on the ComfyUI host manually.`,
+      };
+    }
+    // Verify gone rather than trusting the syscall — the whole point is proof.
+    if (!existsSync(p)) deletedPaths.push(p);
+  }
+  if (deletedPaths.length !== found.length) {
+    const surviving = found.filter((p) => !deletedPaths.includes(p));
+    return {
+      outcome: "failed",
+      deletedPaths,
+      checkedPaths,
+      detail:
+        `the deferred restore file still exists after deletion was attempted ` +
+        `(${surviving.join(", ")}). The restore may still run at the next ` +
+        `ComfyUI restart — delete it on the ComfyUI host manually.`,
+    };
+  }
+  return {
+    outcome: "cancelled",
+    deletedPaths,
+    checkedPaths,
+    detail:
+      `deleted the deferred restore file (${deletedPaths.join(", ")}) — the ` +
+      `snapshot restore will NOT run at the next ComfyUI restart.`,
+  };
 }
 
 /**

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -23,6 +23,12 @@
 //     longer pending (an empty, idle queue / a missing restore file cannot
 //     land later). Everything else — in-flight work, remote hosts, reset
 //     failures, unreadable state — keeps the marker and its warning.
+//   - A marker proves things ONLY about the server recorded in it. A marker
+//     with no recorded base, or whose base is not the current target, must
+//     NEVER be resolved on the current target's evidence: a queue reset or a
+//     local file deletion there may hit the WRONG ComfyUI while the original
+//     work still runs. Those paths act best-effort at most, report UNVERIFIED
+//     / cannot-cancel, and keep the marker.
 //   - A queue reset is BLUNT: it drops ALL pending Manager tasks, not just the
 //     update_all. The report says so.
 
@@ -91,15 +97,17 @@ function finalize(
 }
 
 async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelReport> {
-  // Aim at the server the update_all was queued on. resetQueue re-resolves the
-  // current target when given no base — thread the marker's capture so a
-  // retarget between enqueue and pin can't send the reset to the WRONG ComfyUI
-  // (which would both miss the real queue and wipe an innocent one).
-  const base = op.base ?? getComfyUIBaseUrl();
-  const baseNote = op.base
-    ? ` on ${base}`
-    : ` on the CURRENT target ${base} (the marker recorded no server, so this ` +
-      `may not be the ComfyUI the update_all was queued on)`;
+  // A marker proves things only about the server RECORDED in it. Without a
+  // base (markers written before the capture existed), the current target may
+  // be a different ComfyUI entirely — its queue state says NOTHING about the
+  // server the update_all was queued on. Never a proven cancel from that.
+  if (!op.base) return cancelUpdateAllUnbased(op);
+
+  // Aim at the server the update_all was queued on: a retarget between
+  // enqueue and pin must not send the reset to the WRONG ComfyUI (which would
+  // both miss the real queue and wipe an innocent one).
+  const base = op.base;
+  const baseNote = ` on ${base}`;
 
   const before = await fetchManagerQueueCounts(base);
   if (!before) {
@@ -237,8 +245,160 @@ async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelRe
   });
 }
 
+/**
+ * A base-less update-all marker (written before the base capture existed).
+ * The current target is the LIKELY server — retargets between enqueue and pin
+ * are the rare case — so a reset there is attempted as the only protective
+ * move available. But it is never PROOF: if the current target is not the
+ * ComfyUI the update_all was queued on, the reset wiped an innocent queue
+ * while the original update still runs. Every outcome here is therefore
+ * UNVERIFIED and keeps the marker and its warning.
+ */
+async function cancelUpdateAllUnbased(op: PanelPendingOp): Promise<PanelPendingCancelReport> {
+  const base = getComfyUIBaseUrl();
+  const before = await fetchManagerQueueCounts(base);
+  if (!before) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `the marker recorded NO server, and the queue on the current target ` +
+        `${base} could not be read — the update_all may be queued on a ` +
+        `DIFFERENT ComfyUI. NOTHING was sent; the warning stands.`,
+    };
+  }
+
+  if (before.pending === 0) {
+    const state =
+      before.inProgress > 0 || before.processing
+        ? `has nothing pending but ${before.inProgress} task(s) running`
+        : `is empty and idle`;
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `the marker recorded NO server. The current target ${base} ${state}, ` +
+        `which proves NOTHING about the ComfyUI the update_all was actually ` +
+        `queued on — no reset was sent. If ${base} is not that server, the ` +
+        `update may still land after this pin; the warning stands.`,
+      pendingBefore: 0,
+      inProgress: before.inProgress,
+    };
+  }
+
+  try {
+    await resetQueue(base);
+  } catch (err) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `the marker recorded NO server, and a best-effort queue reset on the ` +
+        `current target ${base} FAILED: ${
+          err instanceof Error ? err.message : String(err)
+        }. The update_all may be queued on a different ComfyUI entirely; the ` +
+        `warning stands.`,
+      pendingBefore: before.pending,
+      inProgress: before.inProgress,
+    };
+  }
+
+  const after = await fetchManagerQueueCounts(base);
+  return {
+    op,
+    outcome: "could-not-verify",
+    markerCleared: false,
+    detail:
+      `the marker recorded NO server, so this is UNVERIFIED: a best-effort ` +
+      `queue reset on the current target ${base} ` +
+      (after
+        ? `dropped ${before.pending - after.pending} pending task(s) there. `
+        : `was sent (${before.pending} task(s) were pending), but the ` +
+          `post-reset state could not be read. `) +
+      `If ${base} is NOT the ComfyUI the update_all was queued on, the ` +
+      `original update is still queued there and may land after this pin — ` +
+      `the warning stands. Check install_panel(action='status') on the server ` +
+      `update_all was run against.`,
+    pendingBefore: before.pending,
+    pendingAfter: after?.pending,
+    inProgress: after?.inProgress ?? before.inProgress,
+  };
+}
+
 function cancelSnapshotRestore(op: PanelPendingOp): PanelPendingCancelReport {
+  // The deferred restore file lives on the host the restore was REQUESTED
+  // against. Local filesystem state proves things only about the CURRENT
+  // target: a marker recorded for a different server (e.g. before a
+  // remote→local retarget) must NEVER be cleared on local evidence — the
+  // remote restore is still scheduled whatever the local disk says.
+  const currentBase = getComfyUIBaseUrl();
+  if (op.base && op.base !== currentBase) {
+    return {
+      op,
+      outcome: "cannot-cancel",
+      markerCleared: false,
+      detail:
+        `cannot cancel from here — the deferred restore was scheduled on ` +
+        `${op.base}, but this orchestrator now targets ${currentBase}. The ` +
+        `restore file (<ComfyUI>/user/**/startup-scripts/restore-snapshot.json) ` +
+        `lives on ${op.base} and must be deleted THERE before its next ComfyUI ` +
+        `restart; the current target's local state says nothing about that ` +
+        `host. The warning stands.`,
+    };
+  }
+
   const result = cancelPendingSnapshotRestore();
+
+  // No recorded server: the local action is at best a guess about which host
+  // the restore was scheduled on. It is still applied (a local restore file
+  // WILL run at the next local restart, so deleting it is protective), but
+  // nothing here is PROOF — report UNVERIFIED and keep the marker.
+  if (!op.base) {
+    switch (result.outcome) {
+      case "cancelled":
+        return {
+          op,
+          outcome: "could-not-verify",
+          markerCleared: false,
+          detail:
+            `${result.detail} — HOWEVER the marker recorded no server, so this ` +
+            `is UNVERIFIED: if the restore was scheduled on a DIFFERENT (e.g. ` +
+            `remote) host, it is still scheduled there and will run at its next ` +
+            `restart. The warning stands.`,
+        };
+      case "not-scheduled":
+        return {
+          op,
+          outcome: "could-not-verify",
+          markerCleared: false,
+          detail:
+            `no deferred restore file exists on the current target, but the ` +
+            `marker recorded no server — the restore may be scheduled on a ` +
+            `DIFFERENT host and still run at its next ComfyUI restart. The ` +
+            `warning stands.`,
+        };
+      case "remote":
+        return {
+          op,
+          outcome: "cannot-cancel-remote",
+          markerCleared: false,
+          detail: result.detail,
+        };
+      case "failed":
+        return {
+          op,
+          outcome: "could-not-verify",
+          markerCleared: false,
+          detail: result.detail,
+        };
+    }
+  }
+
+  // The marker's base IS the current target — local evidence is about the
+  // right host, so outcomes are provable here.
   switch (result.outcome) {
     case "cancelled":
       return finalize(op, { outcome: "cancelled", detail: result.detail });

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -454,13 +454,23 @@ async function cancelUpdateAllProvable(
     };
   }
   if (afterLookup || mineAfter.inProgress > 0 || mineAfter.processing) {
+    // A concurrent same-orchestrator enqueue can re-fill the queue between the
+    // pre- and post-reset reads, making mineAfter.pending >= mine.pending — a
+    // zero or negative "dropped" is NOT a provable drop, so claim it only when
+    // it is positive; otherwise say the count moved and nothing more.
+    const dropClaim =
+      dropped > 0
+        ? `dropped ${dropped} of this orchestrator's pending task(s) via a ` +
+          `queue reset on ${base} (${mine.pending} → ${mineAfter.pending}), BUT `
+        : `sent a queue reset on ${base} (this orchestrator's pending went ` +
+          `${mine.pending} → ${mineAfter.pending} — a concurrent enqueue may have ` +
+          `re-filled it, so what the reset dropped is UNPROVEN), BUT `;
     return {
       op,
       outcome: "partially-cancelled",
       markerCleared: false,
       detail:
-        `dropped ${dropped} of this orchestrator's pending task(s) via a ` +
-        `queue reset on ${base} (${mine.pending} → ${mineAfter.pending}), BUT ${
+        `${dropClaim}${
           afterLookup
             ? `the panel's task COMPLETED in the meantime (it is in the queue history)`
             : `${mineAfter.inProgress} task(s) were already RUNNING and in-flight work cannot be cancelled`

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -1,0 +1,311 @@
+// Pin-write CANCELLATION of pending panel-affecting work (#689).
+//
+// update_all and deferred snapshot restores are handed to ComfyUI-Manager and
+// applied out of band (see panel-pin-guard.ts). Before this fix, a pin written
+// inside their window only WARNED that the queued work could still move the
+// now-pinned panel — violating the owner's constraint "never auto-update over
+// an explicit pin". This module is what the pin-write path calls, inside the
+// pin's critical section, to actually CANCEL that work:
+//
+//   update-all       → POST <prefix>/manager/queue/reset on the server the op
+//                      was queued on (the marker's recorded base), which drops
+//                      every PENDING Manager task. A task the worker already
+//                      dequeued keeps running and CANNOT be cancelled — both
+//                      halves are reported, never just the convenient one.
+//   snapshot-restore → delete <manager files>/startup-scripts/
+//                      restore-snapshot.json before the next ComfyUI restart
+//                      consumes it (local installs only).
+//
+// HONESTY RULES (the point of the exercise):
+//   - Queue counts are read BEFORE and AFTER a reset; the report names the
+//     pending-dropped numbers rather than claiming the panel was saved.
+//   - The marker is cleared ONLY for what was provably cancelled or proven no
+//     longer pending (an empty, idle queue / a missing restore file cannot
+//     land later). Everything else — in-flight work, remote hosts, reset
+//     failures, unreadable state — keeps the marker and its warning.
+//   - A queue reset is BLUNT: it drops ALL pending Manager tasks, not just the
+//     update_all. The report says so.
+
+import { getComfyUIBaseUrl } from "../config.js";
+import { resetQueue } from "./manager-config.js";
+import { fetchManagerQueueCounts } from "./node-management.js";
+import { cancelPendingSnapshotRestore } from "./node-snapshots.js";
+import { clearPanelPendingOp, type PanelPendingOp } from "./panel-pin-guard.js";
+import { logger } from "../utils/logger.js";
+
+export type PanelPendingCancelOutcome =
+  /** Provably cancelled before it could run; marker cleared. */
+  | "cancelled"
+  /** Provably nothing left to cancel (queue empty+idle / no restore file), so
+   *  the window is closed — but the work may ALREADY have landed; marker
+   *  cleared, and the report says the panel may already have moved. */
+  | "already-drained"
+  /** Pending work was dropped, but a task was already RUNNING and cannot be
+   *  cancelled; marker KEPT, warning preserved. */
+  | "partially-cancelled"
+  /** Nothing pending; the task is in flight on the Manager worker and cannot
+   *  be cancelled; marker KEPT, warning preserved. */
+  | "already-running"
+  /** The state could not be read, the reset/delete failed, or the marker
+   *  itself could not be cleared — nothing is claimed; marker KEPT. */
+  | "could-not-verify"
+  /** The deferred restore file lives on a remote ComfyUI host; marker KEPT. */
+  | "cannot-cancel-remote"
+  /** A marker kind this build has no cancellation route for (e.g. the
+   *  synthetic unreadable-record marker); marker KEPT. */
+  | "cannot-cancel";
+
+export interface PanelPendingCancelReport {
+  op: PanelPendingOp;
+  outcome: PanelPendingCancelOutcome;
+  /** Whether the pending-op marker was removed (only ever true for
+   *  "cancelled" / "already-drained"). */
+  markerCleared: boolean;
+  /** Human-facing explanation — appended to the pin result verbatim. */
+  detail: string;
+  /** update-all only: pending tasks read BEFORE the reset. */
+  pendingBefore?: number;
+  /** update-all only: pending tasks read AFTER the reset. */
+  pendingAfter?: number;
+  /** update-all only: tasks in flight after the reset (cannot be cancelled). */
+  inProgress?: number;
+}
+
+/** Clear the marker and fold the outcome into the report when even THAT
+ *  fails — a proven cancel with an unremovable marker must keep warning. */
+function finalize(
+  op: PanelPendingOp,
+  report: Omit<PanelPendingCancelReport, "op" | "markerCleared">,
+): PanelPendingCancelReport {
+  const cleared = clearPanelPendingOp(op);
+  return {
+    ...report,
+    op,
+    markerCleared: cleared,
+    outcome: cleared ? report.outcome : "could-not-verify",
+    detail: cleared
+      ? report.detail
+      : `${report.detail} — HOWEVER the pending-op marker itself could not be ` +
+        `cleared, so its warning remains.`,
+  };
+}
+
+async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelReport> {
+  // Aim at the server the update_all was queued on. resetQueue re-resolves the
+  // current target when given no base — thread the marker's capture so a
+  // retarget between enqueue and pin can't send the reset to the WRONG ComfyUI
+  // (which would both miss the real queue and wipe an innocent one).
+  const base = op.base ?? getComfyUIBaseUrl();
+  const baseNote = op.base
+    ? ` on ${base}`
+    : ` on the CURRENT target ${base} (the marker recorded no server, so this ` +
+      `may not be the ComfyUI the update_all was queued on)`;
+
+  const before = await fetchManagerQueueCounts(base);
+  if (!before) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `could not read the ComfyUI-Manager queue${baseNote} — NOTHING was sent. ` +
+        `The queued update_all may still be pending; the warning stands.`,
+    };
+  }
+
+  // Nothing pending and nothing running: the queued work has already drained
+  // (or a Manager restart dropped it in memory). It cannot land LATER, so the
+  // marker's window is closed — but it may ALREADY have moved the panel, and
+  // the report must say that rather than imply protection.
+  if (before.pending === 0 && before.inProgress === 0 && !before.processing) {
+    return finalize(op, {
+      outcome: "already-drained",
+      detail:
+        `the Manager queue${baseNote} was already empty and idle, so there was ` +
+        `NOTHING left to cancel — the update_all already drained (or never ` +
+        `reached the queue). The panel may ALREADY have been moved — check ` +
+        `install_panel(action='status').`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: 0,
+    });
+  }
+
+  // Nothing pending but the worker is busy: our task may be the one in
+  // flight, and an in-flight task CANNOT be cancelled (queue/reset only drops
+  // PENDING work). Do not even send the reset — it would drop nothing of ours
+  // while wiping other clients' queued work.
+  if (before.pending === 0) {
+    const busy =
+      before.inProgress > 0
+        ? `${before.inProgress} task(s) are RUNNING`
+        : `the queue worker is busy`;
+    return {
+      op,
+      outcome: "already-running",
+      markerCleared: false,
+      detail:
+        `cannot cancel — the Manager queue${baseNote} has nothing pending but ` +
+        `${busy}, and in-flight work cannot be cancelled (a queue reset only ` +
+        `drops PENDING work). The update_all may STILL move the panel after ` +
+        `this pin — check install_panel(action='status') once it settles.`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: before.inProgress,
+    };
+  }
+
+  // There IS pending work: reset the queue and measure what it dropped.
+  try {
+    await resetQueue(base);
+  } catch (err) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `the queue reset FAILED${baseNote}: ${
+          err instanceof Error ? err.message : String(err)
+        }. The queued update_all may still be pending; the warning stands.`,
+      pendingBefore: before.pending,
+      inProgress: before.inProgress,
+    };
+  }
+
+  const after = await fetchManagerQueueCounts(base);
+  if (!after) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `a queue reset was sent${baseNote} (${before.pending} task(s) were ` +
+        `pending), but the post-reset queue state could not be read — what was ` +
+        `dropped is UNVERIFIED. The queued update_all may still be pending.`,
+      pendingBefore: before.pending,
+      inProgress: before.inProgress,
+    };
+  }
+
+  if (after.pending > 0) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `a queue reset was sent${baseNote}, but ${after.pending} task(s) are ` +
+        `still pending (was ${before.pending}) — the reset did not provably ` +
+        `clear the queue (concurrent enqueues can re-fill it). The update_all ` +
+        `may still be pending; the warning stands.`,
+      pendingBefore: before.pending,
+      pendingAfter: after.pending,
+      inProgress: after.inProgress,
+    };
+  }
+
+  const dropped = before.pending - after.pending;
+  if (after.inProgress > 0 || after.processing) {
+    const busy =
+      after.inProgress > 0
+        ? `${after.inProgress} task(s) were already RUNNING`
+        : `the queue worker was already busy`;
+    return {
+      op,
+      outcome: "partially-cancelled",
+      markerCleared: false,
+      detail:
+        `dropped ${dropped} pending task(s) via a queue reset${baseNote} (the ` +
+        `Manager queue is shared, so unrelated queued work was dropped too), ` +
+        `BUT ${busy} and in-flight work cannot be cancelled — the update_all ` +
+        `may STILL move the panel after this pin.`,
+      pendingBefore: before.pending,
+      pendingAfter: 0,
+      inProgress: after.inProgress,
+    };
+  }
+
+  return finalize(op, {
+    outcome: "cancelled",
+    detail:
+      `cancelled the queued update_all before it ran: a queue reset${baseNote} ` +
+      `dropped ${dropped} pending task(s), none remain, and nothing is running ` +
+      `(the Manager queue is shared, so this also dropped any unrelated queued ` +
+      `work).`,
+    pendingBefore: before.pending,
+    pendingAfter: 0,
+    inProgress: 0,
+  });
+}
+
+function cancelSnapshotRestore(op: PanelPendingOp): PanelPendingCancelReport {
+  const result = cancelPendingSnapshotRestore();
+  switch (result.outcome) {
+    case "cancelled":
+      return finalize(op, { outcome: "cancelled", detail: result.detail });
+    case "not-scheduled":
+      return finalize(op, { outcome: "already-drained", detail: result.detail });
+    case "remote":
+      return {
+        op,
+        outcome: "cannot-cancel-remote",
+        markerCleared: false,
+        detail: result.detail,
+      };
+    case "failed":
+      return {
+        op,
+        outcome: "could-not-verify",
+        markerCleared: false,
+        detail: result.detail,
+      };
+  }
+}
+
+/** Attempt to cancel ONE pending panel-affecting op, honestly reported. */
+export async function cancelPanelPendingOp(
+  op: PanelPendingOp,
+): Promise<PanelPendingCancelReport> {
+  try {
+    if (op.kind === "update-all") return await cancelUpdateAll(op);
+    if (op.kind === "snapshot-restore") return cancelSnapshotRestore(op);
+    return {
+      op,
+      outcome: "cannot-cancel",
+      markerCleared: false,
+      detail:
+        `no cancellation route exists for "${op.kind}" pending ops — the ` +
+        `warning stands.`,
+    };
+  } catch (err) {
+    // A cancel must NEVER break the pin write itself: the pin governs every
+    // future op either way, and the warning only fails closed.
+    logger.warn("[panel] pending-op cancellation threw; keeping the marker", {
+      kind: op.kind,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `cancellation of the pending ${op.kind} failed unexpectedly (${
+          err instanceof Error ? err.message : String(err)
+        }) — the warning stands.`,
+    };
+  }
+}
+
+/**
+ * Attempt to cancel every active pending op, sequentially (Manager state is
+ * measured before/after each reset, so parallel attempts would make the
+ * counts uninterpretable). One report per op, in the same order.
+ */
+export async function cancelPanelPendingOps(
+  ops: PanelPendingOp[],
+): Promise<PanelPendingCancelReport[]> {
+  const reports: PanelPendingCancelReport[] = [];
+  for (const op of ops) {
+    reports.push(await cancelPanelPendingOp(op));
+  }
+  return reports;
+}

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -248,7 +248,9 @@ async function cancelUpdateAllNoUiId(
       inProgress: 0,
     });
   }
-  if (mine.pending === 0) {
+  // In-flight first, as in the ui_id path: running work cannot be cancelled
+  // regardless of what else is pending, and no reset may be sent into it.
+  if (mine.inProgress > 0 || mine.processing) {
     const busy =
       mine.inProgress > 0
         ? `${mine.inProgress} task(s) from this orchestrator are RUNNING`
@@ -258,12 +260,11 @@ async function cancelUpdateAllNoUiId(
       outcome: "already-running",
       markerCleared: false,
       detail:
-        `cannot cancel — nothing of this orchestrator's is pending on ${base}, ` +
-        `but ${busy}, and in-flight work cannot be cancelled (a queue reset ` +
-        `only drops PENDING work). The update_all may STILL move the panel ` +
-        `after this pin.`,
-      pendingBefore: 0,
-      pendingAfter: 0,
+        `cannot cancel — ${busy} on ${base} and the update_all's tasks may be ` +
+        `among them; in-flight work cannot be cancelled (a queue reset only ` +
+        `drops PENDING work). NO reset was sent. The update_all may STILL move ` +
+        `the panel after this pin.`,
+      pendingBefore: mine.pending,
       inProgress: mine.inProgress,
     };
   }
@@ -353,20 +354,10 @@ async function cancelUpdateAllProvable(
         `NOTHING was sent; the warning stands.`,
     };
   }
-  if (mine.pending === 0 && mine.inProgress === 0 && !mine.processing) {
-    return finalize(op, {
-      outcome: "already-drained",
-      detail:
-        `the panel's update task is not pending, not running, and not in the ` +
-        `Manager's (bounded) queue history on ${base} — it never ran or already ` +
-        `finished, and NOTHING remains that can move the panel. Check ` +
-        `install_panel(action='status').`,
-      pendingBefore: 0,
-      pendingAfter: 0,
-      inProgress: 0,
-    });
-  }
-  if (mine.pending === 0) {
+  // In-flight FIRST: a running task of ours may be the panel's update, and
+  // in-flight work cannot be cancelled — regardless of what else is pending.
+  // Checking pending first would send a reset into a live update (#689 round 4).
+  if (mine.inProgress > 0 || mine.processing) {
     const busy =
       mine.inProgress > 0
         ? `${mine.inProgress} task(s) from this orchestrator are RUNNING`
@@ -376,19 +367,32 @@ async function cancelUpdateAllProvable(
       outcome: "already-running",
       markerCleared: false,
       detail:
-        `cannot cancel — nothing of this orchestrator's is pending on ${base}, ` +
-        `but ${busy} and the panel's task may be among them; in-flight work ` +
-        `cannot be cancelled (a reset only drops PENDING work). NO reset was ` +
-        `sent. The update_all may STILL move the panel after this pin.`,
-      pendingBefore: 0,
-      pendingAfter: 0,
+        `cannot cancel — ${busy} on ${base} and the panel's task may be among ` +
+        `them; in-flight work cannot be cancelled (a queue reset only drops ` +
+        `PENDING work, so it would only wipe unrelated queued tasks). NO reset ` +
+        `was sent. The update_all may STILL move the panel after this pin.`,
+      pendingBefore: mine.pending,
       inProgress: mine.inProgress,
     };
   }
+  if (mine.pending === 0) {
+    return finalize(op, {
+      outcome: "already-drained",
+      detail:
+        `the panel's update task is not pending, not running, and not in the ` +
+        `Manager's (bounded) queue history on ${base} — it never ran or already ` +
+        `finished, so there was NOTHING left to cancel. The panel may ALREADY ` +
+        `have been moved — check install_panel(action='status').`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: 0,
+    });
+  }
 
-  // 3. Our tasks are PROVABLY pending (the panel's, if enqueued, is among
-  //    them: it did not run and is not running). The reset is a targeted
-  //    cancel now — still queue-wide, so measure the blast radius too.
+  // 3. Our tasks are PROVABLY pending and NOTHING is running (the panel's, if
+  //    enqueued, is among them: it did not run and is not running). The reset
+  //    is a targeted cancel now — still queue-wide, so measure the blast
+  //    radius too.
   const shared = await fetchManagerQueueCounts(base);
   try {
     await resetQueue(base);
@@ -407,29 +411,32 @@ async function cancelUpdateAllProvable(
   }
 
   // 4. Prove the end state: the panel's task is gone from EVERYWHERE (a task
-  //    could have been dequeued or completed in the race).
+  //    could have been dequeued or completed in the race). A reset fired, so
+  //    every branch below names the shared-queue blast radius, and every
+  //    dropped count is DERIVED from before/after reads — never asserted.
   const mineAfter = await fetchManagerClientQueueCounts(base);
   const sharedAfter = await fetchManagerQueueCounts(base);
-  if (!mineAfter) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `a queue reset was sent on ${base} (${mine.pending} of this ` +
-        `orchestrator's task(s) were pending), but the post-reset state could ` +
-        `not be read — what was dropped is UNVERIFIED. The update_all may ` +
-        `still be pending.`,
-      pendingBefore: mine.pending,
-      inProgress: mine.inProgress,
-    };
-  }
   const blast =
     shared && sharedAfter
       ? ` Queue-wide pending went ${shared.pending} → ${sharedAfter.pending} ` +
         `(the Manager queue is shared — unrelated queued work was dropped too).`
       : ` The Manager queue is shared, so unrelated queued work may have been ` +
         `dropped too.`;
+  if (!mineAfter) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `a queue reset was sent on ${base} with ${mine.pending} of this ` +
+        `orchestrator's task(s) pending, but the post-reset state could not be ` +
+        `read — what was dropped is UNVERIFIED and nothing is claimed.${blast} ` +
+        `The update_all may still be pending.`,
+      pendingBefore: mine.pending,
+      inProgress: mine.inProgress,
+    };
+  }
+  const dropped = mine.pending - mineAfter.pending;
   const afterLookup = await panelTaskState(uiId, base);
   if (afterLookup === undefined) {
     return {
@@ -437,10 +444,10 @@ async function cancelUpdateAllProvable(
       outcome: "could-not-verify",
       markerCleared: false,
       detail:
-        `a queue reset was sent on ${base} and dropped ${mine.pending} of this ` +
-        `orchestrator's pending task(s), but the queue history could not be ` +
-        `re-read — whether the panel's task ran in the meantime is UNKNOWN.` +
-        `${blast} The warning stands.`,
+        `a queue reset was sent on ${base} (this orchestrator's pending tasks ` +
+        `went ${mine.pending} → ${mineAfter.pending}), but the queue history ` +
+        `could not be re-read — whether the panel's task ran in the meantime ` +
+        `is UNKNOWN.${blast} The warning stands.`,
       pendingBefore: mine.pending,
       pendingAfter: mineAfter.pending,
       inProgress: mineAfter.inProgress,
@@ -452,8 +459,8 @@ async function cancelUpdateAllProvable(
       outcome: "partially-cancelled",
       markerCleared: false,
       detail:
-        `dropped ${mine.pending} of this orchestrator's pending task(s) via a ` +
-        `queue reset on ${base}, BUT ${
+        `dropped ${dropped} of this orchestrator's pending task(s) via a ` +
+        `queue reset on ${base} (${mine.pending} → ${mineAfter.pending}), BUT ${
           afterLookup
             ? `the panel's task COMPLETED in the meantime (it is in the queue history)`
             : `${mineAfter.inProgress} task(s) were already RUNNING and in-flight work cannot be cancelled`
@@ -470,9 +477,9 @@ async function cancelUpdateAllProvable(
       markerCleared: false,
       detail:
         `a queue reset was sent on ${base}, but ${mineAfter.pending} of this ` +
-        `orchestrator's task(s) are STILL pending (concurrent enqueues can ` +
-        `re-fill the queue) — the update_all was not provably cancelled. The ` +
-        `warning stands.`,
+        `orchestrator's task(s) are STILL pending (was ${mine.pending}; ` +
+        `concurrent enqueues can re-fill the queue) — the update_all was not ` +
+        `provably cancelled.${blast} The warning stands.`,
       pendingBefore: mine.pending,
       pendingAfter: mineAfter.pending,
       inProgress: mineAfter.inProgress,
@@ -485,7 +492,7 @@ async function cancelUpdateAllProvable(
       `panel's update task is not in the queue history and, after a queue ` +
       `reset on ${base}, nothing from this orchestrator is pending or running ` +
       `— it was dropped (or never enqueued) and CANNOT run. The reset dropped ` +
-      `${mine.pending} of this orchestrator's pending task(s).${blast}`,
+      `${dropped} of this orchestrator's pending task(s).${blast}`,
     pendingBefore: mine.pending,
     pendingAfter: 0,
     inProgress: 0,

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -17,11 +17,17 @@
 //                      consumes it (local installs only).
 //
 // HONESTY RULES (the point of the exercise):
-//   - Queue counts are read BEFORE and AFTER a reset; the report names the
+//   - SHARED queue counts never identify OUR update_all: unrelated pending
+//     tasks look exactly like it. A cancel is only PROVEN on v4, where the
+//     panel's per-pack task id (`${uiId}_${pack}`) can be checked against the
+//     queue history and this orchestrator's tasks are countable via the
+//     client_id filter. On 3.x / legacy-UI, or without a recorded ui_id, a
+//     reset would be BLIND — it could wipe others' pending work while the
+//     update_all runs on regardless — so none is sent (could-not-verify).
+//   - Queue counts are read BEFORE and AFTER any reset; the report names the
 //     pending-dropped numbers rather than claiming the panel was saved.
 //   - The marker is cleared ONLY for what was provably cancelled or proven no
-//     longer pending (an empty, idle queue / a missing restore file cannot
-//     land later). Everything else — in-flight work, remote hosts, reset
+//     longer pending. Everything else — in-flight work, remote hosts, reset
 //     failures, unreadable state — keeps the marker and its warning.
 //   - A marker proves things ONLY about the server recorded in it. A marker
 //     with no recorded base, or whose base is not the current target, must
@@ -34,9 +40,20 @@
 
 import { getComfyUIBaseUrl } from "../config.js";
 import { resetQueue } from "./manager-config.js";
-import { fetchManagerQueueCounts } from "./node-management.js";
+import {
+  detectManagerApi,
+  fetchManagerClientQueueCounts,
+  fetchManagerQueueCounts,
+  fetchManagerTaskHistoryEntry,
+  type ManagerApi,
+  type ManagerTaskHistoryEntry,
+} from "./node-management.js";
 import { cancelPendingSnapshotRestore } from "./node-snapshots.js";
-import { clearPanelPendingOp, type PanelPendingOp } from "./panel-pin-guard.js";
+import {
+  clearPanelPendingOp,
+  PANEL_PACK_ALIASES,
+  type PanelPendingOp,
+} from "./panel-pin-guard.js";
 import { logger } from "../utils/logger.js";
 
 export type PanelPendingCancelOutcome =
@@ -102,34 +119,59 @@ async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelRe
   // be a different ComfyUI entirely — its queue state says NOTHING about the
   // server the update_all was queued on. Never a proven cancel from that.
   if (!op.base) return cancelUpdateAllUnbased(op);
-
-  // Aim at the server the update_all was queued on: a retarget between
-  // enqueue and pin must not send the reset to the WRONG ComfyUI (which would
-  // both miss the real queue and wipe an innocent one).
   const base = op.base;
-  const baseNote = ` on ${base}`;
 
-  const before = await fetchManagerQueueCounts(base);
-  if (!before) {
+  // A reset is only worth sending — and only REPORTABLE as a cancel — when
+  // OUR update_all's state is provable. Shared queue counts can never provide
+  // that (unrelated pending tasks look exactly like ours), so the dialect
+  // decides what is provable at all.
+  let api: ManagerApi;
+  try {
+    api = await detectManagerApi(base);
+  } catch {
     return {
       op,
       outcome: "could-not-verify",
       markerCleared: false,
       detail:
-        `could not read the ComfyUI-Manager queue${baseNote} — NOTHING was sent. ` +
+        `could not reach the ComfyUI-Manager on ${base} — NOTHING was sent. ` +
         `The queued update_all may still be pending; the warning stands.`,
     };
   }
 
-  // Nothing pending and nothing running: the queued work has already drained
-  // (or a Manager restart dropped it in memory). It cannot land LATER, so the
-  // marker's window is closed — but it may ALREADY have moved the panel, and
-  // the report must say that rather than imply protection.
-  if (before.pending === 0 && before.inProgress === 0 && !before.processing) {
+  if (api !== "v2") return cancelUpdateAllUnattributable(op, base, api);
+  if (!op.uiId) return cancelUpdateAllNoUiId(op, base);
+  return cancelUpdateAllProvable(op, base, op.uiId);
+}
+
+/**
+ * 3.x and legacy-UI (v2-batch) Managers expose no task history and no client
+ * filter, so OUR update_all can never be told apart from unrelated pending
+ * work — and a queue reset there is always BLIND (it could wipe someone
+ * else's queued tasks while ours runs on). Never send one (#689 round 3).
+ */
+async function cancelUpdateAllUnattributable(
+  op: PanelPendingOp,
+  base: string,
+  api: ManagerApi,
+): Promise<PanelPendingCancelReport> {
+  const counts = await fetchManagerQueueCounts(base);
+  const dialect = api === "legacy" ? "3.x" : "legacy-UI";
+  if (!counts) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `could not read the ComfyUI-Manager queue on ${base} — NOTHING was ` +
+        `sent. The queued update_all may still be pending; the warning stands.`,
+    };
+  }
+  if (counts.pending === 0 && counts.inProgress === 0 && !counts.processing) {
     return finalize(op, {
       outcome: "already-drained",
       detail:
-        `the Manager queue${baseNote} was already empty and idle, so there was ` +
+        `the Manager queue on ${base} was already empty and idle, so there was ` +
         `NOTHING left to cancel — the update_all already drained (or never ` +
         `reached the queue). The panel may ALREADY have been moved — check ` +
         `install_panel(action='status').`,
@@ -138,32 +180,216 @@ async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelRe
       inProgress: 0,
     });
   }
-
-  // Nothing pending but the worker is busy: our task may be the one in
-  // flight, and an in-flight task CANNOT be cancelled (queue/reset only drops
-  // PENDING work). Do not even send the reset — it would drop nothing of ours
-  // while wiping other clients' queued work.
-  if (before.pending === 0) {
+  if (counts.pending === 0) {
     const busy =
-      before.inProgress > 0
-        ? `${before.inProgress} task(s) are RUNNING`
+      counts.inProgress > 0
+        ? `${counts.inProgress} task(s) are RUNNING`
         : `the queue worker is busy`;
     return {
       op,
       outcome: "already-running",
       markerCleared: false,
       detail:
-        `cannot cancel — the Manager queue${baseNote} has nothing pending but ` +
+        `cannot cancel — the Manager queue on ${base} has nothing pending but ` +
         `${busy}, and in-flight work cannot be cancelled (a queue reset only ` +
         `drops PENDING work). The update_all may STILL move the panel after ` +
         `this pin — check install_panel(action='status') once it settles.`,
       pendingBefore: 0,
       pendingAfter: 0,
-      inProgress: before.inProgress,
+      inProgress: counts.inProgress,
+    };
+  }
+  return {
+    op,
+    outcome: "could-not-verify",
+    markerCleared: false,
+    detail:
+      `${counts.pending} task(s) are pending on this ${dialect} ComfyUI-Manager, ` +
+      `which exposes no task history — the queued update_all cannot be told ` +
+      `apart from UNRELATED pending work, and a queue reset would be blind: it ` +
+      `could wipe someone else's queued tasks while the update_all runs on ` +
+      `regardless. NO reset was sent; the warning stands.`,
+    pendingBefore: counts.pending,
+    inProgress: counts.inProgress,
+  };
+}
+
+/**
+ * v4 without a recorded ui_id: the update_all's tasks can be narrowed to this
+ * orchestrator (client filter) but not identified individually, so a reset
+ * still cannot be PROVEN to drop them — and it always drops unrelated work
+ * too. Only queue states that need no reset are provable here (#689 round 3).
+ */
+async function cancelUpdateAllNoUiId(
+  op: PanelPendingOp,
+  base: string,
+): Promise<PanelPendingCancelReport> {
+  const mine = await fetchManagerClientQueueCounts(base);
+  if (!mine) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `could not read this orchestrator's queue state on ${base} — NOTHING ` +
+        `was sent. The queued update_all may still be pending; the warning stands.`,
+    };
+  }
+  if (mine.pending === 0 && mine.inProgress === 0 && !mine.processing) {
+    return finalize(op, {
+      outcome: "already-drained",
+      detail:
+        `nothing enqueued by this orchestrator is pending or running on ${base} ` +
+        `— the update_all already drained (or never queued), so there was ` +
+        `NOTHING left to cancel. The panel may ALREADY have been moved — check ` +
+        `install_panel(action='status').`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: 0,
+    });
+  }
+  if (mine.pending === 0) {
+    const busy =
+      mine.inProgress > 0
+        ? `${mine.inProgress} task(s) from this orchestrator are RUNNING`
+        : `the queue worker is busy`;
+    return {
+      op,
+      outcome: "already-running",
+      markerCleared: false,
+      detail:
+        `cannot cancel — nothing of this orchestrator's is pending on ${base}, ` +
+        `but ${busy}, and in-flight work cannot be cancelled (a queue reset ` +
+        `only drops PENDING work). The update_all may STILL move the panel ` +
+        `after this pin.`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: mine.inProgress,
+    };
+  }
+  return {
+    op,
+    outcome: "could-not-verify",
+    markerCleared: false,
+    detail:
+      `the marker recorded no ui_id, so the update_all cannot be told apart ` +
+      `from the ${mine.pending} task(s) this orchestrator has pending on ${base} ` +
+      `(other installs/updates included) — a queue reset could wipe unrelated ` +
+      `work and STILL not provably drop it. NO reset was sent; the warning stands.`,
+    pendingBefore: mine.pending,
+    inProgress: mine.inProgress,
+  };
+}
+
+/**
+ * The panel's per-pack update task in the v4 queue history: the entry when it
+ * COMPLETED, null when it provably did not, undefined when history is
+ * unreadable. update_all names each per-pack task `${uiId}_${packKey}`, and
+ * the panel's pack key is one of its two aliases.
+ */
+async function panelTaskState(
+  uiId: string,
+  base: string,
+): Promise<ManagerTaskHistoryEntry | null | undefined> {
+  let unknown = false;
+  for (const alias of PANEL_PACK_ALIASES) {
+    const entry = await fetchManagerTaskHistoryEntry(`${uiId}_${alias}`, base);
+    if (entry) return entry;
+    if (entry === undefined) unknown = true;
+  }
+  return unknown ? undefined : null;
+}
+
+/**
+ * v4 with a recorded ui_id — the only PROVABLE cancel on a shared queue
+ * (#689 round 3). The panel's per-pack task id is checked against the queue
+ * history (completed ⇒ already-drained), and this orchestrator's tasks are
+ * counted via the client filter (none pending/running ⇒ already-drained;
+ * running ⇒ already-running; provably pending ⇒ a reset that is then
+ * RE-PROVEN to have removed the panel's task).
+ */
+async function cancelUpdateAllProvable(
+  op: PanelPendingOp,
+  base: string,
+  uiId: string,
+): Promise<PanelPendingCancelReport> {
+  // 1. Did the panel's task already RUN? (Queue history = completed tasks.)
+  const panelLookup = await panelTaskState(uiId, base);
+  if (panelLookup === undefined) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `the Manager's queue history on ${base} could not be read, so whether ` +
+        `the panel's update task already ran is UNKNOWN — NOTHING was sent; ` +
+        `the warning stands.`,
+    };
+  }
+  if (panelLookup) {
+    return finalize(op, {
+      outcome: "already-drained",
+      detail:
+        `the panel's update task (${panelLookup.uiId}) is in the Manager's ` +
+        `queue history on ${base} — it already RAN` +
+        `${panelLookup.result ? ` (${panelLookup.result})` : ""}, so there was ` +
+        `NOTHING left to cancel. The panel may ALREADY have been moved — check ` +
+        `install_panel(action='status').`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: 0,
+    });
+  }
+
+  // 2. Not completed. Is anything of OURS still pending or running?
+  const mine = await fetchManagerClientQueueCounts(base);
+  if (!mine) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `this orchestrator's queue state on ${base} could not be read — ` +
+        `NOTHING was sent; the warning stands.`,
+    };
+  }
+  if (mine.pending === 0 && mine.inProgress === 0 && !mine.processing) {
+    return finalize(op, {
+      outcome: "already-drained",
+      detail:
+        `the panel's update task is not pending, not running, and not in the ` +
+        `Manager's (bounded) queue history on ${base} — it never ran or already ` +
+        `finished, and NOTHING remains that can move the panel. Check ` +
+        `install_panel(action='status').`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: 0,
+    });
+  }
+  if (mine.pending === 0) {
+    const busy =
+      mine.inProgress > 0
+        ? `${mine.inProgress} task(s) from this orchestrator are RUNNING`
+        : `the queue worker is busy`;
+    return {
+      op,
+      outcome: "already-running",
+      markerCleared: false,
+      detail:
+        `cannot cancel — nothing of this orchestrator's is pending on ${base}, ` +
+        `but ${busy} and the panel's task may be among them; in-flight work ` +
+        `cannot be cancelled (a reset only drops PENDING work). NO reset was ` +
+        `sent. The update_all may STILL move the panel after this pin.`,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      inProgress: mine.inProgress,
     };
   }
 
-  // There IS pending work: reset the queue and measure what it dropped.
+  // 3. Our tasks are PROVABLY pending (the panel's, if enqueued, is among
+  //    them: it did not run and is not running). The reset is a targeted
+  //    cancel now — still queue-wide, so measure the blast radius too.
+  const shared = await fetchManagerQueueCounts(base);
   try {
     await resetQueue(base);
   } catch (err) {
@@ -172,74 +398,95 @@ async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelRe
       outcome: "could-not-verify",
       markerCleared: false,
       detail:
-        `the queue reset FAILED${baseNote}: ${
+        `the queue reset on ${base} FAILED: ${
           err instanceof Error ? err.message : String(err)
         }. The queued update_all may still be pending; the warning stands.`,
-      pendingBefore: before.pending,
-      inProgress: before.inProgress,
+      pendingBefore: mine.pending,
+      inProgress: mine.inProgress,
     };
   }
 
-  const after = await fetchManagerQueueCounts(base);
-  if (!after) {
+  // 4. Prove the end state: the panel's task is gone from EVERYWHERE (a task
+  //    could have been dequeued or completed in the race).
+  const mineAfter = await fetchManagerClientQueueCounts(base);
+  const sharedAfter = await fetchManagerQueueCounts(base);
+  if (!mineAfter) {
     return {
       op,
       outcome: "could-not-verify",
       markerCleared: false,
       detail:
-        `a queue reset was sent${baseNote} (${before.pending} task(s) were ` +
-        `pending), but the post-reset queue state could not be read — what was ` +
-        `dropped is UNVERIFIED. The queued update_all may still be pending.`,
-      pendingBefore: before.pending,
-      inProgress: before.inProgress,
+        `a queue reset was sent on ${base} (${mine.pending} of this ` +
+        `orchestrator's task(s) were pending), but the post-reset state could ` +
+        `not be read — what was dropped is UNVERIFIED. The update_all may ` +
+        `still be pending.`,
+      pendingBefore: mine.pending,
+      inProgress: mine.inProgress,
     };
   }
-
-  if (after.pending > 0) {
+  const blast =
+    shared && sharedAfter
+      ? ` Queue-wide pending went ${shared.pending} → ${sharedAfter.pending} ` +
+        `(the Manager queue is shared — unrelated queued work was dropped too).`
+      : ` The Manager queue is shared, so unrelated queued work may have been ` +
+        `dropped too.`;
+  const afterLookup = await panelTaskState(uiId, base);
+  if (afterLookup === undefined) {
     return {
       op,
       outcome: "could-not-verify",
       markerCleared: false,
       detail:
-        `a queue reset was sent${baseNote}, but ${after.pending} task(s) are ` +
-        `still pending (was ${before.pending}) — the reset did not provably ` +
-        `clear the queue (concurrent enqueues can re-fill it). The update_all ` +
-        `may still be pending; the warning stands.`,
-      pendingBefore: before.pending,
-      pendingAfter: after.pending,
-      inProgress: after.inProgress,
+        `a queue reset was sent on ${base} and dropped ${mine.pending} of this ` +
+        `orchestrator's pending task(s), but the queue history could not be ` +
+        `re-read — whether the panel's task ran in the meantime is UNKNOWN.` +
+        `${blast} The warning stands.`,
+      pendingBefore: mine.pending,
+      pendingAfter: mineAfter.pending,
+      inProgress: mineAfter.inProgress,
     };
   }
-
-  const dropped = before.pending - after.pending;
-  if (after.inProgress > 0 || after.processing) {
-    const busy =
-      after.inProgress > 0
-        ? `${after.inProgress} task(s) were already RUNNING`
-        : `the queue worker was already busy`;
+  if (afterLookup || mineAfter.inProgress > 0 || mineAfter.processing) {
     return {
       op,
       outcome: "partially-cancelled",
       markerCleared: false,
       detail:
-        `dropped ${dropped} pending task(s) via a queue reset${baseNote} (the ` +
-        `Manager queue is shared, so unrelated queued work was dropped too), ` +
-        `BUT ${busy} and in-flight work cannot be cancelled — the update_all ` +
-        `may STILL move the panel after this pin.`,
-      pendingBefore: before.pending,
-      pendingAfter: 0,
-      inProgress: after.inProgress,
+        `dropped ${mine.pending} of this orchestrator's pending task(s) via a ` +
+        `queue reset on ${base}, BUT ${
+          afterLookup
+            ? `the panel's task COMPLETED in the meantime (it is in the queue history)`
+            : `${mineAfter.inProgress} task(s) were already RUNNING and in-flight work cannot be cancelled`
+        } — the update_all may STILL have moved the panel.${blast}`,
+      pendingBefore: mine.pending,
+      pendingAfter: mineAfter.pending,
+      inProgress: mineAfter.inProgress,
     };
   }
-
+  if (mineAfter.pending > 0) {
+    return {
+      op,
+      outcome: "could-not-verify",
+      markerCleared: false,
+      detail:
+        `a queue reset was sent on ${base}, but ${mineAfter.pending} of this ` +
+        `orchestrator's task(s) are STILL pending (concurrent enqueues can ` +
+        `re-fill the queue) — the update_all was not provably cancelled. The ` +
+        `warning stands.`,
+      pendingBefore: mine.pending,
+      pendingAfter: mineAfter.pending,
+      inProgress: mineAfter.inProgress,
+    };
+  }
   return finalize(op, {
     outcome: "cancelled",
     detail:
-      `cancelled the queued update_all before it ran: a queue reset${baseNote} ` +
-      `dropped ${dropped} pending task(s), none remain, and nothing is running ` +
-      `(the Manager queue is shared, so this also dropped any unrelated queued ` +
-      `work).`,
-    pendingBefore: before.pending,
+      `cancelled the queued update_all before it could touch the panel: the ` +
+      `panel's update task is not in the queue history and, after a queue ` +
+      `reset on ${base}, nothing from this orchestrator is pending or running ` +
+      `— it was dropped (or never enqueued) and CANNOT run. The reset dropped ` +
+      `${mine.pending} of this orchestrator's pending task(s).${blast}`,
+    pendingBefore: mine.pending,
     pendingAfter: 0,
     inProgress: 0,
   });
@@ -247,17 +494,17 @@ async function cancelUpdateAll(op: PanelPendingOp): Promise<PanelPendingCancelRe
 
 /**
  * A base-less update-all marker (written before the base capture existed).
- * The current target is the LIKELY server — retargets between enqueue and pin
- * are the rare case — so a reset there is attempted as the only protective
- * move available. But it is never PROOF: if the current target is not the
- * ComfyUI the update_all was queued on, the reset wiped an innocent queue
- * while the original update still runs. Every outcome here is therefore
- * UNVERIFIED and keeps the marker and its warning.
+ * The current target may be a different ComfyUI entirely, so its queue state
+ * proves NOTHING about the server the update_all was queued on — and a reset
+ * there could wipe an innocent queue while the original update still runs.
+ * NO reset is ever sent from here; every outcome is UNVERIFIED and keeps the
+ * marker (#689 round 3 — round 2's best-effort reset retired for exactly the
+ * blind-reset reason above).
  */
 async function cancelUpdateAllUnbased(op: PanelPendingOp): Promise<PanelPendingCancelReport> {
   const base = getComfyUIBaseUrl();
-  const before = await fetchManagerQueueCounts(base);
-  if (!before) {
+  const counts = await fetchManagerQueueCounts(base);
+  if (!counts) {
     return {
       op,
       outcome: "could-not-verify",
@@ -268,11 +515,10 @@ async function cancelUpdateAllUnbased(op: PanelPendingOp): Promise<PanelPendingC
         `DIFFERENT ComfyUI. NOTHING was sent; the warning stands.`,
     };
   }
-
-  if (before.pending === 0) {
+  if (counts.pending === 0) {
     const state =
-      before.inProgress > 0 || before.processing
-        ? `has nothing pending but ${before.inProgress} task(s) running`
+      counts.inProgress > 0 || counts.processing
+        ? `has nothing pending but ${counts.inProgress} task(s) running`
         : `is empty and idle`;
     return {
       op,
@@ -284,47 +530,20 @@ async function cancelUpdateAllUnbased(op: PanelPendingOp): Promise<PanelPendingC
         `queued on — no reset was sent. If ${base} is not that server, the ` +
         `update may still land after this pin; the warning stands.`,
       pendingBefore: 0,
-      inProgress: before.inProgress,
+      inProgress: counts.inProgress,
     };
   }
-
-  try {
-    await resetQueue(base);
-  } catch (err) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `the marker recorded NO server, and a best-effort queue reset on the ` +
-        `current target ${base} FAILED: ${
-          err instanceof Error ? err.message : String(err)
-        }. The update_all may be queued on a different ComfyUI entirely; the ` +
-        `warning stands.`,
-      pendingBefore: before.pending,
-      inProgress: before.inProgress,
-    };
-  }
-
-  const after = await fetchManagerQueueCounts(base);
   return {
     op,
     outcome: "could-not-verify",
     markerCleared: false,
     detail:
-      `the marker recorded NO server, so this is UNVERIFIED: a best-effort ` +
-      `queue reset on the current target ${base} ` +
-      (after
-        ? `dropped ${before.pending - after.pending} pending task(s) there. `
-        : `was sent (${before.pending} task(s) were pending), but the ` +
-          `post-reset state could not be read. `) +
-      `If ${base} is NOT the ComfyUI the update_all was queued on, the ` +
-      `original update is still queued there and may land after this pin — ` +
-      `the warning stands. Check install_panel(action='status') on the server ` +
-      `update_all was run against.`,
-    pendingBefore: before.pending,
-    pendingAfter: after?.pending,
-    inProgress: after?.inProgress ?? before.inProgress,
+      `the marker recorded NO server, and ${counts.pending} task(s) are ` +
+      `pending on the current target ${base}. Resetting that queue could wipe ` +
+      `an innocent server's work while the update_all runs on its real host — ` +
+      `so NO reset was sent; the warning stands.`,
+    pendingBefore: counts.pending,
+    inProgress: counts.inProgress,
   };
 }
 

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -469,6 +469,10 @@ export interface PanelPendingOp {
   /** What is pending: "update-all" | "snapshot-restore" (unknown kinds are
    *  tolerated when reading, so an older/newer record never reads as clear). */
   kind: string;
+  /** Unique record id (records written before ids existed fall back to
+   *  kind+queuedAt matching — which collides for two records minted in the
+   *  same millisecond, so a stale clear could take the live one with it). */
+  id?: string;
   /** When it was handed to ComfyUI-Manager (ISO). */
   queuedAt: string;
   /** When the warning lapses (ISO). After this the pin governs as usual — the
@@ -571,6 +575,7 @@ export function recordPanelPendingOp(
   const now = Date.now();
   const op: PanelPendingOp = {
     kind,
+    id: randomUUID(),
     queuedAt: new Date(now).toISOString(),
     expiresAt: new Date(now + ttlMs).toISOString(),
     detail,
@@ -630,8 +635,12 @@ export function recordPanelPendingOp(
  * about work this call did).
  */
 export function clearPanelPendingOp(op: PanelPendingOp): boolean {
+  // Identity by unique id when the record has one; only legacy records fall
+  // back to kind+queuedAt (collision-prone in the same millisecond).
   const matches = (candidate: PanelPendingOp): boolean =>
-    candidate.kind === op.kind && candidate.queuedAt === op.queuedAt;
+    op.id !== undefined
+      ? candidate.id === op.id
+      : candidate.kind === op.kind && candidate.queuedAt === op.queuedAt;
   try {
     const path = panelPendingOpsPath();
     const prior = readPanelPendingOpsFile();

--- a/src/services/panel-pin-guard.ts
+++ b/src/services/panel-pin-guard.ts
@@ -452,13 +452,17 @@ export function withPanelPinGuard<T>(
 // lock cannot be held across that window (it would wedge pinning for minutes
 // to days), and no completion/apply path exists IN THIS PROCESS to re-check a
 // pin at — the Manager, not us, is the applying agent, which is exactly why
-// the window exists. What this process CAN keep truthful is the next pin
-// write: a pin set while one of these is pending must not leave the user
-// believing the panel cannot move. So each op records a marker here (with an
-// expiry), and the pin-write path warns while one is active. The lock-held
-// variants — update_custom_node(id="all"), which waits for the drain inside
-// the lock, and every install_panel mutation — need no marker: no pin can be
-// written inside their window at all.
+// the window exists. So each op records a marker here (with an expiry), and
+// the pin-write path reads it inside the pin's critical section.
+//
+// A pin written while a marker is active does NOT just warn (#689): it
+// attempts to CANCEL the pending work first (reset the Manager task queue /
+// delete the deferred-restore file), clears the marker only for what was
+// PROVABLY cancelled or proven no longer pending, and keeps the warning for
+// the residue — in-flight work, remote hosts, anything unverifiable. The
+// lock-held variants — update_custom_node(id="all"), which waits for the
+// drain inside the lock, and every install_panel mutation — need no marker:
+// no pin can be written inside their window at all.
 // ---------------------------------------------------------------------------
 
 export interface PanelPendingOp {
@@ -472,6 +476,16 @@ export interface PanelPendingOp {
   expiresAt: string;
   /** Human-facing explanation for the pin-write warning. */
   detail: string;
+  /** The ComfyUI base URL the op was handed to, captured at enqueue time. A
+   *  pin-write cancellation must target the ORIGINAL server even if the
+   *  orchestrator has since been retargeted; when absent (older markers) the
+   *  cancel falls back to the current target and says so in its report. */
+  base?: string;
+  /** update-all only: the ui_id of the enqueue attempt that actually landed
+   *  (v4 derives each per-pack task id as `${uiId}_${pack}`), so a v4 host can
+   *  later answer "did the panel's task already run" via
+   *  /v2/manager/queue/history?ui_id=…. */
+  uiId?: string;
 }
 
 /** update_all drains in minutes on the Manager's worker; an hour is far beyond
@@ -498,7 +512,9 @@ function isPanelPendingOp(value: unknown): value is PanelPendingOp {
     typeof op.kind === "string" &&
     typeof op.queuedAt === "string" &&
     typeof op.expiresAt === "string" &&
-    typeof op.detail === "string"
+    typeof op.detail === "string" &&
+    (op.base === undefined || typeof op.base === "string") &&
+    (op.uiId === undefined || typeof op.uiId === "string")
   );
 }
 
@@ -550,6 +566,7 @@ export function recordPanelPendingOp(
   kind: "update-all" | "snapshot-restore",
   detail: string,
   ttlMs: number,
+  extra: { base?: string; uiId?: string } = {},
 ): PanelPendingOp {
   const now = Date.now();
   const op: PanelPendingOp = {
@@ -557,6 +574,8 @@ export function recordPanelPendingOp(
     queuedAt: new Date(now).toISOString(),
     expiresAt: new Date(now + ttlMs).toISOString(),
     detail,
+    ...(extra.base ? { base: extra.base } : {}),
+    ...(extra.uiId ? { uiId: extra.uiId } : {}),
   };
   try {
     const path = panelPendingOpsPath();
@@ -577,7 +596,9 @@ export function recordPanelPendingOp(
           candidate.kind === op.kind &&
           candidate.queuedAt === op.queuedAt &&
           candidate.expiresAt === op.expiresAt &&
-          candidate.detail === op.detail,
+          candidate.detail === op.detail &&
+          candidate.base === op.base &&
+          candidate.uiId === op.uiId,
       )
     ) {
       throw new Error("pending-operation record did not survive a read-back verification");
@@ -590,6 +611,45 @@ export function recordPanelPendingOp(
     );
   }
   return op;
+}
+
+/**
+ * Remove a pending-op marker — ONLY the exact record handed in (matched by
+ * kind + queuedAt), so a NEWER marker of the same kind recorded after it is
+ * never silently dropped.
+ *
+ * Call this only for an op that was PROVABLY dealt with by the pin-write
+ * cancellation path (#689): cancelled before it could run, or proven to be no
+ * longer pending. Clearing anything else would let a later pin write report
+ * clean protection while queued work is still out there.
+ *
+ * Read-back verified like recordPanelPendingOp, and fails CLOSED: any read or
+ * write failure returns false and leaves the marker (and its warning) in
+ * place. Returns true when the exact record is gone afterwards — including
+ * when it was already absent (that is the goal state, not a success claim
+ * about work this call did).
+ */
+export function clearPanelPendingOp(op: PanelPendingOp): boolean {
+  const matches = (candidate: PanelPendingOp): boolean =>
+    candidate.kind === op.kind && candidate.queuedAt === op.queuedAt;
+  try {
+    const path = panelPendingOpsPath();
+    const prior = readPanelPendingOpsFile();
+    if (prior.unreadable) return false;
+    if (!prior.ops.some(matches)) return true; // already gone
+    const kept = prior.ops.filter((candidate) => !matches(candidate));
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ ops: kept }, null, 2), "utf-8");
+    const confirmed = readPanelPendingOpsFile();
+    return !confirmed.unreadable && !confirmed.ops.some(matches);
+  } catch (err) {
+    logger.warn(
+      `[panel] could not clear the pending ${op.kind} marker: ${
+        err instanceof Error ? err.message : String(err)
+      } — leaving it (and its warning) in place.`,
+    );
+    return false;
+  }
 }
 
 /**

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { platform } from "node:os";
-import { config, getComfyUIBaseUrl } from "../config.js";
+import { config } from "../config.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
 import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
@@ -225,24 +225,27 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
     // conservative marker: a transport failure cannot prove Manager did not
     // accept the request.
     //
-    // The marker carries the base URL it is about to be queued on, so the
-    // pin-write cancellation path (#689) can aim its queue reset at the
-    // ORIGINAL server even after a retarget.
+    // The marker starts BASE-UNKNOWN on purpose (#689 round 3): the base that
+    // matters is the one the ENQUEUE actually uses (captured inside
+    // queueUpdateAllCustomNodes), and guessing it here risks a retarget leaving
+    // the marker naming the WRONG server — which a later pin would reset and
+    // clear as "cancelled" while the update lands elsewhere. A base-unknown
+    // marker routes to the unverified/no-reset path instead.
     const detail =
       `an update_all request may have been handed to ComfyUI-Manager and can update EVERY ` +
       `installed pack — the sidebar panel included — on the Manager's own schedule ` +
       `(usually seconds to minutes; a ComfyUI restart then loads the result)`;
-    recordPanelPendingOp("update-all", detail, UPDATE_ALL_PENDING_MS, {
-      base: getComfyUIBaseUrl(),
-    });
+    recordPanelPendingOp("update-all", detail, UPDATE_ALL_PENDING_MS);
     const result = await queueUpdateAllCustomNodes();
 
     // Enrich the marker with what the ENQUEUE actually used: the base it
     // captured at invocation and the ui_id of the attempt that landed (a
-    // self-heal retry mints a fresh one). The ui_id lets a v4 host later
-    // answer "did the panel's task already run" via queue history. Best
-    // effort only — if the rewrite fails, the base-only marker above remains
-    // and cancellation still works; refusing now would punish a success.
+    // self-heal retry mints a fresh one). On v4 the ui_id identifies the
+    // update_all's per-pack tasks (each `${ui_id}_${pack}`) in the queue
+    // history, which is what makes a later pin's cancel PROVABLE (#689 round
+    // 3). If the rewrite fails, the marker stays base-unknown — never a stale
+    // base — so the pin-cancel path treats it as unverifiable and sends no
+    // blind reset. Refusing now would punish a success.
     try {
       recordPanelPendingOp("update-all", detail, UPDATE_ALL_PENDING_MS, {
         base: result.base,
@@ -251,7 +254,8 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
     } catch (err) {
       logger.warn(
         `[panel] update_all is queued, but the pending-op marker could not be ` +
-          `enriched with its ui_id (the base-only marker remains): ${
+          `enriched with its base/ui_id — it remains base-unknown, so a later ` +
+          `pin will report it as unverifiable rather than cancel blindly: ${
             err instanceof Error ? err.message : String(err)
           }`,
       );

--- a/src/services/update-comfyui.ts
+++ b/src/services/update-comfyui.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { platform } from "node:os";
-import { config } from "../config.js";
+import { config, getComfyUIBaseUrl } from "../config.js";
 import { resolveInstallInterpreter } from "./workspace-env.js";
 import { queueUpdateAllCustomNodes } from "./node-management.js";
 import { ProcessControlError } from "../utils/errors.js";
@@ -224,14 +224,38 @@ export async function updateAllCustomNodes(): Promise<UpdateNodesResult> {
     // protection it cannot provide. If the request itself fails, retain this
     // conservative marker: a transport failure cannot prove Manager did not
     // accept the request.
-    recordPanelPendingOp(
-      "update-all",
+    //
+    // The marker carries the base URL it is about to be queued on, so the
+    // pin-write cancellation path (#689) can aim its queue reset at the
+    // ORIGINAL server even after a retarget.
+    const detail =
       `an update_all request may have been handed to ComfyUI-Manager and can update EVERY ` +
-        `installed pack — the sidebar panel included — on the Manager's own schedule ` +
-        `(usually seconds to minutes; a ComfyUI restart then loads the result)`,
-      UPDATE_ALL_PENDING_MS,
-    );
+      `installed pack — the sidebar panel included — on the Manager's own schedule ` +
+      `(usually seconds to minutes; a ComfyUI restart then loads the result)`;
+    recordPanelPendingOp("update-all", detail, UPDATE_ALL_PENDING_MS, {
+      base: getComfyUIBaseUrl(),
+    });
     const result = await queueUpdateAllCustomNodes();
+
+    // Enrich the marker with what the ENQUEUE actually used: the base it
+    // captured at invocation and the ui_id of the attempt that landed (a
+    // self-heal retry mints a fresh one). The ui_id lets a v4 host later
+    // answer "did the panel's task already run" via queue history. Best
+    // effort only — if the rewrite fails, the base-only marker above remains
+    // and cancellation still works; refusing now would punish a success.
+    try {
+      recordPanelPendingOp("update-all", detail, UPDATE_ALL_PENDING_MS, {
+        base: result.base,
+        uiId: result.uiId,
+      });
+    } catch (err) {
+      logger.warn(
+        `[panel] update_all is queued, but the pending-op marker could not be ` +
+          `enriched with its ui_id (the base-only marker remains): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+      );
+    }
 
     return {
       // Queue acceptance is not proof a generic/bulk Manager update moved the

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -19,6 +19,7 @@ import {
   setPanelVersionPin,
 } from "../services/panel-settings.js";
 import { activePanelPendingOps } from "../services/panel-pin-guard.js";
+import { cancelPanelPendingOps } from "../services/panel-pending-cancel.js";
 import { errorToToolResult } from "../utils/errors.js";
 
 function json(value: unknown) {
@@ -105,13 +106,17 @@ export function registerInstallPanelTools(server: McpServer): void {
           // so the response could describe a pin that was no longer the real one.
           // The pending-op read is inside too: a marker recorded by an update_all
           // or snapshot restore (both hold this lock while recording) must be
-          // seen by the very pin write that follows them.
-          const { pin, resolved, pending } = await withPanelOpLock(async () => {
+          // seen by the very pin write that follows them — and so must its
+          // CANCELLATION (#689): each marker is dealt with here, in the same
+          // critical section, before the pin result is reported.
+          const { pin, resolved, pending, cancels } = await withPanelOpLock(async () => {
             const written = setPanelVersionPin(target, reason);
+            const ops = activePanelPendingOps();
             return {
               pin: written,
               resolved: getPanelPinState(),
-              pending: activePanelPendingOps(),
+              pending: ops,
+              cancels: ops.length > 0 ? await cancelPanelPendingOps(ops) : [],
             };
           });
           // What actually governs is NOT necessarily what we just wrote:
@@ -121,21 +126,29 @@ export function registerInstallPanelTools(server: McpServer): void {
           // checking is the fabricated-success failure this feature exists to
           // prevent, so each outcome is named distinctly.
           const outcome = classifyPinWrite(resolved, pin.version);
-          // A pin cannot recall work ALREADY handed to ComfyUI-Manager (a queued
-          // update_all draining on the Manager's worker, or a snapshot restore
-          // deferred to the next ComfyUI restart). WARN rather than refuse: the
-          // pin is valid and governs every FUTURE operation — refusing it would
-          // leave the user LESS protected against the next sync, to punish them
-          // for a race they could not see. Truthful beats silent.
-          const pendingWarning = pending.length
+          // A pin written during a pending update_all / snapshot-restore window
+          // now CANCELS what it provably can (#689): each op's report says what
+          // happened — cancelled (with before/after pending counts), already
+          // drained (nothing left to cancel; the panel may ALREADY have moved),
+          // already running (in-flight work CANNOT be cancelled), or
+          // could-not-verify — and the marker is cleared only for the first two.
+          // What remains (residue) keeps the warning below. WARN rather than
+          // refuse for the residue: the pin is valid and governs every FUTURE
+          // operation — refusing it would leave the user LESS protected against
+          // the next sync, to punish them for a race they could not see.
+          const residue = pending.filter((_, i) => !cancels[i]?.markerCleared);
+          const pendingWarning = residue.length
             ? ` WARNING — ${
-                pending.length === 1
+                residue.length === 1
                   ? "a panel-affecting operation is"
-                  : `${pending.length} panel-affecting operations are`
+                  : `${residue.length} panel-affecting operations are`
               } still pending and may move the panel AFTER this pin: ` +
-              `${pending.map((op) => op.detail).join("; ")}. The pin governs every ` +
+              `${residue.map((op) => op.detail).join("; ")}. The pin governs every ` +
               `install/update/reinstall/sync from now on, but it cannot stop work ` +
-              `already queued — check install_panel(action='status') once it has landed.`
+              `already running — check install_panel(action='status') once it has landed.`
+            : "";
+          const cancelNote = cancels.length
+            ? ` Pending-op handling: ${cancels.map((c) => c.detail).join(" ")}`
             : "";
           // panelStatus is advisory here (it only supplies installedVersion for
           // the message); the authoritative pin is `resolved`, captured above.
@@ -150,8 +163,28 @@ export function registerInstallPanelTools(server: McpServer): void {
             installedVersion: status.installedVersion,
             requiredPanelVersion: requiredPanelVersion(),
             /** Panel-affecting operations already handed to ComfyUI-Manager that
-             *  may still land out-of-band (absent when none are pending). */
-            pendingPanelOps: pending.length ? pending : undefined,
+             *  may STILL land out-of-band — the residue after cancellation
+             *  (#689): what was provably cancelled or proven drained is absent. */
+            pendingPanelOps: residue.length ? residue : undefined,
+            /** One report per pending op found at pin time (#689): what was
+             *  attempted, the before/after pending counts, and the outcome —
+             *  cancelled / already-drained / partially-cancelled /
+             *  already-running / could-not-verify / cannot-cancel-remote. */
+            pendingOpCancellations: cancels.length
+              ? cancels.map((c) => ({
+                  kind: c.op.kind,
+                  outcome: c.outcome,
+                  markerCleared: c.markerCleared,
+                  ...(c.pendingBefore !== undefined
+                    ? {
+                        pendingBefore: c.pendingBefore,
+                        pendingAfter: c.pendingAfter,
+                        inProgress: c.inProgress,
+                      }
+                    : {}),
+                  detail: c.detail,
+                }))
+              : undefined,
             // A pin records intent; it does NOT move the panel. Saying so
             // prevents "pinned to 0.11.20" being read as "now on 0.11.20".
             note:
@@ -160,27 +193,31 @@ export function registerInstallPanelTools(server: McpServer): void {
                   `what is installed (currently ${status.installedVersion ?? "unknown"}). ` +
                   `install/update/reinstall/sync and the on-load auto-install will now ` +
                   `refuse until the pin is cleared with install_panel(action='unpin').` +
-                  pendingWarning
+                  pendingWarning +
+                  cancelNote
                 : outcome === "env-overrides-with-pin"
                   ? `Saved a pin at ${pin.version}, but it is NOT the pin in force: the ` +
                     `${PANEL_PIN_ENV_VAR} environment variable takes precedence and the ` +
                     `panel is ${describePanelPin(resolved)}. The panel IS protected — ` +
                     `just at the env pin's version, not yours. Unset ${PANEL_PIN_ENV_VAR} ` +
                     `and restart the orchestrator for the saved ${pin.version} to govern.` +
-                    pendingWarning
+                    pendingWarning +
+                    cancelNote
                   : outcome === "superseded"
                     ? `Saved a pin at ${pin.version}, but another pin was written at the ` +
                       `same time and won: the panel is ${describePanelPin(resolved)}. The ` +
                       `panel IS pinned, just not at ${pin.version} — re-run the pin if you ` +
                       `meant yours to stand.` +
-                      pendingWarning
+                      pendingWarning +
+                      cancelNote
                     : `WARNING — the pin was saved to disk but is NOT IN FORCE, and the ` +
                       `panel is NOT protected: ${PANEL_PIN_ENV_VAR} is set to an explicit ` +
                       `"no pin" value, which overrides the saved pin. ` +
                       `install/update/reinstall/sync will still proceed. Unset ` +
                       `${PANEL_PIN_ENV_VAR} in the environment / ~/.comfyui-mcp/.env and ` +
                       `restart the orchestrator for the saved pin to take effect.` +
-                      pendingWarning,
+                      pendingWarning +
+                      cancelNote,
           });
         }
 


### PR DESCRIPTION
Refs #689. Filed from the #657 gate: a pin written during a pending `update_all` / snapshot-restore window only **warned** — the queued ComfyUI-Manager work could still move the now-pinned panel, violating the owner's constraint *"never auto-update over an explicit pin"*.

## What changed

The pin-write critical section (`install_panel(action='pin')`) now attempts to **cancel** each active pending-op marker, inside the same lock, before reporting:

- **`update-all`** → `POST <prefix>/manager/queue/reset` via `resetQueue(base)` (now takes an optional base, `ManagerFetchOptions.base` convention). The reset is aimed at the server the marker was queued on — captured in the marker at enqueue time — so a retarget between enqueue and pin can't send it to the wrong ComfyUI (or wipe an innocent queue). A marker with no recorded base falls back to the current target and says so.
- **`snapshot-restore`** → deletes `<manager files>/startup-scripts/restore-snapshot.json` before the next ComfyUI restart consumes it — the exact file `POST /snapshot/restore` writes and `prestartup_script.py` applies (`if os.path.exists(...)`), verified against ComfyUI-Manager 3.x `main` and the v4 pip package. Local installs only; remote mode reports **"cannot cancel — remote host"** and names the manual remedy.

## Provably honest reporting — never "the panel was saved"

Queue counts are read **before and after** the reset (v4 `pending_count`; 3.x `total−done−in_progress`) and the pin result's new `pendingOpCancellations` field names the numbers:

| outcome | meaning | marker |
|---|---|---|
| `cancelled` | reset dropped N pending tasks, none remain, nothing running (shared-queue blast radius stated) | cleared |
| `partially-cancelled` | pending dropped, but task(s) already running — in-flight work cannot be cancelled | kept + warning |
| `already-drained` | queue empty+idle / no restore file — nothing left to cancel; the panel may **already** have moved | cleared |
| `already-running` | nothing pending, worker busy — no reset even sent; cannot cancel | kept + warning |
| `could-not-verify` | state unreadable, reset/delete failed, incoherent counts (#639 signature), or marker itself wouldn't clear — a blind reset is never sent | kept + warning |
| `cannot-cancel-remote` | deferred restore file lives on the ComfyUI host | kept + warning |

Markers are cleared via the new `clearPanelPendingOp` (exact `kind`+`queuedAt` match, read-back verified, fails closed) **only** for provably-cancelled / proven-drained work. The pin itself always lands; refusal semantics are unchanged.

`PanelPendingOp` now also carries `base` + `uiId` of the update_all enqueue attempt that landed (v4 derives per-pack task ids as `${ui_id}_${pack}`), so a v4 host can later answer "did the panel's task already run" via `/v2/manager/queue/history` (capture only — no history query yet).

## Tests

- New `panel-pin-cancel.test.ts` (15 tests) drives the real pin tool handler: cancel on the marker's server after a retarget, reset failure, unverifiable state (nothing sent), in-flight, partial, already-drained, legacy-3.x arithmetic + unprefixed reset route, incoherent counts, local/remote/not-scheduled snapshot cases, no-markers (zero Manager calls), and base/ui_id capture at enqueue.
- `panel-pin-guard.test.ts` gains `clearPanelPendingOp` + marker round-trip tests.
- Full suite: **229 files / 3741 tests passed** (2 skipped); `tsc --noEmit` clean. No tool descriptions changed, so no docs regen.