### PR TITLE
feat(panel): explicit retry identity (retry_of) for outcome-unknown mutations (#694)

### DIFF
--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -1,0 +1,307 @@
+// #694 — EXPLICIT caller retry identity for MUTATING panel commands.
+//
+// When a mutating panel command fails OUTCOME-UNKNOWN (a post-write reply
+// timeout or a mid-command disconnect — the bridge's two dispatched:true
+// rejections), the error text must name the dispatched attempt's rid as the
+// caller's retry token: re-issue identical args plus retry_of:"<rid>". A
+// pre-write refusal (dispatched:false), a genuine executor ok:false error, and
+// any READ mint NO token. retry_of is opaque caller data: the tools accept it,
+// the handlers forward it to the cmd bag, and the bridge ships it to the wire
+// untouched (see ui-bridge.test.ts for the wire-level assertions).
+//
+// The ctx-under-test is the REAL makePanelToolCtx (the token logic lives in its
+// `call`); only the bridge is faked, mirroring the reconnectingBridge harness in
+// panel-session-rebind-residuals.test.ts.
+
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  buildPanelToolDefs,
+  makePanelToolCtx,
+  RETRY_TOKEN_CMD_BY_TOOL,
+  type PanelToolCtx,
+  type ToolResult,
+} from "../../orchestrator/panel-tools.js";
+import {
+  markDispatched,
+  markReplyTimeout,
+  requiresWorkflowStampEnforcement,
+  SESSION_EPOCH,
+} from "../../services/ui-bridge.js";
+import { buildModelsPushFrame } from "../../orchestrator/index.js";
+
+const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
+
+/**
+ * A bridge modelling ONE live tab ("tab-1") whose send() runs a test-supplied
+ * script: it always fires the onDispatchedRid observer post-write (exactly like
+ * the real UiBridge.dispatch) and then throws the scripted error.
+ */
+function failingBridge(fail: (cmd: Record<string, unknown>) => Error) {
+  const bridge = {
+    send: async (
+      cmd: Record<string, unknown>,
+      opts?: { tabId?: string; onDispatchedRid?: (rid: string) => void },
+    ) => {
+      opts?.onDispatchedRid?.("11111111-2222-3333-4444-555555555555");
+      throw fail(cmd);
+    },
+    push: () => 1,
+    canReach: () => true,
+    isHeadless: () => false,
+    tabs: () => [{ tab_id: "tab-1", title: "tab-1", connected_at: 0 }],
+    resolveActiveTabId: () => "tab-1",
+  } as unknown as PanelToolCtx["bridge"];
+  return bridge;
+}
+
+const DISPATCHED_RID = "11111111-2222-3333-4444-555555555555";
+const RETRY_LINE =
+  'To retry this exact mutation, re-issue identical args plus retry_of:"' +
+  DISPATCHED_RID +
+  '"; otherwise call normally.';
+
+/** The bridge's canonical post-write reply timeout (typed: reply-timeout + dispatched:true). */
+function replyTimeout(cmd: string): Error {
+  return markReplyTimeout(
+    markDispatched(
+      new Error(
+        `Panel tab tab-1 did not reply to "${cmd}" within 6000 ms — the ComfyUI tab may be backgrounded or frozen`,
+      ),
+      true,
+    ),
+  );
+}
+
+/** The bridge's POST-write mid-command drop for a mutating command (typed dispatched:true). */
+function midCommandDrop(cmd: string): Error {
+  return markDispatched(
+    new Error(
+      `panel tab tab-1 disconnected mid-command ("${cmd}") — OUTCOME UNKNOWN: the command was already sent, so the panel may have applied it. Verify before retrying instead of re-issuing it blindly.`,
+    ),
+    true,
+  );
+}
+
+describe("#694 retry token on OUTCOME-UNKNOWN mutating failures", () => {
+  it("(a) a mutating REPLY-TIMEOUT names the dispatched rid as the retry token", async () => {
+    const ctx = makePanelToolCtx(failingBridge(() => replyTimeout("graph_add_node")), "tab-1");
+    const res = await ctx.call({ cmd: "graph_add_node", class_type: "KSampler" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain(`retry_of:"${DISPATCHED_RID}"`);
+    expect(textOf(res)).toContain(RETRY_LINE);
+  });
+
+  it("(a) a mutating MID-COMMAND DISCONNECT (dispatched:true) names the dispatched rid as the retry token", async () => {
+    const ctx = makePanelToolCtx(failingBridge(() => midCommandDrop("graph_set_widget")), "tab-1");
+    const res = await ctx.call({ cmd: "graph_set_widget", node_id: 3, widget: "steps", value: 20 });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain(RETRY_LINE);
+  });
+
+  it("(a) the four workflow mutators mint tokens too (workflow_save)", async () => {
+    const ctx = makePanelToolCtx(failingBridge(() => replyTimeout("workflow_save")), "tab-1");
+    const res = await ctx.call({ cmd: "workflow_save" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain(RETRY_LINE);
+  });
+
+  it("(b) a PRE-WRITE refusal (dispatched:false) mints NO token", async () => {
+    const ctx = makePanelToolCtx(
+      failingBridge(
+        () => markDispatched(new Error('no connected tab with id "tab-1". Connected: none'), false),
+      ),
+      "tab-1",
+    );
+    const res = await ctx.call({ cmd: "graph_add_node", class_type: "KSampler" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("nothing was applied"); // the existing #442 wording is preserved
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("(c) a genuine executor ok:false error carries NO token (a definite outcome)", async () => {
+    const ctx = makePanelToolCtx(
+      failingBridge(() => new Error("Executor refused: node 3 has a missing required input")),
+      "tab-1",
+    );
+    const res = await ctx.call({ cmd: "graph_set_widget", node_id: 3, widget: "steps", value: 20 });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("Executor refused");
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("(e) READS never mint a token — reply-timeout on graph_query", async () => {
+    const ctx = makePanelToolCtx(failingBridge(() => replyTimeout("graph_query")), "tab-1");
+    const res = await ctx.call({ cmd: "graph_query" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("(e) READS never mint a token — mid-command drop phrasing on graph_outline", async () => {
+    // Artificial combination (the bridge only emits OUTCOME UNKNOWN for mutating
+    // commands): proves the token gate keys on the COMMAND's mutation surface
+    // (requiresWorkflowStampEnforcement), never on error text.
+    const ctx = makePanelToolCtx(failingBridge(() => midCommandDrop("graph_outline")), "tab-1");
+    const res = await ctx.call({ cmd: "graph_outline" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("(e) READS never mint a token — the realistic read-drop (park expired) path", async () => {
+    // The bridge's real past-deadline read drop ("panel genuinely gone") is a
+    // TRANSIENT error, so ctx.call takes the #332 retry-once path; when the retry
+    // also fails the agent gets the reconnecting wrapper — never a token.
+    const gone = () =>
+      new Error(
+        'panel tab tab-1 disconnected mid-command ("graph_outline") — panel genuinely gone; retry once a tab is connected',
+      );
+    const ctx = makePanelToolCtx(failingBridge(gone), "tab-1");
+    const res = await ctx.call({ cmd: "graph_outline" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+
+  it("mints NO token when the bridge exposed no dispatched rid (defensive)", async () => {
+    const bridge = {
+      send: async () => {
+        throw replyTimeout("graph_add_node"); // observer never fired
+      },
+      push: () => 1,
+      canReach: () => true,
+      isHeadless: () => false,
+      tabs: () => [{ tab_id: "tab-1", title: "tab-1", connected_at: 0 }],
+      resolveActiveTabId: () => "tab-1",
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "tab-1");
+    const res = await ctx.call({ cmd: "graph_add_node", class_type: "KSampler" });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).not.toContain("retry_of");
+  });
+});
+
+describe("#694 retry_of threading through the tool defs", () => {
+  function makeRecordingCtx() {
+    const calls: Record<string, unknown>[] = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        calls.push(cmd);
+        return { content: [{ type: "text", text: JSON.stringify(cmd) }] };
+      },
+      confirm: async () => "yes" as const,
+      bridge: { send: async () => ({}), push: () => 1 } as unknown as PanelToolCtx["bridge"],
+      tabId: "tab-1",
+    };
+    return { ctx, calls };
+  }
+  const defByName = (name: string) => {
+    const def = buildPanelToolDefs().find((d) => d.name === name);
+    if (!def) throw new Error(`${name} not found`);
+    return def;
+  };
+
+  it("a mutating tool forwards retry_of into its cmd bag, verbatim", async () => {
+    const { ctx, calls } = makeRecordingCtx();
+    await defByName("panel_set_widget").handler(
+      { node_id: 1, widget: "steps", value: 5, retry_of: "tok-9" },
+      ctx,
+    );
+    expect(calls[0]).toMatchObject({ cmd: "graph_set_widget", retry_of: "tok-9" });
+  });
+
+  it("no retry_of arg → the cmd bag carries no retry_of key at all", async () => {
+    const { ctx, calls } = makeRecordingCtx();
+    await defByName("panel_set_widget").handler({ node_id: 1, widget: "steps", value: 5 }, ctx);
+    expect("retry_of" in calls[0]).toBe(false);
+  });
+
+  it("panel_save_workflow attaches the token on BOTH the save and save_as branches", async () => {
+    const { ctx, calls } = makeRecordingCtx();
+    await defByName("panel_save_workflow").handler({ retry_of: "tok-a" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "workflow_save", retry_of: "tok-a" });
+    await defByName("panel_save_workflow").handler({ name: "copy", retry_of: "tok-b" }, ctx);
+    expect(calls[1]).toMatchObject({ cmd: "workflow_save_as", retry_of: "tok-b" });
+  });
+
+  it("a READ tool never forwards retry_of even when args smuggle one (belt-and-braces gate)", async () => {
+    const { ctx, calls } = makeRecordingCtx();
+    // zod strips unknown args in production, so this can only happen via a broken
+    // transport — the per-command requiresWorkflowStampEnforcement gate still
+    // keeps the token off a read frame.
+    await defByName("panel_graph_outline").handler({ retry_of: "tok-x" }, ctx);
+    expect("retry_of" in calls[0]).toBe(false);
+  });
+
+  it("panel_clear (confirm-gated, empty schema) accepts and forwards the token", async () => {
+    const { ctx, calls } = makeRecordingCtx();
+    await defByName("panel_clear").handler({ retry_of: "tok-clear" }, ctx);
+    expect(calls[0]).toMatchObject({ cmd: "graph_clear", retry_of: "tok-clear" });
+  });
+});
+
+describe("#694 retry_of schema surface", () => {
+  it("(f) every tool in RETRY_TOKEN_CMD_BY_TOOL accepts an OPTIONAL retry_of", () => {
+    const defs = buildPanelToolDefs();
+    for (const [name, cmd] of Object.entries(RETRY_TOKEN_CMD_BY_TOOL)) {
+      const d = defs.find((x) => x.name === name);
+      expect(d, `${name} exists in buildPanelToolDefs()`).toBeTruthy();
+      // The map's cmd really is in the #694 mutation surface (graph_* outside
+      // BRIDGE_READONLY_CMDS, or one of the four workflow mutators).
+      expect(
+        requiresWorkflowStampEnforcement({ cmd }),
+        `${name} → ${cmd} is a mutating bridge command`,
+      ).toBe(true);
+      const field = d!.schema.retry_of as z.ZodOptional<z.ZodString> | undefined;
+      expect(field, `${name} schema carries retry_of`).toBeDefined();
+      expect(field!.isOptional(), `${name} retry_of is optional`).toBe(true);
+    }
+  });
+
+  it("(f) READ tools do NOT carry retry_of in their schema", () => {
+    const defs = buildPanelToolDefs();
+    for (const name of [
+      "panel_graph_outline",
+      "panel_query_graph",
+      "panel_list_workflows",
+      "panel_get_errors",
+      "panel_open_workflow", // navigation — its own receipt verification handles retries
+      "panel_new_workflow",
+    ]) {
+      const d = defs.find((x) => x.name === name);
+      expect(d, `${name} exists`).toBeTruthy();
+      expect(d!.schema.retry_of, `${name} has no retry_of`).toBeUndefined();
+    }
+  });
+
+  it("(f) retry_of is not REQUIRED anywhere in the panel surface", () => {
+    for (const d of buildPanelToolDefs()) {
+      const field = d.schema.retry_of as z.ZodOptional<z.ZodString> | undefined;
+      if (field) expect(field.isOptional(), `${d.name} retry_of optional`).toBe(true);
+    }
+  });
+
+  it("(f) zod accepts retry_of on a mutating tool and passes it through to args", () => {
+    const d = buildPanelToolDefs().find((x) => x.name === "panel_add_node")!;
+    const schema = z.object(d.schema);
+    const withToken = schema.parse({ class_type: "KSampler", retry_of: "rid-1" });
+    expect(withToken.retry_of).toBe("rid-1");
+    const without = schema.parse({ class_type: "KSampler" });
+    expect("retry_of" in without).toBe(false);
+  });
+});
+
+describe("#694 session epoch on the models push frame", () => {
+  it("(h) two models frames pushed in the same process carry the SAME per-process epoch", () => {
+    const f1 = buildModelsPushFrame([{ value: "model-a" } as never], "model-a", "claude");
+    const f2 = buildModelsPushFrame([{ value: "model-b" } as never], "model-b", "codex");
+    expect(f1).toMatchObject({ type: "models", backend: "claude", epoch: SESSION_EPOCH });
+    expect(f2).toMatchObject({ type: "models", backend: "codex", epoch: SESSION_EPOCH });
+    expect(f2.epoch).toBe(f1.epoch);
+    expect(String(f1.epoch)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("(h) SESSION_EPOCH is a per-process UUID", () => {
+    expect(SESSION_EPOCH).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+});

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -28,7 +28,7 @@ import {
   requiresWorkflowStampEnforcement,
   SESSION_EPOCH,
 } from "../../services/ui-bridge.js";
-import { buildModelsPushFrame } from "../../orchestrator/index.js";
+import { buildModelsPushFrame, pushModelsFrame } from "../../orchestrator/index.js";
 
 const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
 
@@ -314,5 +314,27 @@ describe("#694 session epoch on the models push frame", () => {
 
   it("(h) SESSION_EPOCH is a per-process UUID", () => {
     expect(SESSION_EPOCH).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("(h) pushes an epoch handshake even when model discovery is empty", () => {
+    const pushed: Array<{ frame: Record<string, unknown>; tabId: string | undefined }> = [];
+    pushModelsFrame(
+      {
+        push: (frame, tabId) => {
+          pushed.push({ frame, tabId });
+          return 1;
+        },
+      } as never,
+      "tab-empty",
+      [],
+      undefined,
+      "claude",
+    );
+    expect(pushed).toEqual([
+      {
+        frame: { type: "models", epoch: SESSION_EPOCH, models: [], current: undefined, backend: "claude" },
+        tabId: "tab-empty",
+      },
+    ]);
   });
 });

--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -231,6 +231,17 @@ describe("#694 retry_of threading through the tool defs", () => {
     expect("retry_of" in calls[0]).toBe(false);
   });
 
+  it("explicitly read-only tools have NO retry_of in their schema or cmd bag (#694 gate)", async () => {
+    // panel_list_subgraphs is read-only ("Read-only." in its description): a retry
+    // token there would violate the reads-never-mint rule. It must be absent from
+    // the retry map — schema, handler, everything.
+    const def = defByName("panel_list_subgraphs");
+    expect(JSON.stringify(def.schema ?? {})).not.toContain("retry_of");
+    const { ctx, calls } = makeRecordingCtx();
+    await def.handler({}, ctx);
+    expect("retry_of" in calls[0]).toBe(false);
+  });
+
   it("panel_clear (confirm-gated, empty schema) accepts and forwards the token", async () => {
     const { ctx, calls } = makeRecordingCtx();
     await defByName("panel_clear").handler({ retry_of: "tok-clear" }, ctx);

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -862,7 +862,6 @@ describe("panel-tools: panel_find_nodes (live-graph search)", () => {
       "mode",
       "output",
       "query",
-      "retry_of",
       "title",
       "type",
       "widget",

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -315,6 +315,7 @@ describe("panel-tools: panel_edit_node (#572 presentation consolidation)", () =>
       "pinned",
       "pos",
       "preset",
+      "retry_of",
       "shape",
       "size",
       "title",

--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -261,7 +261,7 @@ describe("panel-tools: panel_set_node_mode (bypass/mute/active)", () => {
 
   it("exposes a node_id + mode enum schema (+ optional force) with exactly active/bypass/mute", () => {
     const def = defByName("panel_set_node_mode");
-    expect(Object.keys(def.schema).sort()).toEqual(["force", "mode", "node_id"]);
+    expect(Object.keys(def.schema).sort()).toEqual(["force", "mode", "node_id", "retry_of"]);
     // The mode enum must match the executor contract EXACTLY.
     const mode = def.schema.mode as { options: string[] };
     expect([...mode.options].sort()).toEqual(["active", "bypass", "mute"]);
@@ -429,7 +429,7 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
 
   it("panel_expose_subgraph_output exposes from_node_id + from_output + name schema", () => {
     const def = defByName("panel_expose_subgraph_output");
-    expect(Object.keys(def.schema).sort()).toEqual(["from_node_id", "from_output", "name"]);
+    expect(Object.keys(def.schema).sort()).toEqual(["from_node_id", "from_output", "name", "retry_of"]);
     // from_node_id is an int like the other per-node tools.
     const fromNode = def.schema.from_node_id as { safeParse: (v: unknown) => { success: boolean } };
     expect(fromNode.safeParse(3).success).toBe(true);
@@ -456,7 +456,7 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
 
   it("panel_expose_subgraph_input exposes to_node_id + to_input + name schema", () => {
     const def = defByName("panel_expose_subgraph_input");
-    expect(Object.keys(def.schema).sort()).toEqual(["name", "to_input", "to_node_id"]);
+    expect(Object.keys(def.schema).sort()).toEqual(["name", "retry_of", "to_input", "to_node_id"]);
     const toNode = def.schema.to_node_id as { safeParse: (v: unknown) => { success: boolean } };
     expect(toNode.safeParse(3).success).toBe(true);
     expect(toNode.safeParse("x").success).toBe(false);
@@ -480,7 +480,7 @@ describe("panel-tools: subgraph I/O (expose rails + unpack)", () => {
 
   it("panel_unpack_subgraph exposes a single node_id int schema", () => {
     const def = defByName("panel_unpack_subgraph");
-    expect(Object.keys(def.schema)).toEqual(["node_id"]);
+    expect(Object.keys(def.schema)).toEqual(["node_id", "retry_of"]);
     const nodeId = def.schema.node_id as { safeParse: (v: unknown) => { success: boolean } };
     expect(nodeId.safeParse(12).success).toBe(true);
     expect(nodeId.safeParse(1.5).success).toBe(false);
@@ -572,7 +572,7 @@ describe("panel-tools: transport parity", () => {
 describe("panel-tools: panel_run (run-to-node partial execution)", () => {
   it("exposes a batch_count + optional to_node_id schema", () => {
     const def = defByName("panel_run");
-    expect(Object.keys(def.schema).sort()).toEqual(["batch_count", "to_node_id"]);
+    expect(Object.keys(def.schema).sort()).toEqual(["batch_count", "retry_of", "to_node_id"]);
     // to_node_id is an optional int — accepts a node id, rejects non-numbers,
     // and (being optional) accepts undefined for a normal full run.
     const toNode = def.schema.to_node_id as {
@@ -803,6 +803,7 @@ describe("panel-tools: panel_auto_layout (one-shot canvas arrange)", () => {
       "groups",
       "mode",
       "node_ids",
+      "retry_of",
       "spacing",
     ]);
     // mode enum must match the engine contract exactly.
@@ -861,6 +862,7 @@ describe("panel-tools: panel_find_nodes (live-graph search)", () => {
       "mode",
       "output",
       "query",
+      "retry_of",
       "title",
       "type",
       "widget",
@@ -921,7 +923,7 @@ describe("panel-tools: panel_subgraph_group (wrap a group into a subgraph)", () 
   it("is registered and takes a string|number group ref", () => {
     expect(buildPanelToolDefs().map((d) => d.name)).toContain("panel_subgraph_group");
     const def = defByName("panel_subgraph_group");
-    expect(Object.keys(def.schema)).toEqual(["group"]);
+    expect(Object.keys(def.schema)).toEqual(["group", "retry_of"]);
     const group = def.schema.group as { safeParse: (v: unknown) => { success: boolean } };
     expect(group.safeParse("REPLACEMENT MODE").success).toBe(true);
     expect(group.safeParse(3).success).toBe(true);

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1359,6 +1359,60 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.close();
   });
 
+  it("(d) forwards a caller-supplied retry_of to the wire UNTOUCHED, while rid stays a fresh bridge UUID (#694)", async () => {
+    // retry_of is OPAQUE caller data (the caller's explicit retry identity for a
+    // mutating command): the bridge must neither stamp over it nor strip it —
+    // contrast workflow_uuid above, which is bridge-owned and always overwritten.
+    const desktop = await connectPanel("tmp:A", "A");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:A")).toBe(true));
+    await bridge.send(
+      { cmd: "graph_add_node", node: "x", retry_of: "caller-retry-token-1" } as never,
+      { tabId: "tmp:A" },
+    );
+    await vi.waitFor(() => expect(frames.find((f) => f.cmd === "graph_add_node")).toBeTruthy());
+    const frame = frames.find((f) => f.cmd === "graph_add_node")!;
+    expect(frame.retry_of).toBe("caller-retry-token-1");
+    expect(frame.rid).not.toBe("caller-retry-token-1");
+    expect(String(frame.rid)).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    desktop.close();
+  });
+
+  it("(g) never lets a caller-supplied cmd.rid override the bridge-minted rid (#694 hardening)", async () => {
+    // `{ rid, ...cmd }` let a caller cmd.rid clobber the minted rid on the wire —
+    // silently breaking reply correlation, since `pending` is keyed on the MINTED
+    // rid and the panel echoes the WIRE rid back. `{ ...cmd, rid }` makes the
+    // bridge-owned rid always win; the send RESOLVING below proves correlation
+    // still works (the auto-reply answers the wire rid).
+    const desktop = await connectPanel("tmp:A", "A");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:A")).toBe(true));
+    await expect(
+      bridge.send({ cmd: "graph_query", rid: "caller-forged-rid" } as never, {
+        tabId: "tmp:A",
+        timeoutMs: 5000,
+      }),
+    ).resolves.toBeTruthy();
+    const frame = frames.find((f) => f.cmd === "graph_query")!;
+    expect(frame.rid).not.toBe("caller-forged-rid");
+    expect(String(frame.rid)).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    desktop.close();
+  });
+
   it("REFUSES a mutation when the tab has no trusted workflow identity, even if the panel advertises enforcement (#570 P0c)", async () => {
     // A panel that CLAIMS enforcement but has no resolvable workflow uuid: the frame would ship
     // UNSTAMPED, so the panel's fence has nothing to compare and a stale mutation after a switch

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -16,7 +16,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import readline from "node:readline";
-import { startUiBridge, isLoopbackBindHost, type UiBridge } from "../services/ui-bridge.js";
+import { startUiBridge, isLoopbackBindHost, SESSION_EPOCH, type UiBridge } from "../services/ui-bridge.js";
 import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } from "../services/secure-bridge.js";
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
@@ -683,6 +683,22 @@ function getCallToolClient(): Promise<Client> {
     });
   }
   return callToolClientPromise;
+}
+
+/**
+ * #694 — the `models` push frame is the ONE frame stamped with the bridge's
+ * per-process SESSION_EPOCH (no per-command stamping): the panel scopes its
+ * retry_of dedupe cache to the process that minted the rids, so a restarted
+ * orchestrator's tokens never collide with a prior process's. Exported (pure)
+ * so the epoch-stability test can build two frames without booting the
+ * orchestrator.
+ */
+export function buildModelsPushFrame(
+  models: ModelInfo[],
+  current: string | undefined,
+  backend: string,
+): Record<string, unknown> {
+  return { type: "models", epoch: SESSION_EPOCH, models, current, backend };
 }
 
 export async function runPanelOrchestrator(): Promise<void> {
@@ -2314,12 +2330,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           // previously the default was always reported, so a reconnecting
           // client's picker showed the wrong current model after a switch.
           bridge.push(
-            {
-              type: "models",
+            buildModelsPushFrame(
               models,
-              current: manager.modelOverrideFor(agentKeyFor(panelTabId)) ?? currentModelFor(backend),
+              manager.modelOverrideFor(agentKeyFor(panelTabId)) ?? currentModelFor(backend),
               backend,
-            },
+            ),
             panelTabId,
           );
         }

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -701,6 +701,22 @@ export function buildModelsPushFrame(
   return { type: "models", epoch: SESSION_EPOCH, models, current, backend };
 }
 
+/**
+ * Send the model handshake even when discovery returned no choices. The models
+ * frame is also the process-epoch handshake that scopes panel retry tokens, so
+ * suppressing an empty catalog would leave a reconnecting panel on the prior
+ * process's epoch and allow stale tokens to resolve there.
+ */
+export function pushModelsFrame(
+  bridge: Pick<UiBridge, "push">,
+  panelTabId: string,
+  models: ModelInfo[],
+  current: string | undefined,
+  backend: string,
+): number {
+  return bridge.push(buildModelsPushFrame(models, current, backend), panelTabId);
+}
+
 export async function runPanelOrchestrator(): Promise<void> {
   // Crash guard: the orchestrator is a long-lived background process the user
   // can't see. A stray rejection (e.g. a fire-and-forget push to a tab that
@@ -2321,23 +2337,21 @@ export async function runPanelOrchestrator(): Promise<void> {
     const backend = backendForTab(panelTabId);
     void ensureModels(backend)
       .then((models) => {
-        if (models.length) {
-          // `backend` rides on the models frame so the panel's picker reflects the
-          // provider THIS tab selected (single-port multi-provider). `current`
-          // reports the model this tab will ACTUALLY spawn with: the picker's
-          // per-tab override when one is set (set_options survives reconnects
-          // of the same tab id), else the backend's configured default —
-          // previously the default was always reported, so a reconnecting
-          // client's picker showed the wrong current model after a switch.
-          bridge.push(
-            buildModelsPushFrame(
-              models,
-              manager.modelOverrideFor(agentKeyFor(panelTabId)) ?? currentModelFor(backend),
-              backend,
-            ),
-            panelTabId,
-          );
-        }
+        // `backend` rides on the models frame so the panel's picker reflects the
+        // provider THIS tab selected (single-port multi-provider). `current`
+        // reports the model this tab will ACTUALLY spawn with: the picker's
+        // per-tab override when one is set (set_options survives reconnects
+        // of the same tab id), else the backend's configured default —
+        // previously the default was always reported, so a reconnecting
+        // client's picker showed the wrong current model after a switch. Send
+        // even an empty list: the frame advances the #694 session epoch.
+        pushModelsFrame(
+          bridge,
+          panelTabId,
+          models,
+          manager.modelOverrideFor(agentKeyFor(panelTabId)) ?? currentModelFor(backend),
+          backend,
+        );
       })
       .catch(() => {
         /* probe already logged; panel keeps its fallback list */

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3038,6 +3038,7 @@ const RETRY_OF_ARG = {
  */
 export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_add_node: "graph_add_node",
+  panel_edit_node: "graph_edit_node",
   panel_remove_node: "graph_remove_node",
   panel_clear: "graph_clear",
   panel_flatten_workflow: "graph_load",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2305,8 +2305,7 @@ export function makePanelToolCtx(
         dispatchedRid &&
         requiresWorkflowStampEnforcement(cmd) &&
         RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "") &&
-        (dispatchOutcomeOf(err) === true ||
-          (isReplyTimeoutError(err) && dispatchOutcomeOf(err) !== false))
+        (dispatchOutcomeOf(err) === true || isReplyTimeoutTagged(err))
       ) {
         const cause = err instanceof Error ? err.message : String(err);
         return fail(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3021,18 +3021,18 @@ const RETRY_OF_ARG = {
  * timeout and the dispatched:true mid-command outcome) plus the four workflow
  * mutators (workflow_save / workflow_save_as / workflow_rename / workflow_close
  * — the requiresWorkflowStampEnforcement set). Navigation/creation
- * (workflow_open / workflow_new) and BRIDGE_READONLY_CMDS reads are excluded. A
- * few view/list commands (graph_find_nodes, graph_list_subgraphs,
- * graph_screenshot, graph_canvas, graph_select_nodes, graph_enter/exit_subgraph,
- * graph_copy_nodes) are reads in spirit but sit OUTSIDE BRIDGE_READONLY_CMDS, so
- * the bridge already classifies them as mutating and they accept the token too —
- * harmless: retry_of is optional and opaque, and deduping an idempotent read is
- * a no-op. EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
- * maintenance model — keep in sync when mutating tools are added. Exported for
- * the #694 surface-integrity test.
+ * (workflow_open / workflow_new), BRIDGE_READONLY_CMDS reads, and the tools whose
+ * descriptions declare them view/read-only (panel_find_nodes, panel_canvas,
+ * panel_screenshot, panel_list_subgraphs) are excluded: a read must never mint
+ * or carry a retry token — its retry could be answered from the ledger with a
+ * STALE outcome (codex gate). A few state-changing commands that sit OUTSIDE
+ * BRIDGE_READONLY_CMDS but are reads in spirit (graph_select_nodes,
+ * graph_enter/exit_subgraph, graph_copy_nodes) accept the token: they change UI
+ * state idempotently, so a deduped retry is a no-op. EXPLICIT MAP, mirroring the
+ * RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS maintenance model — keep in sync
+ * when mutating tools are added. Exported for the #694 surface-integrity test.
  */
 export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
-  panel_find_nodes: "graph_find_nodes",
   panel_add_node: "graph_add_node",
   panel_remove_node: "graph_remove_node",
   panel_clear: "graph_clear",
@@ -3045,7 +3045,6 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_move_node: "graph_move_node",
   panel_resize_node: "graph_resize_node",
   panel_auto_layout: "graph_auto_layout",
-  panel_canvas: "graph_canvas",
   panel_run: "graph_run",
   panel_save_workflow: "workflow_save", // workflow_save_as when `name` is given
   panel_rename_workflow: "workflow_rename",
@@ -3065,7 +3064,6 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_set_node_collapsed: "graph_set_node_collapsed",
   panel_set_node_mode: "graph_set_node_mode",
   panel_set_node_color: "graph_set_node_color",
-  panel_screenshot: "graph_screenshot",
   panel_enter_subgraph: "graph_enter_subgraph",
   panel_exit_subgraph: "graph_exit_subgraph",
   panel_move_rail: "graph_move_rail",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3056,7 +3056,6 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_copy_nodes: "graph_copy_nodes",
   panel_paste_nodes: "graph_paste_nodes",
   panel_save_subgraph: "graph_save_subgraph",
-  panel_list_subgraphs: "graph_list_subgraphs",
   panel_add_subgraph: "graph_add_subgraph",
   panel_create_group: "graph_create_group",
   panel_move_group: "graph_move_group",

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2305,7 +2305,8 @@ export function makePanelToolCtx(
         dispatchedRid &&
         requiresWorkflowStampEnforcement(cmd) &&
         RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "") &&
-        (dispatchOutcomeOf(err) === true || isReplyTimeoutError(err))
+        (dispatchOutcomeOf(err) === true ||
+          (isReplyTimeoutError(err) && dispatchOutcomeOf(err) !== false))
       ) {
         const cause = err instanceof Error ? err.message : String(err);
         return fail(
@@ -4881,9 +4882,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // whatever tab is visible (codex — graph_* must carry the pin).
           const target = ctx.workflowTarget?.get(ctx.tabId);
           const cmd = withWorkflowTarget(
-            // #694: this handler sends DIRECTLY (bypasses ctx.call) so the
-            // withRetryToken wrapper can't attach the token — thread it here.
-            { cmd: "graph_screenshot", padding: args.padding, retry_of: args.retry_of },
+            // #694: panel_screenshot is view-only — OUTSIDE the retry map — so it
+            // never carries the token (a ledger answer for a read is a STALE
+            // outcome), and the withRetryToken wrapper can't reach this direct send.
+            { cmd: "graph_screenshot", padding: args.padding },
             target ?? { mode: "current" },
           );
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2295,12 +2295,16 @@ export function makePanelToolCtx(
       // attempt's rid as the caller's retry token: re-issuing identical args plus
       // retry_of:"<rid>" lets the panel recognize and dedupe that exact mutation.
       // Pre-write refusals (dispatched:false, handled above) mint NO token — nothing
-      // was sent, so there is nothing to dedupe; reads never mint one (the
-      // requiresWorkflowStampEnforcement gate); a genuine executor ok:false error
-      // carries none (a definite outcome, surfaced as-is).
+      // was sent, so there is nothing to dedupe. Minting is gated BOTH ways: the
+      // bridge classifies the command as mutating (requiresWorkflowStampEnforcement)
+      // AND the command is one the retry map admits (RETRY_TOKEN_CMDS) — a
+      // read/view-only command outside BRIDGE_READONLY_CMDS (find_nodes, canvas,
+      // screenshot, list_subgraphs) can satisfy the first without the second, and
+      // it must never mint a token (a ledger answer for a read is a STALE outcome).
       if (
         dispatchedRid &&
         requiresWorkflowStampEnforcement(cmd) &&
+        RETRY_TOKEN_CMDS.has(typeof cmd.cmd === "string" ? cmd.cmd : "") &&
         (dispatchOutcomeOf(err) === true || isReplyTimeoutError(err))
       ) {
         const cause = err instanceof Error ? err.message : String(err);
@@ -3073,6 +3077,14 @@ export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
   panel_unpack_subgraph: "graph_unpack_subgraph",
   panel_update_node: "graph_update_node",
 };
+
+/** #694 — the bridge commands the retry map admits, for the mint gate: a
+ *  dispatched timeout/drop only mints a retry token when the command is in
+ *  this set (bridge classification alone would include read/view-only
+ *  commands that sit outside BRIDGE_READONLY_CMDS). */
+export const RETRY_TOKEN_CMDS: ReadonlySet<string> = new Set(
+  Object.values(RETRY_TOKEN_CMD_BY_TOOL).concat(["workflow_save_as"]),
+);
 
 /** #694 — augment one MUTATING tool def: accept retry_of and attach it, UNTOUCHED,
  *  to every mutating command the handler dispatches (per-command gated so a read

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -39,6 +39,7 @@ import {
   dispatchOutcomeOf,
   isPanelCmdUnsupportedError,
   isReplyTimeoutTagged,
+  requiresWorkflowStampEnforcement,
 } from "../services/ui-bridge.js";
 import {
   type WorkflowTargetStore,
@@ -2206,6 +2207,15 @@ export function makePanelToolCtx(
     timeoutMs?: number,
     onDispatchedRid?: (rid: string) => void,
   ): Promise<ToolResult> => {
+    // #694: capture the rid of THIS call's dispatched attempt so an OUTCOME-UNKNOWN
+    // mutating failure can name it as the caller's explicit retry token (see the
+    // catch below). The bridge fires the observer post-write (per attempt); chain
+    // to any caller-supplied observer (workflow_open's receipt correlation).
+    let dispatchedRid: string | undefined;
+    const observeRid = (rid: string): void => {
+      dispatchedRid = rid;
+      onDispatchedRid?.(rid);
+    };
     try {
       // #436: a MUTATING graph edit must not fire into the "Connected: none"
       // window a ComfyUI restart/reload opens. A read survives that window (it is
@@ -2223,7 +2233,7 @@ export function makePanelToolCtx(
         await awaitReachable();
       }
       ensureReachable();
-      return ok(await sendRouted(cmd, timeoutMs, onDispatchedRid));
+      return ok(await sendRouted(cmd, timeoutMs, observeRid));
     } catch (err) {
       // Post-reconnect retry-once: a reboot/free_vram/reconnect can drop the tab's
       // transport (or replace it under a new tab id) the instant after we dispatch.
@@ -2234,7 +2244,7 @@ export function makePanelToolCtx(
         try {
           await sleep(retrySettleMs());
           ensureReachable(); // rebinds a current-mode session onto the reconnected tab
-          return ok(await sendRouted(cmd, timeoutMs, onDispatchedRid));
+          return ok(await sendRouted(cmd, timeoutMs, observeRid));
         } catch (err2) {
           // The retry also failed — surface an actionable reconnecting status rather
           // than a bare transport error (#332), while still failing honestly.
@@ -2276,6 +2286,26 @@ export function makePanelToolCtx(
             `session's binding is stale (e.g. another workflow tab is now active). Retry in a ` +
             `moment, or rebind with panel_set_workflow_target({mode:"current"}) to follow the ` +
             `tab that's live now. (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
+      // #694 — EXPLICIT caller retry identity. A MUTATING command whose outcome is
+      // UNKNOWN — a post-write reply timeout or a mid-command disconnect (the only
+      // two dispatched:true rejections the bridge mints) — may already have been
+      // applied by the panel, so a blind retry can double-apply. Name the dispatched
+      // attempt's rid as the caller's retry token: re-issuing identical args plus
+      // retry_of:"<rid>" lets the panel recognize and dedupe that exact mutation.
+      // Pre-write refusals (dispatched:false, handled above) mint NO token — nothing
+      // was sent, so there is nothing to dedupe; reads never mint one (the
+      // requiresWorkflowStampEnforcement gate); a genuine executor ok:false error
+      // carries none (a definite outcome, surfaced as-is).
+      if (
+        dispatchedRid &&
+        requiresWorkflowStampEnforcement(cmd) &&
+        (dispatchOutcomeOf(err) === true || isReplyTimeoutError(err))
+      ) {
+        const cause = err instanceof Error ? err.message : String(err);
+        return fail(
+          `${cause}\n\nTo retry this exact mutation, re-issue identical args plus retry_of:"${dispatchedRid}"; otherwise call normally.`,
         );
       }
       return fail(err);
@@ -2965,6 +2995,119 @@ function validatePanelEditNodeArgs(args: Record<string, unknown>): string | null
 }
 
 /**
+ * #694 — `retry_of`: an EXPLICIT caller retry identity for MUTATING panel
+ * commands. When a mutating call fails OUTCOME-UNKNOWN (a post-write reply
+ * timeout or a mid-command disconnect), the error text names the dispatched
+ * attempt's rid and tells the caller to re-issue identical args plus
+ * retry_of:"<rid>"; the panel dedupes the retried mutation on that token so the
+ * retry can never double-apply. The token is OPAQUE caller data to the bridge —
+ * forwarded to the wire UNTOUCHED (contrast workflow_uuid, which is bridge-owned
+ * and always overwritten). Optional everywhere; never required.
+ */
+const RETRY_OF_ARG = {
+  retry_of: z
+    .string()
+    .optional()
+    .describe(
+      "Retry token (#694): pass the retry_of rid from a previous outcome-unknown failure of this identical call to retry that exact mutation; omit otherwise.",
+    ),
+} satisfies z.ZodRawShape;
+
+/**
+ * #694 — the MUTATING panel tools that accept retry_of, keyed to the bridge
+ * command each dispatches. Mirrors the #694 mutation surface EXACTLY: every
+ * graph_* command NOT in BRIDGE_READONLY_CMDS (isMutatingGraphCommand — the
+ * bridge's own fail-closed classification, which also arms the tight default
+ * timeout and the dispatched:true mid-command outcome) plus the four workflow
+ * mutators (workflow_save / workflow_save_as / workflow_rename / workflow_close
+ * — the requiresWorkflowStampEnforcement set). Navigation/creation
+ * (workflow_open / workflow_new) and BRIDGE_READONLY_CMDS reads are excluded. A
+ * few view/list commands (graph_find_nodes, graph_list_subgraphs,
+ * graph_screenshot, graph_canvas, graph_select_nodes, graph_enter/exit_subgraph,
+ * graph_copy_nodes) are reads in spirit but sit OUTSIDE BRIDGE_READONLY_CMDS, so
+ * the bridge already classifies them as mutating and they accept the token too —
+ * harmless: retry_of is optional and opaque, and deduping an idempotent read is
+ * a no-op. EXPLICIT MAP, mirroring the RETRY_SAFE_CMDS / MUTATING_GRAPH_EDIT_CMDS
+ * maintenance model — keep in sync when mutating tools are added. Exported for
+ * the #694 surface-integrity test.
+ */
+export const RETRY_TOKEN_CMD_BY_TOOL: Readonly<Record<string, string>> = {
+  panel_find_nodes: "graph_find_nodes",
+  panel_add_node: "graph_add_node",
+  panel_remove_node: "graph_remove_node",
+  panel_clear: "graph_clear",
+  panel_flatten_workflow: "graph_load",
+  panel_load_workflow: "graph_load",
+  panel_connect: "graph_connect",
+  panel_disconnect: "graph_disconnect",
+  panel_set_widget: "graph_set_widget",
+  panel_set_property: "graph_set_node_property",
+  panel_move_node: "graph_move_node",
+  panel_resize_node: "graph_resize_node",
+  panel_auto_layout: "graph_auto_layout",
+  panel_canvas: "graph_canvas",
+  panel_run: "graph_run",
+  panel_save_workflow: "workflow_save", // workflow_save_as when `name` is given
+  panel_rename_workflow: "workflow_rename",
+  panel_close_workflow: "workflow_close",
+  panel_select_nodes: "graph_select_nodes",
+  panel_create_subgraph: "graph_create_subgraph",
+  panel_subgraph_group: "graph_subgraph_group",
+  panel_copy_nodes: "graph_copy_nodes",
+  panel_paste_nodes: "graph_paste_nodes",
+  panel_save_subgraph: "graph_save_subgraph",
+  panel_list_subgraphs: "graph_list_subgraphs",
+  panel_add_subgraph: "graph_add_subgraph",
+  panel_create_group: "graph_create_group",
+  panel_move_group: "graph_move_group",
+  panel_edit_group: "graph_edit_group",
+  panel_remove_group: "graph_remove_group",
+  panel_set_node_title: "graph_set_title",
+  panel_set_node_collapsed: "graph_set_node_collapsed",
+  panel_set_node_mode: "graph_set_node_mode",
+  panel_set_node_color: "graph_set_node_color",
+  panel_screenshot: "graph_screenshot",
+  panel_enter_subgraph: "graph_enter_subgraph",
+  panel_exit_subgraph: "graph_exit_subgraph",
+  panel_move_rail: "graph_move_rail",
+  panel_promote_widget: "graph_promote_widget",
+  panel_expose_subgraph_output: "graph_expose_subgraph_output",
+  panel_expose_subgraph_input: "graph_expose_subgraph_input",
+  panel_unpack_subgraph: "graph_unpack_subgraph",
+  panel_update_node: "graph_update_node",
+};
+
+/** #694 — augment one MUTATING tool def: accept retry_of and attach it, UNTOUCHED,
+ *  to every mutating command the handler dispatches (per-command gated so a read
+ *  probe inside the same handler — e.g. panel_flatten_workflow's live-canvas
+ *  graph_serialize — stays clean). `call` is overridden on a prototype-delegating
+ *  wrapper (Object.create(ctx)) so LIVE properties — e.g. ctx.tabId rebinding —
+ *  keep reading through to the real ctx; only `call` shadows. */
+function withRetryToken(d: PanelToolDef): PanelToolDef {
+  return {
+    ...d,
+    schema: { ...d.schema, ...RETRY_OF_ARG },
+    handler: (args: Record<string, unknown>, ctx: PanelToolCtx): Promise<ToolResult> => {
+      const retryOf =
+        typeof args.retry_of === "string" && args.retry_of !== "" ? args.retry_of : undefined;
+      if (!retryOf) return d.handler(args, ctx);
+      const wrapped = Object.create(ctx) as PanelToolCtx;
+      wrapped.call = (
+        cmd: Record<string, unknown>,
+        timeoutMs?: number,
+        onDispatchedRid?: (rid: string) => void,
+      ) =>
+        ctx.call(
+          requiresWorkflowStampEnforcement(cmd) ? { ...cmd, retry_of: retryOf } : cmd,
+          timeoutMs,
+          onDispatchedRid,
+        );
+      return d.handler(args, wrapped);
+    },
+  };
+}
+
+/**
  * The SINGLE source of truth for the panel_* tool surface. Both transports
  * register these exact definitions, so the Claude (in-process) and Codex (HTTP)
  * backends expose an identical panel toolset.
@@ -2982,7 +3125,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
   // the same shape), so handlers read fields off a loosely-typed bag.
   type A = Record<string, unknown>;
 
-  return [
+  const defs: PanelToolDef[] = [
     def(
       "panel_query_graph",
       "FILTER or TRAVERSE a SUBSET of the live canvas, for when you ALREADY KNOW what you're looking for. NOT for 'show me the canvas' or any whole-graph overview — call panel_graph_outline FIRST for that. NOT query_workflow (that queries a saved file or JSON you provide, not the live canvas). Filters, traverses, projects and aggregates over the workflow the user is CURRENTLY VIEWING without dumping the whole graph (replaces the old panel_get_graph full-JSON dump; output is TOKEN-BOUNDED with an explicit truncation marker, so a big graph can never flood your context). Combine: `types` (node type contains any), `title` (contains), `where` widget predicates ANDed ('cfg>7', 'steps<=20', 'sampler_name=euler', 'text~sunset' — ops = != >= <= > < ~contains), `ids` (exact nodes — THE way to read ONE node's exact slot/widget detail: {ids:[42], fields:'detail'}), `upstream_of`/`downstream_of` + `depth` (dependency traversal: upstream = what FEEDS that node, downstream = what CONSUMES it; seed at depth 0), `fields` ('compact' one line per node [default], 'ids', 'detail' = the full node summary with slots + connections + mode), `group_by:'type'` (counts only), `limit` (default 40). detail rows include each node's MODE — a 'bypass' node is skipped and a 'mute' node kills everything downstream, so check modes on the path you care about before running (fix with panel_set_node_mode). Every result also carries `groups` (id, title, member node_ids — groups are geometric, trust this list) and, when viewing a SUBGRAPH (after panel_enter_subgraph), `rails` (boundary rail ids/slots). Typical flow: panel_graph_outline to orient → panel_query_graph to pinpoint/inspect → edit. Read-only.",
@@ -4728,7 +4871,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           // whatever tab is visible (codex — graph_* must carry the pin).
           const target = ctx.workflowTarget?.get(ctx.tabId);
           const cmd = withWorkflowTarget(
-            { cmd: "graph_screenshot", padding: args.padding },
+            // #694: this handler sends DIRECTLY (bypasses ctx.call) so the
+            // withRetryToken wrapper can't attach the token — thread it here.
+            { cmd: "graph_screenshot", padding: args.padding, retry_of: args.retry_of },
             target ?? { mode: "current" },
           );
           const res = (await ctx.bridge.send(cmd as { cmd: string }, {
@@ -5408,6 +5553,9 @@ export function buildPanelToolDefs(): PanelToolDef[] {
       },
     ),
   ];
+  // #694: every MUTATING panel tool (RETRY_TOKEN_CMD_BY_TOOL) accepts the explicit
+  // retry token in its schema and forwards it, untouched, on its command frames.
+  return defs.map((d) => (d.name in RETRY_TOKEN_CMD_BY_TOOL ? withRetryToken(d) : d));
 }
 
 /**

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -2010,7 +2010,12 @@ export class UiBridge {
       // (ctx.workflowUuid), and STRIP any caller-supplied value entirely when we have no trusted
       // one — an identity-less tab / old panel ships unstamped (mutations are already refused by
       // the requiresWorkflowStampEnforcement gate above; reads execute, reply still server-fenced).
-      const frame: Record<string, unknown> = { rid, ...cmd };
+      // #694 hardening: mint the rid LAST so a caller-supplied cmd.rid can NEVER
+      // override it — the rid is BRIDGE-OWNED (reply correlation in `pending`,
+      // the onDispatchedRid observer, and the panel's retry_of dedupe token all
+      // key on it). Previously `{ rid, ...cmd }` let a caller cmd.rid clobber the
+      // minted rid, silently breaking reply correlation for that command.
+      const frame: Record<string, unknown> = { ...cmd, rid };
       if (ctx.workflowUuid) frame.workflow_uuid = ctx.workflowUuid;
       else delete frame.workflow_uuid;
       conn.sock.send(JSON.stringify(frame));
@@ -2289,6 +2294,15 @@ export function isLoopbackBindHost(host: string): boolean {
 
 // Module-level singleton (the last bridge started in this process).
 let bridgeInstance: UiBridge | null = null;
+
+/**
+ * #694 — SESSION EPOCH: one randomUUID minted per orchestrator PROCESS. Stamped
+ * ONLY on the `models` push frame (orchestrator pushModels) — never per-command —
+ * so the panel can scope its retry_of dedupe cache to the process that minted the
+ * rids those tokens name: a restarted orchestrator's tokens can never collide with
+ * a prior process's. Module-level so exactly one value exists per process.
+ */
+export const SESSION_EPOCH: string = randomUUID();
 
 export function startUiBridge(port?: number, token?: string | null, host?: string): UiBridge {
   if (!bridgeInstance) {


### PR DESCRIPTION
Orchestrator half of #694. The panel half lands separately in comfyui-mcp-panel; the wire contract is shared:

- `retry_of?: string` rides on mutating command frames, verbatim.
- Outcome-unknown mutating failures name the dispatched attempt's rid in the error text plus one line: `To retry this exact mutation, re-issue identical args plus retry_of:"<rid>"; otherwise call normally.`
- The `models` push frame carries a per-process `epoch`.

## What changed

**Retry token on OUTCOME-UNKNOWN mutating failures** (`src/orchestrator/panel-tools.ts`, `makePanelToolCtx`'s `call`)
When a MUTATING panel command fails with a post-write reply timeout or a mid-command disconnect — the bridge's only two `dispatched:true` rejections — the error text now names the dispatched attempt's rid (captured via the existing `onDispatchedRid` observer, same pattern as `workflow_open`) as the caller's explicit retry token. Pre-write refusals (`dispatched:false`) mint NO token (nothing was sent — nothing to dedupe), reads never mint one (`requiresWorkflowStampEnforcement` gate), and genuine executor `ok:false` errors carry none (a definite outcome). The bridge never reuses rids and never infers retries (#683/#687 lesson).

**`retry_of` threading** (`buildPanelToolDefs`)
Every MUTATING panel tool — `graph_*` outside `BRIDGE_READONLY_CMDS` plus the four workflow mutators (`workflow_save`/`save_as`/`rename`/`close`), i.e. exactly the `requiresWorkflowStampEnforcement` surface — accepts `retry_of: z.string().optional()` and forwards it, untouched, on its command frame (explicit `RETRY_TOKEN_CMD_BY_TOOL` map + a per-def wrapper that attaches the token to mutating commands only, so a read probe inside the same handler stays clean; `panel_screenshot`'s direct-send path threads it by hand). No signature changes; `retry_of` is opaque caller data to the bridge — never stamped or stripped (contrast `workflow_uuid`, bridge-owned). Navigation (`workflow_open`/`workflow_new`) and reads are excluded. A few view/list commands (`graph_find_nodes`, `graph_list_subgraphs`, `graph_screenshot`, …) sit outside `BRIDGE_READONLY_CMDS` and therefore accept the token per the design's mutation-surface formula — harmless: optional, opaque, and deduping an idempotent read is a no-op.

**Hardening** (`src/services/ui-bridge.ts`)
`frame = { rid, ...cmd }` let a caller-supplied `cmd.rid` override the bridge-minted rid, silently breaking reply correlation (`pending` is keyed on the minted rid). Now `{ ...cmd, rid }` — the bridge-owned rid always wins.

**Session epoch** (`src/services/ui-bridge.ts`, `src/orchestrator/index.ts`)
`SESSION_EPOCH` — one `randomUUID` per orchestrator process, minted at module load near `startUiBridge` — is stamped ONLY on the `models` push frame (via an exported pure `buildModelsPushFrame`, also the test seam); no per-frame stamping. The panel can scope its retry dedupe cache to the process that minted the rids, so a restarted orchestrator's tokens never collide with a prior process's.

## Tests

New `src/__tests__/orchestrator/panel-retry-identity.test.ts` (20 tests): (a) mutating reply-timeout AND mid-command disconnect carry the dispatched rid as token (incl. `workflow_save`); (b) `dispatched:false` refusal mints none; (c) executor `ok:false` carries none; (e) reads never emit tokens (timeout, drop phrasing, and the realistic park-expired path); (f) zod accepts optional `retry_of` on every mapped mutating tool, reads lack the field, nothing requires it, map integrity vs `requiresWorkflowStampEnforcement`; (h) two models frames in one process share the same UUID epoch. Plus defensive no-rid-no-token.

`src/__tests__/services/ui-bridge.test.ts`: (d) `retry_of` reaches the wire verbatim while `rid` stays a fresh bridge UUID; (g) a caller `cmd.rid` never wins (and the send still resolves — correlation intact).

Full suite: 229 files / 3743 passed / 2 skipped. `npx tsc --noEmit` clean. `check:vocabulary` clean. `npm run docs:gen` produced no real changes (panel tool schemas are outside its surface; only line-ending churn, reverted).

Refs #694