### PR TITLE
fix(panel): use saved workspace for panel management

### DIFF
--- a/docs/tools/install-environment.mdx
+++ b/docs/tools/install-environment.mdx
@@ -85,7 +85,7 @@ Install, update, reinstall, sync, pin, or report status of the ComfyUI sidebar p
 ### Parameters
 
 <ParamField path="action" type="enum" default="status">
-  status: report installed/version/dev-symlink/pin plus a sync assessment (never errors). sync: bring the panel up to what this orchestrator needs — no-ops when already current, WARNS ONLY when pinned, and reports the version re-read from disk afterwards. install: add the panel (nightly). update: pull the latest nightly. reinstall: uninstall + reinstall (nightly). pin: hold the panel at a version (requires `version`). unpin: clear the pin so a sync can proceed. install/update/reinstall/sync refuse on a dev symlink or an active pin, and require a local COMFYUI_PATH. Options: `status`, `install`, `update`, `reinstall`, `sync`, `pin`, `unpin`.
+  status: report installed/version/dev-symlink/pin plus a sync assessment (never errors). sync: bring the panel up to what this orchestrator needs — no-ops when already current, WARNS ONLY when pinned, and reports the version re-read from disk afterwards. install: add the panel (nightly). update: pull the latest nightly. reinstall: uninstall + reinstall (nightly). pin: hold the panel at a version (requires `version`). unpin: clear the pin so a sync can proceed. install/update/reinstall/sync refuse on a dev symlink or an active pin, and require a local workspace (COMFYUI_PATH or the saved default workspace). Options: `status`, `install`, `update`, `reinstall`, `sync`, `pin`, `unpin`.
 </ParamField>
 <ParamField path="version" type="string">
   action='pin' only: the panel version to hold at, e.g. '0.11.20'. Use the installedVersion from action='status' to pin where you already are.

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -16,6 +16,14 @@ process.env.COMFYUI_MCP_PANEL_LOCK = join(
 // import graph still pulls config in.)
 vi.mock("../../config.js", () => ({
   config: { comfyuiPath: undefined as string | undefined },
+  isLocalMode: () => true,
+}));
+
+// #700: panel management must use the same saved-default workspace resolution
+// as get_environment when COMFYUI_PATH itself is unset.
+const workspace = vi.hoisted(() => ({ base: undefined as string | undefined }));
+vi.mock("../../services/workspace-env.js", () => ({
+  resolveEffectiveComfyUIBase: () => workspace.base,
 }));
 
 import {
@@ -32,6 +40,7 @@ import {
   PanelInstallError,
   PANEL_REGISTRY_ID,
   PANEL_VERSION,
+  defaultDeps,
   type PanelInstallerDeps,
 } from "../../services/panel-installer.js";
 import type { PanelPinState } from "../../services/panel-settings.js";
@@ -132,6 +141,27 @@ function makeDeps(opts: {
 }
 
 describe("detectPanelInstall", () => {
+  it("#700: default deps inspect the saved local workspace when COMFYUI_PATH is unset", async () => {
+    const root = mkdtempSync(join(tmpdir(), "cmcp-panel-saved-workspace-"));
+    try {
+      workspace.base = root;
+      const panelDir = join(root, "custom_nodes", "comfyui-mcp-panel");
+      mkdirSync(panelDir, { recursive: true });
+      writeFileSync(join(panelDir, "pyproject.toml"), pyproject(PANEL_REGISTRY_ID, "0.8.0"));
+
+      const detected = await detectPanelInstall(defaultDeps);
+      expect(detected).toMatchObject({
+        applicable: true,
+        installed: true,
+        dir: panelDir,
+        version: "0.8.0",
+      });
+    } finally {
+      workspace.base = undefined;
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("returns not-applicable when no local ComfyUI (remote/cloud mode)", async () => {
     const { deps } = makeDeps({ comfyuiPath: undefined });
     const d = await detectPanelInstall(deps);

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -43,6 +43,7 @@ import {
   type PanelPinState,
 } from "./panel-settings.js";
 import { withPanelMutationLock } from "./panel-pin-guard.js";
+import { resolveEffectiveComfyUIBase } from "./workspace-env.js";
 
 /** Comfy Registry id (also pyproject [project].name). Authoritative for detection. */
 export const PANEL_REGISTRY_ID = "comfyui-agent-panel";
@@ -85,7 +86,7 @@ export interface PanelInstallerDeps {
    * the WRONG filesystem). The on-load ensure also no-ops.
    */
   isLocalMode: () => boolean;
-  /** Resolved local ComfyUI root, or undefined in remote/cloud mode. */
+  /** Resolved local ComfyUI root, or undefined when no local workspace is known. */
   comfyuiPath: () => string | undefined;
   /** Process env (for the opt-out flag). */
   env: () => NodeJS.ProcessEnv;
@@ -215,7 +216,10 @@ export function resolveGitRevision(dir: string): string | undefined {
 
 export const defaultDeps: PanelInstallerDeps = {
   isLocalMode: () => isLocalMode(),
-  comfyuiPath: () => config.comfyuiPath,
+  // Keep panel management aligned with get_environment, downloads, and
+  // comfy-cli: an explicit COMFYUI_PATH wins, then a saved default workspace
+  // is a valid local install when this target is not remote (#700).
+  comfyuiPath: () => resolveEffectiveComfyUIBase(),
   env: () => process.env,
   existsSync,
   probeFile: (p) => {

--- a/src/tools/install-panel.ts
+++ b/src/tools/install-panel.ts
@@ -62,7 +62,7 @@ export function registerInstallPanelTools(server: McpServer): void {
             "+ reinstall (nightly). pin: hold the panel at a version (requires " +
             "`version`). unpin: clear the pin so a sync can proceed. " +
             "install/update/reinstall/sync refuse on a dev symlink or an active " +
-            "pin, and require a local COMFYUI_PATH.",
+            "pin, and require a local workspace (COMFYUI_PATH or the saved default workspace).",
         ),
       version: z
         .string()


### PR DESCRIPTION
Fixes #700.\n\nWhen COMFYUI_PATH is unset, install_panel now resolves the same saved default workspace used by get_environment, comfy-cli, and local downloads. Remote-mode gating remains unchanged.\n\nTests:\n- npx.cmd vitest run src/__tests__/services/panel-installer.test.ts\n- npx.cmd tsc --noEmit\n- npm.cmd run docs:gen\n- npm.cmd run check:vocabulary\n- npm.cmd run vocab:export -- --check