### PR TITLE
fix(panel): preserve flatten load failures

### DIFF
--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -106,6 +106,21 @@ describe("#694 retry token on OUTCOME-UNKNOWN mutating failures", () => {
     expect(textOf(res)).toContain(RETRY_LINE);
   });
 
+  it.each([
+    ["reply timeout", () => replyTimeout("graph_load")],
+    ["mid-command disconnect", () => midCommandDrop("graph_load")],
+  ])(
+    "(a) panel_flatten_workflow preserves an outcome-unknown %s instead of fabricating load success",
+    async (_kind, failure) => {
+      const ctx = makePanelToolCtx(failingBridge(failure), "tab-1");
+      const flatten = buildPanelToolDefs().find((d) => d.name === "panel_flatten_workflow")!;
+      const res = await flatten.handler({ graph: { nodes: [], links: [] } }, ctx);
+      expect(res.isError).toBe(true);
+      expect(textOf(res)).toContain(RETRY_LINE);
+      expect(textOf(res)).not.toContain("Loaded onto the canvas");
+    },
+  );
+
   it("(b) a PRE-WRITE refusal (dispatched:false) mints NO token", async () => {
     const ctx = makePanelToolCtx(
       failingBridge(

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -3437,6 +3437,10 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           return ok(`${summary}\n\n${JSON.stringify(graph)}`);
         }
         const loaded = await ctx.call({ cmd: "graph_load", graph: graph as never }, 30000);
+        // ctx.call returns an error ToolResult for an outcome-unknown graph_load
+        // (rather than throwing). Preserve it verbatim: wrapping it as a successful
+        // "Loaded" result would fabricate success and hide its retry_of token.
+        if (loaded.isError) return loaded;
         const loadText = (loaded as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? "";
         return ok(`${summary}\nLoaded onto the canvas (one undo restores the original). ${loadText.slice(0, 120)}`);
       },


### PR DESCRIPTION
Propagates outcome-unknown graph_load errors from panel_flatten_workflow instead of returning a fabricated Loaded onto the canvas success. The original retry_of guidance stays visible. Tests cover post-write timeout and mid-command disconnect; full test and release gates pass.