### PR TITLE
fix: sync panel skew when desktop tab connects

### DIFF
--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1580,26 +1580,35 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(res.from).toBe("desktop"); // forged flag ignored — takeover refused
   });
 
-  it("keeps auto-sync eligibility headless across omitted or forged re-hello flags (#710 P1)", async () => {
+  it("keeps auto-sync eligibility on the current socket's pinned kind (#710 P1)", async () => {
     const phone = await connectHeadless("phone-sync-pinned");
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-sync-pinned")).toBe(true));
     // This is the exact classification the orchestrator must use after each hello.
-    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+    expect(bridge.isCurrentHeadless("phone-sync-pinned")).toBe(true);
 
     // A later hello cannot turn this socket into a desktop install/update target.
     phone.send(JSON.stringify({ type: "hello", tab_id: "phone-sync-pinned", title: "phone" }));
     await settle();
-    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+    expect(bridge.isCurrentHeadless("phone-sync-pinned")).toBe(true);
     phone.send(JSON.stringify({ type: "hello", tab_id: "phone-sync-pinned", title: "phone", headless: false }));
     await settle();
-    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+    expect(bridge.isCurrentHeadless("phone-sync-pinned")).toBe(true);
 
-    // A first-hello desktop keeps its legitimate sync eligibility.
-    const desktop = await connectPanel("desktop-sync-eligible", "G");
+    // The old mobile client is gone. A fresh desktop socket may reuse its id;
+    // stale headless history must not suppress this desktop's legitimate sync.
+    phone.close();
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-sync-pinned")).toBe(false));
+    const desktop = await connectPanel("phone-sync-pinned", "G");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-sync-pinned")).toBe(true));
+    expect(bridge.isCurrentHeadless("phone-sync-pinned")).toBe(false);
+    expect(bridge.isHeadless("phone-sync-pinned")).toBe(false);
+
+    // A first-hello desktop is likewise a legitimate sync target.
+    const separateDesktop = await connectPanel("desktop-sync-eligible", "G");
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "desktop-sync-eligible")).toBe(true));
     expect(bridge.isHeadless("desktop-sync-eligible")).toBe(false);
-    phone.close();
     desktop.close();
+    separateDesktop.close();
   });
 
   it("re-attaching to another tab stops the first tab's fanout", async () => {

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1480,7 +1480,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     // A mutating graph command is refused BEFORE dispatch (never written to the socket).
     await expect(
       bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "tmp:old" }),
-    ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
+    ).rejects.toThrow(/enforce.*workflow targeting|install_panel\(action:'update'\)/i);
 
     // …but a READ-ONLY graph command still works (read-only graph access retained).
     await expect(
@@ -1491,7 +1491,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     // refused — the class the graph_-only gate previously missed (#570 P0c, codex cycle 8).
     await expect(
       bridge.send({ cmd: "workflow_close", force: true } as never, { tabId: "tmp:old" }),
-    ).rejects.toThrow(/enforces per-command workflow targeting|update the ComfyUI-MCP panel/i);
+    ).rejects.toThrow(/enforce.*workflow targeting|install_panel\(action:'update'\)/i);
 
     // ALL FOUR workflow mutators are refused on a non-enforcing panel — regardless of path,
     // including an EXPLICIT non-empty path. The server can't resolve the selector or prove it
@@ -1505,9 +1505,25 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
       { cmd: "workflow_close", path: "workflows/other.json", force: true }, // explicit path — still gated
     ]) {
       await expect(bridge.send(cmd as never, { tabId: "tmp:old" })).rejects.toThrow(
-        /enforces per-command workflow targeting|update the ComfyUI-MCP panel/i,
+        /enforce.*workflow targeting|install_panel\(action:'update'\)/i,
       );
     }
+    old.close();
+  });
+
+  it("names the versioned panel-sync remedy when stamp enforcement is absent (#706)", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        old.send(JSON.stringify({ type: "hello", tab_id: "old-skew", title: "wf", panel_version: "0.11.0" }));
+        res();
+      });
+      old.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "old-skew")).toBe(true));
+    await expect(
+      bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "old-skew" }),
+    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.28\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
     old.close();
   });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1580,6 +1580,28 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(res.from).toBe("desktop"); // forged flag ignored — takeover refused
   });
 
+  it("keeps auto-sync eligibility headless across omitted or forged re-hello flags (#710 P1)", async () => {
+    const phone = await connectHeadless("phone-sync-pinned");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "phone-sync-pinned")).toBe(true));
+    // This is the exact classification the orchestrator must use after each hello.
+    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+
+    // A later hello cannot turn this socket into a desktop install/update target.
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-sync-pinned", title: "phone" }));
+    await settle();
+    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+    phone.send(JSON.stringify({ type: "hello", tab_id: "phone-sync-pinned", title: "phone", headless: false }));
+    await settle();
+    expect(bridge.isHeadless("phone-sync-pinned")).toBe(true);
+
+    // A first-hello desktop keeps its legitimate sync eligibility.
+    const desktop = await connectPanel("desktop-sync-eligible", "G");
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "desktop-sync-eligible")).toBe(true));
+    expect(bridge.isHeadless("desktop-sync-eligible")).toBe(false);
+    phone.close();
+    desktop.close();
+  });
+
   it("re-attaching to another tab stops the first tab's fanout", async () => {
     await connectPanel("desktop-A", "A");
     await connectPanel("desktop-B", "B");

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2444,10 +2444,12 @@ export async function runPanelOrchestrator(): Promise<void> {
       // local install under the panel-op lock, refuses pins/dev installs/shadows
       // and unverifiable scans, and only reports a version it verified on disk.
       // A desktop hello is the first point at which we can both repair an
-      // unpinned skew and tell the affected user that ComfyUI must restart. Do
-      // not run this for a headless mirror: it cannot load the desktop extension.
+      // unpinned skew and tell the affected user that ComfyUI must restart. The
+      // bridge pins each socket's kind on its FIRST hello, so query that trusted
+      // session state rather than this raw (and replayable) hello's `headless`.
+      // A headless mirror cannot load the desktop extension.
       if (
-        (event as { headless?: unknown }).headless !== true &&
+        !bridge.isHeadless(panelTab) &&
         !isPanelAutoInstallDisabled()
       ) {
         void performPanelSync()

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -20,6 +20,8 @@ import { startUiBridge, isLoopbackBindHost, SESSION_EPOCH, type UiBridge } from 
 import { setupSecureBridge, resolveComfyuiPathForTarget, type SecureBridge } from "../services/secure-bridge.js";
 import { startQuickTunnel } from "../services/tunnel.js";
 import { detectInstallMode } from "../services/self-update.js";
+import { performPanelSync } from "../services/panel-sync.js";
+import { isPanelAutoInstallDisabled } from "../services/panel-installer.js";
 import { SelfRestarter } from "../services/self-restart.js";
 import {
   SessionStore,
@@ -2436,6 +2438,45 @@ export async function runPanelOrchestrator(): Promise<void> {
       if (typeof helloPanelVer === "string" && helloPanelVer && helloPanelVer !== latestPanelVersion) {
         latestPanelVersion = helloPanelVer;
         void refreshEnvCapabilities();
+      }
+      // #706 — an npm-orchestrator update can require a newer Registry panel.
+      // The panel-sync service owns the ENTIRE safety decision: it re-reads the
+      // local install under the panel-op lock, refuses pins/dev installs/shadows
+      // and unverifiable scans, and only reports a version it verified on disk.
+      // A desktop hello is the first point at which we can both repair an
+      // unpinned skew and tell the affected user that ComfyUI must restart. Do
+      // not run this for a headless mirror: it cannot load the desktop extension.
+      if (
+        (event as { headless?: unknown }).headless !== true &&
+        !isPanelAutoInstallDisabled()
+      ) {
+        void performPanelSync()
+          .then((sync) => {
+            // An already-current local panel needs no chat noise. Every other
+            // outcome is actionable: synced => restart, pinned => unpin first,
+            // blocked/unknown/dev => its truthful recovery guidance.
+            if (sync.decision === "up-to-date" || sync.decision === "not-applicable") return;
+            bridge.push({ type: "say", text: `âš ï¸ ${sync.message}` }, panelTab);
+            logger.info(
+              `[panel-orchestrator] panel sync on hello for ${panelTab.slice(0, 8)}: ` +
+                `${sync.decision}${sync.synced ? ` (verified ${sync.verifiedVersion ?? "unknown"})` : ""}`,
+            );
+          })
+          .catch((err) => {
+            // Never translate a Manager queue/verification failure into success.
+            // The explicit tool remains available for diagnosis and retry.
+            const detail = err instanceof Error ? err.message : String(err);
+            logger.warn(`[panel-orchestrator] panel auto-sync on hello failed: ${detail}`);
+            bridge.push(
+              {
+                type: "say",
+                text:
+                  `âš ï¸ Could not automatically sync the ComfyUI-MCP panel; no update was claimed. ` +
+                  `Run install_panel(action:'status') to inspect it, then retry install_panel(action:'sync') if appropriate. (${detail})`,
+              },
+              panelTab,
+            );
+          });
       }
       // Retarget ComfyUI to the URL the browser was served from (window.location),
       // BEFORE the readiness probe so the "ready" ack reflects the right instance —

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -2445,11 +2445,11 @@ export async function runPanelOrchestrator(): Promise<void> {
       // and unverifiable scans, and only reports a version it verified on disk.
       // A desktop hello is the first point at which we can both repair an
       // unpinned skew and tell the affected user that ComfyUI must restart. The
-      // bridge pins each socket's kind on its FIRST hello, so query that trusted
-      // session state rather than this raw (and replayable) hello's `headless`.
-      // A headless mirror cannot load the desktop extension.
+      // bridge pins each CURRENT socket's kind on its FIRST hello, so query that
+      // trusted session state rather than this raw (and replayable) hello's
+      // `headless`. A headless mirror cannot load the desktop extension.
       if (
-        !bridge.isHeadless(panelTab) &&
+        !bridge.isCurrentHeadless(panelTab) &&
         !isPanelAutoInstallDisabled()
       ) {
         void performPanelSync()

--- a/src/services/panel-installer.ts
+++ b/src/services/panel-installer.ts
@@ -777,7 +777,12 @@ export interface EnsureOptions {
   timeoutMs?: number;
 }
 
-function isAutoInstallDisabled(env: NodeJS.ProcessEnv): boolean {
+/**
+ * The explicit opt-out applies to every unattended panel mutation. A user who
+ * disables on-load installation must not get an automatic version sync later
+ * merely because a desktop tab says hello.
+ */
+export function isPanelAutoInstallDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const v = (env.COMFYUI_MCP_PANEL_AUTOINSTALL ?? "").trim().toLowerCase();
   return v === "0" || v === "false" || v === "no" || v === "off";
 }
@@ -802,7 +807,7 @@ function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
 }
 
 async function ensureInner(deps: PanelInstallerDeps): Promise<EnsureResult> {
-  if (isAutoInstallDisabled(deps.env())) {
+  if (isPanelAutoInstallDisabled(deps.env())) {
     return {
       action: "skipped",
       reason: "COMFYUI_MCP_PANEL_AUTOINSTALL disabled",

--- a/src/services/panel-sync.ts
+++ b/src/services/panel-sync.ts
@@ -37,12 +37,10 @@ import {
   PANEL_PIN_ENV_VAR,
   type PanelPinState,
 } from "./panel-settings.js";
-import {
-  BRIDGE_CMD_MIN_PANEL_VERSION,
-  MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS,
-  SEMVER_RE,
-} from "./ui-bridge.js";
+import { requiredPanelVersion as requiredBridgePanelVersion, SEMVER_RE } from "./ui-bridge.js";
 import { compareSemver, detectInstallMode } from "./self-update.js";
+
+export { requiredBridgePanelVersion as requiredPanelVersion };
 
 /*
  * Version screening. `compareSemver` returns 0 for anything it cannot parse, so
@@ -64,23 +62,6 @@ import { compareSemver, detectInstallMode } from "./self-update.js";
 
 function isComparableVersion(v: string | undefined): v is string {
   return typeof v === "string" && SEMVER_RE.test(v.trim());
-}
-
-/**
- * The highest panel version THIS orchestrator build is known to require.
- *
- * Derived, not hand-maintained: it is the maximum of the bridge baseline and
- * every per-command minimum the orchestrator declares. A release that adds a
- * command needing a newer panel raises this automatically, so the sync advice
- * can never drift from the code that actually needs the newer panel.
- */
-export function requiredPanelVersion(): string {
-  let best = MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS;
-  for (const min of Object.values(BRIDGE_CMD_MIN_PANEL_VERSION)) {
-    if (!isComparableVersion(min)) continue;
-    if (!isComparableVersion(best) || compareSemver(min, best) > 0) best = min;
-  }
-  return best;
 }
 
 /**
@@ -167,7 +148,7 @@ export function evaluatePanelSync(
   status: PanelStatus,
   opts: EvaluateOptions = {},
 ): PanelSyncAssessment {
-  const required = opts.requiredVersion ?? requiredPanelVersion();
+  const required = opts.requiredVersion ?? requiredBridgePanelVersion();
   const orchestratorVersion =
     opts.orchestratorVersion ?? detectInstallMode().currentVersion ?? undefined;
   // A PanelStatus without a `pin` is a caller that predates the pin (or built

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -243,6 +243,20 @@ export function minPanelVersionForCmd(cmd: string): string {
 export const SEMVER_RE =
   /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
+/**
+ * The highest panel version this MCP build needs across its bridge commands.
+ * Keep this beside the command capability table so both proactive panel sync
+ * and a bridge refusal report the same derived requirement.
+ */
+export function requiredPanelVersion(): string {
+  let best = MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS;
+  for (const min of Object.values(BRIDGE_CMD_MIN_PANEL_VERSION)) {
+    if (!SEMVER_RE.test(min.trim())) continue;
+    if (!SEMVER_RE.test(best.trim()) || compareSemver(min, best) > 0) best = min;
+  }
+  return best;
+}
+
 /** True when the panel ADVERTISED a PARSEABLE version (in its `hello`) that already
  *  meets `cmd`'s AUTHORITATIVE, command-specific minimum — i.e. this panel is provably
  *  new enough to support the command, so an "Unknown command" reply is NOT an age
@@ -1866,7 +1880,9 @@ export class UiBridge {
       if (!conn.enforcesWorkflowStamp || !hasTrustedStamp) {
         const why = !conn.enforcesWorkflowStamp
           ? `panel tab ${conn.tabId.slice(0, 8)} does not enforce per-command workflow targeting ` +
-            `(update the ComfyUI-MCP panel to edit the graph)`
+            `(detected panel ${conn.panelVersion ?? "version unknown"}; this MCP requires panel ` +
+              `${requiredPanelVersion()}+). Run install_panel(action:'update') and restart ComfyUI; ` +
+              `rebinding cannot add the missing capability`
           : `this workflow has no trusted identity for the panel to fence the command against`;
         return Promise.reject(
           markDispatched(

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -678,8 +678,9 @@ export class UiBridge {
   private readonly mailbox = new Map<string, Array<{ cmd: BridgeCommand; ts: number }>>();
   private static readonly MAILBOX_MAX = 30;
   private static readonly MAILBOX_TTL_MS = 24 * 60 * 60 * 1000;
-  /** Tab ids that ever connected as a headless (mobile/remote) client — kept so
-   *  `isHeadless` stays true across a disconnect (see isHeadless). */
+  /** Tab ids whose most recent connected socket was headless. Retained across a
+   *  disconnect for mailbox/media routing, but cleared if a fresh desktop socket
+   *  later reuses the id (see isCurrentHeadless). */
   private readonly headlessSeen = new Set<string>();
   private seenTabs = new Set<string>(); // tabIds ever announced — dedup connect logs across reconnect churn
   /** True once a CANVAS-OWNING (non-headless) tab has helloed — i.e. a real ComfyUI
@@ -1193,13 +1194,21 @@ export class UiBridge {
         // Unknown-command reply cleared it — re-bypassing the undercut-version gate
         // (codex round-8 P1).
         migratedProvenSupported = undefined;
-        if (incomingHeadless) this.headlessSeen.add(tabId);
-        // A canvas-owning (non-headless) hello PROVES the comfyui-mcp-panel pack is
-        // installed and a real ComfyUI browser tab was open — the precondition for
-        // the "refresh the browser tab" guidance (#436.4). A headless mobile/remote
-        // pseudo-panel must NOT set this: if only a phone ever connected, there may be
-        // no desktop tab to refresh and no proof the sidebar pack is installed (codex).
-        else this.everConnectedDesktopTab = true;
+        if (incomingHeadless) {
+          this.headlessSeen.add(tabId);
+        } else {
+          // A different, fresh socket may legally reuse a disconnected tab id. Its
+          // first hello is authoritative for THIS live session, so do not let an
+          // old phone's sticky media classification hide a real desktop tab or
+          // suppress its panel-version repair.
+          this.headlessSeen.delete(tabId);
+          // A canvas-owning (non-headless) hello PROVES the comfyui-mcp-panel pack is
+          // installed and a real ComfyUI browser tab was open — the precondition for
+          // the "refresh the browser tab" guidance (#436.4). A headless mobile/remote
+          // pseudo-panel must NOT set this: if only a phone ever connected, there may be
+          // no desktop tab to refresh and no proof the sidebar pack is installed (codex).
+          this.everConnectedDesktopTab = true;
+        }
         this.broadcastTabList(); // a tab connected/reconnected — refresh mirror pickers
         // Log a real connect ONCE per tab id. A reconnect/ping-pong loop (a new
         // socket every couple seconds — e.g. two browser contexts sharing one tab
@@ -1525,6 +1534,15 @@ export class UiBridge {
     // offline, so a render finishing during a disconnect is byte-inlined (not a
     // bytes-less viewRef) and is renderable when the mailbox flushes to the phone.
     return this.conns.get(tabId)?.headless === true || this.headlessSeen.has(tabId);
+  }
+
+  /**
+   * The current live socket's first-hello-pinned kind. Unlike isHeadless(), this
+   * deliberately does not consult disconnected history: unattended operations
+   * such as panel auto-sync must act on the tab that is connected NOW.
+   */
+  isCurrentHeadless(tabId: string): boolean {
+    return this.conns.get(tabId)?.headless === true;
   }
 
   /** Drop expired late-ask entries (buffered answers + unresolved rid mappings) so


### PR DESCRIPTION
Fixes #706.\n\n- run the hardened, pin-safe panel sync after a desktop hello\n- notify the panel only with verified outcomes; never claim Manager success after a failed verification\n- preserve COMFYUI_MCP_PANEL_AUTOINSTALL=0 as an opt-out for unattended mutations\n- make the graph-write refusal name detected/required versions, update/restart recovery, and that rebinding cannot recover the missing capability\n\nTests: 
px vitest run src/__tests__/services/panel-installer.test.ts src/__tests__/services/panel-sync.test.ts src/__tests__/services/ui-bridge.test.ts (284 passed); 
pm run lint; 
pm run build.