### PR TITLE
fix(panel): sync handshake capability floor

### DIFF
--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -36,8 +36,9 @@ import {
   type PanelStatus,
 } from "../../services/panel-installer.js";
 import type { PanelPinState } from "../../services/panel-settings.js";
+import { BRIDGE_CAPABILITY_MIN_PANEL_VERSION } from "../../services/ui-bridge.js";
 
-const REQUIRED = "0.11.28";
+const REQUIRED = "0.11.30";
 const ORCH = "0.48.32";
 const UNPINNED: PanelPinState = { pinned: false, source: "none" };
 
@@ -64,10 +65,24 @@ function decide(over: Partial<PanelStatus>): PanelSyncDecision {
 }
 
 describe("requiredPanelVersion", () => {
-  it("is the maximum of the bridge baseline and every per-command minimum", () => {
-    // Derived from the orchestrator's own declared command minimums, so it can
-    // never drift from the code that needs the newer panel.
+  it("includes handshake capabilities as well as bridge-command minimums", () => {
+    // A capability gate is just as much a version requirement as a command
+    // gate: otherwise install_panel can call the panel current while the bridge
+    // refuses every active-workflow write (#708).
+    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp).toBe(REQUIRED);
     expect(requiredPanelVersion()).toBe(REQUIRED);
+  });
+
+  it("marks a 0.11.28 panel behind without a caller-supplied requirement (#708)", () => {
+    // This is the status/auto-sync path. It must use the same derived floor as
+    // the bridge's stamp-enforcement refusal, rather than reporting the old
+    // 0.11.28 panel up-to-date.
+    const assessment = evaluatePanelSync(status({ installedVersion: "0.11.28" }), {
+      orchestratorVersion: ORCH,
+    });
+    expect(assessment.requiredPanelVersion).toBe(REQUIRED);
+    expect(assessment.decision).toBe("sync");
+    expect(assessment.behind).toBe(true);
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1523,7 +1523,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "old-skew")).toBe(true));
     await expect(
       bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "old-skew" }),
-    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.28\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
+    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.30\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
     old.close();
   });
 

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -216,6 +216,21 @@ export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
   graph_resize_node: "0.11.25",
 };
 
+/**
+ * The panel version each non-command bridge capability was ACTUALLY introduced
+ * in.  These belong beside the command minimums because the orchestrator uses
+ * their combined maximum for proactive sync advice.  Otherwise a capability
+ * gate can correctly refuse an old panel while install_panel incorrectly calls
+ * that same panel current (#708).
+ */
+export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
+  // #570 P0c — `enforces_workflow_stamp` first shipped in panel 0.11.30. A
+  // 0.11.29-or-older panel ignores a stamped active-workflow mutation, so the
+  // server must refuse that write rather than risk applying it after a tab
+  // switch.  It is a handshake capability, not a command, hence this table.
+  enforces_workflow_stamp: "0.11.30",
+};
+
 /** The minimum panel version that supports `cmd`. For a command WITH an
  *  authoritative BRIDGE_CMD_MIN_PANEL_VERSION entry this is its true introduction
  *  version; for anything else it is the 0.11.4 full-set baseline FLOOR — a lower
@@ -244,13 +259,16 @@ export const SEMVER_RE =
   /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
 /**
- * The highest panel version this MCP build needs across its bridge commands.
- * Keep this beside the command capability table so both proactive panel sync
- * and a bridge refusal report the same derived requirement.
+ * The highest panel version this MCP build needs across its bridge commands and
+ * handshake capabilities. Keep this beside both capability tables so proactive
+ * panel sync and a bridge refusal report the same derived requirement.
  */
 export function requiredPanelVersion(): string {
   let best = MIN_PANEL_VERSION_FOR_BRIDGE_COMMANDS;
-  for (const min of Object.values(BRIDGE_CMD_MIN_PANEL_VERSION)) {
+  for (const min of [
+    ...Object.values(BRIDGE_CMD_MIN_PANEL_VERSION),
+    ...Object.values(BRIDGE_CAPABILITY_MIN_PANEL_VERSION),
+  ]) {
     if (!SEMVER_RE.test(min.trim())) continue;
     if (!SEMVER_RE.test(best.trim()) || compareSemver(min, best) > 0) best = min;
   }


### PR DESCRIPTION
Fixes #708.

The panel's enforces_workflow_stamp handshake capability first shipped in panel 0.11.30, but the derived sync floor only considered command minima and still considered 0.11.28 current. Add an explicit capability-minimum table to the same derived requirement used by panel status/auto-sync and the bridge refusal.

Tests:
- npm.cmd exec vitest run src/__tests__/services/panel-sync.test.ts src/__tests__/services/ui-bridge.test.ts
- npm.cmd run lint
- npm.cmd run build