### PR TITLE
feat: epoch-first session frame on hello (#694 refinement)

### DIFF
--- a/src/__tests__/orchestrator/panel-retry-identity.test.ts
+++ b/src/__tests__/orchestrator/panel-retry-identity.test.ts
@@ -28,7 +28,7 @@ import {
   requiresWorkflowStampEnforcement,
   SESSION_EPOCH,
 } from "../../services/ui-bridge.js";
-import { buildModelsPushFrame, pushModelsFrame } from "../../orchestrator/index.js";
+import { buildModelsPushFrame, buildSessionEpochFrame, pushModelsFrame } from "../../orchestrator/index.js";
 
 const textOf = (res: ToolResult): string => (res.content[0] as { text: string }).text;
 
@@ -329,6 +329,10 @@ describe("#694 session epoch on the models push frame", () => {
 
   it("(h) SESSION_EPOCH is a per-process UUID", () => {
     expect(SESSION_EPOCH).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it("(h) the epoch-first session frame carries the same per-process epoch", () => {
+    expect(buildSessionEpochFrame()).toEqual({ type: "session_epoch", epoch: SESSION_EPOCH });
   });
 
   it("(h) pushes an epoch handshake even when model discovery is empty", () => {

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -703,6 +703,15 @@ export function buildModelsPushFrame(
   return { type: "models", epoch: SESSION_EPOCH, models, current, backend };
 }
 
+/** #694 (epoch-first) — the tiny immediate frame a hello gets before any async
+ *  work: advances the session epoch without waiting for model discovery, so a
+ *  command arriving in the gap can never resolve retry_of against the prior
+ *  process's epoch. Exported (pure) for the shape test. Type is "session_epoch"
+ *  — NEVER "session": that frame name is taken (session_id lifecycle). */
+export function buildSessionEpochFrame(): Record<string, unknown> {
+  return { type: "session_epoch", epoch: SESSION_EPOCH };
+}
+
 /**
  * Send the model handshake even when discovery returned no choices. The models
  * frame is also the process-epoch handshake that scopes panel retry tokens, so
@@ -2430,6 +2439,14 @@ export async function runPanelOrchestrator(): Promise<void> {
     // tell the difference (and warn if no ack arrives).
     if (event.type === "hello" && event.tab_id) {
       const panelTab = event.tab_id;
+      // #694 (epoch-first) — restamp the session epoch IMMEDIATELY on hello,
+      // before any async work (model discovery, panel sync, retarget probe).
+      // The models frame carries the epoch too, but it awaits async discovery,
+      // so a command arriving in the gap could resolve retry_of against the
+      // PRIOR process's epoch/journal. This tiny "session_epoch" frame (NEVER
+      // "session" — that name is the session_id lifecycle frame) advances the
+      // epoch first thing; the panel stamps on any epoch-carrying frame.
+      bridge.push(buildSessionEpochFrame(), panelTab);
       // Learn the sidebar panel's version from its hello and, the first time we
       // see it (or when it changes on a panel update), refresh the env block so
       // the agent's ENVIRONMENT line carries the panel version — bug reports get


### PR DESCRIPTION
Closes the documented #704 residual: the session epoch previously advanced only when the `models` frame arrived (after async discovery), leaving a reconnect-window where a retry could resolve against the prior process's epoch/journal.

- Orchestrator: every hello gets an immediate `{type:"session", epoch}` push before any async work (panel sync, discovery, retarget probe). Models frame keeps the epoch for legacy panels.
- Panel (sibling PR): stamps the epoch from ANY epoch-carrying frame.

Tests: frame shape/epoch identity (mcp, 25/25); wiring order generic-stamp-before-models-branch (panel, 1536/1536).