### PR TITLE
fix(panel): report stale graph capability after restart

### DIFF
--- a/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
+++ b/src/__tests__/orchestrator/panel-restart-legacy-fallback.test.ts
@@ -73,6 +73,9 @@ function makeCtx(
       tabIsLocal: () => frontsBoot,
     } as unknown as PanelToolCtx["bridge"],
     tabId: "t",
+    panelConnectionIdentity: () => ({ generation: 1, tabSessionId: "browser-tab-a" }),
+    awaitPostRestartReachable: async () => true,
+    tabCanMutateGraph: () => true,
   } as unknown as PanelToolCtx;
   return { ctx, calls };
 }
@@ -140,6 +143,36 @@ describe("panel_restart_comfyui — legacy no-endpoint fallback", () => {
     expect(out.via).toBe("observed-cycle");
     expect(String(out.note)).toMatch(/came back healthy/i);
     expect(res.isError).toBeFalsy();
+  });
+
+  it("does not claim graph tools are ready when the legacy restart reconnects a stale panel bundle (#709)", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.awaitPostRestartReachable = async () => true;
+    ctx.tabCanMutateGraph = () => false; // stale pre-workflow-stamp browser bundle
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(String(out.note)).toMatch(/stale panel bundle|Hard-refresh.*Ctrl\+Shift\+R/i);
+    expect(String(out.note)).not.toMatch(/rebind with panel_set_workflow_target/i);
+  });
+
+  it("does not claim graph tools are ready when the legacy restart server recovers before its panel tab", async () => {
+    const { ctx } = makeCtx(NO_ENDPOINT_REPLY);
+    ctx.awaitReachable = async () => true; // the pre-restart tab is still reachable
+    ctx.awaitPostRestartReachable = async () => false;
+    ctx.tabCanMutateGraph = () => true;
+
+    const res = (await restartTool().handler({}, ctx)) as ToolResult;
+    const out = JSON.parse(res.content.find((c) => c.type === "text")!.text as string);
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(String(out.note)).toMatch(/has NOT reconnected|rebind/i);
   });
 
   it("Desktop first-healthy (NO observed down) → couldn't-confirm (a no-op leaves the endpoint healthy)", async () => {

--- a/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
+++ b/src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts
@@ -468,6 +468,11 @@ describe("#400 panel_restart_comfyui awaits the tab reconnect before returning",
       tabOrigin: () => BOOT_BASE,
       tabServerOrigin: () => BOOT_BASE,
       tabIsLocal: () => true,
+      tabConnectionIdentity: (id: string) =>
+        live.has(id)
+          ? { generation: id === "reconnected-tab" ? 2 : 1, tabSessionId: "browser-tab-a" }
+          : undefined,
+      tabCanMutateGraph: () => true,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "bound-tab", new WorkflowTargetStore());
     ctx.confirm = async () => "yes" as const; // skip the human confirm card
@@ -478,6 +483,127 @@ describe("#400 panel_restart_comfyui awaits the tab reconnect before returning",
     expect(out.confirmed_cycle).toBe(true);
     expect(out.panel_tab_reconnected).toBe(true); // did not hand back a tabless window
     expect(ctx.tabId).toBe("reconnected-tab"); // rebound onto the reconnected tab
+  });
+
+  it("does not treat the pre-restart reachable tab as a post-restart reconnect (#709)", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 60, intervalMs: 5 });
+    const seq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () =>
+      seq[Math.min(i++, seq.length - 1)] as "down" | "healthy",
+    );
+
+    // The old websocket remains briefly reachable. It has not sent a new hello, so
+    // a restart result must not call it a reconnected, graph-ready panel.
+    const live = new Set<string>(["bound-tab"]);
+    const bridge = {
+      send: async () => ({ rebooting: true }),
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => "bound-tab",
+      tabOrigin: () => BOOT_BASE,
+      tabServerOrigin: () => BOOT_BASE,
+      tabIsLocal: () => true,
+      tabConnectionIdentity: (id: string) =>
+        live.has(id) ? { generation: 1, tabSessionId: "browser-tab-a" } : undefined,
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "bound-tab", new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await defByName("panel_restart_comfyui").handler({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+
+  it("does not certify a different browser tab that reuses the rebooted workflow id (#709)", async () => {
+    __panelToolsTestHooks.setReconnectWaitTiming({ budgetMs: 60, intervalMs: 5 });
+    const seq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () =>
+      seq[Math.min(i++, seq.length - 1)] as "down" | "healthy",
+    );
+
+    // The original browser tab receives the reboot. Before it reconnects, a
+    // different browser tab opens the same saved workflow, so it has the exact
+    // same routing tab id but a new hello generation and its own tab session id.
+    // Generation + tab id alone would fabricate ready:true here.
+    let generation = 1;
+    let tabSessionId = "browser-tab-original";
+    const bridge = {
+      send: async () => {
+        generation = 2;
+        tabSessionId = "browser-tab-other";
+        return { rebooting: true };
+      },
+      push: () => 1,
+      canReach: () => true,
+      tabs: () => [{ tab_id: "wf:shared.json", title: "shared", connected_at: 0 }],
+      resolveActiveTabId: () => "wf:shared.json",
+      tabOrigin: () => BOOT_BASE,
+      tabServerOrigin: () => BOOT_BASE,
+      tabIsLocal: () => true,
+      tabConnectionIdentity: () => ({ generation, tabSessionId }),
+      tabCanMutateGraph: () => true,
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "wf:shared.json", new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await defByName("panel_restart_comfyui").handler({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(false);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+  });
+
+  it("does not claim graph tools are ready when the reconnected tab has stale JS", async () => {
+    const seq = ["down", "healthy"];
+    let i = 0;
+    __panelToolsTestHooks.setHealthProbe(async () =>
+      seq[Math.min(i++, seq.length - 1)] as "down" | "healthy",
+    );
+
+    const live = new Set<string>(["bound-tab"]);
+    const bridge = {
+      send: async (cmd: Record<string, unknown>, opts?: { tabId?: string }) => {
+        if (cmd.cmd === "comfy_reboot") {
+          live.delete("bound-tab");
+          setTimeout(() => live.add("reconnected-tab"), 40);
+          return { rebooting: true };
+        }
+        const id = opts?.tabId;
+        if (id && !live.has(id)) throw new Error(`no connected tab with id "${id}". Connected: none`);
+        return { ok: true, routedTo: id };
+      },
+      push: () => 1,
+      canReach: (id: string) => live.has(id),
+      tabs: () => [...live].map((t) => ({ tab_id: t, title: t, connected_at: 0 })),
+      resolveActiveTabId: () => {
+        if (live.size === 1) return [...live][0];
+        throw new Error("Panel not reachable: no panel connected");
+      },
+      tabOrigin: () => BOOT_BASE,
+      tabServerOrigin: () => BOOT_BASE,
+      tabIsLocal: () => true,
+      tabConnectionIdentity: (id: string) =>
+        live.has(id)
+          ? { generation: id === "reconnected-tab" ? 2 : 1, tabSessionId: "browser-tab-a" }
+          : undefined,
+      tabCanMutateGraph: () => false, // stale pre-workflow-stamp browser bundle
+    } as unknown as PanelToolCtx["bridge"];
+    const ctx = makePanelToolCtx(bridge, "bound-tab", new WorkflowTargetStore());
+    ctx.confirm = async () => "yes" as const;
+
+    const out = parse(await defByName("panel_restart_comfyui").handler({ force: false }, ctx));
+    expect(out.server_ready).toBe(true);
+    expect(out.panel_tab_reconnected).toBe(true);
+    expect(out.graph_tools_ready).toBe(false);
+    expect(out.ready).toBe(false);
+    expect(String(out.note)).toMatch(/stale panel bundle|Hard-refresh.*Ctrl\+Shift\+R/i);
+    expect(String(out.note)).not.toMatch(/rebind with panel_set_workflow_target/i);
   });
 
   it("returns ready:false (server_ready:true) when the panel tab NEVER reconnects", async () => {
@@ -508,6 +634,9 @@ describe("#400 panel_restart_comfyui awaits the tab reconnect before returning",
       tabOrigin: () => BOOT_BASE,
       tabServerOrigin: () => BOOT_BASE,
       tabIsLocal: () => true,
+      tabConnectionIdentity: (id: string) =>
+        live.has(id) ? { generation: 1, tabSessionId: "browser-tab-a" } : undefined,
+      tabCanMutateGraph: () => true,
     } as unknown as PanelToolCtx["bridge"];
     const ctx = makePanelToolCtx(bridge, "bound-tab", new WorkflowTargetStore());
     ctx.confirm = async () => "yes" as const;

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1459,6 +1459,80 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.close();
   });
 
+  it("reports graph-mutation capability from the same enforcement and stamp conditions as dispatch (#709)", async () => {
+    const desktop = await connectPanel("tmp:capable", "capable");
+    await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:capable")).toBe(true));
+
+    // A same-tab re-hello from a stale browser bundle resets capability. It must not
+    // inherit the prior modern hello, because dispatch will refuse the unfenced write.
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:capable", title: "stale" }));
+    await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:capable")).toBe(false));
+
+    // Enforcement without a trusted stamp is still not graph-mutation-ready.
+    bridge.setTabWorkflowUuidResolver(() => undefined);
+    desktop.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "tmp:capable",
+        title: "no-stamp",
+        enforces_workflow_stamp: true,
+      }),
+    );
+    await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:capable")).toBe(false));
+    desktop.close();
+  });
+
+  it("does not report graph-mutation capability after the panel socket closes (#709)", async () => {
+    const desktop = await connectPanel("tmp:closing", "closing");
+    await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:closing")).toBe(true));
+
+    // Wait for the server-side connection to observe the close; neither readiness
+    // accessor may retain capability or a generation after its socket is gone.
+    desktop.close();
+    await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:closing")).toBe(false));
+    expect(bridge.tabConnectionGeneration("tmp:closing")).toBeUndefined();
+  });
+
+  it("keeps the browser-tab session identity per hello rather than inheriting it across a workflow-id takeover (#709)", async () => {
+    const original = await connectPanel("wf:shared.json", "shared");
+    original.send(
+      JSON.stringify({
+        type: "hello",
+        tab_id: "wf:shared.json",
+        title: "shared",
+        enforces_workflow_stamp: true,
+        tab_session_id: "browser-tab-original",
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(bridge.tabConnectionIdentity("wf:shared.json")).toMatchObject({ tabSessionId: "browser-tab-original" }),
+    );
+    const before = bridge.tabConnectionIdentity("wf:shared.json");
+
+    const replacement = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      replacement.on("open", () => {
+        replacement.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "wf:shared.json",
+            title: "same saved workflow, different browser tab",
+            enforces_workflow_stamp: true,
+            tab_session_id: "browser-tab-other",
+          }),
+        );
+        resolve();
+      });
+      replacement.on("error", reject);
+    });
+    await vi.waitFor(() =>
+      expect(bridge.tabConnectionIdentity("wf:shared.json")).toMatchObject({ tabSessionId: "browser-tab-other" }),
+    );
+    const after = bridge.tabConnectionIdentity("wf:shared.json");
+    expect(after?.generation).toBeGreaterThan(before?.generation ?? Number.MAX_SAFE_INTEGER);
+    replacement.close();
+  });
+
   it("FAILS CLOSED: a MUTATING graph command is refused for an OLD panel that doesn't enforce the stamp; reads still work (#570 P0c)", async () => {
     // An OLD panel hellos WITHOUT enforces_workflow_stamp — it would silently ignore the
     // per-command workflow stamp and could apply a stale write to the wrong canvas.

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2066,6 +2066,27 @@ export interface PanelToolCtx {
    * Optional so lightweight test contexts can omit it.
    */
   awaitReachable?: (budgetMs?: number) => Promise<boolean>;
+  /** Snapshot of the current panel registration. The browser-tab session id is
+   * separate from the workflow-derived routing tab id, which another browser
+   * tab may reuse for the same saved workflow. */
+  panelConnectionIdentity?: () => { generation: number; tabSessionId: string } | undefined;
+  /**
+   * Wait for a panel hello that is strictly newer than `before`, from the SAME
+   * browser-tab session that received the restart dispatch. This is distinct
+   * from awaitReachable: an old tab can still be reachable while ComfyUI is
+   * rebooting, and a different browser tab can reuse the same saved-workflow id.
+   */
+  awaitPostRestartReachable?: (
+    before: { generation: number; tabSessionId: string } | undefined,
+    budgetMs?: number,
+  ) => Promise<boolean>;
+  /**
+   * Whether the currently bound, live panel tab can safely perform active
+   * workflow graph mutations. A reconnect proves only transport reachability:
+   * the browser may still be serving a cached pre-workflow-stamp panel bundle.
+   * Optional only for lightweight legacy test contexts.
+   */
+  tabCanMutateGraph?: () => boolean;
 }
 
 /** Build a tab-bound execution context shared by both transports. */
@@ -2189,6 +2210,52 @@ export function makePanelToolCtx(
       const left = deadline - Date.now();
       if (left <= 0) return bridge.canReach(ctx.tabId);
       await sleep(Math.min(intervalMs, left));
+    }
+  };
+
+  const panelConnectionIdentity = (): { generation: number; tabSessionId: string } | undefined =>
+    typeof bridge.tabConnectionIdentity === "function"
+      ? bridge.tabConnectionIdentity(ctx.tabId)
+      : undefined;
+
+  // A restart report must NEVER count the panel socket that existed before the
+  // reboot command. Unlike awaitReachable(), which intentionally returns at once
+  // for a healthy binding, this waits for a strictly newer hello generation. The
+  // fresh hello can keep the same tab/socket id or arrive under a new one; in the
+  // latter case only rebind after the old target is gone, preserving strict
+  // multi-tab routing and never guessing away from a still-live pre-restart tab.
+  const awaitPostRestartReachable = async (
+    before: { generation: number; tabSessionId: string } | undefined,
+    budgetMs?: number,
+  ): Promise<boolean> => {
+    // The actual UiBridge exposes a tab-session binding. Preserve historical
+    // lightweight/mock-context behavior only when that capability does not exist
+    // at all; a real bridge missing the pre-dispatch identity fails closed.
+    if (typeof bridge.tabConnectionIdentity !== "function") return awaitReachable(budgetMs);
+    if (before == null) return false;
+    const timing = reconnectWaitTiming();
+    const budget = Math.max(0, budgetMs != null ? Math.min(budgetMs, timing.budgetMs) : timing.budgetMs);
+    const deadline = Date.now() + budget;
+    const isOriginalTabReconnected = (): boolean => {
+      const current = panelConnectionIdentity();
+      return (
+        current != null &&
+        current.generation > before.generation &&
+        current.tabSessionId === before.tabSessionId
+      );
+    };
+    for (;;) {
+      if (isOriginalTabReconnected()) return true;
+      // A new tab id cannot resolve through the retired binding. Once that binding is
+      // actually gone, the existing conservative rebind can follow the sole new tab.
+      if (!bridge.canReach(ctx.tabId)) {
+        const interactive = interactiveTabIds() ?? [];
+        if (interactive.length > 0) ensureReachable();
+        if (isOriginalTabReconnected()) return true;
+      }
+      const left = deadline - Date.now();
+      if (left <= 0) return false;
+      await sleep(Math.min(Math.max(1, timing.intervalMs), left));
     }
   };
 
@@ -2420,6 +2487,9 @@ export function makePanelToolCtx(
   ctx.rebindToActiveTab = rebindToActiveTab;
   ctx.ensureReachable = ensureReachable;
   ctx.awaitReachable = awaitReachable;
+  ctx.panelConnectionIdentity = panelConnectionIdentity;
+  ctx.awaitPostRestartReachable = awaitPostRestartReachable;
+  ctx.tabCanMutateGraph = () => bridge.tabCanMutateGraph(ctx.tabId);
   return ctx;
 }
 
@@ -5110,6 +5180,11 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // to (null unless the bound tab provably fronts our boot instance).
         ctx.ensureReachable?.();
         const boundTabId = ctx.tabId;
+        // Snapshot the exact browser-tab registration that is about to receive the
+        // reboot. A post-restart success must observe a strictly newer hello from
+        // this SAME browser tab; a different tab can reuse the same saved-workflow
+        // routing id while the original is still reconnecting.
+        const preRestartPanelIdentity = ctx.panelConnectionIdentity?.();
         const healthBase = captureRebootHealthBase(ctx);
         const timing = getPanelRebootTiming();
         const dispatchTimeout = Math.max(1, Math.min(15000, overallDeadline - Date.now()));
@@ -5300,16 +5375,45 @@ export function buildPanelToolDefs(): PanelToolDef[] {
             // poll merely expired — neither terminal) DEFER to OUR OWN observed DOWN→UP.
             const recovery = await proofPromise;
             const observed = recovery.via === "observed-cycle";
+            // The legacy Manager path restarts ComfyUI out-of-band too. Server recovery alone
+            // is not graph-tool readiness: wait for the browser tab to reconnect, then verify
+            // the same workflow-stamp capability the bridge requires before it dispatches a
+            // mutation. Without this, updating the panel pack followed by a legacy restart can
+            // falsely report ready while the browser is still running stale panel JS (#709).
+            const tabBack = recovery.ready
+              ? ctx.awaitPostRestartReachable
+                ? await ctx.awaitPostRestartReachable(
+                    preRestartPanelIdentity,
+                    Math.max(0, overallDeadline - Date.now()),
+                  )
+                : ctx.awaitReachable
+                  ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
+                  : true
+              : false;
+            const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
             return ok({
               rebooting: true,
-              ready: recovery.ready,
+              ready: graphToolsReady,
+              graph_tools_ready: graphToolsReady,
+              server_ready: recovery.ready,
+              panel_tab_reconnected: tabBack,
               confirmed_cycle: observed, // true = we directly observed the down→up cycle
               recovered_ms: recovery.waited_ms,
               probes: recovery.attempts,
               saw_down: recovery.sawDown,
               via: recovery.ready ? recovery.via : undefined,
               note:
-                "ComfyUI-Manager (legacy 3.x) had no reboot endpoint; ran the headless managed " +
+                recovery.ready && !graphToolsReady
+                  ? "ComfyUI-Manager (legacy 3.x) had no reboot endpoint; the headless managed restart " +
+                    `came back healthy in ${(recovery.waited_ms / 1000).toFixed(1)}s, but ` +
+                    (!tabBack
+                      ? "the panel tab has NOT reconnected yet (ready:false). Wait a moment then retry, or " +
+                        'rebind with panel_set_workflow_target({mode:"current"}) before issuing graph tools.'
+                      : "the panel tab reconnected but cannot safely run graph mutations (ready:false), usually " +
+                        "because it is still running a stale panel bundle. Hard-refresh the ComfyUI browser tab " +
+                        "(Ctrl+Shift+R) before issuing graph tools; if that does not restore it, update the panel " +
+                        "and open/reload a saved workflow with a stable identity.")
+                  : "ComfyUI-Manager (legacy 3.x) had no reboot endpoint; ran the headless managed " +
                 "restart (kill + relaunch) " +
                 (recovery.ready
                   ? `and it came back healthy in ${(recovery.waited_ms / 1000).toFixed(1)}s` +
@@ -5379,21 +5483,35 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               : `The reboot command was sent but I could NOT confirm ComfyUI actually cycled within ${waited}s (it never went down — the panel may have merely disconnected/inferred a reboot without one). Verify with health_check / panel_node_queue_status; do NOT assume it restarted.`,
           });
         }
-        // #400: ComfyUI is healthy, but the panel's browser tab re-registers its own
-        // socket a moment later. If we return NOW, the very next graph tool in this turn
+        // #400/#709: ComfyUI is healthy, but the panel's browser tab re-registers its own
+        // socket a moment later. The old socket can still be reachable after dispatch, so
+        // the generation waiter below requires a fresh hello before reporting readiness.
         // hits "no connected tab … Connected: none" and the agent is told to hand-rebind.
         // Wait (bounded, clamped to THIS handler's deadline) for the tab to reconnect and
         // rebind this session onto it. `ready` reflects GRAPH-TOOL readiness (a bound tab),
         // NOT just server health — a caller keying off `ready` must not be led into the
         // Connected:none window (codex). `server_ready` carries the certified cycle either
-        // way. When ctx has no awaitReachable (older/lightweight ctx) tabBack is true, so
-        // the historical ready:true-on-healthy-restart contract is preserved.
-        const tabBack = ctx.awaitReachable
-          ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
-          : true;
+        // way. A production PanelToolCtx supplies the generation waiter; an explicitly
+        // lightweight context retains the historical reachability-only test contract.
+        const tabBack = ctx.awaitPostRestartReachable
+          ? await ctx.awaitPostRestartReachable(
+              preRestartPanelIdentity,
+              Math.max(0, overallDeadline - Date.now()),
+            )
+          : ctx.awaitReachable
+            ? await ctx.awaitReachable(Math.max(0, overallDeadline - Date.now()))
+            : true;
+        // A recovered socket does NOT mean graph mutations are usable: an already-open
+        // browser tab can reconnect after ComfyUI restarts while still serving stale panel
+        // JS, which lacks the #570 workflow-stamp fence. Report the same capability the
+        // bridge enforces before dispatch so this success path never fabricates readiness.
+        // Old/lightweight contexts have no capability accessor, so preserve their historical
+        // contract rather than claiming a production tab passed a check it never ran.
+        const graphToolsReady = tabBack && (ctx.tabCanMutateGraph ? ctx.tabCanMutateGraph() : true);
         return ok({
           rebooting: true,
-          ready: tabBack, // graph tools are usable only once a panel tab is bound
+          ready: graphToolsReady, // graph tools require a bound AND workflow-stamp-capable tab
+          graph_tools_ready: graphToolsReady,
           server_ready: true, // ComfyUI itself cycled and is healthy
           confirmed_cycle: true, // we directly observed the down→up cycle on the boot endpoint
           recovered_ms: recovery.waited_ms,
@@ -5402,7 +5520,13 @@ export function buildPanelToolDefs(): PanelToolDef[] {
           via: recovery.via,
           panel_tab_reconnected: tabBack,
           note:
-            `ComfyUI restart accepted and it is healthy again in ${(recovery.waited_ms / 1000).toFixed(1)}s` +
+            (tabBack && !graphToolsReady
+              ? `ComfyUI restart accepted and it is healthy again in ${(recovery.waited_ms / 1000).toFixed(1)}s` +
+                " (observed it go down then come back); the panel tab reconnected but cannot safely run " +
+                "graph mutations (ready:false), usually because it is still running a stale panel bundle. " +
+                "Hard-refresh the ComfyUI browser tab (Ctrl+Shift+R) before issuing graph tools; if that " +
+                "does not restore it, update the panel and open/reload a saved workflow with a stable identity"
+              : `ComfyUI restart accepted and it is healthy again in ${(recovery.waited_ms / 1000).toFixed(1)}s` +
             " (observed it go down then come back)" +
             (dropped ? "; connection dropped as expected while it went down" : "") +
             (tabBack
@@ -5410,7 +5534,7 @@ export function buildPanelToolDefs(): PanelToolDef[] {
               : "; ComfyUI is back but the panel tab has NOT reconnected yet (ready:false) — " +
                 'wait a moment then retry, or rebind with panel_set_workflow_target({mode:"current"}) ' +
                 "before issuing graph tools.") +
-            ".",
+            "."),
         });
       },
     ),

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -95,6 +95,16 @@ interface Conn {
   tabId: string;
   title: string;
   connectedAt: string;
+  /** Monotonic bridge-local hello generation. Every hello gets a new value, even
+   * on the same socket/tab id, so restart readiness can require a post-dispatch
+   * panel registration rather than mistaking the pre-restart socket for a reconnect. */
+  helloGeneration: number;
+  /** Browser-tab-scoped session identity supplied by current panel builds.
+   * Unlike `tabId`, which is commonly derived from a saved workflow path and
+   * can therefore recur in a second browser tab, this stays with one browser
+   * tab across a ComfyUI restart. It is used only as an accidental-routing
+   * correctness proof for restart readiness; absence fails that proof closed. */
+  tabSessionId?: string;
   /** Canvas-less client (mobile/remote pseudo-panel) — advertised in `hello`.
    *  Lets tools resolve media to inline bytes instead of a browser /view ref. */
   headless: boolean;
@@ -627,6 +637,8 @@ export class UiBridge {
    *  listener stays token-less so the local browser panel is unaffected. */
   private readonly extraServers: WebSocketServer[] = [];
   private conns = new Map<string, Conn>(); // tabId -> connection (canvas-owning primary)
+  /** Incremented for every accepted panel hello; never reused during this bridge lifetime. */
+  private nextHelloGeneration = 0;
   /** Mobile "mirror" viewers subscribed to a tab's live output (remote control):
    *  push()-path frames for a tabId fan out to these IN ADDITION to the primary,
    *  so a phone sees the desktop tab's agent activity/renders. They NEVER receive
@@ -1142,6 +1154,16 @@ export class UiBridge {
           tabId,
           title: typeof msg.title === "string" && msg.title ? msg.title : "untitled",
           connectedAt: existing?.connectedAt ?? new Date().toISOString(),
+          helloGeneration: ++this.nextHelloGeneration,
+          // #709: do not inherit across a different socket reusing a workflow
+          // tab id. The browser-tab identity must have arrived on THIS hello,
+          // otherwise it cannot prove that the tab receiving the reboot is the
+          // tab that came back afterwards.
+          tabSessionId:
+            typeof (msg as { tab_session_id?: unknown }).tab_session_id === "string" &&
+            (msg as { tab_session_id?: string }).tab_session_id?.trim()
+              ? (msg as { tab_session_id?: string }).tab_session_id!.trim()
+              : undefined,
           headless: incomingHeadless,
           panelVersion:
             typeof (msg as { panel_version?: unknown }).panel_version === "string"
@@ -1434,6 +1456,68 @@ export class UiBridge {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Whether the live tab resolved for `tabId` can safely accept a mutation of
+   * its active workflow. This mirrors the two pre-dispatch conditions in
+   * {@link send}: the tab's CURRENT hello must advertise workflow-stamp
+   * enforcement, and the orchestrator must have a trusted workflow stamp to
+   * put on the command. A websocket reconnect alone proves neither (the browser
+   * can reconnect with a cached, pre-#570 panel bundle), so callers reporting
+   * graph-tool readiness must use this rather than `canReach` alone.
+   *
+   * This is an accidental-version-skew capability signal, not an attestation:
+   * like the send gate, it intentionally describes the local panel protocol
+   * needed to avoid an unfenced wrong-workflow write.
+   */
+  tabCanMutateGraph(tabId: string): boolean {
+    try {
+      const conn = this.resolveTarget(tabId);
+      const stamp = this.resolveTabWorkflowUuid?.(tabId);
+      return (
+        conn.sock.readyState === WebSocket.OPEN &&
+        conn.enforcesWorkflowStamp &&
+        typeof stamp === "string" &&
+        stamp.length > 0
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Monotonic registration generation for a currently OPEN panel connection.
+   * Restart readiness snapshots this immediately before dispatch, then requires
+   * a strictly newer hello before saying graph tools are back. Unknown, migrated
+   * aliases that no longer resolve, and closing sockets deliberately return
+   * undefined: none proves a usable post-restart panel binding.
+   */
+  tabConnectionGeneration(tabId: string): number | undefined {
+    try {
+      const conn = this.resolveTarget(tabId);
+      return conn.sock.readyState === WebSocket.OPEN ? conn.helloGeneration : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Restart-readiness binding for a live panel. A generation alone is not
+   * sufficient: another browser tab can open the same saved workflow and take
+   * over its recurring `tabId`. The tuple proves a newer hello from the SAME
+   * browser-tab session that received the restart dispatch. Old panels which do
+   * not advertise `tab_session_id` deliberately return undefined rather than
+   * fabricating graph-tool readiness.
+   */
+  tabConnectionIdentity(tabId: string): { generation: number; tabSessionId: string } | undefined {
+    try {
+      const conn = this.resolveTarget(tabId);
+      if (conn.sock.readyState !== WebSocket.OPEN || !conn.tabSessionId) return undefined;
+      return { generation: conn.helloGeneration, tabSessionId: conn.tabSessionId };
+    } catch {
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary
- distinguish a reconnected panel websocket from a panel that can safely accept workflow-stamped graph writes
- make panel_restart_comfyui return ready:false and graph_tools_ready:false for a stale or otherwise incapable tab
- direct the stale-bundle recovery to a ComfyUI hard refresh instead of a futile retry/rebind

## Root cause
A ComfyUI restart reconnects the existing browser tab but does not refresh its cached panel JavaScript. The previous readiness signal tested only transport reachability, while graph mutations require the current hello to enforce workflow stamps and a trusted workflow identity.

## Validation
- npm.cmd test -- src/__tests__/orchestrator/panel-session-rebind-residuals.test.ts src/__tests__/services/ui-bridge.test.ts
- npm.cmd run lint
- npm.cmd run build