### PR TITLE
fix: preserve unrelated work on panel pin

### DIFF
--- a/src/__tests__/services/panel-pin-cancel.test.ts
+++ b/src/__tests__/services/panel-pin-cancel.test.ts
@@ -280,23 +280,22 @@ describe("pin write cancels a pending update_all (#689)", () => {
     // then the reset.
     expect(historyGets().some((c) => c.url.includes("ui_id=ui-1_comfyui-agent-panel"))).toBe(true);
     expect(historyGets().some((c) => c.url.includes("ui_id=ui-1_comfyui-mcp-panel"))).toBe(true);
-    expect(clientStatusGets().length).toBeGreaterThanOrEqual(2); // before + after
-    expect(resetPosts().map((c) => c.url)).toEqual([`${ORIG}/v2/manager/queue/reset`]);
+    expect(clientStatusGets()).toHaveLength(1);
+    expect(resetPosts()).toEqual([]);
 
     // The report names OUR dropped count AND the shared blast radius — never "saved".
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("cancelled");
-    expect(cancel.markerCleared).toBe(true);
+    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.markerCleared).toBe(false);
     expect(cancel.pendingBefore).toBe(2);
-    expect(cancel.pendingAfter).toBe(0);
     expect(cancel.inProgress).toBe(0);
-    expect(cancel.detail).toMatch(/dropped 2 of this orchestrator's pending task/);
-    expect(cancel.detail).toMatch(/Queue-wide pending went 5 → 0/);
+    expect(cancel.detail).toMatch(/queue-wide reset/);
+    expect(cancel.detail).toMatch(/NOTHING was sent/);
 
     // Marker provably cleared; no residue warning in the note.
-    expect(activePanelPendingOps()).toEqual([]);
-    expect(report.pendingPanelOps).toBeUndefined();
-    expect(report.note as string).not.toMatch(/WARNING — a panel-affecting operation/);
+    expect(activePanelPendingOps()).toHaveLength(1);
+    expect(report.pendingPanelOps).toHaveLength(1);
+    expect(report.note as string).toMatch(/WARNING — a panel-affecting operation/);
     expect(report.note as string).toMatch(/Pending-op handling:/);
   });
 
@@ -407,11 +406,11 @@ describe("pin write cancels a pending update_all (#689)", () => {
 
     const report = await writePin();
 
-    expect(resetPosts()).toHaveLength(1); // the reset WAS attempted
+    expect(resetPosts()).toHaveLength(0);
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/queue reset on .* FAILED/);
+    expect(cancel.detail).toMatch(/queue-wide reset/);
     // The marker and today's warning survive.
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.pendingPanelOps).toHaveLength(1);
@@ -484,7 +483,7 @@ describe("pin write cancels a pending update_all (#689)", () => {
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
   });
 
-  it("partial with a concurrent RE-FILL (pending 2 → 3): drop UNPROVEN, never a 'dropped' claim", async () => {
+  it("a possible concurrent refill never triggers a queue-wide reset", async () => {
     recordUpdateAllMarker({ base: ORIG, uiId: "ui-5b" });
     const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
     v4Persona(
@@ -500,22 +499,18 @@ describe("pin write cancels a pending update_all (#689)", () => {
 
     const report = await writePin();
 
-    expect(resetPosts()).toHaveLength(1);
+    expect(resetPosts()).toHaveLength(0);
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("partially-cancelled");
+    expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
     expect(cancel.pendingBefore).toBe(2);
-    expect(cancel.pendingAfter).toBe(3);
     // mineAfter.pending > mine.pending: a "dropped" count would be zero or
     // negative, i.e. fabricated. The report names the movement and stops there.
-    expect(cancel.detail).not.toMatch(/dropped \d/);
-    expect(cancel.detail).toMatch(/UNPROVEN/);
-    expect(cancel.detail).toMatch(/2 → 3/);
-    expect(cancel.detail).toMatch(/RUNNING/);
+    expect(cancel.detail).toMatch(/NOTHING was sent/);
     expect(activePanelPendingOps()).toHaveLength(1);
   });
 
-  it("partial: the dropped count is DERIVED from before/after reads, never asserted", async () => {    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
+  it("a possible partial drain is not claimed because no reset is sent", async () => {    recordUpdateAllMarker({ base: ORIG, uiId: "ui-5" });
     const mine: QueueState = { pending: 2, inProgress: 0, done: 1 };
     v4Persona(
       { pending: 2, inProgress: 0, done: 3 },
@@ -530,35 +525,28 @@ describe("pin write cancels a pending update_all (#689)", () => {
 
     const report = await writePin();
 
-    expect(resetPosts()).toHaveLength(1);
+    expect(resetPosts()).toHaveLength(0);
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("partially-cancelled");
+    expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
     expect(cancel.pendingBefore).toBe(2);
-    expect(cancel.pendingAfter).toBe(1);
-    expect(cancel.inProgress).toBe(1);
     // 2 → 1 is a drop of ONE: the report must not claim both were dropped.
-    expect(cancel.detail).toMatch(/dropped 1 of this orchestrator's pending task/);
-    expect(cancel.detail).toMatch(/\(2 → 1\)/);
-    expect(cancel.detail).not.toMatch(/dropped 2/);
-    expect(cancel.detail).toMatch(/Queue-wide pending went/);
+    expect(cancel.detail).toMatch(/NOTHING was sent/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING/);
   });
 
-  it("post-reset state unreadable: UNVERIFIED claims NO drop and names the blast radius", async () => {
+  it("post-reset state is never needed because no reset is sent", async () => {
     recordUpdateAllMarker({ base: ORIG, uiId: "ui-8" });
     v4Persona({ pending: 2, inProgress: 0, done: 1 }, { clientStatusFailsAfterReset: true });
 
     const report = await writePin();
 
-    expect(resetPosts()).toHaveLength(1); // the reset DID fire
+    expect(resetPosts()).toHaveLength(0);
     const [cancel] = cancelReports(report);
     expect(cancel.outcome).toBe("could-not-verify");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/what was dropped is UNVERIFIED/);
-    expect(cancel.detail).toMatch(/Queue-wide pending went 2 → 0/);
-    expect(cancel.detail).not.toMatch(/dropped \d/); // no unmeasured claim
+    expect(cancel.detail).toMatch(/NOTHING was sent/);
     expect(activePanelPendingOps()).toHaveLength(1);
   });
 
@@ -681,13 +669,12 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
 
     const report = await writePin();
 
-    expect(existsSync(restoreFile)).toBe(false);
+    expect(existsSync(restoreFile)).toBe(true);
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("cancelled");
-    expect(cancel.markerCleared).toBe(true);
-    expect(cancel.detail).toMatch(/deleted the deferred restore file/);
-    expect(cancel.detail).toContain(restoreFile);
-    expect(activePanelPendingOps()).toEqual([]);
+    expect(cancel.outcome).toBe("cannot-cancel");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/no operation identity/);
+    expect(activePanelPendingOps()).toHaveLength(1);
     // The cancel is filesystem-local — the Manager was never contacted.
     expect(managerCalls).toEqual([]);
   });
@@ -699,11 +686,10 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
     const report = await writePin();
 
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("already-drained");
-    expect(cancel.markerCleared).toBe(true);
-    expect(cancel.detail).toMatch(/NOTHING left to cancel/);
-    expect(cancel.detail).toMatch(/may ALREADY have been reverted/);
-    expect(activePanelPendingOps()).toEqual([]);
+    expect(cancel.outcome).toBe("cannot-cancel");
+    expect(cancel.markerCleared).toBe(false);
+    expect(cancel.detail).toMatch(/no operation identity/);
+    expect(activePanelPendingOps()).toHaveLength(1);
     expect(managerCalls).toEqual([]);
   });
 
@@ -714,10 +700,9 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
     const report = await writePin();
 
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("cannot-cancel-remote");
+    expect(cancel.outcome).toBe("cannot-cancel");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/cannot cancel — remote host/);
-    expect(cancel.detail).toMatch(/BEFORE the next ComfyUI restart/);
+    expect(cancel.detail).toMatch(/no operation identity/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(report.pendingPanelOps).toHaveLength(1);
     expect(report.note as string).toMatch(/WARNING — a panel-affecting operation is still pending/);
@@ -784,12 +769,11 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
 
     // The local file WILL run at the next local restart, so deleting it is
     // protective — but it proves nothing about which host the marker is for.
-    expect(existsSync(restoreFile)).toBe(false);
+    expect(existsSync(restoreFile)).toBe(true);
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.outcome).toBe("cannot-cancel");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/UNVERIFIED/);
-    expect(cancel.detail).toMatch(/recorded no server/);
+    expect(cancel.detail).toMatch(/no operation identity/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(managerCalls).toEqual([]);
   });
@@ -805,9 +789,9 @@ describe("pin write cancels a deferred snapshot restore (#689)", () => {
     const report = await writePin();
 
     const [cancel] = cancelReports(report);
-    expect(cancel.outcome).toBe("could-not-verify");
+    expect(cancel.outcome).toBe("cannot-cancel");
     expect(cancel.markerCleared).toBe(false);
-    expect(cancel.detail).toMatch(/recorded no server/);
+    expect(cancel.detail).toMatch(/no operation identity/);
     expect(activePanelPendingOps()).toHaveLength(1);
     expect(managerCalls).toEqual([]);
   });

--- a/src/services/panel-pending-cancel.ts
+++ b/src/services/panel-pending-cancel.ts
@@ -1,4 +1,4 @@
-// Pin-write CANCELLATION of pending panel-affecting work (#689).
+// Pin-write handling of pending panel-affecting work (#689).
 //
 // update_all and deferred snapshot restores are handed to ComfyUI-Manager and
 // applied out of band (see panel-pin-guard.ts). Before this fix, a pin written
@@ -39,7 +39,6 @@
 //     update_all. The report says so.
 
 import { getComfyUIBaseUrl } from "../config.js";
-import { resetQueue } from "./manager-config.js";
 import {
   detectManagerApi,
   fetchManagerClientQueueCounts,
@@ -48,7 +47,6 @@ import {
   type ManagerApi,
   type ManagerTaskHistoryEntry,
 } from "./node-management.js";
-import { cancelPendingSnapshotRestore } from "./node-snapshots.js";
 import {
   clearPanelPendingOp,
   PANEL_PACK_ALIASES,
@@ -389,124 +387,24 @@ async function cancelUpdateAllProvable(
     });
   }
 
-  // 3. Our tasks are PROVABLY pending and NOTHING is running (the panel's, if
-  //    enqueued, is among them: it did not run and is not running). The reset
-  //    is a targeted cancel now — still queue-wide, so measure the blast
-  //    radius too.
-  const shared = await fetchManagerQueueCounts(base);
-  try {
-    await resetQueue(base);
-  } catch (err) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `the queue reset on ${base} FAILED: ${
-          err instanceof Error ? err.message : String(err)
-        }. The queued update_all may still be pending; the warning stands.`,
-      pendingBefore: mine.pending,
-      inProgress: mine.inProgress,
-    };
-  }
-
-  // 4. Prove the end state: the panel's task is gone from EVERYWHERE (a task
-  //    could have been dequeued or completed in the race). A reset fired, so
-  //    every branch below names the shared-queue blast radius, and every
-  //    dropped count is DERIVED from before/after reads — never asserted.
-  const mineAfter = await fetchManagerClientQueueCounts(base);
-  const sharedAfter = await fetchManagerQueueCounts(base);
-  const blast =
-    shared && sharedAfter
-      ? ` Queue-wide pending went ${shared.pending} → ${sharedAfter.pending} ` +
-        `(the Manager queue is shared — unrelated queued work was dropped too).`
-      : ` The Manager queue is shared, so unrelated queued work may have been ` +
-        `dropped too.`;
-  if (!mineAfter) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `a queue reset was sent on ${base} with ${mine.pending} of this ` +
-        `orchestrator's task(s) pending, but the post-reset state could not be ` +
-        `read — what was dropped is UNVERIFIED and nothing is claimed.${blast} ` +
-        `The update_all may still be pending.`,
-      pendingBefore: mine.pending,
-      inProgress: mine.inProgress,
-    };
-  }
-  const dropped = mine.pending - mineAfter.pending;
-  const afterLookup = await panelTaskState(uiId, base);
-  if (afterLookup === undefined) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `a queue reset was sent on ${base} (this orchestrator's pending tasks ` +
-        `went ${mine.pending} → ${mineAfter.pending}), but the queue history ` +
-        `could not be re-read — whether the panel's task ran in the meantime ` +
-        `is UNKNOWN.${blast} The warning stands.`,
-      pendingBefore: mine.pending,
-      pendingAfter: mineAfter.pending,
-      inProgress: mineAfter.inProgress,
-    };
-  }
-  if (afterLookup || mineAfter.inProgress > 0 || mineAfter.processing) {
-    // A concurrent same-orchestrator enqueue can re-fill the queue between the
-    // pre- and post-reset reads, making mineAfter.pending >= mine.pending — a
-    // zero or negative "dropped" is NOT a provable drop, so claim it only when
-    // it is positive; otherwise say the count moved and nothing more.
-    const dropClaim =
-      dropped > 0
-        ? `dropped ${dropped} of this orchestrator's pending task(s) via a ` +
-          `queue reset on ${base} (${mine.pending} → ${mineAfter.pending}), BUT `
-        : `sent a queue reset on ${base} (this orchestrator's pending went ` +
-          `${mine.pending} → ${mineAfter.pending} — a concurrent enqueue may have ` +
-          `re-filled it, so what the reset dropped is UNPROVEN), BUT `;
-    return {
-      op,
-      outcome: "partially-cancelled",
-      markerCleared: false,
-      detail:
-        `${dropClaim}${
-          afterLookup
-            ? `the panel's task COMPLETED in the meantime (it is in the queue history)`
-            : `${mineAfter.inProgress} task(s) were already RUNNING and in-flight work cannot be cancelled`
-        } — the update_all may STILL have moved the panel.${blast}`,
-      pendingBefore: mine.pending,
-      pendingAfter: mineAfter.pending,
-      inProgress: mineAfter.inProgress,
-    };
-  }
-  if (mineAfter.pending > 0) {
-    return {
-      op,
-      outcome: "could-not-verify",
-      markerCleared: false,
-      detail:
-        `a queue reset was sent on ${base}, but ${mineAfter.pending} of this ` +
-        `orchestrator's task(s) are STILL pending (was ${mine.pending}; ` +
-        `concurrent enqueues can re-fill the queue) — the update_all was not ` +
-        `provably cancelled.${blast} The warning stands.`,
-      pendingBefore: mine.pending,
-      pendingAfter: mineAfter.pending,
-      inProgress: mineAfter.inProgress,
-    };
-  }
-  return finalize(op, {
-    outcome: "cancelled",
+  // A v4 history entry proves only that the marked task has not completed; it
+  // does not prove which pending queue entry belongs to this update_all. The
+  // only available cancellation endpoint resets the ENTIRE shared queue, so
+  // using it here can delete unrelated work. Keep the marker and warning until
+  // Manager exposes an owned, atomic per-task cancellation API.
+  return {
+    op,
+    outcome: "could-not-verify",
+    markerCleared: false,
     detail:
-      `cancelled the queued update_all before it could touch the panel: the ` +
-      `panel's update task is not in the queue history and, after a queue ` +
-      `reset on ${base}, nothing from this orchestrator is pending or running ` +
-      `— it was dropped (or never enqueued) and CANNOT run. The reset dropped ` +
-      `${dropped} of this orchestrator's pending task(s).${blast}`,
+      `the panel task has not reached the Manager history and ${mine.pending} ` +
+      `task(s) from this orchestrator are pending on ${base}, but ComfyUI-Manager ` +
+      `offers only a queue-wide reset. That reset could delete unrelated pending ` +
+      `work and cannot prove it cancelled this update_all, so NOTHING was sent; ` +
+      `the warning stands.`,
     pendingBefore: mine.pending,
-    pendingAfter: 0,
-    inProgress: 0,
-  });
+    inProgress: mine.inProgress,
+  };
 }
 
 /**
@@ -586,75 +484,20 @@ function cancelSnapshotRestore(op: PanelPendingOp): PanelPendingCancelReport {
     };
   }
 
-  const result = cancelPendingSnapshotRestore();
-
-  // No recorded server: the local action is at best a guess about which host
-  // the restore was scheduled on. It is still applied (a local restore file
-  // WILL run at the next local restart, so deleting it is protective), but
-  // nothing here is PROOF — report UNVERIFIED and keep the marker.
-  if (!op.base) {
-    switch (result.outcome) {
-      case "cancelled":
-        return {
-          op,
-          outcome: "could-not-verify",
-          markerCleared: false,
-          detail:
-            `${result.detail} — HOWEVER the marker recorded no server, so this ` +
-            `is UNVERIFIED: if the restore was scheduled on a DIFFERENT (e.g. ` +
-            `remote) host, it is still scheduled there and will run at its next ` +
-            `restart. The warning stands.`,
-        };
-      case "not-scheduled":
-        return {
-          op,
-          outcome: "could-not-verify",
-          markerCleared: false,
-          detail:
-            `no deferred restore file exists on the current target, but the ` +
-            `marker recorded no server — the restore may be scheduled on a ` +
-            `DIFFERENT host and still run at its next ComfyUI restart. The ` +
-            `warning stands.`,
-        };
-      case "remote":
-        return {
-          op,
-          outcome: "cannot-cancel-remote",
-          markerCleared: false,
-          detail: result.detail,
-        };
-      case "failed":
-        return {
-          op,
-          outcome: "could-not-verify",
-          markerCleared: false,
-          detail: result.detail,
-        };
-    }
-  }
-
-  // The marker's base IS the current target — local evidence is about the
-  // right host, so outcomes are provable here.
-  switch (result.outcome) {
-    case "cancelled":
-      return finalize(op, { outcome: "cancelled", detail: result.detail });
-    case "not-scheduled":
-      return finalize(op, { outcome: "already-drained", detail: result.detail });
-    case "remote":
-      return {
-        op,
-        outcome: "cannot-cancel-remote",
-        markerCleared: false,
-        detail: result.detail,
-      };
-    case "failed":
-      return {
-        op,
-        outcome: "could-not-verify",
-        markerCleared: false,
-        detail: result.detail,
-      };
-  }
+  // The deferred file has no operation identity: a stale marker for this base
+  // is indistinguishable from a later restore requested by another operation.
+  // Deleting it would therefore risk cancelling the wrong restore. Keep the
+  // marker until Manager provides an owned restore identifier or cancellation
+  // endpoint.
+  return {
+    op,
+    outcome: "cannot-cancel",
+    markerCleared: false,
+    detail:
+      `cannot safely cancel the deferred restore on ${currentBase}: Manager's ` +
+      `restore-snapshot.json has no operation identity, so deleting it could ` +
+      `remove a later unrelated restore. NOTHING was deleted; the warning stands.`,
+  };
 }
 
 /** Attempt to cancel ONE pending panel-affecting op, honestly reported. */


### PR DESCRIPTION
Fixes the two data-loss paths introduced by #702. Pin handling now never uses Manager's queue-wide reset and never deletes restore-snapshot.json without an owned operation identifier; it keeps the pending marker and warning instead.\n\nValidated with the focused 34-test suite, lint, build, and an independent accidental-correctness review.