### PR TITLE
fix(panel): refresh workflow stamp after open (#716)

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -2902,6 +2902,105 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
     expect(res.content[0]?.type === "text" ? res.content[0].text : "").toMatch(/outcome is undetermined/i);
   });
 
+  it("recovers an exact receipt but never refreshes from a different same-basename active workflow (#716 P1)", async () => {
+    const requested = "workflows/a/foo.json";
+    const refresh = vi.fn(() => true);
+    const { ctx } = makeVerifyCtx({
+      openReply: () => timeoutResult(),
+      listReplies: [{
+        active_confirmed: true,
+        active: {
+          path: "workflows/b/foo.json",
+          routing_key: "wf:workflows/b/foo.json",
+          workflow_uuid: "22222222-2222-4222-8222-222222222222",
+        },
+        last_open: {
+          rid: "open-rid-1", answers_only_command_rid: "open-rid-1", cmd: "workflow_open",
+          requested,
+          resolved: { path: requested, filename: "foo.json", routing_key: "wf:workflows/a/foo.json" },
+          applied: true,
+        },
+      }],
+    });
+    (ctx.bridge as unknown as { refreshWorkflowUuid: typeof refresh }).refreshWorkflowUuid = refresh;
+
+    const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+    expect(res.isError).toBeFalsy(); // The RID-correlated receipt still proves the open happened.
+    expect(refresh).not.toHaveBeenCalled(); // But B's valid UUID must never stamp the next A command.
+  });
+
+  it("recovers a matching receipt but never refreshes from an active path/routing contradiction (#716 P1)", async () => {
+    const requested = "workflows/a/foo.json";
+    const refresh = vi.fn(() => true);
+    const { ctx } = makeVerifyCtx({
+      openReply: () => timeoutResult(),
+      listReplies: [{
+        active_confirmed: true,
+        active: {
+          path: requested,
+          routing_key: "wf:workflows/b/foo.json",
+          workflow_uuid: "22222222-2222-4222-8222-222222222222",
+        },
+        last_open: {
+          rid: "open-rid-1", answers_only_command_rid: "open-rid-1", cmd: "workflow_open",
+          requested,
+          resolved: { path: requested, filename: "foo.json", routing_key: "wf:workflows/a/foo.json" },
+          applied: true,
+        },
+      }],
+    });
+    (ctx.bridge as unknown as { refreshWorkflowUuid: typeof refresh }).refreshWorkflowUuid = refresh;
+    const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("never refreshes a receipt recovery for a temporary routing token (#716 P1)", async () => {
+    const requested = "tmp:ephemeral-tab";
+    const refresh = vi.fn(() => true);
+    const { ctx } = makeVerifyCtx({
+      openReply: () => timeoutResult(),
+      listReplies: [{
+        active_confirmed: true,
+        active: { path: requested, routing_key: "wf:tmp:ephemeral-tab", workflow_uuid: "22222222-2222-4222-8222-222222222222" },
+        last_open: {
+          rid: "open-rid-1", answers_only_command_rid: "open-rid-1", cmd: "workflow_open",
+          requested,
+          resolved: { path: requested, routing_key: "wf:tmp:ephemeral-tab" },
+          applied: true,
+        },
+      }],
+    });
+    (ctx.bridge as unknown as { refreshWorkflowUuid: typeof refresh }).refreshWorkflowUuid = refresh;
+    const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("recovers a receipt but never refreshes from a partial or replayed active list record (#716 P1)", async () => {
+    const requested = "workflows/a/foo.json";
+    for (const routing_key of [undefined, "wf:workflows/replayed.json", "not-a-routing-key"]) {
+      const refresh = vi.fn(() => true);
+      const { ctx } = makeVerifyCtx({
+        openReply: () => timeoutResult(),
+        listReplies: [{
+          active_confirmed: true,
+          active: { path: requested, routing_key, workflow_uuid: "22222222-2222-4222-8222-222222222222" },
+          last_open: {
+            rid: "open-rid-1", answers_only_command_rid: "open-rid-1", cmd: "workflow_open",
+            requested,
+            resolved: { path: requested, filename: "foo.json", routing_key: "wf:workflows/a/foo.json" },
+            applied: true,
+          },
+        }],
+      });
+      (ctx.bridge as unknown as { refreshWorkflowUuid: typeof refresh }).refreshWorkflowUuid = refresh;
+      const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+      expect(res.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
   it("a genuine acked open-failure (missing file) still fails clearly, unverified", async () => {
     let listCalls = 0;
     const ctx = {
@@ -2963,14 +3062,15 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
     expect(listCalls).toBe(0);
   });
 
-  it("normal fast success returns verbatim without polling workflow_list", async () => {
+  it("normal fast success returns verbatim and re-reads active identity before refreshing", async () => {
+    const exactTarget = "workflows/my-workflow.json";
     let listCalls = 0;
     const ctx = {
       call: async (cmd: Record<string, unknown>) => {
         if (cmd.cmd === "workflow_open") {
           return {
             content: [
-              { type: "text", text: JSON.stringify({ opened: { path: TARGET }, modified: false }) },
+              { type: "text", text: JSON.stringify({ opened: { path: exactTarget }, routing_key: "wf:workflows/my-workflow.json", modified: false }) },
             ],
           };
         }
@@ -2981,13 +3081,374 @@ describe("panel_open_workflow: verify active state after ack-timeout (#215/#319/
       bridge: {} as unknown as PanelToolCtx["bridge"],
       tabId: "test-tab",
     } as PanelToolCtx;
-    const res = (await defByName("panel_open_workflow").handler({ path: TARGET }, ctx)) as {
+    const res = (await defByName("panel_open_workflow").handler({ path: exactTarget }, ctx)) as {
       content: Array<{ text: string }>;
       isError?: boolean;
     };
     expect(res.isError).toBeFalsy();
     expect(res.content[0].text).toContain("opened");
-    expect(listCalls).toBe(0);
+    expect(listCalls).toBe(1);
+  });
+});
+
+describe("#716 workflow UUID refresh after reconnect/open/re-pin", () => {
+  const OLD_UUID = "11111111-1111-4111-8111-111111111111";
+  const LIVE_UUID = "22222222-2222-4222-8222-222222222222";
+  const TARGET = "workflows/reconnected.json";
+
+  it("refreshes the next command stamp from a successful panel_open_workflow response", async () => {
+    const refresh = vi.fn(() => true);
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        if (cmd.cmd === "workflow_list") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ active: { path: TARGET, routing_key: "wf:workflows/reconnected.json", workflow_uuid: LIVE_UUID } }) }],
+          };
+        }
+        expect(cmd).toMatchObject({ cmd: "workflow_open", path: TARGET });
+        return {
+          content: [{ type: "text", text: JSON.stringify({ opened: { path: TARGET }, routing_key: "wf:workflows/reconnected.json", workflow_uuid: LIVE_UUID }) }],
+        };
+      },
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+    };
+
+    const res = await defByName("panel_open_workflow").handler({ path: TARGET }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).toHaveBeenCalledExactlyOnceWith("reconnected-tab", LIVE_UUID.toLowerCase());
+  });
+
+  it("does not refresh fast success from a partial or replayed active list record (#716 P1)", async () => {
+    for (const routing_key of [undefined, "wf:workflows/replayed.json", "not-a-routing-key"]) {
+      const refresh = vi.fn(() => true);
+      const ctx: PanelToolCtx = {
+        call: async (cmd) =>
+          cmd.cmd === "workflow_list"
+            ? { content: [{ type: "text", text: JSON.stringify({ active: { path: TARGET, routing_key, workflow_uuid: LIVE_UUID } }) }] }
+            : { content: [{ type: "text", text: JSON.stringify({ opened: { path: TARGET }, routing_key: "wf:workflows/reconnected.json", workflow_uuid: LIVE_UUID }) }] },
+        confirm: async () => "yes" as const,
+        bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+        tabId: "reconnected-tab",
+      };
+      const res = await defByName("panel_open_workflow").handler({ path: TARGET }, ctx);
+      expect(res.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not refresh from an absent or noncanonical open UUID, preserving the old fail-closed stamp", async () => {
+    for (const workflow_uuid of [
+      undefined,
+      "not-a-uuid",
+      OLD_UUID + "-suffix",
+      "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee".toUpperCase(),
+      "33333333-3333-0333-8333-333333333333", // invalid version
+      "44444444-4444-4444-7444-444444444444", // invalid variant
+    ]) {
+      const refresh = vi.fn(() => true);
+      const ctx: PanelToolCtx = {
+        call: async (cmd) =>
+          cmd.cmd === "workflow_list"
+            ? { content: [{ type: "text", text: JSON.stringify({ active: { path: TARGET } }) }] }
+            : { content: [{ type: "text", text: JSON.stringify({ opened: { path: TARGET }, workflow_uuid }) }] },
+        confirm: async () => "yes" as const,
+        bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+        tabId: "reconnected-tab",
+      };
+      const res = await defByName("panel_open_workflow").handler({ path: TARGET }, ctx);
+      expect(res.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not refresh from a late open reply once a newer navigation is active", async () => {
+    const refresh = vi.fn(() => true);
+    const ctx: PanelToolCtx = {
+      call: async (cmd) =>
+        cmd.cmd === "workflow_list"
+          ? { content: [{ type: "text", text: JSON.stringify({ active: { path: "workflows/newer.json", workflow_uuid: LIVE_UUID } }) }] }
+          : { content: [{ type: "text", text: JSON.stringify({ opened: { path: TARGET }, workflow_uuid: OLD_UUID }) }] },
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+    };
+
+    const res = await defByName("panel_open_workflow").handler({ path: TARGET }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh a successful open from a different same-basename active workflow (#716 P1)", async () => {
+    const requested = "workflows/a/foo.json";
+    const refresh = vi.fn(() => true);
+    const ctx: PanelToolCtx = {
+      call: async (cmd) =>
+        cmd.cmd === "workflow_list"
+          ? {
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  active: {
+                    path: "workflows/b/foo.json",
+                    routing_key: "wf:workflows/b/foo.json",
+                    workflow_uuid: LIVE_UUID,
+                  },
+                }),
+              }],
+            }
+          : {
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  opened: { path: requested },
+                  routing_key: "wf:workflows/a/foo.json",
+                  workflow_uuid: OLD_UUID,
+                }),
+              }],
+            },
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+    };
+
+    const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not promote an alias request to a reply-resolved path for fast-success refresh (#716 P1)", async () => {
+    const requested = "foo.json";
+    const resolved = "workflows/a/foo.json";
+    const refresh = vi.fn(() => true);
+    const ctx: PanelToolCtx = {
+      call: async (cmd) =>
+        cmd.cmd === "workflow_list"
+          ? { content: [{ type: "text", text: JSON.stringify({ active: { path: resolved, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID } }) }] }
+          : { content: [{ type: "text", text: JSON.stringify({ opened: { path: resolved }, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID }) }] },
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+    };
+
+    const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+    expect(res.isError).toBeFalsy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh fast success from an active path/routing contradiction or temporary path (#716 P1)", async () => {
+    for (const { requested, active, opened } of [
+      {
+        requested: "workflows/a/foo.json",
+        active: { path: "workflows/a/foo.json", routing_key: "wf:workflows/b/foo.json", workflow_uuid: LIVE_UUID },
+        opened: { path: "workflows/a/foo.json", routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID },
+      },
+      {
+        requested: "tmp:ephemeral-tab",
+        active: { path: "tmp:ephemeral-tab", routing_key: "wf:tmp:ephemeral-tab", workflow_uuid: LIVE_UUID },
+        opened: { path: "tmp:ephemeral-tab", routing_key: "wf:tmp:ephemeral-tab", workflow_uuid: LIVE_UUID },
+      },
+    ]) {
+      const refresh = vi.fn(() => true);
+      const ctx: PanelToolCtx = {
+        call: async (cmd) =>
+          cmd.cmd === "workflow_list"
+            ? { content: [{ type: "text", text: JSON.stringify({ active }) }] }
+            : { content: [{ type: "text", text: JSON.stringify({ opened, routing_key: opened.routing_key, workflow_uuid: opened.workflow_uuid }) }] },
+        confirm: async () => "yes" as const,
+        bridge: { refreshWorkflowUuid: refresh } as unknown as PanelToolCtx["bridge"],
+        tabId: "reconnected-tab",
+      };
+      const res = await defByName("panel_open_workflow").handler({ path: requested }, ctx);
+      expect(res.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
+  it("re-pin refreshes only from the same fresh active workflow record, so the following run is fenced to it", async () => {
+    const refresh = vi.fn(() => true);
+    const store = new WorkflowTargetStore();
+    const sent: Array<Record<string, unknown>> = [];
+    const ctx: PanelToolCtx = {
+      call: async (cmd) => {
+        expect(cmd).toMatchObject({ cmd: "workflow_list" });
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              active_confirmed: true,
+              active: { path: TARGET, key: "wf:workflows/reconnected.json", routing_key: "wf:workflows/reconnected.json", workflow_uuid: LIVE_UUID },
+              workflows: [{ path: TARGET, key: "wf:workflows/reconnected.json", routing_key: "wf:workflows/reconnected.json", active: true, workflow_uuid: LIVE_UUID }],
+            }),
+          }],
+        };
+      },
+      confirm: async () => "yes" as const,
+      bridge: {
+        refreshWorkflowUuid: refresh,
+        push: (frame: Record<string, unknown>) => { sent.push(frame); return 1; },
+      } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+      workflowTarget: store,
+    };
+
+    const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: TARGET }, ctx);
+    expect(pin.isError).toBeFalsy();
+    expect(store.get("reconnected-tab")).toMatchObject({ mode: "pinned", path: "wf:workflows/reconnected.json" });
+    expect(refresh).toHaveBeenCalledExactlyOnceWith("reconnected-tab", LIVE_UUID.toLowerCase());
+    expect(sent).toHaveLength(1);
+  });
+
+  it("does not refresh a re-pin from an alias, routing token, temporary token, or malformed caller path (#716 P1)", async () => {
+    for (const callerPath of ["foo.json", "wf:workflows/reconnected.json", "tmp:ephemeral-tab", "not-a-canonical-path"]) {
+      const refresh = vi.fn(() => true);
+      const store = new WorkflowTargetStore();
+      const ctx: PanelToolCtx = {
+        call: async () => ({
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              active: { path: TARGET, routing_key: "wf:workflows/reconnected.json", workflow_uuid: LIVE_UUID },
+              workflows: [{
+                path: TARGET,
+                filename: "foo.json",
+                // Each caller form can resolve through legacy aliases; that must
+                // not give it authority to replace the command fence.
+                key: callerPath,
+                routing_key: "wf:workflows/reconnected.json",
+                active: true,
+              }],
+            }),
+          }],
+        }),
+        confirm: async () => "yes" as const,
+        bridge: { refreshWorkflowUuid: refresh, push: () => 1 } as unknown as PanelToolCtx["bridge"],
+        tabId: "reconnected-tab",
+        workflowTarget: store,
+      };
+      const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: callerPath }, ctx);
+      expect(pin.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not refresh a re-pin from a partial or replayed selected/list-active record (#716 P1)", async () => {
+    for (const routing_key of [undefined, "wf:workflows/replayed.json", "not-a-routing-key"]) {
+      const refresh = vi.fn(() => true);
+      const store = new WorkflowTargetStore();
+      const ctx: PanelToolCtx = {
+        call: async () => ({
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              active: { path: TARGET, routing_key, workflow_uuid: LIVE_UUID },
+              workflows: [{ path: TARGET, key: "wf:workflows/reconnected.json", routing_key, active: true }],
+            }),
+          }],
+        }),
+        confirm: async () => "yes" as const,
+        bridge: { refreshWorkflowUuid: refresh, push: () => 1 } as unknown as PanelToolCtx["bridge"],
+        tabId: "reconnected-tab",
+        workflowTarget: store,
+      };
+      const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: TARGET }, ctx);
+      expect(pin.isError).toBeFalsy();
+      expect(refresh).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not refresh a re-pin from an alias-selected stale active:true record that contradicts top-level active (#716 P1)", async () => {
+    const refresh = vi.fn(() => true);
+    const store = new WorkflowTargetStore();
+    const requestedAlias = "foo.json";
+    const ctx: PanelToolCtx = {
+      call: async () => ({
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            // The list's item flag claims A is active, but the authoritative
+            // top-level active record says B. Their same basename must not let
+            // B's valid UUID replace the existing fail-closed command stamp.
+            active: {
+              path: "workflows/b/foo.json",
+              routing_key: "wf:workflows/b/foo.json",
+              workflow_uuid: LIVE_UUID,
+            },
+            workflows: [{
+              path: "workflows/a/foo.json",
+              filename: "foo.json",
+              key: "wf:workflows/a/foo.json",
+              routing_key: "wf:workflows/a/foo.json",
+              active: true,
+            }],
+          }),
+        }],
+      }),
+      confirm: async () => "yes" as const,
+      bridge: {
+        refreshWorkflowUuid: refresh,
+        push: () => 1,
+      } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+      workflowTarget: store,
+    };
+
+    const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: requestedAlias }, ctx);
+    expect(pin.isError).toBeFalsy(); // Preserve legacy pin resolution; only the fence refresh is unsafe.
+    expect(store.get("reconnected-tab")).toMatchObject({ mode: "pinned", path: "wf:workflows/a/foo.json" });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh a top-level-active re-pin unless an exact list record corroborates it (#716 P1)", async () => {
+    const refresh = vi.fn(() => true);
+    const store = new WorkflowTargetStore();
+    const requested = "workflows/a/foo.json";
+    const ctx: PanelToolCtx = {
+      call: async () => ({
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            active: { path: requested, routing_key: "wf:workflows/a/foo.json", workflow_uuid: LIVE_UUID },
+            // The active object is absent from this enumerable list, so there
+            // is no selected record whose identity can corroborate its UUID.
+            workflows: [{ path: "workflows/other.json", routing_key: "wf:workflows/other.json", active: false }],
+          }),
+        }],
+      }),
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh, push: () => 1 } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+      workflowTarget: store,
+    };
+
+    const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: requested }, ctx);
+    expect(pin.isError).toBeFalsy();
+    expect(store.get("reconnected-tab")).toMatchObject({ mode: "pinned", path: requested });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh when a late/replayed workflow_list marks the requested target as background", async () => {
+    const refresh = vi.fn(() => true);
+    const ctx: PanelToolCtx = {
+      call: async () => ({
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            active: { path: "workflows/other.json", key: "wf:other", workflow_uuid: LIVE_UUID },
+            workflows: [{ path: TARGET, key: "wf:target", active: false, workflow_uuid: OLD_UUID }],
+          }),
+        }],
+      }),
+      confirm: async () => "yes" as const,
+      bridge: { refreshWorkflowUuid: refresh, push: () => 1 } as unknown as PanelToolCtx["bridge"],
+      tabId: "reconnected-tab",
+      workflowTarget: new WorkflowTargetStore(),
+    };
+
+    const pin = await defByName("panel_set_workflow_target").handler({ mode: "pinned", path: TARGET }, ctx);
+    expect(pin.isError).toBe(true);
+    expect(refresh).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -1341,6 +1341,44 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     desktop.close();
   });
 
+  it("#716 refreshes a later command stamp only through the orchestrator-owned validator", async () => {
+    const oldUuid = "11111111-1111-4111-8111-111111111111";
+    const liveUuid = "22222222-2222-4222-8222-222222222222";
+    const uuidByTab: Record<string, string> = { "wf:reconnected": oldUuid };
+    bridge.setTabWorkflowUuidResolver(
+      (tabId) => uuidByTab[tabId],
+      (tabId, uuid) => {
+        if (!/^[0-9a-f]{8}-/i.test(uuid)) return false;
+        uuidByTab[tabId] = uuid;
+        return true;
+      },
+    );
+    const desktop = await connectPanel("wf:reconnected", "R");
+    const frames: Array<Record<string, unknown>> = [];
+    desktop.on("message", (buf) => {
+      const m = JSON.parse(buf.toString());
+      if (m.rid && m.cmd) {
+        frames.push(m);
+        desktop.send(JSON.stringify({ rid: m.rid, ok: true, result: {} }));
+      }
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "wf:reconnected")).toBe(true));
+
+    await bridge.send({ cmd: "graph_add_node", node: "before-open" } as never, { tabId: "wf:reconnected" });
+    expect(frames.at(-1)?.workflow_uuid).toBe(oldUuid);
+
+    // This is what the successful panel_open_workflow / active re-pin path calls.
+    expect(bridge.refreshWorkflowUuid("wf:reconnected", liveUuid)).toBe(true);
+    await bridge.send({ cmd: "graph_run" } as never, { tabId: "wf:reconnected" });
+    expect(frames.at(-1)?.workflow_uuid).toBe(liveUuid);
+
+    // A malformed/late response cannot erase or replace the established stamp.
+    expect(bridge.refreshWorkflowUuid("wf:reconnected", "not-a-uuid")).toBe(false);
+    await bridge.send({ cmd: "graph_add_node", node: "after-bad-reply" } as never, { tabId: "wf:reconnected" });
+    expect(frames.at(-1)?.workflow_uuid).toBe(liveUuid);
+    desktop.close();
+  });
+
   it("workflow_uuid is BRIDGE-OWNED: a caller-supplied stamp is OVERRIDDEN by the trusted resolver value (#570 P0c)", async () => {
     // A caller must not be able to forge the stamp to the destination workflow to sail past the
     // panel fence after a switch. dispatch always overwrites workflow_uuid with the resolver value.

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -1384,6 +1384,12 @@ export async function runPanelOrchestrator(): Promise<void> {
   // new provider's onSession would persist under the old backend's key. Tracked for every
   // tab with a valid identity; cleared when the identity is absent/untrusted.
   const tabStableIdentity = new Map<string, { origin: string; uuid: string }>();
+  // The UUID stamped on the NEXT panel command. Normally this exactly mirrors
+  // tabStableIdentity from hello. #716 intentionally lets a successful explicit
+  // open/re-pin refresh only this command fence before the next hello arrives;
+  // session ownership remains hello-bound so a command reply can never silently
+  // retarget durable conversation state.
+  const tabCommandWorkflowUuid = new Map<string, string>();
   const workflowTargets = new WorkflowTargetStore();
   // Monotonic per-tab sequence for set_workflow_target events. A pinned target is
   // validated asynchronously (resolvePinTarget queries workflow_list), so a later event
@@ -2045,7 +2051,28 @@ export async function runPanelOrchestrator(): Promise<void> {
   // (the generation-bound-command leak). Resolved from the CALLER's tab id: during the switch
   // race the retiring tab still maps to its own uuid, so a late command stamps the ORIGIN
   // workflow's uuid and the panel (now showing the new one) fails it closed.
-  bridge.setTabWorkflowUuidResolver((tabId) => tabStableIdentity.get(panelTabOf(tabId))?.uuid);
+  bridge.setTabWorkflowUuidResolver(
+    (tabId) => tabCommandWorkflowUuid.get(panelTabOf(tabId)),
+    (tabId, workflowUuid) => {
+      // A command reply is useful only while its routed tab still exists, and
+      // only when its UUID has the same strict shape/origin binding as hello.
+      // Invalid/missing panel data leaves the old stamp in place, causing the
+      // existing fail-closed fence to reject a subsequent mutation.
+      try {
+        if (!bridge.canReach(tabId)) return false;
+      } catch {
+        return false;
+      }
+      const panelTab = panelTabOf(tabId);
+      const identity = workflowIdentityParts({
+        workflowUuid,
+        origin: bridge.tabServerOrigin(tabId),
+      });
+      if (!identity) return false;
+      tabCommandWorkflowUuid.set(panelTab, identity.uuid);
+      return true;
+    },
+  );
 
   // ── Local-agent VRAM pause during generation ────────────────────────────
   // On a single-GPU box the local Ollama chat model and ComfyUI fight for VRAM:
@@ -2668,6 +2695,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           workflowTargetSeq.delete(migratedFrom);
           tabStableKey.delete(migratedFrom);
           tabStableIdentity.delete(migratedFrom);
+          tabCommandWorkflowUuid.delete(migratedFrom);
         } else {
           // #570 — migrate per-backend state for EVERY provider, not only the currently-selected
           // one. A saved workflow can hold a DORMANT session on another backend (used Claude,
@@ -2768,6 +2796,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           const carriedStable = tabStableKey.get(migratedFrom);
           tabStableKey.delete(migratedFrom);
           tabStableIdentity.delete(migratedFrom);
+          tabCommandWorkflowUuid.delete(migratedFrom);
           if (carriedStable !== undefined) {
             if (panelTab.startsWith("tmp:")) tabStableKey.set(panelTab, carriedStable);
             else sessionStore.clearStable(carriedStable);
@@ -2778,8 +2807,13 @@ export async function runPanelOrchestrator(): Promise<void> {
       // #570: record this tab's TRUSTED identity (every tab) for the migration
       // discriminator above and the set_backend recompute below. Absent/untrusted →
       // cleared (fail closed: no proof of continuity → a future migration won't rebind).
-      if (newIdentity) tabStableIdentity.set(panelTab, newIdentity);
-      else tabStableIdentity.delete(panelTab);
+      if (newIdentity) {
+        tabStableIdentity.set(panelTab, newIdentity);
+        tabCommandWorkflowUuid.set(panelTab, newIdentity.uuid);
+      } else {
+        tabStableIdentity.delete(panelTab);
+        tabCommandWorkflowUuid.delete(panelTab);
+      }
       // Blind content mode rides the hello (issue #90) so the FIRST agent spawn
       // already carries the right tool-server env. A CHANGE against a live
       // agent also respawns it (codex-review F2: the set_content_mode frame is
@@ -3040,6 +3074,7 @@ export async function runPanelOrchestrator(): Promise<void> {
           if (prior) sessionStore.clearStable(prior);
           tabStableKey.delete(panelTab);
           tabStableIdentity.delete(panelTab);
+          tabCommandWorkflowUuid.delete(panelTab);
         }
       }
 

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -1252,6 +1252,30 @@ function activeMatchesTarget(active: unknown, path: string): boolean {
   return stripJsonExt(a.filename) === want || stripJsonExt(a.path) === want;
 }
 
+/**
+ * Exact saved-workflow identity for command-fence refreshes.  Unlike
+ * activeMatchesTarget(), this deliberately does NOT accept a filename/basename:
+ * a successful open of `workflows/a/foo.json` cannot safely adopt the UUID of
+ * an active `workflows/b/foo.json`.  The panel's saved workflow routing key is
+ * `wf:<canonical path>`, which is the only pathless fallback that is still an
+ * exact identity.
+ */
+function activeMatchesOpenRefreshTarget(active: unknown, path: string): boolean {
+  const targetIdentity = canonicalRequestedSavedIdentity(path);
+  return !!targetIdentity && canonicalSavedRecordIdentity(active) === targetIdentity;
+}
+
+/** Normalizes only syntax the panel's saved-path/routing identity normalizes. */
+function canonicalSavedWorkflowPath(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  const normalized = value.replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+/g, "/");
+  // `tmp:<uuid>` is a per-tab ephemeral routing handle, never a saved workflow
+  // path. `wf:<path>` is likewise a routing token, not a path; accepting either
+  // here could manufacture `wf:tmp:…` and refresh a durable command fence.
+  if (!normalized || /^(?:tmp:|wf:)/i.test(normalized)) return null;
+  return normalized;
+}
+
 interface OpenVerifyTiming {
   /** Total wall-clock budget to confirm the target became active. */
   budgetMs: number;
@@ -1275,8 +1299,74 @@ function getOpenVerifyTiming(): OpenVerifyTiming {
 interface OpenVerifyResult {
   receipt: "applied" | "not_applied" | "unknown" | "unsupported" | "missing";
   error?: string;
+  /**
+   * #716 — only populated when this exact open receipt is applied AND the
+   * currently-active workflow still matches its resolved target.  A late receipt
+   * for an older open must never refresh the command fence for a newer canvas.
+   */
+  workflowUuid?: string;
   waited_ms: number;
   attempts: number;
+}
+
+// Strict canonical RFC UUID for a command-fence refresh: lowercase only, an
+// assigned RFC version, and the RFC variant. Do not normalize this transport
+// value — an uppercase or malformed producer value must leave the prior fence.
+// Keep this check at the command-response boundary: a missing, malformed, or
+// old-panel response must leave the existing command fence intact, never turn
+// a graph mutation into an unstamped send.
+const WORKFLOW_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function responseWorkflowUuid(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = (value as { workflow_uuid?: unknown }).workflow_uuid;
+  if (typeof raw !== "string") return undefined;
+  return WORKFLOW_UUID_RE.test(raw) ? raw : undefined;
+}
+
+/** Refresh only the bridge-owned command stamp, never caller data. */
+function refreshWorkflowUuid(ctx: PanelToolCtx, value: unknown): boolean {
+  const uuid = responseWorkflowUuid(value);
+  const refresh = (ctx.bridge as unknown as { refreshWorkflowUuid?: unknown }).refreshWorkflowUuid;
+  return uuid && typeof refresh === "function" ? refresh.call(ctx.bridge, ctx.tabId, uuid) : false;
+}
+
+/**
+ * A successful open reply belongs to that exact bridge request, but another
+ * navigation may have completed before the caller receives it. Re-read the
+ * active object and accept the returned UUID only while it still names this
+ * open's canonical target; otherwise leave the old stamp to fail closed.
+ */
+async function refreshOpenWorkflowUuid(
+  ctx: PanelToolCtx,
+  requestedPath: string,
+  openResult: ToolResult,
+): Promise<void> {
+  const parsedOpen = parseToolResultJson(openResult);
+  const opened = parsedOpen?.opened;
+  const openedPath =
+    opened && typeof opened === "object" && typeof (opened as { path?: unknown }).path === "string"
+      ? (opened as { path: string }).path
+      : undefined;
+  // The caller's original token is the fence target. A panel can resolve an
+  // alias/basename to a path, but that reply must never retroactively turn the
+  // alias into a UUID-refresh authorization. Require the reply to corroborate
+  // the original exact saved identity before consulting the live active record.
+  const requestedIdentity = canonicalRequestedSavedIdentity(requestedPath);
+  const openedIdentity = openedPath
+    ? canonicalSavedRecordIdentity({ path: openedPath, routing_key: parsedOpen?.routing_key })
+    : null;
+  if (!requestedIdentity || requestedIdentity !== openedIdentity) return;
+  try {
+    const list = parseToolResultJson(await ctx.call({ cmd: "workflow_list" }, 6000));
+    if (!list || !activeMatchesOpenRefreshTarget(list.active, requestedPath)) return;
+    // Prefer the just-read active UUID; use the command's correlated response as
+    // a compatibility fallback only after that same active-target confirmation.
+    refreshWorkflowUuid(ctx, list.active) || refreshWorkflowUuid(ctx, parseToolResultJson(openResult));
+  } catch {
+    // A failed read must not convert a confirmed open into a failure, nor should
+    // it clear the old stamp. The next mutation remains safely fenced.
+  }
 }
 
 /** Exact resolved-path check for an open receipt. A filename/basename is not a
@@ -1329,7 +1419,27 @@ async function waitForOpenReceipt(
             return { receipt: "unknown", waited_ms: Date.now() - start, attempts };
           }
           if (receipt.applied === true) {
-            return { receipt: "applied", waited_ms: Date.now() - start, attempts };
+            // A receipt proves this open applied, but a later user switch could
+            // have made another canvas active before this probe.  Refresh only
+            // when the current active object still names this exact target.
+            const active = parsed.active;
+            const resolved = receipt.resolved as Record<string, unknown>;
+            const resolvedPath = resolved.path as string;
+            // The receipt has already proved the command's exact resolved path.
+            // Still require its routing claim and the live active record to
+            // corroborate the ORIGINAL request identity before refreshing.
+            const requestedIdentity = canonicalRequestedSavedIdentity(path);
+            const resolvedIdentity = canonicalSavedRecordIdentity({
+              path: resolvedPath,
+              routing_key: resolved.routing_key,
+            });
+            const workflowUuid =
+              requestedIdentity &&
+              requestedIdentity === resolvedIdentity &&
+              activeMatchesOpenRefreshTarget(active, path)
+              ? responseWorkflowUuid(active)
+              : undefined;
+            return { receipt: "applied", workflowUuid, waited_ms: Date.now() - start, attempts };
           }
           if (receipt.applied === false) {
             return {
@@ -1392,7 +1502,13 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
   // caller must see it as-is. A slow-ack TIMEOUT or a mid-command reconnect DROP
   // ("OUTCOME UNKNOWN", #402) both warrant a receipt lookup, which can turn an
   // unknown outcome into a definite one without inferring from active state.
-  if (!isAckTimeout(res) && !isReconnectDrop(res)) return res;
+  if (!isAckTimeout(res) && !isReconnectDrop(res)) {
+    // #716 — re-read the active record after this exact successful open before
+    // refreshing the next command's stamp. This prevents a late reply from an
+    // earlier open from overwriting the fence after another tab became active.
+    if (!res.isError) await refreshOpenWorkflowUuid(ctx, path, res);
+    return res;
+  }
 
   if (!dispatchedRid) {
     return fail(
@@ -1404,6 +1520,7 @@ async function openWorkflowWithVerify(path: string, ctx: PanelToolCtx): Promise<
   const timing = getOpenVerifyTiming();
   const verify = await waitForOpenReceipt(ctx, path, dispatchedRid, timing);
   if (verify.receipt === "applied") {
+    if (verify.workflowUuid) refreshWorkflowUuid(ctx, { workflow_uuid: verify.workflowUuid });
     return ok({
       opened: { path },
       recovered: true,
@@ -1476,6 +1593,8 @@ interface ResolvedOpenWorkflow {
   isActive?: boolean;
   /** Human label for the workflow currently active (for a clear pin-time error). */
   activeLabel?: string;
+  /** UUID from the same authoritative active workflow_list record, if valid. */
+  workflowUuid?: string;
 }
 
 /**
@@ -1531,11 +1650,33 @@ async function resolveOpenWorkflow(
   }
 
   if (rec) {
-    return { record: rec, isActive: computeIsActive(rec, activeObj), activeLabel };
+    const isActive = computeIsActive(rec, activeObj);
+    // Only the top-level active object is the panel's direct current-canvas
+    // report. An affirmatively-active per-record flag alone remains sufficient
+    // to route a legacy pin, but is NOT enough to replace a command identity:
+    // a stale/mixed list can say `rec.active:true` for A while top-level active
+    // (and its UUID) is B. Refresh only when both expose the same exact saved
+    // path/routing identity; aliases and routing tokens are deliberately
+    // irrelevant. The caller-path check happens in resolvePinTarget(), where
+    // the refreshed value is handed to the bridge-owned command fence.
+    const workflowUuid =
+      isActive === true &&
+      activeRecordMatchesExactSavedIdentity(rec, activeObj)
+        ? responseWorkflowUuid(activeObj)
+        : undefined;
+    return { record: rec, isActive, activeLabel, workflowUuid };
   }
   // The active object is authoritative too, in case it isn't mirrored in the array.
   if (activeMatchesTarget(activeObj, path)) {
-    return { record: activeObj as OpenWorkflowRecord, isActive: true, activeLabel };
+    return {
+      record: activeObj as OpenWorkflowRecord,
+      isActive: true,
+      activeLabel,
+      // The top-level active object was not corroborated by a selected entry in
+      // workflow_list. It may remain a compatibility-valid pin selector, but it
+      // is never a safe source for replacing a command fence.
+      workflowUuid: undefined,
+    };
   }
   return NOT_OPEN;
 }
@@ -1583,6 +1724,53 @@ function identityVerdict(rec: OpenWorkflowRecord, activeObj: unknown): boolean |
   return comparable ? false : undefined;
 }
 
+/**
+ * Exact saved-workflow identity required before an active-list UUID can refresh
+ * a command fence. `activeMatchesTarget()` and an item's `active:true` are
+ * intentionally alias/compatibility-friendly for pin resolution; neither can
+ * prove that the record carrying the pin and top-level `active` name the same
+ * saved canvas. Reject contradictory path/routing pairs and never fall back to
+ * filename, basename, or key aliases here.
+ */
+function activeRecordMatchesExactSavedIdentity(rec: OpenWorkflowRecord, activeObj: unknown): boolean {
+  if (!activeObj || typeof activeObj !== "object") return false;
+  const recordIdentity = canonicalSavedRecordIdentity(rec);
+  const activeIdentity = canonicalSavedRecordIdentity(activeObj);
+  return !!recordIdentity && recordIdentity === activeIdentity;
+}
+
+/** Canonical `wf:<path>` identity for a caller's literal saved-workflow path. */
+function canonicalRequestedSavedIdentity(path: unknown): string | null {
+  const canonicalPath = canonicalSavedWorkflowPath(path);
+  // A bare basename is an alias selector, not the canonical saved path the
+  // command fence must bind. It may still resolve a legacy pin, but must never
+  // authorize replacing its existing UUID stamp.
+  return canonicalPath && canonicalPath.includes("/") ? `wf:${canonicalPath}` : null;
+}
+
+/**
+ * Canonical `wf:<path>` identity, but only for a complete corroborating record.
+ * Command-fence replacement is stricter than pin routing: a same-path record
+ * with a missing/malformed route may be partial or replayed, and must not let a
+ * new UUID replace the existing fail-closed stamp.
+ */
+function canonicalSavedRecordIdentity(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as { path?: unknown; routing_key?: unknown };
+  const path = canonicalSavedWorkflowPath(record.path);
+  const routing = canonicalSavedWorkflowRoutingIdentity(record.routing_key);
+  // Both fields must be present and corroborate. A mixed, partial, or replayed
+  // snapshot is not a safe source of a command-fence replacement.
+  if (!path || !routing || routing !== `wf:${path}`) return null;
+  return routing;
+}
+
+function canonicalSavedWorkflowRoutingIdentity(value: unknown): string | null {
+  if (typeof value !== "string" || !value.startsWith("wf:")) return null;
+  const path = canonicalSavedWorkflowPath(value.slice(3));
+  return path ? `wf:${path}` : null;
+}
+
 /** Stable-identity match (positive only) — used to prefer the active record among matches. */
 function recMatchesActive(rec: OpenWorkflowRecord, activeObj: unknown): boolean {
   return identityVerdict(rec, activeObj) === true;
@@ -1600,7 +1788,7 @@ function workflowRecordLabel(rec: unknown): string | undefined {
 
 /** Outcome of validating + canonicalizing a pin target. */
 export type PinTargetResolution =
-  | { ok: true; pinPath: string; pinFilename?: string }
+  | { ok: true; pinPath: string; pinFilename?: string; workflowUuid?: string }
   | { ok: false; error: string };
 
 /**
@@ -1647,10 +1835,21 @@ export async function resolvePinTarget(
   if (resolved) {
     // Canonicalize to the stable key so routing survives rename/reconnect.
     const rec = resolved.record;
+    // `resolveOpenWorkflow()` establishes whether rec and top-level active are
+    // exact two-field peers. That is still insufficient to replace a command
+    // fence when the caller supplied a basename/key/routing alias: retain the
+    // legacy pin resolution, but adopt its UUID only for the caller's own exact
+    // canonical saved path.
+    const callerIdentity = canonicalRequestedSavedIdentity(path);
+    const workflowUuid =
+      callerIdentity && callerIdentity === canonicalSavedRecordIdentity(rec)
+        ? resolved.workflowUuid
+        : undefined;
     return {
       ok: true,
       pinPath: rec.key ?? rec.path ?? path,
       pinFilename: filename ?? rec.filename ?? rec.path,
+      workflowUuid,
     };
   }
   // Indeterminate list — stay lenient (older/partial panel).
@@ -1664,6 +1863,8 @@ export const __openWorkflowTestHooks = {
   },
   isAckTimeout,
   activeMatchesTarget,
+  activeMatchesOpenRefreshTarget,
+  activeRecordMatchesExactSavedIdentity,
   resolveOpenWorkflow,
 };
 
@@ -4700,17 +4901,26 @@ export function buildPanelToolDefs(): PanelToolDef[] {
         // so both entry points validate identically.
         let pinPath = path;
         let pinFilename = filename;
+        let pinnedWorkflowUuid: string | undefined;
         if (mode === "pinned" && path) {
           const res = await resolvePinTarget(ctx, path, filename);
           if (!res.ok) return fail(res.error);
           pinPath = res.pinPath;
           pinFilename = res.pinFilename;
+          pinnedWorkflowUuid = res.workflowUuid;
         }
         const target = ctx.workflowTarget.set(ctx.tabId, {
           mode,
           path: pinPath,
           filename: pinFilename,
         });
+        // #716 — a successful, positively-active re-pin is an explicit recovery
+        // boundary after reconnect/open. Its UUID came from the same fresh
+        // workflow_list result that validated the pin. Missing, malformed, or
+        // indeterminate values leave the old command stamp intact (fail closed).
+        if (mode === "pinned" && pinnedWorkflowUuid) {
+          refreshWorkflowUuid(ctx, { workflow_uuid: pinnedWorkflowUuid });
+        }
         ctx.bridge.push({ type: "workflow_target", target }, ctx.tabId);
         const hint =
           target.mode === "pinned"

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -683,6 +683,13 @@ export class UiBridge {
    *  to (the generation-bound-command leak: the server can't retract a frame already
    *  delivered to the browser, but the browser can decline to APPLY a stale one). */
   private resolveTabWorkflowUuid: ((tabId: string) => string | undefined) | null = null;
+  /**
+   * #716 — an explicit workflow navigation can establish a newer command-stamp
+   * identity before the panel's next hello.  The orchestrator owns the value and
+   * validates it against the server-observed origin; the bridge merely gives a
+   * successful tab-bound command a narrow way to ask for that refresh.
+   */
+  private refreshTabWorkflowUuid: ((tabId: string, workflowUuid: string) => boolean) | null = null;
   /** #570 P0a — records the mirror subscribers/viewers a same-socket re-hello OPTIMISTICALLY
    *  moved from the retiring id to the new id, keyed by the RETIRING (from) id. The move
    *  happens BEFORE the orchestrator can classify the switch as proven/unproven; if it turns
@@ -2300,8 +2307,22 @@ export class UiBridge {
 
   /** #570 — inject the tabId → trusted workflow uuid resolver (tabStableIdentity lives in
    *  the orchestrator). Enables the per-command workflow-instance stamp/fence. */
-  setTabWorkflowUuidResolver(fn: (tabId: string) => string | undefined): void {
+  setTabWorkflowUuidResolver(
+    fn: (tabId: string) => string | undefined,
+    refresh?: (tabId: string, workflowUuid: string) => boolean,
+  ): void {
     this.resolveTabWorkflowUuid = fn;
+    this.refreshTabWorkflowUuid = refresh ?? null;
+  }
+
+  /**
+   * #716 — accept a command-stamp refresh only through the orchestrator's
+   * validator.  A panel-tool response is not allowed to write bridge state
+   * directly; missing/invalid values simply leave the existing fail-closed
+   * stamp in place.
+   */
+  refreshWorkflowUuid(tabId: string, workflowUuid: string): boolean {
+    return this.refreshTabWorkflowUuid?.(tabId, workflowUuid) ?? false;
   }
 
   /** The open DESKTOP tabs (non-headless primaries) for the mobile mirror picker. */


### PR DESCRIPTION
Closes #716.\n\nLockstep companion: comfyui-mcp-panel PR updates workflow_open and workflow_list.active to report the live workflow UUID.\n\nThe MCP keeps hello/session ownership separate from the command fence stamp. It refreshes only from a strict UUID proven to be the current active target after open or pin; missing, malformed, stale, or non-active results leave the existing fence intact.\n\nTests: npm.cmd test (232 files, 3836 passed, 2 skipped); npm.cmd run lint; npm.cmd run build.