### PR TITLE
fix(bridge): require at-write workflow fencing (#718)

### DIFF
--- a/src/__tests__/services/panel-sync.test.ts
+++ b/src/__tests__/services/panel-sync.test.ts
@@ -38,7 +38,7 @@ import {
 import type { PanelPinState } from "../../services/panel-settings.js";
 import { BRIDGE_CAPABILITY_MIN_PANEL_VERSION } from "../../services/ui-bridge.js";
 
-const REQUIRED = "0.11.30";
+const REQUIRED = "0.11.35";
 const ORCH = "0.48.32";
 const UNPINNED: PanelPinState = { pinned: false, source: "none" };
 
@@ -69,7 +69,8 @@ describe("requiredPanelVersion", () => {
     // A capability gate is just as much a version requirement as a command
     // gate: otherwise install_panel can call the panel current while the bridge
     // refuses every active-workflow write (#708).
-    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp).toBe(REQUIRED);
+    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp).toBe("0.11.30");
+    expect(BRIDGE_CAPABILITY_MIN_PANEL_VERSION.enforces_workflow_stamp_at_write).toBe(REQUIRED);
     expect(requiredPanelVersion()).toBe(REQUIRED);
   });
 
@@ -377,7 +378,7 @@ describe("performPanelSync", () => {
     const h = makeDeps({
       installedVersion: "0.11.3",
       onUpdate: (files) => {
-        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
       },
     });
     const r = await performPanelSync({ deps: h.deps, ...RUN });
@@ -385,7 +386,7 @@ describe("performPanelSync", () => {
     expect(r.synced).toBe(true);
     expect(r.previousVersion).toBe("0.11.3");
     // The reported version is the one observed on disk afterwards.
-    expect(r.verifiedVersion).toBe("0.11.30");
+    expect(r.verifiedVersion).toBe(REQUIRED);
     expect(r.restartRequired).toBe(true);
     expect(r.stillBehind).toBe(false);
   });
@@ -396,7 +397,7 @@ describe("performPanelSync", () => {
       pin: { pinned: true, version: "0.11.3", source: "settings" },
       onUpdate: (files) => {
         // If this ever runs the guard has failed.
-        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
       },
     });
     const r = await performPanelSync({ deps: h.deps, ...RUN });
@@ -414,7 +415,7 @@ describe("performPanelSync", () => {
         installedVersion: "0.11.3",
         pin,
         onUpdate: (files) => {
-          files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+          files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
         },
       });
 
@@ -426,7 +427,7 @@ describe("performPanelSync", () => {
     const r = await performPanelSync({ deps: cleared.deps, ...RUN });
     expect(r.synced).toBe(true);
     expect(cleared.updates).toBe(1);
-    expect(r.verifiedVersion).toBe("0.11.30");
+    expect(r.verifiedVersion).toBe(REQUIRED);
   });
 
   it("no-ops without touching anything when already current", async () => {
@@ -546,7 +547,7 @@ describe("performPanelSync", () => {
     const scenario = () => ({
       installedVersion: "0.11.3",
       onUpdate: (files: Record<string, string>) => {
-        files[join(PANEL_DIR, "pyproject.toml")] = pyproject("0.11.30");
+        files[join(PANEL_DIR, "pyproject.toml")] = pyproject(REQUIRED);
       },
     });
 

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -98,10 +98,17 @@ function connectPanel(tabId?: string, title = "workflow-a"): Promise<WebSocket> 
     const sock = new WebSocket(`ws://127.0.0.1:${port}`);
     sock.on("open", () => {
       if (tabId) {
-        // Current panels advertise stamp enforcement, so a mutating graph command is not gated
-        // (#570 P0c). Tests exercising the OLD-panel gate hello WITHOUT this flag explicitly.
+        // Current panels advertise both the dispatch and after-await write-boundary
+        // workflow-stamp checks, so a mutating graph command is not gated (#570/#718).
+        // Tests exercising an old-panel gate omit one of these flags explicitly.
         sock.send(
-          JSON.stringify({ type: "hello", tab_id: tabId, title, enforces_workflow_stamp: true }),
+          JSON.stringify({
+            type: "hello",
+            tab_id: tabId,
+            title,
+            enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
+          }),
         );
       }
       resolve(sock);
@@ -1321,7 +1328,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     expect(frames.find((f) => f.cmd === "graph_add_node")?.workflow_uuid).toBe("uuid-A");
 
     // Same socket switches to workflow B (migration alias tmp:A → tmp:B).
-    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B", enforces_workflow_stamp: true }));
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:B", title: "B", enforces_workflow_stamp: true, enforces_workflow_stamp_at_write: true }));
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:B")).toBe(true));
 
     // A late command still ISSUED FOR A (its agent's tab id) must stamp A's uuid — even though
@@ -1449,7 +1456,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     });
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:sA")).toBe(true));
     // Same-socket switch to a different workflow.
-    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:sB", title: "B", enforces_workflow_stamp: true }));
+    desktop.send(JSON.stringify({ type: "hello", tab_id: "tmp:sB", title: "B", enforces_workflow_stamp: true, enforces_workflow_stamp_at_write: true }));
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:sB")).toBe(true));
     // A late command issued for A resolves onto B's socket — with no trusted uuid it is refused,
     // never written unstamped to B.
@@ -1476,6 +1483,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         tab_id: "tmp:capable",
         title: "no-stamp",
         enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
       }),
     );
     await vi.waitFor(() => expect(bridge.tabCanMutateGraph("tmp:capable")).toBe(false));
@@ -1501,6 +1509,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
         tab_id: "wf:shared.json",
         title: "shared",
         enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
         tab_session_id: "browser-tab-original",
       }),
     );
@@ -1518,6 +1527,7 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
             tab_id: "wf:shared.json",
             title: "same saved workflow, different browser tab",
             enforces_workflow_stamp: true,
+            enforces_workflow_stamp_at_write: true,
             tab_session_id: "browser-tab-other",
           }),
         );
@@ -1597,7 +1607,36 @@ describe("UiBridge — desktop-tab mirror (multi-viewer fanout)", () => {
     await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "old-skew")).toBe(true));
     await expect(
       bridge.send({ cmd: "graph_add_node", node: "x" } as never, { tabId: "old-skew" }),
-    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.30\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
+    ).rejects.toThrow(/detected panel 0\.11\.0.*requires panel 0\.11\.35\+.*install_panel\(action:'update'\).*restart ComfyUI.*rebinding cannot/i);
+    old.close();
+  });
+
+  it("FAILS CLOSED when a panel has only the pre-await stamp fence (#718)", async () => {
+    const old = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((res, rej) => {
+      old.on("open", () => {
+        // 0.11.34 and earlier advertise the original dispatch-time fence, but
+        // graph_set_widget can await fresh metadata and write after a user switch.
+        old.send(
+          JSON.stringify({
+            type: "hello",
+            tab_id: "tmp:pre-write-fence",
+            title: "old widget fence",
+            panel_version: "0.11.34",
+            enforces_workflow_stamp: true,
+          }),
+        );
+        res();
+      });
+      old.on("error", rej);
+    });
+    await vi.waitFor(() => expect(bridge.tabs().some((t) => t.tab_id === "tmp:pre-write-fence")).toBe(true));
+    expect(bridge.tabCanMutateGraph("tmp:pre-write-fence")).toBe(false);
+    await expect(
+      bridge.send({ cmd: "graph_set_widget", node_id: 7, widget: "steps", value: 30 } as never, {
+        tabId: "tmp:pre-write-fence",
+      }),
+    ).rejects.toThrow(/does not recheck workflow targeting at the graph write boundary.*0\.11\.35.*hard-refresh/i);
     old.close();
   });
 
@@ -2249,6 +2288,7 @@ describe("UiBridge.send (graceful gate end-to-end)", () => {
         title: "wf",
         panel_version: "0.6.8",
         enforces_workflow_stamp: true,
+        enforces_workflow_stamp_at_write: true,
       }),
     );
     sock.on("message", (buf) => {

--- a/src/services/ui-bridge.ts
+++ b/src/services/ui-bridge.ts
@@ -144,6 +144,12 @@ interface Conn {
    *  workflow B) crossing no privacy boundary, so attestation would buy nothing — #570's real
    *  threat is ACCIDENTAL cross-workflow confusion for an honest user, which this closes. */
   enforcesWorkflowStamp: boolean;
+  /** True only when THIS hello advertises that the workflow stamp is checked at
+   * the actual mutation boundary after an async graph executor resumes (#718).
+   * The original dispatch-time fence alone is insufficient for graph_set_widget:
+   * its required fresh-backend query yields to the browser, allowing a workflow
+   * switch before it writes. Re-read per hello and fail closed if absent. */
+  enforcesWorkflowStampAtWrite: boolean;
   /** Commands THIS connection has already proven it doesn't support, via a real
    *  "Unknown command" reply earlier in the session (#236). Once a cmd lands
    *  here, every later call is gated proactively — rejected before it ever
@@ -234,11 +240,13 @@ export const BRIDGE_CMD_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
  * that same panel current (#708).
  */
 export const BRIDGE_CAPABILITY_MIN_PANEL_VERSION: Readonly<Record<string, string>> = {
-  // #570 P0c — `enforces_workflow_stamp` first shipped in panel 0.11.30. A
-  // 0.11.29-or-older panel ignores a stamped active-workflow mutation, so the
-  // server must refuse that write rather than risk applying it after a tab
-  // switch.  It is a handshake capability, not a command, hence this table.
+  // #570 P0c — `enforces_workflow_stamp` first shipped in panel 0.11.30. #718
+  // added the required after-await write-boundary recheck in 0.11.35: a panel
+  // that only fences before graph_set_widget's fresh /object_info await can
+  // still mutate a workflow the user switched to during that await. Both are
+  // handshake capabilities, not commands, hence this table.
   enforces_workflow_stamp: "0.11.30",
+  enforces_workflow_stamp_at_write: "0.11.35",
 };
 
 /** The minimum panel version that supports `cmd`. For a command WITH an
@@ -1197,6 +1205,8 @@ export class UiBridge {
           // updated build). Strict === true so any non-true / absent value is non-enforcing.
           enforcesWorkflowStamp:
             (msg as { enforces_workflow_stamp?: unknown }).enforces_workflow_stamp === true,
+          enforcesWorkflowStampAtWrite:
+            (msg as { enforces_workflow_stamp_at_write?: unknown }).enforces_workflow_stamp_at_write === true,
           // Fresh per hello — see the field's doc comment (#236).
           unsupportedCmds: new Set<string>(),
           // INHERITED across a reconnect (the panel code did not get older) so a command
@@ -1480,8 +1490,9 @@ export class UiBridge {
   /**
    * Whether the live tab resolved for `tabId` can safely accept a mutation of
    * its active workflow. This mirrors the two pre-dispatch conditions in
-   * {@link send}: the tab's CURRENT hello must advertise workflow-stamp
-   * enforcement, and the orchestrator must have a trusted workflow stamp to
+   * {@link send}: the tab's CURRENT hello must advertise both the dispatch-time
+   * workflow-stamp fence and its after-await write-boundary recheck, and the
+   * orchestrator must have a trusted workflow stamp to
    * put on the command. A websocket reconnect alone proves neither (the browser
    * can reconnect with a cached, pre-#570 panel bundle), so callers reporting
    * graph-tool readiness must use this rather than `canReach` alone.
@@ -1497,6 +1508,7 @@ export class UiBridge {
       return (
         conn.sock.readyState === WebSocket.OPEN &&
         conn.enforcesWorkflowStamp &&
+        conn.enforcesWorkflowStampAtWrite &&
         typeof stamp === "string" &&
         stamp.length > 0
       );
@@ -1983,8 +1995,9 @@ export class UiBridge {
     // serialize, …) and path-targeted workflow ops stay allowed, so an old panel keeps
     // read-only graph access with a clear "update to edit" error, never a silent wrong write.
     //
-    // Require BOTH (codex): the panel must advertise enforcement AND the command must actually
-    // CARRY a trusted workflow-uuid stamp. Enforcement alone is not enough — if the tab has no
+    // Require ALL THREE (codex): the panel must advertise the dispatch-time fence, the
+    // after-await write-boundary recheck, AND the command must actually CARRY a trusted
+    // workflow-uuid stamp. Either fence alone is not enough — if the tab has no
     // resolvable identity (missing/malformed uuid, relay client), the frame ships UNSTAMPED and
     // the panel's fence has nothing to compare, so a stale mutation after a switch would run
     // unfenced despite the "enforces" claim. No stamp ⇒ nothing to fence ⇒ refuse the mutation.
@@ -1997,12 +2010,17 @@ export class UiBridge {
     if (requiresWorkflowStampEnforcement(cmd)) {
       const stamp = this.resolveTabWorkflowUuid?.(opts.tabId ?? conn.tabId);
       const hasTrustedStamp = typeof stamp === "string" && stamp.length > 0;
-      if (!conn.enforcesWorkflowStamp || !hasTrustedStamp) {
+      if (!conn.enforcesWorkflowStamp || !conn.enforcesWorkflowStampAtWrite || !hasTrustedStamp) {
         const why = !conn.enforcesWorkflowStamp
           ? `panel tab ${conn.tabId.slice(0, 8)} does not enforce per-command workflow targeting ` +
             `(detected panel ${conn.panelVersion ?? "version unknown"}; this MCP requires panel ` +
               `${requiredPanelVersion()}+). Run install_panel(action:'update') and restart ComfyUI; ` +
               `rebinding cannot add the missing capability`
+          : !conn.enforcesWorkflowStampAtWrite
+            ? `panel tab ${conn.tabId.slice(0, 8)} does not recheck workflow targeting at the graph write ` +
+              `boundary after asynchronous work (detected panel ${conn.panelVersion ?? "version unknown"}; this MCP ` +
+                `requires panel ${requiredPanelVersion()}+). Run install_panel(action:'update'), restart ComfyUI, ` +
+                `then hard-refresh the ComfyUI browser tab; rebinding cannot add the missing capability`
           : `this workflow has no trusted identity for the panel to fence the command against`;
         return Promise.reject(
           markDispatched(


### PR DESCRIPTION
Closes #718.\n\nCompanion panel draft: artokun/comfyui-mcp-panel#555.\n\n- Requires the new per-hello enforces_workflow_stamp_at_write capability for active graph mutations and readiness.\n- Keeps pre-0.11.35 browser bundles fail-closed with update/restart/hard-refresh guidance.\n- Tests both the older capability and the required capability floor.\n\nLockstep dependency: do not merge/release until the panel companion is published at 0.11.35 and this draft's correctness review/CI are green.