### PR TITLE
fix(#711): restart_comfyui resolves install dir before spawn (no more main.py ENOENT)

### DIFF
--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -191,12 +191,16 @@ describe("process-control startup readiness", () => {
       ["C:\\ComfyUI\\main.py", "--port", "8188"],
       expect.objectContaining({
         detached: true,
-        cwd: "/fake/ComfyUI",
         shell: false,
         stdio: "ignore",
         windowsHide: true,
       }),
     );
+    // The spawn cwd is the ABSOLUTE anchor the script resolved against (#711):
+    // the live script's own install dir when the host parses the Windows argv
+    // path (win32), otherwise the configured install dir (POSIX fallback).
+    const spawnOpts = mockSpawn.mock.calls[0][2] as { cwd?: string };
+    expect(["C:\\ComfyUI", "/fake/ComfyUI"]).toContain(spawnOpts.cwd);
     expect(children[0].unref).toHaveBeenCalled();
   });
 
@@ -249,6 +253,25 @@ describe("process-control startup readiness", () => {
       [join("/fake/ComfyUI", "main.py"), "--port", "8188"],
       expect.objectContaining({ cwd: "/fake/ComfyUI", shell: false }),
     );
+  });
+
+  it("omits the spawn cwd when COMFYUI_PATH points at a nonexistent dir (#711)", async () => {
+    // A stale/nonexistent COMFYUI_PATH passed as the spawn cwd would ENOENT the
+    // relaunch. The fallback must omit cwd instead — the child then inherits
+    // this process's (existing) working directory.
+    mockConfig.comfyuiPath = "/stale/missing/ComfyUI";
+    mockExistsSync.mockImplementation(() => false);
+    setLaunchInfo();
+    mockSpawnedChildren();
+    mockNoPortProcess();
+    mockFetchOk(true);
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const opts = mockSpawn.mock.calls[0][2] as { cwd?: string };
+    expect(opts.cwd).toBeUndefined();
   });
 
   it("reports timeout instead of ready when bounded probes never succeed", async () => {

--- a/src/__tests__/services/process-control.test.ts
+++ b/src/__tests__/services/process-control.test.ts
@@ -31,8 +31,14 @@ vi.mock("node:child_process", () => ({
 // exist on disk. Default: everything exists; a test overrides for the stale-path
 // case.
 const mockExistsSync = vi.hoisted(() => vi.fn((_p: string) => true));
+// statSync drives the spawn-cwd DIRECTORY proof (codex gate: an existing
+// regular FILE at COMFYUI_PATH must not become the cwd). Default: a directory.
+const mockStatSync = vi.hoisted(() =>
+  vi.fn((_p: string) => ({ isDirectory: () => true })),
+);
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
+  statSync: mockStatSync,
 }));
 
 vi.mock("../../comfyui/client.js", () => ({
@@ -118,6 +124,7 @@ beforeEach(() => {
   mockConfig.comfyuiPath = "/fake/ComfyUI";
   mockFindComfyuiPython.mockReturnValue("/fake/ComfyUI/python_embeded/python.exe");
   mockExistsSync.mockImplementation(() => true);
+  mockStatSync.mockImplementation(() => ({ isDirectory: () => true }));
   __processControlTestHooks.reset();
 });
 
@@ -261,6 +268,28 @@ describe("process-control startup readiness", () => {
     // this process's (existing) working directory.
     mockConfig.comfyuiPath = "/stale/missing/ComfyUI";
     mockExistsSync.mockImplementation(() => false);
+    mockStatSync.mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory");
+    });
+    setLaunchInfo();
+    mockSpawnedChildren();
+    mockNoPortProcess();
+    mockFetchOk(true);
+
+    const result = await startComfyUI();
+
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const opts = mockSpawn.mock.calls[0][2] as { cwd?: string };
+    expect(opts.cwd).toBeUndefined();
+  });
+
+  it("omits the spawn cwd when COMFYUI_PATH resolves to a regular FILE (codex gate)", async () => {
+    // An existing-but-not-a-directory COMFYUI_PATH passed as the spawn cwd
+    // fails ENOTDIR after the server was already stopped — the same
+    // lost-server failure class as #711. The fallback must omit cwd.
+    mockConfig.comfyuiPath = "/fake/ComfyUI/main.py";
+    mockStatSync.mockImplementation(() => ({ isDirectory: () => false }));
     setLaunchInfo();
     mockSpawnedChildren();
     mockNoPortProcess();

--- a/src/__tests__/services/restart-live-first.test.ts
+++ b/src/__tests__/services/restart-live-first.test.ts
@@ -12,7 +12,7 @@
 // client, and global fetch. No real process/port/network/filesystem is touched.
 
 import { EventEmitter } from "node:events";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 class FakeChild extends EventEmitter {
@@ -429,6 +429,106 @@ describe("restart_comfyui — live-first script resolution (#476, #426)", () => 
     expect(
       mockExecSync.mock.calls.some(([c]) => /taskkill/i.test(String(c))),
     ).toBe(false);
+
+    killSpy.mockRestore();
+  });
+});
+
+describe("restart_comfyui — explicit absolute spawn cwd, truthful refusal (#711)", () => {
+  it("spawns with the resolved install dir as an EXPLICIT absolute cwd when COMFYUI_PATH is unset", async () => {
+    // #711: the relaunch must not depend on a wrong/undefined working directory.
+    // COMFYUI_PATH is unset; the canonical absolute install comes from the saved
+    // default workspace (mockResolveBase). The spawn must run FROM that absolute
+    // install dir — previously cwd was left undefined and inherited whatever
+    // directory the MCP server happened to run in.
+    expect(isAbsolute(BASE)).toBe(true); // the anchor the test resolves against
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [exe, args, opts] = mockSpawn.mock.calls[0];
+    expect(exe).toBe(ABS_PYTHON);
+    expect(args[0]).toBe(ABS_MAIN);
+    expect((opts as { cwd?: string }).cwd).toBe(BASE);
+
+    killSpy.mockRestore();
+  });
+
+  it("never spawns from a stale COMFYUI_PATH when the script anchored elsewhere — the anchor is the cwd", async () => {
+    // #711's residual ENOENT shape: COMFYUI_PATH points at a stale/nonexistent
+    // dir while the RUNNING server's script resolves against a DIFFERENT,
+    // existing install. Spawning with the stale dir as cwd would ENOENT after
+    // the server was already killed; the anchor must win as the spawn cwd.
+    const STALE_BASE = resolve("stale_missing_install");
+    const LIVE_BASE = resolve("proc", "live_comfy");
+    const LIVE_MAIN = join(LIVE_BASE, "main.py");
+    const LIVE_PY = join(LIVE_BASE, "venv", "bin", "python");
+    mockConfig.comfyuiPath = STALE_BASE;
+    mockResolveBase.mockReturnValue(STALE_BASE); // config.comfyuiPath is base input #1
+    mockLiveRootFromArgv.mockReturnValue(LIVE_BASE); // live server's own argv root
+    mockFindComfyuiPython.mockReturnValue(LIVE_PY);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: [LIVE_MAIN, "--port", "8188"] },
+    });
+    // The LIVE install exists on disk; the stale COMFYUI_PATH does not.
+    mockExistsSync.mockImplementation((p: string) => {
+      const s = String(p);
+      return s === LIVE_MAIN || s === LIVE_PY;
+    });
+    mockLivePortThenFree();
+    mockSpawn.mockImplementation(() => new FakeChild());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true }) as Response),
+    );
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.message).not.toMatch(/refusing to restart/i);
+    expect(result.stopped).toBe(true);
+    expect(result.started).toBe(true);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [, args, opts] = mockSpawn.mock.calls[0];
+    expect(args[0]).toBe(LIVE_MAIN);
+    expect((opts as { cwd?: string }).cwd).toBe(LIVE_BASE);
+
+    killSpy.mockRestore();
+  });
+
+  it("REFUSES with a truthful actionable error (never an ENOENT) when no install can be located", async () => {
+    // cwd unset + nothing resolvable: bare relative main.py, no live root, no
+    // live cwd, no canonical base. The refusal must say WHERE to point the fix
+    // (COMFYUI_PATH or a default workspace) — not surface a raw spawn ENOENT —
+    // and the reachable server must be left running.
+    mockResolveBase.mockReturnValue(undefined);
+    mockGetSystemStats.mockResolvedValue({
+      system: { argv: ["main.py", "--port", "8188"] },
+    });
+    mockExistsSync.mockImplementation((p: string) => String(p) === ABS_PYTHON);
+    mockLivePortThenFree();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const result = await restartComfyUI();
+
+    expect(result.stopped).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.message).toMatch(/refusing to restart/i);
+    expect(result.message).toMatch(/could not locate the ComfyUI install/i);
+    expect(result.message).toMatch(/COMFYUI_PATH or a default workspace/i);
+    expect(result.message).not.toMatch(/ENOENT/i);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(killSpy).not.toHaveBeenCalled();
 
     killSpy.mockRestore();
   });

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -505,10 +505,12 @@ function spawnFromProcessInfo(info: ProcessInfo): SpawnedComfyUI | null {
   const child = spawn(cmd.exe, cmd.args, {
     detached: true,
     stdio: "ignore",
-    // Prefer the cwd the command resolved against (the live process cwd for a
-    // relative-script relaunch, #535); only then the configured install dir. A
-    // stale/nonexistent config.comfyuiPath as cwd would ENOENT the spawn.
-    cwd: cmd.cwd ?? config.comfyuiPath ?? undefined,
+    // Prefer the cwd the command resolved against (the live process cwd or the
+    // absolute install anchor for a relaunch, #535/#711); only then the
+    // configured install dir — and only as an ABSOLUTE path that exists on disk.
+    // A stale/relative/nonexistent config.comfyuiPath as cwd would ENOENT the
+    // spawn (#711); omitting cwd inherits this process's (existing) working dir.
+    cwd: cmd.cwd ?? configuredInstallCwd(),
     shell: false,
     windowsHide: true,
   });
@@ -661,10 +663,14 @@ function resolveLaunchCommand(
           : firstUnquoted;
     // When the script was anchored to the LIVE cwd, use that install's OWN python
     // and spawn FROM that cwd — never a stale/nonexistent config.comfyuiPath, which
-    // would ENOENT the spawn after the server was already killed (#535). Otherwise
-    // keep the existing interpreter + let the caller default cwd to comfyuiPath.
+    // would ENOENT the spawn after the server was already killed (#535). An
+    // absolute / canonical-base script spawns from its OWN anchor dir the same way
+    // (#711): the anchor is the absolute install root the script was resolved
+    // against, so the relaunch never depends on a wrong/undefined working
+    // directory. Only an UNANCHORED relative script leaves cwd unset — the
+    // refuse-safe preflight (#476/#426) rejects that case before any stop.
     const exe = liveCwdScript ? liveCwdPython! : python;
-    const cwd = liveCwdScript ? info.liveCwd : undefined;
+    const cwd = liveCwdScript ? info.liveCwd : anchor;
     return { exe, args: [script, ...rest], cwd };
   }
   return { exe: first, args: rest };
@@ -677,6 +683,20 @@ function fileExists(p: string | undefined): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * config.comfyuiPath as a spawn cwd — only when it is an ABSOLUTE path that
+ * exists on disk. A stale, relative, or nonexistent COMFYUI_PATH passed as cwd
+ * would ENOENT the spawn after the server was already stopped (#711); callers
+ * then omit cwd and the child inherits this process's (existing) working dir.
+ */
+function configuredInstallCwd(): string | undefined {
+  return config.comfyuiPath &&
+    isAbsolute(config.comfyuiPath) &&
+    fileExists(config.comfyuiPath)
+    ? config.comfyuiPath
+    : undefined;
 }
 
 /**
@@ -775,7 +795,9 @@ function assessRelaunch(info: ProcessInfo): { ok: boolean; reason?: string } {
         ok: false,
         reason:
           `Resolved ComfyUI script does not exist on disk: ${script} — ` +
-          "COMFYUI_PATH may point at a stale/old install that has no runnable server.",
+          "could not locate the ComfyUI install; set COMFYUI_PATH or a default " +
+          "workspace (COMFYUI_PATH may point at a stale/old install that has no " +
+          "runnable server).",
       };
     }
   }

--- a/src/services/process-control.ts
+++ b/src/services/process-control.ts
@@ -686,17 +686,23 @@ function fileExists(p: string | undefined): boolean {
 }
 
 /**
- * config.comfyuiPath as a spawn cwd — only when it is an ABSOLUTE path that
- * exists on disk. A stale, relative, or nonexistent COMFYUI_PATH passed as cwd
- * would ENOENT the spawn after the server was already stopped (#711); callers
- * then omit cwd and the child inherits this process's (existing) working dir.
+ * config.comfyuiPath as a spawn cwd — only when it is an ABSOLUTE path to an
+ * existing DIRECTORY. A stale, relative, or nonexistent COMFYUI_PATH passed as
+ * cwd would ENOENT the spawn after the server was already stopped (#711), and
+ * a path that resolves to a regular FILE fails the same way (ENOTDIR) — both
+ * recreate the lost-server failure this guard exists to prevent (codex gate).
+ * Callers then omit cwd and the child inherits this process's (existing)
+ * working dir.
  */
 function configuredInstallCwd(): string | undefined {
-  return config.comfyuiPath &&
-    isAbsolute(config.comfyuiPath) &&
-    fileExists(config.comfyuiPath)
-    ? config.comfyuiPath
-    : undefined;
+  if (!config.comfyuiPath || !isAbsolute(config.comfyuiPath)) return undefined;
+  try {
+    return statSync(config.comfyuiPath).isDirectory()
+      ? config.comfyuiPath
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
## Root cause

`restart_comfyui` stopped the running ComfyUI fine, but the relaunch spawn's working directory came from an unvalidated fallback: `spawnFromProcessInfo` used `cmd.cwd ?? config.comfyuiPath`. When the launch script had been resolved against a different absolute install (the live server's argv-derived root, or the saved default workspace) while `COMFYUI_PATH` was stale/relative/unset, the spawn ran from a wrong or undefined working directory and failed with `spawn main.py ENOENT` — after the server was already killed (#711). The reported scenario was on 0.49.0, which predates the #535/#476 relaunch hardening; the residual cwd gap above still existed on main.

## Fix (`src/services/process-control.ts` only)

- **`resolveLaunchCommand`** now returns the resolved install anchor as the spawn `cwd` for every script relaunch: the live process cwd (#535) or the canonical absolute base the script was anchored to (live argv root → `COMFYUI_PATH`/saved default workspace via `resolveEffectiveComfyUIBase` → `config.comfyuiPath`). The relaunch always spawns from the absolute install dir that holds `main.py`.
- **`spawnFromProcessInfo`** falls back to `config.comfyuiPath` as cwd only when it is an **absolute path that exists on disk** (new `configuredInstallCwd()`); otherwise `cwd` is omitted so the child inherits this process's (existing) working dir instead of ENOENT-ing.
- **`assessRelaunch`**'s refuse-safe error is now truthful and actionable: *"could not locate the ComfyUI install; set COMFYUI_PATH or a default workspace"* — the server is left running, and no raw ENOENT surfaces.

The second half of #711 (`download_model` refusing to write through symlinked model roots) is a separate change and is **not** addressed here.

## Tests

- `restart-live-first.test.ts` — new `#711` describe: spawn uses the resolved install dir as an **explicit absolute cwd** when `COMFYUI_PATH` is unset; a stale `COMFYUI_PATH` never becomes the spawn cwd when the script anchored elsewhere; unresolvable install → truthful actionable refusal (matches `/could not locate the ComfyUI install/`, `/COMFYUI_PATH or a default workspace/`, **no** `ENOENT`, no spawn, no kill).
- `process-control.test.ts` — stale/nonexistent `COMFYUI_PATH` → spawn `cwd` omitted; the #330 interpreter-relaunch test now asserts the anchor-based cwd (live script dir on win32, configured install elsewhere).
- `npx tsc --noEmit` clean; full `npx vitest run`: **232 files, 3886 passed / 2 skipped** (baseline 3882 + 4 new).

Closes #711