### PR TITLE
fix(#436): carry the trusted workflow stamp across proven tab-id migrations

### DIFF
--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -687,6 +687,14 @@ describe("#646 Manager API dialect cache invalidation", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         const path = new URL(url).pathname;
         calls.push({ path, method, body });
+        // #730: single-pack updates re-read the installed list post-op — both
+        // packs must resolve for the ops to succeed.
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({
+            "pack-a": { ver: "1.0.0", enabled: true },
+            "pack-b": { ver: "1.0.0", enabled: true },
+          });
+        }
         if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
         if (path === "/v2/manager/is_legacy_manager_ui") {
           if (gated) await gate;

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -857,11 +857,47 @@ describe("node-management service", () => {
   // ---- update ------------------------------------------------------------
 
   describe("updateCustomNode", () => {
+    // Post-op presence verification (#730): a single-pack update re-queries
+    // /customnode/installed after the drain and fails unless the pack resolves
+    // SOMEWHERE, so success-path tests must report the pack as installed.
+    const installedMyPack = {
+      "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true },
+    };
+
     it("updates a single pack via an update task", async () => {
-      const { calls } = stubFetch();
+      const { calls } = stubFetch({ installedBody: installedMyPack });
       await updateCustomNode({ id: "my-pack" });
       const { params } = taskOf(calls, "update");
       expect(params).toMatchObject({ node_name: "my-pack" });
+    });
+
+    it("fails truthfully for an id that resolves NOWHERE (#730: queue-drain is not proof)", async () => {
+      // Live evidence: the Manager drains "done" with total_count 0 for an
+      // unknown id, and update used to report "Queued + updated" anyway. The
+      // pack resolves nowhere post-op → hard failure, no success claim.
+      stubFetch({ installedBody: {} });
+      const err = await updateCustomNode({ id: "mcp-sweep-nonexistent-pack" }).catch(
+        (e: Error) => e,
+      );
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect((err as Error).message).toMatch(/not present afterward/);
+      expect((err as Error).message).not.toMatch(/updated/i);
+    });
+
+    it("still succeeds for an installed-but-not-in-registry (git-cloned) pack", async () => {
+      // The #730 gate must not break packs the registry does not know: they
+      // match the installed list by module/auxId spellings.
+      const { calls } = stubFetch({
+        installedBody: {
+          "some-git-node": { ver: "abc1234", aux_id: "user/some-git-node", enabled: true },
+        },
+      });
+      const res = await updateCustomNode({ id: "user/some-git-node" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ updated/);
+      expect(taskOf(calls, "update").params).toMatchObject({
+        node_name: "user/some-git-node",
+      });
     });
 
     it("routes 'all' to /v2/manager/queue/update_all with QUERY params (not body)", async () => {
@@ -884,8 +920,15 @@ describe("node-management service", () => {
   // ---- reinstall ---------------------------------------------------------
 
   describe("reinstallCustomNode", () => {
+    // Same #730 post-op presence gate as update (reinstall is uninstall +
+    // install — for a nowhere-resolving id BOTH cycles no-op and both drains
+    // pass trivially), so the success path must report the pack as installed.
+    const installedMyPack = {
+      "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true },
+    };
+
     it("models reinstall as an uninstall task followed by an install task", async () => {
-      const { calls } = stubFetch();
+      const { calls } = stubFetch({ installedBody: installedMyPack });
       await reinstallCustomNode({ id: "my-pack" });
       expect(taskOf(calls, "uninstall").params).toMatchObject({
         node_name: "my-pack",
@@ -894,6 +937,27 @@ describe("node-management service", () => {
         id: "my-pack",
         version: "latest",
       });
+    });
+
+    it("fails truthfully for an id that resolves NOWHERE (#730)", async () => {
+      stubFetch({ installedBody: {} });
+      const err = await reinstallCustomNode({ id: "mcp-sweep-nonexistent-pack" }).catch(
+        (e: Error) => e,
+      );
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect((err as Error).message).toMatch(/not present afterward/);
+      expect((err as Error).message).not.toMatch(/reinstalled/i);
+    });
+
+    it("still succeeds for an installed-but-not-in-registry (git-cloned) pack", async () => {
+      stubFetch({
+        installedBody: {
+          "some-git-node": { ver: "abc1234", aux_id: "user/some-git-node", enabled: true },
+        },
+      });
+      const res = await reinstallCustomNode({ id: "some-git-node" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ reinstalled/);
     });
   });
 
@@ -1210,7 +1274,10 @@ describe("node-management service", () => {
     });
 
     it("routes update / fix to the per-operation legacy endpoints", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: the single-pack update re-reads the installed list post-op.
+        installedBody: { "comfyui-foo": { ver: "1.0.0", cnr_id: "comfyui-foo", enabled: true } },
+      });
       await updateCustomNode({ id: "comfyui-foo" });
       await fixCustomNode({ id: "comfyui-foo" });
       expect(legacyCallTo(calls, "/manager/queue/update")?.body).toMatchObject({
@@ -1238,7 +1305,14 @@ describe("node-management service", () => {
     });
 
     it("caches detection per target (one probe, not one per operation)", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: both packs must resolve post-op; the installed-list re-read
+        // reuses the cached detection, so it adds no probe.
+        installedBody: {
+          a: { ver: "1.0.0", enabled: true },
+          b: { ver: "1.0.0", enabled: true },
+        },
+      });
       await updateCustomNode({ id: "a" });
       await updateCustomNode({ id: "b" });
       const probes = calls.filter(
@@ -1279,7 +1353,10 @@ describe("node-management service", () => {
     });
 
     it("third-party pack update is unchanged by the self-update routing", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: the pack must resolve on the post-op presence re-read.
+        installedBody: { "rgthree-comfy": { ver: "1.0.0", cnr_id: "rgthree-comfy", enabled: true } },
+      });
       mockedExists.mockReturnValue(true);
       const res = await updateCustomNode({ id: "rgthree-comfy" });
       expect(res.mechanism).toBe("manager-http");
@@ -1485,13 +1562,15 @@ describe("node-management service", () => {
   describe("v2 task 405 → v2-batch negotiation (issue #464)", () => {
     /** Stub a build whose /v2 queue surface answers status but 405s the unified
      *  task route, with `is_legacy_manager_ui` absent (catchall HTML). */
-    function stub464Fetch(opts: { failed?: unknown[] } = {}) {
+    function stub464Fetch(opts: { failed?: unknown[]; installedBody?: unknown } = {}) {
       const calls: Call[] = [];
       const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
         const method = init?.method ?? "GET";
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: single-pack updates re-read the installed list post-op.
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse(opts.installedBody ?? {});
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
         }
@@ -1519,7 +1598,9 @@ describe("node-management service", () => {
     }
 
     it("panel_update_node succeeds via batch when /v2 task 405s (no raw 405 surfaced)", async () => {
-      const { calls } = stub464Fetch();
+      const { calls } = stub464Fetch({
+        installedBody: { "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true } },
+      });
       const res = await updateCustomNode({ id: "my-pack" });
       expect(res.mechanism).toBe("manager-http");
       // Downgraded to the batch envelope with the 3.x update body …
@@ -1534,7 +1615,12 @@ describe("node-management service", () => {
     });
 
     it("caches the corrected v2-batch dialect (second op skips the dead task route)", async () => {
-      const { calls } = stub464Fetch();
+      const { calls } = stub464Fetch({
+        installedBody: {
+          "pack-a": { ver: "1.0.0", enabled: true },
+          "pack-b": { ver: "1.0.0", enabled: true },
+        },
+      });
       await updateCustomNode({ id: "pack-a" });
       const taskHitsAfterFirst = calls.filter(
         (c) => new URL(c.url).pathname === "/v2/manager/queue/task",
@@ -1561,6 +1647,14 @@ describe("node-management service", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: the post-op presence re-read (pack-a's op fails at the batch,
+        // pack-b's succeeds and must resolve SOMEWHERE).
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({
+            "pack-a": { ver: "1.0.0", enabled: true },
+            "pack-b": { ver: "1.0.0", enabled: true },
+          });
+        }
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
         }
@@ -1598,6 +1692,10 @@ describe("node-management service", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: the post-op presence re-read must find the pack.
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({ "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true } });
+        }
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, pending_count: 0, is_processing: false });
         }

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -662,8 +662,9 @@ describe("runPanelAction", () => {
   });
 
   it("#639: reinstall where the pack never lands → throws, not silent success", async () => {
-    // reinstallCustomNode does NOT verify presence downstream (unlike install),
-    // so the panel-layer post-op check is what fails this closed.
+    // The panel-layer post-op check is what fails this closed (the generic
+    // reinstallCustomNode gained its own presence gate later, in #730 — but the
+    // deps here are injected, so this exercises the panel's own check).
     const h = makeDeps({ comfyuiPath: COMFY });
     await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
       PanelInstallError,

--- a/src/__tests__/services/ui-bridge.test.ts
+++ b/src/__tests__/services/ui-bridge.test.ts
@@ -17,6 +17,7 @@ import {
   isMutatingGraphCommand,
   requiresWorkflowStampEnforcement,
 } from "../../services/ui-bridge.js";
+import { carryWorkflowCommandStamp } from "../../orchestrator/session-store.js";
 
 // #570 P0c — classifier that decides which commands must pass the enforcement+stamp gate.
 describe("requiresWorkflowStampEnforcement (#570 P0c)", () => {
@@ -824,6 +825,91 @@ describe("UiBridge (multi-tab)", () => {
       expect(dispatchOutcomeOf(readErr)).toBe(false);
       expect(dispatchOutcomeOf(writeErr)).toBe(false);
       expect(readErr.message).toMatch(/no connected tab with id "wf:workflows\/x\.json"/);
+    });
+  });
+
+  // The trusted workflow-uuid stamp registry (orchestrator's tabCommandWorkflowUuid)
+  // is keyed by the CALLER's tab id, while command ROUTING resolves through the
+  // bridge's same-socket migration alias. A proven same-workflow migration (a save /
+  // rename, or a reconnect that re-registers the tab under a new id) used to retire
+  // the old id's stamp: a session still bound to the pre-migration id (a Codex HTTP
+  // MCP session is never re-pointed) kept reading through the alias while EVERY write
+  // was refused "no trusted identity" — and panel_set_workflow_target({mode:"current"})
+  // reported success without repairing anything (canReach is true through the alias).
+  // Only a browser refresh restored writes (#436 priority 3).
+  describe("the trusted stamp survives a proven same-workflow migration (#436.3)", () => {
+    it("a session bound to the pre-migration id keeps mutating once the stamp is carried", async () => {
+      // Wire the stamp registry exactly as the orchestrator does (caller-keyed map).
+      const stamps = new Map<string, string>();
+      bridge.setTabWorkflowUuidResolver((tabId) => stamps.get(tabId));
+      const UUID = "22222222-2222-4222-8222-222222222222";
+
+      const sock = await connectPanel();
+      const frames: Array<Record<string, unknown>> = [];
+      sock.on("message", (buf) => {
+        const m = JSON.parse(buf.toString());
+        if (m.rid && m.cmd) {
+          frames.push(m);
+          sock.send(JSON.stringify({ rid: m.rid, ok: true, result: { ok: true } }));
+        }
+      });
+
+      // 1) The panel connects on an UNSAVED tab with a trusted identity; the
+      //    hello handler records its stamp and an agent session binds to the id.
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: "tmp:unsaved",
+          title: "Unsaved Workflow",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+          workflow_uuid: UUID,
+        }),
+      );
+      await vi.waitFor(() => expect(bridge.tabs()).toHaveLength(1));
+      stamps.set("tmp:unsaved", UUID);
+      const before = await bridge.send({ cmd: "graph_add_node" }, { tabId: "tmp:unsaved" });
+      expect(before).toMatchObject({ ok: true });
+      expect(frames.pop()?.workflow_uuid).toBe(UUID);
+
+      // 2) The user saves: the SAME socket re-hellos under the new wf: id — a
+      //    PROVEN same-workflow migration (identical uuid). Reads keep routing to
+      //    the live tab through the migration alias…
+      sock.send(
+        JSON.stringify({
+          type: "hello",
+          tab_id: "wf:saved.json",
+          title: "saved",
+          enforces_workflow_stamp: true,
+          enforces_workflow_stamp_at_write: true,
+          workflow_uuid: UUID,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(bridge.tabs()).toHaveLength(1);
+        expect(bridge.tabs()[0].tab_id).toBe("wf:saved.json");
+      });
+      stamps.set("wf:saved.json", UUID); // the hello handler records the new id's stamp
+
+      // …but when the migration RETIRES the old id's stamp (the pre-fix behavior),
+      // the still-bound session reads fine while EVERY write is refused — the flap.
+      // Pinned here so the gate keeps failing closed whenever no stamp resolves.
+      stamps.delete("tmp:unsaved");
+      const read = await bridge.send({ cmd: "graph_outline" }, { tabId: "tmp:unsaved" });
+      expect(read).toMatchObject({ ok: true }); // reads ride the alias
+      await expect(
+        bridge.send({ cmd: "graph_add_node" }, { tabId: "tmp:unsaved" }),
+      ).rejects.toThrow(/no trusted identity/);
+
+      // 3) The fix: the proven migration CARRIES the stamp (the exact call the
+      //    hello handler now makes) — the session writes again without a browser
+      //    refresh, stamped with the SAME trusted uuid the panel fences on.
+      carryWorkflowCommandStamp(stamps, "tmp:unsaved", { uuid: UUID });
+      const after = await bridge.send({ cmd: "graph_add_node" }, { tabId: "tmp:unsaved" });
+      expect(after).toMatchObject({ ok: true });
+      expect(frames.pop()?.workflow_uuid).toBe(UUID);
+
+      sock.close();
     });
   });
 

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -26,6 +26,7 @@ import { SelfRestarter } from "../services/self-restart.js";
 import {
   SessionStore,
   armableResume,
+  carryWorkflowCommandStamp,
   deriveStableKey,
   destinationHasCollisionState,
   keepsBackendState,
@@ -2796,7 +2797,11 @@ export async function runPanelOrchestrator(): Promise<void> {
           const carriedStable = tabStableKey.get(migratedFrom);
           tabStableKey.delete(migratedFrom);
           tabStableIdentity.delete(migratedFrom);
-          tabCommandWorkflowUuid.delete(migratedFrom);
+          // #436 — the command stamp is the ONE per-tab map that must NOT be retired
+          // here: carry it onto the old id (same uuid — sameWorkflow proved it). See
+          // carryWorkflowCommandStamp for why deleting it flapped sessions still
+          // bound to the pre-migration id into read-ok / write-refused.
+          carryWorkflowCommandStamp(tabCommandWorkflowUuid, migratedFrom, newIdentity!);
           if (carriedStable !== undefined) {
             if (panelTab.startsWith("tmp:")) tabStableKey.set(panelTab, carriedStable);
             else sessionStore.clearStable(carriedStable);

--- a/src/orchestrator/session-store.ts
+++ b/src/orchestrator/session-store.ts
@@ -151,6 +151,33 @@ export function deriveWorkflowIdentity(opts: {
   return p ? `${p.origin}::${p.uuid}` : undefined;
 }
 
+/** #436 — on a PROVEN same-workflow tab-id migration (the hello handler has already
+ *  established prior uuid === new uuid), KEEP the per-tab command stamp resolvable
+ *  under the PRE-migration id, not only under the canonical new one. A session can
+ *  stay bound to the old id across the migration — a Codex HTTP MCP session's URL
+ *  names the spawn-time tab id and is never re-pointed (no rebindTab hook on that
+ *  transport) — and UiBridge.send resolves the trusted workflow-uuid stamp by the
+ *  CALLER's tab id. Deleting the old entry made every mutating command fail "no
+ *  trusted identity" while reads kept routing through the bridge's migration alias
+ *  (the #436 flap: panel_graph_outline succeeds, the next panel_add_node /
+ *  panel_set_widget is refused, and panel_set_workflow_target({mode:"current"})
+ *  reports success without repairing anything because canReach is true through the
+ *  alias). Only a manual browser refresh re-registered the tab under an id the
+ *  session could be rebound to.
+ *
+ *  Carrying is safe: the value is the SAME uuid by the proven-migration
+ *  precondition, so commands addressed to the old id stamp exactly what the panel
+ *  fences on; a later in-place replacement of the workflow keeps failing closed
+ *  (the panel refuses the stale uuid); and any hello registered under the old id
+ *  overwrites or clears the entry (fail closed). */
+export function carryWorkflowCommandStamp(
+  stamps: Map<string, string>,
+  migratedFrom: string,
+  identity: { uuid: string },
+): void {
+  stamps.set(migratedFrom, identity.uuid);
+}
+
 /** #570 — does the DESTINATION of a tab-id migration already hold state for a backend, so the
  *  incoming tab would inherit/leak it? Covers EVERY kind of per-backend state that must be reset
  *  before the source is rebound in: manager live/pending/held (`hasManagerState`), a dormant

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1921,6 +1921,41 @@ async function installCustomNodeImpl(
   };
 }
 
+/**
+ * Post-op presence gate for update/reinstall (#730) — the same fail-closed
+ * check install got in #232, reusing the same helpers (listInstalledNodesAt +
+ * nodeInstalledMatches). A drained Manager queue proves NOTHING about whether
+ * work happened: for an id that resolves nowhere the enqueue is a silent no-op
+ * and the drain passes trivially (total_count 0 while done_count increments),
+ * which is how update/reinstall reported "Queued + updated/reinstalled" for
+ * packs that do not exist. So re-read the installed list afterward —
+ * /customnode/installed reflects the on-disk custom_nodes — and require the
+ * pack to resolve SOMEWHERE before claiming success.
+ *
+ * A pack that IS installed but not in the registry (git-cloned) still matches —
+ * nodeInstalledMatches covers the module/auxId spellings — so that path is
+ * unaffected; only an id that resolves NOWHERE fails.
+ */
+async function assertPackPresentAfterOp(
+  id: string,
+  op: "update" | "reinstall",
+  base: string,
+  status: QueueStatus,
+): Promise<void> {
+  const installed = await listInstalledNodesAt(base).catch(
+    () => [] as InstalledNode[],
+  );
+  if (!nodeInstalledMatches(id, installed)) {
+    throw new NodeManagementError(
+      `"${id}" was queued for ${op} but is not present afterward — it is not ` +
+        `installed locally and was not found in the ComfyUI-Manager registry, ` +
+        `so there was nothing to ${op}. Check the pack id (list_installed_nodes ` +
+        `shows what is actually installed).`,
+      status,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // update
 // ---------------------------------------------------------------------------
@@ -2151,6 +2186,10 @@ async function updateCustomNodeImpl(
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
     status = await queueManagerTask("update", { node_name: id }, base);
+    // VERIFY (#730): the drain passes trivially for an id Manager never
+    // enqueued (total_count 0 — the "Queued + updated" lie in the issue).
+    // Require the pack to resolve SOMEWHERE post-op before claiming success.
+    await assertPackPresentAfterOp(id, "update", base, status);
   }
   return {
     mechanism: "manager-http",
@@ -2268,6 +2307,10 @@ async function reinstallCustomNodeImpl(
     channel,
     mode,
   }, base);
+  // VERIFY (#730): same queue-drain trust hole as update — for an id that
+  // resolves nowhere BOTH cycles no-op and both drains pass trivially. Require
+  // the pack to be present afterward before claiming a reinstall.
+  await assertPackPresentAfterOp(id, "reinstall", base, status);
   return {
     mechanism: "manager-http",
     message: `Queued + reinstalled "${id}" (uninstall + install) via ComfyUI-Manager. A restart may be required.`,


### PR DESCRIPTION
## Summary

Fixes the still-open recurrence in artokun/comfyui-mcp-panel#436 (0.49.0): after a workflow switch/reconnect, reads succeed and `panel_set_workflow_target({mode:"current"})` reports success, but every write is refused — `graph_set_widget could not be dispatched … workflow has no trusted identity for the panel to fence the command against` — until the user hard-refreshes the browser tab.

## Root cause

Command ROUTING and the trusted workflow-uuid STAMP are keyed differently:

- `UiBridge.send` resolves the target conn through the bridge's same-socket **migration alias**, so a session bound to a pre-migration tab id keeps reaching the live tab (reads work).
- The pre-dispatch stamp gate, however, resolves the trusted uuid **by the CALLER's tab id** (`tabCommandWorkflowUuid.get(panelTabOf(opts.tabId))`) — deliberately, so a command issued for workflow A can never be stamped for workflow B.

On a **proven same-workflow tab-id migration** (identical trusted uuid: a save/rename, or a reconnect/re-registration that re-hellos under a new id), the hello handler moved the agent and per-tab state to the new id but **deleted the old id's stamp**. A session still bound to the pre-migration id — notably a Codex HTTP MCP session, whose per-tab URL names the spawn-time id and is never re-pointed (no `rebindTab` hook on that transport) — then read fine through the alias while EVERY write was refused "no trusted identity". The documented recovery, `panel_set_workflow_target({mode:"current"})`, no-opped: `canReach(oldId)` is true through the alias, so `awaitReachable`/`rebindToActiveTab` returned instantly and reported success without repairing anything. Only F5 (full tab re-registration under an id the session could be rebound to) restored writes — the reported flap.

This is the remaining piece after #603 (writes await a stable binding), #615 (actionable refresh guidance), and #714 (honest post-restart capability reporting): those made the state visible and the routing resilient, but nothing re-established the caller-keyed stamp for a still-bound session (issue ask #3: re-register the binding keyed on the workflow path so the pre-restart id resolves).

## Fix

One behavioral change in the hello handler's proven-migration branch (`src/orchestrator/index.ts`): **carry** the command stamp onto the pre-migration id instead of deleting it, via the new `carryWorkflowCommandStamp` helper (`src/orchestrator/session-store.ts`). Safety argues:

- The `sameWorkflow` precondition guarantees the carried value is the SAME uuid, so commands addressed to the old id stamp exactly what the panel fences on.
- A later in-place replacement of the workflow keeps failing closed — the panel refuses the stale uuid (verified against the #570 fence design).
- Any hello registered under the old id overwrites or clears the entry (fail closed); the UNPROVEN switch branch still revokes the alias AND deletes the stamp, unchanged.

No panel (comfyui-mcp-panel) change needed: the panel already advertises `workflow_uuid`/`tab_session_id` on every hello and fences stamped commands correctly; the gap was purely the orchestrator dropping the caller-keyed stamp.

## Validation

- New regression test in `src/__tests__/services/ui-bridge.test.ts` (#436.3): real bridge + real websocket; a session bound to a pre-migration id reads through the alias, is refused "no trusted identity" once the old id's stamp is retired (pinning the fail-closed gate), and writes again with the SAME uuid stamp after `carryWorkflowCommandStamp` — the exact call the hello handler now makes.
- Targeted runs: ui-bridge, session-store, panel-session-rebind-residuals, tab-id-migration-staleness, in-place-replace-reset, panel-restart-legacy-fallback — all pass.
- Full `npx vitest run`: **232 files, 3892 passed | 2 skipped** (baseline 3882/2 plus this test).
- `npm run lint` (tsc --noEmit) and `npm run build` clean.

Refs artokun/comfyui-mcp-panel#436