### PR TITLE
fix(#730): update/reinstall require post-op presence proof (no queue-drain trust)

### DIFF
--- a/src/__tests__/services/manager-dialect-cache.test.ts
+++ b/src/__tests__/services/manager-dialect-cache.test.ts
@@ -687,6 +687,14 @@ describe("#646 Manager API dialect cache invalidation", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         const path = new URL(url).pathname;
         calls.push({ path, method, body });
+        // #730: single-pack updates re-read the installed list post-op — both
+        // packs must resolve for the ops to succeed.
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({
+            "pack-a": { ver: "1.0.0", enabled: true },
+            "pack-b": { ver: "1.0.0", enabled: true },
+          });
+        }
         if (path === "/v2/manager/queue/status") return jsonResponse(DRAINED);
         if (path === "/v2/manager/is_legacy_manager_ui") {
           if (gated) await gate;

--- a/src/__tests__/services/node-management.test.ts
+++ b/src/__tests__/services/node-management.test.ts
@@ -857,11 +857,47 @@ describe("node-management service", () => {
   // ---- update ------------------------------------------------------------
 
   describe("updateCustomNode", () => {
+    // Post-op presence verification (#730): a single-pack update re-queries
+    // /customnode/installed after the drain and fails unless the pack resolves
+    // SOMEWHERE, so success-path tests must report the pack as installed.
+    const installedMyPack = {
+      "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true },
+    };
+
     it("updates a single pack via an update task", async () => {
-      const { calls } = stubFetch();
+      const { calls } = stubFetch({ installedBody: installedMyPack });
       await updateCustomNode({ id: "my-pack" });
       const { params } = taskOf(calls, "update");
       expect(params).toMatchObject({ node_name: "my-pack" });
+    });
+
+    it("fails truthfully for an id that resolves NOWHERE (#730: queue-drain is not proof)", async () => {
+      // Live evidence: the Manager drains "done" with total_count 0 for an
+      // unknown id, and update used to report "Queued + updated" anyway. The
+      // pack resolves nowhere post-op → hard failure, no success claim.
+      stubFetch({ installedBody: {} });
+      const err = await updateCustomNode({ id: "mcp-sweep-nonexistent-pack" }).catch(
+        (e: Error) => e,
+      );
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect((err as Error).message).toMatch(/not present afterward/);
+      expect((err as Error).message).not.toMatch(/updated/i);
+    });
+
+    it("still succeeds for an installed-but-not-in-registry (git-cloned) pack", async () => {
+      // The #730 gate must not break packs the registry does not know: they
+      // match the installed list by module/auxId spellings.
+      const { calls } = stubFetch({
+        installedBody: {
+          "some-git-node": { ver: "abc1234", aux_id: "user/some-git-node", enabled: true },
+        },
+      });
+      const res = await updateCustomNode({ id: "user/some-git-node" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ updated/);
+      expect(taskOf(calls, "update").params).toMatchObject({
+        node_name: "user/some-git-node",
+      });
     });
 
     it("routes 'all' to /v2/manager/queue/update_all with QUERY params (not body)", async () => {
@@ -884,8 +920,15 @@ describe("node-management service", () => {
   // ---- reinstall ---------------------------------------------------------
 
   describe("reinstallCustomNode", () => {
+    // Same #730 post-op presence gate as update (reinstall is uninstall +
+    // install — for a nowhere-resolving id BOTH cycles no-op and both drains
+    // pass trivially), so the success path must report the pack as installed.
+    const installedMyPack = {
+      "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true },
+    };
+
     it("models reinstall as an uninstall task followed by an install task", async () => {
-      const { calls } = stubFetch();
+      const { calls } = stubFetch({ installedBody: installedMyPack });
       await reinstallCustomNode({ id: "my-pack" });
       expect(taskOf(calls, "uninstall").params).toMatchObject({
         node_name: "my-pack",
@@ -894,6 +937,27 @@ describe("node-management service", () => {
         id: "my-pack",
         version: "latest",
       });
+    });
+
+    it("fails truthfully for an id that resolves NOWHERE (#730)", async () => {
+      stubFetch({ installedBody: {} });
+      const err = await reinstallCustomNode({ id: "mcp-sweep-nonexistent-pack" }).catch(
+        (e: Error) => e,
+      );
+      expect(err).toBeInstanceOf(NodeManagementError);
+      expect((err as Error).message).toMatch(/not present afterward/);
+      expect((err as Error).message).not.toMatch(/reinstalled/i);
+    });
+
+    it("still succeeds for an installed-but-not-in-registry (git-cloned) pack", async () => {
+      stubFetch({
+        installedBody: {
+          "some-git-node": { ver: "abc1234", aux_id: "user/some-git-node", enabled: true },
+        },
+      });
+      const res = await reinstallCustomNode({ id: "some-git-node" });
+      expect(res.mechanism).toBe("manager-http");
+      expect(res.message).toMatch(/Queued \+ reinstalled/);
     });
   });
 
@@ -1210,7 +1274,10 @@ describe("node-management service", () => {
     });
 
     it("routes update / fix to the per-operation legacy endpoints", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: the single-pack update re-reads the installed list post-op.
+        installedBody: { "comfyui-foo": { ver: "1.0.0", cnr_id: "comfyui-foo", enabled: true } },
+      });
       await updateCustomNode({ id: "comfyui-foo" });
       await fixCustomNode({ id: "comfyui-foo" });
       expect(legacyCallTo(calls, "/manager/queue/update")?.body).toMatchObject({
@@ -1238,7 +1305,14 @@ describe("node-management service", () => {
     });
 
     it("caches detection per target (one probe, not one per operation)", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: both packs must resolve post-op; the installed-list re-read
+        // reuses the cached detection, so it adds no probe.
+        installedBody: {
+          a: { ver: "1.0.0", enabled: true },
+          b: { ver: "1.0.0", enabled: true },
+        },
+      });
       await updateCustomNode({ id: "a" });
       await updateCustomNode({ id: "b" });
       const probes = calls.filter(
@@ -1279,7 +1353,10 @@ describe("node-management service", () => {
     });
 
     it("third-party pack update is unchanged by the self-update routing", async () => {
-      const { calls } = stubLegacyFetch();
+      const { calls } = stubLegacyFetch({
+        // #730: the pack must resolve on the post-op presence re-read.
+        installedBody: { "rgthree-comfy": { ver: "1.0.0", cnr_id: "rgthree-comfy", enabled: true } },
+      });
       mockedExists.mockReturnValue(true);
       const res = await updateCustomNode({ id: "rgthree-comfy" });
       expect(res.mechanism).toBe("manager-http");
@@ -1485,13 +1562,15 @@ describe("node-management service", () => {
   describe("v2 task 405 → v2-batch negotiation (issue #464)", () => {
     /** Stub a build whose /v2 queue surface answers status but 405s the unified
      *  task route, with `is_legacy_manager_ui` absent (catchall HTML). */
-    function stub464Fetch(opts: { failed?: unknown[] } = {}) {
+    function stub464Fetch(opts: { failed?: unknown[]; installedBody?: unknown } = {}) {
       const calls: Call[] = [];
       const fetchMock = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
         const method = init?.method ?? "GET";
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: single-pack updates re-read the installed list post-op.
+        if (path.startsWith("/v2/customnode/installed")) return jsonResponse(opts.installedBody ?? {});
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
         }
@@ -1519,7 +1598,9 @@ describe("node-management service", () => {
     }
 
     it("panel_update_node succeeds via batch when /v2 task 405s (no raw 405 surfaced)", async () => {
-      const { calls } = stub464Fetch();
+      const { calls } = stub464Fetch({
+        installedBody: { "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true } },
+      });
       const res = await updateCustomNode({ id: "my-pack" });
       expect(res.mechanism).toBe("manager-http");
       // Downgraded to the batch envelope with the 3.x update body …
@@ -1534,7 +1615,12 @@ describe("node-management service", () => {
     });
 
     it("caches the corrected v2-batch dialect (second op skips the dead task route)", async () => {
-      const { calls } = stub464Fetch();
+      const { calls } = stub464Fetch({
+        installedBody: {
+          "pack-a": { ver: "1.0.0", enabled: true },
+          "pack-b": { ver: "1.0.0", enabled: true },
+        },
+      });
       await updateCustomNode({ id: "pack-a" });
       const taskHitsAfterFirst = calls.filter(
         (c) => new URL(c.url).pathname === "/v2/manager/queue/task",
@@ -1561,6 +1647,14 @@ describe("node-management service", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: the post-op presence re-read (pack-a's op fails at the batch,
+        // pack-b's succeeds and must resolve SOMEWHERE).
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({
+            "pack-a": { ver: "1.0.0", enabled: true },
+            "pack-b": { ver: "1.0.0", enabled: true },
+          });
+        }
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, is_processing: false });
         }
@@ -1598,6 +1692,10 @@ describe("node-management service", () => {
         const body = init?.body ? JSON.parse(init.body as string) : undefined;
         calls.push({ url, method, body });
         const path = new URL(url).pathname;
+        // #730: the post-op presence re-read must find the pack.
+        if (path.startsWith("/v2/customnode/installed")) {
+          return jsonResponse({ "my-pack": { ver: "1.0.0", cnr_id: "my-pack", enabled: true } });
+        }
         if (path === "/v2/manager/queue/status") {
           return jsonResponse({ total_count: 1, done_count: 1, in_progress_count: 0, pending_count: 0, is_processing: false });
         }

--- a/src/__tests__/services/panel-installer.test.ts
+++ b/src/__tests__/services/panel-installer.test.ts
@@ -662,8 +662,9 @@ describe("runPanelAction", () => {
   });
 
   it("#639: reinstall where the pack never lands → throws, not silent success", async () => {
-    // reinstallCustomNode does NOT verify presence downstream (unlike install),
-    // so the panel-layer post-op check is what fails this closed.
+    // The panel-layer post-op check is what fails this closed (the generic
+    // reinstallCustomNode gained its own presence gate later, in #730 — but the
+    // deps here are injected, so this exercises the panel's own check).
     const h = makeDeps({ comfyuiPath: COMFY });
     await expect(runPanelAction("reinstall", h.deps)).rejects.toBeInstanceOf(
       PanelInstallError,

--- a/src/services/node-management.ts
+++ b/src/services/node-management.ts
@@ -1921,6 +1921,41 @@ async function installCustomNodeImpl(
   };
 }
 
+/**
+ * Post-op presence gate for update/reinstall (#730) — the same fail-closed
+ * check install got in #232, reusing the same helpers (listInstalledNodesAt +
+ * nodeInstalledMatches). A drained Manager queue proves NOTHING about whether
+ * work happened: for an id that resolves nowhere the enqueue is a silent no-op
+ * and the drain passes trivially (total_count 0 while done_count increments),
+ * which is how update/reinstall reported "Queued + updated/reinstalled" for
+ * packs that do not exist. So re-read the installed list afterward —
+ * /customnode/installed reflects the on-disk custom_nodes — and require the
+ * pack to resolve SOMEWHERE before claiming success.
+ *
+ * A pack that IS installed but not in the registry (git-cloned) still matches —
+ * nodeInstalledMatches covers the module/auxId spellings — so that path is
+ * unaffected; only an id that resolves NOWHERE fails.
+ */
+async function assertPackPresentAfterOp(
+  id: string,
+  op: "update" | "reinstall",
+  base: string,
+  status: QueueStatus,
+): Promise<void> {
+  const installed = await listInstalledNodesAt(base).catch(
+    () => [] as InstalledNode[],
+  );
+  if (!nodeInstalledMatches(id, installed)) {
+    throw new NodeManagementError(
+      `"${id}" was queued for ${op} but is not present afterward — it is not ` +
+        `installed locally and was not found in the ComfyUI-Manager registry, ` +
+        `so there was nothing to ${op}. Check the pack id (list_installed_nodes ` +
+        `shows what is actually installed).`,
+      status,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // update
 // ---------------------------------------------------------------------------
@@ -2151,6 +2186,10 @@ async function updateCustomNodeImpl(
   } else {
     // Single-pack update → unified task; UpdatePackParams uses node_name/node_ver.
     status = await queueManagerTask("update", { node_name: id }, base);
+    // VERIFY (#730): the drain passes trivially for an id Manager never
+    // enqueued (total_count 0 — the "Queued + updated" lie in the issue).
+    // Require the pack to resolve SOMEWHERE post-op before claiming success.
+    await assertPackPresentAfterOp(id, "update", base, status);
   }
   return {
     mechanism: "manager-http",
@@ -2268,6 +2307,10 @@ async function reinstallCustomNodeImpl(
     channel,
     mode,
   }, base);
+  // VERIFY (#730): same queue-drain trust hole as update — for an id that
+  // resolves nowhere BOTH cycles no-op and both drains pass trivially. Require
+  // the pack to be present afterward before claiming a reinstall.
+  await assertPackPresentAfterOp(id, "reinstall", base, status);
   return {
     mechanism: "manager-http",
     message: `Queued + reinstalled "${id}" (uninstall + install) via ComfyUI-Manager. A restart may be required.`,


### PR DESCRIPTION
## Problem

Fixes #730.

`update_custom_node` / `reinstall_custom_node` trusted the ComfyUI-Manager queue drain as proof of work. For an id that resolves nowhere, the Manager never enqueues anything — the drain passes trivially (`total_count: 0` while `done_count` increments) — and both tools reported `Queued + updated` / `Queued + reinstalled` for packs that do not exist. Same fabricate-success class as #639 (panel path, already hardened) and #232 (`install_custom_node`, already hardened).

Live repro (ComfyUI 0.29.2, Manager v4): `update_custom_node {id:"mcp-sweep-nonexistent-pack"}` → ok; `reinstall_custom_node` same id → ok; `install_custom_node` same id → correct failure.

## Fix

Mirror the #232 install check, reusing the same helpers — no parallel verification built:

- New `assertPackPresentAfterOp()` in `src/services/node-management.ts`: after the queue drains, re-read the installed list (`listInstalledNodesAt` — `/customnode/installed` reflects on-disk custom_nodes) and require the pack to resolve SOMEWHERE (`nodeInstalledMatches`) before claiming success. An id resolving nowhere fails truthfully: *"not installed locally and was not found in the ComfyUI-Manager registry — there was nothing to update/reinstall"*.
- Wired into the single-pack manager-http paths of `updateCustomNodeImpl` and `reinstallCustomNodeImpl` (on the same call-scoped pinned base as the op itself).

Deliberately untouched:

- **Installed-but-not-in-registry (git-cloned) packs** — `nodeInstalledMatches` covers module/auxId spellings, so that path still succeeds (test added for both tools).
- **`id="all"`** — bulk path already hedges ("not verified yet"); no single pack to check.
- **Manager self-update (#424)** — its own hedged route/verdict.
- **cm-cli paths** — the CLI errors on unknown ids itself (same scoping as #232).
- **panel-installer.ts / process-control.ts / dialect cache** — per constraints.

## Tests

- New: update + reinstall on a nowhere-resolving id → rejects `NodeManagementError` matching /not present afterward/, with no success claim; update + reinstall on installed registry AND git-cloned packs → still succeed.
- Existing dialect/legacy/#464 stubs now report the exercised pack as installed for the post-op re-read; one stale panel-installer test comment updated ("reinstallCustomNode does NOT verify presence downstream" — it now does).
- `npx tsc --noEmit` clean; targeted suites (node-management, manager-dialect-cache, panel-installer, panel-pin-bypass, panel-pin-guard) 327/327; full `npx vitest run`: **3892 passed / 2 skipped** (baseline 3887/2 + 4 new here + 1 from a concurrently-landed ui-bridge test).