### PR TITLE
fix(#721): strip hint only claims unsupported graph_serialize when it actually is

### DIFF
--- a/src/__tests__/orchestrator/panel-tools.test.ts
+++ b/src/__tests__/orchestrator/panel-tools.test.ts
@@ -4009,4 +4009,62 @@ describe("panel_strip_workflow live-canvas fallback (issue #384)", () => {
     expect(sent).toContain("graph_get_state");
     expect(wf.nodes[0].type).toBe("PreviewImage");
   });
+
+  // #721 — the version hint ("an older panel may not support graph_serialize —
+  // pass pack, path, or graph instead") is only accurate for an actual
+  // unsupported-command rejection. Appending it to ANY capture failure
+  // misdiagnosed e.g. the panel's graph desync guard (whose remedy is
+  // rebinding/opening the workflow), sending the agent down the wrong path.
+  it("does NOT append the version hint to a desync-guard-style error (original message preserved)", async () => {
+    const sent: string[] = [];
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          sent.push(cmd.cmd);
+          // The panel's graph desync guard — NOT an unsupported-command
+          // rejection; its own message already carries the remedy.
+          throw new Error(
+            "live graph is out of sync with the active workflow — rebind or open the workflow in the panel, then retry",
+          );
+        },
+      },
+    } as unknown as PanelToolCtx;
+    const err = await __panelToolsTestHooks.resolveWorkflowInput({}, ctx).then(
+      () => {
+        throw new Error("expected resolveWorkflowInput to reject");
+      },
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toContain("live graph is out of sync with the active workflow");
+    expect(err.message).toContain("Couldn't capture the live canvas");
+    expect(err.message).not.toContain("may not support graph_serialize");
+    expect(err.message).not.toContain("pass pack, path, or graph");
+    // no graph_get_state fallback attempt for a non-unsupported failure
+    expect(sent).not.toContain("graph_get_state");
+  });
+
+  it("DOES append the version hint when the error IS an unsupported-command rejection", async () => {
+    const ctx = {
+      tabId: "t",
+      ensureReachable: () => {},
+      bridge: {
+        send: async (cmd: { cmd: string }) => {
+          // Every command unsupported — the graph_get_state fallback also
+          // fails, so the throw path is reached with the original
+          // unsupported-command error for graph_serialize.
+          throw new Error(`Unknown command "${cmd.cmd}"`);
+        },
+      },
+    } as unknown as PanelToolCtx;
+    const err = await __panelToolsTestHooks.resolveWorkflowInput({}, ctx).then(
+      () => {
+        throw new Error("expected resolveWorkflowInput to reject");
+      },
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toContain("may not support graph_serialize");
+    expect(err.message).toContain("pass pack, path, or graph");
+  });
 });

--- a/src/orchestrator/panel-tools.ts
+++ b/src/orchestrator/panel-tools.ts
@@ -2918,10 +2918,18 @@ async function resolveWorkflowInput(
         /* fall through to the actionable error below */
       }
     }
-    throw new Error(
-      `Couldn't capture the live canvas (${msg}). ` +
-        `An older panel version may not support graph_serialize — pass pack, path, or graph instead.`,
-    );
+    // #721: only blame an old panel when the error actually IS an
+    // unsupported-command rejection. Anything else (e.g. the panel's graph
+    // desync guard, whose remedy is rebinding/opening the workflow) already
+    // carries its own remedy in the message — appending the version hint
+    // there misdirects the agent to pack/path/graph instead.
+    if (isPanelCmdUnsupportedError(err, "graph_serialize")) {
+      throw new Error(
+        `Couldn't capture the live canvas (${msg}). ` +
+          `An older panel version may not support graph_serialize — pass pack, path, or graph instead.`,
+      );
+    }
+    throw new Error(`Couldn't capture the live canvas (${msg}).`);
   }
   const wf = (reply as { workflow?: unknown } | null)?.workflow;
   if (!wf || typeof wf !== "object") {


### PR DESCRIPTION
## Problem

When capturing the live canvas (`graph_serialize`) throws for ANY reason, `resolveWorkflowInput` appended:

> An older panel version may not support graph_serialize — pass pack, path, or graph instead.

That's a misdiagnosis whenever the underlying error was something else — notably the panel's graph desync guard ("live graph is out of sync with the active workflow"), whose real remedy is rebinding/opening the workflow, not passing pack/path/graph (panel issue #545). The unsupported-command fallback right above the throw already discriminated structurally via `isPanelCmdUnsupportedError(err, "graph_serialize")`; the throw didn't.

## Fix

The version hint is now appended only when `isPanelCmdUnsupportedError(err, "graph_serialize")` is true — the same structural check the `graph_get_state` fallback uses. Any other capture failure still gets the `Couldn't capture the live canvas (<original message>)` wrapper, with the original panel message surfaced verbatim (it already carries the panel's own remedy). Fallback logic untouched.

Closes #721.

## Panel-side companion

The panel-side rebind work for the desync guard is PR #558 in the panel repo.

## Tests

- New: a desync-guard-style error does NOT get the version hint (original message preserved, no `graph_get_state` fallback attempt).
- New: a genuine unsupported-command rejection DOES get the hint.
- `npx tsc --noEmit`: clean.
- Full `npx vitest run`: 232 files, **3894 passed / 2 skipped** (baseline 3892 + 2 new).